### PR TITLE
Fix span of redundant generic arguments

### DIFF
--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -626,30 +626,35 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         let remove_entire_generics = num_redundant_args >= self.gen_args.args.len();
 
         let remove_lifetime_args = |err: &mut DiagnosticBuilder<'_>| {
-            let idx_first_redundant_lt_args = self.num_expected_lifetime_args();
-            let span_lo_redundant_lt_args =
-                self.gen_args.args[idx_first_redundant_lt_args].span().shrink_to_lo();
-            let span_hi_redundant_lt_args = self.gen_args.args
-                [idx_first_redundant_lt_args + num_redundant_lt_args - 1]
-                .span()
-                .shrink_to_hi();
-            let eat_comma =
-                idx_first_redundant_lt_args + num_redundant_lt_args - 1 != self.gen_args.args.len();
+            let mut lt_arg_spans = Vec::new();
+            let mut found_redundant = false;
+            for arg in self.gen_args.args {
+                if let hir::GenericArg::Lifetime(_) = arg {
+                    lt_arg_spans.push(arg.span());
+                    if lt_arg_spans.len() > self.num_expected_lifetime_args() {
+                        found_redundant = true;
+                    }
+                } else if found_redundant {
+                    // Argument which is redundant and separated like this `'c`
+                    // is not included to avoid including `Bar` in span.
+                    // ```
+                    // type Foo<'a, T> = &'a T;
+                    // let _: Foo<'a, 'b, Bar, 'c>;
+                    // ```
+                    break;
+                }
+            }
 
-            let span_redundant_lt_args = if eat_comma {
-                let span_hi = self.gen_args.args
-                    [idx_first_redundant_lt_args + num_redundant_lt_args - 1]
-                    .span()
-                    .shrink_to_hi();
-                span_lo_redundant_lt_args.to(span_hi)
-            } else {
-                span_lo_redundant_lt_args.to(span_hi_redundant_lt_args)
-            };
+            let span_lo_redundant_lt_args = lt_arg_spans[self.num_expected_lifetime_args()];
+            let span_hi_redundant_lt_args = lt_arg_spans[lt_arg_spans.len() - 1];
+
+            let span_redundant_lt_args = span_lo_redundant_lt_args.to(span_hi_redundant_lt_args);
             debug!("span_redundant_lt_args: {:?}", span_redundant_lt_args);
 
+            let num_redundant_lt_args = lt_arg_spans.len() - self.num_expected_lifetime_args();
             let msg_lifetimes = format!(
                 "remove {} {} argument{}",
-                if num_redundant_args == 1 { "this" } else { "these" },
+                if num_redundant_lt_args == 1 { "this" } else { "these" },
                 "lifetime",
                 pluralize!(num_redundant_lt_args),
             );
@@ -663,26 +668,34 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         };
 
         let remove_type_or_const_args = |err: &mut DiagnosticBuilder<'_>| {
-            let idx_first_redundant_type_or_const_args = self.get_lifetime_args_offset()
-                + num_redundant_lt_args
-                + self.num_expected_type_or_const_args();
+            let mut gen_arg_spans = Vec::new();
+            let mut found_redundant = false;
+            for arg in self.gen_args.args {
+                match arg {
+                    hir::GenericArg::Type(_) | hir::GenericArg::Const(_) => {
+                        gen_arg_spans.push(arg.span());
+                        if gen_arg_spans.len() > self.num_expected_type_or_const_args() {
+                            found_redundant = true;
+                        }
+                    }
+                    _ if found_redundant => break,
+                    _ => {}
+                }
+            }
 
             let span_lo_redundant_type_or_const_args =
-                self.gen_args.args[idx_first_redundant_type_or_const_args].span().shrink_to_lo();
-
-            let span_hi_redundant_type_or_const_args = self.gen_args.args
-                [idx_first_redundant_type_or_const_args + num_redundant_type_or_const_args - 1]
-                .span()
-                .shrink_to_hi();
+                gen_arg_spans[self.num_expected_type_or_const_args()];
+            let span_hi_redundant_type_or_const_args = gen_arg_spans[gen_arg_spans.len() - 1];
 
             let span_redundant_type_or_const_args =
                 span_lo_redundant_type_or_const_args.to(span_hi_redundant_type_or_const_args);
