### PR TITLE
Use preorder traversal when checking for SSA locals

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -18,7 +18,10 @@ pub fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let mir = fx.mir;
     let mut analyzer = LocalAnalyzer::new(fx);
 
-    for (bb, data) in mir.basic_blocks().iter_enumerated() {
+    // If there exists a local definition that dominates all uses of that local,
+    // the definition should be visited first. Traverse blocks in preorder which
+    // is a topological sort of dominance partial order.
+    for (bb, data) in traversal::preorder(&mir) {
         analyzer.visit_basic_block_data(bb, data);
     }
 


### PR DESCRIPTION
Traverse blocks in topological sort of dominance partial order, to ensure that
local analyzer correctly identifies locals that are already in static single
assignment form, while avoiding dependency on implicit numeric order of blocks.
    
When rebuilding the standard library, this change reduces the number of locals
that require an alloca from 62452 to 62348.