### PR TITLE
Fixed #85845: Added a note in E0369 if the missing trait is PartialEq

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1042,6 +1042,49 @@ impl BinOpKind {
         }
     }
 
+    pub fn as_std_trait(self, assign: bool) -> Option<&'static str> {
+        Some(if assign {
+            match self {
+                BinOpKind::Add => "std::ops::AddAssign",
+                BinOpKind::Sub => "std::ops::SubAssign",
+                BinOpKind::Mul => "std::ops::MulAssign",
+                BinOpKind::Div => "std::ops::DivAssign",
+                BinOpKind::Rem => "std::ops::RemAssign",
+                BinOpKind::BitAnd => "std::ops::BitAndAssign",
+                BinOpKind::BitXor => "std::ops::BitXorAssign",
+                BinOpKind::BitOr => "std::ops::BitOrAssign",
+                BinOpKind::Shl => "std::ops::ShlAssign",
+                BinOpKind::Shr => "std::ops::ShrAssign",
+                BinOpKind::Eq
+                | BinOpKind::Ne
+                | BinOpKind::Lt
+                | BinOpKind::Le
+                | BinOpKind::Ge
+                | BinOpKind::Gt
+                | BinOpKind::And
+                | BinOpKind::Or => return None,
+            }
+        } else {
+            match self {
+                BinOpKind::Add => "std::ops::Add",
+                BinOpKind::Sub => "std::ops::Sub",
+                BinOpKind::Mul => "std::ops::Mul",
+                BinOpKind::Div => "std::ops::Div",
+                BinOpKind::Rem => "std::ops::Rem",
+                BinOpKind::BitAnd => "std::ops::BitAnd",
+                BinOpKind::BitXor => "std::ops::BitXor",
+                BinOpKind::BitOr => "std::ops::BitOr",
+                BinOpKind::Shl => "std::ops::Shl",
+                BinOpKind::Shr => "std::ops::Shr",
+                BinOpKind::Eq | BinOpKind::Ne => "std::cmp::PartialEq",
+                BinOpKind::Lt | BinOpKind::Le | BinOpKind::Ge | BinOpKind::Gt => {
+                    "std::cmp::PartialOrd"
+                }
+                BinOpKind::And | BinOpKind::Or => return None,
+            }
+        })
+    }
+
     pub fn is_lazy(self) -> bool {
         matches!(self, BinOpKind::And | BinOpKind::Or)
     }
@@ -1122,6 +1165,13 @@ impl UnOp {
             Self::Deref => "*",
             Self::Not => "!",
             Self::Neg => "-",
+        }
+    }
+    pub fn as_std_trait(self) -> &'static str {
+        match self {
+            Self::Neg => "std::ops::Neg",
+            Self::Not => "std::ops::Not",
+            Self::Deref => "std::ops::UnDerf",
         }
     }
 

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -959,6 +959,13 @@ fn suggest_impl_missing(err: &mut DiagnosticBuilder<'_>, ty: Ty<'_>, missing_tra
                 "an implementation of `{}` might be missing for `{}`",
                 missing_trait, ty
             ));
+            // This checks if the missing trait is PartialEq to suggest adding a derive
+            if missing_trait.ends_with("PartialEq") {
+                err.note(&format!(
+                    "add `#[derive(PartialEq)]` or manually implement `PartialEq` for `{}`",
+                    ty
+                ));
+            }
         }
     }
 }

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -415,7 +415,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
                 if let Some(missing_trait) = missing_trait {
-                    let missing_trait_str = missing_trait.as_std_trait();
+                    let missing_trait_str = missing_trait.as_std_trait().unwrap_or_default();
                     let mut visitor = TypeParamVisitor(vec![]);
                     visitor.visit_ty(lhs_ty);
 
@@ -463,7 +463,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             bug!("type param visitor stored a non type param: {:?}", ty.kind());
                         }
                     } else if !suggested_deref && !involves_fn {
-                        suggest_impl_missing(&mut err, lhs_ty, &missing_trait);
+                        suggest_impl_missing(&mut err, lhs_ty, missing_trait);
                     }
                 }
                 err.emit();
@@ -701,7 +701,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             suggest_impl_missing(
                                 &mut err,
                                 operand_ty,
-                                &STDImplementationMissing::Unop(op),
+                                STDImplementationMissing::Unop(op),
                             );
                         }
                     }
@@ -965,7 +965,7 @@ fn suggest_impl_missing(
             if let Some(missing_trait_name) = missing_trait.as_std_trait() {
                 err.note(&format!(
                     "an implementation of `{}` might be missing for `{}`",
-                    missing_trait, ty
+                    missing_trait_name, ty
                 ));
             }
             // This checks if the missing trait is PartialEq to suggest adding a derive

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -965,6 +965,11 @@ fn suggest_impl_missing(err: &mut DiagnosticBuilder<'_>, ty: Ty<'_>, missing_tra
                     "add `#[derive(PartialEq)]` or manually implement `PartialEq` for `{}`",
                     ty
                 ));
+            } else if missing_trait == "std::cmp::PartialOrd" {
+                err.note(&format!(
+                    "add `#[derive(PartialOrd)]` or manually implement `PartialOrd` for `{}`",
+                    ty
+                ));
             }
         }
     }

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -960,7 +960,7 @@ fn suggest_impl_missing(err: &mut DiagnosticBuilder<'_>, ty: Ty<'_>, missing_tra
                 missing_trait, ty
             ));
             // This checks if the missing trait is PartialEq to suggest adding a derive
