### PR TITLE
Fix `Ipv6Addr::is_unicast_global` to check for unicast global scope

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1349,30 +1349,6 @@ impl Ipv6Addr {
         (self.segments()[0] & 0xffc0) == 0xfe80
     }
 
-    /// Returns [`true`] if this is an address reserved for documentation
-    /// (`2001:db8::/32`).
-    ///
-    /// This property is defined in [IETF RFC 3849].
-    ///
-    /// [IETF RFC 3849]: https://tools.ietf.org/html/rfc3849
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(ip)]
-    ///
-    /// use std::net::Ipv6Addr;
-    ///
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_documentation(), false);
-    /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_documentation(), true);
-    /// ```
-    #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
-    #[unstable(feature = "ip", issue = "27709")]
-    #[inline]
-    pub const fn is_documentation(&self) -> bool {
-        (self.segments()[0] == 0x2001) && (self.segments()[1] == 0xdb8)
-    }
-
     /// Returns `true` if the address is a unicast address with global scope,
     /// as defined in [RFC 4291].
     ///
@@ -1441,6 +1417,30 @@ impl Ipv6Addr {
             && !self.is_unspecified()
             && !self.is_loopback()
             && !self.has_unicast_link_local_scope()
+    }
+
+    /// Returns [`true`] if this is an address reserved for documentation
+    /// (`2001:db8::/32`).
+    ///
+    /// This property is defined in [IETF RFC 3849].
+    ///
+    /// [IETF RFC 3849]: https://tools.ietf.org/html/rfc3849
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ip)]
+    ///
+    /// use std::net::Ipv6Addr;
+    ///
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_documentation(), false);
+    /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_documentation(), true);
+    /// ```
+    #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
+    #[unstable(feature = "ip", issue = "27709")]
+    #[inline]
+    pub const fn is_documentation(&self) -> bool {
+        (self.segments()[0] == 0x2001) && (self.segments()[1] == 0xdb8)
     }
 
     /// Returns the address's multicast scope if the address is multicast.

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1240,7 +1240,8 @@ impl Ipv6Addr {
         match self.multicast_scope() {
             Some(Ipv6MulticastScope::Global) => true,
             None => {
-                self.is_unicast_global() && !(self.is_unique_local() || self.is_documentation())
+                self.has_unicast_global_scope()
+                    && !(self.is_unique_local() || self.is_documentation())
             }
             _ => false,
         }
@@ -1331,20 +1332,20 @@ impl Ipv6Addr {
     /// use std::net::Ipv6Addr;
     ///
     /// // The loopback address (`::1`) does not actually have link-local scope.
-    /// assert_eq!(Ipv6Addr::LOCALHOST.is_unicast_link_local(), false);
+    /// assert_eq!(Ipv6Addr::LOCALHOST.has_unicast_link_local_scope(), false);
     ///
     /// // Only addresses in `fe80::/10` have link-local scope.
-    /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_unicast_link_local(), false);
-    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0).is_unicast_link_local(), true);
+    /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).has_unicast_link_local_scope(), false);
+    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0).has_unicast_link_local_scope(), true);
     ///
     /// // Addresses outside the stricter `fe80::/64` also have link-local scope.
-    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 1, 0, 0, 0, 0).is_unicast_link_local(), true);
-    /// assert_eq!(Ipv6Addr::new(0xfe81, 0, 0, 0, 0, 0, 0, 0).is_unicast_link_local(), true);
+    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 1, 0, 0, 0, 0).has_unicast_link_local_scope(), true);
+    /// assert_eq!(Ipv6Addr::new(0xfe81, 0, 0, 0, 0, 0, 0, 0).has_unicast_link_local_scope(), true);
     /// ```
     #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
     #[unstable(feature = "ip", issue = "27709")]
     #[inline]
