### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,11 +16,3 @@ config.toml.example linguist-language=TOML
 *.ico binary
 *.woff binary
 *.woff2 binary
-
-# Needed as part of converting rustfmt to a subtree, can hopefully be removed later.
-src/tools/rustfmt/tests/source/issue-3494/crlf.rs -text
-src/tools/rustfmt/tests/source/comment_crlf_newline.rs -text
-src/tools/rustfmt/tests/source/configs/enum_discrim_align_threshold/40.rs -text
-src/tools/rustfmt/tests/target/issue-3494/crlf.rs -text
-src/tools/rustfmt/tests/target/comment_crlf_newline.rs -text
-src/tools/rustfmt/tests/target/configs/enum_discrim_align_threshold/40.rs -text

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -553,8 +553,8 @@ E0783: include_str!("./error_codes/E0783.md"),
     E0311, // thing may not live long enough
     E0313, // lifetime of borrowed pointer outlives lifetime of captured
            // variable
-    E0314, // closure outlives stack frame
-    E0315, // cannot invoke closure outside of its lifetime
+//  E0314, // closure outlives stack frame
+//  E0315, // cannot invoke closure outside of its lifetime
     E0316, // nested quantification of lifetimes
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
@@ -584,21 +584,21 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0470, removed
 //  E0471, // constant evaluation error (in pattern)
     E0472, // llvm_asm! is unsupported on this target
-    E0473, // dereference of reference outside its lifetime
-    E0474, // captured variable `..` does not outlive the enclosing closure
-    E0475, // index of slice outside its lifetime
+//  E0473, // dereference of reference outside its lifetime
+//  E0474, // captured variable `..` does not outlive the enclosing closure
+//  E0475, // index of slice outside its lifetime
     E0476, // lifetime of the source pointer does not outlive lifetime bound...
-    E0479, // the type `..` (provided as the value of a type parameter) is...
-    E0480, // lifetime of method receiver does not outlive the method call
-    E0481, // lifetime of function argument does not outlive the function call
+//  E0479, // the type `..` (provided as the value of a type parameter) is...
+//  E0480, // lifetime of method receiver does not outlive the method call
+//  E0481, // lifetime of function argument does not outlive the function call
     E0482, // lifetime of return value does not outlive the function call
-    E0483, // lifetime of operand does not outlive the operation
-    E0484, // reference is not valid at the time of borrow
-    E0485, // automatically reference is not valid at the time of borrow
-    E0486, // type of expression contains references that are not valid during..
-    E0487, // unsafe use of destructor: destructor might be called while...
-    E0488, // lifetime of variable does not enclose its declaration
-    E0489, // type/lifetime parameter not in scope here
+//  E0483, // lifetime of operand does not outlive the operation
+//  E0484, // reference is not valid at the time of borrow
+//  E0485, // automatically reference is not valid at the time of borrow
+//  E0486, // type of expression contains references that are not valid during..
+//  E0487, // unsafe use of destructor: destructor might be called while...
+//  E0488, // lifetime of variable does not enclose its declaration
+//  E0489, // type/lifetime parameter not in scope here
     E0490, // a value of type `..` is borrowed for too long
     E0498,  // malformed plugin attribute
     E0514, // metadata version mismatch

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -157,6 +157,7 @@ E0308: include_str!("./error_codes/E0308.md"),
 E0309: include_str!("./error_codes/E0309.md"),
 E0310: include_str!("./error_codes/E0310.md"),
 E0312: include_str!("./error_codes/E0312.md"),
+E0316: include_str!("./error_codes/E0316.md"),
 E0317: include_str!("./error_codes/E0317.md"),
 E0321: include_str!("./error_codes/E0321.md"),
 E0322: include_str!("./error_codes/E0322.md"),
@@ -555,7 +556,6 @@ E0783: include_str!("./error_codes/E0783.md"),
            // variable
 //  E0314, // closure outlives stack frame
 //  E0315, // cannot invoke closure outside of its lifetime
-    E0316, // nested quantification of lifetimes
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
 //  E0372, // coherence not object safe

