### PR TITLE
Add debug info tests for range, fix-sized array, and cell types

### DIFF
--- a/src/test/debuginfo/fixed-sized-array.rs
+++ b/src/test/debuginfo/fixed-sized-array.rs
@@ -1,0 +1,39 @@
+// Testing the display of fixed sized arrays in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx xs,d
+// cdb-check:xs,d             [Type: int [5]]
+// cdb-check:    [0]              : 1 [Type: int]
+// cdb-check:    [1]              : 2 [Type: int]
+// cdb-check:    [2]              : 3 [Type: int]
+// cdb-check:    [3]              : 4 [Type: int]
+// cdb-check:    [4]              : 5 [Type: int]
+
+// cdb-command: dx ys,d
+// cdb-check:ys,d             [Type: int [3]]
+// cdb-check:    [0]              : 0 [Type: int]
+// cdb-check:    [1]              : 0 [Type: int]
+// cdb-check:    [2]              : 0 [Type: int]
+
+fn main() {
+    // Fixed-size array (type signature is superfluous)
+    let xs: [i32; 5] = [1, 2, 3, 4, 5];
+
+    // All elements can be initialized to the same value
+    let ys: [i32; 3] = [0; 3];
+
+    // Indexing starts at 0
+    println!("first element of the array: {}", xs[0]);
+    println!("second element of the array: {}", xs[1]);
+
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/mutable-locs.rs
+++ b/src/test/debuginfo/mutable-locs.rs
@@ -1,0 +1,51 @@
+// Testing the display of Cell, RefCell, and RefMut in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command:dx static_c,d
+// cdb-check:static_c,d       [Type: core::cell::Cell<i32>]
+// cdb-check:    [...] value            [Type: core::cell::UnsafeCell<i32>]
+
+// cdb-command: dx static_c.value,d
+// cdb-check:static_c.value,d [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] value            : 10 [Type: int]
+
+// cdb-command:  dx dynamic_c,d
+// cdb-check:dynamic_c,d      [Type: core::cell::RefCell<i32>]
+// cdb-check:    [...] borrow           [Type: core::cell::Cell<isize>]
+// cdb-check:    [...] value            [Type: core::cell::UnsafeCell<i32>]
+
+// cdb-command: dx dynamic_c.value,d
+// cdb-check:dynamic_c.value,d [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] value            : 15 [Type: int]
+
+// cdb-command: dx b,d
+// cdb-check:b,d              [Type: core::cell::RefMut<i32>]
+// cdb-check:    [...] value            : [...] : 42 [Type: int *]
+// cdb-check:    [...] borrow           [Type: core::cell::BorrowRefMut]
+
+#![allow(unused_variables)]
+
+use std::cell::{Cell, RefCell};
+
+fn main() {
+    let static_c = Cell::new(5);
+    static_c.set(10);
+
+    let dynamic_c = RefCell::new(5);
+    dynamic_c.replace(15);
+
+    let dynamic_c_0 = RefCell::new(15);
+    let mut b = dynamic_c_0.borrow_mut();
+    *b = 42;
+
+    zzz(); // #break
+}
+
+fn zzz() {()}

--- a/src/test/debuginfo/mutex.rs
+++ b/src/test/debuginfo/mutex.rs
@@ -1,0 +1,39 @@
+// Testing the display of Mutex and MutexGuard in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.21287.1005
+// compile-flags:-g
+// ignore-tidy-linelength
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx m,d
+// cdb-check:m,d              [Type: std::sync::mutex::Mutex<i32>]
+// cdb-check:    [...] inner            [Type: std::sys_common::mutex::MovableMutex]
+// cdb-check:    [...] poison           [Type: std::sync::poison::Flag]
+// cdb-check:    [...] data             [Type: core::cell::UnsafeCell<i32>]
+
+//
+// cdb-command:dx m.data,d
+// cdb-check:m.data,d         [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] value            : 0 [Type: int]
+
+//
+// cdb-command:dx lock,d
+// cdb-check:lock,d           : Ok [Type: enum$<core::result::Result<std::sync::mutex::MutexGuard<i32>, enum$<std::sync::poison::TryLockError<std::sync::mutex::MutexGuard<i32>>, 0, 1, Poisoned>>>]
+// cdb-check:    [...] variant$         : Ok (0) [Type: core::result::Result]
+// cdb-check:    [...] __0              [Type: std::sync::mutex::MutexGuard<i32>]
+
+use std::sync::Mutex;
+
+#[allow(unused_variables)]
+fn main()
+{
+    let m = Mutex::new(0);
+    let lock = m.try_lock();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -5,6 +5,7 @@
 // compile-flags:-g
 // min-gdb-version: 7.7
 // min-lldb-version: 310
+// min-cdb-version: 10.0.18317.1001
 
 // === GDB TESTS ===================================================================================
 
@@ -71,8 +72,12 @@
 // cdb-command: g
 
 // cdb-command: dx slice,d
-// cdb-check:slice,d [...]
-// NOTE: While slices have a .natvis entry that works in VS & VS Code, it fails in CDB 10.0.18362.1
+// cdb-check:slice,d          : { len=4 } [Type: slice<i32>]
+// cdb-check:    [len]            : 4 [Type: [...]]
+// cdb-check:    [0]              : 0 [Type: int]
+// cdb-check:    [1]              : 1 [Type: int]
+// cdb-check:    [2]              : 2 [Type: int]
+// cdb-check:    [3]              : 3 [Type: int]
 
 // cdb-command: dx vec,d
 // cdb-check:vec,d [...] : { len=4 } [Type: [...]::Vec<u64, alloc::alloc::Global>]
@@ -84,8 +89,7 @@
 // cdb-check:    [3]              : 7 [Type: unsigned __int64]
 
 // cdb-command: dx str_slice
-// cdb-check:str_slice [...]
-// NOTE: While string slices have a .natvis entry that works in VS & VS Code, it fails in CDB
+// cdb-check:str_slice        : "IAMA string slice!" [Type: str]
 
 // cdb-command: dx string
 // cdb-check:string           : "IAMA string!" [Type: [...]::String]
@@ -113,9 +117,15 @@
 
 // cdb-command: dx some
 // cdb-check:some             : Some [Type: enum$<core::option::Option<i16>>]
+// cdb-check:    [...] variant$         : Some (0x1) [Type: core::option::Option]
+// cdb-check:    [...] __0              : 8 [Type: short]
+
 // cdb-command: dx none
 // cdb-check:none             : None [Type: enum$<core::option::Option<i64>>]
+// cdb-check:    [...] variant$         : None (0x0) [Type: core::option::Option]
+
 // cdb-command: dx some_string
+// NOTE: cdb fails to interpret debug info of Option enums on i686.
 // cdb-check:some_string      [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>]
 
 #![allow(unused_variables)]

--- a/src/test/debuginfo/range-types.rs
+++ b/src/test/debuginfo/range-types.rs
@@ -1,0 +1,47 @@
+// Testing the display of range types in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx r1,d
+// cdb-check:r1,d             [Type: core::ops::range::Range<i32>]
+// cdb-check:    [...] start            : 3 [Type: int]
+// cdb-check:    [...] end              : 5 [Type: int]
+
+// cdb-command: dx r2,d
+// cdb-check:r2,d             [Type: core::ops::range::RangeFrom<i32>]
+// cdb-check:    [...] start            : 2 [Type: int]
+
+// cdb-command: dx r3,d
+// cdb-check:r3,d             [Type: core::ops::range::RangeInclusive<i32>]
+// cdb-check:    [...] start            : 1 [Type: int]
+// cdb-check:    [...] end              : 4 [Type: int]
+// cdb-check:    [...] exhausted        : false [Type: bool]
+
+// cdb-command: dx r4,d
+// cdb-check:r4,d             [Type: core::ops::range::RangeToInclusive<i32>]
+// cdb-check:    [...] end              : 3 [Type: int]
+
+// cdb-command: dx r5,d
+// cdb-check:r5,d             [Type: core::ops::range::RangeFull]
+
+#[allow(unused_variables)]
+
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+fn main()
+{
+    let r1 = Range{start: 3, end: 5};
+    let r2 = RangeFrom{start: 2};
+    let r3 = RangeInclusive::new(1, 4);
+    let r4 = RangeToInclusive{end: 3};
+    let r5 = RangeFull{};
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -1,7 +1,9 @@
-// ignore-windows pretty-printers are not loaded
+// pretty-printers are not loaded
 // compile-flags:-g
+// ignore-tidy-linelength
 
 // min-gdb-version: 8.1
+// min-cdb-version: 10.0.18317.1001
 
 // === GDB TESTS ==================================================================================
 
@@ -21,6 +23,29 @@
 // lldb-check:[...]$0 = strong=2, weak=1 { value = 42 }
 // lldb-command:print a
 // lldb-check:[...]$1 = strong=2, weak=1 { data = 42 }
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command:g
+
+// cdb-command:dx r,d
+// cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
+
+// cdb-command:dx r1,d
+// cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
+
+// cdb-command:dx w1,d
+// cdb-check:w1,d             [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [...] ptr              : [...] [Type: core::ptr::non_null::NonNull<alloc::rc::RcBox<i32>>]
+
+// cdb-command:dx a,d
+// cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
+
+// cdb-command:dx a1,d
+// cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
+
+// cdb-command:dx w2,d
+// cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/test/debuginfo/result-types.rs
+++ b/src/test/debuginfo/result-types.rs
@@ -1,0 +1,28 @@
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx x,d
+// cdb-check:x,d              : Ok [Type: enum$<core::result::Result<i32, str>>]
+// cdb-check:    [...] __0              : -3 [Type: int]
+
+// cdb-command: dx y
+// cdb-check:y                : Err [Type: enum$<core::result::Result<i32, str>>]
+// cdb-check:    [...] __0              : "Some error message" [Type: str]
+
+fn main()
+{
+    let x: Result<i32, &str> = Ok(-3);
+    assert_eq!(x.is_ok(), true);
+
+    let y: Result<i32, &str> = Err("Some error message");
+    assert_eq!(y.is_ok(), false);
+
+    zzz(); // #break.
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/rwlock-read.rs
+++ b/src/test/debuginfo/rwlock-read.rs
@@ -1,0 +1,35 @@
+// Testing the display of RwLock and RwLockReadGuard in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx l
+// cdb-check:l                [Type: std::sync::rwlock::RwLock<i32>]
+// cdb-check:    [...] poison           [Type: std::sync::poison::Flag]
+// cdb-check:    [...] data             [Type: core::cell::UnsafeCell<i32>]
+//
+// cdb-command:dx r
+// cdb-check:r                [Type: std::sync::rwlock::RwLockReadGuard<i32>]
+// cdb-check:    [...] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
+//
+// cdb-command:dx r.lock->data,d
+// cdb-check:r.lock->data,d   [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] value            : 0 [Type: int]
+
+#[allow(unused_variables)]
+
+use std::sync::RwLock;
+
+fn main()
+{
+    let l = RwLock::new(0);
+    let r = l.read().unwrap();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/rwlock-write.rs
+++ b/src/test/debuginfo/rwlock-write.rs
@@ -1,0 +1,27 @@
+// Testing the display of RwLockWriteGuard.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx w
+// cdb-check:w                [Type: std::sync::rwlock::RwLockWriteGuard<i32>]
+// cdb-check:    [...] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
+// cdb-check:    [...] poison           [Type: std::sync::poison::Guard]
+
+#[allow(unused_variables)]
+
+use std::sync::RwLock;
+
+fn main()
+{
+    let l = RwLock::new(0);
+    let w = l.write().unwrap();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/thread.rs
+++ b/src/test/debuginfo/thread.rs
@@ -1,0 +1,31 @@
+// Testing the the display of JoinHandle and Thread in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx join_handle,d
+// cdb-check:join_handle,d    [Type: std::thread::JoinHandle<tuple<>>]
+// cdb-check:    [...] __0              [Type: std::thread::JoinInner<tuple<>>]
+//
+// cdb-command:dx t,d
+// cdb-check:t,d              : [...] [Type: std::thread::Thread *]
+// cdb-check:    [...] inner            : {...} [Type: alloc::sync::Arc<std::thread::Inner>]
+
+use std::thread;
+
+#[allow(unused_variables)]
+fn main()
+{
+    let join_handle = thread::spawn(|| {
+        println!("Initialize a thread");
+    });
+    let t = join_handle.thread();
+    zzz(); // #break
+}
+
+fn zzz() {}


### PR DESCRIPTION
This PR add several debug info tests to guarantee that the displays of fixed sized arrays, range types, cell types, threads, locks, and mutexes in CDB are correct.

It also updates CDB tests for slices in pretty-std.rs after string visualization in WinDbg is fixed by this PR: #81898.