### PR TITLE
Revert "Auto merge of #83770 - the8472:tra-extend, r=Mark-Simulacrum"

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -416,10 +416,6 @@ impl<A: Debug + TrustedRandomAccess, B: Debug + TrustedRandomAccess> ZipFmt<A, B
 
 /// An iterator whose items are random-accessible efficiently
 ///
-/// Iterators that implement this trait should also implement TrustedLen which
-/// allows specialization to disambiguate overlaps with a `TrustedLen + TrustedRandomAccess`
-/// bound.
-///
 /// # Safety
 ///
 /// The iterator's `size_hint` must be exact and cheap to call.


### PR DESCRIPTION
Due to a performance regression that didn't show up in the original perf run
this reverts commit 9111b8ae9793f18179a1336417618fc07a9cac85 (#83770), reversing
changes made to 9a700d2947f2d7f97a2c0dfca3117a8dcc255bdd.

Since since is expected to have the inverse impact it should probably be rollup=never.

r? @Mark-Simulacrum 