### PR TITLE
 readd capture disjoint fields gate

### DIFF
--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -185,21 +185,26 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 //     match x { _ => () } // fake read of `x`
                 // };
                 // ```
-                for (thir_place, cause, hir_id) in fake_reads.into_iter() {
-                    let place_builder =
-                        unpack!(block = this.as_place_builder(block, &this.thir[*thir_place]));
+                //
+                // FIXME(RFC2229, rust#85435): Remove feature gate once diagnostics are
+                // improved and unsafe checking works properly in closure bodies again.
+                if this.tcx.features().capture_disjoint_fields {
+                    for (thir_place, cause, hir_id) in fake_reads.into_iter() {
+                        let place_builder =
+                            unpack!(block = this.as_place_builder(block, &this.thir[*thir_place]));
 
-                    if let Ok(place_builder_resolved) =
-                        place_builder.try_upvars_resolved(this.tcx, this.typeck_results)
-                    {
-                        let mir_place =
-                            place_builder_resolved.into_place(this.tcx, this.typeck_results);
-                        this.cfg.push_fake_read(
-                            block,
-                            this.source_info(this.tcx.hir().span(*hir_id)),
-                            *cause,
-                            mir_place,
-                        );
+                        if let Ok(place_builder_resolved) =
+                            place_builder.try_upvars_resolved(this.tcx, this.typeck_results)
+                        {
+                            let mir_place =
+                                place_builder_resolved.into_place(this.tcx, this.typeck_results);
+                            this.cfg.push_fake_read(
+                                block,
+                                this.source_info(this.tcx.hir().span(*hir_id)),
+                                *cause,
+                                mir_place,
+                            );
+                        }
                     }
                 }
 

--- a/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
+++ b/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
@@ -1,4 +1,6 @@
 // check-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 // This is issue #85435. But the real story is reflected in issue #85561, where
 // a bug in the implementation of feature(capture_disjoint_fields) () was

--- a/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
+++ b/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+// This is issue #85435. But the real story is reflected in issue #85561, where
+// a bug in the implementation of feature(capture_disjoint_fields) () was
+// exposed to non-feature-gated code by a diagnostic changing PR that removed
+// the gating in one case.
+
+// This test is double-checking that the case of interest continues to work as
+// expected in the *absence* of that feature gate. At the time of this writing,
+// enabling the feature gate will cause this test to fail. We obviously cannot
+// stabilize that feature until it can correctly handle this test.
+
+fn main() {
+    let val: u8 = 5;
+    let u8_ptr: *const u8 = &val;
+    let _closure = || {
+        unsafe {
+            // Fails compilation with:
+            // error[E0133]: dereference of raw pointer is unsafe and
+            //               requires unsafe function or block
+            let tmp = *u8_ptr;
+            tmp
+
+            // Just dereferencing and returning directly compiles fine:
+            // *u8_ptr
+        }
+    };
+}

--- a/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
+++ b/src/test/ui/unsafe/issue-85435-unsafe-op-in-let-under-unsafe-under-closure.rs
@@ -15,9 +15,6 @@ fn main() {
     let u8_ptr: *const u8 = &val;
     let _closure = || {
         unsafe {
-            // Fails compilation with:
-            // error[E0133]: dereference of raw pointer is unsafe and
-            //               requires unsafe function or block
             let tmp = *u8_ptr;
             tmp
 


### PR DESCRIPTION
This readds a feature gate guard that was added in PR #83521. (Basically, there were unintended consequences to the code exposed by removing the feature gate guard.)

The root bug still remains to be resolved, as discussed in issue #85561. This is just a band-aid suitable for a beta backport.

Cc issue #85435

Note that the latter issue is unfixed until we backport this (or another fix) to 1.53 beta