### PR TITLE
Suggest a trailing comma if a 1-tuple is expected and a parenthesized expression is found

### DIFF
--- a/src/test/ui/suggestions/issue-86100-tuple-paren-comma.rs
+++ b/src/test/ui/suggestions/issue-86100-tuple-paren-comma.rs
@@ -1,0 +1,25 @@
+// Tests that a suggestion is issued for type mismatch errors when a
+// 1-tuple is expected and a parenthesized expression of non-tuple
+// type is supplied.
+
+fn foo<T>(_t: (T,)) {}
+struct S { _s: (String,) }
+
+fn main() {
+    let _x: (i32,) = (5);
+    //~^ ERROR: mismatched types [E0308]
+    //~| HELP: use a trailing comma to create a tuple with one element
+
+    foo((Some(3)));
+    //~^ ERROR: mismatched types [E0308]
+    //~| HELP: use a trailing comma to create a tuple with one element
+
+    let _s = S { _s: ("abc".to_string()) };
+    //~^ ERROR: mismatched types [E0308]
+    //~| HELP: use a trailing comma to create a tuple with one element
+
+    // Do not issue the suggestion if the found type is already a tuple.
+    let t = (1, 2);
+    let _x: (i32,) = (t);
+    //~^ ERROR: mismatched types [E0308]
+}

--- a/src/test/ui/suggestions/issue-86100-tuple-paren-comma.stderr
+++ b/src/test/ui/suggestions/issue-86100-tuple-paren-comma.stderr
@@ -1,0 +1,55 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-86100-tuple-paren-comma.rs:9:22
+   |
+LL |     let _x: (i32,) = (5);
+   |             ------   ^^^ expected tuple, found integer
+   |             |
+   |             expected due to this
+   |
+   = note: expected tuple `(i32,)`
+               found type `{integer}`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     let _x: (i32,) = (5,);
+   |                      ^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86100-tuple-paren-comma.rs:13:9
+   |
+LL |     foo((Some(3)));
+   |         ^^^^^^^^^ expected tuple, found enum `Option`
+   |
+   = note: expected tuple `(_,)`
+               found enum `Option<{integer}>`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     foo((Some(3),));
+   |         ^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86100-tuple-paren-comma.rs:17:22
+   |
+LL |     let _s = S { _s: ("abc".to_string()) };
+   |                      ^^^^^^^^^^^^^^^^^^^ expected tuple, found struct `String`
+   |
+   = note: expected tuple `(String,)`
+             found struct `String`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     let _s = S { _s: ("abc".to_string(),) };
+   |                      ^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-86100-tuple-paren-comma.rs:23:22
+   |
+LL |     let _x: (i32,) = (t);
+   |             ------   ^^^ expected a tuple with 1 element, found one with 2 elements
+   |             |
+   |             expected due to this
+   |
+   = note: expected tuple `(i32,)`
+              found tuple `({integer}, {integer})`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This pull request fixes #86100. The following code:
```rust
fn main() {
    let t: (i32,) = (1);
}
```
currently produces:
```
warning: unnecessary parentheses around assigned value
 --> test.rs:2:21
  |
2 |     let t: (i32,) = (1);
  |                     ^^^ help: remove these parentheses
  |
  = note: `#[warn(unused_parens)]` on by default

error[E0308]: mismatched types
 --> test.rs:2:21
  |
2 |     let t: (i32,) = (1);
  |            ------   ^^^ expected tuple, found integer
  |            |
  |            expected due to this
  |
  = note: expected tuple `(i32,)`
              found type `{integer}`

error: aborting due to previous error; 1 warning emitted
```
With my changes, I get the same warning and the following error:
```
error[E0308]: mismatched types
 --> test.rs:2:21
  |
2 |     let t: (i32,) = (1);
  |            ------   ^^^ expected tuple, found integer
  |            |
  |            expected due to this
  |
  = note: expected tuple `(i32,)`
              found type `{integer}`
help: use a trailing comma to create a tuple with one element
  |
2 |     let t: (i32,) = (1,);
  |                     ^^^^
```
i.e. I have added a suggestion to add a trailing comma to create a 1-tuple. This suggestion is only issued if a 1-tuple is expected and the expression (`(1)` in the example above) is surrounded by parentheses and does not already have a tuple type. In this situation, I'd say that it is pretty likely that the user meant to create a tuple.