### PR TITLE
CTFE mir is sufficient for statics and consts

### DIFF
--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -919,7 +919,7 @@ fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) ->
         return false;
     }
 
-    if !tcx.is_mir_available(def_id) {
+    if !tcx.is_mir_available(def_id) && !tcx.is_ctfe_mir_available(def_id) {
         bug!("no MIR available for {:?}", def_id);
     }
 

--- a/src/test/ui/rmeta/auxiliary/rmeta-mir-static.rs
+++ b/src/test/ui/rmeta/auxiliary/rmeta-mir-static.rs
@@ -1,0 +1,6 @@
+// no-prefer-dynamic
+// compile-flags: --emit=metadata -Zalways-encode-mir=yes
+#![crate_type="rlib"]
+
+pub static FOO: &str = "foo";
+pub const BAR: i32 = 123;

--- a/src/test/ui/rmeta/rlib-lib-pass-static.rs
+++ b/src/test/ui/rmeta/rlib-lib-pass-static.rs
@@ -1,0 +1,15 @@
+// aux-build:rmeta-mir-static.rs
+// no-prefer-dynamic
+// build-pass (FIXME(62277): could be check-pass?)
+
+// Check that building a an rlib crate dependent on a rmeta crate can
+// use statics, consts and type aliases.
+
+#![crate_type="rlib"]
+
+extern crate rmeta_mir_static;
+use rmeta_mir_static::{FOO, BAR};
+
+pub fn main() {
+    println!("foo {} bar {}", FOO, BAR);
+}


### PR DESCRIPTION
The issue isn't that the MIR is missing, but that it's for CTFE, so extend the check for that as well.

Closes issue #85401