### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -296,7 +296,7 @@ impl UnsafeOpKind {
             ),
             DerefOfRawPointer => (
                 "dereference of raw pointer",
-                "raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules \
+                "raw pointers may be null, dangling or unaligned; they can violate aliasing rules \
                  and cause data races: all of these are undefined behavior",
             ),
             AssignToDroppingUnionField => (

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1008,9 +1008,9 @@ mod mod_keyword {}
 ///     move || println!("This is a: {}", text)
 /// }
 ///
-///     let fn_plain = create_fn();
+/// let fn_plain = create_fn();
 ///
-///     fn_plain();
+/// fn_plain();
 /// ```
 ///
 /// `move` is often used when [threads] are involved.

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -145,6 +145,7 @@ h4.type.trait-impl, h4.associatedconstant.trait-impl, h4.associatedtype.trait-im
 
 h1, h2, h3, h4,
 .sidebar, a.source, .search-input, .search-results .result-name,
+.content table td:first-child > a,
 div.item-list .out-of-band,
 #source-sidebar, #sidebar-toggle,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -783,15 +783,14 @@ a {
 	flex-flow: row wrap;
 }
 
-.search-results > a > div > div {
+.search-results .result-name, .search-results > a > div > div:nth-child(2), .search-results .result-description {
 	width: 50%;
 }
-
-.result-name {
+.search-results .result-name {
 	padding-right: 1em;
 }
 
-.result-name > span {
+.search-results .result-name > span {
 	display: inline-block;
 }
 
@@ -1753,10 +1752,10 @@ details.undocumented[open] > summary::before {
 	.search-results > a {
 		border-bottom: 1px solid #aaa9;
 	}
-	.search-results > a > div > div {
+	.search-results .result-name {
 		width: 100%;
 	}
-	.search-results > a > div > div:nth-child(2) {
+	.search-results > a > div > div:nth-child(2), .search-results .result-description {
 		padding-left: 2em;
 	}
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1754,7 +1754,7 @@ details.undocumented[open] > summary::before {
 		border-bottom: 1px solid #aaa9;
 		padding: 5px 0px;
 	}
-	.search-results .result-name {
+	.search-results .result-name, .search-results > a > div > div:nth-child(2), .search-results .result-description {
 		width: 100%;
 	}
 	.search-results > a > div > div:nth-child(2), .search-results .result-description {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -772,6 +772,7 @@ a {
 
 .search-results > a {
 	display: block;
+	width: 100%;
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;
@@ -1751,6 +1752,7 @@ details.undocumented[open] > summary::before {
 	/* Display an alternating layout on tablets and phones */
 	.search-results > a {
 		border-bottom: 1px solid #aaa9;
+		padding: 5px 0px;
 	}
 	.search-results .result-name {
 		width: 100%;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -768,16 +768,29 @@ a {
 	display: block;
 }
 
-.search-results a {
+.search-results > a {
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;
 	display: block;
 }
 
-.result-name {
+.search-results > a > div {
+	display: flex;
+}
+
+.search-results > a > div > div {
+	min-width: 50%;
+	max-width: 50%;
 	width: 50%;
-	float: left;
+}
+
+.result-name {
+	padding-right: 10px;
+}
+
+.result-name > span {
+	display: inline-block;
 }
 
 tr.result span.primitive::after {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -759,6 +759,8 @@ a {
 
 .search-results.active {
 	display: block;
+	/* prevent overhanging tabs from moving the first result */
+	clear: both;
 }
 
 .search-results .desc {
@@ -769,24 +771,24 @@ a {
 }
 
 .search-results > a {
+	display: block;
 	/* A little margin ensures the browser's outlining of focused links has room to display. */
 	margin-left: 2px;
 	margin-right: 2px;
-	display: block;
+	border-bottom: 1px solid #aaa3;
 }
 
 .search-results > a > div {
 	display: flex;
+	flex-flow: row wrap;
 }
 
 .search-results > a > div > div {
-	min-width: 50%;
-	max-width: 50%;
 	width: 50%;
 }
 
 .result-name {
-	padding-right: 10px;
+	padding-right: 1em;
 }
 
 .result-name > span {
@@ -1745,6 +1747,17 @@ details.undocumented[open] > summary::before {
 	}
 	.search-container > div {
 		width: calc(100% - 32px);
+	}
+
+	/* Display an alternating layout on tablets and phones */
+	.search-results > a {
+		border-bottom: 1px solid #aaa9;
+	}
+	.search-results > a > div > div {
+		width: 100%;
+	}
+	.search-results > a > div > div:nth-child(2) {
+		padding-left: 2em;
 	}
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -763,7 +763,7 @@ a {
 	clear: both;
 }
 
-.search-results .desc {
+.search-results .desc > span {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -784,7 +784,7 @@ a {
 	flex-flow: row wrap;
 }
 
-.search-results .result-name, .search-results > a > div > div:nth-child(2), .search-results .result-description {
+.search-results .result-name, .search-results div.desc, .search-results .result-description {
 	width: 50%;
 }
 .search-results .result-name {
@@ -1754,10 +1754,10 @@ details.undocumented[open] > summary::before {
 		border-bottom: 1px solid #aaa9;
 		padding: 5px 0px;
 	}
-	.search-results .result-name, .search-results > a > div > div:nth-child(2), .search-results .result-description {
+	.search-results .result-name, .search-results div.desc, .search-results .result-description {
 		width: 100%;
 	}
-	.search-results > a > div > div:nth-child(2), .search-results .result-description {
+	.search-results div.desc, .search-results .result-description {
 		padding-left: 2em;
 	}
 }

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -994,8 +994,8 @@ window.initSearch = function(rawSearchIndex) {
                            ("<span class=\"alias\"><b>" + item.alias + " </b></span><span " +
                               "class=\"grey\"><i>&nbsp;- see&nbsp;</i></span>") : "") +
                           item.displayPath + "<span class=\"" + type + "\">" +
-                          name + "</span></div><div>" +
-                          "<span class=\"desc\">" + item.desc +
+                          name + "</span></div><div class=\"desc\">" +
+                          "<span>" + item.desc +
                           "&nbsp;</span></div></div></a>";
             });
             output += "</div>";

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -1,0 +1,12 @@
+goto: file://|DOC_PATH|/test_docs/index.html
+size: (900, 1000)
+write: (".search-input", "test")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+// The width is returned by "getComputedStyle" which returns the exact number instead of the
+// CSS rule which is "50%"...
+assert: (".search-results div.desc", {"width": "320px"})
+size: (600, 100)
+// As counter-intuitive as it may seem, in this width, the width is "100%", which is why
+// when computed it's larger.
+assert: (".search-results div.desc", {"width": "570px"})

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |         *(1 as *mut u32) = 42;
    |         ^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47412.thir.stderr
+++ b/src/test/ui/issues/issue-47412.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     match *ptr {}
    |           ^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/safety-fn-body.thir.stderr
+++ b/src/test/ui/traits/safety-fn-body.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |         *self += 1;
    |         ^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *(1 as *mut u32) = 42;
    |     ^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *p = 0;
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     return *p;
    |            ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
@@ -4,7 +4,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe function 
 LL |     *a == b
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #85271 (Fix indentation in move keyword documentation)
 - #85551 (Fix search results display)
 - #85621 (Restore sans-serif font for module items.)
 - #85628 (Replace more "NULL" with "null")

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85271,85551,85621,85628)
<!-- homu-ignore:end -->