### PR TITLE
Make some `TryV1` and `TryV2` impls `#[inline(always)]`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1658,7 +1658,7 @@ impl<T> ops::TryV1 for Option<T> {
         Some(v)
     }
 
-    #[inline)]
+    #[inline]
     fn from_error(_: NoneError) -> Self {
         None
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1648,17 +1648,17 @@ impl<T> ops::TryV1 for Option<T> {
     type Output = T;
     type Error = NoneError;
 
-    #[inline(always)]
+    #[inline]
     fn into_result(self) -> Result<T, NoneError> {
         self.ok_or(NoneError)
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_ok(v: T) -> Self {
         Some(v)
     }
 
-    #[inline(always)]
+    #[inline)]
     fn from_error(_: NoneError) -> Self {
         None
     }
@@ -1669,7 +1669,7 @@ impl<T> ops::TryV2 for Option<T> {
     type Output = T;
     type Residual = Option<convert::Infallible>;
 
-    #[inline(always)]
+    #[inline]
     fn from_output(output: Self::Output) -> Self {
         Some(output)
     }
@@ -1685,7 +1685,7 @@ impl<T> ops::TryV2 for Option<T> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T> ops::FromResidual for Option<T> {
-    #[inline(always)]
+    #[inline]
     fn from_residual(residual: Option<convert::Infallible>) -> Self {
         match residual {
             None => None,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1648,17 +1648,17 @@ impl<T> ops::TryV1 for Option<T> {
     type Output = T;
     type Error = NoneError;
 
-    #[inline]
+    #[inline(always)]
     fn into_result(self) -> Result<T, NoneError> {
         self.ok_or(NoneError)
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_ok(v: T) -> Self {
         Some(v)
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_error(_: NoneError) -> Self {
         None
     }
@@ -1669,12 +1669,12 @@ impl<T> ops::TryV2 for Option<T> {
     type Output = T;
     type Residual = Option<convert::Infallible>;
 
-    #[inline]
+    #[inline(always)]
     fn from_output(output: Self::Output) -> Self {
         Some(output)
     }
 
-    #[inline]
+    #[inline(always)]
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self {
             Some(v) => ControlFlow::Continue(v),
@@ -1685,7 +1685,7 @@ impl<T> ops::TryV2 for Option<T> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T> ops::FromResidual for Option<T> {
-    #[inline]
+    #[inline(always)]
     fn from_residual(residual: Option<convert::Infallible>) -> Self {
         match residual {
             None => None,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1631,17 +1631,17 @@ impl<T, E> ops::TryV1 for Result<T, E> {
     type Output = T;
     type Error = E;
 
-    #[inline]
+    #[inline(always)]
     fn into_result(self) -> Self {
         self
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_ok(v: T) -> Self {
         Ok(v)
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_error(v: E) -> Self {
         Err(v)
     }
@@ -1652,12 +1652,12 @@ impl<T, E> ops::TryV2 for Result<T, E> {
     type Output = T;
     type Residual = Result<convert::Infallible, E>;
 
-    #[inline]
+    #[inline(always)]
     fn from_output(output: Self::Output) -> Self {
         Ok(output)
     }
 
-    #[inline]
+    #[inline(always)]
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self {
             Ok(v) => ControlFlow::Continue(v),
@@ -1668,7 +1668,7 @@ impl<T, E> ops::TryV2 for Result<T, E> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
-    #[inline]
+    #[inline(always)]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {
             Err(e) => Err(From::from(e)),

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1668,7 +1668,7 @@ impl<T, E> ops::TryV2 for Result<T, E> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
-    #[inline(always)]
+    #[inline]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {
             Err(e) => Err(From::from(e)),

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1631,17 +1631,17 @@ impl<T, E> ops::TryV1 for Result<T, E> {
     type Output = T;
     type Error = E;
 
-    #[inline(always)]
+    #[inline]
     fn into_result(self) -> Self {
         self
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_ok(v: T) -> Self {
         Ok(v)
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_error(v: E) -> Self {
         Err(v)
     }
@@ -1652,7 +1652,7 @@ impl<T, E> ops::TryV2 for Result<T, E> {
     type Output = T;
     type Residual = Result<convert::Infallible, E>;
 
-    #[inline(always)]
+    #[inline]
     fn from_output(output: Self::Output) -> Self {
         Ok(output)
     }


### PR DESCRIPTION
See the discussion [on Zulip][z].

[z]: https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/Suggestions.20for.20a.20beginner/near/237879817

r? @scottmcm
