### PR TITLE
Don't explicitly track crate_name getters

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -187,7 +187,6 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     foreign_modules => { cdata.get_foreign_modules(tcx) }
     crate_hash => { cdata.root.hash }
     crate_host_hash => { cdata.host_hash }
-    crate_name => { cdata.root.name }
 
     extra_filename => { cdata.root.extra_filename.clone() }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1360,10 +1360,6 @@ rustc_queries! {
         eval_always
         desc { "fetching what a dependency looks like" }
     }
-    query crate_name(_: CrateNum) -> Symbol {
-        eval_always
-        desc { "fetching what a crate is named" }
-    }
     query item_children(def_id: DefId) -> &'tcx [Export<hir::HirId>] {
         desc { |tcx| "collecting child items of `{}`", tcx.def_path_str(def_id) }
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1307,6 +1307,16 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[inline]
+    pub fn crate_name(self, crate_num: CrateNum) -> Symbol {
+        // Note: Changing the local crate name will invalidate the incremental caches
+        if crate_num == LOCAL_CRATE {
+            self.crate_name
+        } else {
+            self.untracked_resolutions.cstore.crate_name(crate_num)
+        }
+    }
+
+    #[inline]
     pub fn stable_crate_id(self, crate_num: CrateNum) -> StableCrateId {
         if crate_num == LOCAL_CRATE {
             self.sess.local_stable_crate_id()
@@ -2842,10 +2852,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
     providers.in_scope_traits_map = |tcx, id| tcx.hir_crate(()).trait_map.get(&id);
     providers.resolutions = |tcx, ()| &tcx.untracked_resolutions;
     providers.module_exports = |tcx, id| tcx.resolutions(()).export_map.get(&id).map(|v| &v[..]);
-    providers.crate_name = |tcx, id| {
-        assert_eq!(id, LOCAL_CRATE);
-        tcx.crate_name
-    };
     providers.maybe_unused_trait_import =
         |tcx, id| tcx.resolutions(()).maybe_unused_trait_imports.contains(&id);
     providers.maybe_unused_extern_crates =


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/85804#discussion_r642078611

Both require a `CrateNum` as argument whose identity depends on both the stable crate id and thus also the crate name.