### PR TITLE
Report an error if resolution of closure call functions failed

### DIFF
--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -588,10 +588,17 @@ impl<'a, 'tcx> DeferredCallResolution<'tcx> {
                 fcx.write_method_call(self.call_expr.hir_id, method_callee);
             }
             None => {
-                span_bug!(
+                // This can happen if `#![no_core]` is used and the `fn/fn_mut/fn_once`
+                // lang items are not defined (issue #86238).
+                let mut err = fcx.inh.tcx.sess.struct_span_err(
                     self.call_expr.span,
-                    "failed to find an overloaded call trait for closure call"
+                    "failed to find an overloaded call trait for closure call",
                 );
+                err.help(
+                    "make sure the `fn`/`fn_mut`/`fn_once` lang items are defined \
+                     and have an associated `call`/`call_mut`/`call_once` function",
+                );
+                err.emit();
             }
         }
     }

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -596,7 +596,7 @@ impl<'a, 'tcx> DeferredCallResolution<'tcx> {
                 );
                 err.help(
                     "make sure the `fn`/`fn_mut`/`fn_once` lang items are defined \
-                     and have an associated `call`/`call_mut`/`call_once` function",
+                     and have associated `call`/`call_mut`/`call_once` functions",
                 );
                 err.emit();
             }

--- a/src/test/ui/lang-items/issue-86238.rs
+++ b/src/test/ui/lang-items/issue-86238.rs
@@ -1,0 +1,16 @@
+// Regression test for the ICE described in issue #86238.
+
+#![feature(lang_items)]
+#![feature(no_core)]
+
+#![no_core]
+fn main() {
+    let one = || {};
+    one()
+    //~^ ERROR: failed to find an overloaded call trait for closure call
+    //~| HELP: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined
+}
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}

--- a/src/test/ui/lang-items/issue-86238.stderr
+++ b/src/test/ui/lang-items/issue-86238.stderr
@@ -1,0 +1,10 @@
+error: failed to find an overloaded call trait for closure call
+  --> $DIR/issue-86238.rs:9:5
+   |
+LL |     one()
+   |     ^^^^^
+   |
+   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have an associated `call`/`call_mut`/`call_once` function
+
+error: aborting due to previous error
+

--- a/src/test/ui/lang-items/issue-86238.stderr
+++ b/src/test/ui/lang-items/issue-86238.stderr
@@ -4,7 +4,7 @@ error: failed to find an overloaded call trait for closure call
 LL |     one()
    |     ^^^^^
    |
-   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have an associated `call`/`call_mut`/`call_once` function
+   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have associated `call`/`call_mut`/`call_once` functions
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This pull request fixes #86238. The current implementation seems to assume that resolution of closure call functions (I'm not sure what the proper term is; I mean `call` of `Fn` etc.) can never fail:
https://github.com/rust-lang/rust/blob/60f1a2fc4b535ead9c85ce085fdce49b1b097531/compiler/rustc_typeck/src/check/callee.rs#L590-L595

But actually, it can, if the `fn`/`fn_mut`/`fn_once` lang items are not defined, or don't have an associated `call`/`call_mut`/`call_once` function, leading to the ICE described in #86238. I have therefore turned the `span_bug!()` into an error message, which prevents the ICE.