### PR TITLE
Add inline attr to CString::into_inner so it can optimize out NonNull checks

### DIFF
--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -672,6 +672,7 @@ impl CString {
     }
 
     /// Bypass "move out of struct which implements [`Drop`] trait" restriction.
+    #[inline]
     fn into_inner(self) -> Box<[u8]> {
         // Rationale: `mem::forget(self)` invalidates the previous call to `ptr::read(&self.inner)`
         // so we use `ManuallyDrop` to ensure `self` is not dropped.


### PR DESCRIPTION
It seems that currently if you convert any of the standard library's container to a pointer and then to a NonNull pointer, all will optimize out the NULL check except `CString`(https://godbolt.org/z/YPKW9G5xn), 
because for some reason `CString::into_inner` isn't inlined even though it's a private function that should compile into a simple `mov` instruction.

Adding a simple `#[inline]` attribute solves this, code example:
```rust
use std::ffi::CString;
use std::ptr::NonNull;

pub fn cstring_nonull(mut n: CString) -> NonNull<i8> {
    NonNull::new(CString::into_raw(n)).unwrap()
}
```

assembly before: 
```asm
__ZN3wat14cstring_nonull17h371c755bcad76294E:
	.cfi_startproc
	pushq	%rbp
	.cfi_def_cfa_offset 16
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
	.cfi_def_cfa_register %rbp
	callq	__ZN3std3ffi5c_str7CString10into_inner17h28ece07b276e2878E
	testq	%rax, %rax
	je	LBB0_2
	popq	%rbp
	retq
LBB0_2:
	leaq	l___unnamed_1(%rip), %rdi
	leaq	l___unnamed_2(%rip), %rdx
	movl	$43, %esi
	callq	__ZN4core9panicking5panic17h92a83fa9085a8f73E
	.cfi_endproc

	.section	__TEXT,__const
l___unnamed_1:
	.ascii	"called `Option::unwrap()` on a `None` value"

l___unnamed_3:
	.ascii	"wat.rs"

	.section	__DATA,__const
	.p2align	3
l___unnamed_2:
	.quad	l___unnamed_3
	.asciz	"\006\000\000\000\000\000\000\000\006\000\000\000(\000\000"
```

Assembly after:
```asm
__ZN3wat14cstring_nonull17h9645eb9341fb25d7E:
	.cfi_startproc
	pushq	%rbp
	.cfi_def_cfa_offset 16
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
	.cfi_def_cfa_register %rbp
	movq	%rdi, %rax
	popq	%rbp
	retq
	.cfi_endproc
```

(Related discussion on zulip: https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/NonNull.20From.3CBox.3CT.3E.3E)