### PR TITLE
Allow limited transmuting between types involving type parameters

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2012,6 +2012,18 @@ impl<'tcx> SizeSkeleton<'tcx> {
                 }
             }
 
+            ty::Param(param_ty) => {
+                let param_ty = param_ty.to_ty(tcx);
+                if param_ty.is_sized(tcx.at(DUMMY_SP), param_env) {
+                    Ok(SizeSkeleton::UnresolvedConstant {
+                        related_ty: param_ty,
+                        multiple: ty::Const::from_usize(tcx, 1),
+                    })
+                } else {
+                    Err(err)
+                }
+            }
+
             _ => Err(err),
         }
     }

--- a/compiler/rustc_passes/src/intrinsicck.rs
+++ b/compiler/rustc_passes/src/intrinsicck.rs
@@ -97,7 +97,7 @@ impl ExprVisitor<'tcx> {
         let skeleton_string = |ty: Ty<'tcx>, sk| match sk {
             Ok(SizeSkeleton::Known(size)) => format!("{} bits", size.bits()),
             Ok(SizeSkeleton::Pointer { tail, .. }) => format!("pointer to `{}`", tail),
-            Ok(SizeSkeleton::UnresolvedConstant { related_ty, multiple: _ }) => {
+            Ok(SizeSkeleton::RepeatedTy { ty: related_ty, repetitions: _ }) => {
                 format!("size can vary because of {}", related_ty)
             }
             Err(LayoutError::Unknown(bad)) => {

--- a/compiler/rustc_passes/src/intrinsicck.rs
+++ b/compiler/rustc_passes/src/intrinsicck.rs
@@ -97,6 +97,9 @@ impl ExprVisitor<'tcx> {
         let skeleton_string = |ty: Ty<'tcx>, sk| match sk {
             Ok(SizeSkeleton::Known(size)) => format!("{} bits", size.bits()),
             Ok(SizeSkeleton::Pointer { tail, .. }) => format!("pointer to `{}`", tail),
+            Ok(SizeSkeleton::UnresolvedConstant { related_ty, multiple: _ }) => {
+                format!("size can vary because of {}", related_ty)
+            }
             Err(LayoutError::Unknown(bad)) => {
                 if bad == ty {
                     "this type does not have a fixed size".to_owned()

--- a/src/test/ui/transmute/transmute-related-type-parameters-with-arrays.rs
+++ b/src/test/ui/transmute/transmute-related-type-parameters-with-arrays.rs
@@ -1,4 +1,4 @@
-// Tests that `transmute` can be called in simple cases on types using type parameters.
+// Tests that `transmute` can be called in simple cases on types using type parameters with arrays.
 
 // run-pass
 

--- a/src/test/ui/transmute/transmute-related-type-parameters-with-arrays.rs
+++ b/src/test/ui/transmute/transmute-related-type-parameters-with-arrays.rs
@@ -1,0 +1,51 @@
+// Tests that `transmute` can be called in simple cases on types using type parameters.
+
+// run-pass
+
+use std::mem::transmute;
+
+#[repr(transparent)]
+struct Wrapper<T>([T; 10]);
+
+#[repr(transparent)]
+struct OtherWrapper<T>([T; 10]);
+
+#[repr(transparent)]
+struct ArbitrarySizedWrapper<T, const N: usize>([T; N]);
+
+fn wrap<T>(unwrapped: [T; 10]) -> Wrapper<T> {
+    unsafe {
+        transmute(unwrapped)
+    }
+}
+
+fn rewrap<T>(wrapped: Wrapper<T>) -> OtherWrapper<T> {
+    unsafe {
+        transmute(wrapped)
+    }
+}
+
+fn unwrap<T>(wrapped: OtherWrapper<T>) -> [T; 10] {
+    unsafe {
+        transmute(wrapped)
+    }
+}
+
+fn wrap_arbitrary_size<T, const N: usize>(arr: [T; N]) -> ArbitrarySizedWrapper<T, N> {
+    unsafe { transmute(arr) }
+}
+
+fn main() {
+    let unwrapped = [5_u64; 10];
+    let wrapped = wrap(unwrapped);
+    assert_eq!([5_u64; 10], wrapped.0);
+
+    let rewrapped = rewrap(wrapped);
+    assert_eq!([5_u64; 10], rewrapped.0);
+
+    let unwrapped = unwrap(rewrapped);
+    assert_eq!([5_u64; 10], unwrapped);
+
+    let arbitrary_sized_wrapper = wrap_arbitrary_size(unwrapped);
+    assert_eq!([5_u64; 10], arbitrary_sized_wrapper.0);
+}

--- a/src/test/ui/transmute/transmute-related-type-parameters.rs
+++ b/src/test/ui/transmute/transmute-related-type-parameters.rs
@@ -1,0 +1,29 @@
+// Tests that `transmute` can be called in simple cases on types using type parameters.
+
+// run-pass
+
+use std::mem::transmute;
+
+#[repr(transparent)]
+struct Wrapper<T>(T);
+
+fn wrap<T>(unwrapped: T) -> Wrapper<T> {
+    unsafe {
+        transmute(unwrapped)
+    }
+}
+
+fn unwrap<T>(wrapped: Wrapper<T>) -> T {
+    unsafe {
+        transmute(wrapped)
+    }
+}
+
+fn main() {
+    let unwrapped = 5_u64;
+    let wrapped = wrap(unwrapped);
+    assert_eq!(5_u64, wrapped.0);
+
+    let unwrapped = unwrap(wrapped);
+    assert_eq!(5_u64, unwrapped);
+}

--- a/src/test/ui/transmute/transmute-type-parameters.rs
+++ b/src/test/ui/transmute/transmute-type-parameters.rs
@@ -1,4 +1,4 @@
-// Tests that `transmute` cannot be called on type parameters.
+// Tests that `transmute` cannot be called on arbitrary type parameters.
 
 use std::mem::transmute;
 

--- a/src/test/ui/transmute/transmute-type-parameters.stderr
+++ b/src/test/ui/transmute/transmute-type-parameters.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let _: i32 = transmute(x);
    |                  ^^^^^^^^^
    |
-   = note: source type: `T` (this type does not have a fixed size)
+   = note: source type: `T` (size can vary because of T)
    = note: target type: `i32` (32 bits)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types


### PR DESCRIPTION
Before this change, functions could never perform transmutes between types which involve type parameters.

This opens up slightly less limited analysis whereby certain types involving `Sized` type parameters can be considered relative to each other, even if the exact size of that type parameter isn't yet known because monomorphization hasn't happened yet. Specifically it allows:
1. `repr(transparent)` types to be considered to have the same size as the `Sized` type they wrap.
2. Arrays of type parameters (or `repr(transaprent)` wrappers thereof) to be considered to have the same size as other arrays of the same type parameters (or `repr(transparent)` wrappers thereof), as long as their element count is the same.

It only supports very limited comparisons, but it opens up more safe and legal transmutes than were previously allowed.

In particular, it allows for transmutes like:
```rust
fn make_array<T, const N: usize>() -> [T; N] {
    let mut values: [MaybeUninit<T>; N] = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
    // [... Init values]
    std::mem::transmute(values)
}
```
which are currently not allowed because `[T; N]` isn't considered to have the same size as `[MaybeUninit<T>; N]`

Fixes #61956.