### PR TITLE
Make closures inherit their parent's "safety context"

### DIFF
--- a/src/test/ui/async-await/async-await.rs
+++ b/src/test/ui/async-await/async-await.rs
@@ -1,7 +1,8 @@
 // run-pass
 
-// revisions: default nomiropt
+// revisions: default nomiropt thirunsafeck
 //[nomiropt]compile-flags: -Z mir-opt-level=0
+//[thirunsafeck]compile-flags: -Zthir-unsafeck
 
 #![allow(unused)]
 

--- a/src/test/ui/command/command-pre-exec.rs
+++ b/src/test/ui/command/command-pre-exec.rs
@@ -1,4 +1,6 @@
 // run-pass
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 #![allow(stable_features)]
 // ignore-windows - this is a unix-specific test

--- a/src/test/ui/generator/static-mut-reference-across-yield.rs
+++ b/src/test/ui/generator/static-mut-reference-across-yield.rs
@@ -1,4 +1,7 @@
 // build-pass
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
+
 #![feature(generators)]
 
 static mut A: [i32; 5] = [1, 2, 3, 4, 5];

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,5 +1,7 @@
 // run-pass
 // ignore-wasm32-bare compiled with panic=abort by default
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 // This test checks panic emitted from `mem::{uninitialized,zeroed}`.
 

