### PR TITLE
Update std::array module doc header

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -1,6 +1,4 @@
-//! Implementations of things like `Eq` for fixed-length arrays
-//! up to a certain length. Eventually, we should be able to generalize
-//! to all lengths.
+//! Helper functions and types for fixed-length arrays.
 //!
 //! *[See also the array primitive type](array).*
 


### PR DESCRIPTION
This line is very outdated; not only are traits implemented on arrays of arbitrary length, those implementations are documented on the primitive type, not in this module.