### PR TITLE
Search description codeblock

### DIFF
--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1024,7 +1024,7 @@ window.initSearch = function(rawSearchIndex) {
                 var description = document.createElement("div");
                 description.className = "desc";
                 var spanDesc = document.createElement("span");
-                spanDesc.innerText = item.desc + "\u00A0";
+                spanDesc.insertAdjacentHTML("beforeend", item.desc);
 
                 description.appendChild(spanDesc);
                 wrapper.appendChild(description);

--- a/src/test/rustdoc-gui/search-result-description.goml
+++ b/src/test/rustdoc-gui/search-result-description.goml
@@ -1,0 +1,5 @@
+// This test is to ensure that the codeblocks are correctly rendered in the search results.
+goto: file://|DOC_PATH|/test_docs/index.html?search=some_more_function
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert: (".search-results .desc code", "format!")


### PR DESCRIPTION
The codeblocks are not displayed correctly:

![Screenshot from 2021-06-07 11-11-53](https://user-images.githubusercontent.com/3050060/120991915-5fb05680-c782-11eb-9b32-973a64b1f631.png)

This PR interprets the HTML correctly (and still prevent invalid HTML because of how it inserts it):

![Screenshot from 2021-06-07 11-12-00](https://user-images.githubusercontent.com/3050060/120991919-6048ed00-c782-11eb-8ac5-c3aa6508bc8b.png)

r? @jsha 