### PR TITLE
Use caret requirements to keep using latest mdBook

### DIFF
--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -10,6 +10,6 @@ clap = "2.25.0"
 env_logger = "0.7.1"
 
 [dependencies.mdbook]
-version = "0.4.6"
+version = "^0.4"
 default-features = false
 features = ["search"]


### PR DESCRIPTION
From [rust-lang/book#2747](https://github.com/rust-lang/book/issues/2747), the version of mdBook which the Book uses to deploy depends on the `src/tools/rustbook/Cargo.toml`. Since the minor updates of mdBook also bring new features, I think it is good to use the latest mdBook.

There are two ways to automatically use the latest mdBook:

* Use caret requirements of mdBook like this PR writes
* Use a [dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically) to update the dependency version

So shall we use the latest version of mdBook for deploy all books in <https://www.rust-lang.org/learn>, and which way shall we take to automatically update mdBook's version?