### PR TITLE
std: Stabilize wasm simd intrinsics

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -205,7 +205,7 @@ const RISCV_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
 ];
 
 const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
-    ("simd128", Some(sym::wasm_target_feature)),
+    ("simd128", None),
     ("atomics", Some(sym::wasm_target_feature)),
     ("nontrapping-fptoint", Some(sym::wasm_target_feature)),
 ];

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -165,6 +165,7 @@
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
 #![feature(int_error_matching)]
+#![cfg_attr(bootstrap, feature(target_feature_11))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(or_patterns_back_compat)]
 

--- a/src/test/rustdoc-ui/wasm-safe.rs
+++ b/src/test/rustdoc-ui/wasm-safe.rs
@@ -1,7 +1,5 @@
 // check-pass
 
-#![feature(wasm_target_feature)]
-
 #[cfg(any(target_arch = "wasm32", doc))]
 #[target_feature(enable = "simd128")]
 pub fn foo() {}

--- a/src/test/ui/simd/wasm-simd-indirect.rs
+++ b/src/test/ui/simd/wasm-simd-indirect.rs
@@ -1,7 +1,5 @@
 // build-pass
 
-#![cfg_attr(target_arch = "wasm32", feature(wasm_simd, wasm_target_feature))]
-
 #[cfg(target_arch = "wasm32")]
 fn main() {
     unsafe {


### PR DESCRIPTION
This commit performs two changes to stabilize Rust support for
WebAssembly simd intrinsics:

* The stdarch submodule is updated to pull in rust-lang/stdarch#1179.
* The `wasm_target_feature` feature gate requirement for the `simd128`
  feature has been removed, stabilizing the name `simd128`.

This should conclude the FCP started on #74372 and...

Closes #74372