### PR TITLE
PassWrapper: update for LLVM change D102093

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -789,16 +789,23 @@ LLVMRustOptimizeWithNewPassManager(
     PGOOpt = PGOOptions(PGOUsePath, "", "", PGOOptions::IRUse);
   }
 
-#if LLVM_VERSION_GE(12, 0)
+#if LLVM_VERSION_GE(12, 0) && !LLVM_VERSION_GE(13,0)
   PassBuilder PB(DebugPassManager, TM, PTO, PGOOpt, &PIC);
 #else
   PassBuilder PB(TM, PTO, PGOOpt, &PIC);
 #endif
 
+#if LLVM_VERSION_GE(13, 0)
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+#else
   LoopAnalysisManager LAM(DebugPassManager);
   FunctionAnalysisManager FAM(DebugPassManager);
   CGSCCAnalysisManager CGAM(DebugPassManager);
   ModuleAnalysisManager MAM(DebugPassManager);
+#endif
 
   FAM.registerPass([&] { return PB.buildDefaultAAPipeline(); });
 
@@ -935,7 +942,11 @@ LLVMRustOptimizeWithNewPassManager(
     }
   }
 
+#if LLVM_VERSION_GE(13, 0)
+  ModulePassManager MPM;
+#else
   ModulePassManager MPM(DebugPassManager);
+#endif
   bool NeedThinLTOBufferPasses = UseThinLTOBuffers;
   if (!NoPrepopulatePasses) {
     if (OptLevel == PassBuilder::OptimizationLevel::O0) {


### PR DESCRIPTION
In https://reviews.llvm.org/D102093 lots of things stopped taking the
DebugLogging boolean parameter. Mercifully we appear to always set
DebugPassManager to false, so I don't think we're losing anything by not
passing this parameter.