### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -553,8 +553,8 @@ E0783: include_str!("./error_codes/E0783.md"),
     E0311, // thing may not live long enough
     E0313, // lifetime of borrowed pointer outlives lifetime of captured
            // variable
-    E0314, // closure outlives stack frame
-    E0315, // cannot invoke closure outside of its lifetime
+//  E0314, // closure outlives stack frame
+//  E0315, // cannot invoke closure outside of its lifetime
     E0316, // nested quantification of lifetimes
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
@@ -584,21 +584,21 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0470, removed
 //  E0471, // constant evaluation error (in pattern)
     E0472, // llvm_asm! is unsupported on this target
-    E0473, // dereference of reference outside its lifetime
-    E0474, // captured variable `..` does not outlive the enclosing closure
-    E0475, // index of slice outside its lifetime
+//  E0473, // dereference of reference outside its lifetime
+//  E0474, // captured variable `..` does not outlive the enclosing closure
+//  E0475, // index of slice outside its lifetime
     E0476, // lifetime of the source pointer does not outlive lifetime bound...
-    E0479, // the type `..` (provided as the value of a type parameter) is...
-    E0480, // lifetime of method receiver does not outlive the method call
-    E0481, // lifetime of function argument does not outlive the function call
+//  E0479, // the type `..` (provided as the value of a type parameter) is...
+//  E0480, // lifetime of method receiver does not outlive the method call
+//  E0481, // lifetime of function argument does not outlive the function call
     E0482, // lifetime of return value does not outlive the function call
-    E0483, // lifetime of operand does not outlive the operation
-    E0484, // reference is not valid at the time of borrow
-    E0485, // automatically reference is not valid at the time of borrow
-    E0486, // type of expression contains references that are not valid during..
-    E0487, // unsafe use of destructor: destructor might be called while...
-    E0488, // lifetime of variable does not enclose its declaration
-    E0489, // type/lifetime parameter not in scope here
+//  E0483, // lifetime of operand does not outlive the operation
+//  E0484, // reference is not valid at the time of borrow
+//  E0485, // automatically reference is not valid at the time of borrow
+//  E0486, // type of expression contains references that are not valid during..
+//  E0487, // unsafe use of destructor: destructor might be called while...
+//  E0488, // lifetime of variable does not enclose its declaration
+//  E0489, // type/lifetime parameter not in scope here
     E0490, // a value of type `..` is borrowed for too long
     E0498,  // malformed plugin attribute
     E0514, // metadata version mismatch

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -157,6 +157,7 @@ E0308: include_str!("./error_codes/E0308.md"),
 E0309: include_str!("./error_codes/E0309.md"),
 E0310: include_str!("./error_codes/E0310.md"),
 E0312: include_str!("./error_codes/E0312.md"),
+E0316: include_str!("./error_codes/E0316.md"),
 E0317: include_str!("./error_codes/E0317.md"),
 E0321: include_str!("./error_codes/E0321.md"),
 E0322: include_str!("./error_codes/E0322.md"),
@@ -555,7 +556,6 @@ E0783: include_str!("./error_codes/E0783.md"),
            // variable
 //  E0314, // closure outlives stack frame
 //  E0315, // cannot invoke closure outside of its lifetime
-    E0316, // nested quantification of lifetimes
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
 //  E0372, // coherence not object safe

