### PR TITLE
Preserve metadata w/ Solaris-like linkers.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1642,10 +1642,16 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     // Make the binary compatible with data execution prevention schemes.
     cmd.add_no_exec();
 
+    // OBJECT-FILES-YES
+    add_local_crate_metadata_objects(cmd, crate_type, codegen_results);
+
     // NO-OPT-OUT, OBJECT-FILES-NO
     // Avoid linking to dynamic libraries unless they satisfy some undefined symbols
     // at the point at which they are specified on the command line.
     // Must be passed before any dynamic libraries.
+    // On solaris-like systems, this also will ignore unreferenced ELF sections
+    // from relocatable objects. For that reason, we move the metadata objects
+    // to before this flag as they would otherwise be removed.
     cmd.add_as_needed();
 
     // NO-OPT-OUT, OBJECT-FILES-NO
@@ -1696,9 +1702,6 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     // need to make sure that all symbols are exported correctly from the
     // dynamic library.
     cmd.export_symbols(tmpdir, crate_type);
-
-    // OBJECT-FILES-YES
-    add_local_crate_metadata_objects(cmd, crate_type, codegen_results);
 
     // OBJECT-FILES-YES
     add_local_crate_allocator_objects(cmd, codegen_results);


### PR DESCRIPTION
#84468 moved the `-zignore` linker flag from the `gc_sections` method to `add_as_needed` which is more accurate but Solaris-style linkers will also end up removing an unreferenced ELF sections [1]. This had the unfortunate side effect of causing the `.rustc` section (which has the metada) to be removed which could cause issues when trying to link against the resulting crates or use proc macros.

Since the `-zignore` is positional, we fix this by moving the metadata objects to before the flag.


[1] Specifically a section is considered unreferenced if:
* The section is allocatable
* No other sections bind to (relocate) to this section
* The section provides no global symbols

https://docs.oracle.com/cd/E19683-01/817-3677/6mj8mbtbs/index.html#chapter4-19