### PR TITLE
Stabilize `str::from_utf8_unchecked` as `const`

### DIFF
--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -156,7 +156,7 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_str_from_utf8_unchecked", issue = "75196")]
+#[rustc_const_stable(feature = "const_str_from_utf8_unchecked", since = "1.55.0")]
 #[rustc_allow_const_fn_unstable(const_fn_transmute)]
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
     // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.


### PR DESCRIPTION
This stabilizes `unsafe fn str::from_utf8_unchecked` as `const` pending FCP on #75196. By the time FCP finishes, the beta will have already been cut, so I've set 1.55 as the stable-since version.

(should also be +relnotes but I don't have the permission to do that)

r? @m-ou-se 

Closes #75196