### PR TITLE
Fix details rustdoc toggle for blanket impl

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1468,13 +1468,12 @@ details.rustdoc-toggle > summary.hideme::before {
 details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
 	left: -23px;
-	top: initial;
+	top: 3px;
 }
 
 .impl-items > details.rustdoc-toggle > summary:not(.hideme)::before,
 .undocumented > details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
-	top: 3px;
 	left: -2px;
 }
 


### PR DESCRIPTION
In the meantime, allow all of the details to have the same top.

Before

![image](https://user-images.githubusercontent.com/4687791/120214139-a673ed00-c266-11eb-9154-3a8148199c8f.png)
![image](https://user-images.githubusercontent.com/4687791/120214232-c5727f00-c266-11eb-8bda-871e6e04819e.png)

After

![image](https://user-images.githubusercontent.com/4687791/120214121-9d831b80-c266-11eb-8c33-db1317c42375.png)
![image](https://user-images.githubusercontent.com/4687791/120214273-d4f1c800-c266-11eb-89ee-0f2b7c2e5bdb.png)

I stumbled across this while wanting to do a details button for the layout.

