### PR TITLE
Lint against non-CamelCase trait alias names

### DIFF
--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -176,6 +176,7 @@ impl EarlyLintPass for NonCamelCaseTypes {
             | ast::ItemKind::Struct(..)
             | ast::ItemKind::Union(..) => self.check_case(cx, "type", &it.ident),
             ast::ItemKind::Trait(..) => self.check_case(cx, "trait", &it.ident),
+            ast::ItemKind::TraitAlias(..) => self.check_case(cx, "trait alias", &it.ident),
             _ => (),
         }
     }

--- a/src/test/ui/traits/alias/style_lint.rs
+++ b/src/test/ui/traits/alias/style_lint.rs
@@ -1,0 +1,8 @@
+// check-pass
+
+#![feature(trait_alias)]
+
+trait Foo = std::fmt::Display + std::fmt::Debug;
+trait bar = std::fmt::Display + std::fmt::Debug; //~WARN trait alias `bar` should have an upper camel case name
+
+fn main() {}

--- a/src/test/ui/traits/alias/style_lint.stderr
+++ b/src/test/ui/traits/alias/style_lint.stderr
@@ -1,0 +1,10 @@
+warning: trait alias `bar` should have an upper camel case name
+  --> $DIR/style_lint.rs:6:7
+   |
+LL | trait bar = std::fmt::Display + std::fmt::Debug;
+   |       ^^^ help: convert the identifier to upper camel case: `Bar`
+   |
+   = note: `#[warn(non_camel_case_types)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Type aliases are linted as such, so (unstable) trait aliases should be treated the same way.