--- a/compiler/rustc_error_codes/src/error_codes/E0316.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0316.md
@@ -1,0 +1,32 @@
+A `where` clause contains a nested quantification over lifetimes.
+
+Erroneous code example:
+
+```compile_fail,E0316
+trait Tr<'a, 'b> {}
+
+fn foo<T>(t: T)
+where
+    for<'a> &'a T: for<'b> Tr<'a, 'b>, // error: nested quantification
+{
+}
+```
+
+Rust syntax allows lifetime quantifications in two places within
+`where` clauses: Quantifying over the trait bound only (as in
+`Ty: for<'l> Trait<'l>`) and quantifying over the whole clause
+(as in `for<'l> &'l Ty: Trait<'l>`). Using both in the same clause
+leads to a nested lifetime quantification, which is not supported.
+
+The following example compiles, because the clause with the nested
+quantification has been rewritten to use only one `for<>`:
+
+```
+trait Tr<'a, 'b> {}
+
+fn foo<T>(t: T)
+where
+    for<'a, 'b> &'a T: Tr<'a, 'b>, // ok
+{
+}
+```

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -680,16 +680,11 @@ pub fn transparent_newtype_field<'a, 'tcx>(
     variant: &'a ty::VariantDef,
 ) -> Option<&'a ty::FieldDef> {
     let param_env = tcx.param_env(variant.def_id);
-    for field in &variant.fields {
+    variant.fields.iter().find(|field| {
         let field_ty = tcx.type_of(field.did);
         let is_zst = tcx.layout_of(param_env.and(field_ty)).map_or(false, |layout| layout.is_zst());
-
-        if !is_zst {
-            return Some(field);
-        }
-    }
-
-    None
+        !is_zst
+    })
 }
 
 /// Is type known to be non-null?

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1841,14 +1841,6 @@ fn object_lifetime_defaults_for_item(
 }
 
 impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
-    // FIXME(#37666) this works around a limitation in the region inferencer
-    fn hack<F>(&mut self, f: F)
-    where
-        F: for<'b> FnOnce(&mut LifetimeContext<'b, 'tcx>),
-    {
-        f(self)
-    }
-
     fn with<F>(&mut self, wrap_scope: Scope<'_>, f: F)
     where
         F: for<'b> FnOnce(ScopeRef<'_>, &mut LifetimeContext<'b, 'tcx>),
@@ -2252,7 +2244,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         };
         self.with(scope, move |old_scope, this| {
             this.check_lifetime_params(old_scope, &generics.params);
-            this.hack(walk); // FIXME(#37666) workaround in place of `walk(this)`
+            walk(this);
         });
     }
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -686,7 +686,7 @@ impl<T> Bound<T> {
         }
     }
 
-    /// Converts from `&mut Bound<T>` to `Bound<&T>`.
+    /// Converts from `&mut Bound<T>` to `Bound<&mut T>`.
     #[inline]
     #[unstable(feature = "bound_as_ref", issue = "80996")]
     pub fn as_mut(&mut self) -> Bound<&mut T> {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2100,9 +2100,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search_by`], [`binary_search_by_key`], and [`partition_point`].
     ///
@@ -2153,9 +2155,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search`], [`binary_search_by_key`], and [`partition_point`].
     ///
