### PR TITLE
bootstrap: make cmake executable configurable with config.toml

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -258,6 +258,9 @@ changelog-seen = 2
 # Defaults to the Python interpreter used to execute x.py
 #python = "python"
 
+# Path to (or name of) the CMake 3 executable to build LLVM.
+#cmake = "cmake"
+
 # Force Cargo to check that Cargo.lock describes the precise dependency
 # set that all the Cargo.toml files create, instead of updating it.
 #locked-deps = false

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -185,6 +185,7 @@ pub struct Config {
     pub npm: Option<PathBuf>,
     pub gdb: Option<PathBuf>,
     pub python: Option<PathBuf>,
+    pub cmake: Option<PathBuf>,
     pub cargo_native_static: bool,
     pub configure_args: Vec<String>,
 
@@ -474,6 +475,7 @@ define_config! {
         nodejs: Option<String> = "nodejs",
         npm: Option<String> = "npm",
         python: Option<String> = "python",
+        cmake: Option<String> = "cmake",
         locked_deps: Option<bool> = "locked-deps",
         vendor: Option<bool> = "vendor",
         full_bootstrap: Option<bool> = "full-bootstrap",
@@ -793,6 +795,7 @@ impl Config {
         config.npm = build.npm.map(PathBuf::from);
         config.gdb = build.gdb.map(PathBuf::from);
         config.python = build.python.map(PathBuf::from);
+        config.cmake = build.cmake.map(PathBuf::from);
         config.submodules = build.submodules;
         set(&mut config.low_priority, build.low_priority);
         set(&mut config.compiler_docs, build.compiler_docs);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -645,6 +645,9 @@ impl Build {
         unsafe {
             job::setup(self);
         }
+        if let Some(cmake) = self.config.cmake.as_ref() {
+            env::set_var("CMAKE", cmake); // https://docs.rs/cmake/0.1.48/src/cmake/lib.rs.html#515
+        }
 
         self.maybe_update_submodules();
 


### PR DESCRIPTION
This is a spiritual successor to #71262

Fixes #71227

TODO

- [x] Add a template section to `config.toml.example`
- [x] Official CI runs the build with a weird setup; it is trivial to add `if-else` just to avoid crashing under the CI but its implications should be reviewed
- [x] With this change, `CMAKE` env var to control [`cmake` crate](https://docs.rs/cmake/0.1.45/src/cmake/lib.rs.html#456) will no longer be a pass-through field; `bootstrap` will (almost) always overwrite it. Its implications should be reviewed