### PR TITLE
Change `Ipv6Addr::is_loopback` to include IPv4-mapped loopback addresses

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -84,12 +84,61 @@ pub struct Ipv4Addr {
 /// IPv6 addresses are defined as 128-bit integers in [IETF RFC 4291].
 /// They are usually represented as eight 16-bit segments.
 ///
-/// See [`IpAddr`] for a type encompassing both IPv4 and IPv6 addresses.
-///
 /// The size of an `Ipv6Addr` struct may vary depending on the target operating
 /// system.
 ///
 /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
+///
+/// # Embedding IPv4 Addresses
+///
+/// See [`IpAddr`] for a type encompassing both IPv4 and IPv6 addresses.
+///
+/// To assist in the transition from IPv4 to IPv6 two types of IPv6 addresses that embed an IPv4 address were defined:
+/// IPv4-compatible and IPv4-mapped addresses. Of these IPv4-compatible addresses have been officially deprecated and are only minimally supported.
+///
+/// ## IPv4-Compatible IPv6 Addresses
+///
+/// IPv4-compatible IPv6 addresses are defined in [IETF RFC 4291 Section 2.5.5.1], and have been officially deprecated.
+/// The RFC describes the format of an "IPv4-Compatible IPv6 address" as follows:
+///
+/// ```text
+/// |                80 bits               | 16 |      32 bits        |
+/// +--------------------------------------+--------------------------+
+/// |0000..............................0000|0000|    IPv4 address     |
+/// +--------------------------------------+----+---------------------+
+/// ```
+/// So `::a.b.c.d` would be an IPv4-compatible IPv6 address representing the IPv4 address `a.b.c.d`.
+///
+/// Despite IPv4-compatible IPv6 addresses having been officially deprecated, there is minimal support for handling these addresses:
+/// Only converting to and from these addresses is supported, see [`Ipv4Addr::to_ipv6_compatible`] and [`Ipv6Addr::to_ipv4`].
+/// No further special meaning is ascribed to these addresses; for example [`is_loopback`](Ipv6Addr::is_loopback) will return `false` for `::127.0.0.1`,
+/// even though it represents the IPv4 address `127.0.0.1` (which is a loopback address).
+///
+/// [IETF RFC 4291 Section 2.5.5.1]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.5.1
+///
+/// ## IPv4-Mapped IPv6 Addresses
+///
+/// IPv4-mapped IPv6 addresses are defined in [IETF RFC 4291 Section 2.5.5.2].
+/// The RFC describes the format of an "IPv4-Mapped IPv6 address" as follows:
+///
+/// ```text
+/// |                80 bits               | 16 |      32 bits        |
+/// +--------------------------------------+--------------------------+
+/// |0000..............................0000|FFFF|    IPv4 address     |
+/// +--------------------------------------+----+---------------------+
+/// ```
+/// So `::ffff:a.b.c.d` would be an IPv4-mapped IPv6 address representing the IPv4 address `a.b.c.d`.
+///
+/// There is more support for handling these addresses than there is for IPv4-compatible addresses:
+/// Converting to and from these addresses is supported, see [`Ipv4Addr::to_ipv6_mapped`] and [`Ipv6Addr::to_ipv4`].
+/// There is also rudimentary support for the embedded IPv4 addresses; for example [`is_loopback`](Ipv6Addr::is_loopback) will return `true` for `::ffff:127.0.0.1`,
+/// because it represents the IPv4 address `127.0.0.1` (which is a loopback address).
+///
+/// Note: Currently `is_loopback` is the only method that is aware of IPv4-mapped addresses.
+///
+/// This support for the embedded IPv4 addresses is in line with other languages and the behaviour of many real-world networking hardware.
+///
+/// [IETF RFC 4291 Section 2.5.5.2]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.5.2
 ///
 /// # Textual representation
 ///
@@ -758,13 +807,14 @@ impl Ipv4Addr {
         }
     }
 
-    /// Converts this address to an IPv4-compatible [`IPv6` address].
+    /// Converts this address to an [IPv4-compatible] [`IPv6` address].
     ///
     /// `a.b.c.d` becomes `::a.b.c.d`
     ///
