### PR TITLE
Fix display for search results

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -800,6 +800,8 @@ a {
 
 .search-results .result-name > span {
 	display: inline-block;
+	margin: 0;
+	font-weight: normal;
 }
 
 body.blur > :not(#help) {


### PR DESCRIPTION
This fixes unwanted margin and font-weight coming from `.method`. Before:

![Screenshot from 2021-06-05 23-03-34](https://user-images.githubusercontent.com/3050060/120905486-9e46f380-c652-11eb-8008-6db6e0517ba3.png)

after:

![Screenshot from 2021-06-05 23-05-02](https://user-images.githubusercontent.com/3050060/120905489-9edf8a00-c652-11eb-817d-f676f6ab7303.png)

r? @jsha 