### PR TITLE
Remove surplus prepend LinkedList fn

### DIFF
--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -442,27 +442,6 @@ impl<T> LinkedList<T> {
         }
     }
 
-    /// Moves all elements from `other` to the begin of the list.
-    #[unstable(feature = "linked_list_prepend", issue = "none")]
-    pub fn prepend(&mut self, other: &mut Self) {
-        match self.head {
-            None => mem::swap(self, other),
-            Some(mut head) => {
-                // `as_mut` is okay here because we have exclusive access to the entirety
-                // of both lists.
-                if let Some(mut other_tail) = other.tail.take() {
-                    unsafe {
-                        head.as_mut().prev = Some(other_tail);
-                        other_tail.as_mut().next = Some(head);
-                    }
-
-                    self.head = other.head.take();
-                    self.len += mem::replace(&mut other.len, 0);
-                }
-            }
-        }
-    }
-
     /// Provides a forward iterator.
     ///
     /// # Examples


### PR DESCRIPTION
This nightly library feature provides a function on `LinkedList<T>` that is identical to `fn append` with a reversed order of arguments. Observe this diff against the `fn append` doctest:
```diff
+#![feature(linked_list_prepend)]
 fn main() {
    use std::collections::LinkedList;
    let mut list1 = LinkedList::new();
    list1.push_back('a');
    let mut list2 = LinkedList::new();
    list2.push_back('b');
    list2.push_back('c');

-    list1.append(&mut list2);
+    list2.prepend(&mut list1);

-    let mut iter = list1.iter();
+    let mut iter = list2.iter();
     assert_eq!(iter.next(), Some(&'a'));
     assert_eq!(iter.next(), Some(&'b'));
     assert_eq!(iter.next(), Some(&'c'));
     assert!(iter.next().is_none());

-    assert!(list2.is_empty());
+    assert!(list1.is_empty());
 }
```

As this has received no obvious request to stabilize it, nor does it have a tracking issue, and was left on nightly and the consensus seems to have been to deprecate it in this pre-1.0 PR in 2014, https://github.com/rust-lang/rust/pull/20356, I propose simply removing it.