-    /// This isn't typically the method you want; these addresses don't typically
-    /// function on modern systems. Use `to_ipv6_mapped` instead.
+    /// Note that IPv4-compatible addresses have been officially deprecated.
+    /// If you don't explicitly need an IPv4-compatible address for legacy reasons, consider using `to_ipv6_mapped` instead.
     ///
+    /// [IPv4-compatible]: Ipv6Addr#ipv4-compatible-ipv6-addresses
     /// [`IPv6` address]: Ipv6Addr
     ///
     /// # Examples
@@ -787,10 +837,11 @@ impl Ipv4Addr {
         }
     }
 
-    /// Converts this address to an IPv4-mapped [`IPv6` address].
+    /// Converts this address to an [IPv4-mapped] [`IPv6` address].
     ///
     /// `a.b.c.d` becomes `::ffff:a.b.c.d`
     ///
+    /// [IPv4-mapped]: Ipv6Addr#ipv4-mapped-ipv6-addresses
     /// [`IPv6` address]: Ipv6Addr
     ///
     /// # Examples
@@ -1195,13 +1246,15 @@ impl Ipv6Addr {
 
     /// Returns [`true`] if this is either:
     /// - the [loopback address] as defined in [IETF RFC 4291 section 2.5.3] (`::1`).
-    /// - an IPv4-mapped address representing an IPv4 loopback address as defined in [IETF RFC 1122] (`::ffff:127.0.0.0/104`).
+    /// - an [IPv4-mapped] address representing an IPv4 loopback address as defined in [IETF RFC 1122] (`::ffff:127.0.0.0/104`).
     ///
-    /// Note that this returns [`false`] for an IPv4-compatible address representing an IPv4 loopback address (`::127.0.0.0/104`).
+    /// Note that this returns [`false`] for an [IPv4-compatible] address representing an IPv4 loopback address (`::127.0.0.0/104`).
     ///
     /// [loopback address]: Ipv6Addr::LOCALHOST
     /// [IETF RFC 4291 section 2.5.3]: https://tools.ietf.org/html/rfc4291#section-2.5.3
     /// [IETF RFC 1122]: https://tools.ietf.org/html/rfc1122
+    /// [IPv4-mapped]: Ipv6Addr#ipv4-mapped-ipv6-addresses
+    /// [IPv4-compatible]: Ipv6Addr#ipv4-compatible-ipv6-addresses
     ///
     /// # Examples
     ///
@@ -1529,13 +1582,14 @@ impl Ipv6Addr {
         (self.segments()[0] & 0xff00) == 0xff00
     }
 
-    /// Converts this address to an [`IPv4` address] if it's an "IPv4-mapped IPv6 address"
+    /// Converts this address to an [`IPv4` address] if it's an [IPv4-mapped] address as
     /// defined in [IETF RFC 4291 section 2.5.5.2], otherwise returns [`None`].
     ///
     /// `::ffff:a.b.c.d` becomes `a.b.c.d`.
     /// All addresses *not* starting with `::ffff` will return `None`.
     ///
     /// [`IPv4` address]: Ipv4Addr
+    /// [IPv4-mapped IPv6 address]: Ipv6Addr
     /// [IETF RFC 4291 section 2.5.5.2]: https://tools.ietf.org/html/rfc4291#section-2.5.5.2
     ///
     /// # Examples
@@ -1562,12 +1616,16 @@ impl Ipv6Addr {
         }
     }
 
-    /// Converts this address to an [`IPv4` address]. Returns [`None`] if this address is
-    /// neither IPv4-compatible or IPv4-mapped.
+    /// Converts this address to an [`IPv4` address] if it's an [IPv4-compatible] address as defined in [IETF RFC 4291 section 2.5.5.1]
+    /// or an [IPv4-mapped] address as defined in [IETF RFC 4291 section 2.5.5.2], otherwise returns [`None`].
     ///
     /// `::a.b.c.d` and `::ffff:a.b.c.d` become `a.b.c.d`
     ///
     /// [`IPv4` address]: Ipv4Addr
