### PR TITLE
make UB during CTFE a hard error

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -525,6 +525,7 @@ impl InterpError<'_> {
         use InterpError::*;
         match *self {
             MachineStop(ref err) => err.is_hard_err(),
+            InterpError::UndefinedBehavior(_) => true,
             _ => false,
         }
     }

--- a/src/test/ui/consts/const-eval/dangling.rs
+++ b/src/test/ui/consts/const-eval/dangling.rs
@@ -5,9 +5,8 @@ use std::mem;
 // Make sure we error with the right kind of error on a too large slice.
 const TEST: () = { unsafe {
     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
-    let _val = &*slice; //~ ERROR: any use of this value will cause an error
+    let _val = &*slice; //~ ERROR: evaluation of constant value failed
     //~| slice is bigger than largest supported object
-    //~| WARN this was previously accepted by the compiler but is being phased out
 } };
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/dangling.stderr
+++ b/src/test/ui/consts/const-eval/dangling.stderr
@@ -1,18 +1,9 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/dangling.rs:8:16
    |
-LL | / const TEST: () = { unsafe {
-LL | |     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
-LL | |     let _val = &*slice;
-   | |                ^^^^^^^ invalid metadata in wide pointer: slice is bigger than largest supported object
-LL | |
-LL | |
-LL | | } };
-   | |____-
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     let _val = &*slice;
+   |                ^^^^^^^ invalid metadata in wide pointer: slice is bigger than largest supported object
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -8,8 +8,7 @@ const FOO: i32 = foo();
 const fn foo() -> i32 {
     unsafe {
         let _ = intrinsics::const_allocate(4, 3) as * mut i32;
-        //~^ error: any use of this value will cause an error [const_err]
-        //~| WARN this was previously accepted by the compiler but is being phased out
+        //~^ error: evaluation of constant value failed
     }
     1
 

--- a/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -1,19 +1,15 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/alloc_intrinsic_errors.rs:10:17
    |
 LL | const FOO: i32 = foo();
-   | -----------------------
+   |                  ----- inside `FOO` at $DIR/alloc_intrinsic_errors.rs:7:18
 ...
 LL |         let _ = intrinsics::const_allocate(4, 3) as * mut i32;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 align has to be a power of 2, `3` is not a power of 2
    |                 inside `foo` at $DIR/alloc_intrinsic_errors.rs:10:17
-   |                 inside `FOO` at $DIR/alloc_intrinsic_errors.rs:7:18
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-49296.rs
+++ b/src/test/ui/consts/const-eval/issue-49296.rs
@@ -17,8 +17,7 @@ const fn wat(x: u64) -> &'static u64 {
     unsafe { transmute(&x) }
 }
 const X: u64 = *wat(42);
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 fn main() {
     println!("{}", X);

--- a/src/test/ui/consts/const-eval/issue-49296.stderr
+++ b/src/test/ui/consts/const-eval/issue-49296.stderr
@@ -1,14 +1,9 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/issue-49296.rs:19:16
    |
 LL | const X: u64 = *wat(42);
-   | ---------------^^^^^^^^-
-   |                |
-   |                pointer to alloc1 was dereferenced after this allocation got freed
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                ^^^^^^^^ pointer to alloc1 was dereferenced after this allocation got freed
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,30 +1,17 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | / const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-LL | |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
-   |                |
-   |                invalid vtable: alignment `1000` is not a power of 2
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: alignment `1000` is not a power of 2
 
-error: any use of this value will cause an error
-  --> $DIR/ub-incorrect-vtable.rs:25:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:24:14
    |
-LL | / const INVALID_VTABLE_SIZE: &dyn Trait =
-LL | |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
-   |                |
-   |                invalid vtable: size is bigger than largest supported object
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: size is bigger than largest supported object
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:36:1
+  --> $DIR/ub-incorrect-vtable.rs:34:1
    |
 LL | / const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
 LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
@@ -36,7 +23,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:41:1
+  --> $DIR/ub-incorrect-vtable.rs:39:1
    |
 LL | / const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
 LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,30 +1,17 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | / const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-LL | |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
-   |                |
-   |                invalid vtable: alignment `1000` is not a power of 2
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: alignment `1000` is not a power of 2
 
-error: any use of this value will cause an error
-  --> $DIR/ub-incorrect-vtable.rs:25:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:24:14
    |
-LL | / const INVALID_VTABLE_SIZE: &dyn Trait =
-LL | |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   | |______________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^__-
-   |                |
-   |                invalid vtable: size is bigger than largest supported object
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: size is bigger than largest supported object
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:36:1
+  --> $DIR/ub-incorrect-vtable.rs:34:1
    |
 LL | / const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
 LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
@@ -36,7 +23,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:41:1
+  --> $DIR/ub-incorrect-vtable.rs:39:1
    |
 LL | / const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
 LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -17,14 +17,12 @@ trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-//~^ ERROR any use of this value will cause an error
-//~| WARNING this was previously accepted by the compiler
+//~^ ERROR evaluation of constant value failed
 //~| invalid vtable: alignment `1000` is not a power of 2
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-//~^ ERROR any use of this value will cause an error
-//~| WARNING this was previously accepted by the compiler
+//~^ ERROR evaluation of constant value failed
 //~| invalid vtable: size is bigger than largest supported object
 
 #[repr(transparent)]

--- a/src/test/ui/consts/const-eval/ub-nonnull.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.32bit.stderr
@@ -9,29 +9,14 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ub-nonnull.rs:19:30
    |
-LL | / const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
-LL | |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
-LL | |     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-LL | |     let out_of_bounds_ptr = &ptr[255];
-   | |                              ^^^^^^^^ memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of alloc10 which has size 1
-LL | |
-LL | |     mem::transmute(out_of_bounds_ptr)
-LL | | } };
-   | |____-
-   |
-note: the lint level is defined here
-  --> $DIR/ub-nonnull.rs:15:8
-   |
-LL | #[deny(const_err)] // this triggers a `const_err` so validation does not even happen
-   |        ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     let out_of_bounds_ptr = &ptr[255];
+   |                              ^^^^^^^^ memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of alloc10 which has size 1
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:24:1
+  --> $DIR/ub-nonnull.rs:23:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -42,7 +27,7 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:26:1
+  --> $DIR/ub-nonnull.rs:25:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -53,7 +38,7 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:34:1
+  --> $DIR/ub-nonnull.rs:33:1
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
@@ -64,7 +49,7 @@ LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:42:1
+  --> $DIR/ub-nonnull.rs:41:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
@@ -75,7 +60,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:48:1
+  --> $DIR/ub-nonnull.rs:47:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30