-    pub const fn is_unicast_link_local(&self) -> bool {
+    pub const fn has_unicast_link_local_scope(&self) -> bool {
         (self.segments()[0] & 0xffc0) == 0xfe80
     }
 
@@ -1403,7 +1404,7 @@ impl Ipv6Addr {
     /// [RFC 4291 section 2.5.7]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.7
     /// [unspecified address]: Ipv6Addr::is_unspecified
     /// [loopback address]: Ipv6Addr::is_loopback
-    /// [link-local address]: Ipv6Addr::is_unicast_link_local
+    /// [link-local address]: Ipv6Addr::has_unicast_link_local_scope
     ///
     /// # Examples
     ///
@@ -1413,33 +1414,33 @@ impl Ipv6Addr {
     /// use std::net::Ipv6Addr;
     ///
     /// // The unspecified address (`::`) does not have unicast global scope
-    /// assert_eq!(Ipv6Addr::UNSPECIFIED.is_unicast_global(), false);
+    /// assert_eq!(Ipv6Addr::UNSPECIFIED.has_unicast_global_scope(), false);
     ///
     /// // The loopback address (`::1`) does not have unicast global scope.
-    /// assert_eq!(Ipv6Addr::LOCALHOST.is_unicast_global(), false);
+    /// assert_eq!(Ipv6Addr::LOCALHOST.has_unicast_global_scope(), false);
     ///
     /// // A unicast address with link-local scope (`fe80::/10`) does not have global scope.
-    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0).has_unicast_global_scope(), false);
     ///
     /// // A unicast address that had the deprecated site-local scope (`fec0::/10`) now has global scope.
-    /// assert_eq!(Ipv6Addr::new(0xfec2, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), true);
+    /// assert_eq!(Ipv6Addr::new(0xfec2, 0, 0, 0, 0, 0, 0, 0).has_unicast_global_scope(), true);
     ///
     /// // Any multicast address (`ff00::/8`) does not have unicast global scope;
     /// // there is a difference between unicast global scope and multicast global scope.
-    /// assert_eq!(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
-    /// assert_eq!(Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    /// assert_eq!(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0).has_unicast_global_scope(), false);
+    /// assert_eq!(Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 0).has_unicast_global_scope(), false);
     ///
     /// // Any other address is defined as having unicast global scope.
-    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_unicast_global(), true);
+    /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).has_unicast_global_scope(), true);
     /// ```
     #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
     #[unstable(feature = "ip", issue = "27709")]
     #[inline]
