### PR TITLE
Restore sans-serif font for module items.

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -145,6 +145,7 @@ h4.type.trait-impl, h4.associatedconstant.trait-impl, h4.associatedtype.trait-im
 
 h1, h2, h3, h4,
 .sidebar, a.source, .search-input, .search-results .result-name,
+.content table td:first-child > a,
 div.item-list .out-of-band,
 #source-sidebar, #sidebar-toggle,
 details.rustdoc-toggle > summary::before,


### PR DESCRIPTION
This was broke in #84462 by modifying a style that applied both to
searches and to module items (and other tables).

Fixes #85616.
Fixes https://github.com/rust-lang/rust/issues/85545.

r? @camelid 