### PR TITLE
Fix missing lifetimes diagnostics after #83759

### DIFF
--- a/src/test/ui/suggestions/issue-85347.rs
+++ b/src/test/ui/suggestions/issue-85347.rs
@@ -1,0 +1,10 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+use std::ops::Deref;
+trait Foo {
+    type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+    //~^ ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~| HELP add missing
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-85347.stderr
+++ b/src/test/ui/suggestions/issue-85347.stderr
@@ -1,0 +1,19 @@
+error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-85347.rs:5:42
+   |
+LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+   |                                          ^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-85347.rs:5:10
+   |
+LL |     type Bar<'a>: Deref<Target = <Self>::Bar<Target = Self>>;
+   |          ^^^ --
+help: add missing lifetime argument
+   |
+LL |     type Bar<'a>: Deref<Target = <Self>::Bar<'a, Target = Self>>;
+   |                                              ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
In #83759 while rebasing I didn't realize there was a new function for suggesting to add lifetime arguments. It relied on some invariants, namely that if a generic type/trait has angle brackets then it must have some generic argument, which is now no longer true. This PR updates that function to handle the new invariants.

This also adds a new regression test but I'm not sure if that's the correct place for it.

Fixes #85347