### PR TITLE
Rustfix update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "libc",
  "miow 0.3.6",
  "regex",
- "rustfix 0.5.1",
+ "rustfix 0.6.0",
  "serde",
  "serde_json",
  "tracing",

--- a/src/test/ui/parser/expr-as-stmt.fixed
+++ b/src/test/ui/parser/expr-as-stmt.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// rustfix-only-machine-applicable
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(unused_must_use)]

--- a/src/test/ui/parser/expr-as-stmt.rs
+++ b/src/test/ui/parser/expr-as-stmt.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// rustfix-only-machine-applicable
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(unused_must_use)]

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -1,5 +1,5 @@
 error: expected expression, found `+`
-  --> $DIR/expr-as-stmt.rs:7:9
+  --> $DIR/expr-as-stmt.rs:8:9
    |
 LL |     {2} + {2}
    |     --- ^ expected expression
@@ -7,7 +7,7 @@ LL |     {2} + {2}
    |     help: parentheses are required to parse this as an expression: `({2})`
 
 error: expected expression, found `+`
-  --> $DIR/expr-as-stmt.rs:12:9
+  --> $DIR/expr-as-stmt.rs:13:9
    |
 LL |     {2} + 2
    |     --- ^ expected expression
@@ -15,7 +15,7 @@ LL |     {2} + 2
    |     help: parentheses are required to parse this as an expression: `({2})`
 
 error: expected expression, found `+`
-  --> $DIR/expr-as-stmt.rs:18:12
+  --> $DIR/expr-as-stmt.rs:19:12
    |
 LL |     { 42 } + foo;
    |     ------ ^ expected expression
@@ -23,7 +23,7 @@ LL |     { 42 } + foo;
    |     help: parentheses are required to parse this as an expression: `({ 42 })`
 
 error: expected expression, found `>`
-  --> $DIR/expr-as-stmt.rs:31:7
+  --> $DIR/expr-as-stmt.rs:32:7
    |
 LL |     } > 0
    |       ^ expected expression
@@ -36,7 +36,7 @@ LL |     }) > 0
    |
 
 error[E0308]: mismatched types
-  --> $DIR/expr-as-stmt.rs:7:6
+  --> $DIR/expr-as-stmt.rs:8:6
    |
 LL |     {2} + {2}
    |      ^ expected `()`, found integer
@@ -47,7 +47,7 @@ LL |     {return 2;} + {2}
    |      ^^^^^^  ^
 
 error[E0308]: mismatched types
-  --> $DIR/expr-as-stmt.rs:12:6
+  --> $DIR/expr-as-stmt.rs:13:6
    |
 LL |     {2} + 2
    |      ^ expected `()`, found integer
@@ -58,7 +58,7 @@ LL |     {return 2;} + 2
    |      ^^^^^^  ^
 
 error[E0308]: mismatched types
-  --> $DIR/expr-as-stmt.rs:18:7
+  --> $DIR/expr-as-stmt.rs:19:7
    |
 LL |     { 42 } + foo;
    |       ^^ expected `()`, found integer
@@ -69,7 +69,7 @@ LL |     { return 42; } + foo;
    |       ^^^^^^   ^
 
 error[E0308]: mismatched types
-  --> $DIR/expr-as-stmt.rs:24:7
+  --> $DIR/expr-as-stmt.rs:25:7
    |
 LL |     { 3 } * 3
    |       ^ expected `()`, found integer
@@ -80,7 +80,7 @@ LL |     { return 3; } * 3
    |       ^^^^^^  ^
 
 error[E0614]: type `{integer}` cannot be dereferenced
-  --> $DIR/expr-as-stmt.rs:24:11
+  --> $DIR/expr-as-stmt.rs:25:11
    |
 LL |     { 3 } * 3
    |     ----- ^^^

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = { version = "0.2", default-features = false, features = ["f
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustfix = "0.5.0"
+rustfix = "0.6.0"
 lazy_static = "1.0"
 walkdir = "2"
 glob = "0.3.0"

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3328,8 +3328,11 @@ impl<'test> TestCx<'test> {
                 },
             )
             .unwrap();
-            let fixed_code = apply_suggestions(&unfixed_code, &suggestions).unwrap_or_else(|_| {
-                panic!("failed to apply suggestions for {:?} with rustfix", self.testpaths.file)
+            let fixed_code = apply_suggestions(&unfixed_code, &suggestions).unwrap_or_else(|e| {
+                panic!(
+                    "failed to apply suggestions for {:?} with rustfix: {}",
+                    self.testpaths.file, e
+                )
             });
 
             errors += self.compare_output("fixed", &fixed_code, &expected_fixed);


### PR DESCRIPTION
This updates to rustfix 0.6.0. One of the key changes here is https://github.com/rust-lang/rustfix/pull/195 which changes rustfix to apply multi-part suggestions. One of the tests needs to updated because there are some overlapping suggestions which rustfix cannot handle. The solution is to only apply the machine-applicable suggestions to avoid the overlapping issue.

This also includes a minor change to compiletest to provide better error messages with rustfix.

