### PR TITLE
Fix invalid input:disabled CSS selector

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -248,8 +248,8 @@ details.undocumented > summary::before {
 	box-shadow: 0 0 0 1px #148099,0 0 0 2px transparent;
 }
 
-.search-focus:disabled {
-	color: #929292;
+.search-input:disabled {
+	background-color: #3e3e3e;
 }
 
 .module-item .stab,

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -209,7 +209,7 @@ details.undocumented > summary::before {
 	border-color: #008dfd;
 }
 
-.search-focus:disabled {
+.search-input:disabled {
 	background-color: #c5c4c4;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -207,7 +207,7 @@ details.undocumented > summary::before {
 	border-color: #66afe9;
 }
 
-.search-focus:disabled {
+.search-input:disabled {
 	background-color: #e6e6e6;
 }
 


### PR DESCRIPTION
For some reason, we used "search-focus" instead of "search-input"...

r? @jsha 