### PR TITLE
Demote `ControlFlow::{from|into}_try` to `pub(crate)`

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -186,9 +186,8 @@ impl<B, C> ControlFlow<B, C> {
 #[cfg(bootstrap)]
 impl<R: ops::TryV1> ControlFlow<R, R::Output> {
     /// Create a `ControlFlow` from any type implementing `Try`.
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
     #[inline]
-    pub fn from_try(r: R) -> Self {
+    pub(crate) fn from_try(r: R) -> Self {
         match R::into_result(r) {
             Ok(v) => ControlFlow::Continue(v),
             Err(v) => ControlFlow::Break(R::from_error(v)),
@@ -196,9 +195,8 @@ impl<R: ops::TryV1> ControlFlow<R, R::Output> {
     }
 
     /// Convert a `ControlFlow` into any type implementing `Try`;
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
     #[inline]
-    pub fn into_try(self) -> R {
+    pub(crate) fn into_try(self) -> R {
         match self {
             ControlFlow::Continue(v) => R::from_ok(v),
             ControlFlow::Break(v) => v,
@@ -206,12 +204,14 @@ impl<R: ops::TryV1> ControlFlow<R, R::Output> {
     }
 }
 
+/// These are used only as part of implementing the iterator adapters.
+/// They have mediocre names and non-obvious semantics, so aren't
+/// currently on a path to potential stabilization.
 #[cfg(not(bootstrap))]
 impl<R: ops::TryV2> ControlFlow<R, R::Output> {
     /// Create a `ControlFlow` from any type implementing `Try`.
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
     #[inline]
-    pub fn from_try(r: R) -> Self {
+    pub(crate) fn from_try(r: R) -> Self {
         match R::branch(r) {
             ControlFlow::Continue(v) => ControlFlow::Continue(v),
             ControlFlow::Break(v) => ControlFlow::Break(R::from_residual(v)),
@@ -219,9 +219,8 @@ impl<R: ops::TryV2> ControlFlow<R, R::Output> {
     }
 
     /// Convert a `ControlFlow` into any type implementing `Try`;
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
     #[inline]
-    pub fn into_try(self) -> R {
+    pub(crate) fn into_try(self) -> R {
         match self {
             ControlFlow::Continue(v) => R::from_output(v),
             ControlFlow::Break(v) => v,


### PR DESCRIPTION
They have mediocre names and non-obvious semantics, so personally I don't think they're worth trying to stabilize, and thus might as well just be internal (they're used for convenience in iterator adapters), not something shown in the rustdocs.

I don't think anyone actually wanted to use them outside `core` -- they just got made public-but-unstable along with the whole type in https://github.com/rust-lang/rust/pull/76204 that promoted `LoopState` from an internal type to the exposed `ControlFlow` type.

cc https://github.com/rust-lang/rust/issues/75744, the tracking issue they mention.
cc https://github.com/rust-lang/rust/pull/85608, the PR where I'm proposing stabilizing the type.