### PR TITLE
Revert 85511 to fix nightly regression(s)

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1522,7 +1522,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let ty = tcx.type_of(impl_def_id);
 
             let impl_ty = self.instantiate_type_scheme(span, &substs, ty);
-            match self.at(&self.misc(span), self.param_env).eq(impl_ty, self_ty) {
+            match self.at(&self.misc(span), self.param_env).sup(impl_ty, self_ty) {
                 Ok(ok) => self.register_infer_ok_obligations(ok),
                 Err(_) => {
                     self.tcx.sess.delay_span_bug(

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.rs
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.rs
@@ -17,6 +17,7 @@ fn main() {
     let fp = BufWriter::new(fp);
     //~^ ERROR the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
     //~| ERROR the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
+    //~| ERROR the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
 
     writeln!(fp, "hello world").unwrap(); //~ ERROR the method
 }

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -11,6 +11,19 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14
    |
 LL |     let fp = BufWriter::new(fp);
+   |              ^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   | 
+  ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
+   |
+LL | pub struct BufWriter<W: Write> {
+   |                         ----- required by this bound in `BufWriter`
+   |
+   = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
+
+error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
+  --> $DIR/mut-borrow-needed-by-trait.rs:17:14
+   |
+LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    | 
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
@@ -21,7 +34,7 @@ LL | pub struct BufWriter<W: Write> {
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
 
 error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn std::io::Write>`, but its trait bounds were not satisfied
-  --> $DIR/mut-borrow-needed-by-trait.rs:21:5
+  --> $DIR/mut-borrow-needed-by-trait.rs:22:5
    |
 LL |     writeln!(fp, "hello world").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `BufWriter<&dyn std::io::Write>` due to unsatisfied trait bounds
@@ -36,7 +49,7 @@ LL | pub struct BufWriter<W: Write> {
            which is required by `BufWriter<&dyn std::io::Write>: std::io::Write`
    = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0599.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/wf/wf-static-method.nll.stderr
+++ b/src/test/ui/wf/wf-static-method.nll.stderr
@@ -68,7 +68,7 @@ LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here
    |                  |
    |                  lifetime `'a` defined here
-LL |     <Evil>::inherent_evil(b)
+LL |     <Evil>::inherent_evil(b) // bug? shouldn't this be an error
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`

--- a/src/test/ui/wf/wf-static-method.rs
+++ b/src/test/ui/wf/wf-static-method.rs
@@ -50,5 +50,19 @@ fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
     <Evil>::inherent_evil(b) // bug? shouldn't this be an error
 }
 
+pub enum Bar<'string> {
+    String(&'string str),
+}
+
+impl<'a> Bar<'a> {
+    fn f<'b>(self, other: Bar<'b>) {
+        match (self, other) {
+            // Important: a and b swap between the two patterns, and one pattern uses `Self`
+            // Possibly should be an error: Self::String(b) means that `b` has
+            // lifetime 'a, but in the other branch it has lifetime 'b.
+            (Bar::String(a), Bar::String(b)) | (Self::String(b), Bar::String(a)) => {}
+        }
+    }
+}
 
 fn main() {}

--- a/src/test/ui/wf/wf-static-method.rs
+++ b/src/test/ui/wf/wf-static-method.rs
@@ -47,8 +47,7 @@ fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
 }
 
 fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-    <Evil>::inherent_evil(b)
-    //~^ ERROR cannot infer an appropriate lifetime
+    <Evil>::inherent_evil(b) // bug? shouldn't this be an error
 }
 
 

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -103,34 +103,7 @@ note: ...so that reference does not outlive borrowed content
 LL |     <IndirectEvil>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting requirements
-  --> $DIR/wf-static-method.rs:50:5
-   |
-LL |     <Evil>::inherent_evil(b)
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 49:22...
-  --> $DIR/wf-static-method.rs:49:22
-   |
-LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-   |                      ^^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:50:27
-   |
-LL |     <Evil>::inherent_evil(b)
-   |                           ^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 49:18...
-  --> $DIR/wf-static-method.rs:49:18
-   |
-LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-   |                  ^^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:50:5
-   |
-LL |     <Evil>::inherent_evil(b)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0312, E0478, E0495.
 For more information about an error, try `rustc --explain E0312`.


### PR DESCRIPTION
Reverts #85511 to fix breakage on nightly. It's not clear this is the right approach - a future incompat lint may be warranted - but for now this avoids breaking users on nightly.

Addresses #85574 but doesn't fix it - we'll use it for tracking re-landing #85511 which is necessary for other work.