### PR TITLE
Do not suggest to add type annotations for unnameable types

### DIFF
--- a/src/test/ui/suggestions/unnamable-types.rs
+++ b/src/test/ui/suggestions/unnamable-types.rs
@@ -13,21 +13,27 @@ static B: _ = "abc";
 //~| HELP: replace with the correct type
 
 
+// FIXME: this should also suggest a function pointer, as the closure is non-capturing
 const C: _ = || 42;
 //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
 //~| NOTE: not allowed in type signatures
 //~| NOTE: however, the inferred type
 
 struct S<T> { t: T }
-const D = S { t: || -> i32 { 42 } };
+const D = S { t: { let i = 0; move || -> i32 { i } } };
 //~^ ERROR: missing type for `const` item
 //~| NOTE: however, the inferred type
+
 
 fn foo() -> i32 { 42 }
-const E = S { t: foo };
+const E = foo;
 //~^ ERROR: missing type for `const` item
-//~| NOTE: however, the inferred type
+//~| HELP: provide a type for the item
+const F = S { t: foo };
+//~^ ERROR: missing type for `const` item
+//~| HELP: provide a type for the item
 
-const F = || -> i32 { yield 0; return 1; };
+
+const G = || -> i32 { yield 0; return 1; };
 //~^ ERROR: missing type for `const` item
 //~| NOTE: however, the inferred type

--- a/src/test/ui/suggestions/unnamable-types.rs
+++ b/src/test/ui/suggestions/unnamable-types.rs
@@ -1,0 +1,33 @@
+// Test that we do not suggest to add type annotations for unnamable types.
+
+#![crate_type="lib"]
+#![feature(generators)]
+
+const A = 5;
+//~^ ERROR: missing type for `const` item
+//~| HELP: provide a type for the item
+
+static B: _ = "abc";
+//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+//~| NOTE: not allowed in type signatures
+//~| HELP: replace with the correct type
+
+
+const C: _ = || 42;
+//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+//~| NOTE: not allowed in type signatures
+//~| NOTE: however, the inferred type
+
+struct S<T> { t: T }
+const D = S { t: || -> i32 { 42 } };
+//~^ ERROR: missing type for `const` item
+//~| NOTE: however, the inferred type
+
+fn foo() -> i32 { 42 }
+const E = S { t: foo };
+//~^ ERROR: missing type for `const` item
+//~| NOTE: however, the inferred type
+
+const F = || -> i32 { yield 0; return 1; };
+//~^ ERROR: missing type for `const` item
+//~| NOTE: however, the inferred type

