### PR TITLE
Fix bad suggestions for code from proc_macro

### DIFF
--- a/src/test/ui/suggestions/auxiliary/proc-macro-type-error.rs
+++ b/src/test/ui/suggestions/auxiliary/proc-macro-type-error.rs
@@ -1,0 +1,18 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type = "proc-macro"]
+#![feature(proc_macro_quote)]
+
+extern crate proc_macro;
+
+use proc_macro::{quote, TokenStream};
+
+#[proc_macro_attribute]
+pub fn hello(_: TokenStream, _: TokenStream) -> TokenStream {
+    quote!(
+        fn f(_: &mut i32) {}
+        fn g() {
+            f(123);
+        }
+    )
+}

--- a/src/test/ui/suggestions/suggest-ref-macro.rs
+++ b/src/test/ui/suggestions/suggest-ref-macro.rs
@@ -1,0 +1,29 @@
+// run-check
+// aux-build:proc-macro-type-error.rs
+
+extern crate proc_macro_type_error;
+
+use proc_macro_type_error::hello;
+
+#[hello] //~ERROR mismatched types
+fn abc() {}
+
+fn x(_: &mut i32) {}
+
+macro_rules! bla {
+    () => {
+        x(123);
+        //~^ ERROR mismatched types
+        //~| SUGGESTION &mut 123
+    };
+    ($v:expr) => {
+        x($v)
+    }
+}
+
+fn main() {
+    bla!();
+    bla!(456);
+    //~^ ERROR mismatched types
+    //~| SUGGESTION &mut 456
+}

--- a/src/test/ui/suggestions/suggest-ref-macro.stderr
+++ b/src/test/ui/suggestions/suggest-ref-macro.stderr
@@ -1,0 +1,34 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-ref-macro.rs:8:1
+   |
+LL | #[hello]
+   | ^^^^^^^^ expected `&mut i32`, found integer
+   |
+   = note: this error originates in the attribute macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-ref-macro.rs:15:11
+   |
+LL |         x(123);
+   |           ^^^
+   |           |
+   |           expected `&mut i32`, found integer
+   |           help: consider mutably borrowing here: `&mut 123`
+...
+LL |     bla!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `bla` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-ref-macro.rs:26:10
+   |
+LL |     bla!(456);
+   |          ^^^
+   |          |
+   |          expected `&mut i32`, found integer
+   |          help: consider mutably borrowing here: `&mut 456`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #85932

This disables these suggestions for spans from external macros, while keeping them for macros defined locally:

Before:
```
3 | #[hello]
  | ^^^^^^^^
  | |
  | expected `&mut i32`, found integer
  | help: consider mutably borrowing here: `&mut #[hello]`
```

After:
```
3 | #[hello]
  | ^^^^^^^^ expected `&mut i32`, found integer
```

Unchanged:
```
26 | macro_rules! bla { () => { x(123); } }
   |                              ^^^
   |                              |
   |                              expected `&mut i32`, found integer
   |                              help: consider mutably borrowing here: `&mut 123`
...
29 |     bla!();
   |     ------- in this macro invocation
```