### PR TITLE
Disallow non-monomorphic calls to `needs_drop` in interpreter

### DIFF
--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -56,7 +56,10 @@ crate fn eval_nullary_intrinsic<'tcx>(
             let alloc = type_name::alloc_type_name(tcx, tp_ty);
             ConstValue::Slice { data: alloc, start: 0, end: alloc.len() }
         }
-        sym::needs_drop => ConstValue::from_bool(tp_ty.needs_drop(tcx, param_env)),
+        sym::needs_drop => {
+            ensure_monomorphic_enough(tcx, tp_ty)?;
+            ConstValue::from_bool(tp_ty.needs_drop(tcx, param_env))
+        }
         sym::min_align_of | sym::pref_align_of => {
             let layout = tcx.layout_of(param_env.and(tp_ty)).map_err(|e| err_inval!(Layout(e)))?;
             let n = match name {

--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -61,6 +61,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
             ConstValue::from_bool(tp_ty.needs_drop(tcx, param_env))
         }
         sym::min_align_of | sym::pref_align_of => {
+            // Correctly handles non-monomorphic calls, so there is no need for ensure_monomorphic_enough.
             let layout = tcx.layout_of(param_env.and(tp_ty)).map_err(|e| err_inval!(Layout(e)))?;
             let n = match name {
                 sym::pref_align_of => layout.align.pref.bytes(),
@@ -74,6 +75,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
             ConstValue::from_u64(tcx.type_id_hash(tp_ty))
         }
         sym::variant_count => match tp_ty.kind() {
+            // Correctly handles non-monomorphic calls, so there is no need for ensure_monomorphic_enough.
             ty::Adt(ref adt, _) => ConstValue::from_machine_usize(adt.variants.len() as u64, &tcx),
             ty::Projection(_)
             | ty::Opaque(_, _)

--- a/src/test/ui/consts/const-needs_drop-monomorphic.rs
+++ b/src/test/ui/consts/const-needs_drop-monomorphic.rs
@@ -1,0 +1,17 @@
+// Check that evaluation of needs_drop<T> fails when T is not monomorphic.
+#![feature(const_generics)]
+#![allow(const_evaluatable_unchecked)]
+#![allow(incomplete_features)]
+
+struct Bool<const B: bool> {}
+impl Bool<true> {
+    fn assert() {}
+}
+fn f<T>() {
+    Bool::<{ std::mem::needs_drop::<T>() }>::assert();
+    //~^ ERROR no function or associated item named `assert` found
+    //~| ERROR constant expression depends on a generic parameter
+}
+fn main() {
+    f::<u32>();
+}

--- a/src/test/ui/consts/const-needs_drop-monomorphic.stderr
+++ b/src/test/ui/consts/const-needs_drop-monomorphic.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no function or associated item named `assert` found for struct `Bool<{ std::mem::needs_drop::<T>() }>` in the current scope
+  --> $DIR/const-needs_drop-monomorphic.rs:11:46
+   |
+LL | struct Bool<const B: bool> {}
+   | -------------------------- function or associated item `assert` not found for this
+...
+LL |     Bool::<{ std::mem::needs_drop::<T>() }>::assert();
+   |                                              ^^^^^^ function or associated item cannot be called on `Bool<{ std::mem::needs_drop::<T>() }>` due to unsatisfied trait bounds
+
+error: constant expression depends on a generic parameter
+  --> $DIR/const-needs_drop-monomorphic.rs:11:5
+   |
+LL |     Bool::<{ std::mem::needs_drop::<T>() }>::assert();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
otherwise evaluation could change after further substitutions.