### PR TITLE
Set playground-url value to default to "play.rust-lang.org"

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -216,6 +216,8 @@ crate struct RenderOptions {
     /// If present, playground URL to use in the "Run" button added to code samples.
     ///
     /// Be aware: This option can come both from the CLI and from crate attributes!
+    ///
+    /// If not set, it'll target "play.rust-lang.org" by default.
     crate playground_url: Option<String>,
     /// Whether to sort modules alphabetically on a module page instead of using declaration order.
     /// `true` by default.
@@ -599,7 +601,11 @@ impl Options {
         };
         let crate_name = matches.opt_str("crate-name");
         let proc_macro_crate = crate_types.contains(&CrateType::ProcMacro);
-        let playground_url = matches.opt_str("playground-url");
+        let playground_url = matches
+            .opt_str("playground-url")
+            .map(|s| s.trim().replace("\"", "").replace("\'", ""))
+            .or_else(|| Some("https://play.rust-lang.org/".to_owned()))
+            .filter(|s| !s.is_empty());
         let maybe_sysroot = matches.opt_str("sysroot").map(PathBuf::from);
         let display_warnings = matches.opt_present("display-warnings");
         let sort_modules_alphabetically = !matches.opt_present("sort-modules-by-appearance");

--- a/src/test/rustdoc/hidden-line.rs
+++ b/src/test/rustdoc/hidden-line.rs
@@ -15,5 +15,5 @@
 /// ```
 pub fn foo() {}
 
-// @!has hidden_line/fn.foo.html invisible
+// @!has hidden_line/fn.foo.html '// invisible'
 // @matches - //pre "#\[derive\(PartialEq\)\] // Bar"

--- a/src/test/rustdoc/issue-41783.rs
+++ b/src/test/rustdoc/issue-41783.rs
@@ -1,6 +1,6 @@
 // @has issue_41783/struct.Foo.html
-// @!has - 'space'
-// @!has - 'comment'
+// @!has - ':space'
+// @!has - ':comment'
 // @has - '# <span class="ident">single'
 // @has - '## <span class="ident">double</span>'
 // @has - '### <span class="ident">triple</span>'
@@ -8,8 +8,8 @@
 // @has - '<span class="attribute">#![<span class="ident">inner</span>]</span>'
 
 /// ```no_run
-/// # # space
-/// # comment
+/// # # :space
+/// # :comment
 /// ## single
 /// ### double
 /// #### triple

--- a/src/test/rustdoc/playground-default.rs
+++ b/src/test/rustdoc/playground-default.rs
@@ -1,0 +1,7 @@
+#![crate_name = "foo"]
+
+// @has foo/fn.foo.html '//a[@class="test-arrow"]/@href' 'https://play.rust-lang.org/?code=%23!%5Ballow(unused)%5D%0Afn%20main()%20%7B%0Alet%20x%20%3D%2012%3B%0A%7D&edition=2015'
+/// ```
+/// let x = 12;
+/// ```
+pub fn foo() {}

--- a/src/test/rustdoc/playground-none.rs
+++ b/src/test/rustdoc/playground-none.rs
@@ -1,3 +1,5 @@
+// compile-args: --playground-url="" -Z unstable-options
+
 #![crate_name = "foo"]
 
 //! module docs

--- a/src/test/rustdoc/playground-none.rs
+++ b/src/test/rustdoc/playground-none.rs
@@ -1,4 +1,4 @@
-// compile-args: --playground-url="" -Z unstable-options
+// compile-flags: --playground-url="" -Z unstable-options
 
 #![crate_name = "foo"]
 


### PR DESCRIPTION
Now, by default, the "Run" button will appear on all rust code blocks.

r? @jyn514 