### PR TITLE
Prevent tab title to "null" if the URL is a search one

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -161,7 +161,7 @@ function hideThemeButtonState() {
         outputElement: function() {
             return document.getElementById("search");
         },
-        title: null,
+        title: document.title,
         titleBeforeSearch: document.title,
         timeout: null,
         // On the search screen, so you remain on the last tab you opened.


### PR DESCRIPTION
When we arrive on page with a search parameter in the URL, until the results are displayed, the page title is "null". It's because of this code:

```js
if (params.search !== undefined) {
    var search = searchState.outputElement();
    search.innerHTML = "<h3 style=\"text-align: center;\">" +
       searchState.loadingText + "</h3>";
    searchState.showResults(search);
    loadSearch();
}
```

In `searchState.showResults`, we have this:

```js
document.title = searchState.title;
```

But since it's `null`, we set it as title. This PR fixes it.

r? @jsha 