### PR TITLE
Mention "null pointer optimization" in option docs.

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -83,6 +83,8 @@
 //! * [`ptr::NonNull<U>`]
 //! * `#[repr(transparent)]` struct around one of the types in this list.
 //!
+//! This is called the "null pointer optimization" or NPO.
+//!
 //! It is further guaranteed that, for the cases above, one can
 //! [`mem::transmute`] from all valid values of `T` to `Option<T>` and
 //! from `Some::<T>(_)` to `T` (but transmuting `None::<T>` to `T`


### PR DESCRIPTION
I had seen people discuss "null pointer optimization," but when I tried to find official documentation (using Google), the `std::option` page didn't show up, because it doesn't use that term. Hopefully adding the term will help others find it in the future.