@@ -2224,9 +2228,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search`], [`binary_search_by`], and [`partition_point`].
     ///

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -193,7 +193,7 @@ fn default_hook(info: &PanicInfo<'_>) {
         Some(s) => *s,
         None => match info.payload().downcast_ref::<String>() {
             Some(s) => &s[..],
-            None => "Box<Any>",
+            None => "Box<dyn Any>",
         },
     };
     let thread = thread_info::current_thread();

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -149,8 +149,7 @@ values:
 
 * `y`, `yes`, `on`, or no value: Unwind tables are forced to be generated.
 * `n`, `no`, or `off`: Unwind tables are not forced to be generated. If unwind
-  tables are required by the target or `-C panic=unwind`, an error will be
-  emitted.
+  tables are required by the target an error will be emitted.
 
 The default if not specified depends on the target.
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -138,7 +138,7 @@ h2, h3, h4 {
 	border-bottom: 1px solid;
 }
 .impl, .method,
-.type, .associatedconstant,
+.type:not(.container-rustdoc), .associatedconstant,
 .associatedtype {
 	flex-basis: 100%;
 	font-weight: 600;

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1024,7 +1024,7 @@ window.initSearch = function(rawSearchIndex) {
                 var description = document.createElement("div");
                 description.className = "desc";
                 var spanDesc = document.createElement("span");
-                spanDesc.innerText = item.desc + "\u00A0";
+                spanDesc.insertAdjacentHTML("beforeend", item.desc);
 
                 description.appendChild(spanDesc);
                 wrapper.appendChild(description);

--- a/src/test/debuginfo/fixed-sized-array.rs
+++ b/src/test/debuginfo/fixed-sized-array.rs
@@ -1,0 +1,39 @@
+// Testing the display of fixed sized arrays in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx xs,d
+// cdb-check:xs,d             [Type: int [5]]
+// cdb-check:    [0]              : 1 [Type: int]
+// cdb-check:    [1]              : 2 [Type: int]
+// cdb-check:    [2]              : 3 [Type: int]
+// cdb-check:    [3]              : 4 [Type: int]
+// cdb-check:    [4]              : 5 [Type: int]
+
+// cdb-command: dx ys,d
+// cdb-check:ys,d             [Type: int [3]]
+// cdb-check:    [0]              : 0 [Type: int]
+// cdb-check:    [1]              : 0 [Type: int]
+// cdb-check:    [2]              : 0 [Type: int]
+
+fn main() {
+    // Fixed-size array (type signature is superfluous)
+    let xs: [i32; 5] = [1, 2, 3, 4, 5];
+
+    // All elements can be initialized to the same value
+    let ys: [i32; 3] = [0; 3];
+
+    // Indexing starts at 0
+    println!("first element of the array: {}", xs[0]);
+    println!("second element of the array: {}", xs[1]);
+
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/mutable-locs.rs
+++ b/src/test/debuginfo/mutable-locs.rs
@@ -1,0 +1,51 @@
+// Testing the display of Cell, RefCell, and RefMut in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command:dx static_c,d
+// cdb-check:static_c,d       [Type: core::cell::Cell<i32>]
+// cdb-check:    [+0x000] value            [Type: core::cell::UnsafeCell<i32>]
+
+// cdb-command: dx static_c.value,d
+// cdb-check:static_c.value,d [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [+0x000] value            : 10 [Type: int]
+
+// cdb-command:  dx dynamic_c,d
+// cdb-check:dynamic_c,d      [Type: core::cell::RefCell<i32>]
+// cdb-check:    [+0x000] borrow           [Type: core::cell::Cell<isize>]
+// cdb-check:    [...] value            [Type: core::cell::UnsafeCell<i32>]
+
+// cdb-command: dx dynamic_c.value,d
+// cdb-check:dynamic_c.value,d [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [+0x000] value            : 15 [Type: int]
+
+// cdb-command: dx b,d
+// cdb-check:b,d              [Type: core::cell::RefMut<i32>]
+// cdb-check:    [+0x000] value            : [...] : 42 [Type: int *]
+// cdb-check:    [...] borrow           [Type: core::cell::BorrowRefMut]
+
+#![allow(unused_variables)]
+
+use std::cell::{Cell, RefCell};
+
+fn main() {
+    let static_c = Cell::new(5);
+    static_c.set(10);
+
+    let dynamic_c = RefCell::new(5);
+    dynamic_c.replace(15);
+
+    let dynamic_c_0 = RefCell::new(15);
+    let mut b = dynamic_c_0.borrow_mut();
+    *b = 42;
+
+    zzz(); // #break
+}
+
+fn zzz() {()}

--- a/src/test/debuginfo/mutex.rs
+++ b/src/test/debuginfo/mutex.rs
@@ -1,0 +1,38 @@
+// Testing the display of Mutex and MutexGuard in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.21287.1005
+// compile-flags:-g
+// ignore-tidy-linelength
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx m,d
+// cdb-check:m,d              [Type: std::sync::mutex::Mutex<i32>]
+// cdb-check:    [+0x000] inner            [Type: std::sys_common::mutex::MovableMutex]
+// cdb-check:    [+0x008] poison           [Type: std::sync::poison::Flag]
+// cdb-check:    [+0x00c] data             [Type: core::cell::UnsafeCell<i32>]
+
+//
+// cdb-command:dx m.data,d
+// cdb-check:m.data,d         [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [+0x000] value            : 0 [Type: int]
+
+//
+// cdb-command:dx lock,d
+// cdb-check:lock,d           : Ok({...}) [Type: core::result::Result<std::sync::mutex::MutexGuard<i32>, std::sync::poison::TryLockError<std::sync::mutex::MutexGuard<i32>>>]
+// cdb-check:    [value]          [Type: std::sync::mutex::MutexGuard<i32>]
+
+use std::sync::Mutex;
+
+#[allow(unused_variables)]
+fn main()
+{
+    let m = Mutex::new(0);
+    let lock = m.try_lock();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -5,6 +5,7 @@
 // compile-flags:-g
 // min-gdb-version: 7.7
 // min-lldb-version: 310
+// min-cdb-version: 10.0.18317.1001
 
 // === GDB TESTS ===================================================================================
 
@@ -71,8 +72,12 @@
 // cdb-command: g
 
 // cdb-command: dx slice,d
-// cdb-check:slice,d [...]
-// NOTE: While slices have a .natvis entry that works in VS & VS Code, it fails in CDB 10.0.18362.1
+// cdb-check:slice,d          : { len=4 } [Type: slice<i32>]
+// cdb-check:    [len]            : 4 [Type: unsigned __int64]
+// cdb-check:    [0]              : 0 [Type: int]
+// cdb-check:    [1]              : 1 [Type: int]
+// cdb-check:    [2]              : 2 [Type: int]
+// cdb-check:    [3]              : 3 [Type: int]
 
 // cdb-command: dx vec,d
 // cdb-check:vec,d [...] : { len=4 } [Type: [...]::Vec<u64, alloc::alloc::Global>]
@@ -84,8 +89,7 @@
 // cdb-check:    [3]              : 7 [Type: unsigned __int64]
 
 // cdb-command: dx str_slice
-// cdb-check:str_slice [...]
-// NOTE: While string slices have a .natvis entry that works in VS & VS Code, it fails in CDB
+// cdb-check:str_slice        : "IAMA string slice!" [Type: str]
 
 // cdb-command: dx string
 // cdb-check:string           : "IAMA string!" [Type: [...]::String]

--- a/src/test/debuginfo/range-types.rs
+++ b/src/test/debuginfo/range-types.rs
@@ -1,0 +1,47 @@
+// Testing the display of range types in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx r1,d
+// cdb-check:r1,d             [Type: core::ops::range::Range<i32>]
+// cdb-check:    [+0x000] start            : 3 [Type: int]
+// cdb-check:    [+0x004] end              : 5 [Type: int]
+
+// cdb-command: dx r2,d
+// cdb-check:r2,d             [Type: core::ops::range::RangeFrom<i32>]
+// cdb-check:    [+0x000] start            : 2 [Type: int]
+
+// cdb-command: dx r3,d
+// cdb-check:r3,d             [Type: core::ops::range::RangeInclusive<i32>]
+// cdb-check:    [+0x000] start            : 1 [Type: int]
+// cdb-check:    [+0x004] end              : 4 [Type: int]
+// cdb-check:    [+0x008] exhausted        : false [Type: bool]
+
+// cdb-command: dx r4,d
+// cdb-check:r4,d             [Type: core::ops::range::RangeToInclusive<i32>]
+// cdb-check:    [+0x000] end              : 3 [Type: int]
+
+// cdb-command: dx r5,d
+// cdb-check:r5,d             [Type: core::ops::range::RangeFull]
+
+#[allow(unused_variables)]
+
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+fn main()
+{
+    let r1 = Range{start: 3, end: 5};
+    let r2 = RangeFrom{start: 2};
+    let r3 = RangeInclusive::new(1, 4);
+    let r4 = RangeToInclusive{end: 3};
+    let r5 = RangeFull{};
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -1,7 +1,9 @@
-// ignore-windows pretty-printers are not loaded
+// pretty-printers are not loaded
 // compile-flags:-g
+// ignore-tidy-linelength
 
 // min-gdb-version: 8.1
+// min-cdb-version: 10.0.18317.1001
 
 // === GDB TESTS ==================================================================================
 
@@ -21,6 +23,29 @@
 // lldb-check:[...]$0 = strong=2, weak=1 { value = 42 }
 // lldb-command:print a
 // lldb-check:[...]$1 = strong=2, weak=1 { data = 42 }
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command:g
+
+// cdb-command:dx r,d
+// cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
+
+// cdb-command:dx r1,d
+// cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
+
+// cdb-command:dx w1,d
+// cdb-check:w1,d             [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [+0x000] ptr              : [...] [Type: core::ptr::non_null::NonNull<alloc::rc::RcBox<i32>>]
+
+// cdb-command:dx a,d
+// cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
+
+// cdb-command:dx a1,d
+// cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
+
+// cdb-command:dx w2,d
+// cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/test/debuginfo/result-types.rs
+++ b/src/test/debuginfo/result-types.rs
@@ -1,0 +1,28 @@
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx x,d
+// cdb-check:x,d              : Ok [Type: enum$<core::result::Result<i32, str>>]
+// cdb-check:    [...] __0              : -3 [Type: int]
+
+// cdb-command: dx y
+// cdb-check:y                : Err [Type: enum$<core::result::Result<i32, str>>]
+// cdb-check:    [...] __0              : "Some error message" [Type: str]
+
+fn main()
+{
+    let x: Result<i32, &str> = Ok(-3);
+    assert_eq!(x.is_ok(), true);
+
+    let y: Result<i32, &str> = Err("Some error message");
+    assert_eq!(y.is_ok(), false);
+
+    zzz(); // #break.
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/rwlock-read.rs
+++ b/src/test/debuginfo/rwlock-read.rs
@@ -1,0 +1,36 @@
+// Testing the display of RwLock and RwLockReadGuard in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx l
+// cdb-check:l                [Type: std::sync::rwlock::RwLock<i32>]
+// cdb-check:    [+0x000] inner            : [...] [Type: std::sys_common::rwlock::RWLock *]
+// cdb-check:    [+0x008] poison           [Type: std::sync::poison::Flag]
+// cdb-check:    [+0x00c] data             [Type: core::cell::UnsafeCell<i32>]
+//
+// cdb-command:dx r
+// cdb-check:r                [Type: std::sync::rwlock::RwLockReadGuard<i32>]
+// cdb-check:    [+0x000] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
+//
+// cdb-command:dx r.lock->data,d
+// cdb-check:r.lock->data,d   [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [+0x000] value            : 0 [Type: int]
+
+#[allow(unused_variables)]
+
+use std::sync::RwLock;
+
+fn main()
+{
+    let l = RwLock::new(0);
+    let r = l.read().unwrap();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/rwlock-write.rs
+++ b/src/test/debuginfo/rwlock-write.rs
@@ -1,0 +1,27 @@
+// Testing the display of RwLockWriteGuard.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx w
+// cdb-check:w                [Type: std::sync::rwlock::RwLockWriteGuard<i32>]
+// cdb-check:    [+0x000] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
+// cdb-check:    [+0x008] poison           [Type: std::sync::poison::Guard]
+
+#[allow(unused_variables)]
+
+use std::sync::RwLock;
+
+fn main()
+{
+    let l = RwLock::new(0);
+    let w = l.write().unwrap();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/debuginfo/thread.rs
+++ b/src/test/debuginfo/thread.rs
@@ -1,0 +1,31 @@
+// Testing the the display of JoinHandle and Thread in cdb.
+
+// cdb-only
+// min-cdb-version: 10.0.18317.1001
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+//
+// cdb-command:g
+//
+// cdb-command:dx join_handle,d
+// cdb-check:join_handle,d    [Type: std::thread::JoinHandle<tuple<>>]
+// cdb-check:    [+0x000] __0              [Type: std::thread::JoinInner<tuple<>>]
+//
+// cdb-command:dx t,d
+// cdb-check:t,d              : [...] [Type: std::thread::Thread *]
+// cdb-check:    [+0x000] inner            : {...} [Type: alloc::sync::Arc<std::thread::Inner>]
+
+use std::thread;
+
+#[allow(unused_variables)]
+fn main()
+{
+    let join_handle = thread::spawn(|| {
+        println!("Initialize a thread");
+    });
+    let t = join_handle.thread();
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/src/test/rustdoc-gui/search-result-description.goml
+++ b/src/test/rustdoc-gui/search-result-description.goml
@@ -1,0 +1,5 @@
+// This test is to ensure that the codeblocks are correctly rendered in the search results.
+goto: file://|DOC_PATH|/test_docs/index.html?search=some_more_function
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert: (".search-results .desc code", "format!")

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -11,7 +11,8 @@ assert: (".sidebar-elems > .items > ul > li:nth-child(2)", "Structs")
 assert: (".sidebar-elems > .items > ul > li:nth-child(3)", "Enums")
 assert: (".sidebar-elems > .items > ul > li:nth-child(4)", "Traits")
 assert: (".sidebar-elems > .items > ul > li:nth-child(5)", "Functions")
-assert: (".sidebar-elems > .items > ul > li:nth-child(6)", "Keywords")
+assert: (".sidebar-elems > .items > ul > li:nth-child(6)", "Type Definitions")
+assert: (".sidebar-elems > .items > ul > li:nth-child(7)", "Keywords")
 assert: ("#structs + table td > a", "Foo")
 click: "#structs + table td > a"
 

--- a/src/test/rustdoc-gui/src/lib.rs
+++ b/src/test/rustdoc-gui/src/lib.rs
@@ -96,3 +96,6 @@ pub enum AnEnum {
 
 #[doc(keyword = "CookieMonster")]
 pub mod keyword {}
+
+/// Just some type alias.
+pub type SomeType = u32;

--- a/src/test/rustdoc-gui/type-weight.rs
+++ b/src/test/rustdoc-gui/type-weight.rs
@@ -1,0 +1,2 @@
+goto: file://|DOC_PATH|/test_docs/type.SomeType.html
+assert-all: (".top-block .docblock p", {"font-weight": "400"})

--- a/src/test/ui/panics/panic-macro-any-wrapped.rs
+++ b/src/test/ui/panics/panic-macro-any-wrapped.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![allow(non_fmt_panic)]

--- a/src/test/ui/panics/panic-macro-any.rs
+++ b/src/test/ui/panics/panic-macro-any.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![feature(box_syntax)]

--- a/src/test/ui/where-clauses/where-for-self.stderr
+++ b/src/test/ui/where-clauses/where-for-self.stderr
@@ -6,3 +6,4 @@ LL |     where for<'a> &'a T: for<'b> Bar<'b>
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0316`.


### PR DESCRIPTION
Successful merges:

 - #85448 (Add debug info tests for range, fix-sized array, and cell types)
 - #85906 (Use `Iterator::find` instead of open-coding it)
 - #85951 (Update the documentation of `-C force-unwind-tables` for #83482)
 - #85985 (Clarify documentation of slice sorting methods)
 - #86074 (Default panic message should print Box<dyn Any>)
 - #86078 (Type page font weight)
 - #86090 (:arrow_up: rust-analyzer)
 - #86095 (Search description codeblock)
 - #86096 (Comment out unused error codes and add description for E0316)
 - #86101 (Correct type signature in doc for Bound::as_mut)
 - #86103 (Remove lifetime hack)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85448,85906,85951,85985,86074,86078,86090,86095,86096,86101,86103)
<!-- homu-ignore:end -->