### PR TITLE
Fix cycle on THIR unsafety check on generic closures

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -365,9 +365,11 @@ pub fn check_unsafety<'tcx>(tcx: TyCtxt<'tcx>, def: ty::WithOptConstParam<LocalD
         return;
     }
 
-    // Closures are handled by their parent function
+    // Closures are handled by their parent function, except when they are in const generics
     if tcx.is_closure(def.did.to_def_id()) {
-        tcx.ensure().thir_check_unsafety(tcx.hir().local_def_id_to_hir_id(def.did).owner);
+        if let Some(owner) = tcx.hir().local_def_id_to_hir_id(def.did).as_owner() {
+            tcx.ensure().thir_check_unsafety(owner);
+        }
         return;
     }
 

--- a/src/test/ui/impl-trait/closure-in-impl-trait.mirunsafeck.stderr
+++ b/src/test/ui/impl-trait/closure-in-impl-trait.mirunsafeck.stderr
@@ -1,0 +1,16 @@
+warning: unnecessary `unsafe` block
+  --> $DIR/closure-in-impl-trait.rs:10:54
+   |
+LL | fn bug2<T>() -> impl Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]> {
+   |                                                      ^^^^^^ unnecessary `unsafe` block
+   |
+   = note: `#[warn(unused_unsafe)]` on by default
+
+warning: unnecessary `unsafe` block
+  --> $DIR/closure-in-impl-trait.rs:25:56
+   |
+LL | fn ok2<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]>> {
+   |                                                        ^^^^^^ unnecessary `unsafe` block
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/impl-trait/closure-in-impl-trait.rs
+++ b/src/test/ui/impl-trait/closure-in-impl-trait.rs
@@ -1,14 +1,43 @@
 // run-pass
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
+
 #![allow(unused_must_use)]
 fn bug<T>() -> impl Iterator<Item = [(); { |x: u32| { x }; 4 }]> {
     std::iter::empty()
+}
+
+fn bug2<T>() -> impl Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]> {
+    //~^ WARNING unnecessary `unsafe` block
+    Box::new(std::iter::empty())
+}
+
+fn bug3<T>() -> impl Iterator<Item =
+    [(); {|x: u32| unsafe { std::mem::transmute::<u32, i32>(x) }; 4 }]
+> {
+    Box::new(std::iter::empty())
 }
 
 fn ok<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| { x }; 4 }]>> {
     Box::new(std::iter::empty())
 }
 
+fn ok2<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]>> {
+    //~^ WARNING unnecessary `unsafe` block
+    Box::new(std::iter::empty())
+}
+
+fn ok3<T>() -> Box<dyn Iterator<Item =
+    [(); {|x: u32| unsafe { std::mem::transmute::<u32, i32>(x) }; 4 }]
+>> {
+    Box::new(std::iter::empty())
+}
+
 fn main() {
     for _item in ok::<u32>() {}
+    for _item in ok2::<u32>() {}
+    for _item in ok3::<u32>() {}
     for _item in bug::<u32>() {}
+    for _item in bug2::<u32>() {}
+    for _item in bug3::<u32>() {}
 }

