### PR TITLE
Revert #85176 addition of `clone_from` for `ManuallyDrop`

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -44,7 +44,7 @@ use crate::ptr;
 /// [`MaybeUninit<T>`]: crate::mem::MaybeUninit
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[lang = "manually_drop"]
-#[derive(Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct ManuallyDrop<T: ?Sized> {
     value: T,
@@ -158,18 +158,5 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
         &mut self.value
-    }
-}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: Clone> Clone for ManuallyDrop<T> {
-    #[inline]
-    fn clone(&self) -> ManuallyDrop<T> {
-        ManuallyDrop { value: self.value.clone() }
-    }
-
-    #[inline]
-    fn clone_from(&mut self, other: &Self) {
-        self.value.clone_from(&other.value)
     }
 }


### PR DESCRIPTION
Forwarding `clone_from` to the inner value changes the observable behavior, as previously the inner value would *not* be dropped by the default implementation.

Frankly, this is a super-niche case, so #85176 is welcome to argue the behavior should be otherwise! But if we overrride it, IMO documenting the behavior would be good.

Example: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=c5d0856686fa850c1d7ee16891014efb