### PR TITLE
Do not emit alloca for ZST locals with multiple assignments

### DIFF
--- a/src/test/ui/limits/issue-69485-var-size-diffs-too-large.stderr
+++ b/src/test/ui/limits/issue-69485-var-size-diffs-too-large.stderr
@@ -1,8 +1,8 @@
 error: values of the type `[u8; 18446744073709551615]` are too big for the current architecture
-  --> $DIR/issue-69485-var-size-diffs-too-large.rs:6:12
+  --> $DIR/issue-69485-var-size-diffs-too-large.rs:6:5
    |
 LL |     Bug::V([0; !0]);
-   |            ^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This extends 35566bfd7dd2e316d190078703de54a4dadda062 to additionally stop emitting unnecessary allocas for zero sized locals that are assigned multiple times.

When rebuilding the standard library with `-Zbuild-std` this reduces the number of locals that require an allocation from 62315 to 61767.