### PR TITLE
Add new rustdoc-GUI to ensure correct font is used on module items

### DIFF
--- a/src/test/rustdoc-gui/module-item-font.goml
+++ b/src/test/rustdoc-gui/module-item-font.goml
@@ -1,0 +1,20 @@
+// This test ensures that the correct font is applied on the modules listed items.
+goto: file://|DOC_PATH|/test_docs/index.html
+// modules
+assert-css: ("#modules + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#modules + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})
+// structs
+assert-css: ("#structs + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#structs + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})
+// enums
+assert-css: ("#enums + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#enums + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})
+// traits
+assert-css: ("#traits + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#traits + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})
+// functions
+assert-css: ("#functions + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#functions + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})
+// keywords
+assert-css: ("#keywords + .item-table .item-left > a", {"font-family": '"Fira Sans", Arial, sans-serif'})
+assert-css: ("#keywords + .item-table .docblock-short", {"font-family": '"Source Serif 4", "Noto Sans KR", serif'})


### PR DESCRIPTION
Fixes #85632.

r? @jsha 