### PR TITLE
Move LLVM submodule updates back to native.rs

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -991,28 +991,20 @@ class RustBuild(object):
         ).decode(default_encoding).splitlines()]
         filtered_submodules = []
         submodules_names = []
-        llvm_checked_out = os.path.exists(os.path.join(self.rust_root, "src/llvm-project/.git"))
-        external_llvm_provided = self.get_toml('llvm-config') or self.downloading_llvm()
-        llvm_needed = not self.get_toml('codegen-backends', 'rust') \
-            or "llvm" in self.get_toml('codegen-backends', 'rust')
         for module in submodules:
+            # This is handled by native::Llvm in rustbuild, not here
             if module.endswith("llvm-project"):
-                # Don't sync the llvm-project submodule if an external LLVM was
-                # provided, if we are downloading LLVM or if the LLVM backend is
-                # not being built. Also, if the submodule has been initialized
-                # already, sync it anyways so that it doesn't mess up contributor
-                # pull requests.
-                if external_llvm_provided or not llvm_needed:
-                    if self.get_toml('lld') != 'true' and not llvm_checked_out:
-                        continue
+                continue
             check = self.check_submodule(module, slow_submodules)
             filtered_submodules.append((module, check))
             submodules_names.append(module)
         recorded = subprocess.Popen(["git", "ls-tree", "HEAD"] + submodules_names,
                                     cwd=self.rust_root, stdout=subprocess.PIPE)
         recorded = recorded.communicate()[0].decode(default_encoding).strip().splitlines()
+        # { filename: hash }
         recorded_submodules = {}
         for data in recorded:
+            # [mode, kind, hash, filename]
             data = data.split()
             recorded_submodules[data[3]] = data[2]
         for module in filtered_submodules:

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -472,11 +472,21 @@ impl Build {
         slice::from_ref(&self.build.triple)
     }
 
+    /// If the LLVM submodule has been initialized already, sync it unconditionally. This avoids
+    /// contributors checking in a submodule change by accident.
+    pub fn maybe_update_llvm_submodule(&self) {
+        if self.in_tree_llvm_info.is_git() {
+            native::update_llvm_submodule(self);
+        }
+    }
+
     /// Executes the entire build, as configured by the flags and configuration.
     pub fn build(&mut self) {
         unsafe {
             job::setup(self);
         }
+
+        self.maybe_update_llvm_submodule();
 
         if let Subcommand::Format { check, paths } = &self.config.cmd {
             return format::format(self, *check, &paths);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -472,21 +472,17 @@ impl Build {
         slice::from_ref(&self.build.triple)
     }
 
-    /// If the LLVM submodule has been initialized already, sync it unconditionally. This avoids
-    /// contributors checking in a submodule change by accident.
-    pub fn maybe_update_llvm_submodule(&self) {
-        if self.in_tree_llvm_info.is_git() {
-            native::update_llvm_submodule(self);
-        }
-    }
-
     /// Executes the entire build, as configured by the flags and configuration.
     pub fn build(&mut self) {
         unsafe {
             job::setup(self);
         }
 
-        self.maybe_update_llvm_submodule();
+        // If the LLVM submodule has been initialized already, sync it unconditionally. This avoids
+        // contributors checking in a submodule change by accident.
+        if self.in_tree_llvm_info.is_git() {
+            native::update_llvm_submodule(self);
+        }
 
         if let Subcommand::Format { check, paths } = &self.config.cmd {
             return format::format(self, *check, &paths);

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -107,12 +107,14 @@ pub(crate) fn update_llvm_submodule(build: &Build) {
     }
 
     // check_submodule
+    let buf;
     let checked_out = if build.config.fast_submodules {
-        Some(output(
+        buf = output(
             Command::new("git")
                 .args(&["rev-parse", "HEAD"])
                 .current_dir(build.config.src.join(llvm_project)),
-        ))
+        );
+        Some(buf.trim_end())
     } else {
         None
     };
@@ -124,8 +126,10 @@ pub(crate) fn update_llvm_submodule(build: &Build) {
             .arg(llvm_project)
             .current_dir(&build.config.src),
     );
-    let hash =
-        recorded.split(' ').nth(2).unwrap_or_else(|| panic!("unexpected output `{}`", recorded));
+    let hash = recorded
+        .split_whitespace()
+        .nth(2)
+        .unwrap_or_else(|| panic!("unexpected output `{}`", recorded));
 
     // update_submodule
     if let Some(llvm_hash) = checked_out {

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -130,6 +130,7 @@ pub fn make(host: &str) -> PathBuf {
     }
 }
 
+#[track_caller]
 pub fn output(cmd: &mut Command) -> String {
     let output = match cmd.stderr(Stdio::inherit()).output() {
         Ok(status) => status,


### PR DESCRIPTION
Time to find more bugs!

The first commit is a straight revert of https://github.com/rust-lang/rust/pull/85647, the second is a fix for https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/x.2Epy.20always.20updates.20LLVM.20submodule/near/240113320 and https://github.com/rust-lang/rust/pull/82653#issuecomment-846755631. I haven't been able to replicate https://github.com/rust-lang/rust/pull/82653#issuecomment-849013698.