### PR TITLE
Fix tasklist example in rustdoc book.

### DIFF
--- a/src/doc/rustdoc/src/how-to-write-documentation.md
+++ b/src/doc/rustdoc/src/how-to-write-documentation.md
@@ -229,15 +229,13 @@ Example:
 
 ```md
 - [x] Complete task
-- [ ] IncComplete task
+- [ ] Incomplete task
 ```
 
-This will render as
+This will render as:
 
-<ul>
-    <li><input type="checkbox"></li>
-    <li><input type="checkbox" checked></li>
-</ul>
+> - [x] Complete task
+> - [ ] Incomplete task
 
 See the specification for the [task list extension] for more details.
 


### PR DESCRIPTION
There were a few issues with the tasklist example in the rustdoc book:

* Misspelled "incomplete"
* Checkmarks were backwards
* Didn't show the text for each item
* Used HTML which renders differently from how markdown renders it (which uses "disabled" marks)
* Didn't use blockquotes to offset the example like the other extensions do
* Missing a colon

Before:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/43198/119503519-e7787880-bd1f-11eb-9f13-1c67754ce001.png">

After:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/43198/119503449-d6c80280-bd1f-11eb-9ab5-fe4a6df82124.png">

