### PR TITLE
Remove doubled braces in non_exhaustive structs’ documentation text.

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1502,7 +1502,7 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
             w.write_str(
                 "Non-exhaustive structs could have additional fields added in future. \
                  Therefore, non-exhaustive structs cannot be constructed in external crates \
-                 using the traditional <code>Struct {{ .. }}</code> syntax; cannot be \
+                 using the traditional <code>Struct { .. }</code> syntax; cannot be \
                  matched against without a wildcard <code>..</code>; and \
                  struct update syntax will not work.",
             );


### PR DESCRIPTION
In commit 4b806878549990d2ad2aa3c265751d3d89947cdf (part of Rust 1.52.1) many calls to `write!(w,` were replaced with `w.write_str(`, but this one contained braces that were doubled to escape them when taken as a format string, and so changing the call without changing the text caused them to become doubled in the final HTML output.

I examined `print_item.rs` and the diff of that prior commit for any other occurrences of this mistake and I did not find any.