### PR TITLE
Fix escape handling

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -428,9 +428,9 @@ function hideThemeButtonState() {
     function handleEscape(ev) {
         var help = getHelpElement(false);
         var search = searchState.outputElement();
-        if (!hasClass(help, "hidden")) {
+        if (help && !hasClass(help, "hidden")) {
             displayHelp(false, ev, help);
-        } else if (!hasClass(search, "hidden")) {
+        } else if (search && !hasClass(search, "hidden")) {
             searchState.clearInputTimeout();
             ev.preventDefault();
             searchState.hideResults(search);

--- a/src/test/rustdoc-gui/escape-key.goml
+++ b/src/test/rustdoc-gui/escape-key.goml
@@ -1,0 +1,27 @@
+goto: file://|DOC_PATH|/test_docs/index.html
+// First, we check that the search results are hidden when the Escape key is pressed.
+write: (".search-input", "test")
+wait-for: "#search > h1" // The search element is empty before the first search 
+assert: ("#search", "class", "content")
+assert: ("#main", "class", "content hidden")
+press-key: "Escape"
+assert: ("#search", "class", "content hidden")
+assert: ("#main", "class", "content")
+
+// Check that focusing the search input brings back the search results
+focus: ".search-input"
+assert: ("#search", "class", "content")
+assert: ("#main", "class", "content hidden")
+
+// Now let's check that when the help popup is displayed and we press Escape, it doesn't
+// hide the search results too.
+click: "#help-button"
+assert: ("#help", "class", "")
+press-key: "Escape"
+assert: ("#help", "class", "hidden")
+assert: ("#search", "class", "content")
+assert: ("#main", "class", "content hidden")
+
+// FIXME: Once https://github.com/rust-lang/rust/pull/84462 is merged, add check to ensure
+// that Escape hides the search results when a result is focused.
+// press-key: "ArrowDown"


### PR DESCRIPTION
Currently, when we press Escape while on the search results, nothing is happening, this PR fixes it.

More information: it's because in case the element doesn't exist, `hasClass` will return `null`, which coerces into `false` with the `!` comparison operator. But even if it returned `false`, it would still be an issue because if the element doesn't exist, it means it's hidden so in this case it's just as good, hence the additional check I added.

r? @jsha 