### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -153,6 +153,11 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             ExprKind::InlineAsm { .. } | ExprKind::LlvmInlineAsm { .. } => {
                 self.requires_unsafe(expr.span, UseOfInlineAssembly);
             }
+            ExprKind::Deref { arg } => {
+                if self.thir[arg].ty.is_unsafe_ptr() {
+                    self.requires_unsafe(expr.span, DerefOfRawPointer);
+                }
+            }
             _ => {}
         }
 
@@ -203,7 +208,6 @@ enum UnsafeOpKind {
     UseOfMutableStatic,
     #[allow(dead_code)] // FIXME
     UseOfExternStatic,
-    #[allow(dead_code)] // FIXME
     DerefOfRawPointer,
     #[allow(dead_code)] // FIXME
     AssignToDroppingUnionField,

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -169,13 +169,19 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                     }
                 }
             }
-            ExprKind::InlineAsm { .. } | ExprKind::LlvmInlineAsm { .. } => {
-                self.requires_unsafe(expr.span, UseOfInlineAssembly);
-            }
             ExprKind::Deref { arg } => {
-                if self.thir[arg].ty.is_unsafe_ptr() {
+                if let ExprKind::StaticRef { def_id, .. } = self.thir[arg].kind {
+                    if self.tcx.is_mutable_static(def_id) {
+                        self.requires_unsafe(expr.span, UseOfMutableStatic);
+                    } else if self.tcx.is_foreign_item(def_id) {
+                        self.requires_unsafe(expr.span, UseOfExternStatic);
+                    }
+                } else if self.thir[arg].ty.is_unsafe_ptr() {
                     self.requires_unsafe(expr.span, DerefOfRawPointer);
                 }
+            }
+            ExprKind::InlineAsm { .. } | ExprKind::LlvmInlineAsm { .. } => {
+                self.requires_unsafe(expr.span, UseOfInlineAssembly);
             }
             ExprKind::Adt {
                 adt_def,
@@ -242,9 +248,7 @@ enum UnsafeOpKind {
     UseOfInlineAssembly,
     InitializingTypeWith,
     CastOfPointerToInt,
-    #[allow(dead_code)] // FIXME
     UseOfMutableStatic,
-    #[allow(dead_code)] // FIXME
     UseOfExternStatic,
     DerefOfRawPointer,
     #[allow(dead_code)] // FIXME

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -25,6 +25,7 @@ struct UnsafetyVisitor<'a, 'tcx> {
     /// The `#[target_feature]` attributes of the body. Used for checking
     /// calls to functions with `#[target_feature]` (RFC 2396).
     body_target_features: &'tcx Vec<Symbol>,
+    is_const: bool,
 }
 
 impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
@@ -187,6 +188,16 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 (Bound::Unbounded, Bound::Unbounded) => {}
                 _ => self.requires_unsafe(expr.span, InitializingTypeWith),
             },
+            ExprKind::Cast { source } => {
+                let source = &self.thir[source];
+                if self.tcx.features().const_raw_ptr_to_usize_cast
+                    && self.is_const
+                    && (source.ty.is_unsafe_ptr() || source.ty.is_fn_ptr())
+                    && expr.ty.is_integral()
+                {
+                    self.requires_unsafe(expr.span, CastOfPointerToInt);
+                }
+            }
             _ => {}
         }
 
@@ -230,7 +241,6 @@ enum UnsafeOpKind {
     CallToUnsafeFunction,
     UseOfInlineAssembly,
     InitializingTypeWith,
-    #[allow(dead_code)] // FIXME
     CastOfPointerToInt,
     #[allow(dead_code)] // FIXME
     UseOfMutableStatic,
@@ -331,6 +341,11 @@ pub fn check_unsafety<'tcx>(
     let body_target_features = &tcx.codegen_fn_attrs(def_id).target_features;
     let safety_context =
         if body_unsafety.is_unsafe() { SafetyContext::UnsafeFn } else { SafetyContext::Safe };
+    let is_const = match tcx.hir().body_owner_kind(hir_id) {
+        hir::BodyOwnerKind::Closure => false,
+        hir::BodyOwnerKind::Fn => tcx.is_const_fn_raw(def_id.to_def_id()),
+        hir::BodyOwnerKind::Const | hir::BodyOwnerKind::Static(_) => true,
+    };
     let mut visitor = UnsafetyVisitor {
         tcx,
         thir,
@@ -338,6 +353,7 @@ pub fn check_unsafety<'tcx>(
         hir_context: hir_id,
         body_unsafety,
         body_target_features,
+        is_const,
     };
     visitor.visit_expr(&thir[expr]);
 }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -305,7 +305,7 @@ fn format_rusage_data(_child: Child) -> Option<String> {
     };
     // Mac OS X reports the maxrss in bytes, not kb.
     let divisor = if env::consts::OS == "macos" { 1024 } else { 1 };
-    let maxrss = rusage.ru_maxrss + (divisor - 1) / divisor;
+    let maxrss = (rusage.ru_maxrss + (divisor - 1)) / divisor;
 
     let mut init_str = format!(
         "user: {USER_SEC}.{USER_USEC:03} \

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -764,138 +764,6 @@ function hideThemeButtonState() {
         innerToggle.children[0].innerText = labelForToggleButton(sectionIsCollapsed);
     }
 
-    function collapseDocs(toggle, mode) {
-        if (!toggle || !toggle.parentNode) {
-            return;
-        }
-
-        function adjustToggle(arg) {
-            return function(e) {
-                if (hasClass(e, "toggle-label")) {
-                    if (arg) {
-                        e.style.display = "inline-block";
-                    } else {
-                        e.style.display = "none";
-                    }
-                }
-                if (hasClass(e, "inner")) {
-                    e.innerHTML = labelForToggleButton(arg);
-                }
-            };
-        }
-
-        function implHider(addOrRemove, fullHide) {
-            return function(n) {
-                var shouldHide =
-                    fullHide ||
-                    hasClass(n, "method") ||
-                    hasClass(n, "associatedconstant");
-                if (shouldHide || hasClass(n, "type")) {
-                    if (shouldHide) {
-                        if (addOrRemove) {
-                            addClass(n, "hidden-by-impl-hider");
-                        } else {
-                            removeClass(n, "hidden-by-impl-hider");
-                        }
-                    }
-                    var ns = n.nextElementSibling;
-                    while (ns && (hasClass(ns, "docblock") || hasClass(ns, "item-info"))) {
-                        if (addOrRemove) {
-                            addClass(ns, "hidden-by-impl-hider");
-                        } else {
-                            removeClass(ns, "hidden-by-impl-hider");
-                        }
-                        ns = ns.nextElementSibling;
-                    }
-                }
-            };
-        }
-
-        var relatedDoc;
-        var action = mode;
-        if (!hasClass(toggle.parentNode, "impl")) {
-            relatedDoc = toggle.parentNode.nextElementSibling;
-            if (hasClass(relatedDoc, "item-info")) {
-                relatedDoc = relatedDoc.nextElementSibling;
-            }
-            if (hasClass(relatedDoc, "docblock")) {
-                if (mode === "toggle") {
-                    if (hasClass(relatedDoc, "hidden-by-usual-hider")) {
-                        action = "show";
-                    } else {
-                        action = "hide";
-                    }
-                }
-                if (action === "hide") {
-                    addClass(relatedDoc, "hidden-by-usual-hider");
-                    onEachLazy(toggle.childNodes, adjustToggle(true));
-                    addClass(toggle.parentNode, "collapsed");
-                } else if (action === "show") {
-                    removeClass(relatedDoc, "hidden-by-usual-hider");
-                    removeClass(toggle.parentNode, "collapsed");
-                    onEachLazy(toggle.childNodes, adjustToggle(false));
-                }
-            }
-        } else {
-            // we are collapsing the impl block(s).
-
-            var parentElem = toggle.parentNode;
-            relatedDoc = parentElem;
-            var docblock = relatedDoc.nextElementSibling;
-
-            while (!hasClass(relatedDoc, "impl-items")) {
-                relatedDoc = relatedDoc.nextElementSibling;
-            }
-
-            if (!relatedDoc && !hasClass(docblock, "docblock")) {
-                return;
-            }
-
-            // Hide all functions, but not associated types/consts.
-
-            if (mode === "toggle") {
-                if (hasClass(relatedDoc, "fns-now-collapsed") ||
-                    hasClass(docblock, "hidden-by-impl-hider")) {
-                    action = "show";
-                } else {
-                    action = "hide";
-                }
-            }
-
-            var dontApplyBlockRule = toggle.parentNode.parentNode.id !== "main";
-            if (action === "show") {
-                removeClass(relatedDoc, "fns-now-collapsed");
-                // Stability/deprecation/portability information is never hidden.
-                if (!hasClass(docblock, "item-info")) {
-                    removeClass(docblock, "hidden-by-usual-hider");
-                }
-                onEachLazy(toggle.childNodes, adjustToggle(false, dontApplyBlockRule));
-                onEachLazy(relatedDoc.childNodes, implHider(false, dontApplyBlockRule));
-            } else if (action === "hide") {
-                addClass(relatedDoc, "fns-now-collapsed");
-                // Stability/deprecation/portability information should be shown even when detailed
-                // info is hidden.
-                if (!hasClass(docblock, "item-info")) {
-                    addClass(docblock, "hidden-by-usual-hider");
-                }
-                onEachLazy(toggle.childNodes, adjustToggle(true, dontApplyBlockRule));
-                onEachLazy(relatedDoc.childNodes, implHider(true, dontApplyBlockRule));
-            }
-        }
-    }
-
-    function collapseNonInherent(e) {
-        // inherent impl ids are like "impl" or impl-<number>'.
-        // they will never be hidden by default.
-        var n = e.parentElement;
-        if (n.id.match(/^impl(?:-\d+)?$/) === null) {
-            // Automatically minimize all non-inherent impls
-            if (hasClass(n, "impl")) {
-                collapseDocs(e, "hide");
-            }
-        }
-    }
-
     function insertAfter(newNode, referenceNode) {
         referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
     }
@@ -910,20 +778,6 @@ function hideThemeButtonState() {
         var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
-        var impl_list = document.getElementById("trait-implementations-list");
-        if (impl_list !== null) {
-            onEachLazy(impl_list.getElementsByClassName("rustdoc-toggle"), function(e) {
-                collapseNonInherent(e);
-            });
-        }
-
-        var blanket_list = document.getElementById("blanket-implementations-list");
-        if (blanket_list !== null) {
-            onEachLazy(blanket_list.getElementsByClassName("rustdoc-toggle"), function(e) {
-                collapseNonInherent(e);
-            });
-        }
-
         onEachLazy(document.getElementsByTagName("details"), function (e) {
             var showLargeItem = !hideLargeItemContents && hasClass(e, "type-contents-toggle");
             var showImplementor = !hideImplementors && hasClass(e, "implementors-toggle");
@@ -935,18 +789,6 @@ function hideThemeButtonState() {
             }
 
         });
-
-        var currentType = document.getElementsByClassName("type-decl")[0];
-        if (currentType) {
-            currentType = currentType.getElementsByClassName("rust")[0];
-            if (currentType) {
-                onEachLazy(currentType.classList, function(item) {
-                    if (item !== "main") {
-                        return true;
-                    }
-                });
-            }
-        }
 
         var pageId = getPageId();
         if (pageId !== null) {

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -885,12 +885,12 @@ window.initSearch = function(rawSearchIndex) {
         focusSearchResult();
     }
 
-    // focus the first search result on the active tab, or the result that
+    // Focus the first search result on the active tab, or the result that
     // was focused last time this tab was active.
     function focusSearchResult() {
         var target = searchState.focusedByTab[searchState.currentTab] ||
-          document.querySelectorAll(".search-results.active a").item(0) ||
-          document.querySelectorAll("#titles > button").item(searchState.currentTab);
+            document.querySelectorAll(".search-results.active a").item(0) ||
+            document.querySelectorAll("#titles > button").item(searchState.currentTab);
         if (target) {
             target.focus();
         }
@@ -1076,6 +1076,8 @@ window.initSearch = function(rawSearchIndex) {
             ret_others[0] + ret_in_args[0] + ret_returned[0] + "</div>";
 
         search.innerHTML = output;
+        // Reset focused elements.
+        searchState.focusedByTab = [null, null, null];
         searchState.showResults(search);
         var elems = document.getElementById("titles").childNodes;
         elems[0].onclick = function() { printTab(0); };
@@ -1365,7 +1367,6 @@ window.initSearch = function(rawSearchIndex) {
             if (e.which === 38) { // up
                 var previous = document.activeElement.previousElementSibling;
                 if (previous) {
-                    console.log("previousElementSibling", previous);
                     previous.focus();
                 } else {
                     searchState.focus();

--- a/src/test/ui/cast/cast-ptr-to-int-const.mir.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.mir.stderr
@@ -1,0 +1,19 @@
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:10:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:17:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/cast/cast-ptr-to-int-const.rs
+++ b/src/test/ui/cast/cast-ptr-to-int-const.rs
@@ -1,25 +1,19 @@
-// gate-test-const_raw_ptr_to_usize_cast
-// revisions: with_feature without_feature
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
-#![cfg_attr(with_feature, feature(const_raw_ptr_to_usize_cast))]
+#![feature(const_raw_ptr_to_usize_cast)]
 
 fn main() {
-    const X: usize = unsafe {
-        main as usize //[without_feature]~ ERROR casting pointers to integers in constants is unstable
-    };
     const Y: u32 = 0;
-    const Z: usize = unsafe {
-        &Y as *const u32 as usize //[without_feature]~ ERROR is unstable
-    };
     // Cast in `const` without `unsafe` block
     const SAFE: usize = {
-        &Y as *const u32 as usize //[without_feature]~ ERROR is unstable
-        //[with_feature]~^ ERROR cast of pointer to int is unsafe and requires unsafe
+        &Y as *const u32 as usize
+        //~^ ERROR cast of pointer to int is unsafe and requires unsafe
     };
 }
 
 // Cast in `const fn` without `unsafe` block
 const fn test() -> usize {
-    &0 as *const i32 as usize //[without_feature]~ ERROR is unstable
-    //[with_feature]~^ ERROR cast of pointer to int is unsafe and requires unsafe
+    &0 as *const i32 as usize
+    //~^ ERROR cast of pointer to int is unsafe and requires unsafe
 }

--- a/src/test/ui/cast/cast-ptr-to-int-const.thir.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.thir.stderr
@@ -1,0 +1,19 @@
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:10:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error[E0133]: cast of pointer to int is unsafe and requires unsafe function or block
+  --> $DIR/cast-ptr-to-int-const.rs:17:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cast of pointer to int
+   |
+   = note: casting pointers to integers in constants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.rs
+++ b/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.rs
@@ -1,0 +1,13 @@
+fn main() {
+    const X: usize = unsafe {
+        main as usize //~ ERROR casting pointers to integers in constants is unstable
+    };
+    const Y: u32 = 0;
+    const Z: usize = unsafe {
+        &Y as *const u32 as usize //~ ERROR is unstable
+    };
+}
+
+const fn test() -> usize {
+    &0 as *const i32 as usize //~ ERROR is unstable
+}

--- a/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.stderr
+++ b/src/test/ui/cast/feature-gate-const_raw_ptr_to_usize_cast.stderr
@@ -1,0 +1,30 @@
+error[E0658]: casting pointers to integers in constants is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:3:9
+   |
+LL |         main as usize
+   |         ^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error[E0658]: casting pointers to integers in constants is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:7:9
+   |
+LL |         &Y as *const u32 as usize
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error[E0658]: casting pointers to integers in constant functions is unstable
+  --> $DIR/feature-gate-const_raw_ptr_to_usize_cast.rs:12:5
+   |
+LL |     &0 as *const i32 as usize
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.mir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-45729-unsafe-in-generator.rs:5:9
+  --> $DIR/issue-45729-unsafe-in-generator.rs:8:9
    |
 LL |         *(1 as *mut u32) = 42;
    |         ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.rs
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(generators)]
 
 fn main() {

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-45729-unsafe-in-generator.rs:8:9
+   |
+LL |         *(1 as *mut u32) = 42;
+   |         ^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/intrinsics/issue-28575.mir.stderr
+++ b/src/test/ui/intrinsics/issue-28575.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28575.rs:11:5
+   |
+LL |     FOO()
+   |     ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/intrinsics/issue-28575.rs
+++ b/src/test/ui/intrinsics/issue-28575.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(intrinsics)]
 
 extern "C" {

--- a/src/test/ui/intrinsics/issue-28575.thir.stderr
+++ b/src/test/ui/intrinsics/issue-28575.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28575.rs:11:5
+   |
+LL |     FOO()
+   |     ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/issues/issue-14227.mir.stderr
+++ b/src/test/ui/issues/issue-14227.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-28575.rs:8:5
+  --> $DIR/issue-14227.rs:7:21
    |
-LL |     FOO()
-   |     ^^^ use of extern static
+LL | static CRASH: u32 = symbol;
+   |                     ^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-14227.rs
+++ b/src/test/ui/issues/issue-14227.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     pub static symbol: u32;
 }

--- a/src/test/ui/issues/issue-14227.thir.stderr
+++ b/src/test/ui/issues/issue-14227.thir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-28324.rs:5:24
+  --> $DIR/issue-14227.rs:7:21
    |
-LL | pub static BAZ: u32 = *&error_message_count;
-   |                        ^^^^^^^^^^^^^^^^^^^^ use of extern static
+LL | static CRASH: u32 = symbol;
+   |                     ^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,11 +1,11 @@
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-16538.rs:11:27
+  --> $DIR/issue-16538.rs:14:27
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*const usize` cannot be shared between threads safely
-  --> $DIR/issue-16538.rs:11:1
+  --> $DIR/issue-16538.rs:14:1
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
@@ -14,7 +14,7 @@ LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    = note: shared static variables must have a type that implements `Sync`
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:11:34
+  --> $DIR/issue-16538.rs:14:34
    |
 LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
    |                                  ^^^^ use of extern static

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 mod Y {
     pub type X = usize;
     extern "C" {

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -1,0 +1,27 @@
+error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-16538.rs:14:27
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `*const usize` cannot be shared between threads safely
+  --> $DIR/issue-16538.rs:14:1
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `*const usize`
+   = note: shared static variables must have a type that implements `Sync`
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-16538.rs:14:34
+   |
+LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
+   |                                  ^^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0133, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-28324.mir.stderr
+++ b/src/test/ui/issues/issue-28324.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-14227.rs:4:21
+  --> $DIR/issue-28324.rs:8:24
    |
-LL | static CRASH: u32 = symbol;
-   |                     ^^^^^^ use of extern static
+LL | pub static BAZ: u32 = *&error_message_count;
+   |                        ^^^^^^^^^^^^^^^^^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 

--- a/src/test/ui/issues/issue-28324.rs
+++ b/src/test/ui/issues/issue-28324.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     static error_message_count: u32;
 }

--- a/src/test/ui/issues/issue-28324.thir.stderr
+++ b/src/test/ui/issues/issue-28324.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-28324.rs:8:25
+   |
+LL | pub static BAZ: u32 = *&error_message_count;
+   |                         ^^^^^^^^^^^^^^^^^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/issues/issue-47412.mir.stderr
+++ b/src/test/ui/issues/issue-47412.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: access to union field is unsafe and requires unsafe function or block
-  --> $DIR/issue-47412.rs:11:11
+  --> $DIR/issue-47412.rs:14:11
    |
 LL |     match u.void {}
    |           ^^^^^^ access to union field
@@ -7,7 +7,7 @@ LL |     match u.void {}
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-47412.rs:17:11
+  --> $DIR/issue-47412.rs:21:11
    |
 LL |     match *ptr {}
    |           ^^^^ dereference of raw pointer

--- a/src/test/ui/issues/issue-47412.rs
+++ b/src/test/ui/issues/issue-47412.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #[derive(Copy, Clone)]
 enum Void {}
 
@@ -9,7 +12,8 @@ fn union_field() {
     union Union { unit: (), void: Void }
     let u = Union { unit: () };
     match u.void {}
-    //~^ ERROR access to union field is unsafe
+    //[mir]~^ ERROR access to union field is unsafe
+    // FIXME(thir-unsafeck): AccessToUnionField unimplemented
 }
 
 fn raw_ptr_deref() {

--- a/src/test/ui/issues/issue-47412.thir.stderr
+++ b/src/test/ui/issues/issue-47412.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-47412.rs:21:11
+   |
+LL |     match *ptr {}
+   |           ^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/check-pass.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/check-pass.rs
@@ -8,6 +8,8 @@
 
 // check-pass
 // only-x86_64
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 #![feature(target_feature_11)]
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/closures-inherit-target_feature.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/closures-inherit-target_feature.rs
@@ -1,6 +1,8 @@
 // Tests #73631: closures inherit `#[target_feature]` annotations
 
 // check-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/fn-ptr.rs:9:21
+  --> $DIR/fn-ptr.rs:11:21
    |
 LL | #[target_feature(enable = "sse2")]
    | ---------------------------------- `#[target_feature]` added here

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.rs
@@ -1,3 +1,5 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-ptr.rs:11:21
+   |
+LL | #[target_feature(enable = "sse2")]
+   | ---------------------------------- `#[target_feature]` added here
+...
+LL |     let foo: fn() = foo;
+   |              ----   ^^^ cannot coerce functions with `#[target_feature]` to safe function pointers
+   |              |
+   |              expected due to this
+   |
+   = note: expected fn pointer `fn()`
+                 found fn item `fn() {foo}`
+   = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
@@ -1,69 +1,69 @@
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:21:5
-   |
-LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:22:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:23:5
    |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:28:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:29:5
-   |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:34:5
-   |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:35:5
+  --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:25:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:30:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:31:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:37:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:38:5
+   |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:42:5
+  --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -71,7 +71,7 @@ LL |     sse2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:45:18
+  --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
    |                  ^^^^^^ call to function with `#[target_feature]`

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -1,3 +1,5 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
@@ -1,0 +1,83 @@
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:23:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:24:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:25:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:30:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:31:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:36:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:37:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:38:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:44:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:47:18
+   |
+LL | const name: () = sse2();
+   |                  ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics-mut.mir.stderr
+++ b/src/test/ui/safe-extern-statics-mut.mir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:13:13
+   |
+LL |     let b = B;
+   |             ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:14:14
+   |
+LL |     let rb = &B;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:15:14
+   |
+LL |     let xb = XB;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:16:15
+   |
+LL |     let xrb = &XB;
+   |               ^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics-mut.rs
+++ b/src/test/ui/safe-extern-statics-mut.rs
@@ -1,4 +1,6 @@
 // aux-build:extern-statics.rs
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 extern crate extern_statics;
 use extern_statics::*;

--- a/src/test/ui/safe-extern-statics-mut.thir.stderr
+++ b/src/test/ui/safe-extern-statics-mut.thir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:13:13
+   |
+LL |     let b = B;
+   |             ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:14:15
+   |
+LL |     let rb = &B;
+   |               ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:15:14
+   |
+LL |     let xb = XB;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics-mut.rs:16:16
+   |
+LL |     let xrb = &XB;
+   |                ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/safe-extern-statics.mir.stderr
+++ b/src/test/ui/safe-extern-statics.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:11:13
+  --> $DIR/safe-extern-statics.rs:13:13
    |
 LL |     let a = A;
    |             ^ use of extern static
@@ -7,7 +7,7 @@ LL |     let a = A;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:12:14
+  --> $DIR/safe-extern-statics.rs:14:14
    |
 LL |     let ra = &A;
    |              ^^ use of extern static
@@ -15,7 +15,7 @@ LL |     let ra = &A;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:13:14
+  --> $DIR/safe-extern-statics.rs:15:14
    |
 LL |     let xa = XA;
    |              ^^ use of extern static
@@ -23,7 +23,7 @@ LL |     let xa = XA;
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics.rs:14:15
+  --> $DIR/safe-extern-statics.rs:16:15
    |
 LL |     let xra = &XA;
    |               ^^^ use of extern static

--- a/src/test/ui/safe-extern-statics.rs
+++ b/src/test/ui/safe-extern-statics.rs
@@ -1,4 +1,6 @@
 // aux-build:extern-statics.rs
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 extern crate extern_statics;
 use extern_statics::*;

--- a/src/test/ui/safe-extern-statics.thir.stderr
+++ b/src/test/ui/safe-extern-statics.thir.stderr
@@ -1,0 +1,35 @@
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:13:13
+   |
+LL |     let a = A;
+   |             ^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:14:15
+   |
+LL |     let ra = &A;
+   |               ^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:15:14
+   |
+LL |     let xa = XA;
+   |              ^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/safe-extern-statics.rs:16:16
+   |
+LL |     let xra = &XA;
+   |                ^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.mir.stderr
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.mir.stderr
@@ -1,0 +1,27 @@
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:9:5
+   |
+LL |     a += 3;
+   |     ^^^^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:10:5
+   |
+LL |     a = 4;
+   |     ^^^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:11:14
+   |
+LL |     let _b = a;
+   |              ^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 extern "C" {
     static mut a: i32;
 }

--- a/src/test/ui/static/static-mut-foreign-requires-unsafe.thir.stderr
+++ b/src/test/ui/static/static-mut-foreign-requires-unsafe.thir.stderr
@@ -1,21 +1,21 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:6:5
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:9:5
    |
 LL |     a += 3;
-   |     ^^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:7:5
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:10:5
    |
 LL |     a = 4;
-   |     ^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-foreign-requires-unsafe.rs:8:14
+  --> $DIR/static-mut-foreign-requires-unsafe.rs:11:14
    |
 LL |     let _b = a;
    |              ^ use of mutable static

--- a/src/test/ui/static/static-mut-requires-unsafe.mir.stderr
+++ b/src/test/ui/static/static-mut-requires-unsafe.mir.stderr
@@ -1,35 +1,27 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:11:13
+  --> $DIR/static-mut-requires-unsafe.rs:7:5
    |
-LL |     let b = B;
-   |             ^ use of mutable static
-   |
-   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
-
-error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:12:14
-   |
-LL |     let rb = &B;
-   |              ^^ use of mutable static
+LL |     a += 3;
+   |     ^^^^^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:13:14
+  --> $DIR/static-mut-requires-unsafe.rs:8:5
    |
-LL |     let xb = XB;
-   |              ^^ use of mutable static
+LL |     a = 4;
+   |     ^^^^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:14:15
+  --> $DIR/static-mut-requires-unsafe.rs:9:14
    |
-LL |     let xrb = &XB;
-   |               ^^^ use of mutable static
+LL |     let _b = a;
+   |              ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/static/static-mut-requires-unsafe.rs
+++ b/src/test/ui/static/static-mut-requires-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 static mut a: isize = 3;
 
 fn main() {

--- a/src/test/ui/static/static-mut-requires-unsafe.thir.stderr
+++ b/src/test/ui/static/static-mut-requires-unsafe.thir.stderr
@@ -1,21 +1,21 @@
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:4:5
+  --> $DIR/static-mut-requires-unsafe.rs:7:5
    |
 LL |     a += 3;
-   |     ^^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:5:5
+  --> $DIR/static-mut-requires-unsafe.rs:8:5
    |
 LL |     a = 4;
-   |     ^^^^^ use of mutable static
+   |     ^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/static-mut-requires-unsafe.rs:6:14
+  --> $DIR/static-mut-requires-unsafe.rs:9:14
    |
 LL |     let _b = a;
    |              ^ use of mutable static

--- a/src/test/ui/traits/safety-fn-body.mir.stderr
+++ b/src/test/ui/traits/safety-fn-body.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/safety-fn-body.rs:14:9
+   |
+LL |         *self += 1;
+   |         ^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/traits/safety-fn-body.rs
+++ b/src/test/ui/traits/safety-fn-body.rs
@@ -1,6 +1,9 @@
 // Check that an unsafe impl does not imply that unsafe actions are
 // legal in the methods.
 
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 unsafe trait UnsafeTrait : Sized {
     fn foo(self) { }
 }

--- a/src/test/ui/traits/safety-fn-body.thir.stderr
+++ b/src/test/ui/traits/safety-fn-body.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/safety-fn-body.rs:14:9
+   |
+LL |         *self += 1;
+   |         ^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.mir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/safety-fn-body.rs:11:9
+  --> $DIR/issue-45087-unreachable-unsafe.rs:6:5
    |
-LL |         *self += 1;
-   |         ^^^^^^^^^^ dereference of raw pointer
+LL |     *(1 as *mut u32) = 42;
+   |     ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.rs
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn main() {
     return;
     *(1 as *mut u32) = 42;

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-45087-unreachable-unsafe.rs:6:5
+   |
+LL |     *(1 as *mut u32) = 42;
+   |     ^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/ranged_ints.mir.stderr
+++ b/src/test/ui/unsafe/ranged_ints.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
+  --> $DIR/ranged_ints.rs:10:14
+   |
+LL |     let _x = NonZero(0);
+   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+   |
+   = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/ranged_ints.rs
+++ b/src/test/ui/unsafe/ranged_ints.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 #[rustc_layout_scalar_valid_range_start(1)]

--- a/src/test/ui/unsafe/ranged_ints.thir.stderr
+++ b/src/test/ui/unsafe/ranged_ints.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
+  --> $DIR/ranged_ints.rs:10:14
+   |
+LL |     let _x = NonZero(0);
+   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+   |
+   = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/ranged_ints_const.mir.stderr
+++ b/src/test/ui/unsafe/ranged_ints_const.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
-  --> $DIR/ranged_ints.rs:7:14
+  --> $DIR/ranged_ints_const.rs:11:34
    |
-LL |     let _x = NonZero(0);
-   |              ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
+LL | const fn foo() -> NonZero<u32> { NonZero(0) }
+   |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr
    |
    = note: initializing a layout restricted type's field with a value outside the valid range is undefined behavior
 

--- a/src/test/ui/unsafe/ranged_ints_const.rs
+++ b/src/test/ui/unsafe/ranged_ints_const.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 #[rustc_layout_scalar_valid_range_start(1)]

--- a/src/test/ui/unsafe/ranged_ints_const.thir.stderr
+++ b/src/test/ui/unsafe/ranged_ints_const.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe function or block
-  --> $DIR/ranged_ints_const.rs:8:34
+  --> $DIR/ranged_ints_const.rs:11:34
    |
 LL | const fn foo() -> NonZero<u32> { NonZero(0) }
    |                                  ^^^^^^^^^^ initializing type with `rustc_layout_scalar_valid_range` attr

--- a/src/test/ui/unsafe/ranged_ints_macro.rs
+++ b/src/test/ui/unsafe/ranged_ints_macro.rs
@@ -1,4 +1,7 @@
 // build-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(rustc_attrs)]
 
 macro_rules! apply {

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-assign-deref-ptr.rs:5:5
+   |
+LL |     *p = 0;
+   |     ^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.rs
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn f(p: *mut u8) {
     *p = 0; //~ ERROR dereference of raw pointer is unsafe
     return;

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
@@ -1,10 +1,10 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-unstable-const-fn.rs:8:5
+  --> $DIR/unsafe-fn-assign-deref-ptr.rs:5:5
    |
-LL |     *a == b
+LL |     *p = 0;
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-fn-assign-deref-ptr.rs:2:5
+  --> $DIR/unsafe-fn-deref-ptr.rs:5:12
    |
-LL |     *p = 0;
-   |     ^^^^^^ dereference of raw pointer
+LL |     return *p;
+   |            ^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.rs
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn f(p: *const u8) -> u8 {
     return *p; //~ ERROR dereference of raw pointer is unsafe
 }

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
@@ -1,10 +1,10 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-fn-deref-ptr.rs:2:12
+  --> $DIR/unsafe-fn-deref-ptr.rs:5:12
    |
 LL |     return *p;
    |            ^^ dereference of raw pointer
    |
-   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-45087-unreachable-unsafe.rs:3:5
+  --> $DIR/unsafe-unstable-const-fn.rs:11:5
    |
-LL |     *(1 as *mut u32) = 42;
-   |     ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
+LL |     *a == b
+   |     ^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![stable(feature = "foo", since = "1.33.0")]
 #![feature(staged_api)]
 #![feature(const_raw_ptr_deref)]

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-unstable-const-fn.rs:11:5
+   |
+LL |     *a == b
+   |     ^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 1370;
-const ISSUES_ENTRY_LIMIT: usize = 2555;
+const ROOT_ENTRY_LIMIT: usize = 1371;
+const ISSUES_ENTRY_LIMIT: usize = 2558;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
Successful merges:

 - #85506 (Reset "focusedByTab" field when doing another search)
 - #85548 (Remove dead toggle JS code)
 - #85550 (facepalm: operator precedence fail on my part.)
 - #85555 (Check for more things in THIR unsafeck)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85506,85548,85550,85555)
<!-- homu-ignore:end -->