### PR TITLE
Build crtbegin.o/crtend.o from source code

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -369,7 +369,8 @@ impl<'a> Builder<'a> {
                 tool::Rustfmt,
                 tool::Miri,
                 tool::CargoMiri,
-                native::Lld
+                native::Lld,
+                native::CrtBeginEnd
             ),
             Kind::Check | Kind::Clippy { .. } | Kind::Fix | Kind::Format => describe!(
                 check::Std,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -199,8 +199,9 @@ fn copy_self_contained_objects(
                 DependencyType::TargetSelfContained,
             );
         }
+        let crt_path = builder.ensure(native::CrtBeginEnd { target });
         for &obj in &["crtbegin.o", "crtbeginS.o", "crtend.o", "crtendS.o"] {
-            let src = compiler_file(builder, builder.cc(target), target, obj);
+            let src = crt_path.join(obj);
             let target = libdir_self_contained.join(obj);
             builder.copy(&src, &target);
             target_deps.push((target, DependencyType::TargetSelfContained));

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -144,7 +144,11 @@ ENV TARGETS=$TARGETS,armv7a-none-eabi
 # riscv targets currently do not need a C compiler, as compiler_builtins
 # doesn't currently have it enabled, and the riscv gcc compiler is not
 # installed.
-ENV CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
+ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
+    CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \
+    CFLAGS_arm_unknown_linux_musleabihf="-march=armv6 -marm -mfpu=vfp" \
+    CFLAGS_armv7_unknown_linux_musleabihf="-march=armv7-a" \
+    CC_mipsel_unknown_linux_musl=mipsel-openwrt-linux-gcc \
     CC_mips_unknown_linux_musl=mips-openwrt-linux-gcc \
     CC_mips64el_unknown_linux_muslabi64=mips64el-linux-gnuabi64-gcc \
     CC_mips64_unknown_linux_muslabi64=mips64-linux-gnuabi64-gcc \

--- a/src/test/run-make-fulldeps/issue-47551/Makefile
+++ b/src/test/run-make-fulldeps/issue-47551/Makefile
@@ -1,0 +1,9 @@
+# only-linux
+# ignore-32bit
+
+-include ../tools.mk
+
+all:
+	$(RUSTC) eh_frame-terminator.rs
+	$(call RUN,eh_frame-terminator) | $(CGREP) '1122334455667788'
+	objdump --dwarf=frames $(TMPDIR)/eh_frame-terminator | $(CGREP) 'ZERO terminator'

--- a/src/test/run-make-fulldeps/issue-47551/eh_frame-terminator.rs
+++ b/src/test/run-make-fulldeps/issue-47551/eh_frame-terminator.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+#![feature(backtrace)]
+#[derive(Clone, Copy)]
+struct Foo {
+    array: [u64; 10240],
+}
+
+impl Foo {
+    const fn new() -> Self {
+        Self {
+            array: [0x1122_3344_5566_7788; 10240]
+        }
+    }
+}
+
+static BAR: [Foo; 10240] = [Foo::new(); 10240];
+
+fn main() {
+    let bt = std::backtrace::Backtrace::force_capture();
+    println!("Hello, world! {:?}", bt);
+    println!("{:x}", BAR[0].array[0]);
+}


### PR DESCRIPTION
Build crtbengin.o/crtend.o from source code instead of copying from gcc.

The crtbegin and crtend implementation from llvm don't need `crtbeginS.o` for PIC. `crtbegin{,S,T}.o` is unified into one generic `crtbegin.o`. See the comments in https://reviews.llvm.org/D28791#1419436 and https://reviews.llvm.org/D28791#1420914

fix: https://github.com/rust-lang/rust/issues/85310 , fix: https://github.com/rust-lang/rust/issues/47551 , fix: https://github.com/rust-lang/rust/issues/84033