### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -157,20 +157,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
                 );
             }
         } else {
-            // FIXME this is super_place code, is repeated here to avoid cloning place or changing
-            // visit_place API
-            let mut context = context;
-
-            if !place_ref.projection.is_empty() {
-                context = if context.is_mutating_use() {
-                    PlaceContext::MutatingUse(MutatingUseContext::Projection)
-                } else {
-                    PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
-                };
-            }
-
             self.visit_local(&place_ref.local, context, location);
-            self.visit_projection(*place_ref, context, location);
         }
     }
 }

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -7,9 +7,7 @@ use rustc_data_structures::graph::dominators::Dominators;
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::traversal;
-use rustc_middle::mir::visit::{
-    MutatingUseContext, NonMutatingUseContext, NonUseContext, PlaceContext, Visitor,
-};
+use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, Location, TerminatorKind};
 use rustc_middle::ty;
 use rustc_middle::ty::layout::HasTyCtxt;
@@ -21,7 +19,9 @@ pub fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let mir = fx.mir;
     let mut analyzer = LocalAnalyzer::new(fx);
 
-    analyzer.visit_body(&mir);
+    for (bb, data) in mir.basic_blocks().iter_enumerated() {
+        analyzer.visit_basic_block_data(bb, data);
+    }
 
     for (local, decl) in mir.local_decls.iter_enumerated() {
         let ty = fx.monomorphize(decl.ty);
@@ -142,36 +142,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
 
             if let mir::ProjectionElem::Deref = elem {
                 // Deref projections typically only read the pointer.
-                // (the exception being `VarDebugInfo` contexts, handled below)
                 base_context = PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
-
-                // Indirect debuginfo requires going through memory, that only
-                // the debugger accesses, following our emitted DWARF pointer ops.
-                //
-                // FIXME(eddyb) Investigate the possibility of relaxing this, but
-                // note that `llvm.dbg.declare` *must* be used for indirect places,
-                // even if we start using `llvm.dbg.value` for all other cases,
-                // as we don't necessarily know when the value changes, but only
-                // where it lives in memory.
-                //
-                // It's possible `llvm.dbg.declare` could support starting from
-                // a pointer that doesn't point to an `alloca`, but this would
-                // only be useful if we know the pointer being `Deref`'d comes
-                // from an immutable place, and if `llvm.dbg.declare` calls
-                // must be at the very start of the function, then only function
-                // arguments could contain such pointers.
-                if context == PlaceContext::NonUse(NonUseContext::VarDebugInfo) {
-                    // We use `NonUseContext::VarDebugInfo` for the base,
-                    // which might not force the base local to memory,
-                    // so we have to do it manually.
-                    self.visit_local(&place_ref.local, context, location);
-                }
-            }
-
-            // `NonUseContext::VarDebugInfo` needs to flow all the
-            // way down to the base local (see `visit_local`).
-            if context == PlaceContext::NonUse(NonUseContext::VarDebugInfo) {
-                base_context = context;
             }
 
             self.process_place(&place_base, base_context, location);

--- a/compiler/rustc_error_codes/src/error_codes/E0759.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0759.md
@@ -16,13 +16,13 @@ fn bar(x: &i32) -> Box<dyn Debug> { // error!
 
 Add `'static` requirement to fix them:
 
-```compile_fail,E0759
+```
 # use std::fmt::Debug;
-fn foo(x: &i32) -> impl Debug + 'static { // ok!
+fn foo(x: &'static i32) -> impl Debug + 'static { // ok!
     x
 }
 
-fn bar(x: &i32) -> Box<dyn Debug + 'static> { // ok!
+fn bar(x: &'static i32) -> Box<dyn Debug + 'static> { // ok!
     Box::new(x)
 }
 ```

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -712,15 +712,10 @@ fn ty_is_known_nonnull<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, mode: CItemKi
                 return false;
             }
 
-            for variant in &def.variants {
-                if let Some(field) = transparent_newtype_field(cx.tcx, variant) {
-                    if ty_is_known_nonnull(cx, field.ty(tcx, substs), mode) {
-                        return true;
-                    }
-                }
-            }
-
-            false
+            def.variants
+                .iter()
+                .filter_map(|variant| transparent_newtype_field(cx.tcx, variant))
+                .any(|field| ty_is_known_nonnull(cx, field.ty(tcx, substs), mode))
         }
         _ => false,
     }

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -334,7 +334,6 @@ impl<'a> Parser<'a> {
         mut bounds: GenericBounds,
         plus: bool,
     ) -> PResult<'a, TyKind> {
-        assert_ne!(self.token, token::Question);
         if plus {
             self.eat_plus(); // `+`, or `+=` gets split and `+` is discarded
             bounds.append(&mut self.parse_generic_bounds(Some(self.prev_token.span))?);

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -766,7 +766,7 @@ fn infer_placeholder_type(
             if !ty.references_error() {
                 diag.span_suggestion(
                     span,
-                    "replace `_` with the correct type",
+                    "replace with the correct type",
                     ty.to_string(),
                     Applicability::MaybeIncorrect,
                 );

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -124,6 +124,13 @@ fn main() {
                 cmd.arg("-C").arg("target-feature=-crt-static");
             }
         }
+
+        if stage == "0" {
+            // Cargo doesn't pass RUSTFLAGS to proc_macros:
+            // https://github.com/rust-lang/cargo/issues/4423
+            // Set `--cfg=bootstrap` explicitly instead.
+            cmd.arg("--cfg=bootstrap");
+        }
     }
 
     if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -444,8 +444,13 @@ impl Build {
 
         build.verbose("finding compilers");
         cc_detect::find(&mut build);
-        build.verbose("running sanity check");
-        sanity::check(&mut build);
+        // When running `setup`, the profile is about to change, so any requirements we have now may
+        // be different on the next invocation. Don't check for them until the next time x.py is
+        // run. This is ok because `setup` never runs any build commands, so it won't fail if commands are missing.
+        if !matches!(build.config.cmd, Subcommand::Setup { .. }) {
+            build.verbose("running sanity check");
+            sanity::check(&mut build);
+        }
 
         // If local-rust is the same major.minor as the current version, then force a
         // local-rebuild

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -800,6 +800,8 @@ a {
 
 .search-results .result-name > span {
 	display: inline-block;
+	margin: 0;
+	font-weight: normal;
 }
 
 body.blur > :not(#help) {

--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -14,7 +14,7 @@ LL | static BAR: _ = "test";
    |             ^
    |             |
    |             not allowed in type signatures
-   |             help: replace `_` with the correct type: `&str`
+   |             help: replace with the correct type: `&str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -37,7 +37,7 @@ LL |               const A = "A".$fn();
    |                     ^
    |                     |
    |                     not allowed in type signatures
-   |                     help: replace `_` with the correct type: `bool`
+   |                     help: replace with the correct type: `bool`
 ...
 LL | / suite! {
 LL | |     len;

--- a/src/test/ui/parser/issue-84104.rs
+++ b/src/test/ui/parser/issue-84104.rs
@@ -1,0 +1,3 @@
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected one of
+#[i=i::<ښܖ<

--- a/src/test/ui/parser/issue-84104.stderr
+++ b/src/test/ui/parser/issue-84104.stderr
@@ -1,0 +1,16 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-84104.rs:3:13
+   |
+LL | #[i=i::<ښܖ<
+   |  -          ^
+   |  |
+   |  unclosed delimiter
+
+error: expected one of `>`, a const expression, lifetime, or type, found `]`
+  --> $DIR/issue-84104.rs:3:13
+   |
+LL | #[i=i::<ښܖ<
+   |             ^ expected one of `>`, a const expression, lifetime, or type
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issue-84148-1.rs
+++ b/src/test/ui/parser/issue-84148-1.rs
@@ -1,0 +1,4 @@
+fn f(t:for<>t?)
+//~^ ERROR: expected parameter name
+//~| ERROR: expected one of
+//~| ERROR: expected one of

--- a/src/test/ui/parser/issue-84148-1.stderr
+++ b/src/test/ui/parser/issue-84148-1.stderr
@@ -1,0 +1,23 @@
+error: expected parameter name, found `?`
+  --> $DIR/issue-84148-1.rs:1:14
+   |
+LL | fn f(t:for<>t?)
+   |              ^ expected parameter name
+
+error: expected one of `(`, `)`, `+`, `,`, `::`, or `<`, found `?`
+  --> $DIR/issue-84148-1.rs:1:14
+   |
+LL | fn f(t:for<>t?)
+   |              ^
+   |              |
+   |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
+   |              help: missing `,`
+
+error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+  --> $DIR/issue-84148-1.rs:1:15
+   |
+LL | fn f(t:for<>t?)
+   |               ^ expected one of `->`, `;`, `where`, or `{`
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/parser/issue-84148-2.rs
+++ b/src/test/ui/parser/issue-84148-2.rs
@@ -1,0 +1,4 @@
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected parameter name
+// error-pattern: expected one of
+fn f(t:for<>t?

--- a/src/test/ui/parser/issue-84148-2.stderr
+++ b/src/test/ui/parser/issue-84148-2.stderr
@@ -1,0 +1,31 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-84148-2.rs:4:16
+   |
+LL | fn f(t:for<>t?
+   |     -          ^
+   |     |
+   |     unclosed delimiter
+
+error: expected parameter name, found `?`
+  --> $DIR/issue-84148-2.rs:4:14
+   |
+LL | fn f(t:for<>t?
+   |              ^ expected parameter name
+
+error: expected one of `(`, `)`, `+`, `,`, `::`, or `<`, found `?`
+  --> $DIR/issue-84148-2.rs:4:14
+   |
+LL | fn f(t:for<>t?
+   |              ^
+   |              |
+   |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
+   |              help: missing `,`
+
+error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+  --> $DIR/issue-84148-2.rs:4:16
+   |
+LL | fn f(t:for<>t?
+   |                ^ expected one of `->`, `;`, `where`, or `{`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/parser/unmatched-langle-1.rs
+++ b/src/test/ui/parser/unmatched-langle-1.rs
@@ -1,0 +1,9 @@
+// Check that a suggestion is issued if there are too many `<`s in a
+// generic argument list, and that the parser recovers properly.
+
+fn main() {
+    foo::<<<<Ty<i32>>();
+    //~^ ERROR: unmatched angle brackets
+    //~| ERROR: cannot find function `foo` in this scope [E0425]
+    //~| ERROR: cannot find type `Ty` in this scope [E0412]
+}

--- a/src/test/ui/parser/unmatched-langle-1.stderr
+++ b/src/test/ui/parser/unmatched-langle-1.stderr
@@ -1,0 +1,22 @@
+error: unmatched angle brackets
+  --> $DIR/unmatched-langle-1.rs:5:10
+   |
+LL |     foo::<<<<Ty<i32>>();
+   |          ^^^ help: remove extra angle brackets
+
+error[E0425]: cannot find function `foo` in this scope
+  --> $DIR/unmatched-langle-1.rs:5:5
+   |
+LL |     foo::<<<<Ty<i32>>();
+   |     ^^^ not found in this scope
+
+error[E0412]: cannot find type `Ty` in this scope
+  --> $DIR/unmatched-langle-1.rs:5:14
+   |
+LL |     foo::<<<<Ty<i32>>();
+   |              ^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0425.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/parser/unmatched-langle-2.rs
+++ b/src/test/ui/parser/unmatched-langle-2.rs
@@ -1,0 +1,15 @@
+// When there are too many opening `<`s, the compiler would previously
+// suggest nonsense if the `<`s were interspersed with other tokens:
+//
+//   error: unmatched angle brackets
+//    --> unmatched-langle.rs:2:10
+//     |
+//   2 |     foo::<Ty<<<i32>();
+//     |          ^^^ help: remove extra angle brackets
+//
+// This test makes sure that this is no longer happening.
+
+fn main() {
+    foo::<Ty<<<i32>();
+    //~^ ERROR: expected `::`, found `(`
+}

--- a/src/test/ui/parser/unmatched-langle-2.stderr
+++ b/src/test/ui/parser/unmatched-langle-2.stderr
@@ -1,0 +1,8 @@
+error: expected `::`, found `(`
+  --> $DIR/unmatched-langle-2.rs:13:20
+   |
+LL |     foo::<Ty<<<i32>();
+   |                    ^ expected `::`
+
+error: aborting due to previous error
+

--- a/src/test/ui/typeck/typeck_type_placeholder_item.full_tait.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.full_tait.stderr
@@ -79,7 +79,7 @@ LL | static TEST3: _ = "test";
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `&str`
+   |               help: replace with the correct type: `&str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:19:15
@@ -88,7 +88,7 @@ LL | static TEST4: _ = 145;
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `i32`
+   |               help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:22:15
@@ -210,7 +210,7 @@ LL |     static B: _ = 42;
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `i32`
+   |               help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:80:15
@@ -244,7 +244,7 @@ LL |     static FN_TEST3: _ = "test";
    |                      ^
    |                      |
    |                      not allowed in type signatures
-   |                      help: replace `_` with the correct type: `&str`
+   |                      help: replace with the correct type: `&str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:92:22
@@ -253,7 +253,7 @@ LL |     static FN_TEST4: _ = 145;
    |                      ^
    |                      |
    |                      not allowed in type signatures
-   |                      help: replace `_` with the correct type: `i32`
+   |                      help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:95:22
@@ -435,7 +435,7 @@ LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
    |          |
    |          not allowed in type signatures
-   |          help: replace `_` with the correct type: `Option<u8>`
+   |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:144:31
@@ -526,7 +526,7 @@ LL |     const D: _ = 42;
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `i32`
+   |              help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:201:26
@@ -639,7 +639,7 @@ LL |     const D: _ = 42;
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `i32`
+   |              help: replace with the correct type: `i32`
 
 error: aborting due to 69 previous errors; 1 warning emitted
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item.min_tait.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.min_tait.stderr
@@ -70,7 +70,7 @@ LL | static TEST3: _ = "test";
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `&str`
+   |               help: replace with the correct type: `&str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:19:15
@@ -79,7 +79,7 @@ LL | static TEST4: _ = 145;
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `i32`
+   |               help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:22:15
@@ -201,7 +201,7 @@ LL |     static B: _ = 42;
    |               ^
    |               |
    |               not allowed in type signatures
-   |               help: replace `_` with the correct type: `i32`
+   |               help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:80:15
@@ -235,7 +235,7 @@ LL |     static FN_TEST3: _ = "test";
    |                      ^
    |                      |
    |                      not allowed in type signatures
-   |                      help: replace `_` with the correct type: `&str`
+   |                      help: replace with the correct type: `&str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:92:22
@@ -244,7 +244,7 @@ LL |     static FN_TEST4: _ = 145;
    |                      ^
    |                      |
    |                      not allowed in type signatures
-   |                      help: replace `_` with the correct type: `i32`
+   |                      help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:95:22
@@ -426,7 +426,7 @@ LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
    |          |
    |          not allowed in type signatures
-   |          help: replace `_` with the correct type: `Option<u8>`
+   |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:144:31
@@ -517,7 +517,7 @@ LL |     const D: _ = 42;
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `i32`
+   |              help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:201:26
@@ -630,7 +630,7 @@ LL |     const D: _ = 42;
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `i32`
+   |              help: replace with the correct type: `i32`
 
 error: aborting due to 69 previous errors
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -14,7 +14,7 @@ LL | const TEST2: _ = 42u32;
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `u32`
+   |              help: replace with the correct type: `u32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:10:14
@@ -23,7 +23,7 @@ LL | const TEST3: _ = Some(42);
    |              ^
    |              |
    |              not allowed in type signatures
-   |              help: replace `_` with the correct type: `Option<i32>`
+   |              help: replace with the correct type: `Option<i32>`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
@@ -38,7 +38,7 @@ LL |     const TEST5: _ = 42;
    |                  ^
    |                  |
    |                  not allowed in type signatures
-   |                  help: replace `_` with the correct type: `i32`
+   |                  help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:24:18
@@ -47,7 +47,7 @@ LL |     const TEST6: _ = 13;
    |                  ^
    |                  |
    |                  not allowed in type signatures
-   |                  help: replace `_` with the correct type: `i32`
+   |                  help: replace with the correct type: `i32`
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #83433 (Pass --cfg=bootstrap for proc macros built by stage0)
 - #84940 (Don't run sanity checks for `x.py setup`)
 - #85912 (Use `Iterator::any` and `filter_map` instead of open-coding them)
 - #85965 (Remove dead code from `LocalAnalyzer`)
 - #86010 (Fix two ICEs in the parser)
 - #86040 (Fix display for search results)
 - #86058 (Remove `_`  from E0121 diagnostic suggestions)
 - #86077 (Fix corrected example in E0759.md)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83433,84940,85912,85965,86010,86040,86058,86077)
<!-- homu-ignore:end -->