--- a/compiler/rustc_error_codes/src/error_codes/E0316.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0316.md
@@ -1,0 +1,32 @@
+A `where` clause contains a nested quantification over lifetimes.
+
+Erroneous code example:
+
+```compile_fail,E0316
+trait Tr<'a, 'b> {}
+
+fn foo<T>(t: T)
+where
+    for<'a> &'a T: for<'b> Tr<'a, 'b>, // error: nested quantification
+{
+}
+```
+
+Rust syntax allows lifetime quantifications in two places within
+`where` clauses: Quantifying over the trait bound only (as in
+`Ty: for<'l> Trait<'l>`) and quantifying over the whole clause
+(as in `for<'l> &'l Ty: Trait<'l>`). Using both in the same clause
+leads to a nested lifetime quantification, which is not supported.
+
+The following example compiles, because the clause with the nested
+quantification has been rewritten to use only one `for<>`:
+
+```
+trait Tr<'a, 'b> {}
+
+fn foo<T>(t: T)
+where
+    for<'a, 'b> &'a T: Tr<'a, 'b>, // ok
+{
+}
+```

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -680,16 +680,11 @@ pub fn transparent_newtype_field<'a, 'tcx>(
     variant: &'a ty::VariantDef,
 ) -> Option<&'a ty::FieldDef> {
     let param_env = tcx.param_env(variant.def_id);
-    for field in &variant.fields {
+    variant.fields.iter().find(|field| {
         let field_ty = tcx.type_of(field.did);
         let is_zst = tcx.layout_of(param_env.and(field_ty)).map_or(false, |layout| layout.is_zst());
-
-        if !is_zst {
-            return Some(field);
-        }
-    }
-
-    None
+        !is_zst
+    })
 }
 
 /// Is type known to be non-null?

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1841,14 +1841,6 @@ fn object_lifetime_defaults_for_item(
 }
 
 impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
-    // FIXME(#37666) this works around a limitation in the region inferencer
-    fn hack<F>(&mut self, f: F)
-    where
-        F: for<'b> FnOnce(&mut LifetimeContext<'b, 'tcx>),
-    {
-        f(self)
-    }
-
     fn with<F>(&mut self, wrap_scope: Scope<'_>, f: F)
     where
         F: for<'b> FnOnce(ScopeRef<'_>, &mut LifetimeContext<'b, 'tcx>),
@@ -2252,7 +2244,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         };
         self.with(scope, move |old_scope, this| {
             this.check_lifetime_params(old_scope, &generics.params);
-            this.hack(walk); // FIXME(#37666) workaround in place of `walk(this)`
+            walk(this);
         });
     }
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -686,7 +686,7 @@ impl<T> Bound<T> {
         }
     }
 
-    /// Converts from `&mut Bound<T>` to `Bound<&T>`.
+    /// Converts from `&mut Bound<T>` to `Bound<&mut T>`.
     #[inline]
     #[unstable(feature = "bound_as_ref", issue = "80996")]
     pub fn as_mut(&mut self) -> Bound<&mut T> {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2100,9 +2100,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search_by`], [`binary_search_by_key`], and [`partition_point`].
     ///
@@ -2153,9 +2155,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search`], [`binary_search_by_key`], and [`partition_point`].
     ///
