### PR TITLE
Fix ICE when `main` is declared in an `extern` block

### DIFF
--- a/compiler/rustc_ast/src/entry.rs
+++ b/compiler/rustc_ast/src/entry.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum EntryPointType {
     None,
     MainNamed,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -126,7 +126,7 @@ pub struct ResolverOutputs {
     pub main_def: Option<MainDefinition>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct MainDefinition {
     pub res: Res<ast::NodeId>,
     pub is_import: bool,

--- a/src/test/ui/extern/extern-main-issue-86110.rs
+++ b/src/test/ui/extern/extern-main-issue-86110.rs
@@ -1,0 +1,7 @@
+// missing and missing2 exist to make sure that the error only happens on a `main` declaration
+extern "C" {
+    fn missing();
+    fn main();
+    //~^ the `main` function cannot be declared in an `extern` block
+    fn missing2();
+}

--- a/src/test/ui/extern/extern-main-issue-86110.stderr
+++ b/src/test/ui/extern/extern-main-issue-86110.stderr
@@ -1,0 +1,8 @@
+error: the `main` function cannot be declared in an `extern` block
+  --> $DIR/extern-main-issue-86110.rs:4:5
+   |
+LL |     fn main();
+   |     ^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Changes in #84401 to implement `imported_main` changed how the crate entry point is found, and a declared `main` in an `extern` block was detected erroneously.  This was causing the ICE described in #86110.

This PR adds a check for this case and emits an error instead.  Previously a `main` declaration in an `extern` block was not detected as an entry point at all, so emitting an error shouldn't break anything that worked previously.  In 1.52.1 stable this is demonstrated, with a `` `main` function not found`` error.

Fixes #86110