### PR TITLE
Update rustversion to 1.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
1.0.4 was problematic for bootstrapping rustc on gentoo. See https://github.com/dtolnay/rustversion/issues/28.