### PR TITLE
Support pretty printing slices using GDB

### DIFF
--- a/src/etc/gdb_lookup.py
+++ b/src/etc/gdb_lookup.py
@@ -5,7 +5,6 @@ from gdb_providers import *
 from rust_types import *
 
 
-rust_enabled = 'set language rust' in gdb.execute('complete set language ru', to_string=True)
 _gdb_version_matched = re.search('([0-9]+)\\.([0-9]+)', gdb.VERSION)
 gdb_version = [int(num) for num in _gdb_version_matched.groups()] if _gdb_version_matched else []
 
@@ -52,9 +51,10 @@ def lookup(valobj):
         return StdStringProvider(valobj)
     if rust_type == RustType.STD_OS_STRING:
         return StdOsStringProvider(valobj)
-    if rust_type == RustType.STD_STR and not rust_enabled:
+    if rust_type == RustType.STD_STR:
         return StdStrProvider(valobj)
-
+    if rust_type == RustType.STD_SLICE:
+        return StdSliceProvider(valobj)
     if rust_type == RustType.STD_VEC:
         return StdVecProvider(valobj)
     if rust_type == RustType.STD_VEC_DEQUE:

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -85,6 +85,39 @@ class StdStrProvider:
     def display_hint():
         return "string"
 
+def _enumerate_array_elements(element_ptrs):
+    for (i, element_ptr) in enumerate(element_ptrs):
+        key = "[{}]".format(i)
+        element = element_ptr.dereference()
+
+        try:
+            # rust-lang/rust#64343: passing deref expr to `str` allows
+            # catching exception on garbage pointer
+            str(element)
+        except RuntimeError:
+            yield key, "inaccessible"
+
+            break
+
+        yield key, element
+
+class StdSliceProvider:
+    def __init__(self, valobj):
+        self.valobj = valobj
+        self.length = int(valobj["length"])
+        self.data_ptr = valobj["data_ptr"]
+
+    def to_string(self):
+        return "{}(size={})".format(self.valobj.type, self.length)
+
+    def children(self):
+        return _enumerate_array_elements(
+            self.data_ptr + index for index in xrange(self.length)
+        )
+
+    @staticmethod
+    def display_hint():
+        return "array"
 
 class StdVecProvider:
     def __init__(self, valobj):
@@ -96,19 +129,9 @@ class StdVecProvider:
         return "Vec(size={})".format(self.length)
 
     def children(self):
-        saw_inaccessible = False
-        for index in xrange(self.length):
-            element_ptr = self.data_ptr + index
-            if saw_inaccessible:
-                return
-            try:
-                # rust-lang/rust#64343: passing deref expr to `str` allows
-                # catching exception on garbage pointer
-                str(element_ptr.dereference())
-                yield "[{}]".format(index), element_ptr.dereference()
-            except RuntimeError:
-                saw_inaccessible = True
-                yield str(index), "inaccessible"
+        return _enumerate_array_elements(
+            self.data_ptr + index for index in xrange(self.length)
+        )
 
     @staticmethod
     def display_hint():
@@ -131,9 +154,9 @@ class StdVecDequeProvider:
         return "VecDeque(size={})".format(self.size)
 
     def children(self):
-        for index in xrange(0, self.size):
-            value = (self.data_ptr + ((self.tail + index) % self.cap)).dereference()
-            yield "[{}]".format(index), value
+        return _enumerate_array_elements(
+            (self.data_ptr + ((self.tail + index) % self.cap)) for index in xrange(self.size)
+        )
 
     @staticmethod
     def display_hint():

--- a/src/etc/lldb_commands
+++ b/src/etc/lldb_commands
@@ -1,7 +1,7 @@
 type synthetic add -l lldb_lookup.synthetic_lookup -x ".*" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)String$" --category Rust
-type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&str$" --category Rust
-type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&\\[.+\\]$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?str$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^&(mut )?\\[.+\\]$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(std::ffi::([a-z_]+::)+)OsString$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)Vec<.+>$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(alloc::([a-z_]+::)+)VecDeque<.+>$" --category Rust

--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -34,8 +34,8 @@ class RustType(object):
 
 
 STD_STRING_REGEX = re.compile(r"^(alloc::(\w+::)+)String$")
