### PR TITLE
Use TargetTriple::from_path in rustdoc

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1507,7 +1507,10 @@ fn collect_print_requests(
     prints
 }
 
-fn parse_target_triple(matches: &getopts::Matches, error_format: ErrorOutputType) -> TargetTriple {
+pub fn parse_target_triple(
+    matches: &getopts::Matches,
+    error_format: ErrorOutputType,
+) -> TargetTriple {
     match matches.opt_str("target") {
         Some(target) if target.ends_with(".json") => {
             let path = Path::new(&target);

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -6,8 +6,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_session::config::{self, parse_crate_types_from_list, parse_externs, CrateType};
-use rustc_session::config::{get_cmd_lint_options, host_triple, nightly_options};
+use rustc_session::config::{
+    self, parse_crate_types_from_list, parse_externs, parse_target_triple, CrateType,
+};
+use rustc_session::config::{get_cmd_lint_options, nightly_options};
 use rustc_session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
 use rustc_session::getopts;
 use rustc_session::lint::Level;
@@ -562,14 +564,7 @@ impl Options {
             }
         }
 
-        let target =
-            matches.opt_str("target").map_or(TargetTriple::from_triple(host_triple()), |target| {
-                if target.ends_with(".json") {
-                    TargetTriple::from_path(Path::new(&target))
-                } else {
-                    TargetTriple::TargetTriple(target)
-                }
-            });
+        let target = parse_target_triple(matches, error_format);
 
         let show_coverage = matches.opt_present("show-coverage");
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -565,7 +565,7 @@ impl Options {
         let target =
             matches.opt_str("target").map_or(TargetTriple::from_triple(host_triple()), |target| {
                 if target.ends_with(".json") {
-                    TargetTriple::TargetPath(PathBuf::from(target))
+                    TargetTriple::from_path(Path::new(&target))
                 } else {
                     TargetTriple::TargetTriple(target)
                 }

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/Makefile
@@ -1,0 +1,9 @@
+include ../tools.mk
+
+# Test that rustdoc will properly canonicalize the target spec json path just like rustc
+
+OUTPUT_DIR := "$(TMPDIR)/rustdoc-target-spec-json-path"
+
+all:
+	$(RUSTC) --crate-type lib dummy_core.rs --target target.json
+	$(RUSTDOC) -o $(OUTPUT_DIR) -L $(TMPDIR) my_crate.rs --target target.json

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/dummy_core.rs
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/dummy_core.rs
@@ -1,0 +1,2 @@
+#![feature(no_core)]
+#![no_core]

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/my_crate.rs
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/my_crate.rs
@@ -1,0 +1,3 @@
+#![feature(no_core)]
+#![no_core]
+extern crate dummy_core;

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/target.json
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/target.json
@@ -1,0 +1,39 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "executables": true,
+  "has-elf-tls": true,
+  "has-rpath": true,
+  "is-builtin": true,
+  "linker-is-gnu": true,
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "linux",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gcc": [
+      "-m64"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      11,
+      0,
+      1
+    ]
+  },
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread"
+  ],
+  "target-family": "unix",
+  "target-pointer-width": "64"
+}


### PR DESCRIPTION
This fixes the problem reported in https://github.com/Rust-for-Linux/linux/pull/272 where rustdoc requires the absolute path of a target spec json instead of accepting a relative path like rustc.