### PR TITLE
Error code cleanup and enforce checks

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -609,7 +609,7 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0540, // multiple rustc_deprecated attributes
     E0544, // multiple stability levels
 //  E0548, // replaced with a generic attribute input check
-    E0553, // multiple rustc_const_unstable attributes
+//  E0553, // multiple rustc_const_unstable attributes
 //  E0555, // replaced with a generic attribute input check
 //  E0558, // replaced with a generic attribute input check
 //  E0563, // cannot determine a type for this `impl Trait` removed in 6383de15
@@ -620,10 +620,9 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0612, // merged into E0609
 //  E0613, // Removed (merged with E0609)
     E0625, // thread-local statics cannot be accessed at compile-time
-    E0629, // missing 'feature' (rustc_const_unstable)
-    // rustc_const_unstable attribute must be paired with stable/unstable
-    // attribute
-    E0630,
+//  E0629, // missing 'feature' (rustc_const_unstable)
+//  E0630, // rustc_const_unstable attribute must be paired with stable/unstable
+           // attribute
     E0632, // cannot provide explicit generic arguments when `impl Trait` is
            // used in argument position
     E0640, // infer outlives requirements

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,10 +11,10 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0227", "E0279", "E0280", "E0313", "E0314", "E0315", "E0377", "E0461", "E0462", "E0464",
-    "E0465", "E0473", "E0474", "E0475", "E0476", "E0479", "E0480", "E0481", "E0482", "E0483",
-    "E0484", "E0485", "E0486", "E0487", "E0488", "E0489", "E0514", "E0519", "E0523", "E0553",
-    "E0554", "E0570", "E0629", "E0630", "E0640", "E0717", "E0729",
+    "E0227", "E0279", "E0280", "E0313", "E0315", "E0377", "E0461", "E0462", "E0464", "E0465",
+    "E0473", "E0474", "E0475", "E0476", "E0479", "E0480", "E0481", "E0482", "E0483", "E0484",
+    "E0485", "E0486", "E0487", "E0488", "E0489", "E0514", "E0519", "E0523", "E0554", "E0570",
+    "E0640", "E0717", "E0729",
 ];
 
 // Some error codes don't have any tests apparently...
@@ -290,6 +290,27 @@ pub fn check(paths: &[&Path], bad: &mut bool) {
                      commented in error_codes.rs file",
                     err_code
                 ));
+            }
+        }
+    }
+    if errors.is_empty() {
+        // Checking if local constants need to be cleaned.
+        for err_code in EXEMPTED_FROM_TEST {
+            match error_codes.get(err_code.to_owned()) {
+                Some(status) => {
+                    if status.has_test {
+                        errors.push(format!(
+                            "{} error code has a test and therefore should be \
+                            removed from the `EXEMPTED_FROM_TEST` constant",
+                            err_code
+                        ));
+                    }
+                }
+                None => errors.push(format!(
+                    "{} error code isn't used anymore and therefore should be removed \
+                        from `EXEMPTED_FROM_TEST` constant",
+                    err_code
+                )),
             }
         }
     }

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -17,6 +17,12 @@ const EXEMPTED_FROM_TEST: &[&str] = &[
 // Some error codes don't have any tests apparently...
 const IGNORE_EXPLANATION_CHECK: &[&str] = &["E0570", "E0601", "E0602", "E0729"];
 
+// If the file path contains any of these, we don't want to try to extract error codes from it.
+//
+// We need to declare each path in the windows version (with backslash).
+const PATHS_TO_IGNORE_FOR_EXTRACTION: &[&str] =
+    &["src/test/", "src\\test\\", "src/doc/", "src\\doc\\", "src/tools/", "src\\tools\\"];
+
 #[derive(Default, Debug)]
 struct ErrorCodeStatus {
     has_test: bool,
@@ -220,7 +226,7 @@ pub fn check(paths: &[&Path], bad: &mut bool) {
                 found_tests += 1;
             } else if entry.path().extension() == Some(OsStr::new("rs")) {
                 let path = entry.path().to_string_lossy();
-                if ["src/test/", "src/doc/", "src/tools/"].iter().all(|c| !path.contains(c)) {
+                if PATHS_TO_IGNORE_FOR_EXTRACTION.iter().all(|c| !path.contains(c)) {
                     extract_error_codes_from_source(contents, &mut error_codes, &regex);
                 }
             }

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,10 +11,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0227", "E0279", "E0280", "E0313", "E0315", "E0377", "E0461", "E0462", "E0464", "E0465",
-    "E0473", "E0474", "E0475", "E0476", "E0479", "E0480", "E0481", "E0482", "E0483", "E0484",
-    "E0485", "E0486", "E0487", "E0488", "E0489", "E0514", "E0519", "E0523", "E0554", "E0570",
-    "E0640", "E0717", "E0729",
+    "E0227", "E0279", "E0280", "E0313", "E0377", "E0461", "E0462", "E0464", "E0465", "E0476",
+    "E0482", "E0514", "E0519", "E0523", "E0554", "E0570", "E0640", "E0717", "E0729",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
Fixes #86097.

It now checks if an error code is unused, and if so, will report an error if the error code wasn't commented out in the `error_codes.rs` file. It also checks that the constant used in the tidy check is up-to-date.

r? @Mark-Simulacrum 