### PR TITLE
Don't fire `invalid_doc_attributes` on `extern crate` items

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -577,7 +577,7 @@ impl CheckAttrVisitor<'tcx> {
         target: Target,
         specified_inline: &mut Option<(bool, Span)>,
     ) -> bool {
-        if target == Target::Use {
+        if target == Target::Use || target == Target::ExternCrate {
             let do_inline = meta.name_or_empty() == sym::inline;
             if let Some((prev_inline, prev_span)) = *specified_inline {
                 if do_inline != prev_inline {

--- a/src/test/ui/rustdoc/doc-inline-extern-crate.rs
+++ b/src/test/ui/rustdoc/doc-inline-extern-crate.rs
@@ -1,0 +1,9 @@
+#[doc(inline)]
+//~^ ERROR conflicting
+#[doc(no_inline)]
+pub extern crate core;
+
+// no warning
+pub extern crate alloc;
+
+fn main() {}

--- a/src/test/ui/rustdoc/doc-inline-extern-crate.stderr
+++ b/src/test/ui/rustdoc/doc-inline-extern-crate.stderr
@@ -1,0 +1,13 @@
+error: conflicting doc inlining attributes
+  --> $DIR/doc-inline-extern-crate.rs:1:7
+   |
+LL | #[doc(inline)]
+   |       ^^^^^^ this attribute...
+LL |
+LL | #[doc(no_inline)]
+   |       ^^^^^^^^^ ...conflicts with this attribute
+   |
+   = help: remove one of the conflicting attributes
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/86046.