### PR TITLE
Fix static relocation model for PowerPC64

### DIFF
--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -218,27 +218,3 @@ pub fn visibility_to_llvm(linkage: Visibility) -> llvm::Visibility {
         Visibility::Protected => llvm::Visibility::Protected,
     }
 }
-
-pub fn linkage_from_llvm(linkage: llvm::Linkage) -> Linkage {
-    match linkage {
-        llvm::Linkage::ExternalLinkage => Linkage::External,
-        llvm::Linkage::AvailableExternallyLinkage => Linkage::AvailableExternally,
-        llvm::Linkage::LinkOnceAnyLinkage => Linkage::LinkOnceAny,
-        llvm::Linkage::LinkOnceODRLinkage => Linkage::LinkOnceODR,
-        llvm::Linkage::WeakAnyLinkage => Linkage::WeakAny,
-        llvm::Linkage::WeakODRLinkage => Linkage::WeakODR,
-        llvm::Linkage::AppendingLinkage => Linkage::Appending,
-        llvm::Linkage::InternalLinkage => Linkage::Internal,
-        llvm::Linkage::PrivateLinkage => Linkage::Private,
-        llvm::Linkage::ExternalWeakLinkage => Linkage::ExternalWeak,
-        llvm::Linkage::CommonLinkage => Linkage::Common,
-    }
-}
-
-pub fn visibility_from_llvm(linkage: llvm::Visibility) -> Visibility {
-    match linkage {
-        llvm::Visibility::Default => Visibility::Default,
-        llvm::Visibility::Hidden => Visibility::Hidden,
-        llvm::Visibility::Protected => Visibility::Protected,
-    }
-}

--- a/compiler/rustc_codegen_llvm/src/callee.rs
+++ b/compiler/rustc_codegen_llvm/src/callee.rs
@@ -14,7 +14,6 @@ use tracing::debug;
 
 use rustc_middle::ty::layout::{FnAbiExt, HasTyCtxt};
 use rustc_middle::ty::{self, Instance, TypeFoldable};
-use rustc_target::spec::RelocModel;
 
 /// Codegens a reference to a fn/method item, monomorphizing and
 /// inlining as it goes.
@@ -181,7 +180,7 @@ pub fn get_fn(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'tcx>) -> &'ll Value
                 llvm::LLVMSetDLLStorageClass(llfn, llvm::DLLStorageClass::DllImport);
             }
 
-            if cx.tcx.sess.relocation_model() == RelocModel::Static {
+            if cx.should_assume_dso_local(llfn, true) {
                 llvm::LLVMRustSetDSOLocal(llfn, true);
             }
         }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -72,7 +72,7 @@ pub enum Linkage {
 
 // LLVMRustVisibility
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Visibility {
     Default = 0,
     Hidden = 1,
@@ -1035,6 +1035,7 @@ extern "C" {
     pub fn LLVMDeleteGlobal(GlobalVar: &Value);
     pub fn LLVMGetInitializer(GlobalVar: &Value) -> Option<&Value>;
     pub fn LLVMSetInitializer(GlobalVar: &'a Value, ConstantVal: &'a Value);
+    pub fn LLVMIsThreadLocal(GlobalVar: &Value) -> Bool;
     pub fn LLVMSetThreadLocal(GlobalVar: &Value, IsThreadLocal: Bool);
     pub fn LLVMSetThreadLocalMode(GlobalVar: &Value, Mode: ThreadLocalMode);
     pub fn LLVMIsGlobalConstant(GlobalVar: &Value) -> Bool;

--- a/src/test/assembly/static-relocation-model.rs
+++ b/src/test/assembly/static-relocation-model.rs
@@ -1,9 +1,10 @@
 // min-llvm-version: 12.0.0
-// needs-llvm-components: aarch64 x86
-// revisions:x64 A64
+// needs-llvm-components: aarch64 x86 powerpc
+// revisions: x64 A64 ppc64le
 // assembly-output: emit-asm
 // [x64] compile-flags: --target x86_64-unknown-linux-gnu -Crelocation-model=static
 // [A64] compile-flags: --target aarch64-unknown-linux-gnu -Crelocation-model=static
+// [ppc64le] compile-flags: --target powerpc64le-unknown-linux-gnu -Crelocation-model=static
 
 #![feature(no_core, lang_items)]
 #![no_core]
@@ -75,3 +76,9 @@ pub fn mango() -> u8 {
 pub fn orange() -> &'static u8 {
     &PIERIS
 }
+
+// For ppc64 we need to make sure to generate TOC entries even with the static relocation model
+// ppc64le: .tc chaenomeles[TC],chaenomeles
+// ppc64le: .tc banana[TC],banana
+// ppc64le: .tc EXOCHORDA[TC],EXOCHORDA
+// ppc64le: .tc PIERIS[TC],PIERIS


### PR DESCRIPTION
We now also use `should_assume_dso_local()` for declarations and port two
additional cases from clang:
- Exclude PPC64 [1]
- Exclude thread-local variables [2]

[1]: https://github.com/llvm/llvm-project/blob/033138ea452f5f493fb5095e5963419905ad12e1/clang/lib/CodeGen/CodeGenModule.cpp#L1038-L1040
[2]: https://github.com/llvm/llvm-project/blob/033138ea452f5f493fb5095e5963419905ad12e1/clang/lib/CodeGen/CodeGenModule.cpp#L1048-L1050

Tbh I don't know enough about PowerPC(64) to explain why the TOC (table of contents; like the GOT in x86?) is still needed even with the static relocation model. But with these changes [Rust-For-Linux](https://github.com/Rust-for-Linux/linux) runs again on ppc64le. (instead of [getting loaded successfully but crashing](https://github.com/Bobo1239/linux/runs/2646478783?check_suite_focus=true#step:47:358))

r? @nagisa 