### PR TITLE
msp430 linker does not accept -znoexecstack. Set linker_is_gnu to fal…

### DIFF
--- a/compiler/rustc_target/src/spec/msp430_none_elf.rs
+++ b/compiler/rustc_target/src/spec/msp430_none_elf.rs
@@ -17,6 +17,7 @@ pub fn target() -> Target {
             // dependency on this specific gcc.
             asm_args: vec!["-mcpu=msp430".to_string()],
             linker: Some("msp430-elf-gcc".to_string()),
+            linker_is_gnu: false,
 
             // There are no atomic CAS instructions available in the MSP430
             // instruction set, and the LLVM backend doesn't currently support


### PR DESCRIPTION
…se as workaround for now.

Tested locally and works. Closes #85948.