### PR TITLE
td align attribute

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -82,7 +82,7 @@ pub use core::time::Duration;
 /// Currently, the following system calls are being used to get the current time using `now()`:
 ///
 /// |  Platform |               System call                                            |
-/// |:---------:|:--------------------------------------------------------------------:|
+/// |-----------|----------------------------------------------------------------------|
 /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
 /// | UNIX      | [clock_gettime (Monotonic Clock)]                                    |
 /// | Darwin    | [mach_absolute_time]                                                 |
@@ -158,7 +158,7 @@ pub struct Instant(time::Instant);
 /// Currently, the following system calls are being used to get the current time using `now()`:
 ///
 /// |  Platform |               System call                                            |
-/// |:---------:|:--------------------------------------------------------------------:|
+/// |-----------|----------------------------------------------------------------------|
 /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
 /// | UNIX      | [clock_gettime (Realtime Clock)]                                     |
 /// | Darwin    | [gettimeofday]                                                       |


### PR DESCRIPTION
This is a follow-up of #85972. I have put this one on its own because it changes the display:

![Screenshot from 2021-06-03 21-49-11](https://user-images.githubusercontent.com/3050060/120703622-d533d280-c4b5-11eb-9519-ea1131a40bee.png)

Without align:

![Screenshot from 2021-06-03 21-49-15](https://user-images.githubusercontent.com/3050060/120703623-d5cc6900-c4b5-11eb-95f9-878d3915c7fb.png)

I also opened an issue about it: raphlinus/pulldown-cmark#533. However, I'm not sure if this is the right course of action... Should we instead ignore the warning?

r? @jsha 