### PR TITLE
native lib: defer the duplicate check after relevant_lib check.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1805,13 +1805,14 @@ fn add_local_native_libraries(
     let search_path = archive_search_paths(sess);
     let mut last = (NativeLibKind::Unspecified, None);
     for lib in relevant_libs {
-        // Skip if this library is the same as the last.
-        last = if (lib.kind, lib.name) == last { continue } else { (lib.kind, lib.name) };
-
         let name = match lib.name {
             Some(l) => l,
             None => continue,
         };
+
+        // Skip if this library is the same as the last.
+        last = if (lib.kind, lib.name) == last { continue } else { (lib.kind, lib.name) };
+
         let verbatim = lib.verbatim.unwrap_or(false);
         match lib.kind {
             NativeLibKind::Dylib { as_needed } => {
@@ -2144,9 +2145,6 @@ fn add_upstream_native_libraries(
     let mut last = (NativeLibKind::Unspecified, None);
     for &(cnum, _) in crates {
         for lib in codegen_results.crate_info.native_libraries[&cnum].iter() {
-            // Skip if this library is the same as the last.
-            last = if (lib.kind, lib.name) == last { continue } else { (lib.kind, lib.name) };
-
             let name = match lib.name {
                 Some(l) => l,
                 None => continue,
@@ -2154,6 +2152,10 @@ fn add_upstream_native_libraries(
             if !relevant_lib(sess, &lib) {
                 continue;
             }
+
+            // Skip if this library is the same as the last.
+            last = if (lib.kind, lib.name) == last { continue } else { (lib.kind, lib.name) };
+
             let verbatim = lib.verbatim.unwrap_or(false);
             match lib.kind {
                 NativeLibKind::Dylib { as_needed } => {

--- a/src/test/run-make-fulldeps/link-dedup/Makefile
+++ b/src/test/run-make-fulldeps/link-dedup/Makefile
@@ -1,0 +1,12 @@
+# ignore-msvc
+
+-include ../tools.mk
+
+all:
+	$(RUSTC) depa.rs
+	$(RUSTC) depb.rs
+	$(RUSTC) depc.rs
+	$(RUSTC) empty.rs --cfg bar 2>&1 | $(CGREP) '"-ltesta" "-ltestb" "-ltesta"'
+	$(RUSTC) empty.rs 2>&1 | $(CGREP) '"-ltesta"'
+	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltestb"'
+	$(RUSTC) empty.rs 2>&1 | $(CGREP) -v '"-ltesta" "-ltesta"'

--- a/src/test/run-make-fulldeps/link-dedup/depa.rs
+++ b/src/test/run-make-fulldeps/link-dedup/depa.rs
@@ -1,0 +1,7 @@
+#![crate_type = "rlib"]
+
+#[link(name = "testa")]
+extern "C" {}
+
+#[link(name = "testa")]
+extern "C" {}

--- a/src/test/run-make-fulldeps/link-dedup/depb.rs
+++ b/src/test/run-make-fulldeps/link-dedup/depb.rs
@@ -1,0 +1,8 @@
+#![feature(link_cfg)]
+#![crate_type = "rlib"]
+
+#[link(name = "testb", cfg(foo))]
+extern "C" {}
+
+#[link(name = "testb", cfg(bar))]
+extern "C" {}

--- a/src/test/run-make-fulldeps/link-dedup/depc.rs
+++ b/src/test/run-make-fulldeps/link-dedup/depc.rs
@@ -1,0 +1,4 @@
+#![crate_type = "rlib"]
+
+#[link(name = "testa")]
+extern "C" {}

--- a/src/test/run-make-fulldeps/link-dedup/empty.rs
+++ b/src/test/run-make-fulldeps/link-dedup/empty.rs
@@ -1,0 +1,5 @@
+extern crate depa;
+extern crate depb;
+extern crate depc;
+
+fn main() {}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/84794 break code using conditional-compilation with `#[link]` attributes.

```rust
#[cfg(target_env = "musl")]
cfg_if::cfg_if! {
    if #[cfg(any(target_feature = "crt-static", feature = "llvm-libunwind"))] {
        #[link(name = "unwind", kind = "static", modifiers = "-bundle")]
        extern "C" {}
    } else {
        #[link(name = "unwind", cfg(feature = "system-llvm-libunwind"))]
        #[link(name = "gcc_s", cfg(not(feature = "system-llvm-libunwind")))]
        extern "C" {}
    }
}

```