### PR TITLE
Revert revert of constness in #86003

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -682,7 +682,8 @@ pub unsafe fn uninitialized<T>() -> T {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn swap<T>(x: &mut T, y: &mut T) {
+#[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+pub const fn swap<T>(x: &mut T, y: &mut T) {
     // SAFETY: the raw pointers have been created from safe mutable references satisfying all the
     // constraints on `ptr::swap_nonoverlapping_one`
     unsafe {
@@ -812,7 +813,8 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "if you don't need the old value, you can just assign the new value directly"]
-pub fn replace<T>(dest: &mut T, src: T) -> T {
+#[rustc_const_unstable(feature = "const_replace", issue = "83164")]
+pub const fn replace<T>(dest: &mut T, src: T) -> T {
     // SAFETY: We read from `dest` but directly write `src` into it afterwards,
     // such that the old value is not duplicated. Nothing is dropped and
     // nothing here can panic.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -876,7 +876,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // We are calling the intrinsics directly to avoid function calls in the generated code
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
     extern "rust-intrinsic" {
-        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "none")]
+        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -871,7 +871,7 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
+#[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
 pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // We are calling the intrinsics directly to avoid function calls in the generated code
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
@@ -968,7 +968,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 /// ```
 #[inline]
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
-#[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
+#[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
 pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
     // SAFETY: the caller must guarantee that `dst` is valid for writes.
     // `dst` cannot overlap `src` because the caller has mutable access

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -430,7 +430,8 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
 }
 
 #[inline]
-pub(crate) unsafe fn swap_nonoverlapping_one<T>(x: *mut T, y: *mut T) {
+#[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+pub(crate) const unsafe fn swap_nonoverlapping_one<T>(x: *mut T, y: *mut T) {
     // NOTE(eddyb) SPIR-V's Logical addressing model doesn't allow for arbitrary
     // reinterpretation of values as (chunkable) byte arrays, and the loop in the
     // block optimization in `swap_nonoverlapping_bytes` is hard to rewrite back
@@ -563,7 +564,8 @@ const unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
+#[rustc_const_unstable(feature = "const_replace", issue = "83164")]
+pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
     // SAFETY: the caller must guarantee that `dst` is valid to be
     // cast to a mutable reference (valid for writes, aligned, initialized),
     // and cannot overlap `src` since `dst` must point to a distinct
@@ -869,10 +871,12 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub unsafe fn write<T>(dst: *mut T, src: T) {
+#[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
+pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // We are calling the intrinsics directly to avoid function calls in the generated code
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
     extern "rust-intrinsic" {
+        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "none")]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1002,7 +1002,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::write`]: crate::ptr::write()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     #[inline(always)]
     pub const unsafe fn write(self, val: T)
     where
@@ -1057,7 +1057,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::write_unaligned`]: crate::ptr::write_unaligned()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "86302")]
     #[inline(always)]
     pub const unsafe fn write_unaligned(self, val: T)
     where

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1002,8 +1002,9 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::write`]: crate::ptr::write()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
+    #[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
     #[inline(always)]
-    pub unsafe fn write(self, val: T)
+    pub const unsafe fn write(self, val: T)
     where
         T: Sized,
     {

--- a/library/core/tests/const_ptr.rs
+++ b/library/core/tests/const_ptr.rs
@@ -49,3 +49,53 @@ fn mut_ptr_read() {
     const UNALIGNED: u16 = unsafe { UNALIGNED_PTR.read_unaligned() };
     assert_eq!(UNALIGNED, u16::from_ne_bytes([0x23, 0x45]));
 }
+
+#[test]
+fn write() {
+    use core::ptr;
+
+    const fn write_aligned() -> i32 {
+        let mut res = 0;
+        unsafe {
+            ptr::write(&mut res as *mut _, 42);
+        }
+        res
+    }
+    const ALIGNED: i32 = write_aligned();
+    assert_eq!(ALIGNED, 42);
+
+    const fn write_unaligned() -> [u16; 2] {
+        let mut two_aligned = [0u16; 2];
+        unsafe {
+            let unaligned_ptr = (two_aligned.as_mut_ptr() as *mut u8).add(1) as *mut u16;
+            ptr::write_unaligned(unaligned_ptr, u16::from_ne_bytes([0x23, 0x45]));
+        }
+        two_aligned
+    }
+    const UNALIGNED: [u16; 2] = write_unaligned();
+    assert_eq!(UNALIGNED, [u16::from_ne_bytes([0x00, 0x23]), u16::from_ne_bytes([0x45, 0x00])]);
+}
+
+#[test]
+fn mut_ptr_write() {
+    const fn aligned() -> i32 {
+        let mut res = 0;
+        unsafe {
+            (&mut res as *mut i32).write(42);
+        }
+        res
+    }
+    const ALIGNED: i32 = aligned();
+    assert_eq!(ALIGNED, 42);
+
+    const fn write_unaligned() -> [u16; 2] {
+        let mut two_aligned = [0u16; 2];
+        unsafe {
+            let unaligned_ptr = (two_aligned.as_mut_ptr() as *mut u8).add(1) as *mut u16;
+            unaligned_ptr.write_unaligned(u16::from_ne_bytes([0x23, 0x45]));
+        }
+        two_aligned
+    }
+    const UNALIGNED: [u16; 2] = write_unaligned();
+    assert_eq!(UNALIGNED, [u16::from_ne_bytes([0x00, 0x23]), u16::from_ne_bytes([0x45, 0x00])]);
+}

--- a/src/test/ui/const-ptr/out_of_bounds_read.rs
+++ b/src/test/ui/const-ptr/out_of_bounds_read.rs
@@ -1,0 +1,16 @@
+// error-pattern: any use of this value will cause an error
+
+#![feature(const_ptr_read)]
+#![feature(const_ptr_offset)]
+
+fn main() {
+    use std::ptr;
+
+    const DATA: [u32; 1] = [42];
+
+    const PAST_END_PTR: *const u32 = unsafe { DATA.as_ptr().add(1) };
+
+    const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
+    const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
+    const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
+}

--- a/src/test/ui/const-ptr/out_of_bounds_read.rs
+++ b/src/test/ui/const-ptr/out_of_bounds_read.rs
@@ -1,4 +1,4 @@
-// error-pattern: any use of this value will cause an error
+// error-pattern: evaluation of constant value failed
 
 #![feature(const_ptr_read)]
 #![feature(const_ptr_offset)]

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,0 +1,59 @@
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |         inside `_READ` at $DIR/out_of_bounds_read.rs:13:33
+   | 
+  ::: $DIR/out_of_bounds_read.rs:13:5
+   |
+LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
+   |     ------------------------------------------------------
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |         inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |         inside `_CONST_READ` at $DIR/out_of_bounds_read.rs:14:39
+   | 
+  ::: $DIR/out_of_bounds_read.rs:14:5
+   |
+LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
+   |     --------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |         inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+   |         inside `_MUT_READ` at $DIR/out_of_bounds_read.rs:15:37
+   | 
+  ::: $DIR/out_of_bounds_read.rs:15:5
+   |
+LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
+   |     --------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,12 +1,13 @@
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
-LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
-   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |         inside `_READ` at $DIR/out_of_bounds_read.rs:13:33
+LL |     unsafe { copy_nonoverlapping(src, dst, count) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |              inside `_READ` at $DIR/out_of_bounds_read.rs:13:33
    | 
   ::: $DIR/out_of_bounds_read.rs:13:5
    |
@@ -18,15 +19,16 @@ LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
-LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
-   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |         inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |         inside `_CONST_READ` at $DIR/out_of_bounds_read.rs:14:39
+LL |     unsafe { copy_nonoverlapping(src, dst, count) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |              inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |              inside `_CONST_READ` at $DIR/out_of_bounds_read.rs:14:39
    | 
   ::: $DIR/out_of_bounds_read.rs:14:5
    |
@@ -37,15 +39,16 @@ LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
-LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
-   |         inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |         inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   |         inside `_MUT_READ` at $DIR/out_of_bounds_read.rs:15:37
+LL |     unsafe { copy_nonoverlapping(src, dst, count) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
+   |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |              inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+   |              inside `_MUT_READ` at $DIR/out_of_bounds_read.rs:15:37
    | 
   ::: $DIR/out_of_bounds_read.rs:15:5
    |

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,4 +1,4 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     unsafe { copy_nonoverlapping(src, dst, count) }
@@ -6,19 +6,18 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |              inside `_READ` at $DIR/out_of_bounds_read.rs:13:33
    | 
-  ::: $DIR/out_of_bounds_read.rs:13:5
+  ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   | 
+  ::: $DIR/out_of_bounds_read.rs:13:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
-   |     ------------------------------------------------------
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                 ----------------------- inside `_READ` at $DIR/out_of_bounds_read.rs:13:33
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     unsafe { copy_nonoverlapping(src, dst, count) }
@@ -26,19 +25,23 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |              inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |              inside `_CONST_READ` at $DIR/out_of_bounds_read.rs:14:39
    | 
-  ::: $DIR/out_of_bounds_read.rs:14:5
+  ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   | 
+  ::: $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { read(self) }
+   |                  ---------- inside `ptr::const_ptr::<impl *const u32>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   | 
+  ::: $DIR/out_of_bounds_read.rs:14:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
-   |     --------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                       ------------------- inside `_CONST_READ` at $DIR/out_of_bounds_read.rs:14:39
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
    |
 LL |     unsafe { copy_nonoverlapping(src, dst, count) }
