### PR TITLE
Fix suggestion for removing &mut from &mut macro!().

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -16,6 +16,7 @@ use rustc_span::Span;
 use super::method::probe;
 
 use std::fmt;
+use std::iter;
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn emit_coerce_suggestions(
@@ -577,12 +578,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // We have `&T`, check if what was expected was `T`. If so,
                 // we may want to suggest removing a `&`.
                 if sm.is_imported(expr.span) {
-                    if let Ok(src) = sm.span_to_snippet(sp) {
-                        if let Some(src) = src.strip_prefix('&') {
+                    // Go through the spans from which this span was expanded,
+                    // and find the one that's pointing inside `sp`.
+                    //
+                    // E.g. for `&format!("")`, where we want the span to the
+                    // `format!()` invocation instead of its expansion.
+                    if let Some(call_span) =
+                        iter::successors(Some(expr.span), |s| s.parent()).find(|&s| sp.contains(s))
+                    {
+                        if let Ok(code) = sm.span_to_snippet(call_span) {
                             return Some((
                                 sp,
                                 "consider removing the borrow",
-                                src.to_string(),
+                                code,
                                 Applicability::MachineApplicable,
                             ));
                         }

--- a/src/test/ui/suggestions/format-borrow.rs
+++ b/src/test/ui/suggestions/format-borrow.rs
@@ -3,4 +3,8 @@ fn main() {
     //~^ ERROR mismatched types
     let b: String = &format!("b");
     //~^ ERROR mismatched types
+    let c: String = &mut format!("c");
+    //~^ ERROR mismatched types
+    let d: String = &mut (format!("d"));
+    //~^ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/format-borrow.stderr
+++ b/src/test/ui/suggestions/format-borrow.stderr
@@ -18,6 +18,26 @@ LL |     let b: String = &format!("b");
    |            |        help: consider removing the borrow: `format!("b")`
    |            expected due to this
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/format-borrow.rs:6:21
+   |
+LL |     let c: String = &mut format!("c");
+   |            ------   ^^^^^^^^^^^^^^^^^
+   |            |        |
+   |            |        expected struct `String`, found `&mut String`
+   |            |        help: consider removing the borrow: `format!("c")`
+   |            expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/format-borrow.rs:8:21
+   |
+LL |     let d: String = &mut (format!("d"));
+   |            ------   ^^^^^^^^^^^^^^^^^^^
+   |            |        |
+   |            |        expected struct `String`, found `&mut String`
+   |            |        help: consider removing the borrow: `format!("d")`
+   |            expected due to this
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #85933

Before: (Note the suggestions.)
```
error[E0308]: mismatched types
 --> src/main.rs:2:21
  |
2 |     let _: String = &mut format!("");
  |            ------   ^^^^^^^^^^^^^^^^
  |            |        |
  |            |        expected struct `String`, found `&mut String`
  |            |        help: consider removing the borrow: `mut format!("")`
  |            expected due to this

error[E0308]: mismatched types
 --> src/main.rs:3:21
  |
3 |     let _: String = &mut (format!(""));
  |            ------   ^^^^^^^^^^^^^^^^^^
  |            |        |
  |            |        expected struct `String`, found `&mut String`
  |            |        help: consider removing the borrow: `mut (format!(""))`
  |            expected due to this
```

After:
```
error[E0308]: mismatched types
 --> src/main.rs:2:21
  |
2 |     let _: String = &mut format!("");
  |            ------   ^^^^^^^^^^^^^^^^
  |            |        |
  |            |        expected struct `String`, found `&mut String`
  |            |        help: consider removing the borrow: `format!("")`
  |            expected due to this

error[E0308]: mismatched types
 --> src/main.rs:3:21
  |
3 |     let _: String = &mut (format!(""));
  |            ------   ^^^^^^^^^^^^^^^^^^
  |            |        |
  |            |        expected struct `String`, found `&mut String`
  |            |        help: consider removing the borrow: `format!("")`
  |            expected due to this
```