### PR TITLE
[beta] backport: Remove unsound TrustedRandomAccess implementations

### DIFF
--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess};
+use core::iter::{FusedIterator, TrustedLen};
 
 use super::VecDeque;
 
@@ -36,22 +36,6 @@ impl<T> Iterator for IntoIter<T> {
         let len = self.inner.len();
         (len, Some(len))
     }
-
-    #[inline]
-    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
-    where
-        Self: TrustedRandomAccess,
-    {
-        // Safety: The TrustedRandomAccess contract requires that callers only pass an index
-        // that is in bounds.
-        // Additionally Self: TrustedRandomAccess is only implemented for T: Copy which means even
-        // multiple repeated reads of the same index would be safe and the
-        // values are !Drop, thus won't suffer from double drops.
-        unsafe {
-            let idx = self.inner.wrap_add(self.inner.tail, idx);
-            self.inner.buffer_read(idx)
-        }
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -74,14 +58,3 @@ impl<T> FusedIterator for IntoIter<T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for IntoIter<T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-// T: Copy as approximation for !Drop since get_unchecked does not update the pointers
-// and thus we can't implement drop-handling
-unsafe impl<T> TrustedRandomAccess for IntoIter<T>
-where
-    T: Copy,
-{
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
-}

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     fmt,
-    iter::{self, ExactSizeIterator, FusedIterator, TrustedLen, TrustedRandomAccess},
+    iter::{self, ExactSizeIterator, FusedIterator, TrustedLen},
     mem::{self, MaybeUninit},
     ops::Range,
     ptr,
@@ -130,18 +130,6 @@ impl<T, const N: usize> Iterator for IntoIter<T, N> {
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
-
-    #[inline]
-    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
-    where
-        Self: TrustedRandomAccess,
-    {
-        // SAFETY: Callers are only allowed to pass an index that is in bounds
-        // Additionally Self: TrustedRandomAccess is only implemented for T: Copy which means even
-        // multiple repeated reads of the same index would be safe and the
-        // values aree !Drop, thus won't suffer from double drops.
-        unsafe { self.data.get_unchecked(self.alive.start + idx).assume_init_read() }
-    }
 }
 
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
@@ -195,17 +183,6 @@ impl<T, const N: usize> FusedIterator for IntoIter<T, N> {}
 // always decremented by 1 in those methods, but only if `Some(_)` is returned.
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 unsafe impl<T, const N: usize> TrustedLen for IntoIter<T, N> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-// T: Copy as approximation for !Drop since get_unchecked does not update the pointers
-// and thus we can't implement drop-handling
-unsafe impl<T, const N: usize> TrustedRandomAccess for IntoIter<T, N>
-where
-    T: Copy,
-{
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
-}
 
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T: Clone, const N: usize> Clone for IntoIter<T, N> {


### PR DESCRIPTION
Beta backport of #85874, but just for `vec_deque` and `array`, as discussed [in this meeting](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Badhoc.5D.202021-06-11.20unsound.20stdlib.20specialization.20and.201.2E53/near/242356073) ([archive](https://zulip-archive.rust-lang.org/238009tcompilermeetings/97862adhoc20210611unsoundstdlibspecializationand153.html#242356073), [hackmd](https://hackmd.io/IcaLDGBlStWYkn2qzWGxUg#Consensus)).