@@ -46,17 +49,22 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |              |
    |              memory access failed: pointer must be in-bounds at offset 8, but is outside bounds of alloc6 which has size 4
    |              inside `copy_nonoverlapping::<u32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |              inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |              inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   |              inside `_MUT_READ` at $DIR/out_of_bounds_read.rs:15:37
    | 
-  ::: $DIR/out_of_bounds_read.rs:15:5
+  ::: $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |         --------------------------------------------- inside `std::ptr::read::<u32>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   | 
+  ::: $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+   |
+LL |         unsafe { read(self) }
+   |                  ---------- inside `ptr::mut_ptr::<impl *mut u32>::read` at $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+   | 
+  ::: $DIR/out_of_bounds_read.rs:15:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
-   |     --------------------------------------------------------------------
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                                     --------------------------------- inside `_MUT_READ` at $DIR/out_of_bounds_read.rs:15:37
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -1,0 +1,45 @@
+// ignore-tidy-linelength
+#![feature(const_mut_refs, const_intrinsic_copy, const_ptr_offset)]
+use std::{ptr, mem};
+
+const COPY_ZERO: () = unsafe {
+    // Since we are not copying anything, this should be allowed.
+    let src = ();
+    let mut dst = ();
+    ptr::copy_nonoverlapping(&src as *const _ as *const i32, &mut dst as *mut _ as *mut i32, 0);
+};
+
+const COPY_OOB_1: () = unsafe {
+    let mut x = 0i32;
+    let dangle = (&mut x as *mut i32).wrapping_add(10);
+    // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
+    ptr::copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ ERROR any use of this value will cause an error
+    //~| memory access failed: pointer must be in-bounds
+    //~| previously accepted
+};
+const COPY_OOB_2: () = unsafe {
+    let x = 0i32;
+    let dangle = (&x as *const i32).wrapping_add(10);
+    // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
+    ptr::copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ ERROR any use of this value will cause an error
+    //~| memory access failed: pointer must be in-bounds
+    //~| previously accepted
+};
+
+const COPY_SIZE_OVERFLOW: () = unsafe {
+    let x = 0;
+    let mut y = 0;
+    ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    //~| overflow computing total size of `copy`
+    //~| previously accepted
+};
+const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
+    let x = 0;
+    let mut y = 0;
+    ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    //~| overflow computing total size of `copy_nonoverlapping`
+    //~| previously accepted
+};
+
+fn main() {
+}

