### PR TITLE
Use command line metadata path if provided

### DIFF
--- a/compiler/rustc_session/src/output.rs
+++ b/compiler/rustc_session/src/output.rs
@@ -127,6 +127,11 @@ pub fn filename_for_metadata(
     crate_name: &str,
     outputs: &OutputFilenames,
 ) -> PathBuf {
+    // If the command-line specified the path, use that directly.
+    if let Some(Some(out_filename)) = sess.opts.output_types.get(&OutputType::Metadata) {
+        return out_filename.clone();
+    }
+
     let libname = format!("{}{}", crate_name, sess.opts.cg.extra_filename);
 
     let out_filename = outputs

--- a/src/test/run-make/emit-named-files/Makefile
+++ b/src/test/run-make/emit-named-files/Makefile
@@ -1,0 +1,33 @@
+-include ../../run-make-fulldeps/tools.mk
+
+OUT=$(TMPDIR)/emit
+
+all: asm llvm-bc llvm-ir obj metadata link dep-info mir
+
+asm: $(OUT)
+	$(RUSTC) --emit asm=$(OUT)/libfoo.s foo.rs
+	test -f $(OUT)/libfoo.s
+llvm-bc: $(OUT)
+	$(RUSTC) --emit llvm-bc=$(OUT)/libfoo.bc foo.rs
+	test -f $(OUT)/libfoo.bc
+llvm-ir: $(OUT)
+	$(RUSTC) --emit llvm-ir=$(OUT)/libfoo.ll foo.rs
+	test -f $(OUT)/libfoo.ll
+obj: $(OUT)
+	$(RUSTC) --emit obj=$(OUT)/libfoo.o foo.rs
+	test -f $(OUT)/libfoo.o
+metadata: $(OUT)
+	$(RUSTC) --emit metadata=$(OUT)/libfoo.rmeta foo.rs
+	test -f $(OUT)/libfoo.rmeta
+link: $(OUT)
+	$(RUSTC) --emit link=$(OUT)/libfoo.rlib foo.rs
+	test -f $(OUT)/libfoo.rlib
+dep-info: $(OUT)
+	$(RUSTC) --emit dep-info=$(OUT)/libfoo.d foo.rs
+	test -f $(OUT)/libfoo.d
+mir: $(OUT)
+	$(RUSTC) --emit mir=$(OUT)/libfoo.mir foo.rs
+	test -f $(OUT)/libfoo.mir
+
+$(OUT):
+	mkdir -p $(OUT)

--- a/src/test/run-make/emit-named-files/foo.rs
+++ b/src/test/run-make/emit-named-files/foo.rs
@@ -1,0 +1,1 @@
+#![crate_type = "rlib"]


### PR DESCRIPTION
If the command-line has `--emit metadata=some/path/libfoo.rmeta` then
use that.

Closes #85356

I couldn't find any existing tests for the `--emit TYPE=PATH` command line syntax, so I wasn't sure how to test this aside from ad-hoc manual testing. Is there a ui test type for "generated output file with expected name"?