### PR TITLE
Improve errors for missing Debug and Display impls

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -479,6 +479,7 @@ symbols! {
         discriminant_type,
         discriminant_value,
         dispatch_from_dyn,
+        display_trait,
         div,
         div_assign,
         doc,

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -564,7 +564,7 @@ impl Display for Arguments<'_> {
     on(
         crate_local,
         label = "`{Self}` cannot be formatted using `{{:?}}`",
-        note = "add `#[derive(Debug)]` or manually implement `{Debug}`"
+        note = "add `#[derive(Debug)]` to `{Self}` or manually implement `{Debug}` for `{Self}`"
     ),
     message = "`{Self}` doesn't implement `{Debug}`",
     label = "`{Self}` cannot be formatted using `{{:?}}` because it doesn't implement `{Debug}`"
@@ -662,6 +662,7 @@ pub use macros::Debug;
     note = "in format strings you may be able to use `{{:?}}` (or {{:#?}} for pretty-print) instead"
 )]
 #[doc(alias = "{}")]
+#[rustc_diagnostic_item = "display_trait"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Display {
     /// Formats the value using the given formatter.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -825,6 +825,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
+    #[rustc_diagnostic_item = "format_args"]
     #[macro_export]
     macro_rules! format_args {
         ($fmt:expr) => {{ /* compiler built-in */ }};
@@ -840,6 +841,7 @@ pub(crate) mod builtin {
     )]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
+    #[rustc_diagnostic_item = "format_args_nl"]
     #[macro_export]
     macro_rules! format_args_nl {
         ($fmt:expr) => {{ /* compiler built-in */ }};

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -4,7 +4,6 @@ error[E0277]: `impl Sized` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
@@ -17,7 +16,6 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
@@ -30,7 +28,6 @@ error[E0277]: `T` doesn't implement `Debug`
 LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
@@ -43,7 +40,6 @@ error[E0277]: `Y` doesn't implement `Debug`
 LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y`
    |
@@ -56,7 +52,6 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
@@ -69,7 +64,6 @@ error[E0277]: `X` doesn't implement `Debug`
 LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `X`
    |

--- a/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -5,7 +5,7 @@ LL |      x: Error
    |      ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `Error`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
+   = note: add `#[derive(Debug)]` to `Error` or manually implement `Debug` for `Error`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/derives/derives-span-Debug-enum.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum.stderr
@@ -5,7 +5,7 @@ LL |      Error
    |      ^^^^^ `Error` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `Error`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
+   = note: add `#[derive(Debug)]` to `Error` or manually implement `Debug` for `Error`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/derives/derives-span-Debug-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-struct.stderr
@@ -5,7 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `Error`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
+   = note: add `#[derive(Debug)]` to `Error` or manually implement `Debug` for `Error`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     Error
    |     ^^^^^ `Error` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `Error`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
+   = note: add `#[derive(Debug)]` to `Error` or manually implement `Debug` for `Error`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -5,8 +5,7 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |                           ^^^ `Foo` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `Foo`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
-   = note: required by `std::fmt::Debug::fmt`
+   = note: add `#[derive(Debug)]` to `Foo` or manually implement `Debug` for `Foo`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `Debug`
@@ -16,7 +15,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |                                ^^^ `Bar` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `Bar`
-   = note: required by `std::fmt::Debug::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` doesn't implement `std::fmt::Display`
@@ -27,7 +25,6 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Foo`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required by `std::fmt::Display::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
@@ -38,7 +35,6 @@ LL |     println!("{} {}", Foo, Bar);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required by `std::fmt::Display::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -5,9 +5,7 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    |                       ^^^^^^^^^^^^^^ `NotDebug` cannot be formatted using `{:?}`
    |
    = help: the trait `Debug` is not implemented for `NotDebug`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
-   = note: required because of the requirements on the impl of `Debug` for `&NotDebug`
-   = note: required by `std::fmt::Debug::fmt`
+   = note: add `#[derive(Debug)]` to `NotDebug` or manually implement `Debug` for `NotDebug`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/path-display.stderr
+++ b/src/test/ui/suggestions/path-display.stderr
@@ -6,8 +6,6 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Path`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: required because of the requirements on the impl of `std::fmt::Display` for `&Path`
-   = note: required by `std::fmt::Display::fmt`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error


### PR DESCRIPTION
Currently, if someone tries to pass value that does not implement Debug or Display to a formatting macro, they get a very verbose and confusing error message. This PR changes the error messages for missing Debug and Display impls to be less overwhelming in this case, as suggested by #85844. I was a little less aggressive in changing the error message than that issue proposed. Still, this implementation would be enough to reduce the number of messages to be much more manageable. I'll give an example, taken from that issue.

Before:
```
error[E0277]: `Group` doesn't implement `Debug`
  --> src/tests/a.rs:19:5
   |
19 |     assert_eq!(result.unwrap(), &group);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Group` cannot be formatted using `{:?}`
   |
   = help: the trait `Debug` is not implemented for `Group`
   = note: add `#[derive(Debug)]` or manually implement `Debug`
   = note: required because of the requirements on the impl of `Debug` for `&Group`
   = note: 1 redundant requirements hidden
   = note: required because of the requirements on the impl of `Debug` for `&&Group`
   = note: required by `std::fmt::Debug::fmt`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
   ```
 
After:
```
error[E0277]: `Group` doesn't implement `Debug`
  --> src/tests/a.rs:19:5
   |
19 |     assert_eq!(result.unwrap(), &group);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Group` cannot be formatted using `{:?}`
   |
   = help: the trait `Debug` is not implemented for `Group`
   = note: add `#[derive(Debug)]` to `Group` or manually implement `Debug` for `Group`
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
   ```

Fixes #85844.