### PR TITLE
Add :target selector for highlight on any heading

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -334,6 +334,7 @@ a.test-arrow:hover {
 	color: #999;
 }
 
+h1:target, h2:target, h3:target, h4:target,
 :target > code, :target > .in-band {
 	background: rgba(255, 236, 164, 0.06);
 	border-right: 3px solid rgba(255, 180, 76, 0.85);

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -282,6 +282,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
+h1:target, h2:target, h3:target, h4:target,
 :target > code, :target > .in-band {
 	background-color: #494a3d;
 	border-right: 3px solid #bb7410;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -275,6 +275,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
+h1:target, h2:target, h3:target, h4:target,
 :target > code, :target > .in-band {
 	background: #FDFFD3;
 	border-right: 3px solid #ffb44c;


### PR DESCRIPTION
This gives section headings the same highlight-on-click treatment that
method names get.

Fixes #86012 

r? @GuillaumeGomez 