-
             debug!("span_redundant_type_or_const_args: {:?}", span_redundant_type_or_const_args);
 
+            let num_redundant_gen_args =
+                gen_arg_spans.len() - self.num_expected_type_or_const_args();
             let msg_types_or_consts = format!(
                 "remove {} {} argument{}",
-                if num_redundant_args == 1 { "this" } else { "these" },
+                if num_redundant_gen_args == 1 { "this" } else { "these" },
                 "generic",
                 pluralize!(num_redundant_type_or_const_args),
             );

--- a/src/test/ui/error-codes/E0107.rs
+++ b/src/test/ui/error-codes/E0107.rs
@@ -1,5 +1,7 @@
 struct Foo<'a>(&'a str);
 struct Buzz<'a, 'b>(&'a str, &'b str);
+struct Qux<'a, T>(&'a T);
+struct Quux<T>(T);
 
 enum Bar {
     A,
@@ -19,6 +21,30 @@ struct Baz<'a, 'b, 'c> {
     foo2: Foo<'a, 'b, 'c>,
     //~^ ERROR this struct takes 1 lifetime argument
     //~| HELP remove these lifetime arguments
+
+    qux1: Qux<'a, 'b, i32>,
+    //~^ ERROR this struct takes 1 lifetime argument
+    //~| HELP remove this lifetime argument
+
+    qux2: Qux<'a, i32, 'b>,
+    //~^ ERROR this struct takes 1 lifetime argument
+    //~| HELP remove this lifetime argument
+
+    qux3: Qux<'a, 'b, 'c, i32>,
+    //~^ ERROR this struct takes 1 lifetime argument
+    //~| HELP remove these lifetime arguments
+
+    qux4: Qux<'a, i32, 'b, 'c>,
+    //~^ ERROR this struct takes 1 lifetime argument
+    //~| HELP remove these lifetime arguments
+
+    qux5: Qux<'a, 'b, i32, 'c>,
+    //~^ ERROR this struct takes 1 lifetime argument
+    //~| HELP remove this lifetime argument
+
+    quux: Quux<'a, i32, 'b>,
+    //~^ ERROR this struct takes 0 lifetime arguments
+    //~| HELP remove this lifetime argument
 }
 
 fn main() {}

--- a/src/test/ui/error-codes/E0107.stderr
+++ b/src/test/ui/error-codes/E0107.stderr
@@ -1,5 +1,5 @@
 error[E0107]: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/E0107.rs:11:11
+  --> $DIR/E0107.rs:13:11
    |
 LL |     buzz: Buzz<'a>,
    |           ^^^^ -- supplied 1 lifetime argument
@@ -17,7 +17,7 @@ LL |     buzz: Buzz<'a, 'a>,
    |                  ^^^^
 
 error[E0107]: this enum takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/E0107.rs:15:10
+  --> $DIR/E0107.rs:17:10
    |
 LL |     bar: Bar<'a>,
    |          ^^^---- help: remove these generics
@@ -25,13 +25,13 @@ LL |     bar: Bar<'a>,
    |          expected 0 lifetime arguments
    |
 note: enum defined here, with 0 lifetime parameters
-  --> $DIR/E0107.rs:4:6
+  --> $DIR/E0107.rs:6:6
    |
 LL | enum Bar {
    |      ^^^
 
 error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
-  --> $DIR/E0107.rs:19:11
+  --> $DIR/E0107.rs:21:11
    |
 LL |     foo2: Foo<'a, 'b, 'c>,
    |           ^^^     ------ help: remove these lifetime arguments
@@ -44,6 +44,90 @@ note: struct defined here, with 1 lifetime parameter: `'a`
 LL | struct Foo<'a>(&'a str);
    |        ^^^ --
 
