### PR TITLE
Implement `AsRawFd` for reference types

### DIFF
--- a/library/std/src/os/unix/io.rs
+++ b/library/std/src/os/unix/io.rs
@@ -102,6 +102,20 @@ pub trait IntoRawFd {
     fn into_raw_fd(self) -> RawFd;
 }
 
+#[stable(feature = "as_raw_fd_ref_impl", since = "1.54.0")]
+impl<T: AsRawFd> AsRawFd for &T {
+    fn as_raw_fd(&self) -> RawFd {
+        (**self).as_raw_fd()
+    }
+}
+
+#[stable(feature = "as_raw_fd_ref_impl", since = "1.54.0")]
+impl<T: AsRawFd> AsRawFd for &mut T {
+    fn as_raw_fd(&self) -> RawFd {
+        (**self).as_raw_fd()
+    }
+}
+
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl AsRawFd for RawFd {
     #[inline]


### PR DESCRIPTION
This PR implements `AsRawFd` for `&T` and `&mut T` where `T: AsRawFd`.

This appears not to be breaking any existing guarantees around `AsRawFd`, as it's already possible to make a wrapper struct containing `&T` and implement `AsRawFd` for that. I'm unsure of how this would interact with rust-lang/rfcs#3128, though.