### PR TITLE
Fix force-warns to allow dashes.

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1207,7 +1207,8 @@ pub fn get_cmd_lint_options(
         );
     }
 
-    let force_warns = matches.opt_strs("force-warns");
+    let force_warns =
+        matches.opt_strs("force-warns").into_iter().map(|name| name.replace('-', "_")).collect();
 
     (lint_opts, describe_lints, lint_cap, force_warns)
 }

--- a/src/test/ui/lint/force-warn/force-warn-group-allow-warning.rs
+++ b/src/test/ui/lint/force-warn/force-warn-group-allow-warning.rs
@@ -1,4 +1,4 @@
-// compile-flags: --force-warns rust_2018_idioms -Zunstable-options
+// compile-flags: --force-warns rust-2018-idioms -Zunstable-options
 // check-pass
 
 #![allow(bare_trait_objects)]


### PR DESCRIPTION
The `--force-warns` flag was not allowing lint names with dashes, only supporting underscores.  This changes it to allow dashes to match the behavior of the A/W/D/F flags.