### PR TITLE
Emit a hard error when a panic occurs during const-eval

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -435,8 +435,12 @@ impl<T: Any> AsAny for T {
 }
 
 /// A trait for machine-specific errors (or other "machine stop" conditions).
-pub trait MachineStopType: AsAny + fmt::Display + Send {}
-impl MachineStopType for String {}
+pub trait MachineStopType: AsAny + fmt::Display + Send {
+    /// If `true`, emit a hard error instead of going through the `CONST_ERR` lint
+    fn is_hard_err(&self) -> bool {
+        false
+    }
+}
 
 impl dyn MachineStopType {
     #[inline(always)]

--- a/compiler/rustc_mir/src/const_eval/error.rs
+++ b/compiler/rustc_mir/src/const_eval/error.rs
@@ -9,7 +9,7 @@ use rustc_span::{Span, Symbol};
 
 use super::InterpCx;
 use crate::interpret::{
-    struct_error, ErrorHandled, FrameInfo, InterpError, InterpErrorInfo, Machine,
+    struct_error, ErrorHandled, FrameInfo, InterpError, InterpErrorInfo, Machine, MachineStopType,
 };
 
 /// The CTFE machine has some custom error kinds.
@@ -24,12 +24,21 @@ pub enum ConstEvalErrKind {
     Abort(String),
 }
 
+impl MachineStopType for ConstEvalErrKind {
+    fn is_hard_err(&self) -> bool {
+        match self {
+            Self::Panic { .. } => true,
+            _ => false,
+        }
+    }
+}
+
 // The errors become `MachineStop` with plain strings when being raised.
 // `ConstEvalErr` (in `librustc_middle/mir/interpret/error.rs`) knows to
 // handle these.
 impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalErrKind {
     fn into(self) -> InterpErrorInfo<'tcx> {
-        err_machine_stop!(self.to_string()).into()
+        err_machine_stop!(self).into()
     }
 }
 
