### PR TITLE
Remove invalid suggestion involving `Fn` trait bound

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1604,6 +1604,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     if generics.params.iter().any(|p| p.name != kw::SelfUpper)
                         && !snippet.ends_with('>')
                         && !generics.has_impl_trait()
+                        && !self.tcx.fn_trait_kind_from_lang_item(*def_id).is_some()
                     {
                         // FIXME: To avoid spurious suggestions in functions where type arguments
                         // where already supplied, we check the snippet to make sure it doesn't

--- a/src/test/ui/traits/issue-85735.rs
+++ b/src/test/ui/traits/issue-85735.rs
@@ -1,0 +1,13 @@
+// Regression test for the invalid suggestion in #85735 (the
+// underlying issue #21974 still exists here).
+
+trait Foo {}
+impl<'a, 'b, T> Foo for T
+where
+    T: FnMut(&'a ()),
+    //~^ ERROR: type annotations needed [E0283]
+    T: FnMut(&'b ()),
+{
+}
+
+fn main() {}

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -1,0 +1,16 @@
+error[E0283]: type annotations needed
+  --> $DIR/issue-85735.rs:7:8
+   |
+LL |     T: FnMut(&'a ()),
+   |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   | 
+  ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |
+LL | pub trait FnMut<Args>: FnOnce<Args> {
+   | ----------------------------------- required by this bound in `FnMut`
+   |
+   = note: cannot satisfy `T: FnMut<(&'a (),)>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
This pull request closes #85735. The actual issue is a duplicate of #21974, but #85735 contains a further problem, which is an invalid suggestion if `Fn`/`FnMut`/`FnOnce` trait bounds are involved: The suggestion code checks whether the trait bound ends with `>` to determine whether it has any generic arguments, but the `Fn*` traits have a special syntax for generic arguments that doesn't involve angle brackets. The example given in #85735:
```rust
trait Foo {}
impl<'a, 'b, T> Foo for T
where
    T: FnMut(&'a ()),
    T: FnMut(&'b ()), {

    }
```
currently produces:
```
error[E0283]: type annotations needed
   --> src/lib.rs:4:8
    |
4   |       T: FnMut(&'a ()),
    |          ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
    |
    = note: cannot satisfy `T: FnMut<(&'a (),)>`
help: consider specifying the type arguments in the function call
    |
4   |     T: FnMut(&'a ())::<Self, Args>,
    |                     ^^^^^^^^^^^^^^

error: aborting due to previous error
```
which is incorrect, because there is no function call, and applying the suggestion would lead to a parse error. With my changes, I get:
```
error[E0283]: type annotations needed
   --> test.rs:4:8
    |
4   |     T: FnMut(&'a ()),
    |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
    | 
   ::: [...]/library/core/src/ops/function.rs:147:1
    |
147 | pub trait FnMut<Args>: FnOnce<Args> {
    | ----------------------------------- required by this bound in `FnMut`
    |
    = note: cannot satisfy `T: FnMut<(&'a (),)>`

error: aborting due to previous error
```
i.e. I have added a check to prevent the invalid suggestion from being issued for `Fn*` bounds, while the underlying issue #21974 remains for now.
