### PR TITLE
Fix corrected example in E0759.md

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0759.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0759.md
@@ -16,13 +16,13 @@ fn bar(x: &i32) -> Box<dyn Debug> { // error!
 
 Add `'static` requirement to fix them:
 
-```compile_fail,E0759
+```
 # use std::fmt::Debug;
-fn foo(x: &i32) -> impl Debug + 'static { // ok!
+fn foo(x: &'static i32) -> impl Debug + 'static { // ok!
     x
 }
 
-fn bar(x: &i32) -> Box<dyn Debug + 'static> { // ok!
+fn bar(x: &'static i32) -> Box<dyn Debug + 'static> { // ok!
     Box::new(x)
 }
 ```


### PR DESCRIPTION
This pull request fixes #86061, which was probably caused by a copy-paste error, where the supposedly corrected code example was also marked with `compile_fail`. Thus, the fact that the "correct" example actually _isn't_ correct was not caught by the doc-tests. This pull request removes the incorrect `compile_fail` annotation and fixes the example.

r? @GuillaumeGomez
