### PR TITLE
Fix span calculation in format strings

### DIFF
--- a/src/test/ui/fmt/format-concat-span.rs
+++ b/src/test/ui/fmt/format-concat-span.rs
@@ -1,0 +1,15 @@
+// If the format string is another macro invocation, rustc would previously
+// compute nonsensical spans, such as:
+//
+//   error: invalid format string: unmatched `}` found
+//    --> test.rs:2:17
+//     |
+//   2 |     format!(concat!("abc}"));
+//     |                 ^ unmatched `}` in format string
+//
+// This test checks that this behavior has been fixed.
+
+fn main() {
+    format!(concat!("abc}"));
+    //~^ ERROR: invalid format string: unmatched `}` found
+}

--- a/src/test/ui/fmt/format-concat-span.stderr
+++ b/src/test/ui/fmt/format-concat-span.stderr
@@ -1,0 +1,11 @@
+error: invalid format string: unmatched `}` found
+  --> $DIR/format-concat-span.rs:13:13
+   |
+LL |     format!(concat!("abc}"));
+   |             ^^^^^^^^^^^^^^^ unmatched `}` in format string
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/fmt/issue-86085.rs
+++ b/src/test/ui/fmt/issue-86085.rs
@@ -1,0 +1,6 @@
+// Tests for an ICE with the fuzzed input below.
+
+fn main ( ) {
+format ! ( concat ! ( r#"lJ𐏿Æ�.𐏿�"# , "r} {}" )     ) ;
+//~^ ERROR: invalid format string: unmatched `}` found
+}

--- a/src/test/ui/fmt/issue-86085.stderr
+++ b/src/test/ui/fmt/issue-86085.stderr
@@ -1,0 +1,11 @@
+error: invalid format string: unmatched `}` found
+  --> $DIR/issue-86085.rs:4:12
+   |
+LL | format ! ( concat ! ( r#"lJ𐏿Æ�.𐏿�"# , "r} {}" )     ) ;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in format string
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This pull request fixes #86085. The ICE described there is due to an error in the span calculation inside format strings, if the format string is the result of a macro invocation:
```rust
fn main() {
    format!(concat!("abc}"));
}
```
currently produces:
```
error: invalid format string: unmatched `}` found
 --> test.rs:2:17
  |
2 |     format!(concat!("abc}"));
  |                 ^ unmatched `}` in format string
```
which is obviously incorrect. This happens because the span of the entire `concat!()` is combined with the _relative_ location of the unmatched `` `}` `` in the _result_ of the macro invocation (i.e. 4).

In #86085, this has led to a span that starts or ends in the middle of a multibyte character, but the root cause was the same. This pull request fixes the problem.
