### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -47,7 +47,7 @@ pub enum PointerCast {
 /// 1. The simplest cases are where a pointer is not adjusted fat vs thin.
 ///    Here the pointer will be dereferenced N times (where a dereference can
 ///    happen to raw or borrowed pointers or any smart pointer which implements
-///    Deref, including Box<_>). The types of dereferences is given by
+///    `Deref`, including `Box<_>`). The types of dereferences is given by
 ///    `autoderefs`. It can then be auto-referenced zero or one times, indicated
 ///    by `autoref`, to either a raw or borrowed pointer. In these cases unsize is
 ///    `false`.
@@ -56,7 +56,7 @@ pub enum PointerCast {
 ///    with a thin pointer, deref a number of times, unsize the underlying data,
 ///    then autoref. The 'unsize' phase may change a fixed length array to a
 ///    dynamically sized one, a concrete object to a trait object, or statically
-///    sized struct to a dynamically sized one. E.g., &[i32; 4] -> &[i32] is
+///    sized struct to a dynamically sized one. E.g., `&[i32; 4]` -> `&[i32]` is
 ///    represented by:
 ///
 ///    ```
@@ -66,7 +66,7 @@ pub enum PointerCast {
 ///    ```
 ///
 ///    Note that for a struct, the 'deep' unsizing of the struct is not recorded.
-///    E.g., `struct Foo<T> { x: T }` we can coerce &Foo<[i32; 4]> to &Foo<[i32]>
+///    E.g., `struct Foo<T> { x: T }` we can coerce `&Foo<[i32; 4]>` to `&Foo<[i32]>`
 ///    The autoderef and -ref are the same as in the above example, but the type
 ///    stored in `unsize` is `Foo<[i32]>`, we don't store any further detail about
 ///    the underlying conversions from `[i32; 4]` to `[i32]`.
@@ -75,8 +75,8 @@ pub enum PointerCast {
 ///    that case, we have the pointer we need coming in, so there are no
 ///    autoderefs, and no autoref. Instead we just do the `Unsize` transformation.
 ///    At some point, of course, `Box` should move out of the compiler, in which
-///    case this is analogous to transforming a struct. E.g., Box<[i32; 4]> ->
-///    Box<[i32]> is an `Adjust::Unsize` with the target `Box<[i32]>`.
+///    case this is analogous to transforming a struct. E.g., `Box<[i32; 4]>` ->
+///    `Box<[i32]>` is an `Adjust::Unsize` with the target `Box<[i32]>`.
 #[derive(Clone, TyEncodable, TyDecodable, HashStable, TypeFoldable)]
 pub struct Adjustment<'tcx> {
     pub kind: Adjust<'tcx>,

--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -1,7 +1,7 @@
 use crate::hir::place::{
     Place as HirPlace, PlaceBase as HirPlaceBase, ProjectionKind as HirProjectionKind,
 };
-use crate::ty;
+use crate::{mir, ty};
 
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_hir as hir;
@@ -11,6 +11,10 @@ use rustc_span::Span;
 use super::{Ty, TyCtxt};
 
 use self::BorrowKind::*;
+
+// Captures are represented using fields inside a structure.
+// This represents accessing self in the closure structure
+pub const CAPTURE_STRUCT_LOCAL: mir::Local = mir::Local::from_u32(1);
 
 #[derive(
     Clone,

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -4,10 +4,9 @@ use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind};
-use rustc_index::vec::Idx;
 use rustc_middle::mir::{
     self, AggregateKind, BindingForm, BorrowKind, ClearCrossCrate, ConstraintCategory,
-    FakeReadCause, Local, LocalDecl, LocalInfo, LocalKind, Location, Operand, Place, PlaceRef,
+    FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location, Operand, Place, PlaceRef,
     ProjectionElem, Rvalue, Statement, StatementKind, Terminator, TerminatorKind, VarBindingForm,
 };
 use rustc_middle::ty::{self, suggest_constraining_type_param, Ty, TypeFoldable};
@@ -1274,7 +1273,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         bug!("temporary or return pointer with a name")
                     }
                     LocalKind::Var => "local variable ",
-                    LocalKind::Arg if !self.upvars.is_empty() && local == Local::new(1) => {
+                    LocalKind::Arg
+                        if !self.upvars.is_empty() && local == ty::CAPTURE_STRUCT_LOCAL =>
+                    {
                         "variable captured by `move` "
                     }
                     LocalKind::Arg => "function parameter ",

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -209,9 +209,7 @@ fn to_upvars_resolved_place_builder<'a, 'tcx>(
     match from_builder.base {
         PlaceBase::Local(_) => Ok(from_builder),
         PlaceBase::Upvar { var_hir_id, closure_def_id, closure_kind } => {
-            // Captures are represented using fields inside a structure.
-            // This represents accessing self in the closure structure
-            let mut upvar_resolved_place_builder = PlaceBuilder::from(Local::new(1));
+            let mut upvar_resolved_place_builder = PlaceBuilder::from(ty::CAPTURE_STRUCT_LOCAL);
             match closure_kind {
                 ty::ClosureKind::Fn | ty::ClosureKind::FnMut => {
                     upvar_resolved_place_builder = upvar_resolved_place_builder.deref();

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -433,7 +433,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     } => {
                         // Not in a closure
                         debug_assert!(
-                            local == Local::new(1),
+                            local == ty::CAPTURE_STRUCT_LOCAL,
                             "Expected local to be Local(1), found {:?}",
                             local
                         );

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -896,9 +896,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // the given closure and use the necessary information to create upvar
         // debuginfo and to fill `self.upvar_mutbls`.
         if hir_typeck_results.closure_min_captures.get(&fn_def_id).is_some() {
-            let closure_env_arg = Local::new(1);
             let mut closure_env_projs = vec![];
-            let mut closure_ty = self.local_decls[closure_env_arg].ty;
+            let mut closure_ty = self.local_decls[ty::CAPTURE_STRUCT_LOCAL].ty;
             if let ty::Ref(_, ty, _) = closure_ty.kind() {
                 closure_env_projs.push(ProjectionElem::Deref);
                 closure_ty = ty;
@@ -944,7 +943,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         name,
                         source_info: SourceInfo::outermost(tcx_hir.span(var_id)),
                         value: VarDebugInfoContents::Place(Place {
-                            local: closure_env_arg,
+                            local: ty::CAPTURE_STRUCT_LOCAL,
                             projection: tcx.intern_place_elems(&projs),
                         }),
                     });

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1507,7 +1507,10 @@ fn collect_print_requests(
     prints
 }
 
-fn parse_target_triple(matches: &getopts::Matches, error_format: ErrorOutputType) -> TargetTriple {
+pub fn parse_target_triple(
+    matches: &getopts::Matches,
+    error_format: ErrorOutputType,
+) -> TargetTriple {
     match matches.opt_str("target") {
         Some(target) if target.ends_with(".json") => {
             let path = Path::new(&target);

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -595,7 +595,7 @@ macro_rules! unreachable {
 /// Indicates unimplemented code by panicking with a message of "not implemented".
 ///
 /// This allows your code to type-check, which is useful if you are prototyping or
-/// implementing a trait that requires multiple methods which you don't plan of using all of.
+/// implementing a trait that requires multiple methods which you don't plan to use all of.
 ///
 /// The difference between `unimplemented!` and [`todo!`] is that while `todo!`
 /// conveys an intent of implementing the functionality later and the message is "not yet

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -6,8 +6,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_session::config::{self, parse_crate_types_from_list, parse_externs, CrateType};
-use rustc_session::config::{get_cmd_lint_options, host_triple, nightly_options};
+use rustc_session::config::{
+    self, parse_crate_types_from_list, parse_externs, parse_target_triple, CrateType,
+};
+use rustc_session::config::{get_cmd_lint_options, nightly_options};
 use rustc_session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, Externs};
 use rustc_session::getopts;
 use rustc_session::lint::Level;
@@ -562,14 +564,7 @@ impl Options {
             }
         }
 
-        let target =
-            matches.opt_str("target").map_or(TargetTriple::from_triple(host_triple()), |target| {
-                if target.ends_with(".json") {
-                    TargetTriple::from_path(Path::new(&target))
-                } else {
-                    TargetTriple::TargetTriple(target)
-                }
-            });
+        let target = parse_target_triple(matches, error_format);
 
         let show_coverage = matches.opt_present("show-coverage");
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -565,7 +565,7 @@ impl Options {
         let target =
             matches.opt_str("target").map_or(TargetTriple::from_triple(host_triple()), |target| {
                 if target.ends_with(".json") {
-                    TargetTriple::TargetPath(PathBuf::from(target))
+                    TargetTriple::from_path(Path::new(&target))
                 } else {
                     TargetTriple::TargetTriple(target)
                 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1502,7 +1502,7 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
             w.write_str(
                 "Non-exhaustive structs could have additional fields added in future. \
                  Therefore, non-exhaustive structs cannot be constructed in external crates \
-                 using the traditional <code>Struct {{ .. }}</code> syntax; cannot be \
+                 using the traditional <code>Struct { .. }</code> syntax; cannot be \
                  matched against without a wildcard <code>..</code>; and \
                  struct update syntax will not work.",
             );

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -796,16 +796,6 @@ a {
 	display: inline-block;
 }
 
-.result-name span.primitive::after {
-	content: ' (primitive type)';
-	font-style: italic;
-}
-
-.result-name span.keyword::after {
-	content: ' (keyword)';
-	font-style: italic;
-}
-
 body.blur > :not(#help) {
 	filter: blur(8px);
 	-webkit-filter: blur(8px);

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -975,18 +975,24 @@ window.initSearch = function(rawSearchIndex) {
             output = "<div class=\"search-results " + extraClass + "\">";
 
             array.forEach(function(item) {
-                var name, type;
-
-                name = item.name;
-                type = itemTypes[item.ty];
-
                 if (item.is_alias !== true) {
                     if (duplicates[item.fullPath]) {
                         return;
                     }
                     duplicates[item.fullPath] = true;
                 }
+
+                var name = item.name;
+                var type = itemTypes[item.ty];
+
                 length += 1;
+
+                var extra = "";
+                if (type === "primitive") {
+                    extra = " <i>(primitive type)</i>";
+                } else if (type === "keyword") {
+                    extra = " <i>(keyword)</i>";
+                }
 
                 output += "<a class=\"result-" + type + "\" href=\"" + item.href + "\">" +
                           "<div><div class=\"result-name\">" +
@@ -994,7 +1000,7 @@ window.initSearch = function(rawSearchIndex) {
                            ("<span class=\"alias\"><b>" + item.alias + " </b></span><span " +
                               "class=\"grey\"><i>&nbsp;- see&nbsp;</i></span>") : "") +
                           item.displayPath + "<span class=\"" + type + "\">" +
-                          name + "</span></div><div class=\"desc\">" +
+                          name + extra + "</span></div><div class=\"desc\">" +
                           "<span>" + item.desc +
                           "&nbsp;</span></div></div></a>";
             });

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/Makefile
@@ -1,0 +1,9 @@
+include ../tools.mk
+
+# Test that rustdoc will properly canonicalize the target spec json path just like rustc
+
+OUTPUT_DIR := "$(TMPDIR)/rustdoc-target-spec-json-path"
+
+all:
+	$(RUSTC) --crate-type lib dummy_core.rs --target target.json
+	$(RUSTDOC) -o $(OUTPUT_DIR) -L $(TMPDIR) my_crate.rs --target target.json

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/dummy_core.rs
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/dummy_core.rs
@@ -1,0 +1,2 @@
+#![feature(no_core)]
+#![no_core]

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/my_crate.rs
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/my_crate.rs
@@ -1,0 +1,3 @@
+#![feature(no_core)]
+#![no_core]
+extern crate dummy_core;

--- a/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/target.json
+++ b/src/test/run-make-fulldeps/rustdoc-target-spec-json-path/target.json
@@ -1,0 +1,39 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "executables": true,
+  "has-elf-tls": true,
+  "has-rpath": true,
+  "is-builtin": true,
+  "linker-is-gnu": true,
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "linux",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gcc": [
+      "-m64"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      11,
+      0,
+      1
+    ]
+  },
+  "supported-sanitizers": [
+    "address",
+    "leak",
+    "memory",
+    "thread"
+  ],
+  "target-family": "unix",
+  "target-pointer-width": "64"
+}

--- a/src/test/rustdoc-gui/search-result-keyword.goml
+++ b/src/test/rustdoc-gui/search-result-keyword.goml
@@ -5,7 +5,6 @@ wait-for: "#titles"
 // Note: The two next assert commands could be merged as one but readability would be
 // less good.
 //
-// Checking that the CSS is displaying " (keyword)"...
-assert: (".result-name span.keyword::after", {"content": '" (keyword)"'})
-// ... in italic.
-assert: (".result-name span.keyword::after", {"font-style": "italic"})
+// Checking that the CSS is displaying " (keyword)" in italic.
+assert: (".result-name span.keyword > i", "(keyword)")
+assert: (".result-name span.keyword", "CookieMonster (keyword)")


### PR DESCRIPTION
Successful merges:

 - #85361 (Use TargetTriple::from_path in rustdoc)
 - #85605 (Replace Local::new(1) with CAPTURE_STRUCT_LOCAL)
 - #85631 (Move keyword primitive css dom)
 - #85644 (Better English for documenting when to use unimplemented!())
 - #85650 (Add some backticks to the `rustc_middle::ty::adjustment::Adjustment` docs)
 - #85657 (Remove doubled braces in non_exhaustive structs’ documentation text.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85361,85605,85631,85644,85650,85657)
<!-- homu-ignore:end -->