### PR TITLE
Always produce sub-obligations when using cached projection result

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -529,15 +529,7 @@ fn opt_normalize_projection_type<'a, 'b, 'tcx>(
             // evaluation this is not the case, and dropping the trait
             // evaluations can causes ICEs (e.g., #43132).
             debug!(?ty, "found normalized ty");
-
-            // Once we have inferred everything we need to know, we
-            // can ignore the `obligations` from that point on.
-            if infcx.unresolved_type_vars(&ty.value).is_none() {
-                infcx.inner.borrow_mut().projection_cache().complete_normalized(cache_key, &ty);
-            // No need to extend `obligations`.
-            } else {
-                obligations.extend(ty.obligations);
-            }
+            obligations.extend(ty.obligations);
             return Ok(Some(ty.value));
         }
         Err(ProjectionCacheEntry::Error) => {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/85360

When we skip adding the sub-obligations to the `obligation` list, we can affect whether or not the final result is `EvaluatedToOk` or `EvaluatedToOkModuloObligations`. This creates problems for incremental compilation, since the projection cache is untracked shared state.

To solve this issue, we unconditionally process the sub-obligations. Surprisingly, this is a slight performance *win* in many cases.