### PR TITLE
remove obsolete -m64 option

### DIFF
--- a/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
@@ -5,10 +5,7 @@ pub fn target() -> Target {
     base.cpu = "core2".to_string();
     base.max_atomic_width = Some(128); // core2 support cmpxchg16b
     base.eliminate_frame_pointer = false;
-    base.pre_link_args.insert(
-        LinkerFlavor::Gcc,
-        vec!["-m64".to_string(), "-arch".to_string(), "x86_64".to_string()],
-    );
+    base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-arch".to_string(), "x86_64".to_string()]);
     base.link_env_remove.extend(super::apple_base::macos_link_env_remove());
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;


### PR DESCRIPTION
Apple ld man page

```bash
 -m          Don't treat multiple definitions as an error.  This is no longer supported. This option is obsolete.
```

LLVM MachO lld: option is obsolete
https://github.com/llvm/llvm-project/blob/70804f2a2f7b87227a873cd6d8852ad295068e79/lld/MachO/Options.td#L1040

The LLVM lld is not going to implement -m64. It prevents bringing LLVM lld MachO support for rust.

see https://github.com/rust-lang/rust/issues/85938