### PR TITLE
`#[cfg(bootstrap)]` out `NoneError` and other v1 try_trait stuff

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -63,6 +63,7 @@ pub enum ControlFlow<B, C = ()> {
 }
 
 #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+#[cfg(bootstrap)]
 impl<B, C> ops::TryV1 for ControlFlow<B, C> {
     type Output = C;
     type Error = B;

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -147,6 +147,7 @@ mod function;
 mod generator;
 mod index;
 mod range;
+#[cfg(bootstrap)]
 mod r#try;
 mod try_trait;
 mod unsize;
@@ -187,6 +188,7 @@ pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 pub use self::r#try::Try;
 
 #[unstable(feature = "try_trait_transition", reason = "for bootstrap", issue = "none")]
+#[cfg(bootstrap)]
 pub(crate) use self::r#try::Try as TryV1;
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1641,9 +1641,11 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
 #[rustc_diagnostic_item = "none_error"]
 #[unstable(feature = "try_trait", issue = "42327")]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+#[cfg(bootstrap)]
 pub struct NoneError;
 
 #[unstable(feature = "try_trait", issue = "42327")]
+#[cfg(bootstrap)]
 impl<T> ops::TryV1 for Option<T> {
     type Output = T;
     type Error = NoneError;

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1627,6 +1627,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
 }
 
 #[unstable(feature = "try_trait", issue = "42327")]
+#[cfg(bootstrap)]
 impl<T, E> ops::TryV1 for Result<T, E> {
     type Output = T;
     type Error = E;

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -129,6 +129,7 @@ impl<T> From<T> for Poll<T> {
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]
+#[cfg(bootstrap)]
 impl<T, E> ops::TryV1 for Poll<Result<T, E>> {
     type Output = Poll<T>;
     type Error = E;
@@ -184,6 +185,7 @@ impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Pol
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]
+#[cfg(bootstrap)]
 impl<T, E> ops::TryV1 for Poll<Option<Result<T, E>>> {
     type Output = Poll<Option<T>>;
     type Error = E;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -44,7 +44,6 @@
 #![feature(str_internals)]
 #![feature(test)]
 #![feature(trusted_len)]
-#![feature(try_trait)]
 #![feature(try_trait_v2)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]


### PR DESCRIPTION
Closes #46871

r? @yaahc 