### PR TITLE
Check the number of generic lifetime and const parameters of intrinsics

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0094.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0094.md
@@ -1,4 +1,5 @@
-An invalid number of type parameters was given to an intrinsic function.
+An invalid number of generic type, lifetime, or const parameters was
+given to an intrinsic function.
 
 Erroneous code example:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0094.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0094.md
@@ -1,5 +1,4 @@
-An invalid number of generic type, lifetime, or const parameters was
-given to an intrinsic function.
+An invalid number of generic parameters was passed to an intrinsic function.
 
 Erroneous code example:
 

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -24,13 +24,15 @@ pub struct UnrecognizedAtomicOperation<'a> {
 
 #[derive(SessionDiagnostic)]
 #[error = "E0094"]
-pub struct WrongNumberOfTypeArgumentsToInstrinsic {
-    #[message = "intrinsic has wrong number of type \
+pub struct WrongNumberOfGenericArgumentsToInstrinsic<'a> {
+    #[message = "intrinsic has wrong number of {descr} \
                          parameters: found {found}, expected {expected}"]
-    #[label = "expected {expected} type parameter"]
+    #[label = "expected {expected} {descr} parameter{expected_pluralize}"]
     pub span: Span,
     pub found: usize,
     pub expected: usize,
+    pub expected_pluralize: &'a str,
+    pub descr: &'a str,
 }
 
 #[derive(SessionDiagnostic)]

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -24,7 +24,7 @@ pub struct UnrecognizedAtomicOperation<'a> {
 
 #[derive(SessionDiagnostic)]
 #[error = "E0094"]
-pub struct WrongNumberOfGenericArgumentsToInstrinsic<'a> {
+pub struct WrongNumberOfGenericArgumentsToIntrinsic<'a> {
     #[message = "intrinsic has wrong number of {descr} \
                          parameters: found {found}, expected {expected}"]
     #[label = "expected {expected} {descr} parameter{expected_pluralize}"]

--- a/src/test/ui/simd-intrinsic/issue-85855.rs
+++ b/src/test/ui/simd-intrinsic/issue-85855.rs
@@ -1,0 +1,20 @@
+// Check that appropriate errors are reported if an intrinsic is defined
+// with the wrong number of generic lifetime/type/const parameters, and
+// that no ICE occurs in these cases.
+
+#![feature(platform_intrinsics)]
+#![crate_type="lib"]
+
+extern "platform-intrinsic" {
+    fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
+    //~^ ERROR: intrinsic has wrong number of lifetime parameters
+
+    fn simd_add<'a, T>(x: T, y: T);
+    //~^ ERROR: intrinsic has wrong number of lifetime parameters
+
+    fn simd_sub<T, U>(x: T, y: U);
+    //~^ ERROR: intrinsic has wrong number of type parameters
+
+    fn simd_mul<T, const N: usize>(x: T, y: T);
+    //~^ ERROR: intrinsic has wrong number of const parameters
+}

--- a/src/test/ui/simd-intrinsic/issue-85855.rs
+++ b/src/test/ui/simd-intrinsic/issue-85855.rs
@@ -9,8 +9,7 @@ extern "platform-intrinsic" {
     fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
     //~^ ERROR: intrinsic has wrong number of lifetime parameters
 
-    fn simd_add<'a, T>(x: T, y: T);
-    //~^ ERROR: intrinsic has wrong number of lifetime parameters
+    fn simd_add<'a, T>(x: T, y: T) -> T;
 
     fn simd_sub<T, U>(x: T, y: U);
     //~^ ERROR: intrinsic has wrong number of type parameters

--- a/src/test/ui/simd-intrinsic/issue-85855.stderr
+++ b/src/test/ui/simd-intrinsic/issue-85855.stderr
@@ -1,0 +1,27 @@
+error[E0094]: intrinsic has wrong number of lifetime parameters: found 1, expected 0
+  --> $DIR/issue-85855.rs:9:27
+   |
+LL |     fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
+   |                           ^^^^^^^^^^^ expected 0 lifetime parameters
+
+error[E0094]: intrinsic has wrong number of lifetime parameters: found 1, expected 0
+  --> $DIR/issue-85855.rs:12:16
+   |
+LL |     fn simd_add<'a, T>(x: T, y: T);
+   |                ^^^^^^^ expected 0 lifetime parameters
+
+error[E0094]: intrinsic has wrong number of type parameters: found 2, expected 1
+  --> $DIR/issue-85855.rs:15:16
+   |
+LL |     fn simd_sub<T, U>(x: T, y: U);
+   |                ^^^^^^ expected 1 type parameter
+
+error[E0094]: intrinsic has wrong number of const parameters: found 1, expected 0
+  --> $DIR/issue-85855.rs:18:16
+   |
+LL |     fn simd_mul<T, const N: usize>(x: T, y: T);
+   |                ^^^^^^^^^^^^^^^^^^^ expected 0 const parameters
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0094`.

--- a/src/test/ui/simd-intrinsic/issue-85855.stderr
+++ b/src/test/ui/simd-intrinsic/issue-85855.stderr
@@ -4,24 +4,18 @@ error[E0094]: intrinsic has wrong number of lifetime parameters: found 1, expect
 LL |     fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
    |                           ^^^^^^^^^^^ expected 0 lifetime parameters
 
-error[E0094]: intrinsic has wrong number of lifetime parameters: found 1, expected 0
-  --> $DIR/issue-85855.rs:12:16
-   |
-LL |     fn simd_add<'a, T>(x: T, y: T);
-   |                ^^^^^^^ expected 0 lifetime parameters
-
 error[E0094]: intrinsic has wrong number of type parameters: found 2, expected 1
-  --> $DIR/issue-85855.rs:15:16
+  --> $DIR/issue-85855.rs:14:16
    |
 LL |     fn simd_sub<T, U>(x: T, y: U);
    |                ^^^^^^ expected 1 type parameter
 
 error[E0094]: intrinsic has wrong number of const parameters: found 1, expected 0
-  --> $DIR/issue-85855.rs:18:16
+  --> $DIR/issue-85855.rs:17:16
    |
 LL |     fn simd_mul<T, const N: usize>(x: T, y: T);
    |                ^^^^^^^^^^^^^^^^^^^ expected 0 const parameters
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0094`.


### PR DESCRIPTION
This pull request fixes #85855. The current code for type checking intrinsics only checks the number of generic _type_ parameters, but does not check for an incorrect number of lifetime or const parameters, which can cause problems later on, such as the ICE in #85855, where the code thought that it was looking at a type parameter but found a lifetime parameter:
```
error: internal compiler error: compiler/rustc_middle/src/ty/generics.rs:188:18:
    expected type parameter, but found another generic parameter
```

The changes in this PR add checks for the number of lifetime and const parameters, expand the scope of `E0094` to also apply to these cases, and improve the error message by properly pluralizing the number of expected generic parameters.
