### PR TITLE
Wrap libraries in linker groups, allowing backwards/circular references

### DIFF
--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -22,7 +22,6 @@ use rustc_ast as ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::Lrc;
 use rustc_hir::def_id::CrateNum;
-use rustc_hir::LangItem;
 use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::cstore::{self, CrateSource, LibSource};
 use rustc_middle::middle::dependency_format::Dependencies;
@@ -146,8 +145,6 @@ pub struct CrateInfo {
     pub used_crate_source: FxHashMap<CrateNum, Lrc<CrateSource>>,
     pub used_crates_static: Vec<(CrateNum, LibSource)>,
     pub used_crates_dynamic: Vec<(CrateNum, LibSource)>,
-    pub lang_item_to_crate: FxHashMap<LangItem, CrateNum>,
-    pub missing_lang_items: FxHashMap<CrateNum, Vec<LangItem>>,
     pub dependency_formats: Lrc<Dependencies>,
     pub windows_subsystem: Option<String>,
 }


### PR DESCRIPTION
Some native library sets, such as components of libc, libgcc, or
compiler-builtins, require backwards or circular references.
Additionally, because link order doesn't matter for native libraries
when using dynamic linking, many crates don't take it into account for
static linking either; this can introduce platform-specific issues.
Rather than make the order of `#[link]` lines or `cargo:rustc-link-lib`
lines semantically significant (and potentially even require specifying
some libraries twice), wrap all libraries in linker groups. This ensures
that symbols in all libraries resolve correctly regardless of library
order.

Linker groups of reasonable sizes don't have a substantial cost, but
putting the entirey of a large link line inside a linker group can
add enough cost to be noticeable. To minimize the cost of linker groups,
use separate groups for local native libraries, upstream crates, and
upstream native libraries. This doesn't allow backreferences between
those groups, but in most cases we won't want such backreferences.