### PR TITLE
Resolve type aliases to the type they point to in intra-doc links

### DIFF
--- a/src/test/rustdoc/intra-doc/type-alias.rs
+++ b/src/test/rustdoc/intra-doc/type-alias.rs
@@ -1,0 +1,19 @@
+// Regression test for issue #86120.
+
+#![deny(broken_intra_doc_links)]
+#![crate_name = "foo"]
+
+pub struct Foo;
+
+/// You should really try [`Self::bar`]!
+pub type Bar = Foo;
+
+impl Bar {
+    pub fn bar() {}
+}
+
+/// The minimum is [`Self::MIN`].
+pub type Int = i32;
+
+// @has foo/type.Bar.html '//a[@href="struct.Foo.html#method.bar"]' 'Self::bar'
+// @has foo/type.Int.html '//a[@href="{{channel}}/std/primitive.i32.html#associatedconstant.MIN"]' 'Self::MIN'


### PR DESCRIPTION
This feels a bit sketchy, but I think it's better than just rejecting the link.
Helps with #86120, r? @jyn514