### PR TITLE
Use non-intercrate SelectionContext for normalization in coherence::with_fresh_ty_vars

### DIFF
--- a/src/test/ui/coherence/issue-85898.rs
+++ b/src/test/ui/coherence/issue-85898.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+use std::ops::Range;
+
+struct Foo;
+
+impl From<<Range<usize> as Iterator>::Item> for Foo {
+    fn from(_: <Range<usize> as Iterator>::Item) -> Foo {
+        Foo
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85898

Previously we used a SelectionContext with the `intercrate` flag set in `with_fresh_ty_vars`, which caused projections of foreign types to fail the orphan check. We now use a new SelectionContext for the normalization.