### PR TITLE
Make [-] invisible in most cases

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -863,10 +863,10 @@ function hideThemeButtonState() {
     });
 
     onEachLazy(document.getElementsByTagName("summary"), function(el) {
-        el.addEventListener("click", function(ev) {
+        el.addEventListener("click", function() {
            addClass(el, "used");
         });
-    })
+    });
 
     onEachLazy(document.getElementsByTagName("a"), function(el) {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -862,6 +862,12 @@ function hideThemeButtonState() {
         displayHelp(true, ev);
     });
 
+    onEachLazy(document.getElementsByTagName("summary"), function(el) {
+        el.addEventListener("click", function(ev) {
+           addClass(el, "used");
+        });
+    })
+
     onEachLazy(document.getElementsByTagName("a"), function(el) {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're
         // jumping to *before* jumping there. We can't do this in onHashChange, because it changes

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1487,8 +1487,18 @@ details.rustdoc-toggle[open] > summary.hideme > span {
 	display: none;
 }
 
-details.rustdoc-toggle[open] > summary::before {
+/* If a toggle has been used to open a section, we should make sure */
+/* there's a [-] so it can be closed again. But if a toggle is open */
+/* and has never been used, don't show it. This minimizes clutter on */
+/* the page while still supporting the "auto hide <X>" settings and */
+/* the expand/collapse all functionality. */
+details.rustdoc-toggle[open] > summary.used::before {
 	content: "[−]";
+	display: inline;
+}
+
+details.rustdoc-toggle[open] > summary::before {
+	content: "";
 	display: inline;
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -580,20 +580,12 @@ nav.sub {
 
 .content .item-info {
 	position: relative;
-	margin-left: 33px;
+	margin-left: 24px; /* same as .docblock */
 	margin-top: -13px;
 }
 
 .sub-variant > div > .item-info {
 	margin-top: initial;
-}
-
-.content .item-info::before {
-	content: '⬑';
-	font-size: 25px;
-	position: absolute;
-	top: -6px;
-	left: -19px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant,

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -165,8 +165,6 @@ pre, .rustdoc.source .example-wrap {
 	color: #c5c5c5;
 }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.foreigntype, .content a.foreigntype { color: #ef57ff; }
 .content span.union, .content a.union { color: #98a01c; }
 .content span.constant, .content a.constant,

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -138,8 +138,6 @@ a.result-static:focus { background-color: #0063cc; }
 a.result-primitive:focus { background-color: #00708a; }
 a.result-keyword:focus { background-color: #884719; }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -136,8 +136,6 @@ a.result-static:focus { background-color: #c3e0ff; }
 a.result-primitive:focus { background-color: #9aecff; }
 a.result-keyword:focus { background-color: #f99650; }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }


### PR DESCRIPTION
Many items on doc pages are collapsible, so they have `[-]` / `[+]` items. These icons take up critical space in the gutter, reducing the ability to scan for an item you're looking for. The `[+]` icon is very important, so you can open the item you're looking for once you find it. But for a group of toggles that are already open, having `[-]` is not very useful, since collapsing a single item doesn't give you a much clearer view of the page.

This PR changes the UI so that `[-]` doesn't show up on sections that are toggled open. Those sections can be toggled closed with the keyboard shortcuts or the button in the top right. Also, some sections (like methods) can be toggled closed by a setting.

For sections that start in a closed position, when you click the `[+]` to open them, they will get a `[-]` to close them again. Otherwise it would be frustrating to open a section and not be able to immediately change your mind and close it.

This change made the `⬑` in stability output point into empty space, so I changed the display of stability information to not use `⬑` (see comment on 770f7dd2d01054f64d8433034a8e8ee8ff53c26a).

Fixes #85372

Demo: https://jacob.hoffman-andrews.com/rust/invisible-toggles/std/string/struct.String.html#implementations
https://jacob.hoffman-andrews.com/rust/invisible-toggles/std/io/trait.Read.html#provided-methods

r? @GuillaumeGomez 