### PR TITLE
Fix invalid CSS rules for a:hover

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -151,16 +151,13 @@ pre, .rustdoc.source .example-wrap {
 	color: #c5c5c5;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #777;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #000 !important;
 	background-color: #c6afb3;
-}
-.content a:focus {
-	color: #000 !important;
 }
 .search-results a {
 	color: #0096cf;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -109,11 +109,11 @@ pre, .rustdoc.source .example-wrap {
 	color: #ddd;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #777;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #eee !important;
 	background-color: #616161;
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -109,11 +109,11 @@ pre, .rustdoc.source .example-wrap {
 	color: #4E4C4C;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #ddd;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #000 !important;
 	background-color: #ccc;
 }


### PR DESCRIPTION
When hovering some links:

![Screenshot from 2021-05-19 15-00-31](https://user-images.githubusercontent.com/3050060/118823585-5f2a4b80-b8b9-11eb-8043-bb7759a178c7.png)
![Screenshot from 2021-05-19 15-00-29](https://user-images.githubusercontent.com/3050060/118823566-5b96c480-b8b9-11eb-8c4e-08e490752fbf.png)

It is a side-effect from #84462.

r? @jsha