### PR TITLE
Implement `Default` for `Result<(), E>`

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1379,6 +1379,14 @@ impl<T: Clone, E: Clone> Clone for Result<T, E> {
     }
 }
 
+#[unstable(feature = "unit_result_default_impl", issue = "none")]
+impl<E> Default for Result<(), E> {
+	#[inline]
+	fn default() -> Self {
+		Ok(())
+	}
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, E> IntoIterator for Result<T, E> {
     type Item = T;

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1381,10 +1381,10 @@ impl<T: Clone, E: Clone> Clone for Result<T, E> {
 
 #[unstable(feature = "unit_result_default_impl", issue = "none")]
 impl<E> Default for Result<(), E> {
-	#[inline]
-	fn default() -> Self {
-		Ok(())
-	}
+    #[inline]
+    fn default() -> Self {
+        Ok(())
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Implement the `Default` trait for `Result<(), E>`.
It makes sense for `Result<(), E>` to implement this as a counterpart of `Some(T)`, because both `Ok(())` and `None` signify the absence of a value.
It also goes hand in hand with the common Rust idiom of calling several functions which return a `Result`:
```rust
fn f() -> Result<(), Error> {
    foo()?;
    bar()?;
    baz();
    Ok(()) // <- Here, Ok(()) arguably is the "default".
}
```