### PR TITLE
Fix must_use on `Option::is_none`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -209,7 +209,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.is_none(), true);
     /// ```
     #[must_use = "if you intended to assert that this doesn't have a value, consider \
-                  `.and_then(|| panic!(\"`Option` had a value when expected `None`\"))` instead"]
+                  `.and_then(|_| panic!(\"`Option` had a value when expected `None`\"))` instead"]
     #[inline]
     #[rustc_const_stable(feature = "const_option", since = "1.48.0")]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This fixes the `#[must_use = ...]` on `Option::is_none` to have a working suggestion.