### PR TITLE
optimize Eq implementation for paths

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -951,7 +951,7 @@ impl FusedIterator for Components<'_> {}
 impl<'a> cmp::PartialEq for Components<'a> {
     #[inline]
     fn eq(&self, other: &Components<'a>) -> bool {
-        Iterator::eq(self.clone(), other.clone())
+        Iterator::eq(self.clone().rev(), other.clone().rev())
     }
 }
 


### PR DESCRIPTION
Filesystems generally have a tree-ish structure which means paths are more likely to share a prefix than a suffix. Absolute paths are especially prone to share long prefixes.

quick benchmark consisting of a search through through a vec containing the absolute paths of all (1850) files in `compiler/`:

```
# old
test path::tests::bench_path_cmp                                  ... bench:     227,407 ns/iter (+/- 2,162)

# new
test path::tests::bench_path_cmp                                  ... bench:      64,976 ns/iter (+/- 1,142)
```