### PR TITLE
Stop hashing a `usize` when hashing `[u8; 1]`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -139,10 +139,17 @@ impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N] {
     }
 }
 
+/// Note that `Hash` for arrays provides no guarantees on its behavior other
+/// than the consistency with `Eq` required by the trait, and its implementation
+/// may change between rust versions.
+///
+/// For example, the hash of the array `[x, y, z]` may or may not be the same as
+/// the hash of the tuple `(x, y, z)`, and the hash of the array `[x, y, z]` may
+/// or may not be the same as the hash of the vector `vec![x, y, z]`.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Hash, const N: usize> Hash for [T; N] {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        Hash::hash(&self[..], state)
+        Hash::hash_slice(&self[..], state)
     }
 }
 


### PR DESCRIPTION
This changes `Hash` for arrays to be implemented via `Hash::hash_slice` instead of via `<[T]>::hash`.  The latter calls the former, but only after also hashing the length, which is unnecessary overhead for arrays where it's always the same.

I was inspired to make this PR because I changed an old project from having a `HashMap<(usize, usize), _>` to having a `HashMap<[usize; 2], _>`, and was surprised to see the perf worsen from 3.62s to 4.30s.

(Yes, that project really is dominated by hash table lookups that badly.)