@@ -2224,9 +2228,11 @@ impl<T> [T] {
     ///
     /// If the value is found then [`Result::Ok`] is returned, containing the
     /// index of the matching element. If there are multiple matches, then any
-    /// one of the matches could be returned. If the value is not found then
-    /// [`Result::Err`] is returned, containing the index where a matching
-    /// element could be inserted while maintaining sorted order.
+    /// one of the matches could be returned. The index is chosen
+    /// deterministically, but is subject to change in future versions of Rust.
+    /// If the value is not found then [`Result::Err`] is returned, containing
+    /// the index where a matching element could be inserted while maintaining
+    /// sorted order.
     ///
     /// See also [`binary_search`], [`binary_search_by`], and [`partition_point`].
     ///

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -193,7 +193,7 @@ fn default_hook(info: &PanicInfo<'_>) {
         Some(s) => *s,
         None => match info.payload().downcast_ref::<String>() {
             Some(s) => &s[..],
-            None => "Box<Any>",
+            None => "Box<dyn Any>",
         },
     };
     let thread = thread_info::current_thread();

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -149,8 +149,7 @@ values:
 
 * `y`, `yes`, `on`, or no value: Unwind tables are forced to be generated.
 * `n`, `no`, or `off`: Unwind tables are not forced to be generated. If unwind
-  tables are required by the target or `-C panic=unwind`, an error will be
-  emitted.
+  tables are required by the target an error will be emitted.
 
 The default if not specified depends on the target.
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -138,7 +138,7 @@ h2, h3, h4 {
 	border-bottom: 1px solid;
 }
 .impl, .method,
-.type, .associatedconstant,
+.type:not(.container-rustdoc), .associatedconstant,
 .associatedtype {
 	flex-basis: 100%;
 	font-weight: 600;

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1024,7 +1024,7 @@ window.initSearch = function(rawSearchIndex) {
                 var description = document.createElement("div");
                 description.className = "desc";
                 var spanDesc = document.createElement("span");
-                spanDesc.innerText = item.desc + "\u00A0";
+                spanDesc.insertAdjacentHTML("beforeend", item.desc);
 
                 description.appendChild(spanDesc);
                 wrapper.appendChild(description);

--- a/src/test/rustdoc-gui/search-result-description.goml
+++ b/src/test/rustdoc-gui/search-result-description.goml
@@ -1,0 +1,5 @@
+// This test is to ensure that the codeblocks are correctly rendered in the search results.
+goto: file://|DOC_PATH|/test_docs/index.html?search=some_more_function
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert: (".search-results .desc code", "format!")

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -11,7 +11,8 @@ assert: (".sidebar-elems > .items > ul > li:nth-child(2)", "Structs")
 assert: (".sidebar-elems > .items > ul > li:nth-child(3)", "Enums")
 assert: (".sidebar-elems > .items > ul > li:nth-child(4)", "Traits")
 assert: (".sidebar-elems > .items > ul > li:nth-child(5)", "Functions")
-assert: (".sidebar-elems > .items > ul > li:nth-child(6)", "Keywords")
+assert: (".sidebar-elems > .items > ul > li:nth-child(6)", "Type Definitions")
+assert: (".sidebar-elems > .items > ul > li:nth-child(7)", "Keywords")
 assert: ("#structs + table td > a", "Foo")
 click: "#structs + table td > a"
 

--- a/src/test/rustdoc-gui/src/lib.rs
+++ b/src/test/rustdoc-gui/src/lib.rs
@@ -96,3 +96,6 @@ pub enum AnEnum {
 
 #[doc(keyword = "CookieMonster")]
 pub mod keyword {}
+
+/// Just some type alias.
+pub type SomeType = u32;

--- a/src/test/rustdoc-gui/type-weight.rs
+++ b/src/test/rustdoc-gui/type-weight.rs
@@ -1,0 +1,2 @@
+goto: file://|DOC_PATH|/test_docs/type.SomeType.html
+assert-all: (".top-block .docblock p", {"font-weight": "400"})

--- a/src/test/ui/panics/panic-macro-any-wrapped.rs
+++ b/src/test/ui/panics/panic-macro-any-wrapped.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![allow(non_fmt_panic)]

--- a/src/test/ui/panics/panic-macro-any.rs
+++ b/src/test/ui/panics/panic-macro-any.rs
@@ -1,5 +1,5 @@
 // run-fail
-// error-pattern:panicked at 'Box<Any>'
+// error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
 #![feature(box_syntax)]

--- a/src/test/ui/where-clauses/where-for-self.stderr
+++ b/src/test/ui/where-clauses/where-for-self.stderr
@@ -6,3 +6,4 @@ LL |     where for<'a> &'a T: for<'b> Bar<'b>
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0316`.


### PR DESCRIPTION
Successful merges:

 - #85906 (Use `Iterator::find` instead of open-coding it)
 - #85951 (Update the documentation of `-C force-unwind-tables` for #83482)
 - #85985 (Clarify documentation of slice sorting methods)
 - #85989 (Remove rustfmt tests from top-level .gitattributes)
 - #86074 (Default panic message should print Box<dyn Any>)
 - #86078 (Type page font weight)
 - #86090 (:arrow_up: rust-analyzer)
 - #86095 (Search description codeblock)
 - #86096 (Comment out unused error codes and add description for E0316)
 - #86101 (Correct type signature in doc for Bound::as_mut)
 - #86103 (Remove lifetime hack)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85906,85951,85985,85989,86074,86078,86090,86095,86096,86101,86103)
<!-- homu-ignore:end -->