### PR TITLE
Add core to Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "src/bootstrap",
   "compiler/rustc",
   "library/std",
+  "library/core",
   "library/test",
   "src/rustdoc-json-types",
   "src/tools/cargotest",


### PR DESCRIPTION
This was breaking completion/IDE support for rust-analyzer in libcore (https://github.com/rust-analyzer/rust-analyzer/issues/9203). If this is an intentional omission, can we add a comment documenting the reasoning?