### PR TITLE
Enable combining `+crt-static` and `relocation-model=pic` on `x86_64-unknown-linux-gnu`

### DIFF
--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
@@ -7,6 +7,7 @@ pub fn target() -> Target {
     base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-m64".to_string());
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;
+    base.static_position_independent_executables = true;
     base.supported_sanitizers = SanitizerSet::ADDRESS
         | SanitizerSet::CFI
         | SanitizerSet::LEAK

--- a/src/test/run-make/static-pie/Makefile
+++ b/src/test/run-make/static-pie/Makefile
@@ -1,9 +1,11 @@
 -include ../../run-make-fulldeps/tools.mk
 
-# only-x86_64-unknown-linux-musl
+# only-x86_64
+# only-linux
+# ignore-gnux32
 
 # How to manually run this
-# $ ./x.py test --target x86_64-unknown-linux-musl src/test/run-make/static-pie
+# $ ./x.py test --target x86_64-unknown-linux-[musl,gnu] src/test/run-make/static-pie
 
 all:
 	$(RUSTC) --target $(TARGET) -C target-feature=+crt-static test-aslr.rs

--- a/src/test/run-make/static-pie/Makefile
+++ b/src/test/run-make/static-pie/Makefile
@@ -7,11 +7,12 @@
 # How to manually run this
 # $ ./x.py test --target x86_64-unknown-linux-[musl,gnu] src/test/run-make/static-pie
 
-all:
-	$(RUSTC) --target $(TARGET) -C target-feature=+crt-static test-aslr.rs
-	# Check that no dynamic interpreter is set
-	! readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) INTERP
-	# Check that we have a dynamic executable
-	readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) DYNAMIC
-	# Check for address space layout randomization
-	$(call RUN,test-aslr) --test-aslr
+all: test-clang test-gcc
+
+test-%:
+	if ./check_$*_version.sh; then\
+		${RUSTC} -Clinker=$* -Clinker-flavor=gcc --target ${TARGET} -C target-feature=+crt-static test-aslr.rs; \
+		! readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) INTERP; \
+		readelf -l $(call RUN_BINFILE,test-aslr) | $(CGREP) DYNAMIC; \
+		$(call RUN,test-aslr) --test-aslr; \
+	fi

--- a/src/test/run-make/static-pie/check_clang_version.sh
+++ b/src/test/run-make/static-pie/check_clang_version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if command -v clang > /dev/null
+then
+  CLANG_VERSION=$(echo __clang_major__ | clang -E -x c - | grep -v -e '^#' )
+  echo "clang version $CLANG_VERSION detected"
+  if (( $CLANG_VERSION >= 9 ))
+  then
+    echo "clang supports -static-pie"
+    exit 0
+  else
+    echo "clang too old to support -static-pie, skipping test"
+    exit 1
+  fi
+else
+  echo "No clang version detected"
+  exit 2
+fi

--- a/src/test/run-make/static-pie/check_gcc_version.sh
+++ b/src/test/run-make/static-pie/check_gcc_version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if command -v gcc > /dev/null
+then
+  GCC_VERSION=$(echo __GNUC__ | gcc -E -x c - | grep -v -e '^#' )
+  echo "gcc version $GCC_VERSION detected"
+  if (( $GCC_VERSION >= 8 ))
+  then
+    echo "gcc supports -static-pie"
+    exit 0
+  else
+    echo "gcc too old to support -static-pie, skipping test"
+    exit 1
+  fi
+else
+  echo "No gcc version detected"
+  exit 2
+fi


### PR DESCRIPTION
Modern `gcc` versions support `-static-pie`, and `rustc` will already fall-back to `-static` if the local `gcc` is too old (and hence this change is optimistic rather than absolute).  This brings the `-musl` and `-gnu` targets to feature compatibility (albeit with different default settings).

Of note a `-static` or `-static-pie` binary based on glibc that uses NSS-backed functions (`gethostbyname` or `getpwuid` etc.) need to have access to the `libnss_X.so.2` libraries and any of their dynamic dependencies.

I wasn't sure about the `# only`/`# ignore` changes (I've not got a `gnux32` toolchain to test with hence not also enabling `-static-pie` there).