### PR TITLE
MIR opt: Expand aggregates into multiple locals

### DIFF
--- a/compiler/rustc_mir/src/transform/flatten_locals.rs
+++ b/compiler/rustc_mir/src/transform/flatten_locals.rs
@@ -1,0 +1,211 @@
+use crate::transform::MirPass;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_index::vec::{Idx, IndexVec};
+use rustc_middle::mir::visit::*;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use std::collections::hash_map::Entry;
+
+pub struct FlattenLocals;
+
+impl<'tcx> MirPass<'tcx> for FlattenLocals {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if tcx.sess.mir_opt_level() < 4 {
+            return;
+        }
+
+        let replacements = compute_flattening(tcx, body);
+        let mut all_dead_locals = FxHashSet::default();
+        all_dead_locals.extend(replacements.fields.keys().map(|p| p.local));
+        if all_dead_locals.is_empty() {
+            return;
+        }
+
+        ReplacementVisitor { tcx, map: &replacements, all_dead_locals }.visit_body(body);
+
+        let mut replaced_locals: IndexVec<_, _> = IndexVec::new();
+        for (k, v) in replacements.fields {
+            replaced_locals.ensure_contains_elem(k.local, || Vec::new());
+            replaced_locals[k.local].push(v)
+        }
+        // Sort locals to avoid depending on FxHashMap order.
+        for v in replaced_locals.iter_mut() {
+            v.sort_unstable()
+        }
+        for bbdata in body.basic_blocks_mut().iter_mut() {
+            bbdata.expand_statements(|stmt| {
+                let source_info = stmt.source_info;
+                let (live, origin_local) = match &stmt.kind {
+                    StatementKind::StorageLive(l) => (true, *l),
+                    StatementKind::StorageDead(l) => (false, *l),
+                    _ => return None,
+                };
+                replaced_locals.get(origin_local).map(move |final_locals| {
+                    final_locals.iter().map(move |&l| {
+                        let kind = if live {
+                            StatementKind::StorageLive(l)
+                        } else {
+                            StatementKind::StorageDead(l)
+                        };
+                        Statement { source_info, kind }
+                    })
+                })
+            });
+        }
+    }
+}
+
+fn escaping_locals(body: &Body<'_>) -> FxHashSet<Local> {
+    let mut set: FxHashSet<_> = (0..body.arg_count + 1).map(Local::new).collect();
+    for (local, decl) in body.local_decls().iter_enumerated() {
+        if decl.ty.is_union() || decl.ty.is_enum() {
+            set.insert(local);
+        }
+    }
+    let mut visitor = EscapeVisitor { set };
+    visitor.visit_body(body);
+    return visitor.set;
+
+    struct EscapeVisitor {
+        set: FxHashSet<Local>,
+    }
+
+    impl Visitor<'_> for EscapeVisitor {
+        fn visit_local(&mut self, local: &Local, _: PlaceContext, _: Location) {
+            self.set.insert(*local);
+        }
+
+        fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
+            // Mirror the implementation in PreFlattenVisitor.
+            if let &[PlaceElem::Field(..), ..] = &place.projection[..] {
+                return;
+            }
+            self.super_place(place, context, location);
+        }
+
+        fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
+            if let Rvalue::AddressOf(.., place) | Rvalue::Ref(.., place) = rvalue {
+                if !place.is_indirect() {
+                    // Raw pointers may be used to access anything inside the enclosing place.
+                    self.set.insert(place.local);
+                    return;
+                }
+            }
+            self.super_rvalue(rvalue, location)
+        }
+
+        fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
+            if let StatementKind::StorageLive(..) | StatementKind::StorageDead(..) = statement.kind
+            {
+                // Storage statements are expanded in run_pass.
+                return;
+            }
+            self.super_statement(statement, location)
+        }
+
+        fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+            if let TerminatorKind::Drop { place, .. }
+            | TerminatorKind::DropAndReplace { place, .. } = terminator.kind
+            {
+                if !place.is_indirect() {
+                    // Raw pointers may be used to access anything inside the enclosing place.
+                    self.set.insert(place.local);
+                    return;
+                }
+            }
+            self.super_terminator(terminator, location);
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct ReplacementMap<'tcx> {
+    fields: FxHashMap<PlaceRef<'tcx>, Local>,
+}
+
+fn compute_flattening<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> ReplacementMap<'tcx> {
+    let escaping = escaping_locals(&*body);
+    let (basic_blocks, local_decls, var_debug_info) =
+        body.basic_blocks_local_decls_mut_and_var_debug_info();
+    let mut visitor =
+        PreFlattenVisitor { tcx, escaping, local_decls: local_decls, map: Default::default() };
+    for (block, bbdata) in basic_blocks.iter_enumerated() {
+        visitor.visit_basic_block_data(block, bbdata);
+    }
+    for var_debug_info in &*var_debug_info {
+        visitor.visit_var_debug_info(var_debug_info);
+    }
+    return visitor.map;
+
+    struct PreFlattenVisitor<'tcx, 'll> {
+        tcx: TyCtxt<'tcx>,
+        local_decls: &'ll mut LocalDecls<'tcx>,
+        escaping: FxHashSet<Local>,
+        map: ReplacementMap<'tcx>,
+    }
+
+    impl<'tcx, 'll> PreFlattenVisitor<'tcx, 'll> {
+        fn create_place(&mut self, place: PlaceRef<'tcx>) {
+            if self.escaping.contains(&place.local) {
+                return;
+            }
+
+            match self.map.fields.entry(place) {
+                Entry::Occupied(_) => {}
+                Entry::Vacant(v) => {
+                    let ty = place.ty(&*self.local_decls, self.tcx).ty;
+                    let local = self.local_decls.push(LocalDecl {
+                        ty,
+                        user_ty: None,
+                        ..self.local_decls[place.local].clone()
+                    });
+                    v.insert(local);
+                }
+            }
+        }
+    }
+
+    impl<'tcx, 'll> Visitor<'tcx> for PreFlattenVisitor<'tcx, 'll> {
+        fn visit_place(&mut self, place: &Place<'tcx>, _: PlaceContext, _: Location) {
+            if let &[PlaceElem::Field(..), ..] = &place.projection[..] {
+                let pr = PlaceRef { local: place.local, projection: &place.projection[..1] };
+                self.create_place(pr)
+            }
+        }
+    }
+}
+
+struct ReplacementVisitor<'tcx, 'll> {
+    tcx: TyCtxt<'tcx>,
+    map: &'ll ReplacementMap<'tcx>,
+    all_dead_locals: FxHashSet<Local>,
+}
+
+impl<'tcx, 'll> MutVisitor<'tcx> for ReplacementVisitor<'tcx, 'll> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    fn visit_statement(&mut self, statement: &mut Statement<'tcx>, location: Location) {
+        if let StatementKind::StorageLive(..) | StatementKind::StorageDead(..) = statement.kind {
+            // Storage statements are expanded in run_pass.
+            return;
+        }
+        self.super_statement(statement, location)
+    }
+
+    fn visit_place(&mut self, place: &mut Place<'tcx>, context: PlaceContext, location: Location) {
+        if let &[PlaceElem::Field(..), ref rest @ ..] = &place.projection[..] {
+            let pr = PlaceRef { local: place.local, projection: &place.projection[..1] };
+            if let Some(local) = self.map.fields.get(&pr) {
+                *place = Place { local: *local, projection: self.tcx.intern_place_elems(&rest) };
+                return;
+            }
+        }
+        self.super_place(place, context, location)
+    }
+
+    fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
+        assert!(!self.all_dead_locals.contains(local),);
+    }
+}

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -32,6 +32,7 @@ pub mod dest_prop;
 pub mod dump_mir;
 pub mod early_otherwise_branch;
 pub mod elaborate_drops;
