### PR TITLE
CTFE get_alloc_extra_mut: also provide ref to MemoryExtra

### DIFF
--- a/compiler/rustc_mir/src/interpret/memory.rs
+++ b/compiler/rustc_mir/src/interpret/memory.rs
@@ -673,8 +673,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     pub fn get_alloc_extra_mut<'a>(
         &'a mut self,
         id: AllocId,
-    ) -> InterpResult<'tcx, &'a mut M::AllocExtra> {
-        Ok(&mut self.get_raw_mut(id)?.0.extra)
+    ) -> InterpResult<'tcx, (&'a mut M::AllocExtra, &'a mut M::MemoryExtra)> {
+        let (alloc, memory_extra) = self.get_raw_mut(id)?;
+        Ok((&mut alloc.extra, memory_extra))
     }
 
     /// Obtain the size and alignment of an allocation, even if that allocation has


### PR DESCRIPTION
This would let me use mutable references in more places in Stacked Borrows, avoiding some `RefCell` overhead. :)

r? @oli-obk 