### PR TITLE
deal with `const_evaluatable_checked` in `ConstEquate`

### DIFF
--- a/src/test/ui/const-generics/const_evaluatable_checked/different-fn.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/different-fn.rs
@@ -9,6 +9,7 @@ struct Foo<T>(PhantomData<T>);
 fn test<T>() -> [u8; size_of::<T>()] {
     [0; size_of::<Foo<T>>()]
     //~^ ERROR unconstrained generic constant
+    //~| ERROR mismatched types
 }
 
 fn main() {

--- a/src/test/ui/const-generics/const_evaluatable_checked/different-fn.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/different-fn.stderr
@@ -1,3 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/different-fn.rs:10:5
+   |
+LL |     [0; size_of::<Foo<T>>()]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `size_of::<T>()`, found `size_of::<Foo<T>>()`
+   |
+   = note: expected type `size_of::<T>()`
+              found type `size_of::<Foo<T>>()`
+
 error: unconstrained generic constant
   --> $DIR/different-fn.rs:10:9
    |
@@ -6,5 +15,6 @@ LL |     [0; size_of::<Foo<T>>()]
    |
    = help: try adding a `where` bound using this expression: `where [(); size_of::<Foo<T>>()]:`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/const_evaluatable_checked/evaluated-to-ambig.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/evaluated-to-ambig.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+// We previously always returned ambiguity when equating generic consts, even if they
+// only contain generic parameters. This is incorrect as trying to unify `N > 1` with `M > 1`
+// should fail.
+#![allow(incomplete_features)]
+#![feature(const_generics, const_evaluatable_checked)]
+
+enum Assert<const COND: bool> {}
+trait IsTrue {}
+impl IsTrue for Assert<true> {}
+
+struct Foo<const N: usize, const M: usize>;
+trait Bar<const N: usize, const M: usize> {}
+impl<const N: usize, const M: usize> Bar<N, M> for Foo<N, M>
+where
+    Assert<{ N > 1 }>: IsTrue,
+    Assert<{ M > 1 }>: IsTrue,
+{
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-62504.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.full.stderr
@@ -1,3 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-62504.rs:18:21
+   |
+LL |         ArrayHolder([0; Self::SIZE])
+   |                     ^^^^^^^^^^^^^^^ expected `X`, found `Self::SIZE`
+   |
+   = note: expected type `X`
+              found type `Self::SIZE`
+
 error: constant expression depends on a generic parameter
   --> $DIR/issue-62504.rs:18:25
    |
@@ -6,5 +15,6 @@ LL |         ArrayHolder([0; Self::SIZE])
    |
    = note: this may fail depending on what value the parameter takes
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-62504.rs
+++ b/src/test/ui/const-generics/issues/issue-62504.rs
@@ -17,7 +17,7 @@ impl<const X: usize> ArrayHolder<X> {
     pub const fn new() -> Self {
         ArrayHolder([0; Self::SIZE])
         //~^ ERROR constant expression depends on a generic parameter
-        //[min]~| ERROR mismatched types
+        //~| ERROR mismatched types
     }
 }
 


### PR DESCRIPTION
Failing to evaluate two constants which do not contain inference variables should not result in ambiguity.