### PR TITLE
Remove CrateNum::ReservedForIncrCompCache

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -300,7 +300,7 @@ impl<'a, 'tcx> TyDecoder<'tcx> for DecodeContext<'a, 'tcx> {
     {
         let tcx = self.tcx();
 
-        let key = ty::CReaderCacheKey { cnum: self.cdata().cnum, pos: shorthand };
+        let key = ty::CReaderCacheKey { cnum: Some(self.cdata().cnum), pos: shorthand };
 
         if let Some(&ty) = tcx.ty_rcache.borrow().get(&key) {
             return Ok(ty);

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -269,7 +269,7 @@ pub struct CrateVariancesMap<'tcx> {
 // the types of AST nodes.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CReaderCacheKey {
-    pub cnum: CrateNum,
+    pub cnum: Option<CrateNum>,
     pub pos: usize,
 }
 

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -758,8 +758,7 @@ impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     {
         let tcx = self.tcx();
 
-        let cache_key =
-            ty::CReaderCacheKey { cnum: CrateNum::ReservedForIncrCompCache, pos: shorthand };
+        let cache_key = ty::CReaderCacheKey { cnum: None, pos: shorthand };
 
         if let Some(&ty) = tcx.ty_rcache.borrow().get(&cache_key) {
             return Ok(ty);

--- a/compiler/rustc_mir/src/transform/coverage/debug.rs
+++ b/compiler/rustc_mir/src/transform/coverage/debug.rs
@@ -116,7 +116,6 @@ use crate::util::pretty;
 use crate::util::spanview::{self, SpanViewable};
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_index::vec::Idx;
 use rustc_middle::mir::coverage::*;
 use rustc_middle::mir::{self, BasicBlock, TerminatorKind};
 use rustc_middle::ty::TyCtxt;

--- a/compiler/rustc_mir/src/util/generic_graph.rs
+++ b/compiler/rustc_mir/src/util/generic_graph.rs
@@ -1,6 +1,5 @@
 use gsgdt::{Edge, Graph, Node, NodeStyle};
 use rustc_hir::def_id::DefId;
-use rustc_index::vec::Idx;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -10,63 +10,19 @@ use std::borrow::Borrow;
 use std::fmt;
 
 rustc_index::newtype_index! {
-    pub struct CrateId {
+    pub struct CrateNum {
         ENCODABLE = custom
+        DEBUG_FORMAT = "crate{}"
     }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum CrateNum {
-    /// A special `CrateNum` that we use for the `tcx.rcache` when decoding from
-    /// the incr. comp. cache.
-    ReservedForIncrCompCache,
-    Index(CrateId),
 }
 
 /// Item definitions in the currently-compiled crate would have the `CrateNum`
 /// `LOCAL_CRATE` in their `DefId`.
-pub const LOCAL_CRATE: CrateNum = CrateNum::Index(CrateId::from_u32(0));
-
-impl Idx for CrateNum {
-    #[inline]
-    fn new(value: usize) -> Self {
-        CrateNum::Index(Idx::new(value))
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        match self {
-            CrateNum::Index(idx) => Idx::index(idx),
-            _ => panic!("Tried to get crate index of {:?}", self),
-        }
-    }
-}
+pub const LOCAL_CRATE: CrateNum = CrateNum::from_u32(0);
 
 impl CrateNum {
     pub fn new(x: usize) -> CrateNum {
         CrateNum::from_usize(x)
-    }
-
-    pub fn from_usize(x: usize) -> CrateNum {
-        CrateNum::Index(CrateId::from_usize(x))
-    }
-
-    pub fn from_u32(x: u32) -> CrateNum {
-        CrateNum::Index(CrateId::from_u32(x))
-    }
-
-    pub fn as_usize(self) -> usize {
-        match self {
-            CrateNum::Index(id) => id.as_usize(),
-            _ => panic!("tried to get index of non-standard crate {:?}", self),
-        }
-    }
-
-    pub fn as_u32(self) -> u32 {
-        match self {
-            CrateNum::Index(id) => id.as_u32(),
-            _ => panic!("tried to get index of non-standard crate {:?}", self),
-        }
     }
 
     pub fn as_def_id(&self) -> DefId {
@@ -76,10 +32,7 @@ impl CrateNum {
 
 impl fmt::Display for CrateNum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CrateNum::Index(id) => fmt::Display::fmt(&id.private, f),
-            CrateNum::ReservedForIncrCompCache => write!(f, "crate for decoding incr comp cache"),
-        }
+        fmt::Display::fmt(&self.private, f)
     }
 }
 
@@ -94,15 +47,6 @@ impl<E: Encoder> Encodable<E> for CrateNum {
 impl<D: Decoder> Decodable<D> for CrateNum {
     default fn decode(d: &mut D) -> Result<CrateNum, D::Error> {
         Ok(CrateNum::from_u32(d.read_u32()?))
-    }
-}
-
-impl ::std::fmt::Debug for CrateNum {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match self {
-            CrateNum::Index(id) => write!(fmt, "crate{}", id.private),
-            CrateNum::ReservedForIncrCompCache => write!(fmt, "crate for decoding incr comp cache"),
-        }
     }
 }
 

--- a/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.generics.txt
+++ b/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.generics.txt
@@ -11,15 +11,15 @@
    11|      3|        self.strength = new_strength;
    12|      3|    }
   ------------------
-  | <generics::Firework<f64>>::set_strength:
-  |   10|      2|    fn set_strength(&mut self, new_strength: T) {
-  |   11|      2|        self.strength = new_strength;
-  |   12|      2|    }
-  ------------------
   | <generics::Firework<i32>>::set_strength:
   |   10|      1|    fn set_strength(&mut self, new_strength: T) {
   |   11|      1|        self.strength = new_strength;
   |   12|      1|    }
+  ------------------
+  | <generics::Firework<f64>>::set_strength:
+  |   10|      2|    fn set_strength(&mut self, new_strength: T) {
+  |   11|      2|        self.strength = new_strength;
+  |   12|      2|    }
   ------------------
    13|       |}
    14|       |


### PR DESCRIPTION
It's only use is easily replaceable with `Option<CrateNum>`.