### PR TITLE
Improve display for "copy-path" button, making it more discreet

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1262,12 +1262,11 @@ h4 > .notable-traits {
 }
 
 #copy-path {
+	background: initial;
 	margin-left: 10px;
 	padding: 0;
 	padding-left: 2px;
-}
-#copy-path> img {
-	margin-bottom: 2px;
+	border: 0;
 }
 
 #theme-choices {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -502,20 +502,29 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, #help-button, #copy-path {
+#theme-picker, #settings-menu, #help-button {
 	border-color: #5c6773;
 	background-color: #0f1419;
 	color: #fff;
 }
 
-#theme-picker > img, #settings-menu > img, #copy-path > img {
+#theme-picker > img, #settings-menu > img {
 	filter: invert(100);
+}
+
+#copy-path {
+	color: #fff;
+}
+#copy-path > img {
+	filter: invert(70%);
+}
+#copy-path:hover > img {
+	filter: invert(100%);
 }
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-#help-button:hover, #help-button:focus,
-#copy-path:hover, #copy-path:focus {
+#help-button:hover, #help-button:focus {
 	border-color: #e0e0e0;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -392,7 +392,7 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, #help-button, #copy-path {
+#theme-picker, #settings-menu, #help-button {
 	border-color: #e0e0e0;
 	background: #f0f0f0;
 	color: #000;
@@ -400,9 +400,18 @@ kbd {
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-#help-button:hover, #help-button:focus,
-#copy-path:hover, #copy-path:focus {
+#help-button:hover, #help-button:focus {
 	border-color: #ffb900;
+}
+
+#copy-path {
+	color: #999;
+}
+#copy-path > img {
+	filter: invert(50%);
+}
+#copy-path:hover > img {
+	filter: invert(65%);
 }
 
 #theme-choices {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -384,16 +384,25 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, #help-button, #copy-path {
+#theme-picker, #settings-menu, #help-button {
 	border-color: #e0e0e0;
 	background-color: #fff;
 }
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-#help-button:hover, #help-button:focus,
-#copy-path:hover, #copy-path:focus {
+#help-button:hover, #help-button:focus {
 	border-color: #717171;
+}
+
+#copy-path {
+	color: #999;
+}
+#copy-path > img {
+	filter: invert(50%);
+}
+#copy-path:hover > img {
+	filter: invert(35%);
 }
 
 #theme-choices {


### PR DESCRIPTION
As suggested by @Nemo157 [here](https://github.com/rust-lang/rust/pull/85118#issuecomment-838887670):

![Screenshot from 2021-05-18 11-18-49](https://user-images.githubusercontent.com/3050060/118626882-899ddb00-b7cb-11eb-84c5-ef68dee5e351.png)
![Screenshot from 2021-05-18 11-15-06](https://user-images.githubusercontent.com/3050060/118626880-899ddb00-b7cb-11eb-95c1-2f3bacd22374.png)
![Screenshot from 2021-05-18 11-18-54](https://user-images.githubusercontent.com/3050060/118626885-8a367180-b7cb-11eb-870c-7acdf4259bef.png)
![Screenshot from 2021-05-18 11-15-00](https://user-images.githubusercontent.com/3050060/118626877-89054480-b7cb-11eb-9efc-9a0f153964ce.png)
![Screenshot from 2021-05-18 11-18-58](https://user-images.githubusercontent.com/3050060/118626888-8a367180-b7cb-11eb-91bb-47867cd0f2cc.png)
![Screenshot from 2021-05-18 11-19-00](https://user-images.githubusercontent.com/3050060/118626891-8acf0800-b7cb-11eb-9e3d-d2937b361524.png)

r? @jsha 