### PR TITLE
Add title for copy to clipboard button in rustdoc

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -81,7 +81,8 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer,
         "<button id=\"copy-path\" onclick=\"copy_path(this)\">\
             <img src=\"{static_root_path}clipboard{suffix}.svg\" \
                 width=\"19\" height=\"18\" \
-                alt=\"Copy item import\">\
+                alt=\"Copy item import\" \
+                title=\"Copy item import to clipboard\">\
          </button>",
         static_root_path = page.get_static_root_path(),
         suffix = page.resource_suffix,


### PR DESCRIPTION
This button 
![image](https://user-images.githubusercontent.com/4687791/120210874-da4d1380-c262-11eb-9987-9145c4354029.png)
