### PR TITLE
wasm: Make simd types passed via indirection again

### DIFF
--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -103,12 +103,6 @@ pub fn options() -> TargetOptions {
         linker: Some("rust-lld".to_owned()),
         lld_flavor: LldFlavor::Wasm,
 
-        // No need for indirection here, simd types can always be passed by
-        // value as the whole module either has simd or not, which is different
-        // from x86 (for example) where programs can have functions that don't
-        // enable simd features.
-        simd_types_indirect: false,
-
         pre_link_args,
 
         crt_objects_fallback: Some(CrtObjectsFallback::Wasm),

--- a/src/test/ui/simd/wasm-simd-indirect.rs
+++ b/src/test/ui/simd/wasm-simd-indirect.rs
@@ -1,0 +1,33 @@
+// build-pass
+
+#![cfg_attr(target_arch = "wasm32", feature(wasm_simd, wasm_target_feature))]
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    unsafe {
+        a::api_with_simd_feature();
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod a {
+    use std::arch::wasm32::*;
+
+    #[target_feature(enable = "simd128")]
+    pub unsafe fn api_with_simd_feature() {
+        crate::b::api_takes_v128(u64x2(0, 1));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod b {
+    use std::arch::wasm32::*;
+
+    #[inline(never)]
+    pub fn api_takes_v128(a: v128) -> v128 {
+        a
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}


### PR DESCRIPTION
This commit updates wasm target specs to use `simd_types_indirect: true`
again. Long ago this was added since wasm simd types were always
translated to `v128` under-the-hood in LLVM, meaning that it didn't
matter whether that target feature was enabled or not. Now, however,
`v128` is conditionally used in codegen depending on target features
enabled, meaning that it's possible to get linker errors about different
signatures in code that correctly uses simd types. The fix is the same
as for all other platforms, which is to pass the type indirectly.