### PR TITLE
Search result extra info

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -780,12 +780,12 @@ a {
 	float: left;
 }
 
-tr.result span.primitive::after {
+.result-name span.primitive::after {
 	content: ' (primitive type)';
 	font-style: italic;
 }
 
-tr.result span.keyword::after {
+.result-name span.keyword::after {
 	content: ' (keyword)';
 	font-style: italic;
 }

--- a/src/test/rustdoc-gui/search-result-keyword.goml
+++ b/src/test/rustdoc-gui/search-result-keyword.goml
@@ -1,0 +1,11 @@
+goto: file://|DOC_PATH|/test_docs/index.html
+write: (".search-input", "CookieMonster")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+// Note: The two next assert commands could be merged as one but readability would be
+// less good.
+//
+// Checking that the CSS is displaying " (keyword)"...
+assert: (".result-name span.keyword::after", {"content": '" (keyword)"'})
+// ... in italic.
+assert: (".result-name span.keyword::after", {"font-style": "italic"})

--- a/src/test/rustdoc-gui/src/lib.rs
+++ b/src/test/rustdoc-gui/src/lib.rs
@@ -2,6 +2,7 @@
 //! documentation generated so we can test each different features.
 
 #![crate_name = "test_docs"]
+#![feature(doc_keyword)]
 
 use std::fmt;
 
@@ -91,3 +92,6 @@ pub fn check_list_code_block() {}
 pub enum AnEnum {
     WithVariants { and: usize, sub: usize, variants: usize },
 }
+
+#[doc(keyword = "CookieMonster")]
+pub mod keyword {}


### PR DESCRIPTION
The CSS rule was not updated when we updated the search result, this fixes it:

Before:
![Screenshot from 2021-05-21 22-56-17](https://user-images.githubusercontent.com/3050060/119197314-d31a4e80-ba87-11eb-863a-bc0b3de3bfb2.png)

After:
![Screenshot from 2021-05-21 22-54-53](https://user-images.githubusercontent.com/3050060/119197227-b54ce980-ba87-11eb-9f43-c10803ca1b90.png)

r? @jsha