### PR TITLE
Fix trait methods' toggle

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -578,14 +578,23 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         info!("Documenting {} on {:?}", name, t.name);
         let item_type = m.type_();
         let id = cx.derive_id(format!("{}.{}", item_type, name));
-        write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
-        write!(w, "<h3 id=\"{id}\" class=\"method\"><code>", id = id,);
+        let mut content = Buffer::empty_from(w);
+        document(&mut content, cx, m, Some(t));
+        let toggled = !content.is_empty();
+        if toggled {
+            write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
+        }
+        write!(w, "<h3 id=\"{id}\" class=\"method\"><code>", id = id);
         render_assoc_item(w, m, AssocItemLink::Anchor(Some(&id)), ItemType::Impl, cx);
         w.write_str("</code>");
         render_stability_since(w, m, t, cx.tcx());
         write_srclink(cx, m, w);
-        w.write_str("</h3></summary>");
-        document(w, cx, m, Some(t));
+        w.write_str("</h3>");
+        if toggled {
+            write!(w, "</summary>");
+            w.push_buffer(content);
+            write!(w, "</details>");
+        }
     }
 
     if !types.is_empty() {

--- a/src/test/rustdoc/toggle-trait-fn.rs
+++ b/src/test/rustdoc/toggle-trait-fn.rs
@@ -1,7 +1,11 @@
 #![crate_name = "foo"]
 
 // @has foo/trait.Foo.html
-// @has - '//details[@class="rustdoc-toggle"]//code' 'bar'
+// @!has - '//details[@class="rustdoc-toggle"]//code' 'bar'
+// @has - '//code' 'bar'
+// @has - '//details[@class="rustdoc-toggle"]//code' 'foo'
 pub trait Foo {
     fn bar() -> ();
+    /// hello
+    fn foo();
 }


### PR DESCRIPTION
A `<details>` tag wasn't closed on trait methods, which created broken DOM. I also used this occasion to only generate the toggle in case there is documentation on the method.

r? @jsha 