### PR TITLE
Remove some eval_always

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -915,11 +915,9 @@ rustc_queries! {
 
     /// Performs part of the privacy check and computes "access levels".
     query privacy_access_levels(_: ()) -> &'tcx AccessLevels {
-        eval_always
         desc { "privacy access levels" }
     }
     query check_private_in_public(_: ()) -> () {
-        eval_always
         desc { "checking for private elements in public interfaces" }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1484,25 +1484,21 @@ rustc_queries! {
 
     query get_lib_features(_: ()) -> LibFeatures {
         storage(ArenaCacheSelector<'tcx>)
-        eval_always
         desc { "calculating the lib features map" }
     }
-    query defined_lib_features(_: CrateNum)
-        -> &'tcx [(Symbol, Option<Symbol>)] {
+    query defined_lib_features(_: CrateNum) -> &'tcx [(Symbol, Option<Symbol>)] {
         desc { "calculating the lib features defined in a crate" }
         separate_provide_extern
     }
     /// Returns the lang items defined in another crate by loading it from metadata.
     query get_lang_items(_: ()) -> LanguageItems {
         storage(ArenaCacheSelector<'tcx>)
-        eval_always
         desc { "calculating the lang items map" }
     }
 
     /// Returns all diagnostic items defined in all crates.
     query all_diagnostic_items(_: ()) -> rustc_hir::diagnostic_items::DiagnosticItems {
         storage(ArenaCacheSelector<'tcx>)
-        eval_always
         desc { "calculating the diagnostic items map" }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1473,7 +1473,6 @@ rustc_queries! {
 
     /// Gets the name of the crate.
     query crate_name(_: CrateNum) -> Symbol {
-        eval_always
         desc { "fetching what a crate is named" }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1595,7 +1595,6 @@ rustc_queries! {
     }
 
     query collect_and_partition_mono_items(_: ()) -> (&'tcx DefIdSet, &'tcx [CodegenUnit<'tcx>]) {
-        eval_always
         desc { "collect_and_partition_mono_items" }
     }
     query is_codegened_item(def_id: DefId) -> bool {
@@ -1604,7 +1603,6 @@ rustc_queries! {
 
     /// All items participating in code generation together with items inlined into them.
     query codegened_and_inlined_items(_: ()) -> &'tcx DefIdSet {
-        eval_always
        desc { "codegened_and_inlined_items" }
     }
 


### PR DESCRIPTION
Some `eval_always` marker may not be useful and trigger unnecessary query recomputations. This PR attempts to measure the amount of such recomputations.

Blocked on #90581