### PR TITLE
Show `::{{constructor}}` in std::any::type_name().

### DIFF
--- a/compiler/rustc_mir/src/interpret/intrinsics/type_name.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics/type_name.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def_id::CrateNum;
-use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
+use rustc_hir::definitions::DisambiguatedDefPathData;
 use rustc_middle::mir::interpret::Allocation;
 use rustc_middle::ty::{
     self,
@@ -126,11 +126,6 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<Self::Path, Self::Error> {
         self = print_prefix(self)?;
-
-        // Skip `::{{constructor}}` on tuple/unit structs.
-        if disambiguated_data.data == DefPathData::Ctor {
-            return Ok(self);
-        }
 
         write!(self.path, "::{}", disambiguated_data.data).unwrap();
 

--- a/library/core/tests/any.rs
+++ b/library/core/tests/any.rs
@@ -114,3 +114,16 @@ fn any_unsized() {
     fn is_any<T: Any + ?Sized>() {}
     is_any::<[i32]>();
 }
+
+#[test]
+fn distinct_type_names() {
+    // https://github.com/rust-lang/rust/issues/84666
+
+    struct Velocity(f32, f32);
+
+    fn type_name_of_val<T>(_: T) -> &'static str {
+        type_name::<T>()
+    }
+
+    assert_ne!(type_name_of_val(Velocity), type_name_of_val(Velocity(0.0, -9.8)),);
+}


### PR DESCRIPTION
Fix #84666

Before:
```
[src/main.rs:6] type_name::<T>() = "playground::Velocity"
[src/main.rs:6] type_name::<T>() = "playground::Velocity"
```

After:
```
[src/main.rs:6] type_name::<T>() = "scratchpad::Velocity::{{constructor}}"
[src/main.rs:6] type_name::<T>() = "scratchpad::Velocity"
```

cc @scottmcm 