### PR TITLE
Bufwriter disassembly tweaks

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -323,7 +323,7 @@ impl<W: Write> BufWriter<W> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bufwriter_into_raw_parts)]
+    /// #![feature(bufwriter_into_parts)]
     /// use std::io::{BufWriter, Write};
     ///
     /// let mut buffer = [0u8; 10];
@@ -334,7 +334,7 @@ impl<W: Write> BufWriter<W> {
     /// assert_eq!(recovered_writer.len(), 0);
     /// assert_eq!(&buffered_data.unwrap(), b"ata");
     /// ```
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+    #[unstable(feature = "bufwriter_into_parts", issue = "80690")]
     pub fn into_parts(mut self) -> (W, Result<Vec<u8>, WriterPanicked>) {
         let buf = mem::take(&mut self.buf);
         let buf = if !self.panicked { Ok(buf) } else { Err(WriterPanicked { buf }) };
@@ -444,14 +444,14 @@ impl<W: Write> BufWriter<W> {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 /// Error returned for the buffered data from `BufWriter::into_parts`, when the underlying
 /// writer has previously panicked.  Contains the (possibly partly written) buffered data.
 ///
 /// # Example
 ///
 /// ```
-/// #![feature(bufwriter_into_raw_parts)]
+/// #![feature(bufwriter_into_parts)]
 /// use std::io::{self, BufWriter, Write};
 /// use std::panic::{catch_unwind, AssertUnwindSafe};
 ///
@@ -478,7 +478,7 @@ pub struct WriterPanicked {
 impl WriterPanicked {
     /// Returns the perhaps-unwritten data.  Some of this data may have been written by the
     /// panicking call(s) to the underlying writer, so simply writing it again is not a good idea.
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+    #[unstable(feature = "bufwriter_into_parts", issue = "80690")]
     pub fn into_inner(self) -> Vec<u8> {
         self.buf
     }
@@ -487,7 +487,7 @@ impl WriterPanicked {
         "BufWriter inner writer panicked, what data remains unwritten is not known";
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 impl error::Error for WriterPanicked {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
@@ -495,14 +495,14 @@ impl error::Error for WriterPanicked {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 impl fmt::Display for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::DESCRIPTION)
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 impl fmt::Debug for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriterPanicked")

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -307,7 +307,7 @@ impl<W: Write> BufWriter<W> {
     pub fn into_inner(mut self) -> Result<W, IntoInnerError<BufWriter<W>>> {
         match self.flush_buf() {
             Err(e) => Err(IntoInnerError::new(self, e)),
-            Ok(()) => Ok(self.into_raw_parts().0),
+            Ok(()) => Ok(self.into_parts().0),
         }
     }
 
@@ -318,7 +318,7 @@ impl<W: Write> BufWriter<W> {
     /// In this case, we return `WriterPanicked` for the buffered data (from which the buffer
     /// contents can still be recovered).
     ///
-    /// `into_raw_parts` makes no attempt to flush data and cannot fail.
+    /// `into_parts` makes no attempt to flush data and cannot fail.
     ///
     /// # Examples
     ///
@@ -330,12 +330,12 @@ impl<W: Write> BufWriter<W> {
     /// let mut stream = BufWriter::new(buffer.as_mut());
     /// write!(stream, "too much data").unwrap();
     /// stream.flush().expect_err("it doesn't fit");
-    /// let (recovered_writer, buffered_data) = stream.into_raw_parts();
+    /// let (recovered_writer, buffered_data) = stream.into_parts();
     /// assert_eq!(recovered_writer.len(), 0);
     /// assert_eq!(&buffered_data.unwrap(), b"ata");
     /// ```
     #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
-    pub fn into_raw_parts(mut self) -> (W, Result<Vec<u8>, WriterPanicked>) {
+    pub fn into_parts(mut self) -> (W, Result<Vec<u8>, WriterPanicked>) {
         let buf = mem::take(&mut self.buf);
         let buf = if !self.panicked { Ok(buf) } else { Err(WriterPanicked { buf }) };
 
@@ -445,7 +445,7 @@ impl<W: Write> BufWriter<W> {
 }
 
 #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
-/// Error returned for the buffered data from `BufWriter::into_raw_parts`, when the underlying
+/// Error returned for the buffered data from `BufWriter::into_parts`, when the underlying
 /// writer has previously panicked.  Contains the (possibly partly written) buffered data.
 ///
 /// # Example
@@ -467,7 +467,7 @@ impl<W: Write> BufWriter<W> {
 ///     stream.flush().unwrap()
 /// }));
 /// assert!(result.is_err());
-/// let (recovered_writer, buffered_data) = stream.into_raw_parts();
+/// let (recovered_writer, buffered_data) = stream.into_parts();
 /// assert!(matches!(recovered_writer, PanickingWriter));
 /// assert_eq!(buffered_data.unwrap_err().into_inner(), b"some data");
 /// ```

--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -14,6 +14,8 @@ use crate::io::Error;
 
 pub use bufreader::BufReader;
 pub use bufwriter::BufWriter;
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+pub use bufwriter::WriterPanicked;
 pub use linewriter::LineWriter;
 use linewritershim::LineWriterShim;
 

--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -14,7 +14,7 @@ use crate::io::Error;
 
 pub use bufreader::BufReader;
 pub use bufwriter::BufWriter;
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 pub use bufwriter::WriterPanicked;
 pub use linewriter::LineWriter;
 use linewritershim::LineWriterShim;

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -264,6 +264,8 @@ use crate::sys_common::memchr;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::IntoInnerError;
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+pub use self::buffered::WriterPanicked;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::{BufReader, BufWriter, LineWriter};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -264,7 +264,7 @@ use crate::sys_common::memchr;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::IntoInnerError;
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[unstable(feature = "bufwriter_into_parts", issue = "80690")]
 pub use self::buffered::WriterPanicked;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::{BufReader, BufWriter, LineWriter};


### PR DESCRIPTION
In #80690 @BurntSushi observed that `WriterPanicked` was erroneously not exported, and suggested renaming `into_raw_parts` to `into_parts`. (More info in my commit messages.)

r? @BurntSushi