### PR TITLE
Suppress spurious errors inside `async fn`

### DIFF
--- a/src/test/ui/async-await/issue-73741-type-err.rs
+++ b/src/test/ui/async-await/issue-73741-type-err.rs
@@ -1,0 +1,14 @@
+// edition:2018
+//
+// Regression test for issue #73741
+// Ensures that we don't emit spurious errors when
+// a type error ocurrs in an `async fn`
+
+async fn weird() {
+    1 = 2; //~ ERROR invalid left-hand side
+
+    let mut loop_count = 0;
+    async {}.await
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issue-73741-type-err.stderr
+++ b/src/test/ui/async-await/issue-73741-type-err.stderr
@@ -1,0 +1,11 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/issue-73741-type-err.rs:8:7
+   |
+LL |     1 = 2;
+   |     - ^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
Fixes #73741