### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "pretty_env_logger",
  "rand 0.8.3",
  "rustc-workspace-hack",
- "rustfix",
+ "rustfix 0.6.0",
  "semver 1.0.3",
  "serde",
  "serde_ignored",
@@ -672,7 +672,7 @@ dependencies = [
  "libc",
  "miow 0.3.6",
  "regex",
- "rustfix",
+ "rustfix 0.5.1",
  "serde",
  "serde_json",
  "tracing",
@@ -696,7 +696,7 @@ dependencies = [
  "log",
  "miow 0.3.6",
  "regex",
- "rustfix",
+ "rustfix 0.5.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4547,6 +4547,18 @@ name = "rustfix"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
+dependencies = [
+ "anyhow",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rustfix"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0be05fc0675ef4f47119dc39cfc46636bb77d4fc4ef1bd851b9c3f7697f32a"
 dependencies = [
  "anyhow",
  "log",


### PR DESCRIPTION
11 commits in aa8b09297bb3156b849e73db48af4cd050492fe6..44456677b5d1d82fe981c955dc5c67734b31f340
2021-06-09 00:28:53 +0000 to 2021-06-12 18:00:01 +0000
- Fix package_default_run test. (rust-lang/cargo#9577)
- Change how the fix_deny_warnings_but_not_others test works (rust-lang/cargo#9571)
- Add mising documentation regarding `cargo doc` (rust-lang/cargo#9565)
- Implement warning for ignored trailing arguments (rust-lang/cargo#9561)
- Make clippy happy (rust-lang/cargo#9569)
- Fix rustc/rustdoc config values to be config-relative. (rust-lang/cargo#9566)
- Update rustfix. (rust-lang/cargo#9567)
- Warn if an "all" target is specified, but we don't match anything (rust-lang/cargo#9549)
- add default_run to SerializedPackage (rust-lang/cargo#9550)
- respect user choice of lib/bin over heuristics (rust-lang/cargo#9522)
- Add a mean to mutably access the members of a workspace (rust-lang/cargo#9547)