### PR TITLE
Use better error message for hard errors in CTFE

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -502,4 +502,14 @@ impl InterpError<'_> {
             _ => false,
         }
     }
+
+    /// Should this error be reported as a hard error, preventing compilation, or a soft error,
+    /// causing a deny-by-default lint?
+    pub fn is_hard_err(&self) -> bool {
+        use InterpError::*;
+        match *self {
+            MachineStop(ref err) => err.is_hard_err(),
+            _ => false,
+        }
+    }
 }

--- a/compiler/rustc_mir/src/const_eval/error.rs
+++ b/compiler/rustc_mir/src/const_eval/error.rs
@@ -157,7 +157,7 @@ impl<'tcx> ConstEvalErr<'tcx> {
         tcx: TyCtxtAt<'tcx>,
         message: &str,
         emit: impl FnOnce(DiagnosticBuilder<'_>),
-        mut lint_root: Option<hir::HirId>,
+        lint_root: Option<hir::HirId>,
     ) -> ErrorHandled {
         let finish = |mut err: DiagnosticBuilder<'_>, span_msg: Option<String>| {
             trace!("reporting const eval failure at {:?}", self.span);
@@ -193,12 +193,6 @@ impl<'tcx> ConstEvalErr<'tcx> {
             }
             _ => {}
         };
-
-        // If we have a 'hard error', then set `lint_root` to `None` so that we don't
-        // emit a lint.
-        if matches!(&self.error, InterpError::MachineStop(err) if err.is_hard_err()) {
-            lint_root = None;
-        }
 
         let err_msg = self.error.to_string();
 

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -2,8 +2,8 @@ use super::{CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr, Memory
 use crate::interpret::eval_nullary_intrinsic;
 use crate::interpret::{
     intern_const_alloc_recursive, Allocation, ConstAlloc, ConstValue, CtfeValidationMode, GlobalId,
-    Immediate, InternKind, InterpCx, InterpResult, MPlaceTy, MemoryKind, OpTy, RefTracking, Scalar,
-    ScalarMaybeUninit, StackPopCleanup,
+    Immediate, InternKind, InterpCx, InterpError, InterpResult, MPlaceTy, MemoryKind, OpTy,
+    RefTracking, Scalar, ScalarMaybeUninit, StackPopCleanup,
 };
 use crate::util::pretty::display_allocation;
 
@@ -315,6 +315,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             let emit_as_lint = if let Some(def) = def.as_local() {
                 // (Associated) consts only emit a lint, since they might be unused.
                 matches!(tcx.def_kind(def.did.to_def_id()), DefKind::Const | DefKind::AssocConst)
+                    && !matches!(&err.error, InterpError::MachineStop(err) if err.is_hard_err())
             } else {
                 // use of broken constant from other crate: always an error
                 false

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -2,8 +2,8 @@ use super::{CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr, Memory
 use crate::interpret::eval_nullary_intrinsic;
 use crate::interpret::{
     intern_const_alloc_recursive, Allocation, ConstAlloc, ConstValue, CtfeValidationMode, GlobalId,
-    Immediate, InternKind, InterpCx, InterpError, InterpResult, MPlaceTy, MemoryKind, OpTy,
-    RefTracking, Scalar, ScalarMaybeUninit, StackPopCleanup,
+    Immediate, InternKind, InterpCx, InterpResult, MPlaceTy, MemoryKind, OpTy, RefTracking, Scalar,
+    ScalarMaybeUninit, StackPopCleanup,
 };
 use crate::util::pretty::display_allocation;
 
@@ -312,23 +312,17 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             let err = ConstEvalErr::new(&ecx, error, None);
             // Some CTFE errors raise just a lint, not a hard error; see
             // <https://github.com/rust-lang/rust/issues/71800>.
-            let emit_as_lint = if let Some(def) = def.as_local() {
+            let is_hard_err = if let Some(def) = def.as_local() {
                 // (Associated) consts only emit a lint, since they might be unused.
-                matches!(tcx.def_kind(def.did.to_def_id()), DefKind::Const | DefKind::AssocConst)
-                    && !matches!(&err.error, InterpError::MachineStop(err) if err.is_hard_err())
+                !matches!(tcx.def_kind(def.did.to_def_id()), DefKind::Const | DefKind::AssocConst)
+                    // check if the inner InterpError is hard
+                    || err.error.is_hard_err()
             } else {
                 // use of broken constant from other crate: always an error
-                false
+                true
             };
-            if emit_as_lint {
-                let hir_id = tcx.hir().local_def_id_to_hir_id(def.as_local().unwrap().did);
-                Err(err.report_as_lint(
-                    tcx.at(tcx.def_span(def.did)),
-                    "any use of this value will cause an error",
-                    hir_id,
-                    Some(err.span),
-                ))
-            } else {
+
+            if is_hard_err {
                 let msg = if is_static {
                     Cow::from("could not evaluate static initializer")
                 } else {
@@ -346,6 +340,14 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
                 };
 
                 Err(err.report_as_error(ecx.tcx.at(ecx.cur_span()), &msg))
+            } else {
+                let hir_id = tcx.hir().local_def_id_to_hir_id(def.as_local().unwrap().did);
+                Err(err.report_as_lint(
+                    tcx.at(tcx.def_span(def.did)),
+                    "any use of this value will cause an error",
+                    hir_id,
+                    Some(err.span),
+                ))
             }
         }
         Ok(mplace) => {

--- a/src/test/ui/consts/const-eval/const_panic.rs
+++ b/src/test/ui/consts/const-eval/const_panic.rs
@@ -5,31 +5,31 @@
 const MSG: &str = "hello";
 
 const Z: () = std::panic!("cheese");
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Z2: () = std::panic!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Y: () = std::unreachable!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const X: () = std::unimplemented!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 //
 const W: () = std::panic!(MSG);
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Z_CORE: () = core::panic!("cheese");
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Z2_CORE: () = core::panic!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Y_CORE: () = core::unreachable!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const X_CORE: () = core::unimplemented!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const W_CORE: () = core::panic!(MSG);
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -1,100 +1,80 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:7:15
    |
 LL | const Z: () = std::panic!("cheese");
-   | --------------^^^^^^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'cheese', $DIR/const_panic.rs:7:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:7:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:10:16
    |
 LL | const Z2: () = std::panic!();
-   | ---------------^^^^^^^^^^^^^-
-   |                |
-   |                the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:10:16
+   |                ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:10:16
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:13:15
    |
 LL | const Y: () = std::unreachable!();
-   | --------------^^^^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:13:15
+   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:13:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:16:15
    |
 LL | const X: () = std::unimplemented!();
-   | --------------^^^^^^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:16:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:16:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:19:15
    |
 LL | const W: () = std::panic!(MSG);
-   | --------------^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'hello', $DIR/const_panic.rs:19:15
+   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:19:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:22:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
-   | -------------------^^^^^^^^^^^^^^^^^^^^^^-
-   |                    |
-   |                    the evaluated program panicked at 'cheese', $DIR/const_panic.rs:22:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:22:20
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:25:21
    |
 LL | const Z2_CORE: () = core::panic!();
-   | --------------------^^^^^^^^^^^^^^-
-   |                     |
-   |                     the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:25:21
+   |                     ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:25:21
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:28:20
    |
 LL | const Y_CORE: () = core::unreachable!();
-   | -------------------^^^^^^^^^^^^^^^^^^^^-
-   |                    |
-   |                    the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:28:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:28:20
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:31:20
    |
 LL | const X_CORE: () = core::unimplemented!();
-   | -------------------^^^^^^^^^^^^^^^^^^^^^^-
-   |                    |
-   |                    the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:31:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:31:20
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:34:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
-   | -------------------^^^^^^^^^^^^^^^^^-
-   |                    |
-   |                    the evaluated program panicked at 'hello', $DIR/const_panic.rs:34:20
+   |                    ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:34:20
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
@@ -7,13 +7,13 @@
 use core::panic::PanicInfo;
 
 const Z: () = panic!("cheese");
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const Y: () = unreachable!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 const X: () = unimplemented!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 #[lang = "eh_personality"]
 fn eh() {}

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -1,30 +1,24 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:9:15
    |
 LL | const Z: () = panic!("cheese");
-   | --------------^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:9:15
+   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:9:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:12:15
    |
 LL | const Y: () = unreachable!();
-   | --------------^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:12:15
+   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:12:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:15:15
    |
 LL | const X: () = unimplemented!();
-   | --------------^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:15:15
+   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:15:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -9,7 +9,7 @@ struct PrintName;
 
 impl PrintName {
     const VOID: ! = panic!();
-    //~^ ERROR any use of this value will cause an error
+    //~^ ERROR evaluation of constant value failed
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -1,10 +1,8 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/panic-assoc-never-type.rs:11:21
    |
 LL |     const VOID: ! = panic!();
-   |     ----------------^^^^^^^^-
-   |                     |
-   |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:11:21
+   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:11:21
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/panic-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-never-type.rs
@@ -4,7 +4,7 @@
 #![feature(never_type)]
 
 const VOID: ! = panic!();
-//~^ ERROR any use of this value will cause an error
+//~^ ERROR evaluation of constant value failed
 
 fn main() {
     let _ = VOID;

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -1,10 +1,8 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/panic-never-type.rs:6:17
    |
 LL | const VOID: ! = panic!();
-   | ----------------^^^^^^^^-
-   |                 |
-   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:6:17
+   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:6:17
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-eval/unwind-abort.rs
+++ b/src/test/ui/consts/const-eval/unwind-abort.rs
@@ -2,7 +2,7 @@
 
 #[unwind(aborts)]
 const fn foo() {
-    panic!() //~ ERROR any use of this value will cause an error
+    panic!() //~ ERROR evaluation of constant value failed
 }
 
 const _: () = foo();

--- a/src/test/ui/consts/const-eval/unwind-abort.stderr
+++ b/src/test/ui/consts/const-eval/unwind-abort.stderr
@@ -1,4 +1,4 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/unwind-abort.rs:5:5
    |
 LL |     panic!()
@@ -6,10 +6,9 @@ LL |     panic!()
    |     |
    |     the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:5:5
    |     inside `foo` at $SRC_DIR/std/src/panic.rs:LL:COL
-   |     inside `_` at $DIR/unwind-abort.rs:8:15
 ...
 LL | const _: () = foo();
-   | --------------------
+   |               ----- inside `_` at $DIR/unwind-abort.rs:8:15
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-unwrap.stderr
+++ b/src/test/ui/consts/const-unwrap.stderr
@@ -1,4 +1,4 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL |             None => panic!("called `Option::unwrap()` on a `None` value"),
@@ -6,12 +6,11 @@ LL |             None => panic!("called `Option::unwrap()` on a `None` value"),
    |                     |
    |                     the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:9:38
    |                     inside `Option::<i32>::unwrap` at $SRC_DIR/core/src/panic.rs:LL:COL
-   |                     inside `BAR` at $DIR/const-unwrap.rs:9:18
    | 
-  ::: $DIR/const-unwrap.rs:9:1
+  ::: $DIR/const-unwrap.rs:9:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   | ----------------------------------------------
+   |                  ---------------------------- inside `BAR` at $DIR/const-unwrap.rs:9:18
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/assert.const_panic.stderr
+++ b/src/test/ui/consts/control-flow/assert.const_panic.stderr
@@ -1,10 +1,8 @@
-error[E0080]: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/assert.rs:10:15
    |
 LL | const _: () = assert!(false);
-   | --------------^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:10:15
+   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:10:15
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/control-flow/assert.rs
+++ b/src/test/ui/consts/control-flow/assert.rs
@@ -9,6 +9,6 @@ const _: () = assert!(true);
 
 const _: () = assert!(false);
 //[stock]~^ ERROR panicking in constants is unstable
-//[const_panic]~^^ ERROR any use of this value will cause an error
+//[const_panic]~^^ ERROR evaluation of constant value failed
 
 fn main() {}


### PR DESCRIPTION
I noticed this while working on #86255: currently the same message is used for hard errors and soft errors in CTFE. This changes the error messages to make hard errors use a message that indicates the reality of the situation correctly, since usage of the constant is never allowed when there was a hard error evaluating it. This doesn't affect the behaviour of these error messages, only the content.

This changes the error logic to check if the error should be hard or soft where it is generated, instead of where it is emitted, to allow this distinction in error messages.