### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2646,7 +2646,7 @@ pub trait Iterator {
     /// assert_eq!(
     ///     vec![2.4, f32::NAN, 1.3]
     ///         .into_iter()
-    ///         .reduce(|a, b| f32::min(a, b))
+    ///         .reduce(f32::min)
     ///         .unwrap(),
     ///     1.3
     /// );

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2602,6 +2602,18 @@ pub trait Iterator {
     /// If several elements are equally maximum, the last element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
+    /// Note that [`f32`]/[`f64`] doesn't implement [`Ord`] due to NaN being
+    /// incomparable. You can work around this by using [`Iterator::reduce`]:
+    /// ```
+    /// assert_eq!(
+    ///     vec![2.4, f32::NAN, 1.3]
+    ///         .into_iter()
+    ///         .reduce(|a, b| f32::max(a, b))
+    ///         .unwrap(),
+    ///     2.4
+    /// );
+    /// ```
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -2625,8 +2637,20 @@ pub trait Iterator {
 
     /// Returns the minimum element of an iterator.
     ///
-    /// If several elements are equally minimum, the first element is
-    /// returned. If the iterator is empty, [`None`] is returned.
+    /// If several elements are equally minimum, the first element is returned.
+    /// If the iterator is empty, [`None`] is returned.
+    ///
+    /// Note that [`f32`]/[`f64`] doesn't implement [`Ord`] due to NaN being
+    /// incomparable. You can work around this by using [`Iterator::reduce`]:
+    /// ```
+    /// assert_eq!(
+    ///     vec![2.4, f32::NAN, 1.3]
+    ///         .into_iter()
+    ///         .reduce(|a, b| f32::min(a, b))
+    ///         .unwrap(),
+    ///     1.3
+    /// );
+    /// ```
     ///
     /// # Examples
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2608,7 +2608,7 @@ pub trait Iterator {
     /// assert_eq!(
     ///     vec![2.4, f32::NAN, 1.3]
     ///         .into_iter()
-    ///         .reduce(|a, b| f32::max(a, b))
+    ///         .reduce(f32::max)
     ///         .unwrap(),
     ///     2.4
     /// );

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -62,7 +62,7 @@ impl Socket {
                     target_os = "illumos",
                     target_os = "linux",
                     target_os = "netbsd",
-                    target_os = "opensbd",
+                    target_os = "openbsd",
                 ))] {
                     // On platforms that support it we pass the SOCK_CLOEXEC
                     // flag to atomically create the socket and set it as
@@ -99,7 +99,7 @@ impl Socket {
                     target_os = "illumos",
                     target_os = "linux",
                     target_os = "netbsd",
-                    target_os = "opensbd",
+                    target_os = "openbsd",
                 ))] {
                     // Like above, set cloexec atomically
                     cvt(libc::socketpair(fam, ty | libc::SOCK_CLOEXEC, 0, fds.as_mut_ptr()))?;
@@ -204,7 +204,7 @@ impl Socket {
                 target_os = "illumos",
                 target_os = "linux",
                 target_os = "netbsd",
-                target_os = "opensbd",
+                target_os = "openbsd",
             ))] {
                 let fd = cvt_r(|| unsafe {
                     libc::accept4(self.0.raw(), storage, len, libc::SOCK_CLOEXEC)

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -578,14 +578,23 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         info!("Documenting {} on {:?}", name, t.name);
         let item_type = m.type_();
         let id = cx.derive_id(format!("{}.{}", item_type, name));
-        write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
-        write!(w, "<h3 id=\"{id}\" class=\"method\"><code>", id = id,);
+        let mut content = Buffer::empty_from(w);
+        document(&mut content, cx, m, Some(t));
+        let toggled = !content.is_empty();
+        if toggled {
+            write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
+        }
+        write!(w, "<h3 id=\"{id}\" class=\"method\"><code>", id = id);
         render_assoc_item(w, m, AssocItemLink::Anchor(Some(&id)), ItemType::Impl, cx);
         w.write_str("</code>");
         render_stability_since(w, m, t, cx.tcx());
         write_srclink(cx, m, w);
-        w.write_str("</h3></summary>");
-        document(w, cx, m, Some(t));
+        w.write_str("</h3>");
+        if toggled {
+            write!(w, "</summary>");
+            w.push_buffer(content);
+            write!(w, "</details>");
+        }
     }
 
     if !types.is_empty() {

--- a/src/test/rustdoc/toggle-trait-fn.rs
+++ b/src/test/rustdoc/toggle-trait-fn.rs
@@ -1,7 +1,11 @@
 #![crate_name = "foo"]
 
 // @has foo/trait.Foo.html
-// @has - '//details[@class="rustdoc-toggle"]//code' 'bar'
+// @!has - '//details[@class="rustdoc-toggle"]//code' 'bar'
+// @has - '//code' 'bar'
+// @has - '//details[@class="rustdoc-toggle"]//code' 'foo'
 pub trait Foo {
     fn bar() -> ();
+    /// hello
+    fn foo();
 }


### PR DESCRIPTION
Successful merges:

 - #85722 (Fix trait methods' toggle)
 - #85730 (Mention workaround for floats in Iterator::{min, max})
 - #85738 (Rename opensbd to openbsd)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85722,85730,85738)
<!-- homu-ignore:end -->