### PR TITLE
Add #[track_caller] to panic_any

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -55,6 +55,7 @@ pub use core::panic::{Location, PanicInfo};
 /// See the [`panic!`] macro for more information about panicking.
 #[stable(feature = "panic_any", since = "1.51.0")]
 #[inline]
+#[track_caller]
 pub fn panic_any<M: 'static + Any + Send>(msg: M) -> ! {
     crate::panicking::begin_panic(msg);
 }


### PR DESCRIPTION
Report the panic location from the user code.

```rust
use std::panic;
use std::panic::panic_any;

fn main() {
    panic::set_hook(Box::new(|panic_info| {
        if let Some(location) = panic_info.location() {
            println!(
                "panic occurred in file '{}' at line {}",
                location.file(),
                location.line(),
            );
        } else {
            println!("panic occurred but can't get location information...");
        }
    }));

    panic_any(42);
}
````

Before:
`panic occurred in file '/rustc/ff2c947c00f867b9f012e28ba88cecfbe556f904/library/std/src/panic.rs' at line 59`

After:
`panic occurred in file 'src/main.rs' at line 17`