### PR TITLE
Check for use of mutable/extern statics in THIR unsafeck

### DIFF
--- a/src/test/ui/intrinsics/issue-28575.mir.stderr
+++ b/src/test/ui/intrinsics/issue-28575.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28575.rs:11:5
+   |
+LL |     FOO()
+   |     ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/intrinsics/issue-28575.rs
+++ b/src/test/ui/intrinsics/issue-28575.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(intrinsics)]
 
 extern "C" {

--- a/src/test/ui/intrinsics/issue-28575.thir.stderr
+++ b/src/test/ui/intrinsics/issue-28575.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28575.rs:11:5
+   |
+LL |     FOO()
+   |     ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/issues/issue-14227.mir.stderr
+++ b/src/test/ui/issues/issue-14227.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-28575.rs:8:5
+  --> $DIR/issue-14227.rs:7:21
    |
-LL |     FOO()
-   |     ^^^ use of extern static
+LL | static CRASH: u32 = symbol;
+   |                     ^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-14227.rs
+++ b/src/test/ui/issues/issue-14227.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     pub static symbol: u32;
 }

--- a/src/test/ui/issues/issue-14227.thir.stderr
+++ b/src/test/ui/issues/issue-14227.thir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-28324.rs:5:24
+  --> $DIR/issue-14227.rs:7:21
    |