-error: aborting due to 3 previous errors
+error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+  --> $DIR/E0107.rs:25:11
+   |
+LL |     qux1: Qux<'a, 'b, i32>,
+   |           ^^^     -- help: remove this lifetime argument
+   |           |
+   |           expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/E0107.rs:3:8
+   |
+LL | struct Qux<'a, T>(&'a T);
+   |        ^^^ --
+
+error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+  --> $DIR/E0107.rs:29:11
+   |
+LL |     qux2: Qux<'a, i32, 'b>,
+   |           ^^^          -- help: remove this lifetime argument
+   |           |
+   |           expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/E0107.rs:3:8
+   |
+LL | struct Qux<'a, T>(&'a T);
+   |        ^^^ --
+
+error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+  --> $DIR/E0107.rs:33:11
+   |
+LL |     qux3: Qux<'a, 'b, 'c, i32>,
+   |           ^^^     ------ help: remove these lifetime arguments
+   |           |
+   |           expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/E0107.rs:3:8
+   |
+LL | struct Qux<'a, T>(&'a T);
+   |        ^^^ --
+
+error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+  --> $DIR/E0107.rs:37:11
+   |
+LL |     qux4: Qux<'a, i32, 'b, 'c>,
+   |           ^^^          ------ help: remove these lifetime arguments
+   |           |
+   |           expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/E0107.rs:3:8
+   |
+LL | struct Qux<'a, T>(&'a T);
+   |        ^^^ --
+
+error[E0107]: this struct takes 1 lifetime argument but 3 lifetime arguments were supplied
+  --> $DIR/E0107.rs:41:11
+   |
+LL |     qux5: Qux<'a, 'b, i32, 'c>,
+   |           ^^^     -- help: remove this lifetime argument
+   |           |
+   |           expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/E0107.rs:3:8
+   |
+LL | struct Qux<'a, T>(&'a T);
+   |        ^^^ --
+
+error[E0107]: this struct takes 0 lifetime arguments but 2 lifetime arguments were supplied
+  --> $DIR/E0107.rs:45:11
+   |
+LL |     quux: Quux<'a, i32, 'b>,
+   |           ^^^^ -- help: remove this lifetime argument
+   |           |
+   |           expected 0 lifetime arguments
+   |
+note: struct defined here, with 0 lifetime parameters
+  --> $DIR/E0107.rs:4:8
+   |
+LL | struct Quux<T>(T);
+   |        ^^^^
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generics/wrong-number-of-args.rs
+++ b/src/test/ui/generics/wrong-number-of-args.rs
@@ -66,6 +66,12 @@ mod lifetime_and_type {
     //~| ERROR missing lifetime specifier
     //~| HELP consider introducing
     //~| HELP add missing
+
+    type F = Ty<'static, usize, 'static, usize>;
+    //~^ ERROR this struct takes 1 lifetime argument but 2 lifetime arguments
+    //~| ERROR this struct takes 1 generic argument but 2 generic arguments
+    //~| HELP remove this lifetime argument
+    //~| HELP remove this generic argument
 }
 
 mod type_and_type_and_type {

--- a/src/test/ui/generics/wrong-number-of-args.stderr
+++ b/src/test/ui/generics/wrong-number-of-args.stderr
@@ -213,14 +213,42 @@ help: consider introducing a named lifetime parameter
 LL |     type E<'a> = Ty<'a>;
    |           ^^^^      ^^
 
+error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
+  --> $DIR/wrong-number-of-args.rs:70:14
+   |
+LL |     type F = Ty<'static, usize, 'static, usize>;
+   |              ^^                 ------- help: remove this lifetime argument
+   |              |
+   |              expected 1 lifetime argument
+   |
+note: struct defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/wrong-number-of-args.rs:46:12
+   |
+LL |     struct Ty<'a, T>;
+   |            ^^ --
+
+error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
+  --> $DIR/wrong-number-of-args.rs:70:14
+   |
+LL |     type F = Ty<'static, usize, 'static, usize>;
+   |              ^^                          ----- help: remove this generic argument
+   |              |
+   |              expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `T`
+  --> $DIR/wrong-number-of-args.rs:46:12
+   |
+LL |     struct Ty<'a, T>;
+   |            ^^     -
+
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
-  --> $DIR/wrong-number-of-args.rs:74:14
+  --> $DIR/wrong-number-of-args.rs:80:14
    |
 LL |     type A = Ty;
    |              ^^ expected at least 2 generic arguments
    |
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:72:12
+  --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
    |            ^^ -  -
@@ -230,7 +258,7 @@ LL |     type A = Ty<A, B>;
    |              ^^^^^^^^
 
 error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:78:14
+  --> $DIR/wrong-number-of-args.rs:84:14
    |
 LL |     type B = Ty<usize>;
    |              ^^ ----- supplied 1 generic argument
@@ -238,7 +266,7 @@ LL |     type B = Ty<usize>;
    |              expected at least 2 generic arguments
    |
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:72:12
+  --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
    |            ^^ -  -
@@ -248,7 +276,7 @@ LL |     type B = Ty<usize, B>;
    |                      ^^^
 
 error[E0107]: this struct takes at most 3 generic arguments but 4 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:86:14
+  --> $DIR/wrong-number-of-args.rs:92:14
    |
 LL |     type E = Ty<usize, String, char, f64>;
    |              ^^                      --- help: remove this generic argument
@@ -256,19 +284,19 @@ LL |     type E = Ty<usize, String, char, f64>;
    |              expected at most 3 generic arguments
    |
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
-  --> $DIR/wrong-number-of-args.rs:72:12
+  --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
    |            ^^ -  -  -
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:90:14
+  --> $DIR/wrong-number-of-args.rs:96:14
    |
 LL |     type F = Ty<>;
    |              ^^ expected at least 2 generic arguments
    |
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:72:12
+  --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
    |            ^^ -  -
@@ -278,7 +306,7 @@ LL |     type F = Ty<A, B>;
    |                 ^^^^
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:110:22
+  --> $DIR/wrong-number-of-args.rs:116:22
    |
 LL |     type A = Box<dyn NonGeneric<usize>>;
    |                      ^^^^^^^^^^------- help: remove these generics
@@ -286,13 +314,13 @@ LL |     type A = Box<dyn NonGeneric<usize>>;
    |                      expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
-  --> $DIR/wrong-number-of-args.rs:98:11
+  --> $DIR/wrong-number-of-args.rs:104:11
    |
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:114:22
+  --> $DIR/wrong-number-of-args.rs:120:22
    |
 LL |     type B = Box<dyn GenericLifetime>;
    |                      ^^^^^^^^^^^^^^^ expected named lifetime parameter
@@ -303,7 +331,7 @@ LL |     type B<'a> = Box<dyn GenericLifetime<'a>>;
    |           ^^^^           ^^^^^^^^^^^^^^^^^^^
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:118:22
+  --> $DIR/wrong-number-of-args.rs:124:22
    |
 LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
    |                      ^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -311,19 +339,19 @@ LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
    |                      expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:102:11
+  --> $DIR/wrong-number-of-args.rs:108:11
    |
 LL |     trait GenericLifetime<'a> {
    |           ^^^^^^^^^^^^^^^ --
 
 error[E0107]: missing generics for trait `GenericType`
-  --> $DIR/wrong-number-of-args.rs:122:22
+  --> $DIR/wrong-number-of-args.rs:128:22
    |
 LL |     type D = Box<dyn GenericType>;
    |                      ^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:106:11
+  --> $DIR/wrong-number-of-args.rs:112:11
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
@@ -333,7 +361,7 @@ LL |     type D = Box<dyn GenericType<A>>;
    |                      ^^^^^^^^^^^^^^
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:126:22
+  --> $DIR/wrong-number-of-args.rs:132:22
    |
 LL |     type E = Box<dyn GenericType<String, usize>>;
    |                      ^^^^^^^^^^^         ----- help: remove this generic argument
@@ -341,13 +369,13 @@ LL |     type E = Box<dyn GenericType<String, usize>>;
    |                      expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:106:11
+  --> $DIR/wrong-number-of-args.rs:112:11
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:130:37
+  --> $DIR/wrong-number-of-args.rs:136:37
    |
 LL |     type F = Box<dyn GenericLifetime<>>;
    |                                     ^- expected named lifetime parameter
@@ -358,13 +386,13 @@ LL |     type F<'a> = Box<dyn GenericLifetime<'a>>;
    |           ^^^^                           ^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:134:22
+  --> $DIR/wrong-number-of-args.rs:140:22
    |
 LL |     type G = Box<dyn GenericType<>>;
    |                      ^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:106:11
+  --> $DIR/wrong-number-of-args.rs:112:11
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
@@ -374,7 +402,7 @@ LL |     type G = Box<dyn GenericType<A>>;
    |                                  ^
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:145:26
+  --> $DIR/wrong-number-of-args.rs:151:26
    |
 LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
    |                          ^^^^^^^^^^^^------------------- help: remove these generics
@@ -382,13 +410,13 @@ LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
    |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
-  --> $DIR/wrong-number-of-args.rs:141:15
+  --> $DIR/wrong-number-of-args.rs:147:15
    |
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:155:44
+  --> $DIR/wrong-number-of-args.rs:161:44
    |
 LL |         type A = Box<dyn GenericLifetimeAT<AssocTy=()>>;
    |                                            ^ expected named lifetime parameter
@@ -399,7 +427,7 @@ LL |         type A<'a> = Box<dyn GenericLifetimeAT<'a, AssocTy=()>>;
    |               ^^^^                             ^^^
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:159:26
+  --> $DIR/wrong-number-of-args.rs:165:26
    |
 LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -407,13 +435,13 @@ LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:151:15
+  --> $DIR/wrong-number-of-args.rs:157:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:163:44
+  --> $DIR/wrong-number-of-args.rs:169:44
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
    |                                            ^ expected named lifetime parameter
@@ -424,7 +452,7 @@ LL |         type C<'a> = Box<dyn GenericLifetimeAT<'a, (), AssocTy=()>>;
    |               ^^^^                             ^^^
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:163:26
+  --> $DIR/wrong-number-of-args.rs:169:26
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ -- help: remove this generic argument
@@ -432,19 +460,19 @@ LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
    |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
-  --> $DIR/wrong-number-of-args.rs:151:15
+  --> $DIR/wrong-number-of-args.rs:157:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:175:26
+  --> $DIR/wrong-number-of-args.rs:181:26
    |
 LL |         type A = Box<dyn GenericTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:171:15
+  --> $DIR/wrong-number-of-args.rs:177:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
@@ -454,7 +482,7 @@ LL |         type A = Box<dyn GenericTypeAT<A, AssocTy=()>>;
    |                                        ^^
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:179:26
+  --> $DIR/wrong-number-of-args.rs:185:26
    |
 LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^     -- help: remove this generic argument
@@ -462,13 +490,13 @@ LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:171:15
+  --> $DIR/wrong-number-of-args.rs:177:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
 
 error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:183:26
+  --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^--------------------- help: remove these generics
@@ -476,19 +504,19 @@ LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
-  --> $DIR/wrong-number-of-args.rs:171:15
+  --> $DIR/wrong-number-of-args.rs:177:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:183:26
+  --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:171:15
+  --> $DIR/wrong-number-of-args.rs:177:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
@@ -498,7 +526,7 @@ LL |         type C = Box<dyn GenericTypeAT<'static, A, AssocTy=()>>;
    |                                               ^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:195:48
+  --> $DIR/wrong-number-of-args.rs:201:48
    |
 LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
    |                                                ^ expected named lifetime parameter
@@ -509,13 +537,13 @@ LL |         type A<'a> = Box<dyn GenericLifetimeTypeAT<'a, AssocTy=()>>;
    |               ^^^^                                 ^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:195:26
+  --> $DIR/wrong-number-of-args.rs:201:26
    |
 LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -525,13 +553,13 @@ LL |         type A = Box<dyn GenericLifetimeTypeAT<A, AssocTy=()>>;
    |                                                ^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:201:26
+  --> $DIR/wrong-number-of-args.rs:207:26
    |
 LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -541,7 +569,7 @@ LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, A, AssocTy=()>>;
    |                                                       ^^^
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:205:26
+  --> $DIR/wrong-number-of-args.rs:211:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -549,19 +577,19 @@ LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:205:26
+  --> $DIR/wrong-number-of-args.rs:211:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -571,7 +599,7 @@ LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, A, AssocTy
    |                                                                ^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:211:48
+  --> $DIR/wrong-number-of-args.rs:217:48
    |
 LL |         type D = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
    |                                                ^ expected named lifetime parameter
@@ -582,7 +610,7 @@ LL |         type D<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), AssocTy=()>>;
    |               ^^^^                                 ^^^
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:215:48
+  --> $DIR/wrong-number-of-args.rs:221:48
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
    |                                                ^ expected named lifetime parameter
