### PR TITLE
Open trait implementations' toggles by default.

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -488,7 +488,7 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
             .into(),
         ("auto-hide-large-items", "Auto-hide item contents for large items.", true).into(),
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
-        ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", true)
+        ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", false)
             .into(),
         ("auto-collapse-implementors", "Auto-hide implementors of a trait", true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result", false)
@@ -1543,15 +1543,10 @@ fn render_impl(
         }
     }
     if render_mode == RenderMode::Normal {
-        let is_implementing_trait = i.inner_impl().trait_.is_some();
         let toggled = !impl_items.is_empty() || !default_impl_items.is_empty();
         if toggled {
             close_tags.insert_str(0, "</details>");
-            if is_implementing_trait {
-                write!(w, "<details class=\"rustdoc-toggle implementors-toggle\">");
-            } else {
-                write!(w, "<details class=\"rustdoc-toggle implementors-toggle\" open>");
-            }
+            write!(w, "<details class=\"rustdoc-toggle implementors-toggle\" open>");
         }
         if toggled {
             write!(w, "<summary>")

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -779,25 +779,25 @@ function hideThemeButtonState() {
 
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
         var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
-        var hideImplementations = getSettingValue("auto-hide-trait-implementations") !== "false";
+        var hideImplementations = getSettingValue("auto-hide-trait-implementations") === "true";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
-        function openImplementors(id) {
+        function setImplementorsTogglesOpen(id, open) {
             var list = document.getElementById(id);
             if (list !== null) {
                 onEachLazy(list.getElementsByClassName("implementors-toggle"), function(e) {
-                    e.open = true;
+                    e.open = open;
                 });
             }
         }
 
-        if (!hideImplementations) {
-            openImplementors("trait-implementations-list");
-            openImplementors("blanket-implementations-list");
+        if (hideImplementations) {
+            setImplementorsTogglesOpen("trait-implementations-list", false);
+            setImplementorsTogglesOpen("blanket-implementations-list", false);
         }
 
         if (!hideImplementors) {
-            openImplementors("implementors-list");
+            setImplementorsTogglesOpen("implementors-list", true);
         }
 
         onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {

--- a/src/test/rustdoc-gui/toggled-open-implementations.goml
+++ b/src/test/rustdoc-gui/toggled-open-implementations.goml
@@ -1,0 +1,5 @@
+// This tests that the "implementations" section on struct/enum pages
+// has all the implementations toggled open by default, so users can
+// find method names in those implementations with Ctrl-F.
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+assert: (".rustdoc-toggle.implementors-toggle", "open", "")


### PR DESCRIPTION
This makes it possible to use Ctrl-F to find methods defined in traits.

As discussed in #85923. This modifies the approach suggested in #40363, but still achieves the goal of skimmability. For new users who aren't familiar with all the traits, their methods are readily visible and searchable. For experienced users who prefer to skim the list of all traits, there are two options: the "collapse all" shortcut, and the "auto hide trait implementations" setting.

Demo https://hoffman-andrews.com/rust/expand-methods/std/string/struct.String.html#trait-implementations

r? @GuillaumeGomez 