### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_mir/src/interpret/machine.rs
+++ b/compiler/rustc_mir/src/interpret/machine.rs
@@ -313,7 +313,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     #[inline(always)]
     fn memory_read(
         _memory_extra: &Self::MemoryExtra,
-        _alloc: &Allocation<Self::PointerTag, Self::AllocExtra>,
+        _alloc_extra: &Self::AllocExtra,
         _ptr: Pointer<Self::PointerTag>,
         _size: Size,
     ) -> InterpResult<'tcx> {
@@ -324,7 +324,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     #[inline(always)]
     fn memory_written(
         _memory_extra: &mut Self::MemoryExtra,
-        _alloc: &mut Allocation<Self::PointerTag, Self::AllocExtra>,
+        _alloc_extra: &mut Self::AllocExtra,
         _ptr: Pointer<Self::PointerTag>,
         _size: Size,
     ) -> InterpResult<'tcx> {
@@ -335,8 +335,9 @@ pub trait Machine<'mir, 'tcx>: Sized {
     #[inline(always)]
     fn memory_deallocated(
         _memory_extra: &mut Self::MemoryExtra,
-        _alloc: &mut Allocation<Self::PointerTag, Self::AllocExtra>,
+        _alloc_extra: &mut Self::AllocExtra,
         _ptr: Pointer<Self::PointerTag>,
+        _size: Size,
     ) -> InterpResult<'tcx> {
         Ok(())
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -131,6 +131,7 @@ symbols! {
         BinaryHeap,
         Borrow,
         C,
+        CStr,
         CString,
         Center,
         Clone,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1849,6 +1849,8 @@ pub trait Iterator {
     ///
     /// The relative order of partitioned items is not maintained.
     ///
+    /// Time Complexity: *O*(*N*)
+    ///
     /// See also [`is_partitioned()`] and [`partition()`].
     ///
     /// [`is_partitioned()`]: Iterator::is_partitioned

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1849,6 +1849,10 @@ pub trait Iterator {
     ///
     /// The relative order of partitioned items is not maintained.
     ///
+    /// # Current implementation
+    /// Current algorithms tries finding the first element for which the predicate evaluates
+    /// to false, and the last element for which it evaluates to true and repeatedly swaps them.
+    ///
     /// Time Complexity: *O*(*N*)
     ///
     /// See also [`is_partitioned()`] and [`partition()`].

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -342,10 +342,12 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 /// ```
 /// use std::ptr;
 ///
-/// let mut array = [0, 1, 2, 3];
+/// let mut array: [i32; 4] = [0, 1, 2, 3];
 ///
-/// let x = array[0..].as_mut_ptr() as *mut [u32; 3]; // this is `array[0..3]`
-/// let y = array[1..].as_mut_ptr() as *mut [u32; 3]; // this is `array[1..4]`
+/// let array_ptr: *mut i32 = array.as_mut_ptr();
+///
+/// let x = array_ptr as *mut [i32; 3]; // this is `array[0..3]`
+/// let y = unsafe { array_ptr.add(1) } as *mut [i32; 3]; // this is `array[1..4]`
 ///
 /// unsafe {
 ///     ptr::swap(x, y);

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -107,6 +107,7 @@ macro_rules! with_api {
             Literal {
                 fn drop($self: $S::Literal);
                 fn clone($self: &$S::Literal) -> $S::Literal;
+                fn from_str(s: &str) -> Result<$S::Literal, ()>;
                 fn debug_kind($self: &$S::Literal) -> String;
                 fn symbol($self: &$S::Literal) -> String;
                 fn suffix($self: &$S::Literal) -> Option<String>;
@@ -312,6 +313,19 @@ impl<T: Unmark> Unmark for Option<T> {
     type Unmarked = Option<T::Unmarked>;
     fn unmark(self) -> Self::Unmarked {
         self.map(T::unmark)
+    }
+}
+
+impl<T: Mark, E: Mark> Mark for Result<T, E> {
+    type Unmarked = Result<T::Unmarked, E::Unmarked>;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        unmarked.map(T::mark).map_err(E::mark)
+    }
+}
+impl<T: Unmark, E: Unmark> Unmark for Result<T, E> {
+    type Unmarked = Result<T::Unmarked, E::Unmarked>;
+    fn unmark(self) -> Self::Unmarked {
+        self.map(T::unmark).map_err(E::unmark)
     }
 }
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -91,6 +91,12 @@ pub struct LexError {
     _inner: (),
 }
 
+impl LexError {
+    fn new() -> Self {
+        LexError { _inner: () }
+    }
+}
+
 #[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1168,6 +1174,28 @@ impl Literal {
         }
 
         self.0.subspan(cloned_bound(range.start_bound()), cloned_bound(range.end_bound())).map(Span)
+    }
+}
+
+/// Parse a single literal from its stringified representation.
+///
+/// In order to parse successfully, the input string must not contain anything
+/// but the literal token. Specifically, it must not contain whitespace or
+/// comments in addition to the literal.
+///
+/// The resulting literal token will have a `Span::call_site()` span.
+///
+/// NOTE: some errors may cause panics instead of returning `LexError`. We
+/// reserve the right to change these errors into `LexError`s later.
+#[stable(feature = "proc_macro_literal_parse", since = "1.54.0")]
+impl FromStr for Literal {
+    type Err = LexError;
+
+    fn from_str(src: &str) -> Result<Self, LexError> {
+        match bridge::client::Literal::from_str(src) {
+            Ok(literal) => Ok(Literal(literal)),
+            Err(()) => Err(LexError::new()),
+        }
     }
 }
 

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -185,6 +185,7 @@ pub struct CString {
 ///
 /// [`&str`]: prim@str
 #[derive(Hash)]
+#[cfg_attr(not(test), rustc_diagnostic_item = "CStr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 // FIXME:
 // `fn from` in `impl From<&CStr> for Box<CStr>` current implementation relies

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -49,7 +49,7 @@ pub mod test {
         cli::{parse_opts, TestOpts},
         filter_tests,
         helpers::metrics::{Metric, MetricMap},
-        options::{Options, RunIgnored, RunStrategy, ShouldPanic},
+        options::{Concurrent, Options, RunIgnored, RunStrategy, ShouldPanic},
         run_test, test_main, test_main_static,
         test_result::{TestResult, TrFailed, TrFailedMsg, TrIgnored, TrOk},
         time::{TestExecTime, TestTimeOptions},

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1352,8 +1352,11 @@ fn render_impl(
         }
         let w = if short_documented && trait_.is_some() { interesting } else { boring };
 
-        if !doc_buffer.is_empty() {
-            w.write_str("<details class=\"rustdoc-toggle\" open><summary>");
+        let toggled = !doc_buffer.is_empty();
+        if toggled {
+            let method_toggle_class =
+                if item_type == ItemType::Method { " method-toggle" } else { "" };
+            write!(w, "<details class=\"rustdoc-toggle{}\" open><summary>", method_toggle_class);
         }
         match *item.kind {
             clean::MethodItem(..) | clean::TyMethodItem(_) => {
@@ -1453,7 +1456,7 @@ fn render_impl(
         }
 
         w.push_buffer(info_buffer);
-        if !doc_buffer.is_empty() {
+        if toggled {
             w.write_str("</summary>");
             w.push_buffer(doc_buffer);
             w.push_str("</details>");

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -924,24 +924,16 @@ function hideThemeButtonState() {
             });
         }
 
-        if (hideMethodDocs) {
-            onEachLazy(document.getElementsByClassName("method"), function(e) {
-                var toggle = e.parentNode;
-                if (toggle) {
-                    toggle = toggle.parentNode;
-                }
-                if (toggle && toggle.tagName === "DETAILS") {
-                    toggle.open = false;
-                }
-            });
-        }
-
         onEachLazy(document.getElementsByTagName("details"), function (e) {
             var showLargeItem = !hideLargeItemContents && hasClass(e, "type-contents-toggle");
             var showImplementor = !hideImplementors && hasClass(e, "implementors-toggle");
             if (showLargeItem || showImplementor) {
                 e.open = true;
             }
+            if (hideMethodDocs && hasClass(e, "method-toggle")) {
+                e.open = false;
+            }
+
         });
 
         var currentType = document.getElementsByClassName("type-decl")[0];

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -151,16 +151,13 @@ pre, .rustdoc.source .example-wrap {
 	color: #c5c5c5;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #777;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #000 !important;
 	background-color: #c6afb3;
-}
-.content a:focus {
-	color: #000 !important;
 }
 .search-results a {
 	color: #0096cf;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -109,11 +109,11 @@ pre, .rustdoc.source .example-wrap {
 	color: #ddd;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #777;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #eee !important;
 	background-color: #616161;
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -109,11 +109,11 @@ pre, .rustdoc.source .example-wrap {
 	color: #4E4C4C;
 }
 
-.content a:hover {
+.search-results a:hover {
 	background-color: #ddd;
 }
 
-.content a:focus {
+.search-results a:focus {
 	color: #000 !important;
 	background-color: #ccc;
 }

--- a/src/test/ui/proc-macro/auxiliary/api/cmp.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/cmp.rs
@@ -1,8 +1,10 @@
-#![feature(proc_macro_span)]
-
 use proc_macro::{LineColumn, Punct};
 
-#[test]
+pub fn test() {
+    test_line_column_ord();
+    test_punct_eq();
+}
+
 fn test_line_column_ord() {
     let line0_column0 = LineColumn { line: 0, column: 0 };
     let line0_column1 = LineColumn { line: 0, column: 1 };
@@ -11,7 +13,6 @@ fn test_line_column_ord() {
     assert!(line0_column1 < line1_column0);
 }
 
-#[test]
 fn test_punct_eq() {
     // Good enough if it typechecks, since proc_macro::Punct can't exist in a test.
     fn _check(punct: Punct) {

--- a/src/test/ui/proc-macro/auxiliary/api/cmp.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/cmp.rs
@@ -1,4 +1,4 @@
-use proc_macro::{LineColumn, Punct};
+use proc_macro::{LineColumn, Punct, Spacing};
 
 pub fn test() {
     test_line_column_ord();
@@ -14,8 +14,8 @@ fn test_line_column_ord() {
 }
 
 fn test_punct_eq() {
-    // Good enough if it typechecks, since proc_macro::Punct can't exist in a test.
-    fn _check(punct: Punct) {
-        let _ = punct == ':';
-    }
+    let colon_alone = Punct::new(':', Spacing::Alone);
+    assert_eq!(colon_alone, ':');
+    let colon_joint = Punct::new(':', Spacing::Joint);
+    assert_eq!(colon_joint, ':');
 }

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -3,14 +3,18 @@
 
 #![crate_type = "proc-macro"]
 #![crate_name = "proc_macro_api_tests"]
+#![feature(proc_macro_span)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;
+
+mod cmp;
 
 use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn run(input: TokenStream) -> TokenStream {
     assert!(input.is_empty());
+    cmp::test();
     TokenStream::new()
 }

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -1,0 +1,16 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![crate_name = "proc_macro_api_tests"]
+#![deny(dead_code)] // catch if a test function is never called
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn run(input: TokenStream) -> TokenStream {
+    assert!(input.is_empty());
+    TokenStream::new()
+}

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -9,12 +9,16 @@
 extern crate proc_macro;
 
 mod cmp;
+mod parse;
 
 use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn run(input: TokenStream) -> TokenStream {
     assert!(input.is_empty());
+
     cmp::test();
+    parse::test();
+
     TokenStream::new()
 }

--- a/src/test/ui/proc-macro/auxiliary/api/parse.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/parse.rs
@@ -1,0 +1,23 @@
+use proc_macro::Literal;
+
+pub fn test() {
+    test_parse_literal();
+}
+
+fn test_parse_literal() {
+    assert_eq!("1".parse::<Literal>().unwrap().to_string(), "1");
+    assert_eq!("1.0".parse::<Literal>().unwrap().to_string(), "1.0");
+    assert_eq!("'a'".parse::<Literal>().unwrap().to_string(), "'a'");
+    assert_eq!("\"\n\"".parse::<Literal>().unwrap().to_string(), "\"\n\"");
+    assert_eq!("b\"\"".parse::<Literal>().unwrap().to_string(), "b\"\"");
+    assert_eq!("r##\"\"##".parse::<Literal>().unwrap().to_string(), "r##\"\"##");
+    assert_eq!("10ulong".parse::<Literal>().unwrap().to_string(), "10ulong");
+
+    assert!("0 1".parse::<Literal>().is_err());
+    assert!("'a".parse::<Literal>().is_err());
+    assert!(" 0".parse::<Literal>().is_err());
+    assert!("0 ".parse::<Literal>().is_err());
+    assert!("/* comment */0".parse::<Literal>().is_err());
+    assert!("0/* comment */".parse::<Literal>().is_err());
+    assert!("0// comment".parse::<Literal>().is_err());
+}

--- a/src/test/ui/proc-macro/test.rs
+++ b/src/test/ui/proc-macro/test.rs
@@ -1,0 +1,12 @@
+// check-pass
+// aux-build:api/mod.rs
+
+//! This is for everything that *would* be a #[test] inside of libproc_macro,
+//! except for the fact that proc_macro objects are not capable of existing
+//! inside of an ordinary Rust test execution, only inside a macro.
+
+extern crate proc_macro_api_tests;
+
+proc_macro_api_tests::run!();
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #84717 (impl FromStr for proc_macro::Literal)
 - #85169 (Add method-toggle to <details> for methods)
 - #85287 (Expose `Concurrent` (private type in public i'face))
 - #85315 (adding time complexity for partition_in_place iter method)
 - #85439 (Add diagnostic item to `CStr`)
 - #85464 (Fix UB in documented example for `ptr::swap`)
 - #85470 (Fix invalid CSS rules for a:hover)
 - #85472 (CTFE Machine: do not expose Allocation)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84717,85169,85287,85315,85439,85464,85470,85472)
<!-- homu-ignore:end -->