-STD_STR_REGEX = re.compile(r"^&str$")
-STD_SLICE_REGEX = re.compile(r"^&\[.+\]$")
+STD_STR_REGEX = re.compile(r"^&(mut )?str$")
+STD_SLICE_REGEX = re.compile(r"^&(mut )?\[.+\]$")
 STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::(\w+::)+)OsString$")
 STD_VEC_REGEX = re.compile(r"^(alloc::(\w+::)+)Vec<.+>$")
 STD_VEC_DEQUE_REGEX = re.compile(r"^(alloc::(\w+::)+)VecDeque<.+>$")

--- a/src/test/debuginfo/pretty-huge-vec.rs
+++ b/src/test/debuginfo/pretty-huge-vec.rs
@@ -13,7 +13,7 @@
 // gdb-check:$1 = Vec(size=1000000000) = {[...]...}
 
 // gdb-command: print slice
-// gdb-check:$2 = &[u8] {data_ptr: [...], length: 1000000000}
+// gdb-check:$2 = &[u8](size=1000000000) = {[...]...}
 
 #![allow(unused_variables)]
 

--- a/src/test/debuginfo/pretty-slices.rs
+++ b/src/test/debuginfo/pretty-slices.rs
@@ -1,3 +1,4 @@
+// ignore-android: FIXME(#10381)
 // compile-flags:-g
 
 // gdb-command: run
@@ -33,7 +34,6 @@
 fn b() {}
 
 fn main() {
-
     let slice: &[i32] = &[0, 1, 2];
     let mut_slice: &mut [i32] = &mut [2, 3, 5, 7];
 

--- a/src/test/debuginfo/pretty-slices.rs
+++ b/src/test/debuginfo/pretty-slices.rs
@@ -1,4 +1,5 @@
 // ignore-android: FIXME(#10381)
+// ignore-windows
 // compile-flags:-g
 
 // gdb-command: run

--- a/src/test/debuginfo/pretty-slices.rs
+++ b/src/test/debuginfo/pretty-slices.rs
@@ -1,0 +1,45 @@
+// compile-flags:-g
+
+// gdb-command: run
+
+// gdb-command: print slice
+// gdbg-check: $1 = struct &[i32](size=3) = {0, 1, 2}
+// gdbr-check: $1 = &[i32](size=3) = {0, 1, 2}
+
+// gdb-command: print mut_slice
+// gdbg-check: $2 = struct &mut [i32](size=4) = {2, 3, 5, 7}
+// gdbr-check: $2 = &mut [i32](size=4) = {2, 3, 5, 7}
+
+// gdb-command: print str_slice
+// gdb-check: $3 = "string slice"
+
+// gdb-command: print mut_str_slice
+// gdb-check: $4 = "mutable string slice"
+
+// lldb-command: run
+
+// lldb-command: print slice
+// lldb-check: (&[i32]) $0 = size=3 { [0] = 0 [1] = 1 [2] = 2 }
+
+// lldb-command: print mut_slice
+// lldb-check: (&mut [i32]) $1 = size=4 { [0] = 2 [1] = 3 [2] = 5 [3] = 7 }
+
+// lldb-command: print str_slice
+// lldb-check: (&str) $2 = "string slice" { data_ptr = [...] length = 12 }
+
+// lldb-command: print mut_str_slice
+// lldb-check: (&mut str) $3 = "mutable string slice" { data_ptr = [...] length = 20 }
+
+fn b() {}
+
+fn main() {
+
+    let slice: &[i32] = &[0, 1, 2];
+    let mut_slice: &mut [i32] = &mut [2, 3, 5, 7];
+
+    let str_slice: &str = "string slice";
+    let mut mut_str_slice_buffer = String::from("mutable string slice");
+    let mut_str_slice: &mut str = mut_str_slice_buffer.as_mut_str();
+
+    b(); // #break
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1133,8 +1133,8 @@ impl<'test> TestCx<'test> {
 
         let rust_type_regexes = vec![
             "^(alloc::([a-z_]+::)+)String$",
-            "^&str$",
-            "^&\\[.+\\]$",
+            "^&(mut )?str$",
+            "^&(mut )?\\[.+\\]$",
             "^(std::ffi::([a-z_]+::)+)OsString$",
             "^(alloc::([a-z_]+::)+)Vec<.+>$",
             "^(alloc::([a-z_]+::)+)VecDeque<.+>$",


### PR DESCRIPTION
Support pretty printing `&[T]`, `&mut [T]` and `&mut str` types using GDB.

Support pretty printing `&mut [T]` and `&mut str` types using LLDB.

Fixes #85219.