### PR TITLE
Path methods — symlinks improvement 

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1007,6 +1007,30 @@ impl Metadata {
         self.file_type().is_file()
     }
 
+    /// Returns `true` if this metadata is for a symbolic link file.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::fs;
+    /// use std::path::Path;
+    /// use std::os::unix::fs::symlink;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let link_path = Path::new("/link");
+    ///     symlink("/origin_does_not_exists/", link_path)?;
+    ///
+    ///     let metadata = fs::symlink_metadata(link_path)?;
+    ///
+    ///     assert!(metadata.is_symlink());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "is_symlink", issue = "none")]
+    pub fn is_symlink(&self) -> bool {
+        self.file_type().is_symlink()
+    }
+
     /// Returns the size of the file, in bytes, this metadata is for.
     ///
     /// # Examples

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1026,7 +1026,7 @@ impl Metadata {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "is_symlink", issue = "none")]
+    #[unstable(feature = "is_symlink", issue = "85748")]
     pub fn is_symlink(&self) -> bool {
         self.file_type().is_symlink()
     }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1007,17 +1007,18 @@ impl Metadata {
         self.file_type().is_file()
     }
 
-    /// Returns `true` if this metadata is for a symbolic link file.
+    /// Returns `true` if this metadata is for a symbolic link.
     ///
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(is_symlink)]
     /// use std::fs;
     /// use std::path::Path;
     /// use std::os::unix::fs::symlink;
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let link_path = Path::new("/link");
+    ///     let link_path = Path::new("link");
     ///     symlink("/origin_does_not_exists/", link_path)?;
     ///
     ///     let metadata = fs::symlink_metadata(link_path)?;

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1011,7 +1011,8 @@ impl Metadata {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(unix, doc = "```no_run")]
+    #[cfg_attr(not(unix), doc = "```ignore")]
     /// #![feature(is_symlink)]
     /// use std::fs;
     /// use std::path::Path;

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2569,7 +2569,6 @@ impl Path {
     }
 
     /// Returns true if the path exists on disk and is pointing at a symbolic link.
-    /// This method can alse be used to check whether symlink exists.
     ///
     /// This function will not traverse symbolic links.
     /// In case of a broken symbolic link this will also return true.

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2588,7 +2588,7 @@ impl Path {
     /// assert_eq!(link_path.is_symlink(), true);
     /// assert_eq!(link_path.exists(), false);
     /// ```
-    #[unstable(feature = "is_symlink", issue = "none")]
+    #[unstable(feature = "is_symlink", issue = "85748")]
     pub fn is_symlink(&self) -> bool {
         fs::symlink_metadata(self).map(|m| m.is_symlink()).unwrap_or(false)
     }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2568,6 +2568,32 @@ impl Path {
         fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
     }
 
+    /// Returns true if the path exists on disk and is pointing at a symbolic link file.
+    /// This method can alse be used to check whether symlink exists.
+    ///
+    /// This function will not traverse symbolic links.
+    /// In case of broken symbolic links this will also return true.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return false.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use std::os::unix::fs::symlink;
+    ///
+    /// let link_path = Path::new("/link");
+    /// symlink("/origin_does_not_exists/", link_path)?;
+    /// assert_eq!(link_path.is_symlink(), true);
+    /// assert_eq!(link_path.exists(), false);
+    /// ```
+    #[unstable(feature = "path_ext", issue = "none")]
+    #[inline]
+    pub fn is_symlink(&self) -> bool {
+        fs::symlink_metadata(self).is_ok()
+    }
+
     /// Converts a [`Box<Path>`](Box) into a [`PathBuf`] without copying or
     /// allocating.
     #[stable(feature = "into_boxed_path", since = "1.20.0")]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2568,11 +2568,11 @@ impl Path {
         fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
     }
 
-    /// Returns true if the path exists on disk and is pointing at a symbolic link file.
+    /// Returns true if the path exists on disk and is pointing at a symbolic link.
     /// This method can alse be used to check whether symlink exists.
     ///
     /// This function will not traverse symbolic links.
-    /// In case of broken symbolic links this will also return true.
+    /// In case of a broken symbolic link this will also return true.
     ///
     /// If you cannot access the directory containing the file, e.g., because of a
     /// permission error, this will return false.
@@ -2580,11 +2580,12 @@ impl Path {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(is_symlink)]
     /// use std::path::Path;
     /// use std::os::unix::fs::symlink;
     ///
-    /// let link_path = Path::new("/link");
-    /// symlink("/origin_does_not_exists/", link_path)?;
+    /// let link_path = Path::new("link");
+    /// symlink("/origin_does_not_exists/", link_path).unwrap();
     /// assert_eq!(link_path.is_symlink(), true);
     /// assert_eq!(link_path.exists(), false);
     /// ```

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2588,10 +2588,9 @@ impl Path {
     /// assert_eq!(link_path.is_symlink(), true);
     /// assert_eq!(link_path.exists(), false);
     /// ```
-    #[unstable(feature = "path_ext", issue = "none")]
-    #[inline]
+    #[unstable(feature = "is_symlink", issue = "none")]
     pub fn is_symlink(&self) -> bool {
-        fs::symlink_metadata(self).is_ok()
+        fs::symlink_metadata(self).map(|m| m.is_symlink()).unwrap_or(false)
     }
 
     /// Converts a [`Box<Path>`](Box) into a [`PathBuf`] without copying or

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2578,7 +2578,8 @@ impl Path {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(unix, doc = "```no_run")]
+    #[cfg_attr(not(unix), doc = "```ignore")]
     /// #![feature(is_symlink)]
     /// use std::path::Path;
     /// use std::os::unix::fs::symlink;


### PR DESCRIPTION
This PR adds symlink method for the `Path`.

Tracking issue: #85748  
For the discussion you can see [internals topic](https://internals.rust-lang.org/t/path-methods-symlinks-improvement/14776)

P.S.
I'm not fully sure about `stable` attribute, correct me if I'm wrong.