### PR TITLE
Replace more "NULL" with "null"

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -296,7 +296,7 @@ impl UnsafeOpKind {
             ),
             DerefOfRawPointer => (
                 "dereference of raw pointer",
-                "raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules \
+                "raw pointers may be null, dangling or unaligned; they can violate aliasing rules \
                  and cause data races: all of these are undefined behavior",
             ),
             AssignToDroppingUnionField => (

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |         *(1 as *mut u32) = 42;
    |         ^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47412.thir.stderr
+++ b/src/test/ui/issues/issue-47412.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     match *ptr {}
    |           ^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/safety-fn-body.thir.stderr
+++ b/src/test/ui/traits/safety-fn-body.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |         *self += 1;
    |         ^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *(1 as *mut u32) = 42;
    |     ^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *p = 0;
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     return *p;
    |            ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *a == b
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Error messages in THIR unsafeck still contain "NULL", make them lowercase to be consistent with MIR unsafeck (cc #84842).