### PR TITLE
Add abstract namespace support for Unix domain sockets

### DIFF
--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -214,6 +214,7 @@ impl SocketAddr {
     ///     Ok(())
     /// }
     /// ```
+    #[doc(cfg(any(target_os = "android", target_os = "linux")))]
     #[cfg(any(doc, target_os = "android", target_os = "linux",))]
     #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
@@ -271,6 +272,7 @@ impl SocketAddr {
     ///     Ok(())
     /// }
     /// ```
+    #[doc(cfg(any(target_os = "android", target_os = "linux")))]
     #[cfg(any(doc, target_os = "android", target_os = "linux",))]
     #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn from_abstract_namespace(namespace: &[u8]) -> io::Result<SocketAddr> {

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -215,7 +215,7 @@ impl SocketAddr {
     /// }
     /// ```
     #[cfg(any(doc, target_os = "android", target_os = "linux",))]
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
         if let AddressKind::Abstract(name) = self.address() { Some(name) } else { None }
     }
@@ -272,7 +272,7 @@ impl SocketAddr {
     /// }
     /// ```
     #[cfg(any(doc, target_os = "android", target_os = "linux",))]
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn from_abstract_namespace(namespace: &[u8]) -> io::Result<SocketAddr> {
         unsafe {
             let mut addr: libc::sockaddr_un = mem::zeroed();

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -285,7 +285,11 @@ impl SocketAddr {
                 ));
             }
 
-            ptr::copy_nonoverlapping(namespace.as_ptr(), addr.sun_path.as_mut_ptr().offset(1) as *mut u8, namespace.len());
+            ptr::copy_nonoverlapping(
+                namespace.as_ptr(),
+                addr.sun_path.as_mut_ptr().offset(1) as *mut u8,
+                namespace.len(),
+            );
             let len = (sun_path_offset(&addr) + 1 + namespace.len()) as libc::socklen_t;
             SocketAddr::from_parts(addr, len)
         }

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -2,7 +2,7 @@ use crate::ffi::OsStr;
 use crate::os::unix::ffi::OsStrExt;
 use crate::path::Path;
 use crate::sys::cvt;
-use crate::{ascii, fmt, io, iter, mem, ptr};
+use crate::{ascii, fmt, io, iter, mem};
 
 // FIXME(#43348): Make libc adapt #[doc(cfg(...))] so we don't need these fake definitions here?
 #[cfg(not(unix))]
@@ -285,7 +285,7 @@ impl SocketAddr {
                 ));
             }
 
