### PR TITLE
Fixed typo

### DIFF
--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -378,7 +378,7 @@ mod prim_char {}
 ///     returns_i64()
 /// };
 /// let is_unit = {
-///     returns_i64();
+///     returns_unit();
 /// };
 /// ```
 ///


### PR DESCRIPTION
Changed the function call from "returns_i64()" to "returns_unit()"