### PR TITLE
add testcase for #82933

### DIFF
--- a/src/test/ui/issues/issue-82933.rs
+++ b/src/test/ui/issues/issue-82933.rs
@@ -1,0 +1,9 @@
+// edition:2018
+pub trait ParallelStream {
+    async fn reduce(&self) {
+//~^ ERROR functions in traits cannot be declared `async`
+        vec![].into_iter().for_each(|_: ()| {})
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-82933.stderr
+++ b/src/test/ui/issues/issue-82933.stderr
@@ -1,0 +1,19 @@
+error[E0706]: functions in traits cannot be declared `async`
+  --> $DIR/issue-82933.rs:3:5
+   |
+LL |       async fn reduce(&self) {
+   |       ^----
+   |       |
+   |  _____`async` because of this
+   | |
+LL | |
+LL | |         vec![].into_iter().for_each(|_: ()| {})
+LL | |     }
+   | |_____^
+   |
+   = note: `async` trait functions are not currently supported
+   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0706`.

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
 const ROOT_ENTRY_LIMIT: usize = 1371;
-const ISSUES_ENTRY_LIMIT: usize = 2558;
+const ISSUES_ENTRY_LIMIT: usize = 2560;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
closes #82933

#82933 was fixed by #83108 but it failed to have a testcase, because no MCVE was present at that date.

I was able to get some from an older ICE of mine (#74318), so here we are now :)