-LL | pub static BAZ: u32 = *&error_message_count;
-   |                        ^^^^^^^^^^^^^^^^^^^^ use of extern static
+LL | static CRASH: u32 = symbol;
+   |                     ^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,11 +1,11 @@
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-16538.rs:11:27
+  --> $DIR/issue-16538.rs:14:27
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*const usize` cannot be shared between threads safely
-  --> $DIR/issue-16538.rs:11:1
+  --> $DIR/issue-16538.rs:14:1
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
@@ -14,7 +14,7 @@ LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    = note: shared static variables must have a type that implements `Sync`
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:11:34
+  --> $DIR/issue-16538.rs:14:34
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    |                                  ^^^^ use of extern static

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 mod Y {
     pub type X = usize;
     extern "C" {

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -1,0 +1,27 @@
+error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-16538.rs:14:27
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `*const usize` cannot be shared between threads safely
+  --> $DIR/issue-16538.rs:14:1
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `*const usize`
+   = note: shared static variables must have a type that implements `Sync`
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-16538.rs:14:34
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   |                                  ^^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0133, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-28324.mir.stderr
+++ b/src/test/ui/issues/issue-28324.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-14227.rs:4:21
+  --> $DIR/issue-28324.rs:8:24
    |
-LL | static CRASH: u32 = symbol;
-   |                     ^^^^^^ use of extern static
+LL | pub static BAZ: u32 = *&error_message_count;
+   |                        ^^^^^^^^^^^^^^^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-28324.rs
+++ b/src/test/ui/issues/issue-28324.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     static error_message_count: u32;
 }

--- a/src/test/ui/issues/issue-28324.thir.stderr
+++ b/src/test/ui/issues/issue-28324.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28324.rs:8:25
+   |
+LL | pub static BAZ: u32 = *&error_message_count;
+   |                         ^^^^^^^^^^^^^^^^^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics-mut.mir.stderr
+++ b/src/test/ui/safe-extern-statics-mut.mir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:13:13
+   |
+LL |     let b = B;
+   |             ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:14:14
+   |
+LL |     let rb = &B;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:15:14
+   |
+LL |     let xb = XB;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:16:15
+   |
+LL |     let xrb = &XB;
+   |               ^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics-mut.rs
+++ b/src/test/ui/safe-extern-statics-mut.rs
@@ -1,4 +1,6 @@
 // aux-build:extern-statics.rs
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 extern crate extern_statics;
 use extern_statics::*;

--- a/src/test/ui/safe-extern-statics-mut.thir.stderr
+++ b/src/test/ui/safe-extern-statics-mut.thir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:13:13
+   |
+LL |     let b = B;
+   |             ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:14:15
+   |
+LL |     let rb = &B;
+   |               ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:15:14
+   |
+LL |     let xb = XB;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:16:16
+   |
+LL |     let xrb = &XB;
+   |                ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics.mir.stderr
+++ b/src/test/ui/safe-extern-statics.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:11:13
+  --> $DIR/safe-extern-statics.rs:13:13
    |
 LL |     let a = A;
    |             ^ use of extern static
@@ -7,7 +7,7 @@ LL |     let a = A;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:12:14
+  --> $DIR/safe-extern-statics.rs:14:14
    |
 LL |     let ra = &A;
    |              ^^ use of extern static
@@ -15,7 +15,7 @@ LL |     let ra = &A;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:13:14
+  --> $DIR/safe-extern-statics.rs:15:14
    |
 LL |     let xa = XA;
    |              ^^ use of extern static
@@ -23,7 +23,7 @@ LL |     let xa = XA;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:14:15
+  --> $DIR/safe-extern-statics.rs:16:15
    |
 LL |     let xra = &XA;
    |               ^^^ use of extern static

--- a/src/test/ui/safe-extern-statics.rs
+++ b/src/test/ui/safe-extern-statics.rs
@@ -1,4 +1,6 @@
 // aux-build:extern-statics.rs
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 extern crate extern_statics;
 use extern_statics::*;

--- a/src/test/ui/safe-extern-statics.thir.stderr
+++ b/src/test/ui/safe-extern-statics.thir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:13:13
+   |
+LL |     let a = A;
+   |             ^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:14:15
+   |
+LL |     let ra = &A;
+   |               ^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:15:14
+   |
+LL |     let xa = XA;
+   |              ^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:16:16
+   |
+LL |     let xra = &XA;
+   |                ^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.mir.stderr
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.mir.stderr
@@ -1,0 +1,27 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:9:5
+   |
+LL |     a += 3;
+   |     ^^^^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:10:5
+   |
+LL |     a = 4;
+   |     ^^^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:11:14
+   |
+LL |     let _b = a;
+   |              ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     static mut a: i32;
 }

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.thir.stderr
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.thir.stderr
@@ -1,21 +1,21 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:6:5
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:9:5
    |
 LL |     a += 3;
-   |     ^^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:7:5
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:10:5
    |
 LL |     a = 4;
-   |     ^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:8:14
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:11:14
    |
 LL |     let _b = a;
    |              ^ use of mutable static

--- a/src/test/ui/static/static-mut-requires-unsafe.mir.stderr
+++ b/src/test/ui/static/static-mut-requires-unsafe.mir.stderr
@@ -1,35 +1,27 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:11:13
+  --> $DIR/static-mut-requires-unsafe.rs:7:5
    |
-LL |     let b = B;
-   |             ^ use of mutable static
-   |
-   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
-
-error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:12:14
-   |
-LL |     let rb = &B;
-   |              ^^ use of mutable static
+LL |     a += 3;
+   |     ^^^^^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:13:14
+  --> $DIR/static-mut-requires-unsafe.rs:8:5
    |
-LL |     let xb = XB;
-   |              ^^ use of mutable static
+LL |     a = 4;
+   |     ^^^^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:14:15
+  --> $DIR/static-mut-requires-unsafe.rs:9:14
    |
-LL |     let xrb = &XB;
-   |               ^^^ use of mutable static
+LL |     let _b = a;
+   |              ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-requires-unsafe.rs
+++ b/src/test/ui/static/static-mut-requires-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 static mut a: isize = 3;
 
 fn main() {

--- a/src/test/ui/static/static-mut-requires-unsafe.thir.stderr
+++ b/src/test/ui/static/static-mut-requires-unsafe.thir.stderr
@@ -1,21 +1,21 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:4:5
+  --> $DIR/static-mut-requires-unsafe.rs:7:5
    |
 LL |     a += 3;
-   |     ^^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:5:5
+  --> $DIR/static-mut-requires-unsafe.rs:8:5
    |
 LL |     a = 4;
-   |     ^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:6:14
+  --> $DIR/static-mut-requires-unsafe.rs:9:14
    |
 LL |     let _b = a;
    |              ^ use of mutable static

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 1370;
-const ISSUES_ENTRY_LIMIT: usize = 2555;
+const ROOT_ENTRY_LIMIT: usize = 1371;
+const ISSUES_ENTRY_LIMIT: usize = 2557;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
Extends THIR unsafeck to check for use of mutable and extern statics.

r? @ghost (I don't want to flood Niko's review queue)
cc rust-lang/project-thir-unsafeck#7