### PR TITLE
rustdoc: design change to separate methods better and improve scanning

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -918,10 +918,9 @@ fn render_assoc_item(
         w.reserve(header_len + "<a href=\"\" class=\"fnname\">{".len() + "</a>".len());
         write!(
             w,
-            "{}{}{}{}{}{}{}fn <a href=\"{href}\" class=\"fnname\">{name}</a>\
+            "{}{}{}{}{}{}<a href=\"{href}\" class=\"fnname\">{name}</a>\
              {generics}{decl}{notable_traits}{where_clause}",
             indent_str,
-            vis,
             constness,
             asyncness,
             unsafety,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -918,9 +918,10 @@ fn render_assoc_item(
         w.reserve(header_len + "<a href=\"\" class=\"fnname\">{".len() + "</a>".len());
         write!(
             w,
-            "{}{}{}{}{}{}<a href=\"{href}\" class=\"fnname\">{name}</a>\
+            "<span class=\"fnqualifiers\">{}{}{}{}{}{}{}fn</span> <a href=\"{href}\" class=\"fnname\">{name}</a>\
              {generics}{decl}{notable_traits}{where_clause}",
             indent_str,
+            vis,
             constness,
             asyncness,
             unsafety,

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -863,10 +863,10 @@ function hideThemeButtonState() {
     });
 
     onEachLazy(document.getElementsByTagName("summary"), function(el) {
-        el.addEventListener("click", function(ev) {
+        el.addEventListener("click", function() {
            addClass(el, "used");
         });
-    })
+    });
 
     onEachLazy(document.getElementsByTagName("a"), function(el) {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -862,6 +862,12 @@ function hideThemeButtonState() {
         displayHelp(true, ev);
     });
 
+    onEachLazy(document.getElementsByTagName("summary"), function(el) {
+        el.addEventListener("click", function(ev) {
+           addClass(el, "used");
+        });
+    })
+
     onEachLazy(document.getElementsByTagName("a"), function(el) {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're
         // jumping to *before* jumping there. We can't do this in onHashChange, because it changes

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -386,6 +386,7 @@ function hideThemeButtonState() {
         while (elem) {
             if (elem.tagName === "DETAILS") {
                 elem.open = true;
+                addClass(elem, "used");
             }
             elem = elem.parentNode;
         }
@@ -865,6 +866,7 @@ function hideThemeButtonState() {
     onEachLazy(document.getElementsByTagName("summary"), function(el) {
         el.addEventListener("click", function() {
            addClass(el, "used");
+           addClass(el.parentElement, "used");
         });
     });
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1487,8 +1487,18 @@ details.rustdoc-toggle[open] > summary.hideme > span {
 	display: none;
 }
 
-details.rustdoc-toggle[open] > summary::before {
+/* If a toggle has been used to open a section, we should make sure */
+/* there's a [-] so it can be closed again. But if a toggle is open */
+/* and has never been used, don't show it. This minimizes clutter on */
+/* the page while still supporting the "auto hide <X>" settings and */
+/* the expand/collapse all functionality. */
+details.rustdoc-toggle[open] > summary.used::before {
 	content: "[−]";
+	display: inline;
+}
+
+details.rustdoc-toggle[open] > summary::before {
+	content: "";
 	display: inline;
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -146,13 +146,6 @@ h2, h3, h4 {
 	margin-bottom: 10px;
 	position: relative;
 }
-.impl, .method.trait-impl,
-.type.trait-impl,
-.associatedconstant.trait-impl,
-.associatedtype.trait-impl {
-	padding-left: 15px;
-}
-
 div.impl-items > div {
 	padding-left: 0;
 }
@@ -581,18 +574,10 @@ nav.sub {
 .content .item-info {
 	position: relative;
 	margin-left: 24px; /* same as .docblock */
-	margin-top: -13px;
 }
 
 .sub-variant > div > .item-info {
 	margin-top: initial;
-}
-
-.content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant,
-.impl-items > .associatedtype, .content .impl-items details > summary > .type,
-.impl-items details > summary > .associatedconstant,
-.impl-items details > summary > .associatedtype {
-	margin-left: 20px;
 }
 
 .content .impl-items .docblock, .content .impl-items .item-info {
@@ -919,7 +904,6 @@ body.blur > :not(#help) {
 	display: flex;
 	flex-basis: 100%;
 	font-size: 16px;
-	margin-bottom: 12px;
 	/* Push the src link out to the right edge consistently */
 	justify-content: space-between;
 }
@@ -1450,16 +1434,20 @@ details.rustdoc-toggle > summary.hideme::before {
 	position: relative;
 }
 
+details.rustdoc-toggle[open].used > summary:not(.hideme)::before,
 details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
 	left: -23px;
 	top: 3px;
 }
 
-.impl-items > details.rustdoc-toggle > summary:not(.hideme)::before,
-.undocumented > details.rustdoc-toggle > summary:not(.hideme)::before {
-	position: absolute;
-	left: -2px;
+details.rustdoc-toggle[open] {
+	margin-left: 0px;
+}
+
+.impl-items .method {
+	padding: 2px 6px;
+	margin-bottom: 6px;
 }
 
 /* When a "hideme" summary is open and the "Expand description" or "Show
@@ -1473,6 +1461,7 @@ details.rustdoc-toggle[open] > summary.hideme {
 
 details.rustdoc-toggle, details.undocumented {
 	position: relative;
+	margin: 12px 0px;
 }
 
 details.rustdoc-toggle[open] > summary.hideme > span {
@@ -1484,7 +1473,7 @@ details.rustdoc-toggle[open] > summary.hideme > span {
 /* and has never been used, don't show it. This minimizes clutter on */
 /* the page while still supporting the "auto hide <X>" settings and */
 /* the expand/collapse all functionality. */
-details.rustdoc-toggle[open] > summary.used::before {
+details.rustdoc-toggle[open].used > summary::before {
 	content: "[−]";
 	display: inline;
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -580,20 +580,12 @@ nav.sub {
 
 .content .item-info {
 	position: relative;
-	margin-left: 33px;
+	margin-left: 24px; /* same as .docblock */
 	margin-top: -13px;
 }
 
 .sub-variant > div > .item-info {
 	margin-top: initial;
-}
-
-.content .item-info::before {
-	content: '⬑';
-	font-size: 25px;
-	position: absolute;
-	top: -6px;
-	left: -19px;
 }
 
 .content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant,

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -146,6 +146,12 @@ h2, h3, h4 {
 	margin-bottom: 10px;
 	position: relative;
 }
+
+.fnqualifiers {
+	font-weight: 400;
+	font-size: 0.8em; /* match with "where" clauses */
+}
+
 div.impl-items > div {
 	padding-left: 0;
 }
@@ -546,6 +552,7 @@ nav.sub {
 .content .where.fmt-newline {
 	display: block;
 	font-size: 0.8em;
+	font-weight: 400;
 }
 
 .content .methods > div:not(.notable-traits):not(.method) {
@@ -1448,6 +1455,12 @@ details.rustdoc-toggle[open] {
 .impl-items .method {
 	padding: 2px 6px;
 	margin-bottom: 6px;
+}
+
+.fnname {
+	border-top-width: 2px;
+	border-top-style: solid;
+	padding-top: 3px;
 }
 
 /* When a "hideme" summary is open and the "Expand description" or "Show

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -165,8 +165,6 @@ pre, .rustdoc.source .example-wrap {
 	color: #c5c5c5;
 }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.foreigntype, .content a.foreigntype { color: #ef57ff; }
 .content span.union, .content a.union { color: #98a01c; }
 .content span.constant, .content a.constant,

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -28,7 +28,7 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #2A2A2A;
 }
 
-details.method-toggle[open] .method {
+details.method-toggle .method {
 	background-color: #2A2A2A;
 	border-top: 2px solid #bb7410;
 }
@@ -161,7 +161,10 @@ a.result-keyword:focus { background-color: #884719; }
 .content span.fn, .content a.fn, .block a.current.fn,
 .content span.method, .content a.method, .block a.current.method,
 .content span.tymethod, .content a.tymethod, .block a.current.tymethod,
-.content .fnname{ color: #2BAB63; }
+.content .fnname{
+	color: #2BAB63;
+	border-color: #2BAB63;
+}
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #de5249; }
 
 pre.rust .comment { color: #8d8d8b; }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -28,6 +28,11 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #2A2A2A;
 }
 
+details.method-toggle[open] .method {
+	background-color: #2A2A2A;
+	border-top: 2px solid #bb7410;
+}
+
 .sidebar {
 	background-color: #505050;
 }
@@ -280,7 +285,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
-:target > code, :target > .in-band {
+:target, :target > .in-band {
 	background-color: #494a3d;
 	border-right: 3px solid #bb7410;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -138,8 +138,6 @@ a.result-static:focus { background-color: #0063cc; }
 a.result-primitive:focus { background-color: #00708a; }
 a.result-keyword:focus { background-color: #884719; }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.enum, .content a.enum, .block a.current.enum { color: #82b089; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #2dbfb8; }
 .content span.type, .content a.type, .block a.current.type { color: #ff7f00; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -30,7 +30,7 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #F5F5F5;
 }
 
-details.method-toggle[open] .method {
+details.method-toggle .method {
 	background-color: #F5F5F5;
 	border-top: 2px solid #ffb44c;
 }
@@ -159,7 +159,10 @@ a.result-keyword:focus { background-color: #f99650; }
 .content span.fn, .content a.fn, .block a.current.fn,
 .content span.method, .content a.method, .block a.current.method,
 .content span.tymethod, .content a.tymethod, .block a.current.tymethod,
-.content .fnname { color: #9a6e31; }
+.content .fnname {
+	color: #9a6e31;
+	border-color: #9a6e31;
+}
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #de5249; }
 
 pre.rust .comment { color: #8E908C; }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -30,6 +30,11 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #F5F5F5;
 }
 
+details.method-toggle[open] .method {
+	background-color: #F5F5F5;
+	border-top: 2px solid #ffb44c;
+}
+
 .sidebar {
 	background-color: #F1F1F1;
 }
@@ -273,7 +278,7 @@ a.test-arrow:hover{
 	color: #999;
 }
 
-:target > code, :target > .in-band {
+:target, :target > .in-band {
 	background: #FDFFD3;
 	border-right: 3px solid #ffb44c;
 }

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -136,8 +136,6 @@ a.result-static:focus { background-color: #c3e0ff; }
 a.result-primitive:focus { background-color: #9aecff; }
 a.result-keyword:focus { background-color: #f99650; }
 
-.content .item-info::before { color: #ccc; }
-
 .content span.enum, .content a.enum, .block a.current.enum { color: #508157; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #ad448e; }
 .content span.type, .content a.type, .block a.current.type { color: #ba5d00; }


### PR DESCRIPTION
This is really more of a demo than a PR, to see if folks are interested in a significant design change like this.

I've heard multiple people say they feel that methods in rust documentation are not "scannable." In other words, it's hard to run your eyes down a page looking at all the method names to find a specific name, or to see if there's a name that matches what you're looking for.

Part of that is that there's a lot of stuff to the left of the method name, so the method name is not always in the same place. Part of that is that there's not a clear visual delineation between the end of one method's documentation and the summary of the next method.

In this demo I removed the `[-] pub fn` from the beginning of each function. My thinking is that `[-]` can be shown just when it needs to be. "fn" is implicit in the fact that we're in a section full of methods (and also the parentheses and arguments are a great hint that we're looking at `fn`s).

"pub" is usually implicit since we're looking at documentation. There's the issue of `--document-private-items`, but we can solve that by marking the private items differently, rather than always marking public items so the private items can be noticed by their lack of "pub".

I've also highlighted the methods with a border-top and a light grey background-color (same as the color on examples). For this I took inspiration from hexdocs (https://hexdocs.pm/phoenix/Phoenix.html#json_library/0)  and Sphinx with the readthedocs theme (https://certbot.eff.org/docs/api/certbot.plugins.dns_common_lexicon.html). Both of those use a background color and a single border to make method headings stand out: hexdocs uses a border-left, and pydoc uses a border-top. I chose the same color we use as a border-right when a heading is `:target` (that is, when you've clicked on it from the sidebar or from a URL with a fragment).

Anyhow, all sorts of feedback welcome. Do you see this as a problem in need of solving? Is this a good way to solve it? Are there other ways? I've intentionally not spent too much time polishing this PR, so if you don't wind up liking it don't worry that I'll be throwing too much work away.

/cc @jyn514 @Manishearth @GuillaumeGomez @Nemo157 

Demo: https://hoffman-andrews.com/rust/scannable-methods/std/string/struct.String.html#implementations

Methods in default open position:

![image](https://user-images.githubusercontent.com/220205/121826068-aadad580-cc6a-11eb-9ca1-6cd358d82948.png)

Methods in closed position:

![image](https://user-images.githubusercontent.com/220205/121826278-d01c1380-cc6b-11eb-9fdb-229aeec72fd4.png)