--- a/src/test/ui/consts/const-eval/ub-nonnull.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.64bit.stderr
@@ -9,29 +9,14 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ub-nonnull.rs:19:30
    |
-LL | / const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
-LL | |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
-LL | |     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-LL | |     let out_of_bounds_ptr = &ptr[255];
-   | |                              ^^^^^^^^ memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of alloc10 which has size 1
-LL | |
-LL | |     mem::transmute(out_of_bounds_ptr)
-LL | | } };
-   | |____-
-   |
-note: the lint level is defined here
-  --> $DIR/ub-nonnull.rs:15:8
-   |
-LL | #[deny(const_err)] // this triggers a `const_err` so validation does not even happen
-   |        ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     let out_of_bounds_ptr = &ptr[255];
+   |                              ^^^^^^^^ memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of alloc10 which has size 1
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:24:1
+  --> $DIR/ub-nonnull.rs:23:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -42,7 +27,7 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:26:1
+  --> $DIR/ub-nonnull.rs:25:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -53,7 +38,7 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:34:1
+  --> $DIR/ub-nonnull.rs:33:1
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
@@ -64,7 +49,7 @@ LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:42:1
+  --> $DIR/ub-nonnull.rs:41:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
@@ -75,7 +60,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:48:1
+  --> $DIR/ub-nonnull.rs:47:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -16,8 +16,7 @@ const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
 const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-    let out_of_bounds_ptr = &ptr[255]; //~ ERROR any use of this value will cause an error
-    //~| WARN this was previously accepted by the compiler but is being phased out
+    let out_of_bounds_ptr = &ptr[255]; //~ ERROR evaluation of constant value failed
     mem::transmute(out_of_bounds_ptr)
 } };
 

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
@@ -1,4 +1,4 @@
-warning: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:5:14
    |
 LL |     unsafe { std::mem::transmute(()) }