@@ -148,31 +157,10 @@ impl<'tcx> ConstEvalErr<'tcx> {
         tcx: TyCtxtAt<'tcx>,
         message: &str,
         emit: impl FnOnce(DiagnosticBuilder<'_>),
-        lint_root: Option<hir::HirId>,
+        mut lint_root: Option<hir::HirId>,
     ) -> ErrorHandled {
-        let must_error = match self.error {
-            err_inval!(Layout(LayoutError::Unknown(_))) | err_inval!(TooGeneric) => {
-                return ErrorHandled::TooGeneric;
-            }
-            err_inval!(AlreadyReported(error_reported)) => {
-                return ErrorHandled::Reported(error_reported);
-            }
-            // We must *always* hard error on these, even if the caller wants just a lint.
-            err_inval!(Layout(LayoutError::SizeOverflow(_))) => true,
-            _ => false,
-        };
-        trace!("reporting const eval failure at {:?}", self.span);
-
-        let err_msg = match &self.error {
-            InterpError::MachineStop(msg) => {
-                // A custom error (`ConstEvalErrKind` in `librustc_mir/interp/const_eval/error.rs`).
-                // Should be turned into a string by now.
-                msg.downcast_ref::<String>().expect("invalid MachineStop payload").clone()
-            }
-            err => err.to_string(),
-        };
-
         let finish = |mut err: DiagnosticBuilder<'_>, span_msg: Option<String>| {
+            trace!("reporting const eval failure at {:?}", self.span);
             if let Some(span_msg) = span_msg {
                 err.span_label(self.span, span_msg);
             }
@@ -186,34 +174,50 @@ impl<'tcx> ConstEvalErr<'tcx> {
             emit(err)
         };
 
-        if must_error {
-            // The `message` makes little sense here, this is a more serious error than the
-            // caller thinks anyway.
-            // See <https://github.com/rust-lang/rust/pull/63152>.
-            finish(struct_error(tcx, &err_msg), None);
-            ErrorHandled::Reported(ErrorReported)
-        } else {
-            // Regular case.
-            if let Some(lint_root) = lint_root {
-                // Report as lint.
-                let hir_id = self
-                    .stacktrace
-                    .iter()
-                    .rev()
-                    .find_map(|frame| frame.lint_root)
-                    .unwrap_or(lint_root);
-                tcx.struct_span_lint_hir(
-                    rustc_session::lint::builtin::CONST_ERR,
-                    hir_id,
-                    tcx.span,
-                    |lint| finish(lint.build(message), Some(err_msg)),
-                );
-                ErrorHandled::Linted
-            } else {
-                // Report as hard error.
-                finish(struct_error(tcx, message), Some(err_msg));
-                ErrorHandled::Reported(ErrorReported)
+        // Special handling for certain errors
+        match &self.error {
+            // Don't emit a new diagnostic for these errors
+            err_inval!(Layout(LayoutError::Unknown(_))) | err_inval!(TooGeneric) => {
+                return ErrorHandled::TooGeneric;
             }
+            err_inval!(AlreadyReported(error_reported)) => {
+                return ErrorHandled::Reported(*error_reported);
+            }
+            err_inval!(Layout(LayoutError::SizeOverflow(_))) => {
+                // We must *always* hard error on these, even if the caller wants just a lint.
+                // The `message` makes little sense here, this is a more serious error than the
+                // caller thinks anyway.
+                // See <https://github.com/rust-lang/rust/pull/63152>.
+                finish(struct_error(tcx, &self.error.to_string()), None);
+                return ErrorHandled::Reported(ErrorReported);
+            }
+            _ => {}
+        };
+
+        // If we have a 'hard error', then set `lint_root` to `None` so that we don't
+        // emit a lint.
+        if matches!(&self.error, InterpError::MachineStop(err) if err.is_hard_err()) {
+            lint_root = None;
+        }
+
+        let err_msg = self.error.to_string();
+
+        // Regular case - emit a lint.
+        if let Some(lint_root) = lint_root {
+            // Report as lint.
+            let hir_id =
+                self.stacktrace.iter().rev().find_map(|frame| frame.lint_root).unwrap_or(lint_root);
+            tcx.struct_span_lint_hir(
+                rustc_session::lint::builtin::CONST_ERR,
+                hir_id,
+                tcx.span,
+                |lint| finish(lint.build(message), Some(err_msg)),
+            );
+            ErrorHandled::Linted
+        } else {
+            // Report as hard error.
+            finish(struct_error(tcx, message), Some(err_msg));
+            ErrorHandled::Reported(ErrorReported)
         }
     }
 }

--- a/src/test/ui/consts/const-eval/const_panic.rs
+++ b/src/test/ui/consts/const-eval/const_panic.rs
@@ -6,40 +6,30 @@ const MSG: &str = "hello";
 
 const Z: () = std::panic!("cheese");
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z2: () = std::panic!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y: () = std::unreachable!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X: () = std::unimplemented!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 //
 const W: () = std::panic!(MSG);
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z_CORE: () = core::panic!("cheese");
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z2_CORE: () = core::panic!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y_CORE: () = core::unreachable!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X_CORE: () = core::unimplemented!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const W_CORE: () = core::panic!(MSG);
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $DIR/const_panic.rs:7:15
    |
 LL | const Z: () = std::panic!("cheese");
@@ -6,118 +6,98 @@ LL | const Z: () = std::panic!("cheese");
    |               |
    |               the evaluated program panicked at 'cheese', $DIR/const_panic.rs:7:15
    |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:11:16
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:10:16
    |
 LL | const Z2: () = std::panic!();
    | ---------------^^^^^^^^^^^^^-
    |                |
-   |                the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:11:16
+   |                the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:10:16
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:15:15
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:13:15
    |
 LL | const Y: () = std::unreachable!();
    | --------------^^^^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:15:15
+   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:13:15
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:19:15
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:16:15
    |
 LL | const X: () = std::unimplemented!();
    | --------------^^^^^^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:19:15
+   |               the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:16:15
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:23:15
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:19:15
    |
 LL | const W: () = std::panic!(MSG);
    | --------------^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'hello', $DIR/const_panic.rs:23:15
+   |               the evaluated program panicked at 'hello', $DIR/const_panic.rs:19:15
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:27:20
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:22:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
    | -------------------^^^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'cheese', $DIR/const_panic.rs:27:20
+   |                    the evaluated program panicked at 'cheese', $DIR/const_panic.rs:22:20
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:31:21
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:25:21
    |
 LL | const Z2_CORE: () = core::panic!();
    | --------------------^^^^^^^^^^^^^^-
    |                     |
-   |                     the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:31:21
+   |                     the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:25:21
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:35:20
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:28:20
    |
 LL | const Y_CORE: () = core::unreachable!();
    | -------------------^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:35:20
+   |                    the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:28:20
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:39:20
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:31:20
    |
 LL | const X_CORE: () = core::unimplemented!();
    | -------------------^^^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:39:20
+   |                    the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:31:20
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:43:20
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic.rs:34:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
    | -------------------^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'hello', $DIR/const_panic.rs:43:20
+   |                    the evaluated program panicked at 'hello', $DIR/const_panic.rs:34:20
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
@@ -8,15 +8,12 @@ use core::panic::PanicInfo;
 
 const Z: () = panic!("cheese");
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y: () = unreachable!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X: () = unimplemented!();
 //~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
 
 #[lang = "eh_personality"]
 fn eh() {}

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $DIR/const_panic_libcore_bin.rs:9:15
    |
 LL | const Z: () = panic!("cheese");
@@ -6,34 +6,28 @@ LL | const Z: () = panic!("cheese");
    |               |
    |               the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:9:15
    |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_bin.rs:13:15
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic_libcore_bin.rs:12:15
    |
 LL | const Y: () = unreachable!();
    | --------------^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:13:15
+   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:12:15
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_bin.rs:17:15
+error[E0080]: any use of this value will cause an error
+  --> $DIR/const_panic_libcore_bin.rs:15:15
    |
 LL | const X: () = unimplemented!();
    | --------------^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:17:15
+   |               the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:15:15
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -9,8 +9,7 @@ struct PrintName;
 
 impl PrintName {
     const VOID: ! = panic!();
-    //~^ WARN any use of this value will cause an error
-    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~^ ERROR any use of this value will cause an error
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -1,4 +1,4 @@
-warning: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $DIR/panic-assoc-never-type.rs:11:21
    |
 LL |     const VOID: ! = panic!();
@@ -6,21 +6,14 @@ LL |     const VOID: ! = panic!();
    |                     |
    |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:11:21
    |
-note: the lint level is defined here
-  --> $DIR/panic-assoc-never-type.rs:4:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
-  --> $DIR/panic-assoc-never-type.rs:17:13
+  --> $DIR/panic-assoc-never-type.rs:16:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^ referenced constant has errors
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-never-type.rs
@@ -1,15 +1,11 @@
-// build-fail
-
 // Regression test for #66975
 #![warn(const_err)]
 #![feature(const_panic)]
 #![feature(never_type)]
 
 const VOID: ! = panic!();
-//~^ WARN any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR any use of this value will cause an error
 
 fn main() {
     let _ = VOID;
-    //~^ ERROR erroneous constant used
 }

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -1,26 +1,13 @@
-warning: any use of this value will cause an error
-  --> $DIR/panic-never-type.rs:8:17
+error[E0080]: any use of this value will cause an error
+  --> $DIR/panic-never-type.rs:6:17
    |
 LL | const VOID: ! = panic!();
    | ----------------^^^^^^^^-
    |                 |
-   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:8:17
+   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:6:17
    |
-note: the lint level is defined here
-  --> $DIR/panic-never-type.rs:4:9
-   |
-LL | #![warn(const_err)]
-   |         ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: erroneous constant used
-  --> $DIR/panic-never-type.rs:13:13
-   |
-LL |     let _ = VOID;
-   |             ^^^^ referenced constant has errors
-
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/unwind-abort.rs
+++ b/src/test/ui/consts/const-eval/unwind-abort.rs
@@ -2,8 +2,7 @@
 
 #[unwind(aborts)]
 const fn foo() {
-    panic!() //~ ERROR any use of this value will cause an error [const_err]
-    //~| WARN this was previously accepted by the compiler but is being phased out
+    panic!() //~ ERROR any use of this value will cause an error
 }
 
 const _: () = foo();

--- a/src/test/ui/consts/const-eval/unwind-abort.stderr
+++ b/src/test/ui/consts/const-eval/unwind-abort.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $DIR/unwind-abort.rs:5:5
    |
 LL |     panic!()
@@ -6,15 +6,13 @@ LL |     panic!()
    |     |
    |     the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:5:5
    |     inside `foo` at $SRC_DIR/std/src/panic.rs:LL:COL
-   |     inside `_` at $DIR/unwind-abort.rs:9:15
+   |     inside `_` at $DIR/unwind-abort.rs:8:15
 ...
 LL | const _: () = foo();
    | --------------------
    |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-unwrap.stderr
+++ b/src/test/ui/consts/const-unwrap.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |             None => panic!("called `Option::unwrap()` on a `None` value"),
@@ -13,10 +13,8 @@ LL |             None => panic!("called `Option::unwrap()` on a `None` value"),
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
    | ----------------------------------------------
    |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/control-flow/assert.const_panic.stderr
+++ b/src/test/ui/consts/control-flow/assert.const_panic.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: any use of this value will cause an error
   --> $DIR/assert.rs:10:15
    |
 LL | const _: () = assert!(false);
@@ -6,10 +6,8 @@ LL | const _: () = assert!(false);
    |               |
    |               the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:10:15
    |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/control-flow/assert.rs
+++ b/src/test/ui/consts/control-flow/assert.rs
@@ -10,6 +10,5 @@ const _: () = assert!(true);
 const _: () = assert!(false);
 //[stock]~^ ERROR panicking in constants is unstable
 //[const_panic]~^^ ERROR any use of this value will cause an error
-//[const_panic]~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}


### PR DESCRIPTION
Previous, a panic during const evaluation would go through the
`const_err` lint. This PR ensures that such a panic always causes
compilation to fail.