### PR TITLE
Fix some diagnostic issues with const_generics_defaults feature gate

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -938,8 +938,11 @@ fn validate_generic_param_order(
                 }
                 GenericParamKind::Type { default: None } => (),
                 GenericParamKind::Lifetime => (),
-                // FIXME(const_generics_defaults)
-                GenericParamKind::Const { ty: _, kw_span: _, default: _ } => (),
+                GenericParamKind::Const { ty: _, kw_span: _, default: Some(default) } => {
+                    ordered_params += " = ";
+                    ordered_params += &pprust::expr_to_string(&*default.value);
+                }
+                GenericParamKind::Const { ty: _, kw_span: _, default: None } => (),
             }
             first = false;
         }
@@ -959,7 +962,7 @@ fn validate_generic_param_order(
             span,
             &format!(
                 "reorder the parameters: lifetimes, {}",
-                if sess.features_untracked().const_generics {
+                if sess.features_untracked().unordered_const_ty_params() {
                     "then consts and types"
                 } else {
                     "then types, then consts"

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -54,7 +54,7 @@ impl<'tcx> TyS<'tcx> {
     /// ADTs with no type arguments.
     pub fn is_simple_text(&self) -> bool {
         match self.kind() {
-            Adt(_, substs) => substs.types().next().is_none() && substs.consts().next().is_none(),
+            Adt(_, substs) => substs.non_erasable_generics().next().is_none(),
             Ref(_, ty, _) => ty.is_simple_text(),
             _ => self.is_simple_ty(),
         }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -54,7 +54,7 @@ impl<'tcx> TyS<'tcx> {
     /// ADTs with no type arguments.
     pub fn is_simple_text(&self) -> bool {
         match self.kind() {
-            Adt(_, substs) => substs.types().next().is_none(),
+            Adt(_, substs) => substs.types().next().is_none() && substs.consts().next().is_none(),
             Ref(_, ty, _) => ty.is_simple_text(),
             _ => self.is_simple_ty(),
         }

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
@@ -2,13 +2,13 @@ error: lifetime parameters must be declared prior to const parameters
   --> $DIR/intermixed-lifetime.rs:7:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           -----------------^^---------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
+   |           -----------------^^---------- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`
 
 error: lifetime parameters must be declared prior to type parameters
   --> $DIR/intermixed-lifetime.rs:10:37
    |
 LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           --------------------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
+   |           --------------------------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/defaults/mismatch.full.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.full.stderr
@@ -5,6 +5,9 @@ LL |     let e: Example::<13> = ();
    |            -------------   ^^ expected struct `Example`, found `()`
    |            |
    |            expected due to this
+   |
+   = note: expected struct `Example`
+           found unit type `()`
 
 error[E0308]: mismatched types
   --> $DIR/mismatch.rs:14:34
@@ -40,12 +43,15 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:22:28
+  --> $DIR/mismatch.rs:20:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`
    |            |
    |            expected due to this
+   |
+   = note: expected struct `Example4<7_usize>`
+           found unit type `()`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/const-generics/defaults/mismatch.full.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.full.stderr
@@ -10,7 +10,7 @@ LL |     let e: Example::<13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:14:34
+  --> $DIR/mismatch.rs:15:34
    |
 LL |     let e: Example2::<u32, 13> = ();
    |            -------------------   ^^ expected struct `Example2`, found `()`
@@ -21,7 +21,7 @@ LL |     let e: Example2::<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:16:34
+  --> $DIR/mismatch.rs:18:34
    |
 LL |     let e: Example3::<13, u32> = ();
    |            -------------------   ^^ expected struct `Example3`, found `()`
@@ -32,7 +32,7 @@ LL |     let e: Example3::<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:18:28
+  --> $DIR/mismatch.rs:21:28
    |
 LL |     let e: Example3::<7> = ();
    |            -------------   ^^ expected struct `Example3`, found `()`
@@ -43,7 +43,7 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:20:28
+  --> $DIR/mismatch.rs:24:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`

--- a/src/test/ui/const-generics/defaults/mismatch.min.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.min.stderr
@@ -5,6 +5,9 @@ LL |     let e: Example::<13> = ();
    |            -------------   ^^ expected struct `Example`, found `()`
    |            |
    |            expected due to this
+   |
+   = note: expected struct `Example`
+           found unit type `()`
 
 error[E0308]: mismatched types
   --> $DIR/mismatch.rs:14:34
@@ -40,12 +43,15 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:22:28
+  --> $DIR/mismatch.rs:20:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`
    |            |
    |            expected due to this
+   |
+   = note: expected struct `Example4<7_usize>`
+           found unit type `()`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/const-generics/defaults/mismatch.min.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.min.stderr
@@ -10,7 +10,7 @@ LL |     let e: Example::<13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:14:34
+  --> $DIR/mismatch.rs:15:34
    |
 LL |     let e: Example2::<u32, 13> = ();
    |            -------------------   ^^ expected struct `Example2`, found `()`
@@ -21,7 +21,7 @@ LL |     let e: Example2::<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:16:34
+  --> $DIR/mismatch.rs:18:34
    |
 LL |     let e: Example3::<13, u32> = ();
    |            -------------------   ^^ expected struct `Example3`, found `()`
@@ -32,7 +32,7 @@ LL |     let e: Example3::<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:18:28
+  --> $DIR/mismatch.rs:21:28
    |
 LL |     let e: Example3::<7> = ();
    |            -------------   ^^ expected struct `Example3`, found `()`
@@ -43,7 +43,7 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:20:28
+  --> $DIR/mismatch.rs:24:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -11,12 +11,17 @@ pub struct Example4<const N: usize=13, const M: usize=4>;
 fn main() {
     let e: Example::<13> = ();
     //~^ Error: mismatched types
+    //~| expected struct `Example`
     let e: Example2::<u32, 13> = ();
     //~^ Error: mismatched types
+    //~| expected struct `Example2`
     let e: Example3::<13, u32> = ();
     //~^ Error: mismatched types
+    //~| expected struct `Example3`
     let e: Example3::<7> = ();
     //~^ Error: mismatched types
+    //~| expected struct `Example3<7_usize>`
     let e: Example4::<7> = ();
     //~^ Error: mismatched types
+    //~| expected struct `Example4<7_usize>`
 }

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -17,8 +17,6 @@ fn main() {
     //~^ Error: mismatched types
     let e: Example3::<7> = ();
     //~^ Error: mismatched types
-    // FIXME(const_generics_defaults): There should be a note for the error below, but it is
-    // missing.
     let e: Example4::<7> = ();
     //~^ Error: mismatched types
 }

--- a/src/test/ui/const-generics/defaults/param-order-err-pretty-prints-default.rs
+++ b/src/test/ui/const-generics/defaults/param-order-err-pretty-prints-default.rs
@@ -1,0 +1,5 @@
+#![feature(const_generics_defaults)]
+struct Foo<const M: usize = 10, 'a>(&'a u32);
+//~^ Error lifetime parameters must be declared prior to const parameters
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/param-order-err-pretty-prints-default.stderr
+++ b/src/test/ui/const-generics/defaults/param-order-err-pretty-prints-default.stderr
@@ -1,0 +1,8 @@
+error: lifetime parameters must be declared prior to const parameters
+  --> $DIR/param-order-err-pretty-prints-default.rs:2:33
+   |
+LL | struct Foo<const M: usize = 10, 'a>(&'a u32);
+   |           ----------------------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, const M: usize = 10>`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR makes a few changes:
- print out const param defaults in "lifetime ordering" errors rather than discarding them
- update `is_simple_text` to account for const params when checking if a type has no generics, this was causing a note to be failed to add to an error message
- fixes some diagnostic wording that incorrectly said there was ordering restrictions between type/const params despite the `const_generics_defaults` feature gate is active