### PR TITLE
Revert #13871, in a new form.

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1186,7 +1186,59 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
         handler.emit_diagnostic(&d);
     }
 
+    // Choose error text
+    //let msg = if !msg.is_empty() { msg } else { "aborted" };
+    //let hash = msg.chars().fold(0, |accum, val| accum + (val as uint) );
+    let hash = info.location()
+        .map(|l| l.line() + l.column())
+        .unwrap_or(5);
+    let quote = match hash % 10 {
+        0 => "
+It was from the artists and poets that the pertinent answers came, and I
+know that panic would have broken loose had they been able to compare notes.
+As it was, lacking their original letters, I half suspected the compiler of
+having asked leading questions, or of having edited the correspondence in
+corroboration of what he had latently resolved to see.",
+        1 => "
+There are not many persons who know what wonders are opened to them in the
+stories and visions of their youth; for when as children we listen and dream,
+we think but half-formed thoughts, and when as men we try to remember, we are
+dulled and prosaic with the poison of life. But some of us awake in the night
+with strange phantasms of enchanted hills and gardens, of fountains that sing
+in the sun, of golden cliffs overhanging murmuring seas, of plains that stretch
+down to sleeping cities of bronze and stone, and of shadowy companies of heroes
+that ride caparisoned white horses along the edges of thick forests; and then
+we know that we have looked back through the ivory gates into that world of
+wonder which was ours before we were wise and unhappy.",
+        2 => "
+Instead of the poems I had hoped for, there came only a shuddering blackness
+and ineffable loneliness; and I saw at last a fearful truth which no one had
+ever dared to breathe before — the unwhisperable secret of secrets — The fact
+that this city of stone and stridor is not a sentient perpetuation of Old New
+York as London is of Old London and Paris of Old Paris, but that it is in fact
+quite dead, its sprawling body imperfectly embalmed and infested with queer
+animate things which have nothing to do with it as it was in life.",
+        3 => "
+The ocean ate the last of the land and poured into the smoking gulf, thereby
+giving up all it had ever conquered. From the new-flooded lands it flowed
+again, uncovering death and decay; and from its ancient and immemorial bed it
+trickled loathsomely, uncovering nighted secrets of the years when Time was
+young and the gods unborn. Above the waves rose weedy remembered spires. The
+moon laid pale lilies of light on dead London, and Paris stood up from its damp
+grave to be sanctified with star-dust. Then rose spires and monoliths that were
+weedy but not remembered; terrible spires and monoliths of lands that men never
+knew were lands...",
+        4 => "
+There was a night when winds from unknown spaces whirled us irresistibly into
+limitless vacuum beyond all thought and entity. Perceptions of the most
+maddeningly untransmissible sort thronged upon us; perceptions of infinity
+which at the time convulsed us with joy, yet which are now partly lost to my
+memory and partly incapable of presentation to others.",
+        _ => "You've met with a terrible fate, haven't you?"
+    };
+
     let mut xs: Vec<Cow<'static, str>> = vec![
+        quote.into(),
         "the compiler unexpectedly panicked. this is a bug.".into(),
         format!("we would appreciate a bug report: {}", bug_report_url).into(),
         format!(

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1189,17 +1189,18 @@ pub fn report_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     // Choose error text
     //let msg = if !msg.is_empty() { msg } else { "aborted" };
     //let hash = msg.chars().fold(0, |accum, val| accum + (val as uint) );
-    let hash = info.location()
-        .map(|l| l.line() + l.column())
-        .unwrap_or(5);
+    let hash = info.location().map(|l| l.line() + l.column()).unwrap_or(5);
     let quote = match hash % 10 {
-        0 => "
+        0 => {
+            "
 It was from the artists and poets that the pertinent answers came, and I
 know that panic would have broken loose had they been able to compare notes.
 As it was, lacking their original letters, I half suspected the compiler of
 having asked leading questions, or of having edited the correspondence in
-corroboration of what he had latently resolved to see.",
-        1 => "
+corroboration of what he had latently resolved to see."
+        }
+        1 => {
+            "
 There are not many persons who know what wonders are opened to them in the
 stories and visions of their youth; for when as children we listen and dream,
 we think but half-formed thoughts, and when as men we try to remember, we are
@@ -1209,16 +1210,20 @@ in the sun, of golden cliffs overhanging murmuring seas, of plains that stretch
 down to sleeping cities of bronze and stone, and of shadowy companies of heroes
 that ride caparisoned white horses along the edges of thick forests; and then
 we know that we have looked back through the ivory gates into that world of
-wonder which was ours before we were wise and unhappy.",
-        2 => "
+wonder which was ours before we were wise and unhappy."
+        }
+        2 => {
+            "
 Instead of the poems I had hoped for, there came only a shuddering blackness
 and ineffable loneliness; and I saw at last a fearful truth which no one had
 ever dared to breathe before — the unwhisperable secret of secrets — The fact
 that this city of stone and stridor is not a sentient perpetuation of Old New
 York as London is of Old London and Paris of Old Paris, but that it is in fact
 quite dead, its sprawling body imperfectly embalmed and infested with queer
-animate things which have nothing to do with it as it was in life.",
-        3 => "
+animate things which have nothing to do with it as it was in life."
+        }
+        3 => {
+            "
 The ocean ate the last of the land and poured into the smoking gulf, thereby
 giving up all it had ever conquered. From the new-flooded lands it flowed
 again, uncovering death and decay; and from its ancient and immemorial bed it
@@ -1227,14 +1232,17 @@ young and the gods unborn. Above the waves rose weedy remembered spires. The
 moon laid pale lilies of light on dead London, and Paris stood up from its damp
 grave to be sanctified with star-dust. Then rose spires and monoliths that were
 weedy but not remembered; terrible spires and monoliths of lands that men never
-knew were lands...",
-        4 => "
+knew were lands..."
+        }
+        4 => {
+            "
 There was a night when winds from unknown spaces whirled us irresistibly into
 limitless vacuum beyond all thought and entity. Perceptions of the most
 maddeningly untransmissible sort thronged upon us; perceptions of infinity
 which at the time convulsed us with joy, yet which are now partly lost to my
-memory and partly incapable of presentation to others.",
-        _ => "You've met with a terrible fate, haven't you?"
+memory and partly incapable of presentation to others."
+        }
+        _ => "You've met with a terrible fate, haven't you?",
     };
 
     let mut xs: Vec<Cow<'static, str>> = vec![


### PR DESCRIPTION
Back in the day, Rust programs printed Lovecraft quotes on panic.  This doesn't add the Lovecraft quotes to generated Rust programs, but adds them as an addition to the compiler ICE messages.  I kind of doubt this will get accepted, but I have to try!