### PR TITLE
[beta] Backport #84894 to fix beta CI

### DIFF
--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -42,23 +42,14 @@ elif isWindows && [[ ${CUSTOM_MINGW-0} -ne 1 ]]; then
     # clang has an output mode compatible with MinGW that we need. If it does we
     # should switch to clang for MinGW as well!
     #
-    # Note that the LLVM installer is an NSIS installer
-    #
-    # Original downloaded here came from:
-    #
-    #   https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe
-    #
-    # That installer was run through `wine ./installer.exe /S /NCRC` on Linux
-    # and then the resulting installation directory (found in
-    # `$HOME/.wine/drive_c/Program Files/LLVM`) was packaged up into a tarball.
-    # We've had issues otherwise that the installer will randomly hang, provide
-    # not a lot of useful information, pollute global state, etc. In general the
-    # tarball is just more confined and easier to deal with when working with
-    # various CI environments.
+    # The LLVM installer is an NSIS installer, which we can extract with 7z. We
+    # don't want to run the installer directly; extracting it is more reliable
+    # in CI environments.
 
-    mkdir -p citools
+    mkdir -p citools/clang-rust
     cd citools
-    curl -f "${MIRRORS_BASE}/LLVM-${LLVM_VERSION}-win64.tar.gz" | tar xzf -
+    curl -f "${MIRRORS_BASE}/LLVM-${LLVM_VERSION}-win64.exe" -o "LLVM-${LLVM_VERSION}-win64.exe"
+    7z x -oclang-rust/ "LLVM-${LLVM_VERSION}-win64.exe"
     ciCommandSetEnv RUST_CONFIGURE_ARGS \
         "${RUST_CONFIGURE_ARGS} --set llvm.clang-cl=$(pwd)/clang-rust/bin/clang-cl.exe"
 fi

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -9,7 +9,7 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Update both macOS's and Windows's tarballs when bumping the version here.
-LLVM_VERSION="10.0.0"
+LLVM_VERSION="12.0.0"
 
 if isMacOS; then
     # If the job selects a specific Xcode version, use that instead of


### PR DESCRIPTION
Currently, beta backports fail with this failure: https://github.com/rust-lang/rust/pull/86036#issuecomment-855318336
```
STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
```

The previous beta backport was successful because it uses a Visual Studio tool v14.28.29910 but now CI uses v14.29.30037.
#84894 updated clang to 12 so master didn't catch this change, I guess. Hopefully, it fixes CI failures on beta.