@@ -6,21 +6,12 @@ LL |     unsafe { std::mem::transmute(()) }
    |              |
    |              transmuting to uninhabited type
    |              inside `foo` at $DIR/validate_uninhabited_zsts.rs:5:14
-   |              inside `FOO` at $DIR/validate_uninhabited_zsts.rs:15:26
 ...
 LL | const FOO: [Empty; 3] = [foo(); 3];
-   | -----------------------------------
-   |
-note: the lint level is defined here
-  --> $DIR/validate_uninhabited_zsts.rs:14:8
-   |
-LL | #[warn(const_err)]
-   |        ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                          ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:14:26
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_uninhabited_zsts.rs:18:1
+  --> $DIR/validate_uninhabited_zsts.rs:17:1
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Empty
@@ -41,7 +32,7 @@ LL |     unsafe { std::mem::transmute(()) }
    = note: the `!` type has no valid value
 
 warning: the type `Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:18:35
+  --> $DIR/validate_uninhabited_zsts.rs:17:35
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,6 +42,6 @@ LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |
    = note: enums with no variants have no valid value
 
-error: aborting due to previous error; 3 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
@@ -1,4 +1,4 @@
-warning: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:5:14
    |
 LL |     unsafe { std::mem::transmute(()) }
@@ -6,21 +6,12 @@ LL |     unsafe { std::mem::transmute(()) }
    |              |
    |              transmuting to uninhabited type
    |              inside `foo` at $DIR/validate_uninhabited_zsts.rs:5:14
-   |              inside `FOO` at $DIR/validate_uninhabited_zsts.rs:15:26
 ...
 LL | const FOO: [Empty; 3] = [foo(); 3];
-   | -----------------------------------
-   |
-note: the lint level is defined here
-  --> $DIR/validate_uninhabited_zsts.rs:14:8
-   |
-LL | #[warn(const_err)]
-   |        ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                          ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:14:26
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_uninhabited_zsts.rs:18:1
+  --> $DIR/validate_uninhabited_zsts.rs:17:1
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Empty
@@ -41,7 +32,7 @@ LL |     unsafe { std::mem::transmute(()) }
    = note: the `!` type has no valid value
 
 warning: the type `Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:18:35
+  --> $DIR/validate_uninhabited_zsts.rs:17:35
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,6 +42,6 @@ LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |
    = note: enums with no variants have no valid value
 
