### PR TITLE
add support for the l4-bender linker on the x86_64-unknown-l4re-uclibc tier 3 target

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1159,6 +1159,7 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     LinkerFlavor::Lld(_) => "lld",
                     LinkerFlavor::PtxLinker => "rust-ptx-linker",
                     LinkerFlavor::BpfLinker => "bpf-linker",
+                    LinkerFlavor::L4Bender => "l4-bender",
                 }),
                 flavor,
             )),

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -3,7 +3,6 @@ use super::command::Command;
 use super::symbol_export;
 use rustc_span::symbol::sym;
 
-use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -150,9 +149,7 @@ pub fn get_linker<'a>(
 
         LinkerFlavor::BpfLinker => Box::new(BpfLinker { cmd, sess }) as Box<dyn Linker>,
 
-        LinkerFlavor::L4Bender => {
-                Box::new(L4Bender::new(cmd, sess)) as Box<dyn Linker>
-        },
+        LinkerFlavor::L4Bender => Box::new(L4Bender::new(cmd, sess)) as Box<dyn Linker>,
     }
 }
 
@@ -1367,10 +1364,10 @@ pub struct L4Bender<'a> {
 }
 
 impl<'a> Linker for L4Bender<'a> {
-    fn link_dylib(&mut self, _lib: Symbol) {
-        panic!("dylibs not supported yet")
+    fn link_dylib(&mut self, _lib: Symbol, _verbatim: bool, _as_needed: bool) {
+        bug!("dylibs are not supported on L4Re");
     }
-    fn link_staticlib(&mut self, lib: Symbol) {
+    fn link_staticlib(&mut self, lib: Symbol, _verbatim: bool) {
         self.hint_static();
         self.cmd.arg(format!("-PC{}", lib));
     }
@@ -1382,36 +1379,44 @@ impl<'a> Linker for L4Bender<'a> {
         self.cmd.arg("-L").arg(path);
     }
     fn framework_path(&mut self, _: &Path) {
-        bug!("Frameworks are not supported on L4Re!");
+        bug!("frameworks are not supported on L4Re");
     }
-    fn output_filename(&mut self, path: &Path) { self.cmd.arg("-o").arg(path); }
-    fn add_object(&mut self, path: &Path) { self.cmd.arg(path); }
-    // not sure about pie on L4Re
-    fn position_independent_executable(&mut self) { }
-    fn no_position_independent_executable(&mut self) { }
-    fn full_relro(&mut self) { self.cmd.arg("-z,relro,-z,now"); }
-    fn partial_relro(&mut self) { self.cmd.arg("-z,relro"); }
-    fn no_relro(&mut self) { self.cmd.arg("-z,norelro"); }
-    fn build_static_executable(&mut self) { self.cmd.arg("-static"); }
+    fn output_filename(&mut self, path: &Path) {
+        self.cmd.arg("-o").arg(path);
+    }
+
+    fn add_object(&mut self, path: &Path) {
+        self.cmd.arg(path);
+    }
+
+    fn full_relro(&mut self) {
+        self.cmd.arg("-zrelro");
+        self.cmd.arg("-znow");
+    }
+
+    fn partial_relro(&mut self) {
+        self.cmd.arg("-zrelro");
+    }
+
+    fn no_relro(&mut self) {
+        self.cmd.arg("-znorelro");
+    }
+
     fn cmd(&mut self) -> &mut Command {
         &mut self.cmd
     }
+
+    fn set_output_kind(&mut self, _output_kind: LinkOutputKind, _out_filename: &Path) {}
 
     fn link_rust_dylib(&mut self, _: Symbol, _: &Path) {
         panic!("Rust dylibs not supported");
     }
 
-    fn link_framework(&mut self, _: Symbol) {
-        bug!("Frameworks not supported on L4Re.");
+    fn link_framework(&mut self, _framework: Symbol, _as_needed: bool) {
+        bug!("frameworks not supported on L4Re");
     }
 
-    // Here we explicitly ask that the entire archive is included into the
-    // result artifact. For more details see #15460, but the gist is that
-    // the linker will strip away any unused objects in the archive if we
-    // don't otherwise explicitly reference them. This can occur for
-    // libraries which are just providing bindings, libraries with generic
-    // functions, etc.
-    fn link_whole_staticlib(&mut self, lib: Symbol, _: &[PathBuf]) {
+    fn link_whole_staticlib(&mut self, lib: Symbol, _verbatim: bool, _search_path: &[PathBuf]) {
         self.hint_static();
         self.cmd.arg("--whole-archive").arg(format!("-l{}", lib));
         self.cmd.arg("--no-whole-archive");
@@ -1428,17 +1433,28 @@ impl<'a> Linker for L4Bender<'a> {
         }
     }
 
-    fn optimize(&mut self) {
-        self.cmd.arg("-O2");
+    fn no_gc_sections(&mut self) {
+        self.cmd.arg("--no-gc-sections");
     }
 
-    fn pgo_gen(&mut self) { }
+    fn optimize(&mut self) {
+        // GNU-style linkers support optimization with -O. GNU ld doesn't
+        // need a numeric argument, but other linkers do.
+        if self.sess.opts.optimize == config::OptLevel::Default
+            || self.sess.opts.optimize == config::OptLevel::Aggressive
+        {
+            self.cmd.arg("-O1");
+        }
+    }
+
+    fn pgo_gen(&mut self) {}
 
     fn debuginfo(&mut self, strip: Strip) {
         match strip {
             Strip::None => {}
             Strip::Debuginfo => {
-                self.cmd().arg("--strip-debug"); }
+                self.cmd().arg("--strip-debug");
+            }
             Strip::Symbols => {
                 self.cmd().arg("--strip-all");
             }
@@ -1449,72 +1465,38 @@ impl<'a> Linker for L4Bender<'a> {
         self.cmd.arg("-nostdlib");
     }
 
-    fn build_dylib(&mut self, _: &Path) {
-        bug!("not implemented");
-    }
-
-    fn export_symbols(&mut self, _: &Path, _: CrateType) {
+    fn export_symbols(&mut self, _: &Path, _: CrateType, _: &[String]) {
         // ToDo, not implemented, copy from GCC
+        self.sess.warn("exporting symbols not implemented yet for L4Bender");
         return;
     }
 
     fn subsystem(&mut self, subsystem: &str) {
-        self.cmd.arg(&format!("--subsystem,{}", subsystem));
+        self.cmd.arg(&format!("--subsystem {}", subsystem));
     }
 
-    fn finalize(&mut self) {
+    fn reset_per_library_state(&mut self) {
         self.hint_static(); // Reset to default before returning the composed command line.
     }
 
-    fn group_start(&mut self) { self.cmd.arg("--start-group"); }
-    fn group_end(&mut self) { self.cmd.arg("--end-group"); }
-    fn linker_plugin_lto(&mut self) {
-        // do nothing
-    }
-    fn control_flow_guard(&mut self) {
-        self.sess.warn("Windows Control Flow Guard is not supported by this linker.");
+    fn group_start(&mut self) {
+        self.cmd.arg("--start-group");
     }
 
-    fn no_crt_objects(&mut self) { }
+    fn group_end(&mut self) {
+        self.cmd.arg("--end-group");
+    }
+
+    fn linker_plugin_lto(&mut self) {}
+
+    fn control_flow_guard(&mut self) {}
+
+    fn no_crt_objects(&mut self) {}
 }
 
 impl<'a> L4Bender<'a> {
-    pub fn new(mut cmd: Command, sess: &'a Session) -> L4Bender<'a> {
-        if let Ok(l4bender_args) = env::var("L4_BENDER_ARGS") {
-            L4Bender::split_cmd_args(&mut cmd, &l4bender_args);
-        }
-
-        cmd.arg("--"); // separate direct l4-bender args from linker args
-
-        L4Bender {
-            cmd: cmd,
-            sess: sess,
-            hinted_static: false,
-        }
-    }
-
-    /// This parses a shell-escaped string and unquotes the arguments. It doesn't attempt to
-    /// completely understand shell, but should instead allow passing arguments like
-    /// `-Dlinker="ld -m x86_64"`, and a copy without quotes, but spaces preserved, is added as an
-    /// argument to the given Command. This means that constructs as \" are not understood, so
-    /// quote wisely.
-    fn split_cmd_args(cmd: &mut Command, shell_args: &str) {
-        let mut arg = String::new();
-        let mut quoted = false;
-        for character in shell_args.chars() {
-            match character {
-                ' ' if !quoted => {
-                    cmd.arg(&arg);
-                    arg.clear();
-                },
-                '"' | '\'' => quoted = !quoted,
-                _ => arg.push(character),
-            };
-        }
-        if arg.len() > 0 {
-            cmd.arg(&arg);
-            arg.clear();
-        }
+    pub fn new(cmd: Command, sess: &'a Session) -> L4Bender<'a> {
+        L4Bender { cmd: cmd, sess: sess, hinted_static: false }
     }
 
     fn hint_static(&mut self) {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::impl_stable_hash_via_hash;
 
 use rustc_target::abi::{Align, TargetDataLayout};
-use rustc_target::spec::{SplitDebuginfo, Target, TargetTriple, TargetWarnings};
+use rustc_target::spec::{LinkerFlavor, SplitDebuginfo, Target, TargetTriple, TargetWarnings};
 
 use rustc_serialize::json;
 
@@ -2235,6 +2235,16 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                 "options `-C embed-bitcode=no` and `-C lto` are incompatible",
             ),
         }
+    }
+
+    if cg.linker_flavor == Some(LinkerFlavor::L4Bender)
+        && !nightly_options::is_unstable_enabled(matches)
+    {
+        early_error(
+            error_format,
+            "`l4-bender` linker flavor is unstable, `-Z unstable-options` \
+             flag must also be passed to explicitly use it",
+        );
     }
 
     let prints = collect_print_requests(&mut cg, &mut debugging_opts, matches, error_format);

--- a/compiler/rustc_target/src/spec/l4re_base.rs
+++ b/compiler/rustc_target/src/spec/l4re_base.rs
@@ -1,16 +1,5 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, TargetOptions};
-//use std::process::Command;
-
-// Use GCC to locate code for crt* libraries from the host, not from L4Re. Note
-// that a few files also come from L4Re, for these, the function shouldn't be
-// used. This uses GCC for the location of the file, but GCC is required for L4Re anyway.
-//fn get_path_or(filename: &str) -> String {
-//    let child = Command::new("gcc")
-//        .arg(format!("-print-file-name={}", filename)).output()
-//        .expect("Failed to execute GCC");
-//    String::from_utf8(child.stdout)
-//        .expect("Couldn't read path from GCC").trim().into()
-//}
+use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use std::default::Default;
 
 pub fn opts() -> TargetOptions {
     TargetOptions {
@@ -19,9 +8,9 @@ pub fn opts() -> TargetOptions {
         linker_flavor: LinkerFlavor::Ld,
         executables: true,
         panic_strategy: PanicStrategy::Abort,
-        linker: Some("ld".to_string()),
-        linker_is_gnu: false,
-        families: vec!["unix".to_string()],
+        linker: Some("l4-bender".to_string()),
+        pre_link_args: args,
+        os_family: Some("unix".to_string()),
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/l4re_base.rs
+++ b/compiler/rustc_target/src/spec/l4re_base.rs
@@ -1,16 +1,16 @@
-use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, TargetOptions};
+use crate::spec::{LinkerFlavor, PanicStrategy, TargetOptions};
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
     TargetOptions {
         os: "l4re".to_string(),
         env: "uclibc".to_string(),
-        linker_flavor: LinkerFlavor::Ld,
+        linker_flavor: LinkerFlavor::L4Bender,
         executables: true,
         panic_strategy: PanicStrategy::Abort,
         linker: Some("l4-bender".to_string()),
-        pre_link_args: args,
-        os_family: Some("unix".to_string()),
+        linker_is_gnu: false,
+        families: vec!["unix".to_string()],
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -90,6 +90,7 @@ mod windows_uwp_msvc_base;
 pub enum LinkerFlavor {
     Em,
     Gcc,
+    L4Bender,
     Ld,
     Msvc,
     Lld(LldFlavor),
@@ -160,6 +161,7 @@ macro_rules! flavor_mappings {
 flavor_mappings! {
     ((LinkerFlavor::Em), "em"),
     ((LinkerFlavor::Gcc), "gcc"),
+    ((LinkerFlavor::L4Bender), "l4-bender"),
     ((LinkerFlavor::Ld), "ld"),
     ((LinkerFlavor::Msvc), "msvc"),
     ((LinkerFlavor::PtxLinker), "ptx-linker"),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
@@ -1,9 +1,12 @@
-use crate::spec::Target;
+use crate::spec::{PanicStrategy, Target};
 
 pub fn target() -> Target {
     let mut base = super::l4re_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
+    base.crt_static_allows_dylibs = false;
+    base.dynamic_linking = false;
+    base.panic_strategy = PanicStrategy::Abort;
 
     Target {
         llvm_target: "x86_64-unknown-l4re-uclibc".to_string(),
@@ -11,10 +14,6 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),
         arch: "x86_64".to_string(),
-        target_os: "l4re".to_string(),
-        target_env: "uclibc".to_string(),
-        target_vendor: "unknown".to_string(),
-        linker_flavor: LinkerFlavor::L4Bender,
         options: base,
     }
 }

--- a/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_l4re_uclibc.rs
@@ -11,6 +11,10 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),
         arch: "x86_64".to_string(),
+        target_os: "l4re".to_string(),
+        target_env: "uclibc".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::L4Bender,
         options: base,
     }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -39,6 +39,10 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "hermit")] {
         #[path = "hermit.rs"]
         mod real_imp;
+    } else if #[cfg(target_os = "l4re")] {
+        // L4Re is unix family but does not yet support unwinding.
+        #[path = "dummy.rs"]
+        mod real_imp;
     } else if #[cfg(target_env = "msvc")] {
         #[path = "seh.rs"]
         mod real_imp;


### PR DESCRIPTION
This PR contains the work by @humenda to update support for the `x86_64-unknown-l4re-uclibc` tier 3 target (published at [humenda/rust](https://github.com/humenda/rust)), rebased and adapted to current rust in follow up commits by myself. The publishing of the rebased changes is authorized and preferred by the original author. As the goal was to distort the original work as little as possible, individual commits introduce changes that are incompatible to the newer code base that the changes were rebased on. These incompatibilities have been remedied in follow up commits, so that the PR as a whole should result in a clean update of the target.
If you prefer another strategy to mainline these changes while preserving attribution, please let me know.