-            if missing_trait.ends_with("std::cmp::PartialEq") {
+            if missing_trait == "std::cmp::PartialEq" {
                 err.note(&format!(
                     "add `#[derive(PartialEq)]` or manually implement `PartialEq` for `{}`",
                     ty

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -960,7 +960,7 @@ fn suggest_impl_missing(err: &mut DiagnosticBuilder<'_>, ty: Ty<'_>, missing_tra
                 missing_trait, ty
             ));
             // This checks if the missing trait is PartialEq to suggest adding a derive
-            if missing_trait.ends_with("PartialEq") {
+            if missing_trait.ends_with("std::cmp::PartialEq") {
                 err.note(&format!(
                     "add `#[derive(PartialEq)]` or manually implement `PartialEq` for `{}`",
                     ty

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -19,7 +19,6 @@ use rustc_span::symbol::{sym, Ident};
 use rustc_span::Span;
 use rustc_trait_selection::infer::InferCtxtExt;
 
-use std::borrow::Borrow;
 use std::ops::ControlFlow;
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
@@ -283,52 +282,52 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let (message, missing_trait, use_output) = match op.node {
                             hir::BinOpKind::Add => (
                                 format!("cannot add `{}` to `{}`", rhs_ty, lhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Sub => (
                                 format!("cannot subtract `{}` from `{}`", rhs_ty, lhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Mul => (
                                 format!("cannot multiply `{}` by `{}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Div => (
                                 format!("cannot divide `{}` by `{}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Rem => (
                                 format!("cannot mod `{}` by `{}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::BitAnd => (
                                 format!("no implementation for `{} & {}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::BitXor => (
                                 format!("no implementation for `{} ^ {}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::BitOr => (
                                 format!("no implementation for `{} | {}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Shl => (
                                 format!("no implementation for `{} << {}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Shr => (
                                 format!("no implementation for `{} >> {}`", lhs_ty, rhs_ty),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 true,
                             ),
                             hir::BinOpKind::Eq | hir::BinOpKind::Ne => (
@@ -337,7 +336,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     op.node.as_str(),
                                     lhs_ty
                                 ),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 false,
                             ),
                             hir::BinOpKind::Lt
@@ -349,7 +348,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     op.node.as_str(),
                                     lhs_ty
                                 ),
-                                Some(op.node),
+                                Some(STDImplementationMissing::BinOp(op.node)),
                                 false,
                             ),
                             _ => (
@@ -970,7 +969,7 @@ fn suggest_impl_missing(
                 ));
             }
             // This checks if the missing trait is PartialEq to suggest adding a derive
-            if let ImplementationMissing::BinOp(binary_op_trait) = missing_trait {
+            if let STDImplementationMissing::BinOp(binary_op_trait) = missing_trait {
                 if matches!(binary_op_trait, hir::BinOpKind::Eq | hir::BinOpKind::Ne) {
                     err.note(&format!(
                         "add `#[derive(PartialEq)]` or manually implement `PartialEq` for `{}`",

--- a/src/test/ui/binop/issue-28837.stderr
+++ b/src/test/ui/binop/issue-28837.stderr
@@ -97,6 +97,7 @@ LL |     a == a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `A`
 
 error[E0369]: binary operation `!=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:26:7
@@ -107,6 +108,7 @@ LL |     a != a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `A`
 
 error[E0369]: binary operation `<` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:28:7
@@ -117,6 +119,7 @@ LL |     a < a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+   = note: add `#[derive(PartialOrd)]` or manually implement `PartialOrd` for `A`
 
 error[E0369]: binary operation `<=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:30:7
@@ -127,6 +130,7 @@ LL |     a <= a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+   = note: add `#[derive(PartialOrd)]` or manually implement `PartialOrd` for `A`
 
 error[E0369]: binary operation `>` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:32:7
@@ -137,6 +141,7 @@ LL |     a > a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+   = note: add `#[derive(PartialOrd)]` or manually implement `PartialOrd` for `A`
 
 error[E0369]: binary operation `>=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:34:7
@@ -147,6 +152,7 @@ LL |     a >= a;
    |     A
    |
    = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+   = note: add `#[derive(PartialOrd)]` or manually implement `PartialOrd` for `A`
 
 error: aborting due to 15 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -5,6 +5,7 @@ LL |      x: Error
    |      ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
@@ -14,6 +15,7 @@ LL |      x: Error
    |      ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -5,6 +5,7 @@ LL |      Error
    |      ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
@@ -14,6 +15,7 @@ LL |      Error
    |      ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -5,6 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
@@ -14,6 +15,7 @@ LL |     x: Error
    |     ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -5,6 +5,7 @@ LL |     Error
    |     ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
@@ -14,6 +15,7 @@ LL |     Error
    |     ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `Error`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -5,6 +5,7 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `NoCloneOrEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
@@ -14,6 +15,7 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `NoCloneOrEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NoCloneOrEq: Clone` is not satisfied

--- a/src/test/ui/issues/issue-62375.stderr
+++ b/src/test/ui/issues/issue-62375.stderr
@@ -7,6 +7,7 @@ LL |     a == A::Value;
    |     A
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+   = note: add `#[derive(PartialEq)]` or manually implement `PartialEq` for `A`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR fixes #85845.
A new note has been added if the missing trait is PartialEq:
```
add `#[derive(PartialEq)]` or manually implement `PartialEq` for `MyStruct`
```

I'm not sure the ends_with is the best way but I want this change to affect `core`, `std` or custom libs. So using a full strict path isn't possible.

This is my first contribution so tell me if some guidelines aren't respected.