@@ -593,7 +621,7 @@ LL |         type E<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), (), AssocTy=()>>
    |               ^^^^                                 ^^^
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:215:26
+  --> $DIR/wrong-number-of-args.rs:221:26
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^     -- help: remove this generic argument
@@ -601,13 +629,13 @@ LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:221:26
+  --> $DIR/wrong-number-of-args.rs:227:26
    |
 LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -615,13 +643,13 @@ LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocT
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:225:26
+  --> $DIR/wrong-number-of-args.rs:231:26
    |
 LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^              -- help: remove this generic argument
@@ -629,13 +657,13 @@ LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:229:26
+  --> $DIR/wrong-number-of-args.rs:235:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -643,13 +671,13 @@ LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), As
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:229:26
+  --> $DIR/wrong-number-of-args.rs:235:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^                       -- help: remove this generic argument
@@ -657,19 +685,19 @@ LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), As
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:191:15
+  --> $DIR/wrong-number-of-args.rs:197:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
 error[E0107]: this trait takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:241:26
+  --> $DIR/wrong-number-of-args.rs:247:26
    |
 LL |         type A = Box<dyn GenericTypeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:237:15
+  --> $DIR/wrong-number-of-args.rs:243:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
@@ -679,7 +707,7 @@ LL |         type A = Box<dyn GenericTypeTypeAT<A, B, AssocTy=()>>;
    |                                            ^^^^^
 
 error[E0107]: this trait takes 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:245:26
