### PR TITLE
metadata-link: add -Zmetadata-link flag

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -45,7 +45,7 @@ pub fn crates_export_threshold(crate_types: &[CrateType]) -> SymbolExportLevel {
 fn reachable_non_generics_provider(tcx: TyCtxt<'_>, cnum: CrateNum) -> DefIdMap<SymbolExportLevel> {
     assert_eq!(cnum, LOCAL_CRATE);
 
-    if !tcx.sess.opts.output_types.should_codegen() {
+    if !tcx.sess.opts.output_types.should_codegen() && !tcx.sess.opts.debugging_opts.metadata_link {
         return Default::default();
     }
 
@@ -164,7 +164,7 @@ fn exported_symbols_provider_local(
 ) -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportLevel)] {
     assert_eq!(cnum, LOCAL_CRATE);
 
-    if !tcx.sess.opts.output_types.should_codegen() {
+    if !tcx.sess.opts.output_types.should_codegen() && !tcx.sess.opts.debugging_opts.metadata_link {
         return &[];
     }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -706,6 +706,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(instrument_mcount, true);
     tracked!(link_only, true);
     tracked!(merge_functions, Some(MergeFunctions::Disabled));
+    tracked!(metadata_link, true);
     tracked!(mir_emit_retag, true);
     tracked!(mir_opt_level, Some(4));
     tracked!(mutable_noalias, Some(true));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1121,6 +1121,8 @@ options! {
         the same values as the target option of the same name"),
     meta_stats: bool = (false, parse_bool, [UNTRACKED],
         "gather metadata statistics (default: no)"),
+    metadata_link: bool = (false, parse_bool, [TRACKED],
+        "always emit metadata that's equivalent to metadata,link"),
     mir_emit_retag: bool = (false, parse_bool, [TRACKED],
         "emit Retagging MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 \
         (default: no)"),

--- a/src/test/run-make/pipelined/Makefile
+++ b/src/test/run-make/pipelined/Makefile
@@ -1,15 +1,33 @@
 -include ../../run-make-fulldeps/tools.mk
 
-O=$(TMPDIR)
+O=$(TMPDIR)/together
+S=$(TMPDIR)/separate
 
-all: $O/main
+all: $O/main $S/main
+	# Should produce identical output
+	cmp $O/main	$S/main
+
+# Build with combined --emit metadata,link
+$O/main: $O/libmiddle.rlib $O/libleaf.rlib
+	$(BARE_RUSTC) --out-dir $O main.rs --extern middle=$O/libmiddle.rlib -Ldependency=$O
 	$O/main
 
-$O/main: $O/libmiddle.rlib $O/libleaf.rlib
-	$(RUSTC) main.rs --extern middle=$O/libmiddle.rlib -Ldependency=$O
-
 $O/libmiddle.rlib: middle.rs $O/libleaf.rmeta
-	$(RUSTC) --emit link middle.rs --extern leaf=$O/libleaf.rmeta
+	$(BARE_RUSTC) --out-dir $O --emit link middle.rs --extern leaf=$O/libleaf.rmeta
 
 $O/libleaf.rlib $O/libleaf.rmeta: leaf.rs
-	$(RUSTC) --emit metadata,link leaf.rs
+	$(BARE_RUSTC) --out-dir $O --emit metadata,link leaf.rs
+
+# Build with separate --emit metadata / --emit link
+$S/main: $S/libmiddle.rlib $S/libleaf.rlib
+	$(BARE_RUSTC) --out-dir $S main.rs --extern middle=$S/libmiddle.rlib -Ldependency=$S
+	$S/main
+
+$S/libmiddle.rlib: middle.rs $S/libleaf.rmeta
+	$(BARE_RUSTC) --out-dir $S --emit link middle.rs --extern leaf=$S/libleaf.rmeta
+
+$S/libleaf.rlib: leaf.rs
+	$(BARE_RUSTC) --out-dir $S --emit link leaf.rs
+
+$S/libleaf.rmeta: leaf.rs
+	$(BARE_RUSTC) --out-dir $S --emit metadata -Zmetadata-link leaf.rs

--- a/src/test/run-make/pipelined/Makefile
+++ b/src/test/run-make/pipelined/Makefile
@@ -1,0 +1,15 @@
+-include ../../run-make-fulldeps/tools.mk
+
+O=$(TMPDIR)
+
+all: $O/main
+	$O/main
+
+$O/main: $O/libmiddle.rlib $O/libleaf.rlib
+	$(RUSTC) main.rs --extern middle=$O/libmiddle.rlib -Ldependency=$O
+
+$O/libmiddle.rlib: middle.rs $O/libleaf.rmeta
+	$(RUSTC) --emit link middle.rs --extern leaf=$O/libleaf.rmeta
+
+$O/libleaf.rlib $O/libleaf.rmeta: leaf.rs
+	$(RUSTC) --emit metadata,link leaf.rs

--- a/src/test/run-make/pipelined/leaf.rs
+++ b/src/test/run-make/pipelined/leaf.rs
@@ -20,6 +20,11 @@ pub fn simple(a: u32, b: u32) -> u32 {
     c
 }
 
+#[inline]
+pub fn inlined(a: u32, b: u32) -> u32 {
+    a * b
+}
+
 pub fn generic<D: std::fmt::Debug>(d: D) {
     println!("generically printing {:?}", d);
 }

--- a/src/test/run-make/pipelined/leaf.rs
+++ b/src/test/run-make/pipelined/leaf.rs
@@ -1,0 +1,25 @@
+#![crate_type = "rlib"]
+
+pub static FOO: &str = "this is a static";
+
+#[derive(Debug)]
+pub struct Plain {
+    pub a: u32,
+    pub b: u32,
+}
+
+#[derive(Debug)]
+pub struct GenericStruct<A> {
+    pub a: A,
+    pub b: Option<A>,
+}
+
+pub fn simple(a: u32, b: u32) -> u32 {
+    let c = a + b;
+    println!("simple {} + {} => {}", a, b, c);
+    c
+}
+
+pub fn generic<D: std::fmt::Debug>(d: D) {
+    println!("generically printing {:?}", d);
+}

--- a/src/test/run-make/pipelined/main.rs
+++ b/src/test/run-make/pipelined/main.rs
@@ -1,0 +1,9 @@
+#![crate_type = "bin"]
+
+fn main() {
+    middle::do_a_thing();
+
+    println!("middle::BAR {}", middle::BAR);
+
+    assert_eq!(middle::simple(2, 3), 5);
+}

--- a/src/test/run-make/pipelined/main.rs
+++ b/src/test/run-make/pipelined/main.rs
@@ -6,4 +6,5 @@ fn main() {
     println!("middle::BAR {}", middle::BAR);
 
     assert_eq!(middle::simple(2, 3), 5);
+    assert_eq!(middle::inlined(2, 3), 6);
 }

--- a/src/test/run-make/pipelined/middle.rs
+++ b/src/test/run-make/pipelined/middle.rs
@@ -5,6 +5,7 @@ extern crate leaf;
 pub static BAR: &str = leaf::FOO;
 
 pub use leaf::simple;
+pub use leaf::inlined;
 
 pub fn do_a_thing() {
     let s = leaf::GenericStruct {

--- a/src/test/run-make/pipelined/middle.rs
+++ b/src/test/run-make/pipelined/middle.rs
@@ -1,0 +1,22 @@
+#![crate_type = "rlib"]
+
+extern crate leaf;
+
+pub static BAR: &str = leaf::FOO;
+
+pub use leaf::simple;
+
+pub fn do_a_thing() {
+    let s = leaf::GenericStruct {
+        a: "hello",
+        b: Some("world")
+    };
+
+    let u = leaf::GenericStruct {
+        a: leaf::Plain { a: 1, b: 2 },
+        b: None
+    };
+
+    leaf::generic(s);
+    leaf::generic(u);
+}


### PR DESCRIPTION
This adds the -Zmetadata-link flag, whose intent is to make the output
of `--emit metadata` equivalent to `--emit metadata,link`. The goal is
to allow pipelined builds with separate invocations of rustc. This is
desireable for two reasons:

1. The "artifact notification" system that rustc and cargo use to
  communicate is very cargo-specific - it doesn't fit well into other
  builds systems such as Buck or Bazel. In general its incompatible with
  any build system which only recognizes output artifacts once the
  compiler process has terminated. This is a particular problem when
  compilation is distributed.

2. The rmeta file could be cached independently from the rlib. For
  example, if one generates compilation-ready rmeta files as part
  of "check" build, then those can be directly used for a full
  compilation from cache, without having to regenerate them. This
  means the build turns into a highly parallelizable invocation of
  `rustc --emit link` commands using cached `rmeta` files as input.

Initially this flag `-Zmetadata-link`, but ultimately I'd expect to
stabilize it as `-Cmetadata-link` (or a better name).

There's some outstanding problems/questions:
- ~~No tests. It's not clear to me that there are existing tests which cover the pipelined
  build mode specifically; `src/tests/ui/rmeta` somewhat touches on it.~~ Added tests for
  plain pipelined builds and with `-Zmetadata-link`.
- ~~The generated rmetas from `--emit metadata -Zmetadata-link` are much larger
  than those from `--emit metadata,link` and I don't know why. While they seem to work
  in local ad-hoc testing, I'm concerned they may have different performance/compilation time/something else
  problems.~~ I'm not sure what I was seeing before, but this looks fine - they're within a couple of bytes of each other.
- This is very similar to `-Zalways-encode-mir` but I think they're logically distinct (eg I see
  this new flag as being on stabilization track).
  - @bjorn3 suggests this might be equivalent to `--emit metadata,link -Zno-codegen` which
    sounds plausible but quite roundabout.
- Another approach might be to make `--emit metadata` always work this way, and maybe
  add `--emit check` which emits a subset of rmeta for check builds. This would either mean
  that there could be a mixture of different kinds of rmeta files which are usable for different uses
  (ie, the confusion of two different `--emit` options producing files with the same name but different
  content. Alternatively `--emit check` could generate (say) `.rcheck` files, but that adds complexity
  to locating files, since we'd end up with a 3 level heirarchy of rlib > rmeta > rcheck in terms of
  what the files are useful for. I experimented with this briefly, but its effects ended up being overwhelmingly
  sprawling and complex (eg affecting Cargo as well).
  `-Zmetadata-link` is much more narrowly scoped and opt-in.