### PR TITLE
Avoid suggesting bounds on non-equal types

### DIFF
--- a/src/test/ui/typeck/issue-84893.rs
+++ b/src/test/ui/typeck/issue-84893.rs
@@ -1,0 +1,25 @@
+#![allow(unreachable_code)]
+
+pub trait MyHash {}
+
+pub struct MyHashSet<T>(T);
+
+impl<T> Eq for MyHashSet<T> where T: Eq + MyHash {}
+
+impl<T> PartialEq for MyHashSet<T> where T: PartialEq + MyHash {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+pub struct CustomSet<T>(MyHashSet<T>);
+
+impl<T> Eq for CustomSet<T> where T: Eq {}
+
+impl<T> PartialEq for CustomSet<T> where T: PartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 //~ERROR E0369
+    }
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-84893.stderr
+++ b/src/test/ui/typeck/issue-84893.stderr
@@ -1,0 +1,13 @@
+error[E0369]: binary operation `==` cannot be applied to type `MyHashSet<T>`
+  --> $DIR/issue-84893.rs:21:16
+   |
+LL |         self.0 == other.0
+   |         ------ ^^ ------- MyHashSet<T>
+   |         |
+   |         MyHashSet<T>
+   |
+   = note: the trait `std::cmp::PartialEq` is not implemented for `MyHashSet<T>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
Part of #84893 

Before applying this PR, the compiler produced the following error message for the issue-84893.rs test case:

```
error[E0369]: binary operation `==` cannot be applied to type `MyHashSet<T>`
  --> src/test/ui/typeck/issue-84893.rs:21:16
   |
21 |         self.0 == other.0 //~ERROR E0369
   |         ------ ^^ ------- MyHashSet<T>
   |         |
   |         MyHashSet<T>
   |
help: consider further restricting this bound
   |
19 | impl<T> PartialEq for CustomSet<T> where T: PartialEq + std::cmp::PartialEq {
   |
```

The line 19 suggestion is wrong. The compiler thought it would work, because it thought that the fix would be applicable if the trait bounds were satisfied after erasing `T`. Erasing `T` does satisfy the trait bounds, but the fix is to add a trait bound `T: MyHash`, not a trait bound `T: PartialEq`. Figuring out the real fix seems horribly complex, because it would need to figure out that the `MyHash` trait is involved. This commit just avoids giving the wrong suggestion.