### PR TITLE
Copy built tools to stage sysroot

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -367,6 +367,7 @@ impl<'a> Builder<'a> {
                 native::Llvm,
                 native::Sanitizers,
                 tool::Rustfmt,
+                tool::Cargofmt,
                 tool::Miri,
                 tool::CargoMiri,
                 native::Lld

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -613,6 +613,27 @@ impl<'a> Builder<'a> {
         self.ensure(compile::Sysroot { compiler })
     }
 
+    pub fn sysroot_bindir(&self, compiler: Compiler) -> Interned<PathBuf> {
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        struct Bindir {
+            compiler: Compiler,
+        }
+        impl Step for Bindir {
+            type Output = Interned<PathBuf>;
+
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+                run.never()
+            }
+
+            fn run(self, builder: &Builder<'_>) -> Interned<PathBuf> {
+                let sysroot_bindir = builder.sysroot(self.compiler).join("bin");
+                t!(fs::create_dir_all(&sysroot_bindir));
+                INTERNER.intern_path(sysroot_bindir)
+            }
+        }
+        self.ensure(Bindir { compiler })
+    }
+
     /// Returns the libdir where the standard library and other artifacts are
     /// found for a compiler's sysroot.
     pub fn sysroot_libdir(&self, compiler: Compiler, target: TargetSelection) -> Interned<PathBuf> {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1125,8 +1125,7 @@ impl Step for Assemble {
         // Link the compiler binary itself into place
         let out_dir = builder.cargo_out(build_compiler, Mode::Rustc, host);
         let rustc = out_dir.join(exe("rustc-main", host));
-        let bindir = sysroot.join("bin");
-        t!(fs::create_dir_all(&bindir));
+        let _ = builder.sysroot_bindir(target_compiler);
         let compiler = builder.rustc(target_compiler);
         builder.copy(&rustc, &compiler);
 


### PR DESCRIPTION
Motivation for this is to enable tools usage when using `rustup toolchain link`.

Just copies the tool directly after it's been built like the [`Rustdoc` step does it](https://github.com/rust-lang/rust/blob/df70463ea5d701489d6f53dc780a2c16294d6143/src/bootstrap/tool.rs#L575).

Fixes https://github.com/rust-lang/rust/issues/81431.