### PR TITLE
Add full debug layout for type layout doc

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1570,6 +1570,14 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
                     pl = if bytes == 1 { "" } else { "s" },
                 );
             }
+            writeln!(
+                w,
+                "<details class=\"rustdoc-toggle\">\
+                    <summary>Full debug layout</summary>\
+                    <pre><code>{:#?}</code></pre>\
+                </details>",
+                ty_layout.layout,
+            );
         }
         // This kind of layout error can occur with valid code, e.g. if you try to
         // get the layout of a generic type such as `Vec<T>`.


### PR DESCRIPTION
See what you can see for `#[rustc_layout(debug)]` but with rustdoc which
is very useful, rather than writing some stuff you can just browse through
the docs. I think it may be useful to put it in json and have something
process it and do sort of `ncdu` to easily optimize on type sizes.

The bad thing is it is at the bottom (I can't find it at first), the good thing is you can go to it with `<end>`.

![image](https://user-images.githubusercontent.com/4687791/120216883-23549600-c26a-11eb-9eed-98153df31d90.png)

![image](https://user-images.githubusercontent.com/4687791/120216950-4121fb00-c26a-11eb-911f-e7d93828f549.png)

It's hidden by default. Not quite sure how to fix the sticky `[+]` next to the text. cc @camelid follow up of https://github.com/rust-lang/rust/pull/83501

It would also be good if we can have a inside rust blog post or something to explain what are the different things within the rust layout.