### PR TITLE
Remove `#[allow(unused_lifetimes)]` which is now unnecessary

### DIFF
--- a/compiler/rustc_data_structures/src/captures.rs
+++ b/compiler/rustc_data_structures/src/captures.rs
@@ -3,8 +3,6 @@
 /// Basically a workaround; see [this comment] for details.
 ///
 /// [this comment]: https://github.com/rust-lang/rust/issues/34511#issuecomment-373423999
-// FIXME(eddyb) false positive, the lifetime parameter is "phantom" but needed.
-#[allow(unused_lifetimes)]
 pub trait Captures<'a> {}
 
 impl<'a, T: ?Sized> Captures<'a> for T {}


### PR DESCRIPTION
Seems FP has been fixed, it doesn't need `#[allow(unused_lifetimes)]` anymore.