### PR TITLE
Default panic message should print Box<dyn Any>

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -193,7 +193,7 @@ fn default_hook(info: &PanicInfo<'_>) {
         Some(s) => *s,
         None => match info.payload().downcast_ref::<String>() {
             Some(s) => &s[..],
-            None => "Box<Any>",
+            None => "Box<dyn Any>",
         },
     };
     let thread = thread_info::current_thread();

--- a/src/test/ui/panics/panic-macro-any-wrapped.rs
+++ b/src/test/ui/panics/panic-macro-any-wrapped.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![allow(non_fmt_panic)]

--- a/src/test/ui/panics/panic-macro-any.rs
+++ b/src/test/ui/panics/panic-macro-any.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![feature(box_syntax)]


### PR DESCRIPTION
Closes #86039 

Prior to this patch, the panic message from running the following code would be `thread 'main' panicked at 'Box<Any>'...`
```rust
use std::panic::panic_any;
fn main() {
    panic_any(42);
}
```

This patch updates the phrasing to be more consistent. It now instead shows the following panic message:

```
thread 'main' panicked at 'Box<dyn Any>', ...
```

It's a very small fix 😄 