### PR TITLE
fix testing Miri with --stage 0

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -709,7 +709,15 @@ impl<'a> Builder<'a> {
             return;
         }
 
-        add_dylib_path(vec![self.rustc_libdir(compiler)], cmd);
+        let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
+
+        // Ensure that the downloaded LLVM libraries can be found.
+        if self.config.llvm_from_ci {
+            let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
+            dylib_dirs.push(ci_llvm_lib);
+        }
+
+        add_dylib_path(dylib_dirs, cmd);
     }
 
     /// Gets a path to the compiler specified.

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -449,6 +449,7 @@ impl Step for Miri {
                 SourceType::Submodule,
                 &[],
             );
+            cargo.add_rustc_lib_path(builder, compiler);
             cargo.arg("--").arg("miri").arg("setup");
 
             // Tell `cargo miri setup` where to find the sources.
@@ -500,6 +501,7 @@ impl Step for Miri {
                 SourceType::Submodule,
                 &[],
             );
+            cargo.add_rustc_lib_path(builder, compiler);
 
             // miri tests need to know about the stage sysroot
             cargo.env("MIRI_SYSROOT", miri_sysroot);
@@ -507,8 +509,6 @@ impl Step for Miri {
             cargo.env("MIRI", miri);
 
             cargo.arg("--").args(builder.config.cmd.test_args());
-
-            cargo.add_rustc_lib_path(builder, compiler);
 
             let mut cargo = Command::from(cargo);
             if !try_run(builder, &mut cargo) {

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -45,6 +45,7 @@ pub fn libdir(target: TargetSelection) -> &'static str {
 }
 
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.
+/// If The dylib_path_par is already set for this cmd, the old value will be overwritten!
 pub fn add_dylib_path(path: Vec<PathBuf>, cmd: &mut Command) {
     let mut list = dylib_path();
     for path in path {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/78778 for Miri.

The issue remains open for error_index_generator, which has its own dylib logic:
https://github.com/rust-lang/rust/blob/903e369c831d52726a5292f847e384622189d9a0/src/bootstrap/tool.rs#L396-L400
@jyn514 I could just copy the logic from `add_rustc_lib_path`, but that does not seem great. Any other suggestions?

Also I wonder if maybe `prepare_tool_cargo` should already call `add_rustc_lib_path`.