--- a/src/test/ui/issues/issue-11740.rs
+++ b/src/test/ui/issues/issue-11740.rs
@@ -1,4 +1,6 @@
 // check-pass
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 struct Attr {
     name: String,

--- a/src/test/ui/issues/issue-39367.rs
+++ b/src/test/ui/issues/issue-39367.rs
@@ -1,4 +1,7 @@
 // run-pass
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
+
 use std::ops::Deref;
 
 struct ArenaSet<U: Deref, V=<U as Deref>::Target>(U, &'static V)

--- a/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.mir.stderr
+++ b/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.mir.stderr
@@ -1,5 +1,5 @@
 error: unnecessary `unsafe` block
-  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:7:13
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:10:13
    |
 LL |     unsafe {
    |     ------ because it's nested under this `unsafe` block
@@ -8,13 +8,13 @@ LL |             unsafe {
    |             ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:1:8
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:4:8
    |
 LL | #[deny(unused_unsafe)]
    |        ^^^^^^^^^^^^^
 
 error: unnecessary `unsafe` block
-  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:9:38
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:12:38
    |
 LL |     unsafe {
    |     ------ because it's nested under this `unsafe` block
@@ -23,7 +23,7 @@ LL |                 |w: &mut Vec<u32>| { unsafe {
    |                                      ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:13:34
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:16:34
    |
 LL |     unsafe {
    |     ------ because it's nested under this `unsafe` block

--- a/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.rs
+++ b/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
+
 #[deny(unused_unsafe)]
 fn main() {
     let mut v = Vec::<i32>::with_capacity(24);

--- a/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.thir.stderr
+++ b/src/test/ui/issues/issue-45107-unnecessary-unsafe-in-closure.thir.stderr
@@ -1,0 +1,35 @@
+error: unnecessary `unsafe` block
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:10:13
+   |
+LL |     unsafe {
+   |     ------ because it's nested under this `unsafe` block
+LL |         let f = |v: &mut Vec<_>| {
+LL |             unsafe {
+   |             ^^^^^^ unnecessary `unsafe` block
+   |
+note: the lint level is defined here
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:4:8
+   |
+LL | #[deny(unused_unsafe)]
+   |        ^^^^^^^^^^^^^
+
+error: unnecessary `unsafe` block
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:12:38
+   |
+LL |     unsafe {
+   |     ------ because it's nested under this `unsafe` block
+...
+LL |                 |w: &mut Vec<u32>| { unsafe {
+   |                                      ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/issue-45107-unnecessary-unsafe-in-closure.rs:16:34
+   |
+LL |     unsafe {
+   |     ------ because it's nested under this `unsafe` block
+...
+LL |             |x: &mut Vec<u32>| { unsafe {
+   |                                  ^^^^^^ unnecessary `unsafe` block
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/lto-still-runs-thread-dtors.rs
+++ b/src/test/ui/lto-still-runs-thread-dtors.rs
@@ -2,6 +2,8 @@
 // compile-flags: -C lto
 // no-prefer-dynamic
 // ignore-emscripten no threads support
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 use std::thread;
 

--- a/src/test/ui/no-stdio.rs
+++ b/src/test/ui/no-stdio.rs
@@ -2,6 +2,8 @@
 // ignore-android
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 #![feature(rustc_private)]
 

--- a/src/test/ui/running-with-no-runtime.rs
+++ b/src/test/ui/running-with-no-runtime.rs
@@ -1,6 +1,8 @@
 // run-pass
 // ignore-emscripten spawning processes is not supported
 // ignore-sgx no processes
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 #![feature(start)]
 

--- a/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
@@ -1,5 +1,7 @@
 // run-pass
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
 
 #![feature(repr_simd, platform_intrinsics, concat_idents)]
 #![allow(non_camel_case_types)]

--- a/src/test/ui/span/lint-unused-unsafe.mir.stderr
+++ b/src/test/ui/span/lint-unused-unsafe.mir.stderr
@@ -1,23 +1,23 @@
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:16:13
+  --> $DIR/lint-unused-unsafe.rs:19:13
    |
 LL | fn bad1() { unsafe {} }
    |             ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/lint-unused-unsafe.rs:4:9
+  --> $DIR/lint-unused-unsafe.rs:7:9
    |
 LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:17:13
+  --> $DIR/lint-unused-unsafe.rs:20:13
    |
 LL | fn bad2() { unsafe { bad1() } }
    |             ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:18:20
+  --> $DIR/lint-unused-unsafe.rs:21:20
    |
 LL | unsafe fn bad3() { unsafe {} }
    | ----------------   ^^^^^^ unnecessary `unsafe` block
@@ -25,13 +25,13 @@ LL | unsafe fn bad3() { unsafe {} }
    | because it's nested under this `unsafe` fn
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:19:13
+  --> $DIR/lint-unused-unsafe.rs:22:13
    |
 LL | fn bad4() { unsafe { callback(||{}) } }
    |             ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:20:20
+  --> $DIR/lint-unused-unsafe.rs:23:20
    |
 LL | unsafe fn bad5() { unsafe { unsf() } }
    | ----------------   ^^^^^^ unnecessary `unsafe` block
@@ -39,7 +39,7 @@ LL | unsafe fn bad5() { unsafe { unsf() } }
    | because it's nested under this `unsafe` fn
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:23:9
+  --> $DIR/lint-unused-unsafe.rs:26:9
    |
 LL |     unsafe {                             // don't put the warning here
    |     ------ because it's nested under this `unsafe` block
@@ -47,7 +47,7 @@ LL |         unsafe {
    |         ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:29:5
+  --> $DIR/lint-unused-unsafe.rs:32:5
    |
 LL | unsafe fn bad7() {
    | ---------------- because it's nested under this `unsafe` fn
@@ -55,7 +55,7 @@ LL |     unsafe {
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/lint-unused-unsafe.rs:30:9
+  --> $DIR/lint-unused-unsafe.rs:33:9
    |
 LL | unsafe fn bad7() {
    | ---------------- because it's nested under this `unsafe` fn

--- a/src/test/ui/span/lint-unused-unsafe.rs
+++ b/src/test/ui/span/lint-unused-unsafe.rs
@@ -1,5 +1,8 @@
 // Exercise the unused_unsafe attribute in some positive and negative cases
 
+// revisions: mir thir
+// [thir]compile-flags: -Zthir-unsafeck
+
 #![allow(dead_code)]
 #![deny(unused_unsafe)]
 

--- a/src/test/ui/span/lint-unused-unsafe.thir.stderr
+++ b/src/test/ui/span/lint-unused-unsafe.thir.stderr
@@ -1,0 +1,66 @@
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:19:13
+   |
+LL | fn bad1() { unsafe {} }
+   |             ^^^^^^ unnecessary `unsafe` block
+   |
+note: the lint level is defined here
+  --> $DIR/lint-unused-unsafe.rs:7:9
+   |
+LL | #![deny(unused_unsafe)]
+   |         ^^^^^^^^^^^^^
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:20:13
+   |
+LL | fn bad2() { unsafe { bad1() } }
+   |             ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:21:20
+   |
+LL | unsafe fn bad3() { unsafe {} }
+   | ----------------   ^^^^^^ unnecessary `unsafe` block
+   | |
+   | because it's nested under this `unsafe` fn
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:22:13
+   |
+LL | fn bad4() { unsafe { callback(||{}) } }
+   |             ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:23:20
+   |
+LL | unsafe fn bad5() { unsafe { unsf() } }
+   | ----------------   ^^^^^^ unnecessary `unsafe` block
+   | |
+   | because it's nested under this `unsafe` fn
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:26:9
+   |
+LL |     unsafe {                             // don't put the warning here
+   |     ------ because it's nested under this `unsafe` block
+LL |         unsafe {
+   |         ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:33:9
+   |
+LL |     unsafe {
+   |     ------ because it's nested under this `unsafe` block
+LL |         unsafe {
+   |         ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/lint-unused-unsafe.rs:32:5
+   |
+LL | unsafe fn bad7() {
+   | ---------------- because it's nested under this `unsafe` fn
+LL |     unsafe {
+   |     ^^^^^^ unnecessary `unsafe` block
+
+error: aborting due to 8 previous errors
+

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
 const ROOT_ENTRY_LIMIT: usize = 1371;
-const ISSUES_ENTRY_LIMIT: usize = 2558;
+const ISSUES_ENTRY_LIMIT: usize = 2559;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
Fixes rust-lang/project-thir-unsafeck#9, ~~blocked on #85273~~.
r? @nikomatsakis