+    /// [IPv4-compatible]: Ipv6Addr#ipv4-compatible-ipv6-addresses
+    /// [IPv4-mapped]: Ipv6Addr#ipv4-mapped-ipv6-addresses
+    /// [IETF RFC 4291 section 2.5.5.1]: https://tools.ietf.org/html/rfc4291#section-2.5.5.1
+    /// [IETF RFC 4291 section 2.5.5.2]: https://tools.ietf.org/html/rfc4291#section-2.5.5.2
     ///
     /// # Examples
     ///

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -822,10 +822,10 @@ impl Ipv4Addr {
     /// ```
     /// use std::net::{Ipv4Addr, Ipv6Addr};
     ///
-    /// assert_eq!(
-    ///     Ipv4Addr::new(192, 0, 2, 255).to_ipv6_compatible(),
-    ///     Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xc000, 0x2ff)
-    /// );
+    /// // ::192.0.2.255
+    /// let ipv6_compatible = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xc000, 0x2ff);
+    ///
+    /// assert_eq!(Ipv4Addr::new(192, 0, 2, 255).to_ipv6_compatible(), ipv6_compatible);
     /// ```
     #[rustc_const_stable(feature = "const_ipv4", since = "1.50.0")]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -849,8 +849,10 @@ impl Ipv4Addr {
     /// ```
     /// use std::net::{Ipv4Addr, Ipv6Addr};
     ///
-    /// assert_eq!(Ipv4Addr::new(192, 0, 2, 255).to_ipv6_mapped(),
-    ///            Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x2ff));
+    /// // ::ffff:192.0.2.255
+    /// let ipv6_mapped = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x2ff);
+    ///
+    /// assert_eq!(Ipv4Addr::new(192, 0, 2, 255).to_ipv6_mapped(), ipv6_mapped);
     /// ```
     #[rustc_const_stable(feature = "const_ipv4", since = "1.50.0")]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1599,10 +1601,18 @@ impl Ipv6Addr {
     ///
     /// use std::net::{Ipv4Addr, Ipv6Addr};
     ///
+    /// let ipv4 = Ipv4Addr::new(192, 10, 2, 255);
+    /// let ipv6_compatible = ipv4.to_ipv6_compatible();
+    /// let ipv6_mapped = ipv4.to_ipv6_mapped();
+    ///
+    /// // Only IPv4-mapped addresses are converted.
+    /// assert_eq!(ipv6_compatible.to_ipv4_mapped(), None);
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xc00a, 0x2ff).to_ipv4_mapped(), None);
+    /// assert_eq!(ipv6_mapped.to_ipv4_mapped(), Some(ipv4));
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4_mapped(), Some(ipv4));
+    ///
+    /// // Addresses that are neither an IPv4-compatible or IPv4-mapped address are not converted.
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).to_ipv4_mapped(), None);
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4_mapped(),
-    ///            Some(Ipv4Addr::new(192, 10, 2, 255)));
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).to_ipv4_mapped(), None);
     /// ```
     #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
     #[unstable(feature = "ip", issue = "27709")]
@@ -1632,11 +1642,18 @@ impl Ipv6Addr {
     /// ```
     /// use std::net::{Ipv4Addr, Ipv6Addr};
     ///
+    /// let ipv4 = Ipv4Addr::new(192, 10, 2, 255);
+    /// let ipv6_compatible = ipv4.to_ipv6_compatible();
+    /// let ipv6_mapped = ipv4.to_ipv6_mapped();
+    ///
+    /// // Both IPv4-compatible and IPv4-mapped addresses are converted.
+    /// assert_eq!(ipv6_compatible.to_ipv4(), Some(ipv4));
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0xc00a, 0x2ff).to_ipv4(), Some(ipv4));
+    /// assert_eq!(ipv6_mapped.to_ipv4(), Some(ipv4));
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4(), Some(ipv4));
+    ///
+    /// // Addresses that are neither an IPv4-compatible or IPv4-mapped address are not converted.
     /// assert_eq!(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0).to_ipv4(), None);
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).to_ipv4(),
-    ///            Some(Ipv4Addr::new(192, 10, 2, 255)));
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).to_ipv4(),
-    ///            Some(Ipv4Addr::new(0, 0, 0, 1)));
     /// ```
     #[rustc_const_stable(feature = "const_ipv6", since = "1.50.0")]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This PR addresses one of the issues that came up during the larger efforts of trying to stabilize the `ip` feature, see also the most recent stabilization PR #85585 and issue #85609 where I have tried to summarize all the relevant discussion so far.