-            ptr::copy_nonoverlapping(
+            crate::ptr::copy_nonoverlapping(
                 namespace.as_ptr(),
                 addr.sun_path.as_mut_ptr().offset(1) as *mut u8,
                 namespace.len(),

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -132,7 +132,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixDatagram> {
         unsafe {
             let socket = UnixDatagram::unbound()?;
@@ -246,7 +246,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn connect_addr(&self, socket_addr: &SocketAddr) -> io::Result<()> {
         unsafe {
             cvt(libc::connect(
@@ -558,7 +558,7 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn send_to_addr(&self, buf: &[u8], socket_addr: &SocketAddr) -> io::Result<usize> {
         unsafe {
             let count = cvt(libc::sendto(

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -112,6 +112,35 @@ impl UnixDatagram {
         }
     }
 
+    /// Creates a Unix datagram socket bound to an address.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(unix_socket_abstract)]
+    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
+    ///     let sock = match UnixDatagram::bind_addr(&addr) {
+    ///         Ok(sock) => sock,
+    ///         Err(err) => {
+    ///             println!("Couldn't bind: {:?}", err);
+    ///             return Err(err);
+    ///         }
+    ///     };
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixDatagram> {
+        unsafe {
+            let socket = UnixDatagram::unbound()?;
+            cvt(libc::bind(*socket.0.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len as _))?;
+            Ok(socket)
+        }
+    }
+
     /// Creates a Unix Datagram socket which is not bound to any address.
     ///
     /// # Examples
@@ -156,7 +185,7 @@ impl UnixDatagram {
         Ok((UnixDatagram(i1), UnixDatagram(i2)))
     }
 
-    /// Connects the socket to the specified address.
+    /// Connects the socket to the specified path address.
     ///
     /// The [`send`] method may be used to send data to the specified address.
     /// [`recv`] and [`recv_from`] will only receive data from that address.
@@ -188,6 +217,35 @@ impl UnixDatagram {
             let (addr, len) = sockaddr_un(path.as_ref())?;
 
             cvt(libc::connect(self.as_raw_fd(), &addr as *const _ as *const _, len))?;
+        }
+        Ok(())
+    }
+
+    /// Connects the socket to an address.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(unix_socket_abstract)]
+    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
+    ///     let sock = UnixDatagram::unbound()?;
+    ///     match sock.connect_addr(&addr) {
+    ///         Ok(sock) => sock,
+    ///         Err(e) => {
+    ///             println!("Couldn't connect: {:?}", e);
+    ///             return Err(e)
+    ///         }
+    ///     };
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    pub fn connect_addr(&self, socket_addr: &SocketAddr) -> io::Result<()> {
+        unsafe {
+            cvt(libc::connect(*self.0.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len))?;
         }
         Ok(())
     }
@@ -468,6 +526,40 @@ impl UnixDatagram {
                 MSG_NOSIGNAL,
                 &addr as *const _ as *const _,
                 len,
+            ))?;
+            Ok(count as usize)
+        }
+    }
+
+    /// Sends data on the socket to the specified [SocketAddr].
+    ///
+    /// On success, returns the number of bytes written.
+    ///
+    /// [SocketAddr]: crate::os::unix::net::SocketAddr
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(unix_socket_abstract)]
+    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?;
+    ///     let sock = UnixDatagram::unbound()?;
+    ///     sock.send_to_addr(b"bacon egg and cheese", &addr).expect("send_to_addr function failed");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    pub fn send_to_addr(&self, buf: &[u8], socket_addr: &SocketAddr) -> io::Result<usize> {
+        unsafe {
+            let count = cvt(libc::sendto(
+                *self.0.as_inner(),
+                buf.as_ptr() as *const _,
+                buf.len(),
+                MSG_NOSIGNAL,
+                &socket_addr.addr as *const _ as *const _,
+                socket_addr.len,
             ))?;
             Ok(count as usize)
         }

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -139,7 +139,7 @@ impl UnixDatagram {
         unsafe {
             let socket = UnixDatagram::unbound()?;
             cvt(libc::bind(
-                *socket.0.as_inner(),
+                socket.as_raw_fd(),
                 &socket_addr.addr as *const _ as *const _,
                 socket_addr.len as _,
             ))?;
@@ -254,7 +254,7 @@ impl UnixDatagram {
     pub fn connect_addr(&self, socket_addr: &SocketAddr) -> io::Result<()> {
         unsafe {
             cvt(libc::connect(
-                *self.0.as_inner(),
+                self.as_raw_fd(),
                 &socket_addr.addr as *const _ as *const _,
                 socket_addr.len,
             ))?;
@@ -568,7 +568,7 @@ impl UnixDatagram {
     pub fn send_to_addr(&self, buf: &[u8], socket_addr: &SocketAddr) -> io::Result<usize> {
         unsafe {
             let count = cvt(libc::sendto(
-                *self.0.as_inner(),
+                self.as_raw_fd(),
                 buf.as_ptr() as *const _,
                 buf.len(),
                 MSG_NOSIGNAL,

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -136,7 +136,11 @@ impl UnixDatagram {
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixDatagram> {
         unsafe {
             let socket = UnixDatagram::unbound()?;
-            cvt(libc::bind(*socket.0.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len as _))?;
+            cvt(libc::bind(
+                *socket.0.as_inner(),
+                &socket_addr.addr as *const _ as *const _,
+                socket_addr.len as _,
+            ))?;
             Ok(socket)
         }
     }
@@ -245,7 +249,11 @@ impl UnixDatagram {
     #[unstable(feature = "unix_socket_abstract", issue = "42048")]
     pub fn connect_addr(&self, socket_addr: &SocketAddr) -> io::Result<()> {
         unsafe {
-            cvt(libc::connect(*self.0.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len))?;
+            cvt(libc::connect(
+                *self.0.as_inner(),
+                &socket_addr.addr as *const _ as *const _,
+                socket_addr.len,
+            ))?;
         }
         Ok(())
     }

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -118,11 +118,13 @@ impl UnixDatagram {
     ///
     /// ```no_run
     /// #![feature(unix_socket_abstract)]
-    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
-    ///     let sock = match UnixDatagram::bind_addr(&addr) {
+    ///     let sock1 = UnixDatagram::bind("path/to/socket")?;
+    ///     let addr = sock1.local_addr()?;
+    ///
+    ///     let sock2 = match UnixDatagram::bind_addr(&addr) {
     ///         Ok(sock) => sock,
     ///         Err(err) => {
     ///             println!("Couldn't bind: {:?}", err);
@@ -231,10 +233,12 @@ impl UnixDatagram {
     ///
     /// ```no_run
     /// #![feature(unix_socket_abstract)]
-    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
+    ///     let bound = UnixDatagram::bind("/path/to/socket")?;
+    ///     let addr = bound.local_addr()?;
+    ///
     ///     let sock = UnixDatagram::unbound()?;
     ///     match sock.connect_addr(&addr) {
     ///         Ok(sock) => sock,
@@ -549,10 +553,12 @@ impl UnixDatagram {
     ///
     /// ```no_run
     /// #![feature(unix_socket_abstract)]
-    /// use std::os::unix::net::{UnixDatagram, SocketAddr};
+    /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?;
+    ///     let bound = UnixDatagram::bind("/path/to/socket")?;
+    ///     let addr = bound.local_addr()?;
+    ///
     ///     let sock = UnixDatagram::unbound()?;
     ///     sock.send_to_addr(b"bacon egg and cheese", &addr).expect("send_to_addr function failed");
     ///     Ok(())

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -103,7 +103,7 @@ impl UnixListener {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixListener> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -89,11 +89,13 @@ impl UnixListener {
     ///
     /// ```no_run
     /// #![feature(unix_socket_abstract)]
-    /// use std::os::unix::net::{UnixListener, SocketAddr};
+    /// use std::os::unix::net::{UnixListener};
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let addr = SocketAddr::from_abstract_namespace(b"namespace")?; // Linux only
-    ///     let listener = match UnixListener::bind_addr(&addr) {
+    ///     let listener1 = UnixListener::bind("path/to/socket")?;
+    ///     let addr = listener1.local_addr()?;
+    ///
+    ///     let listener2 = match UnixListener::bind_addr(&addr) {
     ///         Ok(sock) => sock,
     ///         Err(err) => {
     ///             println!("Couldn't bind: {:?}", err);

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -110,12 +110,11 @@ impl UnixListener {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
             cvt(libc::bind(
-                *inner.as_inner(),
+                inner.as_raw_fd(),
                 &socket_addr.addr as *const _ as *const _,
                 socket_addr.len as _,
             ))?;
-            cvt(libc::listen(*inner.as_inner(), 128))?;
-
+            cvt(libc::listen(inner.as_raw_fd(), 128))?;
             Ok(UnixListener(inner))
         }
     }

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -107,13 +107,16 @@ impl UnixListener {
     pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixListener> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
-            cvt(libc::bind(*inner.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len as _))?;
+            cvt(libc::bind(
+                *inner.as_inner(),
+                &socket_addr.addr as *const _ as *const _,
+                socket_addr.len as _,
+            ))?;
             cvt(libc::listen(*inner.as_inner(), 128))?;
 
             Ok(UnixListener(inner))
         }
     }
-
 
     /// Accepts a new incoming connection to this listener.
     ///

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -81,6 +81,40 @@ impl UnixListener {
         }
     }
 
+    /// Creates a new `UnixListener` bound to the specified [`socket address`].
+    ///
+    /// [`socket address`]: crate::os::unix::net::SocketAddr
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(unix_socket_abstract)]
+    /// use std::os::unix::net::{UnixListener, SocketAddr};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let addr = SocketAddr::from_abstract_namespace(b"namespace")?; // Linux only
+    ///     let listener = match UnixListener::bind_addr(&addr) {
+    ///         Ok(sock) => sock,
+    ///         Err(err) => {
+    ///             println!("Couldn't bind: {:?}", err);
+    ///             return Err(err);
+    ///         }
+    ///     };
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    pub fn bind_addr(socket_addr: &SocketAddr) -> io::Result<UnixListener> {
+        unsafe {
+            let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
+            cvt(libc::bind(*inner.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len as _))?;
+            cvt(libc::listen(*inner.as_inner(), 128))?;
+
+            Ok(UnixListener(inner))
+        }
+    }
+
+
     /// Accepts a new incoming connection to this listener.
     ///
     /// This function will block the calling thread until a new Unix connection

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -135,7 +135,7 @@ impl UnixStream {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
             cvt(libc::connect(
-                *inner.as_inner(),
+                inner.as_raw_fd(),
                 &socket_addr.addr as *const _ as *const _,
                 socket_addr.len,
             ))?;

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -132,7 +132,11 @@ impl UnixStream {
     pub fn connect_addr(socket_addr: &SocketAddr) -> io::Result<UnixStream> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
-            cvt(libc::connect(*inner.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len))?;
+            cvt(libc::connect(
+                *inner.as_inner(),
+                &socket_addr.addr as *const _ as *const _,
+                socket_addr.len,
+            ))?;
             Ok(UnixStream(inner))
         }
     }

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -128,7 +128,7 @@ impl UnixStream {
     ///     Ok(())
     /// }
     /// ````
-    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    #[unstable(feature = "unix_socket_abstract", issue = "85410")]
     pub fn connect_addr(socket_addr: &SocketAddr) -> io::Result<UnixStream> {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -114,11 +114,13 @@ impl UnixStream {
     ///
     /// ```no_run
     /// #![feature(unix_socket_abstract)]
-    /// use std::os::unix::net::{UnixStream, SocketAddr};
+    /// use std::os::unix::net::{UnixListener, UnixStream};
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
-    ///     match UnixStream::connect_addr(&addr) {
+    ///     let listener = UnixListener::bind("/path/to/the/socket")?;
+    ///     let addr = listener.local_addr()?;
+    ///
+    ///     let sock = match UnixStream::connect_addr(&addr) {
     ///         Ok(sock) => sock,
     ///         Err(e) => {
     ///             println!("Couldn't connect: {:?}", e);

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -106,6 +106,37 @@ impl UnixStream {
         }
     }
 
+    /// Connects to the socket specified by [`address`].
+    ///
+    /// [`address`]: crate::os::unix::net::SocketAddr
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(unix_socket_abstract)]
+    /// use std::os::unix::net::{UnixStream, SocketAddr};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let addr = SocketAddr::from_abstract_namespace(b"hidden")?; // Linux only
+    ///     match UnixStream::connect_addr(&addr) {
+    ///         Ok(sock) => sock,
+    ///         Err(e) => {
+    ///             println!("Couldn't connect: {:?}", e);
+    ///             return Err(e)
+    ///         }
+    ///     };
+    ///     Ok(())
+    /// }
+    /// ````
+    #[unstable(feature = "unix_socket_abstract", issue = "42048")]
+    pub fn connect_addr(socket_addr: &SocketAddr) -> io::Result<UnixStream> {
+        unsafe {
+            let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
+            cvt(libc::connect(*inner.as_inner(), &socket_addr.addr as *const _ as *const _, socket_addr.len))?;
+            Ok(UnixStream(inner))
+        }
+    }
+
     /// Creates an unnamed pair of connected sockets.
     ///
     /// Returns two `UnixStream`s which are connected to each other.


### PR DESCRIPTION
Hello! The other day I wanted to mess around with UDS in Rust and found that abstract namespaces ([unix(7)](https://man7.org/linux/man-pages/man7/unix.7.html)) on Linux still needed development. I took the approach of adding `_addr` specific public functions to reduce conflicts.

Feature name: `unix_socket_abstract`
Tracking issue: #85410
Further context: #42048

## Non-platform specific additions

`UnixListener::bind_addr(&SocketAddr) -> Result<UnixListener>`

`UnixStream::connect_addr(&SocketAddr) -> Result<()>`

`UnixDatagram::bind_addr(&SocketAddr) -> Result<UnixDatagram>`

`UnixDatagram::connect_addr(&SocketAddr) -> Result<()>`

`UnixDatagram::send_to_addr(&self, &[u8], &SocketAddr) -> Result<usize>`

## Platform-specific (Linux) additions

`SocketAddr::from_abstract_namespace(&[u8]) -> SocketAddr`

`SockerAddr::as_abstract_namespace() -> Option<&[u8]>`

## Example 

```rust
#![feature(unix_socket_abstract)]
use std::os::unix::net::{UnixListener, SocketAddr};

fn main() -> std::io::Result<()> {
    let addr = SocketAddr::from_abstract_namespace(b"namespace")?; // Linux only
    let listener = match UnixListener::bind_addr(&addr) {
        Ok(sock) => sock,
        Err(err) => {
            println!("Couldn't bind: {:?}", err);
            return Err(err);
        }
    };
    Ok(())
}
```

## Further Details

The main inspiration for the implementation came from the [nix-rust](https://github.com/nix-rust/nix/blob/master/src/sys/socket/addr.rs#L558) crate but there are also other [historical](https://github.com/rust-lang/rust/commit/c4db0685b181f12c4285dac3d932f1859bba74f5) [attempts](https://github.com/tormol/uds/blob/master/src/addr.rs#L324) with similar approaches.

A comment I did have was with this change, we now allow a `SocketAddr` to be constructed explicitly rather than just used almost as a handle for the return of `peer_addr` and `local_addr`. We could consider adding other explicit constructors (e.g. `SocketAddr::from_pathname`, `SockerAddr::from_unnamed`).


Cheers!


