### PR TITLE
fix for undefined behavior in <[T]>::copy_within method

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3093,10 +3093,11 @@ impl<T> [T] {
         let Range { start: src_start, end: src_end } = slice::range(src, ..self.len());
         let count = src_end - src_start;
         assert!(dest <= self.len() - count, "dest is out of bounds");
+        let ptr = self.as_mut_ptr();
         // SAFETY: the conditions for `ptr::copy` have all been checked above,
         // as have those for `ptr::add`.
         unsafe {
-            ptr::copy(self.as_ptr().add(src_start), self.as_mut_ptr().add(dest), count);
+            ptr::copy(ptr.add(src_start), ptr.add(dest), count);
         }
     }
 


### PR DESCRIPTION
`<[T]>::copy_within()` currently contains undefined behavior according to the [Stacked Borrows](https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md) model. This PR brings a fix to restore its soundness.

To help understand where the UB comes from, consider the following code snippet from the original implementation of `copy_within` before the fix:

```rust
        unsafe {
            ptr::copy(self.as_ptr().add(src_start), self.as_mut_ptr().add(dest), count);
        }
```
The arguments to `ptr::copy` are evaluated from left to right. `self.as_ptr()` creates an immutable reference (which is tagged as SharedReadOnly by Stacked Borrows) to the array and derives a valid `*const` pointer from it. When jumping to the next argument, `self.as_mut_ptr()` creates a mutable reference (tagged as Unique) to the array, which invalidates the existing SharedReadOnly reference and any pointers derived from it. The invalidated `*const` pointer (the first argument to `ptr::copy`) is then used after the fact when `ptr::copy` is called, which triggers the undefined behavior.

The fix is to obtain only one mutable reference (tagged Unique) at the start, then cast it to a mutable pointer (tagged SharedReadWrite), for which both of the pointer arguments to `ptr::copy` can be safely derived without invalidating either pointer, like so:

```rust
        let ptr = self.as_mut_ptr();
        // SAFETY: the conditions for `ptr::copy` have all been checked above,
        // as have those for `ptr::add`.
        unsafe {
            ptr::copy(ptr.add(src_start), ptr.add(dest), count);
        }
```