### PR TITLE
rustdoc: restore header sizes

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -427,9 +427,13 @@ nav.sub {
 	border-bottom: 1px solid;
 }
 
-#main > .docblock h1 { font-size: 1.3em; }
-#main > .docblock h2 { font-size: 1.15em; }
-#main > .docblock h3, #main > .docblock h4, #main > .docblock h5 { font-size: 1em; }
+.top-doc .docblock h1 { font-size: 1.3em; }
+.top-doc .docblock h2 { font-size: 1.15em; }
+.top-doc .docblock h3,
+.top-doc .docblock h4,
+.top-doc .docblock h5 {
+	font-size: 1em;
+}
 
 .docblock h1 { font-size: 1em; }
 .docblock h2 { font-size: 0.95em; }


### PR DESCRIPTION
The `<details>` toggle work changed the relationship from #main to the top-doc docblock so it was no longer a parent relationship but a great-grandparent relationship. This updates the CSS rules that set the heading sizes so they still apply.

Fixes #85389

r? @camelid 