### PR TITLE
Revert "implement TrustedRandomAccess for Take iterator adapter"

### DIFF
--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -1,8 +1,5 @@
 use crate::cmp;
-use crate::iter::{
-    adapters::zip::try_get_unchecked, adapters::SourceIter, FusedIterator, InPlaceIterable,
-    TrustedLen, TrustedRandomAccess,
-};
+use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
@@ -114,15 +111,6 @@ where
 
         self.try_fold(init, ok(fold)).unwrap()
     }
-
-    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <I as Iterator>::Item
-    where
-        Self: TrustedRandomAccess,
-    {
-        // SAFETY: the caller must uphold the contract for
-        // `Iterator::__iterator_get_unchecked`.
-        unsafe { try_get_unchecked(&mut self.iter, idx) }
-    }
 }
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
@@ -219,12 +207,3 @@ impl<I> FusedIterator for Take<I> where I: FusedIterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I: TrustedLen> TrustedLen for Take<I> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccess for Take<I>
-where
-    I: TrustedRandomAccess,
-{
-    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
-}


### PR DESCRIPTION
This reverts commit 37a5b515e9c36ee3f57d9e0d7db7efce2fb02195 (#83990).

The original change unintentionally caused side-effects from certain iterator chains combining `take`, `zip` and `next_back()` to be omitted which is observable by user code and thus likely a breaking change

Technically one could declare it not a breaking change since `Zip`'s API contract is silent about about its backwards iteration behavior but on the other hand there is nothing in the stable Iterator API that could justify the currently observable behavior. And either way, this impact wasn't noticed or discussed in the original PR.

Fixes #85969