### PR TITLE
Fix typo and improve documentation for E0632

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -361,6 +361,7 @@ E0626: include_str!("./error_codes/E0626.md"),
 E0627: include_str!("./error_codes/E0627.md"),
 E0628: include_str!("./error_codes/E0628.md"),
 E0631: include_str!("./error_codes/E0631.md"),
+E0632: include_str!("./error_codes/E0632.md"),
 E0633: include_str!("./error_codes/E0633.md"),
 E0634: include_str!("./error_codes/E0634.md"),
 E0635: include_str!("./error_codes/E0635.md"),
@@ -623,8 +624,6 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0629, // missing 'feature' (rustc_const_unstable)
 //  E0630, // rustc_const_unstable attribute must be paired with stable/unstable
            // attribute
-    E0632, // cannot provide explicit generic arguments when `impl Trait` is
-           // used in argument position
     E0640, // infer outlives requirements
 //  E0645, // trait aliases not finished
     E0667, // `impl Trait` in projections

--- a/compiler/rustc_error_codes/src/error_codes/E0632.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0632.md
@@ -1,0 +1,25 @@
+An explicit generic argument was provided when calling a function that
+uses `impl Trait` in argument position.
+
+Erroneous code example:
+
+```compile_fail,E0632
+fn foo<T: Copy>(a: T, b: impl Clone) {}
+
+foo::<i32>(0i32, "abc".to_string());
+```
+
+Either all generic arguments should be inferred at the call site, or
+the function definition should use an explicit generic type parameter
+instead of `impl Trait`. Example:
+
+```
+fn foo<T: Copy>(a: T, b: impl Clone) {}
+fn bar<T: Copy, U: Clone>(a: T, b: U) {}
+
+foo(0i32, "abc".to_string());
+
+bar::<i32, String>(0i32, "abc".to_string());
+bar::<_, _>(0i32, "abc".to_string());
+bar(0i32, "abc".to_string());
+```

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1084,7 +1084,7 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// An function with generics must have its symbol mangled to accommodate
+    /// A function with generics must have its symbol mangled to accommodate
     /// the generic parameter. The [`no_mangle` attribute] has no effect in
     /// this situation, and should be removed.
     ///

--- a/src/test/ui/const-generics/impl-trait-with-const-arguments.full.stderr
+++ b/src/test/ui/const-generics/impl-trait-with-const-arguments.full.stderr
@@ -6,3 +6,4 @@ LL |     assert_eq!(f::<4usize>(Usizable), 20usize);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/const-generics/impl-trait-with-const-arguments.min.stderr
+++ b/src/test/ui/const-generics/impl-trait-with-const-arguments.min.stderr
@@ -6,3 +6,4 @@ LL |     assert_eq!(f::<4usize>(Usizable), 20usize);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -6,3 +6,4 @@ LL |     foo::<String>('a');
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
@@ -8,3 +8,4 @@ LL |     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/synthetic-param.stderr
+++ b/src/test/ui/synthetic-param.stderr
@@ -18,3 +18,4 @@ LL |     Bar::<i8>::func::<u8>(42);
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0632`.


### PR DESCRIPTION
Edit: After https://github.com/rust-lang/rust/pull/85520#issuecomment-870095546, this PR has been boiled down to just an extended description for `E0632` and a fixed typo.