### PR TITLE
facepalm: operator precedence fail on my part.

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -305,7 +305,7 @@ fn format_rusage_data(_child: Child) -> Option<String> {
     };
     // Mac OS X reports the maxrss in bytes, not kb.
     let divisor = if env::consts::OS == "macos" { 1024 } else { 1 };
-    let maxrss = rusage.ru_maxrss + (divisor - 1) / divisor;
+    let maxrss = (rusage.ru_maxrss + (divisor - 1)) / divisor;
 
     let mut init_str = format!(
         "user: {USER_SEC}.{USER_USEC:03} \


### PR DESCRIPTION
This bug was only visible on mac. Also, print_step_rusage is a relatively new
internal feature, that is not heavily used, and has no tests. All of these
factors contributed to how this went uncaught this long. Thanks to Josh Triplett
for pointing it out!