+  --> $DIR/wrong-number-of-args.rs:251:26
    |
 LL |         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ -- supplied 1 generic argument
@@ -687,7 +715,7 @@ LL |         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
    |                          expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:237:15
+  --> $DIR/wrong-number-of-args.rs:243:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
@@ -697,7 +725,7 @@ LL |         type B = Box<dyn GenericTypeTypeAT<(), B, AssocTy=()>>;
    |                                              ^^^
 
 error[E0107]: this trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:249:26
+  --> $DIR/wrong-number-of-args.rs:255:26
    |
 LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^         -- help: remove this generic argument
@@ -705,13 +733,13 @@ LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
    |                          expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:237:15
+  --> $DIR/wrong-number-of-args.rs:243:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/wrong-number-of-args.rs:259:52
+  --> $DIR/wrong-number-of-args.rs:265:52
    |
 LL |         type A = Box<dyn GenericLifetimeLifetimeAT<AssocTy=()>>;
    |                                                    ^ expected 2 lifetime parameters
@@ -722,7 +750,7 @@ LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeAT<'a, 'a, AssocTy=()>>
    |               ^^^^                                     ^^^^^^^
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:263:26
+  --> $DIR/wrong-number-of-args.rs:269:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -730,7 +758,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:255:15
+  --> $DIR/wrong-number-of-args.rs:261:15
    |
 LL |         trait GenericLifetimeLifetimeAT<'a, 'b> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -740,7 +768,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, 'b, AssocTy=()>
    |                                                           ^^^^
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/wrong-number-of-args.rs:273:56
+  --> $DIR/wrong-number-of-args.rs:279:56
    |
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
    |                                                        ^ expected 2 lifetime parameters
