### PR TITLE
Add `os::windows::ffi::OsStrExt::system_cmp` and `system_eq`

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -68,6 +68,10 @@ pub type ADDRESS_FAMILY = USHORT;
 pub const TRUE: BOOL = 1;
 pub const FALSE: BOOL = 0;
 
+pub const CSTR_LESS_THAN: c_int = 1;
+pub const CSTR_EQUAL: c_int = 2;
+pub const CSTR_GREATER_THAN: c_int = 3;
+
 pub const FILE_ATTRIBUTE_READONLY: DWORD = 0x1;
 pub const FILE_ATTRIBUTE_DIRECTORY: DWORD = 0x10;
 pub const FILE_ATTRIBUTE_REPARSE_POINT: DWORD = 0x400;
@@ -996,6 +1000,14 @@ extern "system" {
     pub fn ReleaseSRWLockShared(SRWLock: PSRWLOCK);
     pub fn TryAcquireSRWLockExclusive(SRWLock: PSRWLOCK) -> BOOLEAN;
     pub fn TryAcquireSRWLockShared(SRWLock: PSRWLOCK) -> BOOLEAN;
+
+    pub fn CompareStringOrdinal(
+        lpString1: LPCWSTR,
+        cchCount1: c_int,
+        lpString2: LPCWSTR,
+        cchCount2: c_int,
+        bIgnoreCase: BOOL,
+    ) -> c_int;
 }
 
 #[link(name = "ws2_32")]

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -151,6 +151,25 @@ pub fn to_u16s<S: AsRef<OsStr>>(s: S) -> crate::io::Result<Vec<u16>> {
     inner(s.as_ref())
 }
 
+pub fn compare_case_insensitive<A: AsRef<OsStr>, B: AsRef<OsStr>>(
+    a: A,
+    b: B,
+) -> crate::io::Result<crate::cmp::Ordering> {
+    let a = crate::sys::to_u16s(a.as_ref())?;
+    let b = crate::sys::to_u16s(b.as_ref())?;
+
+    let result = unsafe {
+        c::CompareStringOrdinal(a.as_ptr(), a.len() as _, b.as_ptr(), b.len() as _, c::TRUE)
+    };
+
+    match result {
+        c::CSTR_LESS_THAN => Ok(crate::cmp::Ordering::Less),
+        c::CSTR_EQUAL => Ok(crate::cmp::Ordering::Equal),
+        c::CSTR_GREATER_THAN => Ok(crate::cmp::Ordering::Greater),
+        _ => Err(crate::io::Error::last_os_error()),
+    }
+}
+
 // Many Windows APIs follow a pattern of where we hand a buffer and then they
 // will report back to us how large the buffer should be or how many bytes
 // currently reside in the buffer. This function is an abstraction over these


### PR DESCRIPTION
Adds two methods to the extension trait `OsStrExt` on Windows for dealing with case-insensitive strings: `system_cmp` and `system_eq`. These methods use the system case-insensitive implementation `CompareStringOrdinal` with `bIgnoreCase`, which differs from a pure Unicode case-insensitive comparison (which is why I explicitly named these methods `system_` instead of something like `case_insensitive_`). 

These methods are the correct way for comparing environment variable keys, registry keys, resource handle names etc. on Windows, e.g. `"Path"` and `"PATH"` are treated the same by the system and should compare equal.

This is the minimal way I thought of for enabling the use of Windows specific case-insensitive comparisons. There are several ways this could be extended further if necessary:

- <s>Also have extension traits with `system_cmp` and `system_eq` for `Path`, `[u8]`?, `[u16]`?</s> (This is not the correct way to compare paths: https://github.com/rust-lang/rust/issues/86007#issuecomment-855013160)
- <s>Introduce a trait `SystemOrd` and `SystemEq` in `std::os::windows`.</s>
- Introduce a wrapper type like `num::Wrapping` for `OsStr` that overrides the `Ord` and `Eq` implementation. 

Inspired by #85270

Tracking issue: #86007