### PR TITLE
Update I-unsound label for triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -79,7 +79,7 @@ trigger_labels = [
     "regression-from-stable-to-stable",
     "regression-from-stable-to-beta",
     "regression-from-stable-to-nightly",
-    "I-unsound 💥",
+    "I-unsound",
 ]
 exclude_labels = [
     "P-*",


### PR DESCRIPTION
Following the remaming of the `I-unsound` label (removing the space and the emoji) as discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/A.20way.20to.20self-label.20soundness.20issues.3F/near/240962907) (or [in the archive](https://zulip-archive.rust-lang.org/122651general/88362Awaytoselflabelsoundnessissues.html#240962907)), this change of the `triagebot.toml` is necessary to keep the automatic `I-prioritize` flagging.