### PR TITLE
Add tap doc alias for Iterator inspect

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1591,6 +1591,7 @@ pub trait Iterator {
     /// Parsing error: invalid digit found in string
     /// Sum: 3
     /// ```
+    #[doc(alias = "tap")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn inspect<F>(self, f: F) -> Inspect<Self, F>


### PR DESCRIPTION
Ruby and reactive extension uses tap to inspect stuff.

https://internals.rust-lang.org/t/pre-rfc-tap-and-tapmut-traits/14839