--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -24,32 +24,27 @@ const COPY_OOB_1: () = unsafe {
     let mut x = 0i32;
     let dangle = (&mut x as *mut i32).wrapping_add(10);
     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
-    copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ ERROR any use of this value will cause an error
-    //~| memory access failed: pointer must be in-bounds
-    //~| previously accepted
+    copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ evaluation of constant value failed [E0080]
 };
 const COPY_OOB_2: () = unsafe {
     let x = 0i32;
     let dangle = (&x as *const i32).wrapping_add(10);
     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
-    copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ ERROR any use of this value will cause an error
+    copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ evaluation of constant value failed [E0080]
     //~| memory access failed: pointer must be in-bounds
-    //~| previously accepted
 };
 
 const COPY_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
-    copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ evaluation of constant value failed [E0080]
     //~| overflow computing total size of `copy`
-    //~| previously accepted
 };
 const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
-    copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ evaluation of constant value failed [E0080]
     //~| overflow computing total size of `copy_nonoverlapping`
-    //~| previously accepted
 };
 
 fn main() {

--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -1,19 +1,30 @@
+#![stable(feature = "dummy", since = "1.0.0")]
+
 // ignore-tidy-linelength
+#![feature(intrinsics, staged_api)]
 #![feature(const_mut_refs, const_intrinsic_copy, const_ptr_offset)]
-use std::{ptr, mem};
+use std::mem;
+
+extern "rust-intrinsic" {
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+
+    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    fn copy<T>(src: *const T, dst: *mut T, count: usize);
+}
 
 const COPY_ZERO: () = unsafe {
     // Since we are not copying anything, this should be allowed.
     let src = ();
     let mut dst = ();
-    ptr::copy_nonoverlapping(&src as *const _ as *const i32, &mut dst as *mut _ as *mut i32, 0);
+    copy_nonoverlapping(&src as *const _ as *const i32, &mut dst as *mut _ as *mut i32, 0);
 };
 
 const COPY_OOB_1: () = unsafe {
     let mut x = 0i32;
     let dangle = (&mut x as *mut i32).wrapping_add(10);
     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
-    ptr::copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ ERROR any use of this value will cause an error
+    copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ ERROR any use of this value will cause an error
     //~| memory access failed: pointer must be in-bounds
     //~| previously accepted
 };
@@ -21,7 +32,7 @@ const COPY_OOB_2: () = unsafe {
     let x = 0i32;
     let dangle = (&x as *const i32).wrapping_add(10);
     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
-    ptr::copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ ERROR any use of this value will cause an error
+    copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ ERROR any use of this value will cause an error
     //~| memory access failed: pointer must be in-bounds
     //~| previously accepted
 };
@@ -29,14 +40,14 @@ const COPY_OOB_2: () = unsafe {
 const COPY_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
-    ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
     //~| overflow computing total size of `copy`
     //~| previously accepted
 };
 const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
-    ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
     //~| overflow computing total size of `copy_nonoverlapping`
     //~| previously accepted
 };

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -1,0 +1,99 @@
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |
+LL |       unsafe { copy_nonoverlapping(src, dst, count) }
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
+   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |                inside `COPY_OOB_1` at $DIR/copy-intrinsic.rs:16:5
+   | 
+  ::: $DIR/copy-intrinsic.rs:12:1
+   |
+LL | / const COPY_OOB_1: () = unsafe {
+LL | |     let mut x = 0i32;
+LL | |     let dangle = (&mut x as *mut i32).wrapping_add(10);
+LL | |     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
+...  |
+LL | |
+LL | | };
+   | |__-
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |
+LL |       unsafe { copy_nonoverlapping(src, dst, count) }
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
+   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |                inside `COPY_OOB_2` at $DIR/copy-intrinsic.rs:24:5
+   | 
+  ::: $DIR/copy-intrinsic.rs:20:1
+   |
+LL | / const COPY_OOB_2: () = unsafe {
+LL | |     let x = 0i32;
+LL | |     let dangle = (&x as *const i32).wrapping_add(10);
+LL | |     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
+...  |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |
+LL |       unsafe { copy(src, dst, count) }
+   |                ^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                overflow computing total size of `copy`
+   |                inside `std::intrinsics::copy::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |                inside `COPY_SIZE_OVERFLOW` at $DIR/copy-intrinsic.rs:32:5
+   | 
+  ::: $DIR/copy-intrinsic.rs:29:1
+   |
+LL | / const COPY_SIZE_OVERFLOW: () = unsafe {
+LL | |     let x = 0;
+LL | |     let mut y = 0;
+LL | |     ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |
+LL |       unsafe { copy_nonoverlapping(src, dst, count) }
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                overflow computing total size of `copy_nonoverlapping`
+   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
+   |                inside `COPY_NONOVERLAPPING_SIZE_OVERFLOW` at $DIR/copy-intrinsic.rs:39:5
+   | 
+  ::: $DIR/copy-intrinsic.rs:36:1
+   |
+LL | / const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
+LL | |     let x = 0;
+LL | |     let mut y = 0;
+LL | |     ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -1,69 +1,27 @@
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/copy-intrinsic.rs:27:5
    |
-LL | / const COPY_OOB_1: () = unsafe {
-LL | |     let mut x = 0i32;
-LL | |     let dangle = (&mut x as *mut i32).wrapping_add(10);
-LL | |     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
-LL | |     copy_nonoverlapping(0x100 as *const i32, dangle, 0);
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
-LL | |
-LL | |
-LL | | };
-   | |__-
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     copy_nonoverlapping(0x100 as *const i32, dangle, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
 
-error: any use of this value will cause an error
-  --> $DIR/copy-intrinsic.rs:35:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/copy-intrinsic.rs:33:5
    |
-LL | / const COPY_OOB_2: () = unsafe {
-LL | |     let x = 0i32;
-LL | |     let dangle = (&x as *const i32).wrapping_add(10);
-LL | |     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
-LL | |     copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
-LL | |
-LL | |
-LL | | };
-   | |__-
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
 
-error: any use of this value will cause an error
-  --> $DIR/copy-intrinsic.rs:43:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/copy-intrinsic.rs:40:5
    |
-LL | / const COPY_SIZE_OVERFLOW: () = unsafe {
-LL | |     let x = 0;
-LL | |     let mut y = 0;
-LL | |     copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy`
-LL | |
-LL | |
-LL | | };
-   | |__-
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy`
 
-error: any use of this value will cause an error
-  --> $DIR/copy-intrinsic.rs:50:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/copy-intrinsic.rs:46:5
    |
-LL | / const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
-LL | |     let x = 0;
-LL | |     let mut y = 0;
-LL | |     copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy_nonoverlapping`
-LL | |
-LL | |
-LL | | };
-   | |__-
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+LL |     copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy_nonoverlapping`
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -1,20 +1,13 @@
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |
-LL |       unsafe { copy_nonoverlapping(src, dst, count) }
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                |
-   |                memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
-   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |                inside `COPY_OOB_1` at $DIR/copy-intrinsic.rs:16:5
-   | 
-  ::: $DIR/copy-intrinsic.rs:12:1
+  --> $DIR/copy-intrinsic.rs:27:5
    |
 LL | / const COPY_OOB_1: () = unsafe {
 LL | |     let mut x = 0i32;
 LL | |     let dangle = (&mut x as *mut i32).wrapping_add(10);
 LL | |     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
-...  |
+LL | |     copy_nonoverlapping(0x100 as *const i32, dangle, 0);
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
+LL | |
 LL | |
 LL | | };
    | |__-
@@ -24,22 +17,15 @@ LL | | };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |
-LL |       unsafe { copy_nonoverlapping(src, dst, count) }
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                |
-   |                memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
-   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |                inside `COPY_OOB_2` at $DIR/copy-intrinsic.rs:24:5
-   | 
-  ::: $DIR/copy-intrinsic.rs:20:1
+  --> $DIR/copy-intrinsic.rs:35:5
    |
 LL | / const COPY_OOB_2: () = unsafe {
 LL | |     let x = 0i32;
 LL | |     let dangle = (&x as *const i32).wrapping_add(10);
 LL | |     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
-...  |
+LL | |     copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
+LL | |
 LL | |
 LL | | };
    | |__-
@@ -48,21 +34,13 @@ LL | | };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |
-LL |       unsafe { copy(src, dst, count) }
-   |                ^^^^^^^^^^^^^^^^^^^^^
-   |                |
-   |                overflow computing total size of `copy`
-   |                inside `std::intrinsics::copy::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |                inside `COPY_SIZE_OVERFLOW` at $DIR/copy-intrinsic.rs:32:5
-   | 
-  ::: $DIR/copy-intrinsic.rs:29:1
+  --> $DIR/copy-intrinsic.rs:43:5
    |
 LL | / const COPY_SIZE_OVERFLOW: () = unsafe {
 LL | |     let x = 0;
 LL | |     let mut y = 0;
-LL | |     ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+LL | |     copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy`
 LL | |
 LL | |
 LL | | };
@@ -72,21 +50,13 @@ LL | | };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |
-LL |       unsafe { copy_nonoverlapping(src, dst, count) }
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                |
-   |                overflow computing total size of `copy_nonoverlapping`
-   |                inside `copy_nonoverlapping::<i32>` at $SRC_DIR/core/src/intrinsics.rs:LL:COL
-   |                inside `COPY_NONOVERLAPPING_SIZE_OVERFLOW` at $DIR/copy-intrinsic.rs:39:5
-   | 
-  ::: $DIR/copy-intrinsic.rs:36:1
+  --> $DIR/copy-intrinsic.rs:50:5
    |
 LL | / const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
 LL | |     let x = 0;
 LL | |     let mut y = 0;
-LL | |     ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+LL | |     copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy_nonoverlapping`
 LL | |
 LL | |
 LL | | };

--- a/src/test/ui/thread-local-static.rs
+++ b/src/test/ui/thread-local-static.rs
@@ -11,7 +11,6 @@ const fn g(x: &mut [u32; 8]) {
     //~| ERROR mutable references are not allowed
     //~| ERROR use of mutable static is unsafe
     //~| constant functions cannot refer to statics
-    //~| ERROR calls in constant functions are limited to constant functions
 }
 
 fn main() {}

--- a/src/test/ui/thread-local-static.stderr
+++ b/src/test/ui/thread-local-static.stderr
@@ -30,12 +30,6 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/thread-local-static.rs:9:5
-   |
-LL |     std::mem::swap(x, &mut STATIC_VAR_2)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
   --> $DIR/thread-local-static.rs:9:23
    |
@@ -44,7 +38,7 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0013, E0015, E0133, E0658.
+Some errors have detailed explanations: E0013, E0133, E0658.
 For more information about an error, try `rustc --explain E0013`.


### PR DESCRIPTION
Re-constify `mem::swap`, `mem::replace`, `ptr::write` which were marked as not `const` in #86003

Once the checks pass, this should solve #86236