+pub mod flatten_locals;
 pub mod function_item_references;
 pub mod generator;
 pub mod inline;
@@ -499,6 +500,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     // The main optimizations that we do on MIR.
     let optimizations: &[&dyn MirPass<'tcx>] = &[
         &remove_storage_markers::RemoveStorageMarkers,
+        &flatten_locals::FlattenLocals,
         &remove_zsts::RemoveZsts,
         &const_goto::ConstGoto,
         &remove_unneeded_drops::RemoveUnneededDrops,

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -6,25 +6,32 @@
       let _1: i32;                         // in scope 0 at $DIR/aggregate.rs:5:9: 5:10
       let mut _2: i32;                     // in scope 0 at $DIR/aggregate.rs:5:13: 5:24
       let mut _3: (i32, i32, i32);         // in scope 0 at $DIR/aggregate.rs:5:13: 5:22
+      let mut _4: i32;                     // in scope 0 at $DIR/aggregate.rs:5:13: 5:22
+      let mut _5: i32;                     // in scope 0 at $DIR/aggregate.rs:5:13: 5:22
+      let mut _6: i32;                     // in scope 0 at $DIR/aggregate.rs:5:13: 5:22
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/aggregate.rs:5:9: 5:10
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:5:9: 5:10
-          StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
-          StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
-          (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
--         _2 = (_3.1: i32);                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
+          nop;                             // scope 0 at $DIR/aggregate.rs:5:9: 5:10
+          nop;                             // scope 0 at $DIR/aggregate.rs:5:13: 5:24
+          StorageLive(_4);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          StorageLive(_5);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          StorageLive(_6);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          _4 = const 0_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          _5 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          _6 = const 2_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+-         _2 = _5;                         // scope 0 at $DIR/aggregate.rs:5:13: 5:24
 -         _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/aggregate.rs:5:13: 5:28
 +         _2 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:24
 +         _1 = const 1_i32;                // scope 0 at $DIR/aggregate.rs:5:13: 5:28
-          StorageDead(_2);                 // scope 0 at $DIR/aggregate.rs:5:27: 5:28
-          StorageDead(_3);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
+          nop;                             // scope 0 at $DIR/aggregate.rs:5:27: 5:28
+          StorageDead(_4);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
+          StorageDead(_5);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
+          StorageDead(_6);                 // scope 0 at $DIR/aggregate.rs:5:28: 5:29
           nop;                             // scope 0 at $DIR/aggregate.rs:4:11: 6:2
-          StorageDead(_1);                 // scope 0 at $DIR/aggregate.rs:6:1: 6:2
+          nop;                             // scope 0 at $DIR/aggregate.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/aggregate.rs:6:2: 6:2
       }
   }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -10,6 +10,8 @@
       let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _10: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _11: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
           let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
