### PR TITLE
Remove unnecessary trailing whitespace from error messages

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -954,7 +954,6 @@ impl EmitterWriter {
         //   |
         for pos in 0..=line_len {
             draw_col_separator(buffer, line_offset + pos + 1, width_offset - 2);
-            buffer.putc(line_offset + pos + 1, width_offset - 2, '|', Style::LineNumber);
         }
 
         // Write the horizontal lines for multiline annotations
@@ -1344,7 +1343,11 @@ impl EmitterWriter {
                 let buffer_msg_line_offset = buffer.num_lines();
 
                 // Add spacing line
-                draw_col_separator(&mut buffer, buffer_msg_line_offset, max_line_num_len + 1);
+                draw_col_separator_no_space(
+                    &mut buffer,
+                    buffer_msg_line_offset,
+                    max_line_num_len + 1,
+                );
 
                 // Then, the secondary file indicator
                 buffer.prepend(buffer_msg_line_offset + 1, "::: ", Style::LineNumber);

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -3,7 +3,7 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be sent between th
    |
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                    ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
-   | 
+   |
   ::: $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub unsafe auto trait Send {
@@ -20,7 +20,7 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` is not an iterator
    |
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `<<Self as Case1>::C as Iterator>::Item` is not an iterator
-   | 
+   |
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
 LL | pub trait Iterator {
@@ -37,7 +37,7 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be shared between 
    |
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                                                                             ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
-   | 
+   |
   ::: $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub unsafe auto trait Sync {

--- a/src/test/ui/associated-type-bounds/bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bounds-on-assoc-in-trait.stderr
@@ -3,7 +3,7 @@ error[E0277]: `<<Self as Case1>::A as Iterator>::Item` doesn't implement `Debug`
    |
 LL |     type A: Iterator<Item: Debug>;
    |                            ^^^^^ `<<Self as Case1>::A as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-   | 
+   |
   ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
    |
 LL | pub trait Debug {
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `<<Self as Foo>::Out as Baz>::Assoc: Default` is n
    |
 LL | pub trait Foo { type Out: Baz<Assoc: Default>; }
    |                                      ^^^^^^^ the trait `Default` is not implemented for `<<Self as Foo>::Out as Baz>::Assoc`
-   | 
+   |
   ::: $SRC_DIR/core/src/default.rs:LL:COL
    |
 LL | pub trait Default: Sized {

--- a/src/test/ui/associated-types/defaults-wf.stderr
+++ b/src/test/ui/associated-types/defaults-wf.stderr
@@ -3,7 +3,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
 LL |     type Ty = Vec<[u8]>;
    |               ^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {

--- a/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -3,7 +3,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> {}
    |                      ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
 LL | pub trait Add<Rhs = Self> {

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -37,7 +37,7 @@ LL |     fun((async || {})(), (async || {})());
    |                   --     ^^^^^^^^^^^^^^^ expected `async` closure body, found a different `async` closure body
    |                   |
    |                   the expected `async` closure body
-   | 
+   |
   ::: $SRC_DIR/core/src/future/mod.rs:LL:COL
    |
 LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>

--- a/src/test/ui/async-await/issue-72442.stderr
+++ b/src/test/ui/async-await/issue-72442.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `Option<&str>: AsRef<Path>` is not satisfied
    |
 LL |             let mut f = File::open(path.to_str())?;
    |                                    ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`
-   | 
+   |
   ::: $SRC_DIR/std/src/fs.rs:LL:COL
    |
 LL |     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {

--- a/src/test/ui/async-await/issues/issue-67893.stderr
+++ b/src/test/ui/async-await/issues/issue-67893.stderr
@@ -6,7 +6,7 @@ LL | fn g(_: impl Send) {}
 ...
 LL |     g(issue_67893::run())
    |     ^ `MutexGuard<'_, ()>` cannot be sent between threads safely
-   | 
+   |
   ::: $DIR/auxiliary/issue_67893.rs:7:20
    |
 LL | pub async fn run() {

--- a/src/test/ui/async-await/pin-needed-to-poll.stderr
+++ b/src/test/ui/async-await/pin-needed-to-poll.stderr
@@ -6,7 +6,7 @@ LL | struct Sleep;
 ...
 LL |         self.sleep.poll(cx)
    |                    ^^^^ method not found in `Sleep`
-   | 
+   |
   ::: $SRC_DIR/core/src/future/future.rs:LL:COL
    |
 LL |     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -6,7 +6,7 @@ LL |         let a = $c;
    |                 |
    |                 move occurs because `D` has type `A`, which does not implement the `Copy` trait
    |                 help: consider borrowing here: `&$c`
-   | 
+   |
   ::: $DIR/move-error-snippets.rs:21:1
    |
 LL | sss!();

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -75,7 +75,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -91,7 +91,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -107,7 +107,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -123,7 +123,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -139,7 +139,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -3,7 +3,7 @@ error[E0277]: `T` cannot be sent between threads safely
    |
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
-   | 
+   |
   ::: $DIR/auxiliary/trait_superkinds_in_metadata.rs:7:58
    |
 LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }

--- a/src/test/ui/c-variadic/issue-86053-1.stderr
+++ b/src/test/ui/c-variadic/issue-86053-1.stderr
@@ -63,7 +63,7 @@ error[E0412]: cannot find type `F` in this scope
    |
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
    |                                                ^
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait Fn<Args>: FnMut<Args> {

--- a/src/test/ui/closures/closure-move-sync.stderr
+++ b/src/test/ui/closures/closure-move-sync.stderr
@@ -3,7 +3,7 @@ error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads s
    |
 LL |     let t = thread::spawn(|| {
    |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
-   | 
+   |
   ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
    |
 LL |     F: Send + 'static,
@@ -18,7 +18,7 @@ error[E0277]: `Sender<()>` cannot be shared between threads safely
    |
 LL |     thread::spawn(|| tx.send(()).unwrap());
    |     ^^^^^^^^^^^^^ `Sender<()>` cannot be shared between threads safely
-   | 
+   |
   ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
    |
 LL |     F: Send + 'static,

--- a/src/test/ui/const-generics/const-argument-if-length.full.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.full.stderr
@@ -5,7 +5,7 @@ LL | pub const fn is_zst<T: ?Sized>() -> usize {
    |                     - this type parameter needs to be `std::marker::Sized`
 LL |     if std::mem::size_of::<T>() == 0 {
    |                            ^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
@@ -3,7 +3,7 @@ error: unconstrained generic constant
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
@@ -16,7 +16,7 @@ error: unconstrained generic constant
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
@@ -29,7 +29,7 @@ error: unconstrained generic constant
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
@@ -42,7 +42,7 @@ error: unconstrained generic constant
    |
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -6,12 +6,12 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: alloc7 has size 4, so pointer to 4 bytes starting at offset 4 is out-of-bounds
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   | 
+   |
   ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    |
 LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
    |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   | 
+   |
   ::: $DIR/out_of_bounds_read.rs:13:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
@@ -25,17 +25,17 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: alloc7 has size 4, so pointer to 4 bytes starting at offset 4 is out-of-bounds
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   | 
+   |
   ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    |
 LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
    |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   | 
+   |
   ::: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
 LL |         unsafe { read(self) }
    |                  ---------- inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/out_of_bounds_read.rs:14:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
@@ -49,17 +49,17 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: alloc7 has size 4, so pointer to 4 bytes starting at offset 4 is out-of-bounds
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   | 
+   |
   ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    |
 LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
    |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   | 
+   |
   ::: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
    |
 LL |         unsafe { read(self) }
    |                  ---------- inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/out_of_bounds_read.rs:15:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { intrinsics::unreachable() }
    |              |
    |              entering unreachable code
    |              inside `unreachable_unchecked` at $SRC_DIR/core/src/hint.rs:LL:COL
-   | 
+   |
   ::: $DIR/const_unsafe_unreachable_ub.rs:7:18
    |
 LL |         false => std::hint::unreachable_unchecked(),

--- a/src/test/ui/consts/miri_unleashed/drop.stderr
+++ b/src/test/ui/consts/miri_unleashed/drop.stderr
@@ -6,7 +6,7 @@ LL | pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
    | |
    | calling non-const function `<Vec<i32> as Drop>::drop`
    | inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   | 
+   |
   ::: $DIR/drop.rs:18:1
    |
 LL | };

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -12,7 +12,7 @@ LL |         unsafe { intrinsics::ptr_offset_from(self, origin) }
    |                  |
    |                  0x2a is not a valid pointer
    |                  inside `ptr::const_ptr::<impl *const u8>::offset_from` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_from_ub.rs:24:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }

--- a/src/test/ui/consts/offset_ub.stderr
+++ b/src/test/ui/consts/offset_ub.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
@@ -20,7 +20,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: allocN has size 1, so pointer to 2 bytes starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
@@ -34,7 +34,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: allocN has size 100, so pointer to 101 bytes starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
@@ -48,7 +48,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u16>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:12:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
@@ -62,7 +62,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u16>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:13:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
@@ -76,7 +76,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:14:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
@@ -90,7 +90,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  overflowing in-bounds pointer arithmetic
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:15:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
@@ -104,7 +104,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: allocN has size 1, so pointer to 2 bytes starting at offset -4 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:16:49
    |
 LL | pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
@@ -118,7 +118,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: allocN has size 0, so pointer to 1 byte starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
@@ -132,7 +132,7 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |                  |
    |                  0x1 is not a valid pointer
    |                  inside `ptr::mut_ptr::<impl *mut u8>::offset` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:19:42
    |
 LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
@@ -146,7 +146,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: 0x0 is not a valid pointer
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:22:50
    |
 LL | pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };
@@ -160,7 +160,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  0x7f..f is not a valid pointer
    |                  inside `ptr::const_ptr::<impl *const u8>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/offset_ub.rs:25:47
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  pointer arithmetic failed: alloc3 has size $WORD, so pointer to $TWO_WORDS bytes starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const usize>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   | 
+   |
   ::: $DIR/ptr_comparisons.rs:61:34
    |
 LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };

--- a/src/test/ui/cross/cross-file-errors/main.stderr
+++ b/src/test/ui/cross/cross-file-errors/main.stderr
@@ -3,7 +3,7 @@ error[E0658]: destructuring assignments are unstable
    |
 LL |         _
    |         ^
-   | 
+   |
   ::: $DIR/main.rs:5:5
    |
 LL |     underscore!();
@@ -18,7 +18,7 @@ error: in expressions, `_` can only be used on the left-hand side of an assignme
    |
 LL |         _
    |         ^ `_` not allowed here
-   | 
+   |
   ::: $DIR/main.rs:5:5
    |
 LL |     underscore!();

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq,PartialEq)]
 ...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Eq` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq,PartialEq)]
 ...
 LL |      Error
    |      ^^^^^ the trait `Eq` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq,PartialEq)]
 LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Eq` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq,PartialEq)]
 LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Eq` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Hash)]
 ...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Hash` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Hash)]
 ...
 LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Hash)]
 LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Hash` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Hash)]
 LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Hash` is not implemented for `Error`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/src/test/ui/derives/deriving-meta-unknown-trait.stderr
@@ -3,7 +3,7 @@ error: cannot find derive macro `Eqr` in this scope
    |
 LL | #[derive(Eqr)]
    |          ^^^ help: a derive macro with a similar name exists: `Eq`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub macro Eq($item:item) {
@@ -14,7 +14,7 @@ error: cannot find derive macro `Eqr` in this scope
    |
 LL | #[derive(Eqr)]
    |          ^^^ help: a derive macro with a similar name exists: `Eq`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub macro Eq($item:item) {

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -37,7 +37,7 @@ error: macro expansion ends with an incomplete expression: expected one of `move
    |
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
-   | 
+   |
   ::: $DIR/edition-keywords-2018-2015-parsing.rs:24:8
    |
 LL |     if passes_ident!(async) == 1 {}

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -37,7 +37,7 @@ error: macro expansion ends with an incomplete expression: expected one of `move
    |
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
-   | 
+   |
   ::: $DIR/edition-keywords-2018-2018-parsing.rs:24:8
    |
 LL |     if passes_ident!(async) == 1 {}

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -6,7 +6,7 @@ LL | struct Empty1 {}
 ...
 LL |     let e1 = Empty1;
    |              ^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
@@ -29,7 +29,7 @@ LL | struct Empty1 {}
 ...
 LL |     let e1 = Empty1();
    |              ^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
@@ -67,7 +67,7 @@ error[E0423]: expected value, found struct `XEmpty1`
    |
 LL |     let xe1 = XEmpty1;
    |               ^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:1:1
    |
 LL | pub struct XEmpty1 {}
@@ -89,7 +89,7 @@ error[E0423]: expected function, tuple struct or tuple variant, found struct `XE
    |
 LL |     let xe1 = XEmpty1();
    |               ^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:1:1
    |
 LL | pub struct XEmpty1 {}

--- a/src/test/ui/empty/empty-struct-braces-pat-1.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-1.stderr
@@ -12,7 +12,7 @@ error[E0532]: expected unit struct, unit variant or constant, found struct varia
    |
 LL |         XE::XEmpty3 => ()
    |         ^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:6:5
    |
 LL |     XEmpty3 {},

--- a/src/test/ui/empty/empty-struct-braces-pat-2.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-2.stderr
@@ -6,7 +6,7 @@ LL | struct Empty1 {}
 ...
 LL |         Empty1() => ()
    |         ^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
@@ -26,7 +26,7 @@ error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
    |
 LL |         XEmpty1() => ()
    |         ^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:1:1
    |
 LL | pub struct XEmpty1 {}
@@ -52,7 +52,7 @@ LL | struct Empty1 {}
 ...
 LL |         Empty1(..) => ()
    |         ^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
@@ -72,7 +72,7 @@ error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
    |
 LL |         XEmpty1(..) => ()
    |         ^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:1:1
    |
 LL | pub struct XEmpty1 {}

--- a/src/test/ui/empty/empty-struct-braces-pat-3.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-3.stderr
@@ -12,7 +12,7 @@ error[E0532]: expected tuple struct or tuple variant, found struct variant `XE::
    |
 LL |         XE::XEmpty3() => ()
    |         ^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:6:5
    |
 LL |     XEmpty3 {},
@@ -44,7 +44,7 @@ error[E0532]: expected tuple struct or tuple variant, found struct variant `XE::
    |
 LL |         XE::XEmpty3(..) => ()
    |         ^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:6:5
    |
 LL |     XEmpty3 {},

--- a/src/test/ui/empty/empty-struct-tuple-pat.stderr
+++ b/src/test/ui/empty/empty-struct-tuple-pat.stderr
@@ -30,7 +30,7 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
    |
 LL |         XE::XEmpty5 => (),
    |         ^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:7:5
    |
 LL |     XEmpty4,

--- a/src/test/ui/empty/empty-struct-unit-pat.stderr
+++ b/src/test/ui/empty/empty-struct-unit-pat.stderr
@@ -6,7 +6,7 @@ LL | struct Empty2;
 ...
 LL |         Empty2() => ()
    |         ^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
@@ -26,7 +26,7 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `XEmpty2
    |
 LL |         XEmpty2() => ()
    |         ^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
@@ -51,7 +51,7 @@ LL | struct Empty2;
 ...
 LL |         Empty2(..) => ()
    |         ^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
@@ -71,7 +71,7 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `XEmpty2
    |
 LL |         XEmpty2(..) => ()
    |         ^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
@@ -102,7 +102,7 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `XE::XE
    |
 LL |         XE::XEmpty4() => (),
    |         ^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:7:5
    |
 LL |     XEmpty4,
@@ -133,7 +133,7 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `XE::XE
    |
 LL |         XE::XEmpty4(..) => (),
    |         ^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/empty-struct.rs:7:5
    |
 LL |     XEmpty4,

--- a/src/test/ui/error-codes/E0004-2.stderr
+++ b/src/test/ui/error-codes/E0004-2.stderr
@@ -3,7 +3,7 @@ error[E0004]: non-exhaustive patterns: `None` and `Some(_)` not covered
    |
 LL |     match x { }
    |           ^ patterns `None` and `Some(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     None,

--- a/src/test/ui/error-codes/E0005.stderr
+++ b/src/test/ui/error-codes/E0005.stderr
@@ -3,7 +3,7 @@ error[E0005]: refutable pattern in local binding: `None` not covered
    |
 LL |     let Some(y) = x;
    |         ^^^^^^^ pattern `None` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     None,

--- a/src/test/ui/error-codes/E0297.stderr
+++ b/src/test/ui/error-codes/E0297.stderr
@@ -3,7 +3,7 @@ error[E0005]: refutable pattern in `for` loop binding: `None` not covered
    |
 LL |     for Some(x) in xs {}
    |         ^^^^^^^ pattern `None` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     None,

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -84,7 +84,7 @@ error[E0624]: associated function `pub_crate` is private
    |
 LL |     r.pub_crate();
    |       ^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:114:9
    |
 LL |         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
@@ -95,7 +95,7 @@ error[E0624]: associated function `pub_mod` is private
    |
 LL |     r.pub_mod();
    |       ^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:116:9
    |
 LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
@@ -106,7 +106,7 @@ error[E0624]: associated function `private` is private
    |
 LL |     r.private();
    |       ^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:118:9
    |
 LL |         fn private(&self) -> i32 { self.d_priv }
@@ -135,7 +135,7 @@ error[E0624]: associated function `pub_crate` is private
    |
 LL |     t.pub_crate();
    |       ^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:129:9
    |
 LL |         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
@@ -146,7 +146,7 @@ error[E0624]: associated function `pub_mod` is private
    |
 LL |     t.pub_mod();
    |       ^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:130:9
    |
 LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
@@ -157,7 +157,7 @@ error[E0624]: associated function `private` is private
    |
 LL |     t.private();
    |       ^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub-and-stability.rs:131:9
    |
 LL |         fn private(&self) -> i32 { self.0 }

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -138,7 +138,7 @@ error[E0277]: the trait bound `<<Self as _Tr3>::A as Iterator>::Item: Copy` is n
    |
 LL |     type A: Iterator<Item: Copy>;
    |                            ^^^^ the trait `Copy` is not implemented for `<<Self as _Tr3>::A as Iterator>::Item`
-   | 
+   |
   ::: $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {

--- a/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exhaustive-patterns.stderr
@@ -3,7 +3,7 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(_x) = foo();
    |         ^^^^^^ pattern `Err(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -16,7 +16,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
    |
 LL |    Pin::new(&mut gen).resume(());
    |                       ^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/generator.rs:LL:COL
    |
 LL | pub enum GeneratorState<Y, R> {

--- a/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
+++ b/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `(): AsRef<()>` is not satisfied
    |
 LL |     type Bar = ();
    |     ^^^^^^^^^^^^^^ the trait `AsRef<()>` is not implemented for `()`
-   | 
+   |
   ::: $DIR/auxiliary/foo_defn.rs:6:15
    |
 LL |     type Bar: AsRef<()>;

--- a/src/test/ui/impl-trait/impl-generic-mismatch.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch.stderr
@@ -31,7 +31,7 @@ error[E0643]: method `hash` has incompatible signature for trait
    |
 LL |     fn hash(&self, hasher: &mut impl Hasher) {}
    |                                 ^^^^^^^^^^^ expected generic parameter, found `impl Trait`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/impl-trait/issues/issue-78722.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.stderr
@@ -8,7 +8,7 @@ LL |         let f: F = async { 1 };
    |                -   ^^^^^^^^^^^ expected opaque type, found a different opaque type
    |                |
    |                expected due to this
-   | 
+   |
   ::: $SRC_DIR/core/src/future/mod.rs:LL:COL
    |
 LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -66,7 +66,7 @@ error[E0599]: no method named `method` found for type `i32` in the current scope
    |
 LL |     1i32.method();
    |          ^^^^^^ method not found in `i32`
-   | 
+   |
   ::: $DIR/auxiliary/no_method_suggested_traits.rs:8:12
    |
 LL |         fn method(&self) {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -3,7 +3,7 @@ error: `impl` item signature doesn't match `trait` item signature
    |
 LL |     fn deref(&self) -> &dyn Trait {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&Struct) -> &dyn Trait`
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/deref.rs:LL:COL
    |
 LL |     fn deref(&self) -> &Self::Target;

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -3,7 +3,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
    |
 LL |     catch_unwind(|| { x.set(23); });
    |     ^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
-   | 
+   |
   ::: $SRC_DIR/std/src/panic.rs:LL:COL
    |
 LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {

--- a/src/test/ui/issues/issue-17546.stderr
+++ b/src/test/ui/issues/issue-17546.stderr
@@ -3,7 +3,7 @@ error[E0573]: expected type, found variant `NoResult`
    |
 LL |     fn new() -> NoResult<MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL | pub enum Result<T, E> {
@@ -57,7 +57,7 @@ error[E0573]: expected type, found variant `NoResult`
    |
 LL | fn newer() -> NoResult<foo::MyEnum, String> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL | pub enum Result<T, E> {

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -3,7 +3,7 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
    |
 LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -5,7 +5,7 @@ LL | #[derive(Hash)]
    |          ---- in this derive macro expansion
 LL | struct Foo(Bar);
    |            ^^^ the trait `Hash` is not implemented for `Bar`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);

--- a/src/test/ui/issues/issue-21202.stderr
+++ b/src/test/ui/issues/issue-21202.stderr
@@ -3,7 +3,7 @@ error[E0624]: associated function `foo` is private
    |
 LL |         Foo::foo(&f);
    |              ^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/issue-21202.rs:4:9
    |
 LL |         fn foo(&self) { }

--- a/src/test/ui/issues/issue-27033.stderr
+++ b/src/test/ui/issues/issue-27033.stderr
@@ -3,7 +3,7 @@ error[E0530]: match bindings cannot shadow unit variants
    |
 LL |         None @ _ => {}
    |         ^^^^ cannot be named the same as a unit variant
-   | 
+   |
   ::: $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    |
 LL |     pub use super::v1::*;

--- a/src/test/ui/issues/issue-31173.stderr
+++ b/src/test/ui/issues/issue-31173.stderr
@@ -12,12 +12,12 @@ error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut std:
    |
 LL |         .collect();
    |          ^^^^^^^ method cannot be called on `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/core/src/iter/adapters/cloned.rs:LL:COL
    |
 LL | pub struct Cloned<I> {
    | -------------------- doesn't satisfy `_: Iterator`
-   | 
+   |
   ::: $SRC_DIR/core/src/iter/adapters/take_while.rs:LL:COL
    |
 LL | pub struct TakeWhile<I, P> {

--- a/src/test/ui/issues/issue-43189.stderr
+++ b/src/test/ui/issues/issue-43189.stderr
@@ -3,7 +3,7 @@ error[E0599]: no method named `a` found for unit type `()` in the current scope
    |
 LL |     ().a();
    |        ^ method not found in `()`
-   | 
+   |
   ::: $DIR/auxiliary/xcrate-issue-43189-a.rs:5:8
    |
 LL |     fn a(&self) {}

--- a/src/test/ui/issues/issue-56175.stderr
+++ b/src/test/ui/issues/issue-56175.stderr
@@ -3,7 +3,7 @@ error[E0599]: no method named `trait_method` found for struct `FooStruct` in the
    |
 LL |     reexported_trait::FooStruct.trait_method();
    |                                 ^^^^^^^^^^^^ method not found in `FooStruct`
-   | 
+   |
   ::: $DIR/auxiliary/reexported-trait.rs:3:12
    |
 LL |         fn trait_method(&self) {
@@ -20,7 +20,7 @@ error[E0599]: no method named `trait_method_b` found for struct `FooStruct` in t
    |
 LL |     reexported_trait::FooStruct.trait_method_b();
    |                                 ^^^^^^^^^^^^^^ method not found in `FooStruct`
-   | 
+   |
   ::: $DIR/auxiliary/reexported-trait.rs:7:12
    |
 LL |         fn trait_method_b(&self) {

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -18,7 +18,7 @@ error[E0277]: the size for values of type `<() as Trait<'_>>::Item` cannot be kn
    |
 LL |     foo((), drop)
    |             ^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub fn drop<T>(_x: T) {}

--- a/src/test/ui/issues/issue-69725.stderr
+++ b/src/test/ui/issues/issue-69725.stderr
@@ -3,7 +3,7 @@ error[E0599]: the method `clone` exists for struct `Struct<A>`, but its trait bo
    |
 LL |     let _ = Struct::<A>::new().clone();
    |                                ^^^^^ method cannot be called on `Struct<A>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $DIR/auxiliary/issue-69725.rs:2:1
    |
 LL | pub struct Struct<A>(A);

--- a/src/test/ui/issues/issue-7607-1.stderr
+++ b/src/test/ui/issues/issue-7607-1.stderr
@@ -3,7 +3,7 @@ error[E0412]: cannot find type `Fo` in this scope
    |
 LL | impl Fo {
    |      ^^ help: a trait with a similar name exists: `Fn`
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait Fn<Args>: FnMut<Args> {

--- a/src/test/ui/issues/issue-78720.stderr
+++ b/src/test/ui/issues/issue-78720.stderr
@@ -9,7 +9,7 @@ error[E0412]: cannot find type `F` in this scope
    |
 LL |     _func: F,
    |            ^
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait Fn<Args>: FnMut<Args> {

--- a/src/test/ui/limits/issue-55878.stderr
+++ b/src/test/ui/limits/issue-55878.stderr
@@ -3,7 +3,7 @@ error[E0080]: values of the type `[u8; SIZE]` are too big for the current archit
    |
 LL |     intrinsics::size_of::<T>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ inside `std::mem::size_of::<[u8; SIZE]>` at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   | 
+   |
   ::: $DIR/issue-55878.rs:7:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());

--- a/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
+++ b/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
@@ -21,7 +21,7 @@ LL | |  }
 ...
 LL |        ping!();
    |        -------- in this macro invocation (#1)
-   | 
+   |
   ::: $DIR/auxiliary/ping.rs:5:1
    |
 LL |  / macro_rules! ping {
@@ -43,7 +43,7 @@ LL | |  }
 ...
 LL |        deep!();
    |        -------- in this macro invocation (#1)
-   | 
+   |
   ::: $DIR/auxiliary/ping.rs:5:1
    |
 LL |  / macro_rules! ping {

--- a/src/test/ui/macros/macro-name-typo.stderr
+++ b/src/test/ui/macros/macro-name-typo.stderr
@@ -3,7 +3,7 @@ error: cannot find macro `printlx` in this scope
    |
 LL |     printlx!("oh noes!");
    |     ^^^^^^^ help: a macro with a similar name exists: `println`
-   | 
+   |
   ::: $SRC_DIR/std/src/macros.rs:LL:COL
    |
 LL | macro_rules! println {

--- a/src/test/ui/macros/macro-path-prelude-fail-3.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-3.stderr
@@ -3,7 +3,7 @@ error: cannot find macro `inline` in this scope
    |
 LL |     inline!();
    |     ^^^^^^ help: a macro with a similar name exists: `line`
-   | 
+   |
   ::: $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |
 LL |     macro_rules! line {

--- a/src/test/ui/macros/macro-use-wrong-name.stderr
+++ b/src/test/ui/macros/macro-use-wrong-name.stderr
@@ -3,7 +3,7 @@ error: cannot find macro `macro_two` in this scope
    |
 LL |     macro_two!();
    |     ^^^^^^^^^ help: a macro with a similar name exists: `macro_one`
-   | 
+   |
   ::: $DIR/auxiliary/two_macros.rs:2:1
    |
 LL | macro_rules! macro_one { () => ("one") }

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `Test1: Clone` is not satisfied
    |
 LL | #[derive(Copy(Bad))]
    |          ^^^^ the trait `Clone` is not implemented for `Test1`
-   | 
+   |
   ::: $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `Test2: Clone` is not satisfied
    |
 LL | #[derive(Copy="bad")]
    |          ^^^^ the trait `Clone` is not implemented for `Test2`
-   | 
+   |
   ::: $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -6,7 +6,7 @@ LL |     intrinsics::size_of::<T>()
    |     |
    |     size_of called on unsized type `dyn Debug`
    |     inside `std::mem::size_of::<dyn Debug>` at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   | 
+   |
   ::: $DIR/issue-80742.rs:23:10
    |
 LL |     [u8; size_of::<T>() + 1]: ,
@@ -26,7 +26,7 @@ LL | | }
 ...
 LL |       let dst = Inline::<dyn Debug>::new(0);
    |                                      ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
    |
 LL |   pub trait Debug {
@@ -43,7 +43,7 @@ LL |     intrinsics::size_of::<T>()
    |     |
    |     size_of called on unsized type `dyn Debug`
    |     inside `std::mem::size_of::<dyn Debug>` at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   | 
+   |
   ::: $DIR/issue-80742.rs:15:10
    |
 LL |     [u8; size_of::<T>() + 1]: ,

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -14,7 +14,7 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                       |
    |                                       doesn't satisfy `<_ as FnOnce<(&&str,)>>::Output = bool`
    |                                       doesn't satisfy `_: FnMut<(&&str,)>`
-   | 
+   |
   ::: $SRC_DIR/core/src/iter/adapters/filter.rs:LL:COL
    |
 LL | pub struct Filter<I, P> {

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -24,7 +24,7 @@ error[E0423]: expected value, found type alias `xm1::S`
    |
 LL |     check(xm1::S);
    |           ^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/namespace-mix.rs:3:5
    |
 LL |     pub struct TS();
@@ -73,7 +73,7 @@ error[E0423]: expected value, found struct variant `xm7::V`
    |
 LL |     check(xm7::V);
    |           ^^^^^^
-   | 
+   |
   ::: $DIR/auxiliary/namespace-mix.rs:6:9
    |
 LL |         V {},

--- a/src/test/ui/no-send-res-ports.stderr
+++ b/src/test/ui/no-send-res-ports.stderr
@@ -10,7 +10,7 @@ LL | |         let y = x;
 LL | |         println!("{:?}", y);
 LL | |     });
    | |_____- within this `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6]`
-   | 
+   |
   ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
    |
 LL |       F: Send + 'static,

--- a/src/test/ui/parser/issue-62894.stderr
+++ b/src/test/ui/parser/issue-62894.stderr
@@ -42,7 +42,7 @@ LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
 LL | 
 LL | fn main() {}
    | ^^ unexpected token
-   | 
+   |
   ::: $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |
 LL |     ($left:expr, $right:expr $(,)?) => ({

--- a/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-arm-statics-2.stderr
@@ -12,7 +12,7 @@ error[E0004]: non-exhaustive patterns: `Some(Some(West))` not covered
    |
 LL |     match Some(Some(North)) {
    |           ^^^^^^^^^^^^^^^^^ pattern `Some(Some(West))` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),

--- a/src/test/ui/pattern/usefulness/match-privately-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-privately-empty.stderr
@@ -3,7 +3,7 @@ error[E0004]: non-exhaustive patterns: `Some(Private { misc: true, .. })` not co
    |
 LL |     match private::DATA {
    |           ^^^^^^^^^^^^^ pattern `Some(Private { misc: true, .. })` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -27,7 +27,7 @@ error[E0004]: non-exhaustive patterns: `Some(_)` not covered
    |
 LL |     match Some(10) {
    |           ^^^^^^^^ pattern `Some(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -363,7 +363,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     let a = other::A(());
    |                    ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -380,7 +380,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     let b = other::B(2);
    |                    ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -397,7 +397,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let c = other::C(2, 3);
    |                    ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -414,7 +414,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     let other::A(()) = a;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -431,7 +431,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     let other::A(_) = a;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -448,7 +448,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     match a { other::A(()) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -465,7 +465,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     match a { other::A(_) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -482,7 +482,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     let other::B(_) = b;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -499,7 +499,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     let other::B(_b) = b;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -516,7 +516,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     match b { other::B(_) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -533,7 +533,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     match b { other::B(_b) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -550,7 +550,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     match b { other::B(1) => {}
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -567,7 +567,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |         other::B(_) => {} }
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -584,7 +584,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let other::C(_, _) = c;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -601,7 +601,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let other::C(_a, _) = c;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -618,7 +618,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let other::C(_, _b) = c;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -635,7 +635,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let other::C(_a, _b) = c;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -652,7 +652,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     match c { other::C(_, _) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -669,7 +669,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     match c { other::C(_a, _) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -686,7 +686,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     match c { other::C(_, _b) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -703,7 +703,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     match c { other::C(_a, _b) => {} }
    |                      ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
@@ -720,7 +720,7 @@ error[E0603]: tuple struct constructor `A` is private
    |
 LL |     let a2 = other::A;
    |                     ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
@@ -737,7 +737,7 @@ error[E0603]: tuple struct constructor `B` is private
    |
 LL |     let b2 = other::B;
    |                     ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
@@ -754,7 +754,7 @@ error[E0603]: tuple struct constructor `C` is private
    |
 LL |     let c2 = other::C;
    |                     ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);

--- a/src/test/ui/privacy/private-method-cross-crate.stderr
+++ b/src/test/ui/privacy/private-method-cross-crate.stderr
@@ -3,7 +3,7 @@ error[E0624]: associated function `nap` is private
    |
 LL |   nyan.nap();
    |        ^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/cci_class_5.rs:8:9
    |
 LL |         fn nap(&self) {}

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -87,7 +87,7 @@ error[E0624]: associated function `g` is private
    |
 LL |     u.g();
    |       ^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub_restricted.rs:14:5
    |
 LL |     pub(crate) fn g(&self) {}
@@ -98,7 +98,7 @@ error[E0624]: associated function `h` is private
    |
 LL |     u.h();
    |       ^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/pub_restricted.rs:15:5
    |
 LL |     crate fn h(&self) {}

--- a/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
+++ b/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
@@ -3,7 +3,7 @@ warning: using an old version of `time-macros-impl`
    |
 LL |         #[my_macro] struct One($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:27:5
    |
 LL |     impl_macros!(Foo);
@@ -20,7 +20,7 @@ warning: using an old version of `time-macros-impl`
    |
 LL |         #[my_macro] struct One($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:44:5
    |
 LL |     impl_macros!(Foo);
@@ -36,7 +36,7 @@ warning: using an old version of `js-sys`
    |
 LL |         #[my_macro] struct Two($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:46:5
    |
 LL |     arrays!(Foo);
@@ -52,7 +52,7 @@ warning: using an old version of `actix-web`
    |
 LL |         #[my_macro] struct Three($T);
    |                                  ^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:55:5
    |
 LL |     tuple_from_req!(Foo);
@@ -68,7 +68,7 @@ warning: using an old version of `actix-web`
    |
 LL |         #[my_macro] struct Three($T);
    |                                  ^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:63:5
    |
 LL |     tuple_from_req!(Foo);
@@ -87,7 +87,7 @@ warning: using an old version of `time-macros-impl`
    |
 LL |         #[my_macro] struct One($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:27:5
    |
 LL |     impl_macros!(Foo);
@@ -105,7 +105,7 @@ warning: using an old version of `time-macros-impl`
    |
 LL |         #[my_macro] struct One($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:44:5
    |
 LL |     impl_macros!(Foo);
@@ -122,7 +122,7 @@ warning: using an old version of `js-sys`
    |
 LL |         #[my_macro] struct Two($name);
    |                                ^^^^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:46:5
    |
 LL |     arrays!(Foo);
@@ -139,7 +139,7 @@ warning: using an old version of `actix-web`
    |
 LL |         #[my_macro] struct Three($T);
    |                                  ^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:55:5
    |
 LL |     tuple_from_req!(Foo);
@@ -156,7 +156,7 @@ warning: using an old version of `actix-web`
    |
 LL |         #[my_macro] struct Three($T);
    |                                  ^^
-   | 
+   |
   ::: $DIR/group-compat-hack.rs:63:5
    |
 LL |     tuple_from_req!(Foo);

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -144,7 +144,7 @@ LL |     parent_source_spans!($($tokens)*);
 ...
 LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
@@ -160,7 +160,7 @@ LL |     parent_source_spans!($($tokens)*);
 ...
 LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
@@ -176,7 +176,7 @@ LL |     parent_source_spans!($($tokens)*);
 ...
 LL |     three!("hip", "hop");
    |     --------------------- in this macro invocation
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -3,7 +3,7 @@ error: cannot find macro `bang_proc_macrp` in this scope
    |
 LL |     bang_proc_macrp!();
    |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `bang_proc_macro`
-   | 
+   |
   ::: $DIR/auxiliary/test-macros.rs:15:1
    |
 LL | pub fn empty(_: TokenStream) -> TokenStream {
@@ -50,7 +50,7 @@ error: cannot find derive macro `Dlona` in this scope
    |
 LL | #[derive(Dlona)]
    |          ^^^^^ help: a derive macro with a similar name exists: `Clona`
-   | 
+   |
   ::: $DIR/auxiliary/derive-clona.rs:11:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
@@ -61,7 +61,7 @@ error: cannot find derive macro `Dlona` in this scope
    |
 LL | #[derive(Dlona)]
    |          ^^^^^ help: a derive macro with a similar name exists: `Clona`
-   | 
+   |
   ::: $DIR/auxiliary/derive-clona.rs:11:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
@@ -72,7 +72,7 @@ error: cannot find derive macro `Dlone` in this scope
    |
 LL | #[derive(Dlone)]
    |          ^^^^^ help: a derive macro with a similar name exists: `Clone`
-   | 
+   |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub macro Clone($item:item) {
@@ -83,7 +83,7 @@ error: cannot find derive macro `Dlone` in this scope
    |
 LL | #[derive(Dlone)]
    |          ^^^^^ help: a derive macro with a similar name exists: `Clone`
-   | 
+   |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub macro Clone($item:item) {
@@ -100,7 +100,7 @@ error: cannot find attribute `attr_proc_macra` in this scope
    |
 LL | #[attr_proc_macra]
    |   ^^^^^^^^^^^^^^^ help: an attribute macro with a similar name exists: `attr_proc_macro`
-   | 
+   |
   ::: $DIR/auxiliary/test-macros.rs:20:1
    |
 LL | pub fn empty_attr(_: TokenStream, _: TokenStream) -> TokenStream {
@@ -111,7 +111,7 @@ error: cannot find derive macro `FooWithLongNan` in this scope
    |
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FooWithLongName`
-   | 
+   |
   ::: $DIR/auxiliary/derive-foo.rs:11:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
@@ -122,7 +122,7 @@ error: cannot find derive macro `FooWithLongNan` in this scope
    |
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FooWithLongName`
-   | 
+   |
   ::: $DIR/auxiliary/derive-foo.rs:11:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {

--- a/src/test/ui/proc-macro/span-from-proc-macro.stderr
+++ b/src/test/ui/proc-macro/span-from-proc-macro.stderr
@@ -6,7 +6,7 @@ LL | pub fn error_from_attribute(_args: TokenStream, _input: TokenStream) -> Tok
 ...
 LL |             field: MissingType
    |                    ^^^^^^^^^^^ not found in this scope
-   | 
+   |
   ::: $DIR/span-from-proc-macro.rs:8:1
    |
 LL | #[error_from_attribute]
@@ -20,7 +20,7 @@ LL | pub fn error_from_derive(_input: TokenStream) -> TokenStream {
 ...
 LL |             Variant(OtherMissingType)
    |                     ^^^^^^^^^^^^^^^^ not found in this scope
-   | 
+   |
   ::: $DIR/span-from-proc-macro.rs:11:10
    |
 LL | #[derive(ErrorFromDerive)]
@@ -34,7 +34,7 @@ LL | pub fn other_error_from_bang(_input: TokenStream) -> TokenStream {
 LL |     custom_quote::custom_quote! {
 LL |         my_ident
    |         ^^^^^^^^ not found in this scope
-   | 
+   |
   ::: $DIR/span-from-proc-macro.rs:16:5
    |
 LL |     other_error_from_bang!();
@@ -50,7 +50,7 @@ LL |             let bang_error: bool = 25;
 ...
 LL | pub fn error_from_bang(_input: TokenStream) -> TokenStream {
    | ---------------------------------------------------------- in this expansion of `error_from_bang!`
-   | 
+   |
   ::: $DIR/span-from-proc-macro.rs:15:5
    |
 LL |     error_from_bang!();

--- a/src/test/ui/range/range-1.stderr
+++ b/src/test/ui/range/range-1.stderr
@@ -23,7 +23,7 @@ error[E0277]: the size for values of type `[{integer}]` cannot be known at compi
    |
 LL |     let range = *arr..;
    |                 ^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/range.rs:LL:COL
    |
 LL | pub struct RangeFrom<Idx> {

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -3,7 +3,7 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(x) = res;
    |         ^^^^^ pattern `Err(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),

--- a/src/test/ui/resolve/issue-19452.stderr
+++ b/src/test/ui/resolve/issue-19452.stderr
@@ -12,7 +12,7 @@ error[E0423]: expected value, found struct variant `issue_19452_aux::Homura::Mad
    |
 LL |     let homura = issue_19452_aux::Homura::Madoka;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `issue_19452_aux::Homura::Madoka { /* fields */ }`
-   | 
+   |
   ::: $DIR/auxiliary/issue-19452-aux.rs:2:5
    |
 LL |     Madoka { age: u32 }

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -18,7 +18,7 @@ error[E0412]: cannot find type `Opiton` in this scope
    |
 LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
    |          ^^^^^^ help: an enum with a similar name exists: `Option`
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -103,7 +103,7 @@ error[E0603]: tuple struct constructor `S` is private
    |
 LL |     xcrate::m::S;
    |                ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:2:18
    |
 LL |     pub struct S(u8);
@@ -120,7 +120,7 @@ error[E0603]: tuple struct constructor `Z` is private
    |
 LL |     xcrate::m::n::Z;
    |                   ^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:5:28
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -7,7 +7,7 @@ LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()
 LL | | }
    | |_^ `main` can only return types that implement `Termination`
-   | 
+   |
   ::: $SRC_DIR/test/src/lib.rs:LL:COL
    |
 LL |   pub fn assert_test_result<T: Termination>(result: T) {

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -15,7 +15,7 @@ error[E0603]: tuple struct constructor `TupleStruct` is private
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
    |                                ^^^^^^^^^^^ private tuple struct constructor
-   | 
+   |
   ::: $DIR/auxiliary/structs.rs:11:24
    |
 LL | pub struct TupleStruct(pub u16, pub u16);

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -30,7 +30,7 @@ error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covere
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
-   | 
+   |
   ::: $DIR/auxiliary/uninhabited.rs:17:23
    |
 LL |     #[non_exhaustive] Tuple(!),

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -30,7 +30,7 @@ error[E0004]: non-exhaustive patterns: `Tuple(_)` and `Struct { .. }` not covere
    |
 LL |     match x {}
    |           ^ patterns `Tuple(_)` and `Struct { .. }` not covered
-   | 
+   |
   ::: $DIR/auxiliary/uninhabited.rs:17:23
    |
 LL |     #[non_exhaustive] Tuple(!),

--- a/src/test/ui/rust-2021/future-prelude-collision-shadow.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-shadow.stderr
@@ -3,7 +3,7 @@ error[E0599]: no method named `try_into` found for type `u8` in the current scop
    |
 LL |         let _: u32 = 3u8.try_into().unwrap();
    |                          ^^^^^^^^ method not found in `u8`
-   | 
+   |
   ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
    |
 LL |     fn try_into(self) -> Result<T, Self::Error>;

--- a/src/test/ui/span/transitive-dep-span.stderr
+++ b/src/test/ui/span/transitive-dep-span.stderr
@@ -6,7 +6,7 @@ LL | |             () => { parse error }
    | |                           ^^^^^ expected one of `!` or `::`
 LL | |         }
    | |_________- in this expansion of `transitive_dep_two::parse_error!`
-   | 
+   |
   ::: $DIR/transitive-dep-span.rs:13:1
    |
 LL |   transitive_dep_two::parse_error!();

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -15,7 +15,7 @@ error: cannot find attribute `tests` in this scope
    |
 LL | #[tests]
    |   ^^^^^ help: an attribute macro with a similar name exists: `test`
-   | 
+   |
   ::: $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |
 LL |     pub macro test($item:item) {

--- a/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
+++ b/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
@@ -3,7 +3,7 @@ error[E0573]: expected type, found module `result`
    |
 LL | impl result {
    |      ^^^^^^ help: an enum with a similar name exists: `Result`
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL | pub enum Result<T, E> {

--- a/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -77,7 +77,7 @@ LL | /     async {
 LL | |         42
 LL | |     }
    | |_____^ expected struct `Pin`, found opaque type
-   | 
+   |
   ::: $SRC_DIR/core/src/future/mod.rs:LL:COL
    |
 LL |   pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>

--- a/src/test/ui/suggestions/imm-ref-trait-object.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object.stderr
@@ -3,7 +3,7 @@ error: the `min` method cannot be invoked on a trait object
    |
 LL |      t.min().unwrap()
    |        ^^^
-   | 
+   |
   ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
 LL |         Self: Sized,

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -3,7 +3,7 @@ error[E0599]: no method named `finish` found for struct `DefaultHasher` in the c
    |
 LL |     h.finish()
    |       ^^^^^^ method not found in `DefaultHasher`
-   | 
+   |
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn finish(&self) -> u64;

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
    |
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
-   | 
+   |
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |
 LL | pub struct BufWriter<W: Write> {
@@ -29,7 +29,7 @@ error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn std::io::
    |
 LL |     writeln!(fp, "hello world").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `BufWriter<&dyn std::io::Write>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |
 LL | pub struct BufWriter<W: Write> {

--- a/src/test/ui/suggestions/suggest-change-mut.stderr
+++ b/src/test/ui/suggestions/suggest-change-mut.stderr
@@ -27,7 +27,7 @@ error[E0599]: the method `read_until` exists for struct `BufReader<&T>`, but its
    |
 LL |         stream_reader.read_until(b'\n', &mut buffer).expect("Reading into buffer failed");
    |                       ^^^^^^^^^^ method cannot be called on `BufReader<&T>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/std/src/io/buffered/bufreader.rs:LL:COL
    |
 LL | pub struct BufReader<R> {

--- a/src/test/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/src/test/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -3,7 +3,7 @@ error[E0404]: expected trait, found struct `String`
    |
 LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
    |                                              ^^^^^^ not a trait
-   | 
+   |
   ::: $SRC_DIR/alloc/src/string.rs:LL:COL
    |
 LL | pub trait ToString {
@@ -23,7 +23,7 @@ error[E0404]: expected trait, found struct `String`
    |
 LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
    |                                                      ^^^^^^ not a trait
-   | 
+   |
   ::: $SRC_DIR/alloc/src/string.rs:LL:COL
    |
 LL | pub trait ToString {
@@ -43,7 +43,7 @@ error[E0404]: expected trait, found struct `String`
    |
 LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
    |                                             ^^^^^^ not a trait
-   | 
+   |
   ::: $SRC_DIR/alloc/src/string.rs:LL:COL
    |
 LL | pub trait ToString {
@@ -63,7 +63,7 @@ error[E0404]: expected trait, found struct `String`
    |
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
    |                                                         ^^^^^^ not a trait
-   | 
+   |
   ::: $SRC_DIR/alloc/src/string.rs:LL:COL
    |
 LL | pub trait ToString {

--- a/src/test/ui/traits/bad-sized.stderr
+++ b/src/test/ui/traits/bad-sized.stderr
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
@@ -40,7 +40,7 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {

--- a/src/test/ui/traits/bound/on-structs-and-enums-xc.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-xc.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
    |
 LL | fn explode(x: Foo<usize>) {}
    |               ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
-   | 
+   |
   ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:5:18
    |
 LL | pub struct Foo<T:Trait> {
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `f32: Trait` is not satisfied
    |
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`
-   | 
+   |
   ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
    |
 LL | pub enum Bar<T:Trait> {

--- a/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `f64: Trait` is not satisfied
    |
 LL |     let bar: Bar<f64> = return;
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f64`
-   | 
+   |
   ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
    |
 LL | pub enum Bar<T:Trait> {

--- a/src/test/ui/traits/bound/same-crate-name.stderr
+++ b/src/test/ui/traits/bound/same-crate-name.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `Foo: main::a::Bar` is not satisfied
    |
 LL |         a::try_foo(foo);
    |                    ^^^ the trait `main::a::Bar` is not implemented for `Foo`
-   | 
+   |
   ::: $DIR/auxiliary/crate_a1.rs:3:24
    |
 LL | pub fn try_foo(x: impl Bar) {}
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `DoesNotImplementTrait: main::a::Bar` is not satis
    |
 LL |         a::try_foo(implements_no_traits);
    |                    ^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `DoesNotImplementTrait`
-   | 
+   |
   ::: $DIR/auxiliary/crate_a1.rs:3:24
    |
 LL | pub fn try_foo(x: impl Bar) {}
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `ImplementsWrongTraitConditionally<isize>: main::a
    |
 LL |         a::try_foo(other_variant_implements_mismatched_trait);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsWrongTraitConditionally<isize>`
-   | 
+   |
   ::: $DIR/auxiliary/crate_a1.rs:3:24
    |
 LL | pub fn try_foo(x: impl Bar) {}
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `ImplementsTraitForUsize<isize>: main::a::Bar` is 
    |
 LL |         a::try_foo(other_variant_implements_correct_trait);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsTraitForUsize<isize>`
-   | 
+   |
   ::: $DIR/auxiliary/crate_a1.rs:3:24
    |
 LL | pub fn try_foo(x: impl Bar) {}

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -3,7 +3,7 @@ error[E0283]: type annotations needed
    |
 LL |     T: FnMut(&'a ()),
    |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait FnMut<Args>: FnOnce<Args> {

--- a/src/test/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.stderr
@@ -3,7 +3,7 @@ error[E0275]: overflow evaluating the requirement `Option<_>: Sized`
    |
 LL |     iso(left, right)
    |     ^^^
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {

--- a/src/test/ui/traits/suggest-deferences/issue-39029.stderr
+++ b/src/test/ui/traits/suggest-deferences/issue-39029.stderr
@@ -6,7 +6,7 @@ LL |     let _errors = TcpListener::bind(&bad);
    |                                     |
    |                                     the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
    |                                     help: consider adding dereference here: `&*bad`
-   | 
+   |
   ::: $SRC_DIR/std/src/net/tcp.rs:LL:COL
    |
 LL |     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {

--- a/src/test/ui/traits/suggest-where-clause.stderr
+++ b/src/test/ui/traits/suggest-where-clause.stderr
@@ -6,7 +6,7 @@ LL | fn check<T: Iterator, U: ?Sized>() {
 LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -25,7 +25,7 @@ LL | fn check<T: Iterator, U: ?Sized>() {
 ...
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -90,7 +90,7 @@ error[E0277]: the size for values of type `[T]` cannot be known at compilation t
    |
 LL |     mem::size_of::<[T]>();
    |                    ^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
@@ -103,7 +103,7 @@ error[E0277]: the size for values of type `[&U]` cannot be known at compilation 
    |
 LL |     mem::size_of::<[&U]>();
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {

--- a/src/test/ui/typeck/issue-83693.stderr
+++ b/src/test/ui/typeck/issue-83693.stderr
@@ -3,7 +3,7 @@ error[E0412]: cannot find type `F` in this scope
    |
 LL | impl F {
    |      ^ help: a trait with a similar name exists: `Fn`
-   | 
+   |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait Fn<Args>: FnMut<Args> {

--- a/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -3,7 +3,7 @@ error[E0004]: non-exhaustive patterns: `Err(_)` not covered
    |
 LL |     let _ = match x {
    |                   ^ pattern `Err(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
@@ -57,7 +57,7 @@ error[E0004]: non-exhaustive patterns: `Err(_)` not covered
    |
 LL |     let _ = match x {
    |                   ^ pattern `Err(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
@@ -71,7 +71,7 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
    |
 LL |     let Ok(x) = x;
    |         ^^^^^ pattern `Err(_)` not covered
-   | 
+   |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
 LL |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),

--- a/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `U1: Copy` is not satisfied
    |
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `Copy` is not implemented for `U1`
-   | 
+   |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {

--- a/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
@@ -3,7 +3,7 @@ error[E0277]: the trait bound `U1: Copy` is not satisfied
    |
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `Copy` is not implemented for `U1`
-   | 
+   |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {

--- a/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq)]
 LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Eq)]
 LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
-   | 
+   |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {

--- a/src/test/ui/unique-object-noncopyable.stderr
+++ b/src/test/ui/unique-object-noncopyable.stderr
@@ -9,7 +9,7 @@ LL |   trait Foo {
 ...
 LL |       let _z = y.clone();
    |                  ^^^^^ method cannot be called on `Box<dyn Foo>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
    |
 LL | / pub struct Box<

--- a/src/test/ui/unique-pinned-nocopy.stderr
+++ b/src/test/ui/unique-pinned-nocopy.stderr
@@ -6,7 +6,7 @@ LL |   struct R {
 ...
 LL |       let _j = i.clone();
    |                  ^^^^^ method cannot be called on `Box<R>` due to unsatisfied trait bounds
-   | 
+   |
   ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
    |
 LL | / pub struct Box<

--- a/src/test/ui/wf/wf-impl-self-type.stderr
+++ b/src/test/ui/wf/wf-impl-self-type.stderr
@@ -3,7 +3,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
 LL | impl Foo for Option<[u8]> {}
    |              ^^^^^^^^^^^^ doesn't have a size known at compile-time
-   | 
+   |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {

--- a/src/test/ui/xc-private-method.stderr
+++ b/src/test/ui/xc-private-method.stderr
@@ -3,7 +3,7 @@ error[E0624]: associated function `static_meth_struct` is private
    |
 LL |     let _ = xc_private_method_lib::Struct::static_meth_struct();
    |                                            ^^^^^^^^^^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:8:5
    |
 LL |     fn static_meth_struct() -> Struct {
@@ -14,7 +14,7 @@ error[E0624]: associated function `static_meth_enum` is private
    |
 LL |     let _ = xc_private_method_lib::Enum::static_meth_enum();
    |                                          ^^^^^^^^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:23:5
    |
 LL |     fn static_meth_enum() -> Enum {

--- a/src/test/ui/xc-private-method2.stderr
+++ b/src/test/ui/xc-private-method2.stderr
@@ -3,7 +3,7 @@ error[E0624]: associated function `meth_struct` is private
    |
 LL |     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
    |                                                    ^^^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:12:5
    |
 LL |     fn meth_struct(&self) -> isize {
@@ -14,7 +14,7 @@ error[E0624]: associated function `meth_enum` is private
    |
 LL |     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
    |                                                       ^^^^^^^^^ private associated function
-   | 
+   |
   ::: $DIR/auxiliary/xc-private-method-lib.rs:27:5
    |
 LL |     fn meth_enum(&self) -> isize {

--- a/src/test/ui/xcrate/xcrate-unit-struct.stderr
+++ b/src/test/ui/xcrate/xcrate-unit-struct.stderr
@@ -3,7 +3,7 @@ error[E0423]: expected value, found struct `xcrate_unit_struct::StructWithFields
    |
 LL |     let _ = xcrate_unit_struct::StructWithFields;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `xcrate_unit_struct::StructWithFields { foo: val }`
-   | 
+   |
   ::: $DIR/auxiliary/xcrate_unit_struct.rs:20:1
    |
 LL | pub struct StructWithFields {


### PR DESCRIPTION
Some error messages currently contain unnecessary trailing whitespace. There are some legitimate reasons for having trailing whitespace in the output, such as for uniform indentation of possibly-empty input lines, but the whitespace I have addressed here occurs in a line used only for spacing, and I see no reason why that should have trailing whitespace (spacing lines inserted in other places also don't have trailing whitespace).

I have also removed a superfluous call to `buffer.putc()`, which has no effect because the same character is already placed there by `draw_col_separator()`.

Use `git diff --ignore-space-at-eol` to see my changes; otherwise the diff is quite large due to the whitespace removed from expected outputs in `src/test/ui/`.
