### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -218,8 +218,7 @@ impl AttrAnnotatedTokenStream {
                 AttrAnnotatedTokenTree::Attributes(data) => {
                     let mut outer_attrs = Vec::new();
                     let mut inner_attrs = Vec::new();
-                    let attrs: Vec<_> = data.attrs.clone().into();
-                    for attr in attrs {
+                    for attr in &data.attrs {
                         match attr.style {
                             crate::AttrStyle::Outer => {
                                 assert!(
@@ -264,7 +263,7 @@ impl AttrAnnotatedTokenStream {
                                 // so we never reach this code.
 
                                 let mut builder = TokenStreamBuilder::new();
-                                for inner_attr in &inner_attrs {
+                                for inner_attr in inner_attrs {
                                     builder.push(inner_attr.tokens().to_tokenstream());
                                 }
                                 builder.push(delim_tokens.clone());

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1642,10 +1642,16 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     // Make the binary compatible with data execution prevention schemes.
     cmd.add_no_exec();
 
+    // OBJECT-FILES-YES
+    add_local_crate_metadata_objects(cmd, crate_type, codegen_results);
+
     // NO-OPT-OUT, OBJECT-FILES-NO
     // Avoid linking to dynamic libraries unless they satisfy some undefined symbols
     // at the point at which they are specified on the command line.
     // Must be passed before any dynamic libraries.
+    // On solaris-like systems, this also will ignore unreferenced ELF sections
+    // from relocatable objects. For that reason, we move the metadata objects
+    // to before this flag as they would otherwise be removed.
     cmd.add_as_needed();
 
     // NO-OPT-OUT, OBJECT-FILES-NO
@@ -1696,9 +1702,6 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     // need to make sure that all symbols are exported correctly from the
     // dynamic library.
     cmd.export_symbols(tmpdir, crate_type);
-
-    // OBJECT-FILES-YES
-    add_local_crate_metadata_objects(cmd, crate_type, codegen_results);
 
     // OBJECT-FILES-YES
     add_local_crate_allocator_objects(cmd, codegen_results);

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1005,6 +1005,8 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     || stem.ends_with("-clang")
                 {
                     LinkerFlavor::Gcc
+                } else if stem == "wasm-ld" || stem.ends_with("-wasm-ld") {
+                    LinkerFlavor::Lld(LldFlavor::Wasm)
                 } else if stem == "ld" || stem == "ld.lld" || stem.ends_with("-ld") {
                     LinkerFlavor::Ld
                 } else if stem == "link" || stem == "lld-link" {

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -472,7 +472,9 @@ impl<'a> Linker for GccLinker<'a> {
         // eliminate the metadata. If we're building an executable, however,
         // --gc-sections drops the size of hello world from 1.8MB to 597K, a 67%
         // reduction.
-        } else if self.sess.target.linker_is_gnu && !keep_metadata {
+        } else if (self.sess.target.linker_is_gnu || self.sess.target.is_like_wasm)
+            && !keep_metadata
+        {
             self.linker_arg("--gc-sections");
         }
     }
@@ -480,13 +482,13 @@ impl<'a> Linker for GccLinker<'a> {
     fn no_gc_sections(&mut self) {
         if self.sess.target.is_like_osx {
             self.linker_arg("-no_dead_strip");
-        } else if self.sess.target.linker_is_gnu {
+        } else if self.sess.target.linker_is_gnu || self.sess.target.is_like_wasm {
             self.linker_arg("--no-gc-sections");
         }
     }
 
     fn optimize(&mut self) {
-        if !self.sess.target.linker_is_gnu {
+        if !self.sess.target.linker_is_gnu && !self.sess.target.is_like_wasm {
             return;
         }
 

--- a/compiler/rustc_data_structures/src/obligation_forest/mod.rs
+++ b/compiler/rustc_data_structures/src/obligation_forest/mod.rs
@@ -342,7 +342,7 @@ impl<O: ForestObligation> ObligationForest<O> {
             return Ok(());
         }
 
-        match self.active_cache.entry(cache_key.clone()) {
+        match self.active_cache.entry(cache_key) {
             Entry::Occupied(o) => {
                 let node = &mut self.nodes[*o.get()];
                 if let Some(parent_index) = parent {
@@ -366,7 +366,7 @@ impl<O: ForestObligation> ObligationForest<O> {
                     && self
                         .error_cache
                         .get(&obligation_tree_id)
-                        .map(|errors| errors.contains(&cache_key))
+                        .map(|errors| errors.contains(v.key()))
                         .unwrap_or(false);
 
                 if already_failed {

--- a/compiler/rustc_data_structures/src/obligation_forest/mod.rs
+++ b/compiler/rustc_data_structures/src/obligation_forest/mod.rs
@@ -366,8 +366,7 @@ impl<O: ForestObligation> ObligationForest<O> {
                     && self
                         .error_cache
                         .get(&obligation_tree_id)
-                        .map(|errors| errors.contains(v.key()))
-                        .unwrap_or(false);
+                        .map_or(false, |errors| errors.contains(v.key()));
 
                 if already_failed {
                     Err(())

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -729,13 +729,11 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 let base_ty = Place::ty_from(place_local, proj_base, self.body, self.tcx).ty;
                 if let ty::RawPtr(_) = base_ty.kind() {
                     if proj_base.is_empty() {
-                        if let (local, []) = (place_local, proj_base) {
-                            let decl = &self.body.local_decls[local];
-                            if let Some(box LocalInfo::StaticRef { def_id, .. }) = decl.local_info {
-                                let span = decl.source_info.span;
-                                self.check_static(def_id, span);
-                                return;
-                            }
+                        let decl = &self.body.local_decls[place_local];
+                        if let Some(box LocalInfo::StaticRef { def_id, .. }) = decl.local_info {
+                            let span = decl.source_info.span;
+                            self.check_static(def_id, span);
+                            return;
                         }
                     }
                     self.check_op(ops::RawPtrDeref);

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -577,7 +577,7 @@ impl CheckAttrVisitor<'tcx> {
         target: Target,
         specified_inline: &mut Option<(bool, Span)>,
     ) -> bool {
-        if target == Target::Use {
+        if target == Target::Use || target == Target::ExternCrate {
             let do_inline = meta.name_or_empty() == sym::inline;
             if let Some((prev_inline, prev_span)) = *specified_inline {
                 if do_inline != prev_inline {

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -102,6 +102,7 @@ pub fn options() -> TargetOptions {
         // we use the LLD shipped with the Rust toolchain by default
         linker: Some("rust-lld".to_owned()),
         lld_flavor: LldFlavor::Wasm,
+        linker_is_gnu: false,
 
         // No need for indirection here, simd types can always be passed by
         // value as the whole module either has simd or not, which is different

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -551,19 +551,13 @@ const LEN: usize = 16384;
 #[bench]
 fn bench_chain_collect(b: &mut Bencher) {
     let data = black_box([0; LEN]);
-    b.iter(|| data.iter().cloned().chain([1].iter().cloned()).collect::<Vec<_>>());
+    b.iter(|| data.iter().cloned().chain([1]).collect::<Vec<_>>());
 }
 
 #[bench]
 fn bench_chain_chain_collect(b: &mut Bencher) {
     let data = black_box([0; LEN]);
-    b.iter(|| {
-        data.iter()
-            .cloned()
-            .chain([1].iter().cloned())
-            .chain([2].iter().cloned())
-            .collect::<Vec<_>>()
-    });
+    b.iter(|| data.iter().cloned().chain([1]).chain([2]).collect::<Vec<_>>());
 }
 
 #[bench]

--- a/library/alloc/src/collections/vec_deque/pair_slices.rs
+++ b/library/alloc/src/collections/vec_deque/pair_slices.rs
@@ -1,4 +1,3 @@
-use core::array;
 use core::cmp::{self};
 use core::mem::replace;
 
@@ -37,7 +36,7 @@ impl<'a, 'b, T> PairSlices<'a, 'b, T> {
     }
 
     pub fn remainder(self) -> impl Iterator<Item = &'b [T]> {
-        array::IntoIter::new([self.b0, self.b1])
+        IntoIterator::into_iter([self.b0, self.b1])
     }
 }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -921,7 +921,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// ```
     /// let mut vec = Vec::with_capacity(10);
-    /// vec.extend([1, 2, 3].iter().cloned());
+    /// vec.extend([1, 2, 3]);
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
     /// assert!(vec.capacity() >= 3);
@@ -950,7 +950,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     /// #![feature(shrink_to)]
     /// let mut vec = Vec::with_capacity(10);
-    /// vec.extend([1, 2, 3].iter().cloned());
+    /// vec.extend([1, 2, 3]);
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to(4);
     /// assert!(vec.capacity() >= 4);
@@ -984,7 +984,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// ```
     /// let mut vec = Vec::with_capacity(10);
-    /// vec.extend([1, 2, 3].iter().cloned());
+    /// vec.extend([1, 2, 3]);
     ///
     /// assert_eq!(vec.capacity(), 10);
     /// let slice = vec.into_boxed_slice();
@@ -2586,7 +2586,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     /// let mut v = vec![1, 2, 3];
     /// let new = [7, 8];
-    /// let u: Vec<_> = v.splice(..2, new.iter().cloned()).collect();
+    /// let u: Vec<_> = v.splice(..2, new).collect();
     /// assert_eq!(v, &[7, 8, 3]);
     /// assert_eq!(u, &[1, 2]);
     /// ```

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -14,7 +14,7 @@ use super::{Drain, Vec};
 /// ```
 /// let mut v = vec![0, 1, 2];
 /// let new = [7, 8];
-/// let iter: std::vec::Splice<_> = v.splice(1.., new.iter().cloned());
+/// let iter: std::vec::Splice<_> = v.splice(1.., new);
 /// ```
 #[derive(Debug)]
 #[stable(feature = "vec_splice", since = "1.21.0")]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -793,7 +793,7 @@ fn test_drain_leak() {
 fn test_splice() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
-    v.splice(2..4, a.iter().cloned());
+    v.splice(2..4, a);
     assert_eq!(v, &[1, 2, 10, 11, 12, 5]);
     v.splice(1..3, Some(20));
     assert_eq!(v, &[1, 20, 11, 12, 5]);
@@ -803,7 +803,7 @@ fn test_splice() {
 fn test_splice_inclusive_range() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
-    let t1: Vec<_> = v.splice(2..=3, a.iter().cloned()).collect();
+    let t1: Vec<_> = v.splice(2..=3, a).collect();
     assert_eq!(v, &[1, 2, 10, 11, 12, 5]);
     assert_eq!(t1, &[3, 4]);
     let t2: Vec<_> = v.splice(1..=2, Some(20)).collect();
@@ -816,7 +816,7 @@ fn test_splice_inclusive_range() {
 fn test_splice_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
-    v.splice(5..6, a.iter().cloned());
+    v.splice(5..6, a);
 }
 
 #[test]
@@ -824,7 +824,7 @@ fn test_splice_out_of_bounds() {
 fn test_splice_inclusive_out_of_bounds() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
-    v.splice(5..=5, a.iter().cloned());
+    v.splice(5..=5, a);
 }
 
 #[test]
@@ -848,7 +848,7 @@ fn test_splice_unbounded() {
 fn test_splice_forget() {
     let mut v = vec![1, 2, 3, 4, 5];
     let a = [10, 11, 12];
-    std::mem::forget(v.splice(2..4, a.iter().cloned()));
+    std::mem::forget(v.splice(2..4, a));
     assert_eq!(v, &[1, 2]);
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -416,7 +416,7 @@ impl<T, const N: usize> [T; N] {
     {
         // SAFETY: we know for certain that this iterator will yield exactly `N`
         // items.
-        unsafe { collect_into_array_unchecked(&mut IntoIter::new(self).map(f)) }
+        unsafe { collect_into_array_unchecked(&mut IntoIterator::into_iter(self).map(f)) }
     }
 
     /// 'Zips up' two arrays into a single array of pairs.
@@ -437,7 +437,7 @@ impl<T, const N: usize> [T; N] {
     /// ```
     #[unstable(feature = "array_zip", issue = "80094")]
     pub fn zip<U>(self, rhs: [U; N]) -> [(T, U); N] {
-        let mut iter = IntoIter::new(self).zip(IntoIter::new(rhs));
+        let mut iter = IntoIterator::into_iter(self).zip(rhs);
 
         // SAFETY: we know for certain that this iterator will yield exactly `N`
         // items.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -58,7 +58,7 @@ impl char {
     /// ];
     ///
     /// assert_eq!(
-    ///     decode_utf16(v.iter().cloned())
+    ///     decode_utf16(v)
     ///         .map(|r| r.map_err(|e| e.unpaired_surrogate()))
     ///         .collect::<Vec<_>>(),
     ///     vec![
@@ -82,7 +82,7 @@ impl char {
     /// ];
     ///
     /// assert_eq!(
-    ///     decode_utf16(v.iter().cloned())
+    ///     decode_utf16(v)
     ///        .map(|r| r.unwrap_or(REPLACEMENT_CHARACTER))
     ///        .collect::<String>(),
     ///     "𝄞mus�ic�"

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -41,14 +41,14 @@ fn array_try_from() {
 #[test]
 fn iterator_collect() {
     let arr = [0, 1, 2, 5, 9];
-    let v: Vec<_> = IntoIter::new(arr.clone()).collect();
+    let v: Vec<_> = IntoIterator::into_iter(arr.clone()).collect();
     assert_eq!(&arr[..], &v[..]);
 }
 
 #[test]
 fn iterator_rev_collect() {
     let arr = [0, 1, 2, 5, 9];
-    let v: Vec<_> = IntoIter::new(arr.clone()).rev().collect();
+    let v: Vec<_> = IntoIterator::into_iter(arr.clone()).rev().collect();
     assert_eq!(&v[..], &[9, 5, 2, 1, 0]);
 }
 
@@ -56,11 +56,11 @@ fn iterator_rev_collect() {
 fn iterator_nth() {
     let v = [0, 1, 2, 3, 4];
     for i in 0..v.len() {
-        assert_eq!(IntoIter::new(v.clone()).nth(i).unwrap(), v[i]);
+        assert_eq!(IntoIterator::into_iter(v.clone()).nth(i).unwrap(), v[i]);
     }
-    assert_eq!(IntoIter::new(v.clone()).nth(v.len()), None);
+    assert_eq!(IntoIterator::into_iter(v.clone()).nth(v.len()), None);
 
-    let mut iter = IntoIter::new(v);
+    let mut iter = IntoIterator::into_iter(v);
     assert_eq!(iter.nth(2).unwrap(), v[2]);
     assert_eq!(iter.nth(1).unwrap(), v[4]);
 }
@@ -68,17 +68,17 @@ fn iterator_nth() {
 #[test]
 fn iterator_last() {
     let v = [0, 1, 2, 3, 4];
-    assert_eq!(IntoIter::new(v).last().unwrap(), 4);
-    assert_eq!(IntoIter::new([0]).last().unwrap(), 0);
+    assert_eq!(IntoIterator::into_iter(v).last().unwrap(), 4);
+    assert_eq!(IntoIterator::into_iter([0]).last().unwrap(), 0);
 
-    let mut it = IntoIter::new([0, 9, 2, 4]);
+    let mut it = IntoIterator::into_iter([0, 9, 2, 4]);
     assert_eq!(it.next_back(), Some(4));
     assert_eq!(it.last(), Some(2));
 }
 
 #[test]
 fn iterator_clone() {
-    let mut it = IntoIter::new([0, 2, 4, 6, 8]);
+    let mut it = IntoIterator::into_iter([0, 2, 4, 6, 8]);
     assert_eq!(it.next(), Some(0));
     assert_eq!(it.next_back(), Some(8));
     let mut clone = it.clone();
@@ -92,7 +92,7 @@ fn iterator_clone() {
 
 #[test]
 fn iterator_fused() {
-    let mut it = IntoIter::new([0, 9, 2]);
+    let mut it = IntoIterator::into_iter([0, 9, 2]);
     assert_eq!(it.next(), Some(0));
     assert_eq!(it.next(), Some(9));
     assert_eq!(it.next(), Some(2));
@@ -105,7 +105,7 @@ fn iterator_fused() {
 
 #[test]
 fn iterator_len() {
-    let mut it = IntoIter::new([0, 1, 2, 5, 9]);
+    let mut it = IntoIterator::into_iter([0, 1, 2, 5, 9]);
     assert_eq!(it.size_hint(), (5, Some(5)));
     assert_eq!(it.len(), 5);
     assert_eq!(it.is_empty(), false);
@@ -121,7 +121,7 @@ fn iterator_len() {
     assert_eq!(it.is_empty(), false);
 
     // Empty
-    let it = IntoIter::new([] as [String; 0]);
+    let it = IntoIterator::into_iter([] as [String; 0]);
     assert_eq!(it.size_hint(), (0, Some(0)));
     assert_eq!(it.len(), 0);
     assert_eq!(it.is_empty(), true);
@@ -130,9 +130,9 @@ fn iterator_len() {
 #[test]
 fn iterator_count() {
     let v = [0, 1, 2, 3, 4];
-    assert_eq!(IntoIter::new(v.clone()).count(), 5);
+    assert_eq!(IntoIterator::into_iter(v.clone()).count(), 5);
 
-    let mut iter2 = IntoIter::new(v);
+    let mut iter2 = IntoIterator::into_iter(v);
     iter2.next();
     iter2.next();
     assert_eq!(iter2.count(), 3);
@@ -140,13 +140,13 @@ fn iterator_count() {
 
 #[test]
 fn iterator_flat_map() {
-    assert!((0..5).flat_map(|i| IntoIter::new([2 * i, 2 * i + 1])).eq(0..10));
+    assert!((0..5).flat_map(|i| IntoIterator::into_iter([2 * i, 2 * i + 1])).eq(0..10));
 }
 
 #[test]
 fn iterator_debug() {
     let arr = [0, 1, 2, 5, 9];
-    assert_eq!(format!("{:?}", IntoIter::new(arr)), "IntoIter([0, 1, 2, 5, 9])",);
+    assert_eq!(format!("{:?}", IntoIterator::into_iter(arr)), "IntoIter([0, 1, 2, 5, 9])",);
 }
 
 #[test]
@@ -176,14 +176,14 @@ fn iterator_drops() {
     // Simple: drop new iterator.
     let i = Cell::new(0);
     {
-        IntoIter::new(five(&i));
+        IntoIterator::into_iter(five(&i));
     }
     assert_eq!(i.get(), 5);
 
     // Call `next()` once.
     let i = Cell::new(0);
     {
-        let mut iter = IntoIter::new(five(&i));
+        let mut iter = IntoIterator::into_iter(five(&i));
         let _x = iter.next();
         assert_eq!(i.get(), 0);
         assert_eq!(iter.count(), 4);
@@ -194,7 +194,7 @@ fn iterator_drops() {
     // Check `clone` and calling `next`/`next_back`.
     let i = Cell::new(0);
     {
-        let mut iter = IntoIter::new(five(&i));
+        let mut iter = IntoIterator::into_iter(five(&i));
         iter.next();
         assert_eq!(i.get(), 1);
         iter.next_back();
@@ -217,7 +217,7 @@ fn iterator_drops() {
     // Check via `nth`.
     let i = Cell::new(0);
     {
-        let mut iter = IntoIter::new(five(&i));
+        let mut iter = IntoIterator::into_iter(five(&i));
         let _x = iter.nth(2);
         assert_eq!(i.get(), 2);
         let _y = iter.last();
@@ -227,13 +227,13 @@ fn iterator_drops() {
 
     // Check every element.
     let i = Cell::new(0);
-    for (index, _x) in IntoIter::new(five(&i)).enumerate() {
+    for (index, _x) in IntoIterator::into_iter(five(&i)).enumerate() {
         assert_eq!(i.get(), index);
     }
     assert_eq!(i.get(), 5);
 
     let i = Cell::new(0);
-    for (index, _x) in IntoIter::new(five(&i)).rev().enumerate() {
+    for (index, _x) in IntoIterator::into_iter(five(&i)).rev().enumerate() {
         assert_eq!(i.get(), index);
     }
     assert_eq!(i.get(), 5);

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -1,4 +1,4 @@
-use core::array::{self, IntoIter};
+use core::array;
 use core::convert::TryFrom;
 
 #[test]

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -236,9 +236,7 @@ fn test_zip_trusted_random_access_composition() {
 fn test_double_ended_zip() {
     let xs = [1, 2, 3, 4, 5, 6];
     let ys = [1, 2, 3, 7];
-    let a = xs.iter().cloned();
-    let b = ys.iter().cloned();
-    let mut it = a.zip(b);
+    let mut it = xs.iter().cloned().zip(ys);
     assert_eq!(it.next(), Some((1, 1)));
     assert_eq!(it.next(), Some((2, 2)));
     assert_eq!(it.next_back(), Some((4, 7)));

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -105,7 +105,7 @@ crate fn render<T: Print, S: Print>(
                            placeholder=\"Click or press ‘S’ to search, ‘?’ for more options…\" \
                            type=\"search\">\
                 </div>\
-                <button type=\"button\" id=\"help-button\" title=\"help\">?</button>
+                <button type=\"button\" id=\"help-button\" title=\"help\">?</button>\
                 <a id=\"settings-menu\" href=\"{root_path}settings.html\" title=\"settings\">\
                     <img src=\"{static_root_path}wheel{suffix}.svg\" \
                          width=\"18\" height=\"18\" \

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -161,7 +161,7 @@ crate fn render<T: Print, S: Print>(
             }
         },
         title = page.title,
-        description = page.description,
+        description = Escape(page.description),
         keywords = page.keywords,
         favicon = if layout.favicon.is_empty() {
             format!(

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -322,7 +322,13 @@ impl AllTypes {
             if !e.is_empty() {
                 let mut e: Vec<&ItemEntry> = e.iter().collect();
                 e.sort();
-                write!(f, "<h3 id=\"{}\">{}</h3><ul class=\"{} docblock\">", title, title, class);
+                write!(
+                    f,
+                    "<h3 id=\"{}\">{}</h3><ul class=\"{} docblock\">",
+                    title.replace(' ', "-"), // IDs cannot contain whitespaces.
+                    title,
+                    class
+                );
 
                 for s in e.iter() {
                     write!(f, "<li>{}</li>", s.print());
@@ -346,7 +352,7 @@ impl AllTypes {
              </h1>",
         );
         // Note: print_entries does not escape the title, because we know the current set of titles
-        // don't require escaping.
+        // doesn't require escaping.
         print_entries(f, &self.structs, "Structs", "structs");
         print_entries(f, &self.enums, "Enums", "enums");
         print_entries(f, &self.unions, "Unions", "unions");

--- a/src/test/ui/const-generics/array-impls/into-iter-impls-length-32.rs
+++ b/src/test/ui/const-generics/array-impls/into-iter-impls-length-32.rs
@@ -9,31 +9,31 @@ use std::{
 };
 
 pub fn yes_iterator() -> impl Iterator<Item = i32> {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_double_ended_iterator() -> impl DoubleEndedIterator {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_exact_size_iterator() -> impl ExactSizeIterator {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_fused_iterator() -> impl FusedIterator {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_trusted_len() -> impl TrustedLen {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_clone() -> impl Clone {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 pub fn yes_debug() -> impl Debug {
-    IntoIter::new([0i32; 32])
+    IntoIterator::into_iter([0i32; 32])
 }
 
 

--- a/src/test/ui/const-generics/array-impls/into-iter-impls-length-33.rs
+++ b/src/test/ui/const-generics/array-impls/into-iter-impls-length-33.rs
@@ -9,31 +9,31 @@ use std::{
 };
 
 pub fn yes_iterator() -> impl Iterator<Item = i32> {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_double_ended_iterator() -> impl DoubleEndedIterator {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_exact_size_iterator() -> impl ExactSizeIterator {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_fused_iterator() -> impl FusedIterator {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_trusted_len() -> impl TrustedLen {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_clone() -> impl Clone {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 pub fn yes_debug() -> impl Debug {
-    IntoIter::new([0i32; 33])
+    IntoIterator::into_iter([0i32; 33])
 }
 
 

--- a/src/test/ui/rustdoc/doc-inline-extern-crate.rs
+++ b/src/test/ui/rustdoc/doc-inline-extern-crate.rs
@@ -1,0 +1,9 @@
+#[doc(inline)]
+//~^ ERROR conflicting
+#[doc(no_inline)]
+pub extern crate core;
+
+// no warning
+pub extern crate alloc;
+
+fn main() {}

--- a/src/test/ui/rustdoc/doc-inline-extern-crate.stderr
+++ b/src/test/ui/rustdoc/doc-inline-extern-crate.stderr
@@ -1,0 +1,13 @@
+error: conflicting doc inlining attributes
+  --> $DIR/doc-inline-extern-crate.rs:1:7
+   |
+LL | #[doc(inline)]
+   |       ^^^^^^ this attribute...
+LL |
+LL | #[doc(no_inline)]
+   |       ^^^^^^^^^ ...conflicts with this attribute
+   |
+   = help: remove one of the conflicting attributes
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #85436 (Avoid cloning cache key)
 - #85772 (Preserve metadata w/ Solaris-like linkers.)
 - #85920 (Tweak wasm_base target spec to indicate linker is not GNU and update linker inferring logic for wasm-ld.)
 - #85930 (Update standard library for IntoIterator implementation of arrays )
 - #85972 (Rustdoc html fixes)
 - #86028 (Drop an `if let` that will always succeed)
 - #86043 (don't clone attrs)
 - #86047 (Don't fire `invalid_doc_attributes` on `extern crate` items)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85436,85772,85920,85930,85972,86028,86043,86047)
<!-- homu-ignore:end -->