### PR TITLE
Check for InitializingTypeWith and CastOfPointerToInt in THIR unsafeck

### DIFF
--- a/src/test/ui/cast/cast-ptr-to-int-const.mir.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.mir.stderr
@@ -1,0 +1,19 @@
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:10:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:17:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/cast/cast-ptr-to-int-const.rs
+++ b/src/test/ui/cast/cast-ptr-to-int-const.rs
@@ -1,25 +1,19 @@
-// gate-test-const_raw_ptr_to_usize_cast
-// revisions: with_feature without_feature
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
-#![cfg_attr(with_feature, feature(const_raw_ptr_to_usize_cast))]
+#![feature(const_raw_ptr_to_usize_cast)]
 
 fn main() {
-    const X: usize = unsafe {
-        main as usize //[without_feature]~ ERROR casting pointers to integers in constants is unstable
-    };
     const Y: u32 = 0;
-    const Z: usize = unsafe {
-        &Y as *const u32 as usize //[without_feature]~ ERROR is unstable
-    };
     // Cast in `const` without `unsafe` block
     const SAFE: usize = {
-        &Y as *const u32 as usize //[without_feature]~ ERROR is unstable
-        //[with_feature]~^ ERROR cast of pointer to int is unsafe and requires unsafe
+        &Y as *const u32 as usize
+        //~^ ERROR cast of pointer to int is unsafe and requires unsafe
     };
 }
 
 // Cast in `const fn` without `unsafe` block
 const fn test() -> usize {
-    &0 as *const i32 as usize //[without_feature]~ ERROR is unstable
-    //[with_feature]~^ ERROR cast of pointer to int is unsafe and requires unsafe
+    &0 as *const i32 as usize
+    //~^ ERROR cast of pointer to int is unsafe and requires unsafe
 }

--- a/src/test/ui/cast/cast-ptr-to-int-const.thir.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.thir.stderr
@@ -1,0 +1,19 @@
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:10:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:17:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.rs
+++ b/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.rs
@@ -1,0 +1,13 @@
+fn main() {
+    const X: usize = unsafe {
+        main as usize //~ ERROR casting pointers to integers in constants is unstable
+    };
+    const Y: u32 = 0;
+    const Z: usize = unsafe {
+        &Y as *const u32 as usize //~ ERROR is unstable
+    };
+}
+
+const fn test() -> usize {
+    &0 as *const i32 as usize //~ ERROR is unstable
+}

--- a/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.stderr
+++ b/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.stderr
@@ -1,0 +1,30 @@
+error[E0658]: casting pointers to integers in constants is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:3:9
+   |
+LL |         main as usize
+   |         ^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error[E0658]: casting pointers to integers in constants is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:7:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error[E0658]: casting pointers to integers in constant functions is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:12:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/unsafe/ranged_ints.mir.stderr
+++ b/src/test/ui/unsafe/ranged_ints.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
+  --> $DIR/ranged_ints.rs:10:14
+   |
+LL |     let _x = NonZero(0);
+   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+   |
+   = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/ranged_ints.rs
+++ b/src/test/ui/unsafe/ranged_ints.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 #[rustc_layout_scalar_valid_range_start(1)]

--- a/src/test/ui/unsafe/ranged_ints.thir.stderr
+++ b/src/test/ui/unsafe/ranged_ints.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
+  --> $DIR/ranged_ints.rs:10:14
+   |
+LL |     let _x = NonZero(0);
+   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+   |
+   = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/ranged_ints_const.mir.stderr
+++ b/src/test/ui/unsafe/ranged_ints_const.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
-  --> $DIR/ranged_ints.rs:7:14
+  --> $DIR/ranged_ints_const.rs:11:34
    |
-LL |     let _x = NonZero(0);
-   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL | const fn foo() -> NonZero<u32> { NonZero(0) }
+   |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/src/test/ui/unsafe/ranged_ints_const.rs
+++ b/src/test/ui/unsafe/ranged_ints_const.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 #[rustc_layout_scalar_valid_range_start(1)]

--- a/src/test/ui/unsafe/ranged_ints_const.thir.stderr
+++ b/src/test/ui/unsafe/ranged_ints_const.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
-  --> $DIR/ranged_ints_const.rs:8:34
+  --> $DIR/ranged_ints_const.rs:11:34
    |
 LL | const fn foo() -> NonZero<u32> { NonZero(0) }
    |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr

--- a/src/test/ui/unsafe/ranged_ints_macro.rs
+++ b/src/test/ui/unsafe/ranged_ints_macro.rs
@@ -1,4 +1,7 @@
 // build-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 macro_rules! apply {


### PR DESCRIPTION
Extends THIR unsafeck to check for two more cases of unsafe operations: initialization of layout-restricted types and ptr-to-int casts in const functions.

r? @ghost (I don't want to flood Niko's review queue)
cc rust-lang/project-thir-unsafeck#7