-    pub const fn is_unicast_global(&self) -> bool {
+    pub const fn has_unicast_global_scope(&self) -> bool {
         self.is_unicast()
             && !self.is_unspecified()
             && !self.is_loopback()
-            && !self.is_unicast_link_local()
+            && !self.has_unicast_link_local_scope()
     }
 
     /// Returns the address's multicast scope if the address is multicast.

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1239,7 +1239,9 @@ impl Ipv6Addr {
     pub const fn is_global(&self) -> bool {
         match self.multicast_scope() {
             Some(Ipv6MulticastScope::Global) => true,
-            None => self.is_unicast_global(),
+            None => {
+                self.is_unicast_global() && !(self.is_unique_local() || self.is_documentation())
+            }
             _ => false,
         }
     }
@@ -1370,25 +1372,38 @@ impl Ipv6Addr {
         (self.segments()[0] == 0x2001) && (self.segments()[1] == 0xdb8)
     }
 
-    /// Returns [`true`] if the address is a globally routable unicast address.
+    /// Returns `true` if the address is a unicast address with global scope,
+    /// as defined in [RFC 4291].
     ///
-    /// The following return false:
+    /// Any unicast address has global scope if it is not:
+    ///  - the [unspecified address] (`::`)
+    ///  - the [loopback address] (`::1`)
+    ///  - a [link-local address] (`fe80::/10`)
     ///
-    /// - the loopback address
-    /// - the link-local addresses
-    /// - unique local addresses
-    /// - the unspecified address
-    /// - the address range reserved for documentation
+    /// Note that an address that has global scope may still not be globally reachable.
+    /// If you want to check if an address appears to be globally reachable, use [`is_global`](Ipv6Addr::is_global).
     ///
-    /// This method returns [`true`] for site-local addresses as per [RFC 4291 section 2.5.7]
+    /// # Deprecation of Site-Local Addresses
     ///
-    /// ```no_rust
-    /// The special behavior of [the site-local unicast] prefix defined in [RFC3513] must no longer
-    /// be supported in new implementations (i.e., new implementations must treat this prefix as
-    /// Global Unicast).
-    /// ```
+    /// Site-local addresses have been officially deprecated, see [RFC 4291 section 2.5.7].
+    /// It is stated that the special behaviour of site-local unicast addresses must no longer be
+    /// supported, and that implementations must treat these addresses as having global scope.
     ///
-    /// [RFC 4291 section 2.5.7]: https://tools.ietf.org/html/rfc4291#section-2.5.7
+    /// This method therefore returns [`true`] for any address that had the deprecated site-local scope (`fec0::/10`).
+    ///
+    /// # Stability Guarantees
+    ///
+    /// Note that this method's behavior may be subject to changes in the future,
+    /// as new IETF RFCs are published. Specifically [RFC 4291 section 2.4] mentions:
+    ///
+    /// > "Future specifications may redefine one or more sub-ranges of the Global Unicast space for other purposes"
+    ///
+    /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
+    /// [RFC 4291 section 2.4]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.4
+    /// [RFC 4291 section 2.5.7]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.7
+    /// [unspecified address]: Ipv6Addr::is_unspecified
+    /// [loopback address]: Ipv6Addr::is_loopback
+    /// [link-local address]: Ipv6Addr::is_unicast_link_local
     ///
     /// # Examples
     ///
@@ -1397,7 +1412,24 @@ impl Ipv6Addr {
     ///
     /// use std::net::Ipv6Addr;
     ///
-    /// assert_eq!(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    /// // The unspecified address (`::`) does not have unicast global scope
+    /// assert_eq!(Ipv6Addr::UNSPECIFIED.is_unicast_global(), false);
+    ///
+    /// // The loopback address (`::1`) does not have unicast global scope.
+    /// assert_eq!(Ipv6Addr::LOCALHOST.is_unicast_global(), false);
+    ///
+    /// // A unicast address with link-local scope (`fe80::/10`) does not have global scope.
+    /// assert_eq!(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    ///
+    /// // A unicast address that had the deprecated site-local scope (`fec0::/10`) now has global scope.
+    /// assert_eq!(Ipv6Addr::new(0xfec2, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), true);
+    ///
+    /// // Any multicast address (`ff00::/8`) does not have unicast global scope;
+    /// // there is a difference between unicast global scope and multicast global scope.
+    /// assert_eq!(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    /// assert_eq!(Ipv6Addr::new(0xff0e, 0, 0, 0, 0, 0, 0, 0).is_unicast_global(), false);
+    ///
+    /// // Any other address is defined as having unicast global scope.
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff).is_unicast_global(), true);
     /// ```
     #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
@@ -1405,11 +1437,9 @@ impl Ipv6Addr {
     #[inline]
     pub const fn is_unicast_global(&self) -> bool {
         self.is_unicast()
+            && !self.is_unspecified()
             && !self.is_loopback()
             && !self.is_unicast_link_local()
-            && !self.is_unique_local()
-            && !self.is_unspecified()
-            && !self.is_documentation()
     }
 
     /// Returns the address's multicast scope if the address is multicast.

--- a/library/std/src/net/ip/tests.rs
+++ b/library/std/src/net/ip/tests.rs
@@ -593,12 +593,16 @@ fn ipv6_properties() {
 
     check!("1::", &[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], global | unicast_global);
 
-    check!("fc00::", &[0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], unique_local);
+    check!(
+        "fc00::",
+        &[0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        unique_local | unicast_global
+    );
 
     check!(
         "fdff:ffff::",
         &[0xfd, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        unique_local
+        unique_local | unicast_global
     );
 
     check!(
@@ -676,7 +680,7 @@ fn ipv6_properties() {
     check!(
         "2001:db8:85a3::8a2e:370:7334",
         &[0x20, 1, 0xd, 0xb8, 0x85, 0xa3, 0, 0, 0, 0, 0x8a, 0x2e, 3, 0x70, 0x73, 0x34],
-        documentation
+        documentation | unicast_global
     );
 
     check!(

--- a/library/std/src/net/ip/tests.rs
+++ b/library/std/src/net/ip/tests.rs
@@ -518,14 +518,14 @@ fn ipv6_properties() {
                 assert!(!ip!($s).is_global());
             }
             if ($mask & unicast_link_local) == unicast_link_local {
-                assert!(ip!($s).is_unicast_link_local());
+                assert!(ip!($s).has_unicast_link_local_scope());
             } else {
-                assert!(!ip!($s).is_unicast_link_local());
+                assert!(!ip!($s).has_unicast_link_local_scope());
             }
             if ($mask & unicast_global) == unicast_global {
-                assert!(ip!($s).is_unicast_global());
+                assert!(ip!($s).has_unicast_global_scope());
             } else {
-                assert!(!ip!($s).is_unicast_global());
+                assert!(!ip!($s).has_unicast_global_scope());
             }
             if ($mask & documentation) == documentation {
                 assert!(ip!($s).is_documentation());
@@ -883,14 +883,14 @@ fn ipv6_const() {
     const IS_UNIQUE_LOCAL: bool = IP_ADDRESS.is_unique_local();
     assert!(!IS_UNIQUE_LOCAL);
 
-    const IS_UNICAST_LINK_LOCAL: bool = IP_ADDRESS.is_unicast_link_local();
-    assert!(!IS_UNICAST_LINK_LOCAL);
+    const HAS_UNICAST_LINK_LOCAL_SCOPE: bool = IP_ADDRESS.has_unicast_link_local_scope();
+    assert!(!HAS_UNICAST_LINK_LOCAL_SCOPE);
 
     const IS_DOCUMENTATION: bool = IP_ADDRESS.is_documentation();
     assert!(!IS_DOCUMENTATION);
 
-    const IS_UNICAST_GLOBAL: bool = IP_ADDRESS.is_unicast_global();
-    assert!(!IS_UNICAST_GLOBAL);
+    const HAS_UNICAST_GLOBAL_SCOPE: bool = IP_ADDRESS.has_unicast_global_scope();
+    assert!(!HAS_UNICAST_GLOBAL_SCOPE);
 
     const MULTICAST_SCOPE: Option<Ipv6MulticastScope> = IP_ADDRESS.multicast_scope();
     assert_eq!(MULTICAST_SCOPE, None);


### PR DESCRIPTION
See #85604 for previous discussion.

The current behaviour of `Ipv6Addr::is_unicast_global` is

```rust
/// Returns [`true`] if the address is a globally routable unicast address.
```

This is inconsistent with methods like `is_unicast_link_local` and `is_unicast_site_local`, which check if an address has unicast link-local scope or site-local scope respectively. Similarly one would expect `is_unicast_global` to check if an address has unicast global scope (which is not the same thing as being globally routable, for that we already have `Ipv6Addr::is_global` which is reworked in #86634).

This PR changes the behaviour to

```rust
/// Returns `true` if the address is a unicast address with global scope, as defined in [RFC 4291].
///
/// Any unicast address has global scope if it is not:
///  - the [unspecified address] (`::`)
///  - the [loopback address] (`::1`)
///  - a [link-local address] (`fe80::/10`)
```

Basing itself on the following table from [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291):

```
Address type         Binary prefix        IPv6 notation   Section
------------         -------------        -------------   -------
Unspecified          00...0  (128 bits)   ::/128          2.5.2
Loopback             00...1  (128 bits)   ::1/128         2.5.3
Multicast            11111111             FF00::/8        2.7
Link-Local unicast   1111111010           FE80::/10       2.5.6
Global Unicast       (everything else)
```

The documentation is also updated to reflect that future RFCs may change the behaviour of this method: "Future specifications may redefine one or more sub-ranges of the Global Unicast space for other purposes".

The behaviour of `is_global` is kept the same, it used to delegate to `is_unicast_global` but now performs the checks for global reachability itself.

To avoid further confusion between `is_unicast_global` and `is_global`, and the concepts of "global scope" and "globally reachable", the folowing methods have been renamed:
- `is_unicast_global` -> `has_unicast_global_scope`
- `is_unicast_link_local` -> `has_unicast_link_local_scope`
- <s>`is_unicast_link_local_strict` -> `has_unicast_link_local_scope_strict`</s> (removed in #85819)
- <s>`is_unicast_site_local` -> `has_unicast_site_local_scope`</s> (removed in #85820)
