### PR TITLE
Trait upcasting coercion (part1)

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -683,6 +683,10 @@ declare_features! (
     /// Allows the `?` operator in const contexts.
     (active, const_try, "1.56.0", Some(74935), None),
 
+    /// Allows upcasting trait objects via supertraits.
+    /// Trait upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
+    (active, trait_upcasting, "1.56.0", Some(65991), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -685,7 +685,7 @@ declare_features! (
 
     /// Allows upcasting trait objects via supertraits.
     /// Trait upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
-    (active, trait_upcasting, "1.56.0", Some(65991), None),
+    (incomplete, trait_upcasting, "1.56.0", Some(65991), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1270,6 +1270,7 @@ symbols! {
         trace_macros,
         track_caller,
         trait_alias,
+        trait_upcasting,
         transmute,
         transparent,
         transparent_enums,

--- a/src/test/ui/feature-gates/feature-gate-trait_upcasting.rs
+++ b/src/test/ui/feature-gates/feature-gate-trait_upcasting.rs
@@ -1,0 +1,13 @@
+trait Foo {}
+
+trait Bar: Foo {}
+
+impl Foo for () {}
+
+impl Bar for () {}
+
+fn main() {
+    let bar: &dyn Bar = &();
+    let foo: &dyn Foo = bar;
+    //~^ ERROR trait upcasting is experimental [E0658]
+}

--- a/src/test/ui/feature-gates/feature-gate-trait_upcasting.rs
+++ b/src/test/ui/feature-gates/feature-gate-trait_upcasting.rs
@@ -9,5 +9,5 @@ impl Bar for () {}
 fn main() {
     let bar: &dyn Bar = &();
     let foo: &dyn Foo = bar;
-    //~^ ERROR trait upcasting is experimental [E0658]
+    //~^ ERROR trait upcasting coercion is experimental [E0658]
 }

--- a/src/test/ui/feature-gates/feature-gate-trait_upcasting.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trait_upcasting.stderr
@@ -1,8 +1,8 @@
 error[E0658]: trait upcasting is experimental
-  --> $DIR/issue-11515.rs:9:33
+  --> $DIR/feature-gate-trait_upcasting.rs:11:25
    |
-LL |     let test = box Test { func: closure };
-   |                                 ^^^^^^^
+LL |     let foo: &dyn Foo = bar;
+   |                         ^^^
    |
    = note: see issue #65991 <https://github.com/rust-lang/rust/issues/65991> for more information
    = help: add `#![feature(trait_upcasting)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-trait_upcasting.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trait_upcasting.stderr
@@ -1,4 +1,4 @@
-error[E0658]: trait upcasting is experimental
+error[E0658]: trait upcasting coercion is experimental
   --> $DIR/feature-gate-trait_upcasting.rs:11:25
    |
 LL |     let foo: &dyn Foo = bar;

--- a/src/test/ui/issues/issue-11515.rs
+++ b/src/test/ui/issues/issue-11515.rs
@@ -6,5 +6,5 @@ struct Test {
 
 fn main() {
     let closure: Box<dyn Fn() + 'static> = Box::new(|| ());
-    let test = box Test { func: closure }; //~ ERROR mismatched types
+    let test = box Test { func: closure }; //~ ERROR trait upcasting is experimental [E0658]
 }

--- a/src/test/ui/issues/issue-11515.rs
+++ b/src/test/ui/issues/issue-11515.rs
@@ -1,10 +1,10 @@
 #![feature(box_syntax)]
 
 struct Test {
-    func: Box<dyn FnMut() + 'static>
+    func: Box<dyn FnMut() + 'static>,
 }
 
 fn main() {
     let closure: Box<dyn Fn() + 'static> = Box::new(|| ());
-    let test = box Test { func: closure }; //~ ERROR trait upcasting is experimental [E0658]
+    let test = box Test { func: closure }; //~ ERROR trait upcasting coercion is experimental [E0658]
 }

--- a/src/test/ui/issues/issue-11515.stderr
+++ b/src/test/ui/issues/issue-11515.stderr
@@ -1,4 +1,4 @@
-error[E0658]: trait upcasting is experimental
+error[E0658]: trait upcasting coercion is experimental
   --> $DIR/issue-11515.rs:9:33
    |
 LL |     let test = box Test { func: closure };

--- a/src/test/ui/traits/trait-upcasting/issue-11515-upcast-fn_mut-fn.rs
+++ b/src/test/ui/traits/trait-upcasting/issue-11515-upcast-fn_mut-fn.rs
@@ -1,0 +1,13 @@
+// run-pass
+#![feature(box_syntax, trait_upcasting)]
+#![allow(incomplete_features)]
+
+struct Test {
+    func: Box<dyn FnMut() + 'static>,
+}
+
+fn main() {
+    let closure: Box<dyn Fn() + 'static> = Box::new(|| ());
+    let mut test = box Test { func: closure };
+    (test.func)();
+}

--- a/src/test/ui/traits/trait-upcasting/multiple-occurence-ambiguousity.rs
+++ b/src/test/ui/traits/trait-upcasting/multiple-occurence-ambiguousity.rs
@@ -1,0 +1,22 @@
+// check-fail
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Bar<T> {
+    fn bar(&self, _: T) {}
+}
+
+trait Foo : Bar<i32> + Bar<u32> {
+    fn foo(&self, _: ()) {}
+}
+
+struct S;
+
+impl Bar<i32> for S {}
+impl Bar<u32> for S {}
+impl Foo for S {}
+
+fn main() {
+    let s: &dyn Foo = &S;
+    let t: &dyn Bar<_> = s; //~ ERROR mismatched types
+}

--- a/src/test/ui/traits/trait-upcasting/multiple-occurence-ambiguousity.stderr
+++ b/src/test/ui/traits/trait-upcasting/multiple-occurence-ambiguousity.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/multiple-occurence-ambiguousity.rs:21:26
+   |
+LL |     let t: &dyn Bar<_> = s;
+   |            -----------   ^ expected trait `Bar`, found trait `Foo`
+   |            |
+   |            expected due to this
+   |
+   = note: expected reference `&dyn Bar<_>`
+              found reference `&dyn Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-1.rs
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-1.rs
@@ -1,0 +1,33 @@
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Foo: Bar<i32> + Bar<u32> {}
+trait Bar<T> {
+    fn bar(&self) -> Option<T> {
+        None
+    }
+}
+
+fn test_specific(x: &dyn Foo) {
+    let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+                                //~^ ERROR non-primitive cast
+                                //~^^ ERROR the trait bound `&dyn Foo: Bar<i32>` is not satisfied
+    let _ = x as &dyn Bar<u32>; // FIXME: OK, eventually
+                                //~^ ERROR non-primitive cast
+                                //~^^ ERROR the trait bound `&dyn Foo: Bar<u32>` is not satisfied
+}
+
+fn test_unknown_version(x: &dyn Foo) {
+    let _ = x as &dyn Bar<_>; // Ambiguous
+                              //~^ ERROR non-primitive cast
+                              //~^^ ERROR the trait bound `&dyn Foo: Bar<_>` is not satisfied
+}
+
+fn test_infer_version(x: &dyn Foo) {
+    let a = x as &dyn Bar<_>; // FIXME: OK, eventually
+                              //~^ ERROR non-primitive cast
+                              //~^^ ERROR the trait bound `&dyn Foo: Bar<u32>` is not satisfied
+    let _: Option<u32> = a.bar();
+}
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-1.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-1.stderr
@@ -1,0 +1,80 @@
+error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<i32>`
+  --> $DIR/type-checking-test-1.rs:12:13
+   |
+LL |     let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^^^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let _ = &x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^
+
+error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<u32>`
+  --> $DIR/type-checking-test-1.rs:15:13
+   |
+LL |     let _ = x as &dyn Bar<u32>; // FIXME: OK, eventually
+   |             ^^^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let _ = &x as &dyn Bar<u32>; // FIXME: OK, eventually
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo: Bar<i32>` is not satisfied
+  --> $DIR/type-checking-test-1.rs:12:13
+   |
+LL |     let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^ the trait `Bar<i32>` is not implemented for `&dyn Foo`
+   |
+   = note: required for the cast to the object type `dyn Bar<i32>`
+
+error[E0277]: the trait bound `&dyn Foo: Bar<u32>` is not satisfied
+  --> $DIR/type-checking-test-1.rs:15:13
+   |
+LL |     let _ = x as &dyn Bar<u32>; // FIXME: OK, eventually
+   |             ^ the trait `Bar<u32>` is not implemented for `&dyn Foo`
+   |
+   = note: required for the cast to the object type `dyn Bar<u32>`
+
+error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<_>`
+  --> $DIR/type-checking-test-1.rs:21:13
+   |
+LL |     let _ = x as &dyn Bar<_>; // Ambiguous
+   |             ^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let _ = &x as &dyn Bar<_>; // Ambiguous
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo: Bar<_>` is not satisfied
+  --> $DIR/type-checking-test-1.rs:21:13
+   |
+LL |     let _ = x as &dyn Bar<_>; // Ambiguous
+   |             ^ the trait `Bar<_>` is not implemented for `&dyn Foo`
+   |
+   = note: required for the cast to the object type `dyn Bar<_>`
+
+error[E0605]: non-primitive cast: `&dyn Foo` as `&dyn Bar<u32>`
+  --> $DIR/type-checking-test-1.rs:27:13
+   |
+LL |     let a = x as &dyn Bar<_>; // FIXME: OK, eventually
+   |             ^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let a = &x as &dyn Bar<_>; // FIXME: OK, eventually
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo: Bar<u32>` is not satisfied
+  --> $DIR/type-checking-test-1.rs:27:13
+   |
+LL |     let a = x as &dyn Bar<_>; // FIXME: OK, eventually
+   |             ^ the trait `Bar<u32>` is not implemented for `&dyn Foo`
+   |
+   = note: required for the cast to the object type `dyn Bar<u32>`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0277, E0605.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-2.rs
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-2.rs
@@ -1,0 +1,34 @@
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Foo<T>: Bar<i32> + Bar<T> {}
+trait Bar<T> {
+    fn bar(&self) -> Option<T> {
+        None
+    }
+}
+
+fn test_specific(x: &dyn Foo<i32>) {
+    let _ = x as &dyn Bar<i32>; // OK
+}
+
+fn test_specific2(x: &dyn Foo<u32>) {
+    let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+                                //~^ ERROR non-primitive cast
+                                //~^^ ERROR the trait bound `&dyn Foo<u32>: Bar<i32>` is not satisfied
+}
+
+fn test_specific3(x: &dyn Foo<i32>) {
+    let _ = x as &dyn Bar<u32>; // Error
+                                //~^ ERROR non-primitive cast
+                                //~^^ ERROR the trait bound `&dyn Foo<i32>: Bar<u32>` is not satisfied
+}
+
+fn test_infer_arg(x: &dyn Foo<u32>) {
+    let a = x as &dyn Bar<_>; // Ambiguous
+                              //~^ ERROR non-primitive cast
+                              //~^^ ERROR the trait bound `&dyn Foo<u32>: Bar<_>` is not satisfied
+    let _ = a.bar();
+}
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-2.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-2.stderr
@@ -1,0 +1,61 @@
+error[E0605]: non-primitive cast: `&dyn Foo<u32>` as `&dyn Bar<i32>`
+  --> $DIR/type-checking-test-2.rs:16:13
+   |
+LL |     let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^^^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let _ = &x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo<u32>: Bar<i32>` is not satisfied
+  --> $DIR/type-checking-test-2.rs:16:13
+   |
+LL |     let _ = x as &dyn Bar<i32>; // FIXME: OK, eventually
+   |             ^ the trait `Bar<i32>` is not implemented for `&dyn Foo<u32>`
+   |
+   = note: required for the cast to the object type `dyn Bar<i32>`
+
+error[E0605]: non-primitive cast: `&dyn Foo<i32>` as `&dyn Bar<u32>`
+  --> $DIR/type-checking-test-2.rs:22:13
+   |
+LL |     let _ = x as &dyn Bar<u32>; // Error
+   |             ^^^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let _ = &x as &dyn Bar<u32>; // Error
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo<i32>: Bar<u32>` is not satisfied
+  --> $DIR/type-checking-test-2.rs:22:13
+   |
+LL |     let _ = x as &dyn Bar<u32>; // Error
+   |             ^ the trait `Bar<u32>` is not implemented for `&dyn Foo<i32>`
+   |
+   = note: required for the cast to the object type `dyn Bar<u32>`
+
+error[E0605]: non-primitive cast: `&dyn Foo<u32>` as `&dyn Bar<_>`
+  --> $DIR/type-checking-test-2.rs:28:13
+   |
+LL |     let a = x as &dyn Bar<_>; // Ambiguous
+   |             ^^^^^^^^^^^^^^^^ invalid cast
+   |
+help: consider borrowing the value
+   |
+LL |     let a = &x as &dyn Bar<_>; // Ambiguous
+   |             ^
+
+error[E0277]: the trait bound `&dyn Foo<u32>: Bar<_>` is not satisfied
+  --> $DIR/type-checking-test-2.rs:28:13
+   |
+LL |     let a = x as &dyn Bar<_>; // Ambiguous
+   |             ^ the trait `Bar<_>` is not implemented for `&dyn Foo<u32>`
+   |
+   = note: required for the cast to the object type `dyn Bar<_>`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0605.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-3.rs
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-3.rs
@@ -1,0 +1,22 @@
+// ignore-compare-mode-nll
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Foo<'a>: Bar<'a> {}
+trait Bar<'a> {}
+
+fn test_correct(x: &dyn Foo<'static>) {
+    let _ = x as &dyn Bar<'static>;
+}
+
+fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+    let _ = x as &dyn Bar<'a>; // Error
+                               //~^ ERROR mismatched types
+}
+
+fn test_wrong2<'a>(x: &dyn Foo<'a>) {
+    let _ = x as &dyn Bar<'static>; // Error
+                                    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-3.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-3.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/type-checking-test-3.rs:13:13
+   |
+LL |     let _ = x as &dyn Bar<'a>; // Error
+   |             ^ lifetime mismatch
+   |
+   = note: expected trait object `dyn Bar<'a>`
+              found trait object `dyn Bar<'static>`
+note: the lifetime `'a` as defined on the function body at 12:16...
+  --> $DIR/type-checking-test-3.rs:12:16
+   |
+LL | fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+   |                ^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/type-checking-test-3.rs:18:13
+   |
+LL |     let _ = x as &dyn Bar<'static>; // Error
+   |             ^ lifetime mismatch
+   |
+   = note: expected trait object `dyn Bar<'static>`
+              found trait object `dyn Bar<'a>`
+note: the lifetime `'a` as defined on the function body at 17:16...
+  --> $DIR/type-checking-test-3.rs:17:16
+   |
+LL | fn test_wrong2<'a>(x: &dyn Foo<'a>) {
+   |                ^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-4.rs
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-4.rs
@@ -1,0 +1,32 @@
+// ignore-compare-mode-nll
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait Foo<'a>: Bar<'a, 'a> {}
+trait Bar<'a, 'b> {
+    fn get_b(&self) -> Option<&'a u32> {
+        None
+    }
+}
+
+fn test_correct(x: &dyn Foo<'static>) {
+    let _ = x as &dyn Bar<'static, 'static>;
+}
+
+fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+    let _ = x as &dyn Bar<'static, 'a>; // Error
+                                        //~^ ERROR mismatched types
+}
+
+fn test_wrong2<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+    let _ = x as &dyn Bar<'a, 'static>; // Error
+                                        //~^ ERROR mismatched types
+}
+
+fn test_wrong3<'a>(x: &dyn Foo<'a>) -> Option<&'static u32> {
+    let y = x as &dyn Bar<'_, '_>;
+    //~^ ERROR `x` has lifetime `'a` but it needs to satisfy a `'static` lifetime requirement
+    y.get_b() // ERROR
+}
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-4.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-4.stderr
@@ -1,0 +1,47 @@
+error[E0308]: mismatched types
+  --> $DIR/type-checking-test-4.rs:17:13
+   |
+LL |     let _ = x as &dyn Bar<'static, 'a>; // Error
+   |             ^ lifetime mismatch
+   |
+   = note: expected trait object `dyn Bar<'static, 'a>`
+              found trait object `dyn Bar<'static, 'static>`
+note: the lifetime `'a` as defined on the function body at 16:16...
+  --> $DIR/type-checking-test-4.rs:16:16
+   |
+LL | fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+   |                ^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/type-checking-test-4.rs:22:13
+   |
+LL |     let _ = x as &dyn Bar<'a, 'static>; // Error
+   |             ^ lifetime mismatch
+   |
+   = note: expected trait object `dyn Bar<'a, 'static>`
+              found trait object `dyn Bar<'static, 'static>`
+note: the lifetime `'a` as defined on the function body at 21:16...
+  --> $DIR/type-checking-test-4.rs:21:16
+   |
+LL | fn test_wrong2<'a>(x: &dyn Foo<'static>, y: &'a u32) {
+   |                ^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0759]: `x` has lifetime `'a` but it needs to satisfy a `'static` lifetime requirement
+  --> $DIR/type-checking-test-4.rs:27:27
+   |
+LL | fn test_wrong3<'a>(x: &dyn Foo<'a>) -> Option<&'static u32> {
+   |                       ------------ this data with lifetime `'a`...
+LL |     let y = x as &dyn Bar<'_, '_>;
+   |             -             ^^
+   |             |
+   |             ...is captured here...
+LL |
+LL |     y.get_b() // ERROR
+   |     --------- ...and is required to live as long as `'static` here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0759.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
This revives the first part of earlier PR #60900 .

It's not very clear to me which parts of that pr was design decisions, so i decide to cut it into pieces and land them incrementally. This allows more eyes on the details.

This is the first part, it adds feature gates, adds feature gates tests, and implemented the unsize conversion part.
(I hope i have dealt with the `ExistentialTraitRef` values correctly...)

The next part will be implementing the pointer casting.