### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "humantime 2.0.1",
  "ignore",
  "im-rc",
+ "itertools 0.10.0",
  "jobserver",
  "lazy_static",
  "lazycell",
@@ -293,7 +294,7 @@ dependencies = [
  "rand 0.8.3",
  "rustc-workspace-hack",
  "rustfix",
- "semver 0.10.0",
+ "semver 1.0.1",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -1711,6 +1712,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
@@ -4675,6 +4685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d023dabf011d5dcb5ac64e3685d97d3b0ef412911077a2851455c6098524a723"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,9 +5052,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
+checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
10 commits in e931e4796b61de593aa1097649445e535c9c7ee0..0cecbd67323ca14a7eb6505900d0d7307b00355b
2021-05-24 16:17:27 +0000 to 2021-06-01 20:09:13 +0000
- Configure hosts separately from targets when --target is specified. (rust-lang/cargo#9322)
- Add some validation to rustc-link-arg (rust-lang/cargo#9523)
- Implement suggestions for unknown features in workspace (rust-lang/cargo#9420)
- Extract common `make_dep_path` to cargo_util (rust-lang/cargo#9529)
- Add a note about rustflags compatibility. (rust-lang/cargo#9524)
- Consolidate doc collision detection. (rust-lang/cargo#9526)
- Add `--depth` option for `cargo-tree` (rust-lang/cargo#9499)
- `cargo tree -e no-proc-macro` to hide procedural macro dependencies (rust-lang/cargo#9488)
- Update to semver 1.0.0 (rust-lang/cargo#9508)
- Update tar dependency to 0.4.35 (rust-lang/cargo#9517)