### PR TITLE
Add `Box::{reuse, set, try_set}`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1021,7 +1021,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     ///
     /// # Errors
     ///
-    /// This function fails if `T` and `U` do not have the same [memory layout](Layout).
+    /// This function fails if `T` and `U` do not have the same [memory layout](Layout). If you
+    /// instead want to create a new `Box` in this case, use [`Box::set`].
     ///
     /// # Examples
     ///
@@ -1080,7 +1081,13 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
         Ok(())
     }
 
-    /// Sets the value inside the box, reusing the existing storage if possible.
+    /// Sets the value inside the box, reusing the existing storage if possible and reallocating if
+    /// not.
+    ///
+    /// If the old and new values stored in the box have the same [memory layout](Layout), then the
+    /// contents of the `Box` will be updated in-place and no memory allocation will occur.
+    /// Otherwise, a new `Box` will be created to replace the old one, causing a memory allocation.
+    /// To instead return an error if this happens, use [`Box::reuse`].
     ///
     /// # Examples
     ///
@@ -1111,8 +1118,13 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
         }
     }
 
-    /// Sets the value inside the box, reusing the existing storage if possible and returning an
-    /// error if the allocation fails.
+    /// Sets the value inside the box, reusing the existing storage if possible and reallocating if
+    /// not, returning an error if reallocation failed.
+    ///
+    /// If the old and new values stored in the box have the same [memory layout](Layout), then the
+    /// contents of the `Box` will be updated in-place and no memory allocation will occur.
+    /// Otherwise, a new `Box` will be created to replace the old one, causing a memory allocation.
+    /// To instead return an error if this happens, use [`Box::reuse`].
     ///
     /// # Examples
     ///

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1100,6 +1100,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// assert_eq!(&*numbers, &[4, 5, 6, 7]);
     /// ```
     #[unstable(feature = "box_reuse", issue = "none")]
+    #[cfg(not(no_global_oom_handling))]
     pub fn set<U>(b: &mut Box<T, A>, val: U)
     where
         U: Unsize<T>,

--- a/library/alloc/tests/boxed.rs
+++ b/library/alloc/tests/boxed.rs
@@ -1,5 +1,8 @@
+use std::alloc::{self, AllocError, Allocator, Layout};
+use std::any::Any;
 use std::cell::Cell;
 use std::mem::MaybeUninit;
+use std::panic;
 use std::ptr::NonNull;
 
 #[test]
@@ -16,6 +19,107 @@ fn unitialized_zero_size_box() {
         Box::<[String]>::new_uninit_slice(0).as_ptr(),
         NonNull::<MaybeUninit<String>>::dangling().as_ptr(),
     );