-error: aborting due to previous error; 3 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -3,9 +3,8 @@
 
 const fn foo() -> ! {
     unsafe { std::mem::transmute(()) }
-    //~^ WARN any use of this value will cause an error [const_err]
+    //~^ ERROR evaluation of constant value failed
     //~| WARN the type `!` does not permit zero-initialization [invalid_value]
-    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 #[derive(Clone, Copy)]

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -13,186 +13,137 @@ use std::intrinsics;
 // unsigned types:
 
 const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // signed types:
 
 const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // and make sure we capture y < 0:
 
 const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // and that there's no special relation to the value -1 by picking some
 // negative values at random:
 
 const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // Repeat it all over for `unchecked_shr`
 
 // unsigned types:
 
 const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // signed types:
 
 const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // and make sure we capture y < 0:
 
 const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // and that there's no special relation to the value -1 by picking some
 // negative values at random:
 
 const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // Other arithmetic functions:
 
 const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 // capture fault with zero value
 
 const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,542 +1,297 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const-int-unchecked.rs:15:29
    |
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                             |
-   |                             overflowing shift by 8 in `unchecked_shl`
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:18:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:17:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 16 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:21:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:19:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 32 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:24:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:21:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 64 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:27:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:23:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 128 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:33:29
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:28:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
-   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                             |
-   |                             overflowing shift by 8 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:36:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:30:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 16 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:39:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:32:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 32 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:42:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:34:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 64 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:45:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:36:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 128 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:51:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:41:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 255 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 255 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:54:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:43:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 65535 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65535 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:57:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:45:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 4294967295 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967295 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:60:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:47:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 18446744073709551615 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551615 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:63:37
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:49:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
-   | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                     |
-   |                                     overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:70:40
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:55:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
-   | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                        |
-   |                                        overflowing shift by 250 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 250 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:73:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:57:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 65523 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65523 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:76:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:59:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 4294967271 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967271 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:79:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:61:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 18446744073709551586 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551586 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:82:44
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:63:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
-   | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                            |
-   |                                            overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:90:29
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:70:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                             |
-   |                             overflowing shift by 8 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:93:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:72:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 16 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:96:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:74:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 32 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:99:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:76:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 64 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:102:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:78:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 128 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:108:29
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:83:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
-   | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                             |
-   |                             overflowing shift by 8 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:111:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:85:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 16 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:114:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:87:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 32 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:117:31
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:89:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
-   | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                               |
-   |                               overflowing shift by 64 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:120:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:91:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 128 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:126:33
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:96:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
-   | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                 |
-   |                                 overflowing shift by 255 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 255 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:129:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:98:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 65535 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65535 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:132:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:100:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 4294967295 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967295 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:135:35
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:102:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
-   | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                   |
-   |                                   overflowing shift by 18446744073709551615 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551615 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:138:37
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:104:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
-   | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                     |
-   |                                     overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:145:40
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:110:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
-   | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                        |
-   |                                        overflowing shift by 250 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 250 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:148:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:112:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 65523 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65523 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:151:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:114:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 4294967271 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967271 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:154:42
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:116:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
-   | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                          |
-   |                                          overflowing shift by 18446744073709551586 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551586 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:157:44
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:118:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
-   | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                                            |
-   |                                            overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:163:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:123:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         overflow executing `unchecked_add`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:167:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:126:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         overflow executing `unchecked_sub`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:171:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:129:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         overflow executing `unchecked_mul`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:175:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:132:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         dividing by zero
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dividing by zero
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:178:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:134:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         overflow executing `unchecked_div`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_div`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:182:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:137:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         calculating the remainder with a divisor of zero
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:185:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:139:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         overflow executing `unchecked_rem`
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_rem`
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:191:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:144:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         `ctlz_nonzero` called on 0
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ctlz_nonzero` called on 0
 
-error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:194:25
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-int-unchecked.rs:146:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
-   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                         |
-   |                         `cttz_nonzero` called on 0
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `cttz_nonzero` called on 0
 
 error: aborting due to 49 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.rs
@@ -1,5 +1,4 @@
-// build-fail
-
+// error-pattern: evaluation of constant value failed
 #![feature(const_unreachable_unchecked)]
 
 const unsafe fn foo(x: bool) -> bool {
@@ -9,12 +8,8 @@ const unsafe fn foo(x: bool) -> bool {
     }
 }
 
-#[warn(const_err)]
 const BAR: bool = unsafe { foo(false) };
 
 fn main() {
   assert_eq!(BAR, true);
-  //~^ ERROR E0080
-  //~| ERROR erroneous constant
-  //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -1,4 +1,4 @@
-warning: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/hint.rs:LL:COL
    |
 LL |     unsafe { intrinsics::unreachable() }
@@ -6,39 +6,15 @@ LL |     unsafe { intrinsics::unreachable() }
    |              |
    |              entering unreachable code
    |              inside `unreachable_unchecked` at $SRC_DIR/core/src/hint.rs:LL:COL
-   |              inside `foo` at $DIR/const_unsafe_unreachable_ub.rs:8:18
-   |              inside `BAR` at $DIR/const_unsafe_unreachable_ub.rs:13:28
    | 
-  ::: $DIR/const_unsafe_unreachable_ub.rs:13:1
+  ::: $DIR/const_unsafe_unreachable_ub.rs:7:18
    |
+LL |         false => std::hint::unreachable_unchecked(),
+   |                  ---------------------------------- inside `foo` at $DIR/const_unsafe_unreachable_ub.rs:7:18
+...
 LL | const BAR: bool = unsafe { foo(false) };
-   | ----------------------------------------
-   |
-note: the lint level is defined here
-  --> $DIR/const_unsafe_unreachable_ub.rs:12:8
-   |
-LL | #[warn(const_err)]
-   |        ^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                            ---------- inside `BAR` at $DIR/const_unsafe_unreachable_ub.rs:11:28
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const_unsafe_unreachable_ub.rs:16:14
-   |
-LL |   assert_eq!(BAR, true);
-   |              ^^^ referenced constant has errors
-
-error: erroneous constant used
-  --> $DIR/const_unsafe_unreachable_ub.rs:16:3
-   |
-LL |   assert_eq!(BAR, true);
-   |   ^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -8,12 +8,11 @@ struct Struct {
 }
 
 pub const DIFFERENT_ALLOC: usize = {
-    //~^ NOTE
     let uninit = std::mem::MaybeUninit::<Struct>::uninit();
     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
     let uninit2 = std::mem::MaybeUninit::<Struct>::uninit();
     let field_ptr: *const Struct = &uninit2 as *const _ as *const Struct;
-    let offset = unsafe { field_ptr.offset_from(base_ptr) };
+    let offset = unsafe { field_ptr.offset_from(base_ptr) }; //~NOTE inside `DIFFERENT_ALLOC` at
     offset as usize
 };
 
@@ -23,17 +22,15 @@ pub const NOT_PTR: usize = {
 };
 
 pub const NOT_MULTIPLE_OF_SIZE: isize = {
-    //~^ NOTE
     let data = [5u8, 6, 7];
     let base_ptr = data.as_ptr();
     let field_ptr = &data[1] as *const u8 as *const u16;
-    unsafe { field_ptr.offset_from(base_ptr as *const u16) }
+    unsafe { field_ptr.offset_from(base_ptr as *const u16) } //~NOTE inside `NOT_MULTIPLE_OF_SIZE` at
 };
 
 pub const OFFSET_FROM_NULL: isize = {
-    //~^ NOTE
     let ptr = 0 as *const u8;
-    unsafe { ptr.offset_from(ptr) }
+    unsafe { ptr.offset_from(ptr) } //~NOTE inside `OFFSET_FROM_NULL` at
 };
 
 pub const DIFFERENT_INT: isize = { // offset_from with two different integers: like DIFFERENT_ALLOC

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -1,5 +1,8 @@
 #![feature(const_raw_ptr_deref)]
 #![feature(const_ptr_offset_from)]
+#![feature(core_intrinsics)]
+
+use std::intrinsics::ptr_offset_from;
 
 #[repr(C)]
 struct Struct {
@@ -12,12 +15,12 @@ pub const DIFFERENT_ALLOC: usize = {
     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
     let uninit2 = std::mem::MaybeUninit::<Struct>::uninit();
     let field_ptr: *const Struct = &uninit2 as *const _ as *const Struct;
-    let offset = unsafe { field_ptr.offset_from(base_ptr) }; //~NOTE inside `DIFFERENT_ALLOC` at
+    let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) }; //~ERROR evaluation of constant value failed
+    //~| cannot compute offset of pointers into different allocations.
     offset as usize
 };
 
 pub const NOT_PTR: usize = {
-    //~^ NOTE
     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
 };
 
@@ -25,19 +28,21 @@ pub const NOT_MULTIPLE_OF_SIZE: isize = {
     let data = [5u8, 6, 7];
     let base_ptr = data.as_ptr();
     let field_ptr = &data[1] as *const u8 as *const u16;
-    unsafe { field_ptr.offset_from(base_ptr as *const u16) } //~NOTE inside `NOT_MULTIPLE_OF_SIZE` at
+    unsafe { ptr_offset_from(field_ptr, base_ptr as *const u16) } //~ERROR evaluation of constant value failed
+    //~| 1_isize cannot be divided by 2_isize without remainder
 };
 
 pub const OFFSET_FROM_NULL: isize = {
     let ptr = 0 as *const u8;
-    unsafe { ptr.offset_from(ptr) } //~NOTE inside `OFFSET_FROM_NULL` at
+    unsafe { ptr_offset_from(ptr, ptr) } //~ERROR evaluation of constant value failed
+    //~| null pointer is not a valid pointer
 };
 
 pub const DIFFERENT_INT: isize = { // offset_from with two different integers: like DIFFERENT_ALLOC
-    //~^ NOTE
     let ptr1 = 8 as *const u8;
     let ptr2 = 16 as *const u8;
-    unsafe { ptr2.offset_from(ptr1) }
+    unsafe { ptr_offset_from(ptr2, ptr1) } //~ERROR any use of this value will cause an error
+    //~| WARN previously accepted
 };
 
 fn main() {}

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -1,16 +1,8 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/offset_from_ub.rs:18:27
    |
-LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  |
-   |                  ptr_offset_from cannot compute offset of pointers into different allocations.
-   |                  inside `ptr::const_ptr::<impl *const Struct>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
-  ::: $DIR/offset_from_ub.rs:15:27
-   |
-LL |     let offset = unsafe { field_ptr.offset_from(base_ptr) };
-   |                           ------------------------------- inside `DIFFERENT_ALLOC` at $DIR/offset_from_ub.rs:15:27
+LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ptr_offset_from cannot compute offset of pointers into different allocations.
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -20,12 +12,11 @@ LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
    |                    |
    |                    unable to turn bytes into a pointer
    |                    inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `NOT_PTR` at $DIR/offset_from_ub.rs:21:14
+   |                    inside `NOT_PTR` at $DIR/offset_from_ub.rs:24:14
    | 
-  ::: $DIR/offset_from_ub.rs:19:1
+  ::: $DIR/offset_from_ub.rs:23:1
    |
 LL | / pub const NOT_PTR: usize = {
-LL | |
 LL | |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
 LL | | };
    | |__-
@@ -35,50 +26,26 @@ LL | | };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/offset_from_ub.rs:31:14
    |
-LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  |
-   |                  exact_div: 1_isize cannot be divided by 2_isize without remainder
-   |                  inside `ptr::const_ptr::<impl *const u16>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
-  ::: $DIR/offset_from_ub.rs:28:14
-   |
-LL |     unsafe { field_ptr.offset_from(base_ptr as *const u16) }
-   |              --------------------------------------------- inside `NOT_MULTIPLE_OF_SIZE` at $DIR/offset_from_ub.rs:28:14
+LL |     unsafe { ptr_offset_from(field_ptr, base_ptr as *const u16) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: 1_isize cannot be divided by 2_isize without remainder
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/offset_from_ub.rs:37:14
    |
-LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  |
-   |                  null pointer is not a valid pointer for this operation
-   |                  inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
-  ::: $DIR/offset_from_ub.rs:33:14
-   |
-LL |     unsafe { ptr.offset_from(ptr) }
-   |              -------------------- inside `OFFSET_FROM_NULL` at $DIR/offset_from_ub.rs:33:14
+LL |     unsafe { ptr_offset_from(ptr, ptr) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ null pointer is not a valid pointer for this operation
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    unable to turn bytes into a pointer
-   |                    inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `DIFFERENT_INT` at $DIR/offset_from_ub.rs:40:14
-   | 
-  ::: $DIR/offset_from_ub.rs:36:1
+  --> $DIR/offset_from_ub.rs:44:14
    |
 LL | / pub const DIFFERENT_INT: isize = { // offset_from with two different integers: like DIFFERENT_ALLOC
-LL | |
 LL | |     let ptr1 = 8 as *const u8;
 LL | |     let ptr2 = 16 as *const u8;
-LL | |     unsafe { ptr2.offset_from(ptr1) }
+LL | |     unsafe { ptr_offset_from(ptr2, ptr1) }
+   | |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn bytes into a pointer
+LL | |
 LL | | };
    | |__-
    |

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -1,27 +1,16 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    ptr_offset_from cannot compute offset of pointers into different allocations.
-   |                    inside `ptr::const_ptr::<impl *const Struct>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `DIFFERENT_ALLOC` at $DIR/offset_from_ub.rs:16:27
+LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  ptr_offset_from cannot compute offset of pointers into different allocations.
+   |                  inside `ptr::const_ptr::<impl *const Struct>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    | 
-  ::: $DIR/offset_from_ub.rs:10:1
+  ::: $DIR/offset_from_ub.rs:15:27
    |
-LL | / pub const DIFFERENT_ALLOC: usize = {
-LL | |
-LL | |     let uninit = std::mem::MaybeUninit::<Struct>::uninit();
-LL | |     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
-...  |
-LL | |     offset as usize
-LL | | };
-   | |__-
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     let offset = unsafe { field_ptr.offset_from(base_ptr) };
+   |                           ------------------------------- inside `DIFFERENT_ALLOC` at $DIR/offset_from_ub.rs:15:27
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -31,9 +20,9 @@ LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
    |                    |
    |                    unable to turn bytes into a pointer
    |                    inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `NOT_PTR` at $DIR/offset_from_ub.rs:22:14
+   |                    inside `NOT_PTR` at $DIR/offset_from_ub.rs:21:14
    | 
-  ::: $DIR/offset_from_ub.rs:20:1
+  ::: $DIR/offset_from_ub.rs:19:1
    |
 LL | / pub const NOT_PTR: usize = {
 LL | |
@@ -41,54 +30,37 @@ LL | |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
 LL | | };
    | |__-
    |
+   = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    exact_div: 1_isize cannot be divided by 2_isize without remainder
-   |                    inside `ptr::const_ptr::<impl *const u16>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `NOT_MULTIPLE_OF_SIZE` at $DIR/offset_from_ub.rs:30:14
+LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  exact_div: 1_isize cannot be divided by 2_isize without remainder
+   |                  inside `ptr::const_ptr::<impl *const u16>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    | 
-  ::: $DIR/offset_from_ub.rs:25:1
+  ::: $DIR/offset_from_ub.rs:28:14
    |
-LL | / pub const NOT_MULTIPLE_OF_SIZE: isize = {
-LL | |
-LL | |     let data = [5u8, 6, 7];
-LL | |     let base_ptr = data.as_ptr();
-LL | |     let field_ptr = &data[1] as *const u8 as *const u16;
-LL | |     unsafe { field_ptr.offset_from(base_ptr as *const u16) }
-LL | | };
-   | |__-
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { field_ptr.offset_from(base_ptr as *const u16) }
+   |              --------------------------------------------- inside `NOT_MULTIPLE_OF_SIZE` at $DIR/offset_from_ub.rs:28:14
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    null pointer is not a valid pointer for this operation
-   |                    inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `OFFSET_FROM_NULL` at $DIR/offset_from_ub.rs:36:14
+LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  null pointer is not a valid pointer for this operation
+   |                  inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    | 
-  ::: $DIR/offset_from_ub.rs:33:1
+  ::: $DIR/offset_from_ub.rs:33:14
    |
-LL | / pub const OFFSET_FROM_NULL: isize = {
-LL | |
-LL | |     let ptr = 0 as *const u8;
-LL | |     unsafe { ptr.offset_from(ptr) }
-LL | | };
-   | |__-
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { ptr.offset_from(ptr) }
+   |              -------------------- inside `OFFSET_FROM_NULL` at $DIR/offset_from_ub.rs:33:14
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -98,9 +70,9 @@ LL |           unsafe { intrinsics::ptr_offset_from(self, origin) }
    |                    |
    |                    unable to turn bytes into a pointer
    |                    inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                    inside `DIFFERENT_INT` at $DIR/offset_from_ub.rs:43:14
+   |                    inside `DIFFERENT_INT` at $DIR/offset_from_ub.rs:40:14
    | 
-  ::: $DIR/offset_from_ub.rs:39:1
+  ::: $DIR/offset_from_ub.rs:36:1
    |
 LL | / pub const DIFFERENT_INT: isize = { // offset_from with two different integers: like DIFFERENT_ALLOC
 LL | |
@@ -115,3 +87,4 @@ LL | | };
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/offset_ub.stderr
+++ b/src/test/ui/consts/offset_ub.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -6,18 +6,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `BEFORE_START` at $DIR/offset_ub.rs:6:46
    | 
-  ::: $DIR/offset_ub.rs:6:1
+  ::: $DIR/offset_ub.rs:6:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
-   | ------------------------------------------------------------------------------
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                              ------------------------------ inside `BEFORE_START` at $DIR/offset_ub.rs:6:46
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -25,17 +20,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: pointer must be in-bounds at offset 2, but is outside bounds of allocN which has size 1
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `AFTER_END` at $DIR/offset_ub.rs:7:43
    | 
-  ::: $DIR/offset_ub.rs:7:1
+  ::: $DIR/offset_ub.rs:7:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
-   | --------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                           ----------------------------- inside `AFTER_END` at $DIR/offset_ub.rs:7:43
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -43,17 +34,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: pointer must be in-bounds at offset 101, but is outside bounds of allocN which has size 100
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `AFTER_ARRAY` at $DIR/offset_ub.rs:8:45
    | 
-  ::: $DIR/offset_ub.rs:8:1
+  ::: $DIR/offset_ub.rs:8:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
-   | ------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                             ------------------------------- inside `AFTER_ARRAY` at $DIR/offset_ub.rs:8:45
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -61,17 +48,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u16>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `OVERFLOW` at $DIR/offset_ub.rs:10:43
    | 
-  ::: $DIR/offset_ub.rs:10:1
+  ::: $DIR/offset_ub.rs:10:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
-   | ----------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                           ------------------------------------- inside `OVERFLOW` at $DIR/offset_ub.rs:10:43
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -79,17 +62,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u16>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `UNDERFLOW` at $DIR/offset_ub.rs:11:44
    | 
-  ::: $DIR/offset_ub.rs:11:1
+  ::: $DIR/offset_ub.rs:11:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
-   | -----------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                            ------------------------------------- inside `UNDERFLOW` at $DIR/offset_ub.rs:11:44
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -97,17 +76,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `OVERFLOW_ADDRESS_SPACE` at $DIR/offset_ub.rs:12:56
    | 
-  ::: $DIR/offset_ub.rs:12:1
+  ::: $DIR/offset_ub.rs:12:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
-   | ---------------------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                                        ----------------------------------- inside `OVERFLOW_ADDRESS_SPACE` at $DIR/offset_ub.rs:12:56
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -115,17 +90,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `UNDERFLOW_ADDRESS_SPACE` at $DIR/offset_ub.rs:13:57
    | 
-  ::: $DIR/offset_ub.rs:13:1
+  ::: $DIR/offset_ub.rs:13:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
-   | --------------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                                         --------------------------- inside `UNDERFLOW_ADDRESS_SPACE` at $DIR/offset_ub.rs:13:57
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -133,15 +104,11 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: pointer must be in-bounds at offset 1, but is outside bounds of allocN which has size 0
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `ZERO_SIZED_ALLOC` at $DIR/offset_ub.rs:15:50
    | 
-  ::: $DIR/offset_ub.rs:15:1
+  ::: $DIR/offset_ub.rs:15:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
-   | -------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                                  --------------------------- inside `ZERO_SIZED_ALLOC` at $DIR/offset_ub.rs:15:50
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
@@ -158,10 +125,11 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
 LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
    | ---------------------------------------------------------------------------------------------
    |
+   = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -169,15 +137,11 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: 0x0 is not a valid pointer
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `NULL_OFFSET_ZERO` at $DIR/offset_ub.rs:19:50
    | 
-  ::: $DIR/offset_ub.rs:19:1
+  ::: $DIR/offset_ub.rs:19:50
    |
 LL | pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };
-   | -------------------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                                  --------------------------- inside `NULL_OFFSET_ZERO` at $DIR/offset_ub.rs:19:50
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -199,3 +163,4 @@ LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).off
 
 error: aborting due to 11 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -62,8 +62,8 @@ const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
 
 const _: *const u8 =
     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
-//~^ ERROR any use of this value will cause an error
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
+//~| pointer must be in-bounds
 
 const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
 //~^ ERROR any use of this value will cause an error

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { intrinsics::offset(self, count) }
@@ -6,28 +6,17 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: pointer must be in-bounds at offset $TWO_WORDS, but is outside bounds of alloc2 which has size $WORD
    |                  inside `ptr::const_ptr::<impl *const usize>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `_` at $DIR/ptr_comparisons.rs:61:34
    | 
-  ::: $DIR/ptr_comparisons.rs:61:1
+  ::: $DIR/ptr_comparisons.rs:61:34
    |
 LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
-   | -------------------------------------------------------------------
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                  ------------------------------- inside `_` at $DIR/ptr_comparisons.rs:61:34
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ptr_comparisons.rs:64:33
    |
-LL | / const _: *const u8 =
-LL | |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
-   | |_________________________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^___-
-   |                                   |
-   |                                   memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
 
 error: any use of this value will cause an error
   --> $DIR/ptr_comparisons.rs:68:27
@@ -37,6 +26,7 @@ LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) +
    |                           |
    |                           cannot cast pointer to integer because it was not created by cast from integer
    |
+   = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
@@ -53,3 +43,4 @@ LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This is a next step for https://github.com/rust-lang/rust/issues/71800. `const_err` has been a future-incompatibility lint for 4 months now since https://github.com/rust-lang/rust/pull/80394 (and err-by-default for many years before that), so I think we could try making it a proper hard error at least in some situations.

I didn't yet adjust the tests, since I first want to gauge the fall-out via crater.
Cc @rust-lang/wg-const-eval 