### PR TITLE
Fix font weight

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -71,7 +71,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.2.12 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.2.14 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -137,9 +137,9 @@ h1.fqn > .in-band > a:hover {
 h2, h3, h4 {
 	border-bottom: 1px solid;
 }
-.impl, .method,
-.type:not(.container-rustdoc), .associatedconstant,
-.associatedtype {
+.impl, .impl-items .method,
+.impl-items .type, .impl-items .associatedconstant,
+.impl-items .associatedtype {
 	flex-basis: 100%;
 	font-weight: 600;
 	margin-top: 16px;

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -1,0 +1,7 @@
+goto: file://|DOC_PATH|/lib2/struct.Foo.html
+// This test checks that the font weight is correctly applied.
+assert: ("//*[@class='docblock type-decl']//a[text()='Alias']", {"font-weight": "400"})
+assert: ("//*[@class='structfield small-section-header']//a[text()='Alias']", {"font-weight": "400"})
+assert: ("#method\.a_method > code", {"font-weight": "600"})
+assert: ("#associatedtype\.X > code", {"font-weight": "600"})
+assert: ("#associatedconstant\.Y > code", {"font-weight": "600"})

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -31,7 +31,10 @@ assert: (".sidebar > .location", "Crate lib2")
 assert: (".sidebar-elems > .crate > ul > li > a.current", "lib2")
 // We now go to the "foobar" function page.
 assert: (".sidebar-elems > .items > ul > li:nth-child(1)", "Modules")
-assert: (".sidebar-elems > .items > ul > li:nth-child(2)", "Functions")
+assert: (".sidebar-elems > .items > ul > li:nth-child(2)", "Structs")
+assert: (".sidebar-elems > .items > ul > li:nth-child(3)", "Traits")
+assert: (".sidebar-elems > .items > ul > li:nth-child(4)", "Functions")
+assert: (".sidebar-elems > .items > ul > li:nth-child(5)", "Type Definitions")
 assert:	("#functions + table td > a", "foobar")
 click: "#functions + table td > a"
 

--- a/src/test/rustdoc-gui/src/lib2.rs
+++ b/src/test/rustdoc-gui/src/lib2.rs
@@ -9,3 +9,23 @@ pub mod module {
 }
 
 pub fn foobar() {}
+
+pub type Alias = u32;
+
+pub struct Foo {
+    pub x: Alias,
+}
+
+impl Foo {
+    pub fn a_method(&self) {}
+}
+
+pub trait Trait {
+    type X;
+    const Y: u32;
+}
+
+impl Trait for Foo {
+    type X = u32;
+    const Y: u32 = 0;
+}


### PR DESCRIPTION
Fixes #86256.

I realized that the only cases where we actually needed to have bold text was inside `impl-items`.

cc @camelid 
r? @jsha