+}
+
+#[test]
+fn box_reuse_slice() {
+    let mut numbers: Box<[i32]> = Box::new([1, 2, 3]);
+
+    Box::reuse(&mut numbers, [4, 5, 6]).unwrap();
+    assert_eq!(&*numbers, &[4, 5, 6]);
+
+    Box::reuse(&mut numbers, [0, 0]).unwrap_err();
+    assert_eq!(&*numbers, &[4, 5, 6]);
+
+    Box::reuse(&mut numbers, [0, 0, 0, 0]).unwrap_err();
+    assert_eq!(&*numbers, &[4, 5, 6]);
+}
+
+#[test]
+fn box_reuse_dyn() {
+    let mut boxed: Box<dyn ToString> = Box::new(5_usize);
+
+    Box::reuse(&mut boxed, 9_usize).unwrap();
+    assert_eq!(boxed.to_string(), "9");
+
+    Box::reuse(&mut boxed, 6_i32).unwrap_err();
+
+    Box::reuse(&mut boxed, 26_isize).unwrap();
+    assert_eq!(boxed.to_string(), "26");
+}
+
+#[test]
+fn box_reuse_panic_drop() {
+    struct PanicsOnDrop;
+    impl Drop for PanicsOnDrop {
+        fn drop(&mut self) {
+            panic::panic_any(15_i32);
+        }
+    }
+
+    let mut boxed: Box<dyn Any> = Box::new(PanicsOnDrop);
+
+    let payload =
+        panic::catch_unwind(panic::AssertUnwindSafe(|| Box::reuse(&mut boxed, ()))).unwrap_err();
+    assert_eq!(*payload.downcast::<i32>().unwrap(), 15);
+
+    assert!(boxed.downcast_ref::<PanicsOnDrop>().is_none());
+    boxed.downcast_ref::<()>().unwrap();
+
+    assert!(Box::reuse(&mut boxed, PanicsOnDrop).is_ok());
+
+    let payload =
+        panic::catch_unwind(panic::AssertUnwindSafe(|| Box::set(&mut boxed, 2))).unwrap_err();
+    assert_eq!(*payload.downcast::<i32>().unwrap(), 15);
+
+    assert!(boxed.downcast_ref::<PanicsOnDrop>().is_none());
+    assert!(boxed.downcast_ref::<()>().is_none());
+    assert_eq!(*boxed.downcast_ref::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn box_set_allocator() {
+    // `Box::set` does some tricky things to create a new box with the same allocator.
+
+    thread_local! {
+        static ALLOCATIONS: Cell<usize> = Cell::new(0);
+        static DROPPED: Cell<bool> = Cell::new(false);
+    }
+
+    struct Alloc;
+    unsafe impl Allocator for Alloc {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            ALLOCATIONS.with(|allocations| allocations.set(allocations.get() + 1));
+            alloc::Global.allocate(layout)
+        }
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            alloc::Global.deallocate(ptr, layout)
+        }
+    }
+    impl Drop for Alloc {
+        fn drop(&mut self) {
+            let dropped = DROPPED.with(|dropped| dropped.replace(true));
+            assert!(!dropped, "Box::set dropped allocator twice");
+        }
+    }
+
+    ALLOCATIONS.with(|allocations| allocations.set(0));
+    DROPPED.with(|dropped| dropped.set(false));
+
+    let mut boxed: Box<[i32], Alloc> = Box::new_in([1, 2, 3], Alloc);
+    assert_eq!(ALLOCATIONS.with(Cell::get), 1);
+
+    Box::set(&mut boxed, [4, 5, 6]);
+    assert_eq!(ALLOCATIONS.with(Cell::get), 1);
+
+    Box::set(&mut boxed, [1, 2, 3, 4]);
+    assert_eq!(ALLOCATIONS.with(Cell::get), 2);
+
+    Box::set(&mut boxed, []);
+    assert_eq!(ALLOCATIONS.with(Cell::get), 3);
+
+    drop(boxed);
+    assert!(DROPPED.with(Cell::get));
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -1,5 +1,6 @@
 #![feature(allocator_api)]
 #![feature(box_syntax)]
+#![feature(box_reuse)]
 #![feature(cow_is_borrowed)]
 #![feature(const_cow_is_borrowed)]
 #![feature(drain_filter)]


### PR DESCRIPTION
This change allows [`ReusableBoxFuture`](https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.ReusableBoxFuture.html) and similar utilities to be implemented just using a `Box`.

### Naming

I'm uncertain about the naming on this, because the names `Box::{reuse, set, try_set}` could _also_ belong to the following hypothetical methods:

```rust
impl<T: ?Sized, A: Allocator> Box<T, A> {
    pub fn reuse<U>(b: Box<T, A>, val: U) -> Result<Box<U, A>, (Box<T, A>, U)> { ... }
    pub fn set<U>(b: Box<T, A>, val: U) -> Box<U, A> { ... }
    pub fn try_set<U>(b: Box<T, A>, val: U) -> Result<Box<U, A>, AllocError> { ... }
}
```

Maybe something like `{reuse, set, try_set}_unsized` would be better, but I'm unsure.