### PR TITLE
Fix typo in core::array::IntoIter comment

### DIFF
--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -139,7 +139,7 @@ impl<T, const N: usize> Iterator for IntoIter<T, N> {
         // SAFETY: Callers are only allowed to pass an index that is in bounds
         // Additionally Self: TrustedRandomAccess is only implemented for T: Copy which means even
         // multiple repeated reads of the same index would be safe and the
-        // values aree !Drop, thus won't suffer from double drops.
+        // values are !Drop, thus won't suffer from double drops.
         unsafe { self.data.get_unchecked(self.alive.start + idx).assume_init_read() }
     }
 }


### PR DESCRIPTION
Saw a small typo reading some internal comments and decided to just throw this up to fix it for future readers.