@@ -751,13 +779,13 @@ LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeTypeAT<'a, 'a, AssocTy=
    |               ^^^^                                         ^^^^^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:273:26
+  --> $DIR/wrong-number-of-args.rs:279:26
    |
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:269:15
+  --> $DIR/wrong-number-of-args.rs:275:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -
@@ -767,7 +795,7 @@ LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<A, AssocTy=()>>;
    |                                                        ^^
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:279:26
+  --> $DIR/wrong-number-of-args.rs:285:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -775,7 +803,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:269:15
+  --> $DIR/wrong-number-of-args.rs:275:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -785,13 +813,13 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, 'b, AssocTy
    |                                                               ^^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:279:26
+  --> $DIR/wrong-number-of-args.rs:285:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:269:15
+  --> $DIR/wrong-number-of-args.rs:275:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -
@@ -801,7 +829,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, A, AssocTy=
    |                                                               ^^^
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:285:26
+  --> $DIR/wrong-number-of-args.rs:291:26
    |
 LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -809,7 +837,7 @@ LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:269:15
+  --> $DIR/wrong-number-of-args.rs:275:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -819,7 +847,7 @@ LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, 'b, (), Ass
    |                                                               ^^^^
 
 error[E0107]: missing generics for struct `HashMap`
-  --> $DIR/wrong-number-of-args.rs:295:18
+  --> $DIR/wrong-number-of-args.rs:301:18
    |
 LL |         type A = HashMap;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -835,7 +863,7 @@ LL |         type A = HashMap<K, V>;
    |                  ^^^^^^^^^^^^^
 
 error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:299:18