--- a/src/test/ui/suggestions/unnamable-types.stderr
+++ b/src/test/ui/suggestions/unnamable-types.stderr
@@ -14,53 +14,53 @@ LL | static B: _ = "abc";
    |           help: replace with the correct type: `&str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/unnamable-types.rs:16:10
+  --> $DIR/unnamable-types.rs:17:10
    |
 LL | const C: _ = || 42;
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `[closure@$DIR/unnamable-types.rs:16:14: 16:19]` cannot be named
-  --> $DIR/unnamable-types.rs:16:14
+note: however, the inferred type `[closure@$DIR/unnamable-types.rs:17:14: 17:19]` cannot be named
+  --> $DIR/unnamable-types.rs:17:14
    |
 LL | const C: _ = || 42;
    |              ^^^^^
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:22:7
+  --> $DIR/unnamable-types.rs:23:7
    |
-LL | const D = S { t: || -> i32 { 42 } };
+LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
    |       ^
    |
-note: however, the inferred type `S<[closure@$DIR/unnamable-types.rs:22:18: 22:34]>` cannot be named
-  --> $DIR/unnamable-types.rs:22:11
+note: however, the inferred type `S<[closure@$DIR/unnamable-types.rs:23:31: 23:51]>` cannot be named
+  --> $DIR/unnamable-types.rs:23:11
    |
-LL | const D = S { t: || -> i32 { 42 } };
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:27:7
+  --> $DIR/unnamable-types.rs:29:7
    |
-LL | const E = S { t: foo };
-   |       ^
-   |
-note: however, the inferred type `S<fn() -> i32 {foo}>` cannot be named
-  --> $DIR/unnamable-types.rs:27:11
-   |
-LL | const E = S { t: foo };
-   |           ^^^^^^^^^^^^
+LL | const E = foo;
+   |       ^ help: provide a type for the item: `E: fn() -> i32`
 
 error: missing type for `const` item
-  --> $DIR/unnamable-types.rs:31:7
+  --> $DIR/unnamable-types.rs:32:7
    |
-LL | const F = || -> i32 { yield 0; return 1; };
+LL | const F = S { t: foo };
+   |       ^ help: provide a type for the item: `F: S<fn() -> i32>`
+
+error: missing type for `const` item
+  --> $DIR/unnamable-types.rs:37:7
+   |
+LL | const G = || -> i32 { yield 0; return 1; };
    |       ^
    |
-note: however, the inferred type `[generator@$DIR/unnamable-types.rs:31:11: 31:43 {i32, ()}]` cannot be named
-  --> $DIR/unnamable-types.rs:31:11
+note: however, the inferred type `[generator@$DIR/unnamable-types.rs:37:11: 37:43 {i32, ()}]` cannot be named
+  --> $DIR/unnamable-types.rs:37:11
    |
-LL | const F = || -> i32 { yield 0; return 1; };
+LL | const G = || -> i32 { yield 0; return 1; };
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/suggestions/unnamable-types.stderr
+++ b/src/test/ui/suggestions/unnamable-types.stderr
@@ -1,0 +1,66 @@
+error: missing type for `const` item
+  --> $DIR/unnamable-types.rs:6:7
+   |
+LL | const A = 5;
+   |       ^ help: provide a type for the item: `A: i32`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/unnamable-types.rs:10:11
+   |
+LL | static B: _ = "abc";
+   |           ^
+   |           |
+   |           not allowed in type signatures
+   |           help: replace with the correct type: `&str`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/unnamable-types.rs:16:10
+   |
+LL | const C: _ = || 42;
+   |          ^ not allowed in type signatures
+   |
+note: however, the inferred type `[closure@$DIR/unnamable-types.rs:16:14: 16:19]` cannot be named
+  --> $DIR/unnamable-types.rs:16:14
+   |
+LL | const C: _ = || 42;
+   |              ^^^^^
+
+error: missing type for `const` item
+  --> $DIR/unnamable-types.rs:22:7
+   |
+LL | const D = S { t: || -> i32 { 42 } };
+   |       ^
+   |
+note: however, the inferred type `S<[closure@$DIR/unnamable-types.rs:22:18: 22:34]>` cannot be named
+  --> $DIR/unnamable-types.rs:22:11
+   |
+LL | const D = S { t: || -> i32 { 42 } };
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing type for `const` item
+  --> $DIR/unnamable-types.rs:27:7
+   |
+LL | const E = S { t: foo };
+   |       ^
+   |
+note: however, the inferred type `S<fn() -> i32 {foo}>` cannot be named
+  --> $DIR/unnamable-types.rs:27:11
+   |
+LL | const E = S { t: foo };
+   |           ^^^^^^^^^^^^
+
+error: missing type for `const` item
+  --> $DIR/unnamable-types.rs:31:7
+   |
+LL | const F = || -> i32 { yield 0; return 1; };
+   |       ^
+   |
+note: however, the inferred type `[generator@$DIR/unnamable-types.rs:31:11: 31:43 {i32, ()}]` cannot be named
+  --> $DIR/unnamable-types.rs:31:11
+   |
+LL | const F = || -> i32 { yield 0; return 1; };
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Consider this example:
```rust
const A = || 42;

struct S<T> { t: T }
const B: _ = S { t: || 42 };
```
This currently produces the following output:
```
error: missing type for `const` item
 --> src/lib.rs:1:7
  |
1 | const A = || 42;
  |       ^ help: provide a type for the item: `A: [closure@src/lib.rs:1:11: 1:16]`

error[E0121]: the type placeholder `_` is not allowed within types on item signatures
 --> src/lib.rs:4:10
  |
4 | const B: _ = S { t: || 42 };
  |          ^
  |          |
  |          not allowed in type signatures
  |          help: replace `_` with the correct type: `S<[closure@src/lib.rs:4:21: 4:26]>`

error: aborting due to 2 previous errors
```
However, these suggestions are obviously useless, because the suggested types cannot be written down. With my changes, the suggestion is replaced with a note, because there is no simple fix:
```
error: missing type for `const` item
 --> test.rs:1:7
  |
1 | const A = || 42;
  |       ^
  |
note: however, the inferred type `[closure@test.rs:1:11: 1:16]` cannot be named
 --> test.rs:1:11
  |
1 | const A = || 42;
  |           ^^^^^

error[E0121]: the type placeholder `_` is not allowed within types on item signatures
 --> test.rs:4:10
  |
4 | const B: _ = S { t: || 42 };
  |          ^ not allowed in type signatures
  |
note: however, the inferred type `S<[closure@test.rs:4:21: 4:26]>` cannot be named
 --> test.rs:4:14
  |
4 | const B: _ = S { t: || 42 };
  |              ^^^^^^^^^^^^^^

error: aborting due to 2 previous errors
```