### PR TITLE
Improve linker detection for ld64.lld for Apple devices

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1205,7 +1205,7 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                     LinkerFlavor::Ld
                 } else if stem == "link" || stem == "lld-link" {
                     LinkerFlavor::Msvc
-                } else if stem == "lld" || stem == "rust-lld" {
+                } else if stem == "lld" || stem == "ld64" || stem == "rust-lld" {
                     LinkerFlavor::Lld(sess.target.lld_flavor)
                 } else {
                     // fall back to the value in the target spec
@@ -2183,7 +2183,11 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
 
     // Converts a library file-stem into a cc -l argument
     fn unlib<'a>(target: &Target, stem: &'a str) -> &'a str {
-        if stem.starts_with("lib") && !target.is_like_windows { &stem[3..] } else { stem }
+        if stem.starts_with("lib") && !target.is_like_windows {
+            &stem[3..]
+        } else {
+            stem
+        }
     }
 
     // Adds the static "rlib" versions of all crates to the command line.

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2554,8 +2554,9 @@ fn add_apple_platform_version(cmd: &mut dyn Linker, sess: &Session, flavor: Link
     };
 
     let path = format!("{}/usr/lib", &sdk_path);
+    cmd.args(&["-syslibroot", &sdk_path]);
     cmd.args(&["-L", &path]);
-    cmd.args(&["-platform_version", os, "10.7", &platform_version]);
+    cmd.args(&["-platform_version", os, &platform_version, &platform_version]);
 }
 
 fn get_apple_platform_version(sdk_name: &str) -> Result<String, String> {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2536,6 +2536,15 @@ fn add_apple_platform_version(cmd: &mut dyn Linker, sess: &Session, flavor: Link
             return;
         }
     };
+
+    let sdk_path = match get_apple_sdk_root(sdk_name) {
+        Ok(s) => s,
+        Err(e) => {
+            sess.err(&e);
+            return;
+        }
+    };
+
     let platform_version = match get_apple_platform_version(sdk_name) {
         Ok(s) => s,
         Err(e) => {
@@ -2544,6 +2553,8 @@ fn add_apple_platform_version(cmd: &mut dyn Linker, sess: &Session, flavor: Link
         }
     };
 
+    let path = format!("{}/usr/lib", &sdk_path);
+    cmd.args(&["-L", &path]);
     cmd.args(&["-platform_version", os, "10.7", &platform_version]);
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -231,7 +231,9 @@ impl<'a> GccLinker<'a> {
     fn build_dylib(&mut self, out_filename: &Path) {
         // On mac we need to tell the linker to let this library be rpathed
         if self.sess.target.is_like_osx {
-            self.cmd.arg("-dynamiclib");
+            if self.sess.target.lld_flavor != LldFlavor::Ld64 {
+                self.cmd.arg("-dynamiclib");
+            }
             self.linker_arg("-dylib");
 
             // Note that the `osx_rpath_install_name` option here is a hack

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use crate::spec::{SplitDebuginfo, TargetOptions};
+use crate::spec::{LldFlavor, SplitDebuginfo, TargetOptions};
 
 pub fn opts(os: &str) -> TargetOptions {
     // ELF TLS is only available in macOS 10.7+. If you try to compile for 10.6
@@ -35,6 +35,7 @@ pub fn opts(os: &str) -> TargetOptions {
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
         eh_frame_header: false,
+        lld_flavor: LldFlavor::Ld64,
 
         // The historical default for macOS targets is to run `dsymutil` which
         // generates a packed version of debuginfo split from the main file.

--- a/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
@@ -5,10 +5,7 @@ pub fn target() -> Target {
     base.cpu = "core2".to_string();
     base.max_atomic_width = Some(128); // core2 support cmpxchg16b
     base.eliminate_frame_pointer = false;
-    base.pre_link_args.insert(
-        LinkerFlavor::Gcc,
-        vec!["-m64".to_string(), "-arch".to_string(), "x86_64".to_string()],
-    );
+    base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-arch".to_string(), "x86_64".to_string()]);
     base.link_env_remove.extend(super::apple_base::macos_link_env_remove());
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;

--- a/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
@@ -1,11 +1,18 @@
-use crate::spec::{LinkerFlavor, SanitizerSet, StackProbeType, Target, TargetOptions};
+use crate::spec::{LinkerFlavor, LldFlavor, SanitizerSet, StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts("macos");
     base.cpu = "core2".to_string();
     base.max_atomic_width = Some(128); // core2 support cmpxchg16b
     base.eliminate_frame_pointer = false;
-    base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-arch".to_string(), "x86_64".to_string()]);
+    base.pre_link_args.insert(
+        LinkerFlavor::Gcc,
+        vec!["-m64".to_string(), "-arch".to_string(), "x86_64".to_string()],
+    );
+    base.pre_link_args.insert(
+        LinkerFlavor::Lld(LldFlavor::Ld64),
+        vec!["-arch".to_string(), "x86_64".to_string()],
+    );
     base.link_env_remove.extend(super::apple_base::macos_link_env_remove());
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;


### PR DESCRIPTION
Other Apple devices will need a similar solution, but I have no hardware.

see https://github.com/rust-lang/rust/issues/85938

I can now build a large workspace with 300+ crates.