Fixes #69772

Edit: for an alternative to this PR, see #86335 which commits to *not* supporting IPv4-in-IPv6 addresses (so leaving `is_loopback` unchanged).

## Overview

There are two ways of representing an IPv4 address in a IPv6 address:
- As an IPv4-compatible IPv6 address:  `::1.2.3.4`
- As an IPv4-mapped IPv6 address:  `::ffff:1.2.3.4`

#69772 raised the issue that other languages take IPv4-mapped addresses into account in their equivalent of `is_loopback`, for example `::ffff:127.0.0.1`. This raised the broader question about which (if any) methods of `Ipv6Addr` should consider IPv4-mapped or IPv4-compatible addresses. 

While we don't yet have a clear answer in general, for `is_loopback` is seems pretty clear that supporting addresses like `::ffff:127.0.0.1` is a good idea: .NET, Java, Python and Go all follow this behaviour (#69772, https://github.com/rust-lang/rust/pull/76098#discussion_r528738546). This behaviour is also implemented by many real world networking hardware/software (try `ping ::ffff::127.0.0.1`). In short, it is surprising for users that the Rust implementation is different. Regarding IPv4-compatible addresses, those are deprecated and of the tested other languages none took them into account (try also `ping ::127.0.0.1`).

## Implementation

This PR changes the behaviour of `is_loopback` from

```rust
/// Returns [`true`] if this is a loopback address (::1).
```

to

```rust
/// Returns [`true`] if this is either:
/// - the [loopback address] as defined in [IETF RFC 4291 section 2.5.3] (`::1`).
/// - an [IPv4-mapped] address representing an IPv4 loopback address as defined in [IETF RFC 1122] (`::ffff:127.0.0.0/104`).
///
/// Note that this does not return [`true`] for an [IPv4-compatible] address representing an IPv4 loopback address (`::127.0.0.0/104`).
```

The documentation of `Ipv6Addr` is expanded to include a section explaining IPv4-compatible and IPv4-mapped addresses:
- IPv4-compatible addresses are called out as officially deprecated and that only conversion to and from such an address is supported (`to_ipv6_compatible`, `to_ipv4`). It is also noted that no special meaning is ascribed to these addresses, so the embedded IPv4 address will never be taken into account. 
- IPv4-mapped addresses are explained and it is noted that the embedded IPv4 addresses may be taken into account, `is_loopback` is given as an example. `is_loopback` is specifically mentioned as currently the only method that takes IPv4-mapped addresses into account, and a small explanation is included that this is in line with other languages and real-world hardware.

The documentation of the methods `to_ipv6_compatible`, `to_ipv6_mapped`, `to_ipv4` and `to_ipv4_mapped` is updated to refer to this section.

(Also included are some small improvements to the <s>style consistency of the documentation</s> (pulled out into #85676) and readability of some examples)

## Unresolved Questions

### Stability
This PR changes the behaviour of the stable `is_loopback` from a simple check for equality to `Ipv6Addr::LOCALHOST` to something more complex, although arguable the change makes the behaviour more in line in what users would expect. To what extent is such a change in behaviour covered by stability guarantees; is just a change in documentation enough or should it be called out in compatibility notes?

### Making `is_loopback` special
It is expected that in the future some more methods of `Ipv6Addr` will take IPv4-mapped addresses into account, but this is currently blocked on nailing down the exact semantics (#85609). This PR is written to be largely agnostic to such further changes, `is_loopback` is called out as currently the only method that has this behaviour. However, if eventually the decision is made to not apply this behaviour to other methods, is it worth it to have only `is_loopback` have this special behaviour? Do the arguments in favour of supporting IPv4-mapped addresses pull their weight if only `is_loopback` will ever support it.