### PR TITLE
Fix UB in documented example for `ptr::swap`

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -342,10 +342,12 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 /// ```
 /// use std::ptr;
 ///
-/// let mut array = [0, 1, 2, 3];
+/// let mut array: [i32; 4] = [0, 1, 2, 3];
 ///
-/// let x = array[0..].as_mut_ptr() as *mut [u32; 3]; // this is `array[0..3]`
-/// let y = array[1..].as_mut_ptr() as *mut [u32; 3]; // this is `array[1..4]`
+/// let array_ptr: *mut i32 = array.as_mut_ptr();
+///
+/// let x = array_ptr as *mut [i32; 3]; // this is `array[0..3]`
+/// let y = unsafe { array_ptr.add(1) } as *mut [i32; 3]; // this is `array[1..4]`
 ///
 /// unsafe {
 ///     ptr::swap(x, y);


### PR DESCRIPTION
Compare [this (short) discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Pointers.20to.20overlapping.20arrays) (or [in the archive](https://zulip-archive.rust-lang.org/122651general/92017Pointerstooverlappingarrays.html), if you don’t have an account).

@rustbot label T-doc T-libs