### PR TITLE
Add regression test for issue #37508

### DIFF
--- a/src/test/ui/thread-local/thread-local-issue-37508.rs
+++ b/src/test/ui/thread-local/thread-local-issue-37508.rs
@@ -1,0 +1,36 @@
+// only-x86_64
+// compile-flags: -Ccode-model=large --crate-type lib
+// build-pass
+//
+// Regression test for issue #37508
+
+#![no_main]
+#![no_std]
+#![feature(thread_local, lang_items)]
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+pub struct BB;
+
+#[thread_local]
+static mut KEY: Key = Key { inner: BB, dtor_running: false };
+
+pub unsafe fn set() -> Option<&'static BB> {
+    if KEY.dtor_running {
+        return None;
+    }
+    Some(&KEY.inner)
+}
+
+pub struct Key {
+    inner: BB,
+    dtor_running: bool,
+}


### PR DESCRIPTION
Add regression test for issue #37508

Closes #37508

Took this test from #37508 and updated the panic handler to the modern standard.

r? @Mark-Simulacrum

Mark, I hope you don't me tagging you here. You were involved in the original issue and I hope you might be more comfortable reviewing this.