--- a/src/test/ui/impl-trait/closure-in-impl-trait.thirunsafeck.stderr
+++ b/src/test/ui/impl-trait/closure-in-impl-trait.thirunsafeck.stderr
@@ -1,0 +1,16 @@
+warning: unnecessary `unsafe` block
+  --> $DIR/closure-in-impl-trait.rs:25:56
+   |
+LL | fn ok2<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]>> {
+   |                                                        ^^^^^^ unnecessary `unsafe` block
+   |
+   = note: `#[warn(unused_unsafe)]` on by default
+
+warning: unnecessary `unsafe` block
+  --> $DIR/closure-in-impl-trait.rs:10:54
+   |
+LL | fn bug2<T>() -> impl Iterator<Item = [(); { |x: u32| unsafe { x }; 4 }]> {
+   |                                                      ^^^^^^ unnecessary `unsafe` block
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.mirunsafeck.stderr
+++ b/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.mirunsafeck.stderr
@@ -1,0 +1,35 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:6:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:15:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:24:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:33:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.rs
+++ b/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.rs
@@ -1,0 +1,40 @@
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
+
+fn nested1<T>() -> impl Iterator<Item =
+    [(); {|x: u32| { fn x() {
+        std::mem::transmute::<(), ()>(());
+        //~^ ERROR call to unsafe function is unsafe
+    } }; 4 }]
+> {
+    Box::new(std::iter::empty())
+}
+
+fn nested2<T>() -> Box<dyn Iterator<Item =
+    [(); {|x: u32| { fn x() {
+        std::mem::transmute::<(), ()>(());
+        //~^ ERROR call to unsafe function is unsafe
+    } }; 4 }]
+>> {
+    Box::new(std::iter::empty())
+}
+
+unsafe fn nested3<T>() -> impl Iterator<Item =
+    [(); {|x: u32| { fn x() {
+        std::mem::transmute::<(), ()>(());
+        //~^ ERROR call to unsafe function is unsafe
+    } }; 4 }]
+> {
+    Box::new(std::iter::empty())
+}
+
+unsafe fn nested4<T>() -> Box<dyn Iterator<Item =
+    [(); {|x: u32| { fn x() {
+        std::mem::transmute::<(), ()>(());
+        //~^ ERROR call to unsafe function is unsafe
+    } }; 4 }]
+>> {
+    Box::new(std::iter::empty())
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.thirunsafeck.stderr
+++ b/src/test/ui/impl-trait/unsafe-fn-in-closure-in-const-generic.thirunsafeck.stderr
@@ -1,0 +1,35 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:6:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:15:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:24:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-in-closure-in-const-generic.rs:33:9
+   |
+LL |         std::mem::transmute::<(), ()>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/iife-macro.rs
+++ b/src/test/ui/unsafe/iife-macro.rs
@@ -1,0 +1,15 @@
+// check-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
+macro_rules! tests {
+    () => {
+        || 42
+    }
+}
+fn main() {
+    // these two expressions expand to the same HIR and THIR nodes,
+    // yet the macro version has caused double-steal errors
+    || 42;
+    tests!();
+}

--- a/src/test/ui/unsafe/iife.mir.stderr
+++ b/src/test/ui/unsafe/iife.mir.stderr
@@ -1,0 +1,27 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:7:5
+   |
+LL |     u();
+   |     ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:10:9
+   |
+LL |         u();
+   |         ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:25:17
+   |
+LL |                 u();
+   |                 ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/iife.rs
+++ b/src/test/ui/unsafe/iife.rs
@@ -1,0 +1,39 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
+unsafe fn u() {}
+
+fn main() {
+    u(); //~ ERROR call to unsafe function is unsafe
+
+    (|| {
+        u(); //~ ERROR call to unsafe function is unsafe
+        unsafe {
+            u();
+        }
+    })();
+
+    unsafe {
+        (|| {
+            u();
+        })();
+    }
+
+    {
+        (|| {
+            {
+                u(); //~ ERROR call to unsafe function is unsafe
+            }
+        })();
+    }
+
+    unsafe {
+        {
+            (|| {
+                {
+                    u();
+                }
+            })();
+        }
+    }
+}

--- a/src/test/ui/unsafe/iife.thir.stderr
+++ b/src/test/ui/unsafe/iife.thir.stderr
@@ -1,0 +1,27 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:7:5
+   |
+LL |     u();
+   |     ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:10:9
+   |
+LL |         u();
+   |         ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/iife.rs:25:17
+   |
+LL |                 u();
+   |                 ^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
This fixes cycles on code like this when running with `-Z thir-unsafeck`:
```rust
fn ok<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| { x }; 4 }]>> {
    Box::new(std::iter::empty())
}
```
due to a loop in unsafety checking the item in the closure, caused by trying to make the closure inherit the safety context of the parent, which doesn't work when there is no parent function, as in the case of const generics.