@@ -23,7 +25,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 -         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
@@ -33,10 +35,10 @@
       bb1: {
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
           _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 -         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
@@ -48,19 +50,21 @@
       bb2: {
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
--         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
+          nop;                             // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+          StorageLive(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          StorageLive(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _10 = const 12_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _11 = const 42_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+-         _8 = _11;                        // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
+          StorageDead(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
+          StorageDead(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
           nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
       }
   }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -10,6 +10,8 @@
       let mut _6: usize;                   // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       let mut _7: bool;                    // in scope 0 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       let mut _9: Point;                   // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _10: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+      let mut _11: u32;                    // in scope 0 at $DIR/optimizes_into_variable.rs:14:13: 14:36
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/optimizes_into_variable.rs:12:9: 12:10
           let _3: i32;                     // in scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
@@ -23,7 +25,7 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 -         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _2 = const (4_i32, false);       // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
@@ -33,10 +35,10 @@
       bb1: {
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-          StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32]; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:31
-          StorageLive(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
           _5 = const 3_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:32: 13:33
           _6 = const 6_usize;              // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 -         _7 = Lt(_5, _6);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
@@ -48,19 +50,21 @@
       bb2: {
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-          StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
-          StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
-          StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
-          (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
--         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
+          nop;                             // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
+          StorageLive(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          StorageLive(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _10 = const 12_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          _11 = const 42_u32;              // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+-         _8 = _11;                        // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
 +         _8 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-          StorageDead(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
+          StorageDead(_10);                // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
+          StorageDead(_11);                // scope 2 at $DIR/optimizes_into_variable.rs:14:38: 14:39
           nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:11:11: 15:2
-          StorageDead(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-          StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
+          nop;                             // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
           return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
       }
   }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
@@ -16,15 +16,9 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
         _2 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
         _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
     }
 }

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
@@ -16,15 +16,9 @@ fn main() -> () {
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
-        StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
         _2 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
-        StorageLive(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
         _3 = const 42_u32;               // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38
-        StorageDead(_3);                 // scope 2 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:15:1: 15:2
-        StorageDead(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:15:1: 15:2
         return;                          // scope 0 at $DIR/optimizes_into_variable.rs:15:2: 15:2
     }
 }

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -12,50 +12,53 @@
       let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
       let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
       let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
-+     let mut _10: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
-+     let mut _11: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
+      let mut _10: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+      let mut _11: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
++     let mut _12: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
++     let mut _13: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
       scope 1 {
           debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch.rs:5:15: 5:16
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:5:24: 5:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+          _10 = move _4;                   // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+          _11 = move _5;                   // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+          _7 = discriminant(_10);          // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
 -         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         _11 = Ne(_10, _7);               // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
-+         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         _12 = discriminant(_11);         // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         _13 = Ne(_12, _7);               // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         switchInt(move _13) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
       }
   
       bb1: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
++         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
 -         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
 +         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+-         _6 = discriminant(_11);          // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
 -         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
 -     }
 - 
 -     bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
+          _8 = ((_10 as Some).0: u32);     // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
-          _9 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
+          _9 = ((_11 as Some).0: u32);     // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:5:31: 5:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
@@ -65,12 +68,13 @@
   
 -     bb4: {
 +     bb3: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:8:1: 8:2
+          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:8:1: 8:2
+          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:8:2: 8:2
 +     }
 + 
 +     bb4: {
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
++         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
 +         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -13,56 +13,59 @@
       let mut _8: isize;                   // in scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
       let _9: u32;                         // in scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
       let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
-+     let mut _11: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
-+     let mut _12: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
+      let mut _11: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+      let mut _12: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
++     let mut _13: isize;                  // in scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
++     let mut _14: bool;                   // in scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
       scope 1 {
           debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:13:15: 13:16
           debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch.rs:13:24: 13:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+          StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+          _11 = move _4;                   // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+          _12 = move _5;                   // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+          _8 = discriminant(_11);          // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
 -         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         _12 = Ne(_11, _8);               // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
-+         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         _13 = discriminant(_12);         // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         _14 = Ne(_13, _8);               // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         switchInt(move _14) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+-         _6 = discriminant(_12);          // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
 -         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
 -     bb2: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
++         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
 -         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
       }
   
 -     bb3: {
--         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+-         _7 = discriminant(_12);          // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
 -         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
 -     bb4: {
 +     bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
+          _9 = ((_11 as Some).0: u32);     // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
+          _10 = ((_12 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:13:31: 13:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
@@ -79,12 +82,13 @@
   
 -     bb6: {
 +     bb4: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:17:1: 17:2
+          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:17:1: 17:2
+          StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:17:1: 17:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:17:2: 17:2
 +     }
 + 
 +     bb5: {
-+         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
++         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
 +         switchInt(_8) -> [0_isize: bb3, 1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -16,10 +16,13 @@
       let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
       let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
       let _13: u32;                        // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
-+     let mut _14: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
-+     let mut _15: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
-+     let mut _16: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
-+     let mut _17: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
+      let mut _14: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+      let mut _15: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+      let mut _16: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
++     let mut _17: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
++     let mut _18: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
++     let mut _19: isize;                  // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
++     let mut _20: bool;                   // in scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
       scope 1 {
           debug a => _11;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
           debug b => _12;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
@@ -27,44 +30,46 @@
       }
   
       bb0: {
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          StorageLive(_16);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
           _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
           StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
           _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
-          (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
-          (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          _14 = move _5;                   // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          _15 = move _6;                   // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          _16 = move _7;                   // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
-          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          _10 = discriminant(_14);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
 -         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         _15 = Ne(_14, _10);              // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
-+         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         _17 = discriminant(_15);         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         _18 = Ne(_17, _10);              // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         switchInt(move _18) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
   
       bb1: {
-+         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
++         StorageDead(_20);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
++         StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
 -         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
       }
   
       bb2: {
--         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+-         _9 = discriminant(_15);          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
 -         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 -     }
 - 
 -     bb3: {
-          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+          _8 = discriminant(_16);          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
 -         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 +         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
@@ -72,11 +77,11 @@
 -     bb4: {
 +     bb3: {
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
-          _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
+          _11 = ((_14 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
-          _12 = (((_4.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
+          _12 = ((_15 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
           StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
-          _13 = (((_4.2: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
+          _13 = ((_16 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
@@ -87,12 +92,14 @@
   
 -     bb5: {
 +     bb4: {
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
+          StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
+          StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
+          StorageDead(_16);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:2: 9:2
 +     }
 + 
 +     bb5: {
-+         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
++         StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
 +         switchInt(_10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-final.after.diff
@@ -36,8 +36,10 @@
       let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
       let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:14: 26:28
       let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-+     let mut _34: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
-+     let mut _35: bool;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
+      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++     let mut _36: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
++     let mut _37: bool;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
       scope 1 {
 -         debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
 -         debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
@@ -64,55 +66,61 @@
       }
   
       bb0: {
--         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
--         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
 -         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
+-         _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
+-         _34 = move _5;                   // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _35 = move _6;                   // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
+-         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-          StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
--         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++         _34 = _1;                        // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
++         _35 = _2;                        // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
--         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
+          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _36 = discriminant((*_35));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _37 = Ne(_36, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         switchInt(move _37) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
       bb1: {
--         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb2: {
-+         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
++         StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
--         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+-         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+-         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
 +     bb2: {
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-+         _15 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
++         _15 = (((*_34) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-+         _16 = (((*(_4.1: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
++         _16 = (((*_35) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
@@ -130,12 +138,12 @@
 +     }
 + 
       bb3: {
--         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _8 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-+         _20 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
++         _20 = (((*_34) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-+         _21 = (((*(_4.1: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
++         _21 = (((*_35) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
@@ -153,12 +161,12 @@
       }
   
       bb4: {
--         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _9 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-+         _25 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
++         _25 = (((*_34) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-+         _26 = (((*(_4.1: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
++         _26 = (((*_35) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
@@ -176,12 +184,12 @@
       }
   
       bb5: {
--         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _10 = discriminant((*_35));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-+         _30 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
++         _30 = (((*_34) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-+         _31 = (((*(_4.1: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
++         _31 = (((*_35) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
@@ -200,9 +208,9 @@
   
       bb6: {
 -         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
--         _12 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
+-         _12 = (((*_34) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
 -         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
--         _13 = (((*(_4.1: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+-         _13 = (((*_35) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
 -         StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
 -         StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
 -         _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
@@ -219,16 +227,16 @@
 -         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 +         discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
       bb7: {
 -         StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
--         _17 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
+-         _17 = (((*_34) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 -         StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
--         _18 = (((*(_4.1: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
+-         _18 = (((*_35) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
 -         StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
 -         StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
 -         _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
@@ -247,9 +255,9 @@
 - 
 -     bb8: {
 -         StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
--         _22 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
+-         _22 = (((*_34) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 -         StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
--         _23 = (((*(_4.1: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
+-         _23 = (((*_35) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
 -         StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
 -         StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
 -         _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
@@ -268,9 +276,9 @@
 - 
 -     bb9: {
 -         StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
--         _27 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
+-         _27 = (((*_34) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 -         StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
--         _28 = (((*(_4.1: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
+-         _28 = (((*_35) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
 -         StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
 -         StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
 -         _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
@@ -290,10 +298,11 @@
 -     bb10: {
 -         ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
--         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+-         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+-         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 -         return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
-+         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
++         StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
 +         switchInt(_11) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -36,8 +36,10 @@
       let mut _31: f32;                    // in scope 0 at $DIR/early_otherwise_branch_68867.rs:25:50: 25:55
       let mut _32: !;                      // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:14: 26:28
       let mut _33: ();                     // in scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
-+     let mut _34: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
-+     let mut _35: bool;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
+      let mut _34: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+      let mut _35: &ViewportPercentageLength; // in scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++     let mut _36: isize;                  // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
++     let mut _37: bool;                   // in scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
       scope 1 {
           debug one => _12;                // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
           debug other => _13;              // in scope 1 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
@@ -56,63 +58,65 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+          StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
-          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          _34 = move _5;                   // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          _35 = move _6;                   // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          _11 = discriminant((*_34));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
-+         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _36 = discriminant((*_35));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _37 = Ne(_36, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageDead(_36);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         switchInt(move _37) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
       bb1: {
--         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _7 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb2: {
-+         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
++         StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
 -     bb3: {
--         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _8 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb4: {
--         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _9 = discriminant((*_35));       // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb5: {
--         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         _10 = discriminant((*_35));      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb6: {
 +     bb2: {
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
-          _12 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
+          _12 = (((*_34) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
           StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
-          _13 = (((*(_4.1: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+          _13 = (((*_35) as Vw).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
           StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
           StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
           _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
@@ -133,9 +137,9 @@
 -     bb7: {
 +     bb3: {
           StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
-          _17 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
+          _17 = (((*_34) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
           StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
-          _18 = (((*(_4.1: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
+          _18 = (((*_35) as Vh).0: f32);   // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
           StorageLive(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
           StorageLive(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
           _20 = _17;                       // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:41
@@ -156,9 +160,9 @@
 -     bb8: {
 +     bb4: {
           StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
-          _22 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
+          _22 = (((*_34) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
           StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
-          _23 = (((*(_4.1: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
+          _23 = (((*_35) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
           StorageLive(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
           StorageLive(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
           _25 = _22;                       // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:47
@@ -179,9 +183,9 @@
 -     bb9: {
 +     bb5: {
           StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
-          _27 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
+          _27 = (((*_34) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
           StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
-          _28 = (((*(_4.1: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
+          _28 = (((*_35) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
           StorageLive(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
           StorageLive(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
           _30 = _27;                       // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:47
@@ -203,13 +207,14 @@
 +     bb6: {
           ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+          StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
 +     }
 + 
 +     bb7: {
-+         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
++         StorageDead(_37);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
 +         switchInt(_11) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -15,6 +15,8 @@
       let _10: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
       let _11: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
       let _12: u32;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
+      let mut _13: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+      let mut _14: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
       scope 1 {
           debug a => _9;                   // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
           debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
@@ -27,21 +29,22 @@
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
-          (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          _13 = move _4;                   // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          _14 = move _5;                   // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          _8 = discriminant(_13);          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           switchInt(move _8) -> [0_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
       bb1: {
-          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          _6 = discriminant(_14);          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           switchInt(move _6) -> [0_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
@@ -51,15 +54,15 @@
       }
   
       bb3: {
-          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          _7 = discriminant(_14);          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           switchInt(move _7) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
       bb4: {
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
-          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
+          _9 = ((_13 as Some).0: u32);     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
-          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
+          _10 = ((_14 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
@@ -68,7 +71,7 @@
   
       bb5: {
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
-          _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
+          _11 = ((_13 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
           _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
           StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
@@ -76,14 +79,15 @@
   
       bb6: {
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
-          _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
+          _12 = ((_14 as Some).0: u32);    // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
           _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
       }
   
       bb7: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:1: 14:2
+          StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:1: 14:2
+          StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:1: 14:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt2.EarlyOtherwiseBranch.diff
@@ -12,22 +12,25 @@
       let mut _7: isize;                   // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:10: 20:17
       let _8: u32;                         // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:15: 20:16
       let _9: bool;                        // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:24: 20:25
+      let mut _10: std::option::Option<u32>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+      let mut _11: std::option::Option<bool>; // in scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
       scope 1 {
           debug a => _8;                   // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:20:15: 20:16
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch_noopt.rs:20:24: 20:25
       }
   
       bb0: {
-          StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:12: 19:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:12: 19:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:15: 19:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:15: 19:16
-          (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
-          (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          _10 = move _4;                   // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          _11 = move _5;                   // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:16: 19:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:16: 19:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          _7 = discriminant(_10);          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
           switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 19:17
       }
   
@@ -37,15 +40,15 @@
       }
   
       bb2: {
-          _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          _6 = discriminant(_11);          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
           switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 19:17
       }
   
       bb3: {
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:15: 20:16
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:15: 20:16
+          _8 = ((_10 as Some).0: u32);     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:15: 20:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:24: 20:25
-          _9 = (((_3.1: std::option::Option<bool>) as Some).0: bool); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:24: 20:25
+          _9 = ((_11 as Some).0: bool);    // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:24: 20:25
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
@@ -53,7 +56,8 @@
       }
   
       bb4: {
-          StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:23:1: 23:2
+          StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:23:1: 23:2
+          StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:23:1: 23:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:23:2: 23:2
       }
   }

--- a/src/test/mir-opt/flatten_locals.main.FlattenLocals.diff
+++ b/src/test/mir-opt/flatten_locals.main.FlattenLocals.diff
@@ -1,0 +1,125 @@
+- // MIR for `main` before FlattenLocals
++ // MIR for `main` after FlattenLocals
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/flatten_locals.rs:9:11: 9:11
+      let _1: u8;                          // in scope 0 at $DIR/flatten_locals.rs:10:15: 10:16
+      let _2: ();                          // in scope 0 at $DIR/flatten_locals.rs:10:18: 10:19
+      let _3: &str;                        // in scope 0 at $DIR/flatten_locals.rs:10:21: 10:22
+      let _4: std::option::Option<isize>;  // in scope 0 at $DIR/flatten_locals.rs:10:24: 10:25
+      let mut _5: Foo;                     // in scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+      let mut _6: ();                      // in scope 0 at $DIR/flatten_locals.rs:10:45: 10:47
+      let mut _7: std::option::Option<isize>; // in scope 0 at $DIR/flatten_locals.rs:10:60: 10:68
+      let _8: ();                          // in scope 0 at $DIR/flatten_locals.rs:17:5: 17:35
+      let mut _9: *const u32;              // in scope 0 at $DIR/flatten_locals.rs:17:7: 17:34
+      let _10: &u32;                       // in scope 0 at $DIR/flatten_locals.rs:17:7: 17:34
+      let _11: S;                          // in scope 0 at $DIR/flatten_locals.rs:17:8: 17:32
+      let mut _12: u32;                    // in scope 0 at $DIR/flatten_locals.rs:17:27: 17:30
++     let mut _13: u8;                     // in scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++     let mut _14: ();                     // in scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++     let mut _15: &str;                   // in scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++     let mut _16: std::option::Option<isize>; // in scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+      scope 1 {
+          debug a => _1;                   // in scope 1 at $DIR/flatten_locals.rs:10:15: 10:16
+          debug b => _2;                   // in scope 1 at $DIR/flatten_locals.rs:10:18: 10:19
+          debug c => _3;                   // in scope 1 at $DIR/flatten_locals.rs:10:21: 10:22
+          debug d => _4;                   // in scope 1 at $DIR/flatten_locals.rs:10:24: 10:25
+          scope 2 {
+              scope 3 {
+                  scope 4 {
+                      scope 5 {
+                      }
+                  }
+              }
+          }
+      }
+  
+      bb0: {
+-         StorageLive(_5);                 // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         StorageLive(_13);                // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         StorageLive(_14);                // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         StorageLive(_15);                // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         StorageLive(_16);                // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+          StorageLive(_6);                 // scope 0 at $DIR/flatten_locals.rs:10:45: 10:47
+          StorageLive(_7);                 // scope 0 at $DIR/flatten_locals.rs:10:60: 10:68
+          ((_7 as Some).0: isize) = const -4_isize; // scope 0 at $DIR/flatten_locals.rs:10:60: 10:68
+          discriminant(_7) = 1;            // scope 0 at $DIR/flatten_locals.rs:10:60: 10:68
+-         (_5.0: u8) = const 5_u8;         // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+-         (_5.1: ()) = move _6;            // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+-         (_5.2: &str) = const "a";        // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         _13 = const 5_u8;                // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         _14 = move _6;                   // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         _15 = const "a";                 // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+                                           // ty::Const
+                                           // + ty: &str
+                                           // + val: Value(Slice { data: Allocation { bytes: [97], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 })
+                                           // mir::Constant
+                                           // + span: $DIR/flatten_locals.rs:10:52: 10:55
+                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [97], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+-         (_5.3: std::option::Option<isize>) = move _7; // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
++         _16 = move _7;                   // scope 0 at $DIR/flatten_locals.rs:10:30: 10:70
+          StorageDead(_7);                 // scope 0 at $DIR/flatten_locals.rs:10:69: 10:70
+          StorageDead(_6);                 // scope 0 at $DIR/flatten_locals.rs:10:69: 10:70
+-         StorageLive(_1);                 // scope 0 at $DIR/flatten_locals.rs:10:15: 10:16
+-         _1 = (_5.0: u8);                 // scope 0 at $DIR/flatten_locals.rs:10:15: 10:16
+-         StorageLive(_2);                 // scope 0 at $DIR/flatten_locals.rs:10:18: 10:19
+-         _2 = (_5.1: ());                 // scope 0 at $DIR/flatten_locals.rs:10:18: 10:19
+-         StorageLive(_3);                 // scope 0 at $DIR/flatten_locals.rs:10:21: 10:22
+-         _3 = (_5.2: &str);               // scope 0 at $DIR/flatten_locals.rs:10:21: 10:22
+-         StorageLive(_4);                 // scope 0 at $DIR/flatten_locals.rs:10:24: 10:25
+-         _4 = (_5.3: std::option::Option<isize>); // scope 0 at $DIR/flatten_locals.rs:10:24: 10:25
+-         StorageDead(_5);                 // scope 0 at $DIR/flatten_locals.rs:10:70: 10:71
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:10:15: 10:16
++         _1 = _13;                        // scope 0 at $DIR/flatten_locals.rs:10:15: 10:16
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:10:18: 10:19
++         _2 = _14;                        // scope 0 at $DIR/flatten_locals.rs:10:18: 10:19
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:10:21: 10:22
++         _3 = _15;                        // scope 0 at $DIR/flatten_locals.rs:10:21: 10:22
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:10:24: 10:25
++         _4 = _16;                        // scope 0 at $DIR/flatten_locals.rs:10:24: 10:25
++         StorageDead(_13);                // scope 0 at $DIR/flatten_locals.rs:10:70: 10:71
++         StorageDead(_14);                // scope 0 at $DIR/flatten_locals.rs:10:70: 10:71
++         StorageDead(_15);                // scope 0 at $DIR/flatten_locals.rs:10:70: 10:71
++         StorageDead(_16);                // scope 0 at $DIR/flatten_locals.rs:10:70: 10:71
+          StorageLive(_8);                 // scope 5 at $DIR/flatten_locals.rs:17:5: 17:35
+          StorageLive(_9);                 // scope 5 at $DIR/flatten_locals.rs:17:7: 17:34
+          StorageLive(_10);                // scope 5 at $DIR/flatten_locals.rs:17:7: 17:34
+          StorageLive(_11);                // scope 5 at $DIR/flatten_locals.rs:17:8: 17:32
+          StorageLive(_12);                // scope 5 at $DIR/flatten_locals.rs:17:27: 17:30
+          _12 = g() -> bb1;                // scope 5 at $DIR/flatten_locals.rs:17:27: 17:30
+                                           // mir::Constant
+                                           // + span: $DIR/flatten_locals.rs:17:27: 17:28
+                                           // + literal: Const { ty: fn() -> u32 {g}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          (_11.0: u32) = const 1_u32;      // scope 5 at $DIR/flatten_locals.rs:17:8: 17:32
+          (_11.1: u32) = const 2_u32;      // scope 5 at $DIR/flatten_locals.rs:17:8: 17:32
+          (_11.2: u32) = move _12;         // scope 5 at $DIR/flatten_locals.rs:17:8: 17:32
+          StorageDead(_12);                // scope 5 at $DIR/flatten_locals.rs:17:31: 17:32
+          _10 = &(_11.0: u32);             // scope 5 at $DIR/flatten_locals.rs:17:7: 17:34
+          _9 = &raw const (*_10);          // scope 5 at $DIR/flatten_locals.rs:17:7: 17:34
+          _8 = f(move _9) -> bb2;          // scope 5 at $DIR/flatten_locals.rs:17:5: 17:35
+                                           // mir::Constant
+                                           // + span: $DIR/flatten_locals.rs:17:5: 17:6
+                                           // + literal: Const { ty: fn(*const u32) {f}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb2: {
+          StorageDead(_9);                 // scope 5 at $DIR/flatten_locals.rs:17:34: 17:35
+          StorageDead(_11);                // scope 5 at $DIR/flatten_locals.rs:17:35: 17:36
+          StorageDead(_10);                // scope 5 at $DIR/flatten_locals.rs:17:35: 17:36
+          StorageDead(_8);                 // scope 5 at $DIR/flatten_locals.rs:17:35: 17:36
+          _0 = const ();                   // scope 0 at $DIR/flatten_locals.rs:9:11: 18:2
+-         StorageDead(_4);                 // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
+-         StorageDead(_3);                 // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
+-         StorageDead(_2);                 // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
+-         StorageDead(_1);                 // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
++         nop;                             // scope 0 at $DIR/flatten_locals.rs:18:1: 18:2
+          return;                          // scope 0 at $DIR/flatten_locals.rs:18:2: 18:2
+      }
+  }
+  

--- a/src/test/mir-opt/flatten_locals.rs
+++ b/src/test/mir-opt/flatten_locals.rs
@@ -1,0 +1,33 @@
+struct Foo {
+    a: u8,
+    b: (),
+    c: &'static str,
+    d: Option<isize>,
+}
+
+// EMIT_MIR flatten_locals.main.FlattenLocals.diff
+fn main() {
+    let Foo { a, b, c, d } = Foo { a: 5, b: (), c: "a", d: Some(-4) };
+    let _ = a;
+    let _ = b;
+    let _ = c;
+    let _ = d;
+
+    // Verify this struct is not flattened.
+    f(&S { a: 1, b: 2, c: g() }.a);
+}
+
+#[repr(C)]
+struct S {
+    a: u32,
+    b: u32,
+    c: u32,
+}
+
+fn f(a: *const u32) {
+    println!("{}", unsafe { *a.add(2) });
+}
+
+fn g() -> u32 {
+    3
+}

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -7,31 +7,32 @@
       let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
       let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
       let mut _5: i32;                     // in scope 0 at $DIR/issue-73223.rs:7:22: 7:27
-      let mut _6: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _6: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _7: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _8: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _10: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _13: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _16: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _17: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _12: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           scope 3 {
               debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              let _8: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let _10: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _19: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
-                  debug left_val => _9;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  debug right_val => _10;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _14: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug left_val => _8;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug right_val => _9;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _13: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug kind => _14;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug kind => _13;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -41,66 +42,59 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_5);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _5 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           ((_4 as Some).0: i32) = move _5; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_4) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_5);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          StorageLive(_20);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _6 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _7 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
                                            // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _7 = _19;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _20 = move _6;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = move _7;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _9 = (_6.0: &i32);               // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _10 = (_6.1: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _9 = _21;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _13 = (*_9);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _12 = Eq(move _13, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _11 = Not(move _12);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _12 = (*_8);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = Eq(move _12, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _11) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _10 = Not(move _11);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _10) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {
-          StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_13) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = _8;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _15;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = _16;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_17);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = _17;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_18) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _14, move _16, move _18); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
@@ -113,12 +107,11 @@
       }
   
       bb2: {
-          StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_20);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_21);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -7,31 +7,32 @@
       let mut _2: std::option::Option<i32>; // in scope 0 at $DIR/issue-73223.rs:2:23: 2:30
       let _3: i32;                         // in scope 0 at $DIR/issue-73223.rs:3:14: 3:15
       let mut _5: i32;                     // in scope 0 at $DIR/issue-73223.rs:7:22: 7:27
-      let mut _6: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _6: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _7: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _8: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _10: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _13: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _16: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _17: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _12: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           scope 3 {
               debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
+              let _8: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let _10: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _19: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
-                  debug left_val => _9;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  debug right_val => _10;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _14: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug left_val => _8;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug right_val => _9;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _13: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug kind => _14;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug kind => _13;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -41,66 +42,59 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _3 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _3;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_3);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_5);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _5 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           ((_4 as Some).0: i32) = move _5; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_4) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_5);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          StorageLive(_20);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _6 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _7 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
                                            // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _7 = _19;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _20 = move _6;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = move _7;                   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _9 = (_6.0: &i32);               // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _10 = (_6.1: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _9 = _21;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_10);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _13 = (*_9);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _12 = Eq(move _13, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _11 = Not(move _12);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _12 = (*_8);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = Eq(move _12, const 1_i32); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_12);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _11) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _10 = Not(move _11);             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _10) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {
-          StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_13);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_13) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = _8;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _15;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = _16;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_17);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = _17;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_18) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _14, move _16, move _18); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
@@ -113,12 +107,11 @@
       }
   
       bb2: {
-          StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_10);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_6);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_4);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_20);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_21);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -26,6 +26,8 @@
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _30: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -49,8 +51,8 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          nop;                             // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
+          nop;                             // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -59,25 +61,26 @@
   
       bb1: {
           nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
+          nop;                             // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
+          nop;                             // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          nop;                             // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
+          nop;                             // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
-          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          nop;                             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -89,14 +92,14 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
           _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = move _10;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = move _11;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _13 = (_9.0: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = _29;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _14 = (_9.1: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _30;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -150,11 +153,12 @@
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          nop;                             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           nop;                             // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   }

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -26,6 +26,8 @@
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _30: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -49,8 +51,8 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
-          StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          nop;                             // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
+          nop;                             // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -59,25 +61,26 @@
   
       bb1: {
           nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
+          nop;                             // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
+          nop;                             // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_4);                 // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
-          StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
-          StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
-          StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          nop;                             // scope 0 at $DIR/issue-73223.rs:3:20: 3:21
+          nop;                             // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
-          StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
-          StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          nop;                             // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
+          nop;                             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -89,14 +92,14 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
           _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = move _10;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = move _11;                  // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _13 = (_9.0: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = _29;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _14 = (_9.1: &i32);              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _30;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -150,11 +153,12 @@
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          nop;                             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           nop;                             // scope 0 at $DIR/issue-73223.rs:1:11: 9:2
-          StorageDead(_6);                 // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
-          StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 1 at $DIR/issue-73223.rs:9:1: 9:2
+          nop;                             // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   }

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -6,15 +6,17 @@
 -     let mut _1: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -     let mut _2: (i32, E);                // in scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
 -     let mut _3: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
+-     let mut _4: i32;                     // in scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
+-     let mut _5: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -         discriminant(_1) = 1;            // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
--         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
+-         StorageLive(_4);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
+-         StorageLive(_5);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
 -         discriminant(_3) = 0;            // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
--         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
--         (_2.1: E) = const E::A;          // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
+-         _4 = const 10_i32;               // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
+-         _5 = const E::A;                 // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
 -                                          // ty::Const
 -                                          // + ty: E
 -                                          // + val: Value(Scalar(0x00))
@@ -22,15 +24,15 @@
 -                                          // + span: $DIR/simplify-locals.rs:28:6: 28:16
 -                                          // + literal: Const { ty: E, val: Value(Scalar(0x00)) }
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:15: 28:16
--         (_2.1: E) = const E::B;          // scope 0 at $DIR/simplify-locals.rs:28:5: 28:26
+-         _5 = const E::B;                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:26
 -                                          // ty::Const
 -                                          // + ty: E
 -                                          // + val: Value(Scalar(0x01))
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals.rs:28:5: 28:26
 -                                          // + literal: Const { ty: E, val: Value(Scalar(0x01)) }
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:25: 28:26
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:26: 28:27
+-         StorageDead(_4);                 // scope 0 at $DIR/simplify-locals.rs:28:26: 28:27
+-         StorageDead(_5);                 // scope 0 at $DIR/simplify-locals.rs:28:26: 28:27
           return;                          // scope 0 at $DIR/simplify-locals.rs:29:2: 29:2
       }
   }

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -14,26 +14,20 @@
 -     let mut _9: u8;                      // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
 -     let mut _10: u8;                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -     let mut _11: Temp;                   // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-     let mut _12: ();                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
+-     let mut _13: ();                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
+-     let mut _14: u8;                     // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 +     let _1: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
 +     let _2: ();                          // in scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
       scope 1 {
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
--         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
--         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:27: 13:28
--         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:28: 13:29
--         StorageLive(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
--         StorageLive(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:13: 14:21
--         StorageLive(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:14: 14:16
--         StorageLive(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:18: 14:20
--         StorageDead(_7);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
--         StorageDead(_6);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:20: 14:21
+-         StorageLive(_12);                // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
+-         StorageLive(_13);                // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
+-         StorageDead(_12);                // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:28: 13:29
+-         StorageDead(_13);                // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:28: 13:29
 -         _4 = use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
-+         StorageLive(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
 +         _1 = use_zst(const ((), ())) -> bb1; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:22
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:14:5: 14:12
@@ -41,19 +35,11 @@
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:21: 14:22
--         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
--         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
--         StorageLive(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
--         StorageLive(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
--         StorageLive(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
--         (_11.0: u8) = const 40_u8;       // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-         StorageLive(_14);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-         _14 = const 40_u8;               // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 -         _10 = const 40_u8;               // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -         _9 = const 42_u8;                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
--         StorageDead(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:33: 16:34
 -         _8 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
-+         StorageDead(_1);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
-+         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
 +         _2 = use_u8(const 42_u8) -> bb2; // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
                                            // mir::Constant
                                            // + span: $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:11
@@ -61,10 +47,7 @@
       }
   
       bb2: {
--         StorageDead(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:34: 16:35
--         StorageDead(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
--         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
-+         StorageDead(_2);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
+-         StorageDead(_14);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:17:2: 17:2
       }
   }

--- a/src/test/mir-opt/sroa.dropping.FlattenLocals.diff
+++ b/src/test/mir-opt/sroa.dropping.FlattenLocals.diff
@@ -1,0 +1,62 @@
+- // MIR for `dropping` before FlattenLocals
++ // MIR for `dropping` after FlattenLocals
+  
+  fn dropping() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/sroa.rs:14:19: 14:19
+      let _1: Tag;                         // in scope 0 at $DIR/sroa.rs:15:5: 15:32
+      let mut _2: S;                       // in scope 0 at $DIR/sroa.rs:15:5: 15:30
+      let mut _3: Tag;                     // in scope 0 at $DIR/sroa.rs:15:7: 15:13
+      let mut _4: Tag;                     // in scope 0 at $DIR/sroa.rs:15:15: 15:21
+      let mut _5: Tag;                     // in scope 0 at $DIR/sroa.rs:15:23: 15:29
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/sroa.rs:15:5: 15:32
+          StorageLive(_2);                 // scope 0 at $DIR/sroa.rs:15:5: 15:30
+          StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:15:7: 15:13
+          (_3.0: usize) = const 0_usize;   // scope 0 at $DIR/sroa.rs:15:7: 15:13
+          StorageLive(_4);                 // scope 0 at $DIR/sroa.rs:15:15: 15:21
+          (_4.0: usize) = const 1_usize;   // scope 0 at $DIR/sroa.rs:15:15: 15:21
+          StorageLive(_5);                 // scope 0 at $DIR/sroa.rs:15:23: 15:29
+          (_5.0: usize) = const 2_usize;   // scope 0 at $DIR/sroa.rs:15:23: 15:29
+          (_2.0: Tag) = move _3;           // scope 0 at $DIR/sroa.rs:15:5: 15:30
+          (_2.1: Tag) = move _4;           // scope 0 at $DIR/sroa.rs:15:5: 15:30
+          (_2.2: Tag) = move _5;           // scope 0 at $DIR/sroa.rs:15:5: 15:30
+          StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:15:29: 15:30
+          StorageDead(_4);                 // scope 0 at $DIR/sroa.rs:15:29: 15:30
+          StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:15:29: 15:30
+          _1 = move (_2.1: Tag);           // scope 0 at $DIR/sroa.rs:15:5: 15:32
+          drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  
+      bb1: {
+          drop((_2.0: Tag)) -> [return: bb6, unwind: bb5]; // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  
+      bb2 (cleanup): {
+          drop((_2.0: Tag)) -> bb7;        // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  
+      bb3 (cleanup): {
+          resume;                          // scope 0 at $DIR/sroa.rs:14:1: 16:2
+      }
+  
+      bb4: {
+          StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:15:32: 15:33
+          StorageDead(_1);                 // scope 0 at $DIR/sroa.rs:15:32: 15:33
+          _0 = const ();                   // scope 0 at $DIR/sroa.rs:14:19: 16:2
+          return;                          // scope 0 at $DIR/sroa.rs:16:2: 16:2
+      }
+  
+      bb5 (cleanup): {
+          drop((_2.2: Tag)) -> bb3;        // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  
+      bb6: {
+          drop((_2.2: Tag)) -> [return: bb4, unwind: bb3]; // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  
+      bb7 (cleanup): {
+          drop((_2.2: Tag)) -> bb3;        // scope 0 at $DIR/sroa.rs:15:32: 15:33
+      }
+  }
+  

--- a/src/test/mir-opt/sroa.enums.FlattenLocals.diff
+++ b/src/test/mir-opt/sroa.enums.FlattenLocals.diff
@@ -1,0 +1,44 @@
+- // MIR for `enums` before FlattenLocals
++ // MIR for `enums` after FlattenLocals
+  
+  fn enums(_1: usize) -> usize {
+      debug a => _1;                       // in scope 0 at $DIR/sroa.rs:19:14: 19:15
+      let mut _0: usize;                   // return place in scope 0 at $DIR/sroa.rs:19:27: 19:32
+      let mut _2: std::option::Option<usize>; // in scope 0 at $DIR/sroa.rs:20:22: 20:29
+      let mut _3: usize;                   // in scope 0 at $DIR/sroa.rs:20:27: 20:28
+      let mut _4: isize;                   // in scope 0 at $DIR/sroa.rs:20:12: 20:19
+      let _5: usize;                       // in scope 0 at $DIR/sroa.rs:20:17: 20:18
+      scope 1 {
+          debug a => _5;                   // in scope 1 at $DIR/sroa.rs:20:17: 20:18
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/sroa.rs:20:22: 20:29
+          StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:20:27: 20:28
+          _3 = _1;                         // scope 0 at $DIR/sroa.rs:20:27: 20:28
+          ((_2 as Some).0: usize) = move _3; // scope 0 at $DIR/sroa.rs:20:22: 20:29
+          discriminant(_2) = 1;            // scope 0 at $DIR/sroa.rs:20:22: 20:29
+          StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:20:28: 20:29
+          _4 = discriminant(_2);           // scope 0 at $DIR/sroa.rs:20:12: 20:19
+          switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/sroa.rs:20:12: 20:19
+      }
+  
+      bb1: {
+          _0 = const 0_usize;              // scope 0 at $DIR/sroa.rs:20:43: 20:44
+          goto -> bb3;                     // scope 0 at $DIR/sroa.rs:20:5: 20:46
+      }
+  
+      bb2: {
+          StorageLive(_5);                 // scope 0 at $DIR/sroa.rs:20:17: 20:18
+          _5 = ((_2 as Some).0: usize);    // scope 0 at $DIR/sroa.rs:20:17: 20:18
+          _0 = _5;                         // scope 0 at $DIR/sroa.rs:20:32: 20:33
+          goto -> bb3;                     // scope 0 at $DIR/sroa.rs:20:5: 20:46
+      }
+  
+      bb3: {
+          StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:20:45: 20:46
+          StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:21:1: 21:2
+          return;                          // scope 0 at $DIR/sroa.rs:21:2: 21:2
+      }
+  }
+  

--- a/src/test/mir-opt/sroa.rs
+++ b/src/test/mir-opt/sroa.rs
@@ -1,0 +1,47 @@
+// compile-flags: -Zmir-opt-level=4 -Zinline-mir=yes
+
+struct Tag(usize);
+
+#[repr(C)]
+struct S(Tag, Tag, Tag);
+
+impl Drop for Tag {
+    #[inline(never)]
+    fn drop(&mut self) {}
+}
+
+// EMIT_MIR sroa.dropping.FlattenLocals.diff
+pub fn dropping() {
+    S(Tag(0), Tag(1), Tag(2)).1;
+}
+
+// EMIT_MIR sroa.enums.FlattenLocals.diff
+pub fn enums(a: usize) -> usize {
+    if let Some(a) = Some(a) { a } else { 0 }
+}
+
+// EMIT_MIR sroa.structs.FlattenLocals.diff
+pub fn structs(a: f32) -> f32 {
+    struct U {
+        _foo: usize,
+        a: f32,
+    }
+
+    U { _foo: 0, a }.a
+}
+
+// EMIT_MIR sroa.unions.FlattenLocals.diff
+pub fn unions(a: f32) -> u32 {
+    union Repr {
+        f: f32,
+        u: u32,
+    }
+    unsafe { Repr { f: a }.u }
+}
+
+fn main() {
+    dropping();
+    enums(5);
+    structs(5.);
+    unions(5.);
+}

--- a/src/test/mir-opt/sroa.structs.FlattenLocals.diff
+++ b/src/test/mir-opt/sroa.structs.FlattenLocals.diff
@@ -1,0 +1,31 @@
+- // MIR for `structs` before FlattenLocals
++ // MIR for `structs` after FlattenLocals
+  
+  fn structs(_1: f32) -> f32 {
+      debug a => _1;                       // in scope 0 at $DIR/sroa.rs:24:16: 24:17
+      let mut _0: f32;                     // return place in scope 0 at $DIR/sroa.rs:24:27: 24:30
+      let mut _2: structs::U;              // in scope 0 at $DIR/sroa.rs:30:5: 30:21
+      let mut _3: f32;                     // in scope 0 at $DIR/sroa.rs:30:18: 30:19
++     let mut _4: usize;                   // in scope 0 at $DIR/sroa.rs:30:5: 30:21
++     let mut _5: f32;                     // in scope 0 at $DIR/sroa.rs:30:5: 30:21
+  
+      bb0: {
+-         StorageLive(_2);                 // scope 0 at $DIR/sroa.rs:30:5: 30:21
++         StorageLive(_4);                 // scope 0 at $DIR/sroa.rs:30:5: 30:21
++         StorageLive(_5);                 // scope 0 at $DIR/sroa.rs:30:5: 30:21
+          StorageLive(_3);                 // scope 0 at $DIR/sroa.rs:30:18: 30:19
+          _3 = _1;                         // scope 0 at $DIR/sroa.rs:30:18: 30:19
+-         (_2.0: usize) = const 0_usize;   // scope 0 at $DIR/sroa.rs:30:5: 30:21
+-         (_2.1: f32) = move _3;           // scope 0 at $DIR/sroa.rs:30:5: 30:21
++         _4 = const 0_usize;              // scope 0 at $DIR/sroa.rs:30:5: 30:21
++         _5 = move _3;                    // scope 0 at $DIR/sroa.rs:30:5: 30:21
+          StorageDead(_3);                 // scope 0 at $DIR/sroa.rs:30:20: 30:21
+-         _0 = (_2.1: f32);                // scope 0 at $DIR/sroa.rs:30:5: 30:23
+-         StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:31:1: 31:2
++         _0 = _5;                         // scope 0 at $DIR/sroa.rs:30:5: 30:23
++         StorageDead(_4);                 // scope 0 at $DIR/sroa.rs:31:1: 31:2
++         StorageDead(_5);                 // scope 0 at $DIR/sroa.rs:31:1: 31:2
+          return;                          // scope 0 at $DIR/sroa.rs:31:2: 31:2
+      }
+  }
+  

--- a/src/test/mir-opt/sroa.unions.FlattenLocals.diff
+++ b/src/test/mir-opt/sroa.unions.FlattenLocals.diff
@@ -1,0 +1,23 @@
+- // MIR for `unions` before FlattenLocals
++ // MIR for `unions` after FlattenLocals
+  
+  fn unions(_1: f32) -> u32 {
+      debug a => _1;                       // in scope 0 at $DIR/sroa.rs:34:15: 34:16
+      let mut _0: u32;                     // return place in scope 0 at $DIR/sroa.rs:34:26: 34:29
+      let mut _2: unions::Repr;            // in scope 0 at $DIR/sroa.rs:39:14: 39:27
+      let mut _3: f32;                     // in scope 0 at $DIR/sroa.rs:39:24: 39:25
+      scope 1 {
+      }
+  
+      bb0: {
+          StorageLive(_2);                 // scope 1 at $DIR/sroa.rs:39:14: 39:27
+          StorageLive(_3);                 // scope 1 at $DIR/sroa.rs:39:24: 39:25
+          _3 = _1;                         // scope 1 at $DIR/sroa.rs:39:24: 39:25
+          (_2.0: f32) = move _3;           // scope 1 at $DIR/sroa.rs:39:14: 39:27
+          StorageDead(_3);                 // scope 1 at $DIR/sroa.rs:39:26: 39:27
+          _0 = (_2.1: u32);                // scope 1 at $DIR/sroa.rs:39:14: 39:29
+          StorageDead(_2);                 // scope 0 at $DIR/sroa.rs:40:1: 40:2
+          return;                          // scope 0 at $DIR/sroa.rs:40:2: 40:2
+      }
+  }
+  


### PR DESCRIPTION
The MIR deaggregator expands aggregate assignments into field accesses, downcasts and discriminant assignments. However, this creates needlessly complicated place projections that may limit later optimization passes.

This PR attempts to replace those accesses by new locals that can be optimized more easily, for instance by DestProp.