+  --> $DIR/wrong-number-of-args.rs:305:18
    |
 LL |         type B = HashMap<String>;
    |                  ^^^^^^^ ------ supplied 1 generic argument
@@ -853,7 +881,7 @@ LL |         type B = HashMap<String, V>;
    |                                ^^^
 
 error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:303:18
+  --> $DIR/wrong-number-of-args.rs:309:18
    |
 LL |         type C = HashMap<'static>;
    |                  ^^^^^^^--------- help: remove these generics
@@ -867,7 +895,7 @@ LL | pub struct HashMap<K, V, S = RandomState> {
    |            ^^^^^^^
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:303:18
+  --> $DIR/wrong-number-of-args.rs:309:18
    |
 LL |         type C = HashMap<'static>;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -883,7 +911,7 @@ LL |         type C = HashMap<'static, K, V>;
    |                                 ^^^^^^
 
 error[E0107]: this struct takes at most 3 generic arguments but 4 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:309:18
+  --> $DIR/wrong-number-of-args.rs:315:18
    |
 LL |         type D = HashMap<usize, String, char, f64>;
    |                  ^^^^^^^                      --- help: remove this generic argument
@@ -897,7 +925,7 @@ LL | pub struct HashMap<K, V, S = RandomState> {
    |            ^^^^^^^ -  -  -
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:313:18
+  --> $DIR/wrong-number-of-args.rs:319:18
    |
 LL |         type E = HashMap<>;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -913,7 +941,7 @@ LL |         type E = HashMap<K, V>;
    |                          ^^^^
 
 error[E0107]: missing generics for enum `Result`
-  --> $DIR/wrong-number-of-args.rs:319:18
+  --> $DIR/wrong-number-of-args.rs:325:18
    |
 LL |         type A = Result;
    |                  ^^^^^^ expected 2 generic arguments
@@ -929,7 +957,7 @@ LL |         type A = Result<T, E>;
    |                  ^^^^^^^^^^^^
 
 error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:323:18
+  --> $DIR/wrong-number-of-args.rs:329:18
    |
 LL |         type B = Result<String>;
    |                  ^^^^^^ ------ supplied 1 generic argument
@@ -947,7 +975,7 @@ LL |         type B = Result<String, E>;
    |                               ^^^
 
 error[E0107]: this enum takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:327:18
+  --> $DIR/wrong-number-of-args.rs:333:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^--------- help: remove these generics
@@ -961,7 +989,7 @@ LL | pub enum Result<T, E> {
    |          ^^^^^^
 
 error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:327:18
+  --> $DIR/wrong-number-of-args.rs:333:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^ expected 2 generic arguments
@@ -977,7 +1005,7 @@ LL |         type C = Result<'static, T, E>;
    |                                ^^^^^^
 
 error[E0107]: this enum takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:333:18
+  --> $DIR/wrong-number-of-args.rs:339:18
    |
 LL |         type D = Result<usize, String, char>;
    |                  ^^^^^^                ---- help: remove this generic argument
@@ -991,7 +1019,7 @@ LL | pub enum Result<T, E> {
    |          ^^^^^^ -  -
 
 error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:337:18
+  --> $DIR/wrong-number-of-args.rs:343:18
    |
 LL |         type E = Result<>;
    |                  ^^^^^^ expected 2 generic arguments
@@ -1006,7 +1034,7 @@ help: add missing generic arguments
 LL |         type E = Result<T, E>;
    |                         ^^^^
 
-error: aborting due to 69 previous errors
+error: aborting due to 71 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes #71563

Above issue is about lifetime arguments, but generic arguments also have same problem.
This PR fixes both help messages.