### PR TITLE
Use more precise span for E0282 in cast expressions

### DIFF
--- a/compiler/rustc_typeck/src/check/cast.rs
+++ b/compiler/rustc_typeck/src/check/cast.rs
@@ -609,8 +609,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     }
 
     pub fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {
-        self.expr_ty = fcx.structurally_resolved_type(self.span, self.expr_ty);
-        self.cast_ty = fcx.structurally_resolved_type(self.span, self.cast_ty);
+        self.expr_ty = fcx.structurally_resolved_type(self.expr.span, self.expr_ty);
+        self.cast_ty = fcx.structurally_resolved_type(self.cast_span, self.cast_ty);
 
         debug!("check_cast({}, {:?} as {:?})", self.expr.hir_id, self.expr_ty, self.cast_ty);
 

--- a/src/test/ui/cast/issue-85586.rs
+++ b/src/test/ui/cast/issue-85586.rs
@@ -1,0 +1,10 @@
+// Check that errors for unresolved types in cast expressions are reported
+// for the offending subexpression, not the whole cast expression.
+
+#![allow(unused_variables)]
+
+fn main() {
+    let a = [1, 2, 3].iter().sum();
+    let b = (a + 1) as usize;
+    //~^ ERROR: type annotations needed [E0282]
+}

--- a/src/test/ui/cast/issue-85586.stderr
+++ b/src/test/ui/cast/issue-85586.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-85586.rs:8:13
+   |
+LL |     let b = (a + 1) as usize;
+   |             ^^^^^^^ cannot infer type
+   |
+   = note: type must be known at this point
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
This pull request fixes #85586. The example code given there:
```rust
fn main() {
    let a = [1, 2, 3].iter().sum();
    let b = (a + 1) as usize;
}
```
currently produces
```
error[E0282]: type annotations needed
 --> issue-85586.rs:3:13
  |
3 |     let b = (a + 1) as usize;
  |             ^^^^^^^^^^^^^^^^ cannot infer type
  |
  = note: type must be known at this point

error: aborting due to previous error
```
even though the type of the entire cast expression quite clearly should be `usize`. The error is in the cast's left-hand side, which is made explicit by the changes in this PR:
```
error[E0282]: type annotations needed
 --> issue-85586.rs:3:13
  |
3 |     let b = (a + 1) as usize;
  |             ^^^^^^^ cannot infer type
  |
  = note: type must be known at this point

error: aborting due to previous error
```
