### PR TITLE
Tweak SocketAncillary API

### DIFF
--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -464,6 +464,9 @@ impl<'a> SocketAncillary<'a> {
     /// All data written to the buffer must be valid ancillary data for the target platform,
     /// and you must call [`set_len()`](Self::set_len) after changing
     /// the buffer contents to update the internal bookkeeping.
+    ///
+    /// Make sure to zero-initialize the buffer if you are going to use it with [`libc::CMSG_NXTHDR()`].
+    /// That function requires the buffer to be zero-initialized in order to work correctly
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub unsafe fn buffer_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         self.buffer

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -429,6 +429,34 @@ impl<'a> SocketAncillary<'a> {
         self.buffer.len()
     }
 
+    /// Returns the raw ancillary data as byte slice.
+    #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
+    pub fn data(&self) -> &[u8] {
+        &self.buffer[..self.length]
+    }
+
+    /// Returns the entire buffer, including unused capacity.
+    ///
+    /// Use [`data()`](Self::data) if you are only interested in the used portion of the buffer.
+    #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
+    pub fn buffer(&self) -> &[u8] {
+        self.buffer
+    }
+
+    /// Returns the entire buffer as mutable slice, including unused capacity.
+    ///
+    /// You should normally call [`set_len()`](Self::set_len)
+    /// after changing the contents of the buffer.
+    ///
+    /// # Safety
+    /// All data written to the buffer must be valid ancillary data for the target platform,
+    /// and you must call [`set_len()`](Self::set_len) after changing
+    /// the buffer contents to update the internal bookkeeping.
+    #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
+    pub unsafe fn buffer_mut(&mut self) -> &mut [u8] {
+        self.buffer
+    }
+
     /// Returns `true` if the ancillary data is empty.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn is_empty(&self) -> bool {
@@ -439,6 +467,20 @@ impl<'a> SocketAncillary<'a> {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn len(&self) -> usize {
         self.length
+    }
+
+    /// Set the number of valid ancillary data bytes and the truncated flag.
+    ///
+    /// This can be used with [`buffer_mut()`](Self::buffer_mut)
+    /// to manually write ancillary data into the buffer.
+    ///
+    /// # Safety
+    /// - The length may not exceed [`capacity()`](Self::capacity).
+    /// - The data in the buffer at `0..length` must be valid ancillary data.
+    #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
+    pub unsafe fn set_len(&mut self, length: usize, truncated: bool) {
+        self.length = length;
+        self.truncated = truncated;
     }
 
     /// Returns the iterator of the control messages.

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -521,7 +521,9 @@ impl UnixDatagram {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..])?;
+    ///     unsafe {
+    ///         ancillary.add_fds(&fds[..])?;
+    ///     }
     ///     sock.send_vectored_with_ancillary_to(bufs, &mut ancillary, "/some/sock")
     ///         .expect("send_vectored_with_ancillary_to function failed");
     ///     Ok(())
@@ -570,7 +572,9 @@ impl UnixDatagram {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..])?;
+    ///     unsafe {
+    ///         ancillary.add_fds(&fds[..])?;
+    ///     }
     ///     sock.send_vectored_with_ancillary(bufs, &mut ancillary)
     ///         .expect("send_vectored_with_ancillary function failed");
     ///     Ok(())

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -521,7 +521,7 @@ impl UnixDatagram {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..]);
+    ///     ancillary.add_fds(&fds[..])?;
     ///     sock.send_vectored_with_ancillary_to(bufs, &mut ancillary, "/some/sock")
     ///         .expect("send_vectored_with_ancillary_to function failed");
     ///     Ok(())
@@ -570,7 +570,7 @@ impl UnixDatagram {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..]);
+    ///     ancillary.add_fds(&fds[..])?;
     ///     sock.send_vectored_with_ancillary(bufs, &mut ancillary)
     ///         .expect("send_vectored_with_ancillary function failed");
     ///     Ok(())

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -545,7 +545,7 @@ impl UnixStream {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..]);
+    ///     ancillary.add_fds(&fds[..])?;
     ///     socket.send_vectored_with_ancillary(bufs, &mut ancillary)
     ///         .expect("send_vectored_with_ancillary function failed");
     ///     Ok(())

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -545,7 +545,9 @@ impl UnixStream {
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
     ///     let mut ancillary = SocketAncillary::new(&mut ancillary_buffer[..]);
-    ///     ancillary.add_fds(&fds[..])?;
+    ///     unsafe {
+    ///         ancillary.add_fds(&fds[..])?;
+    ///     }
     ///     socket.send_vectored_with_ancillary(bufs, &mut ancillary)
     ///         .expect("send_vectored_with_ancillary function failed");
     ///     Ok(())

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -490,7 +490,9 @@ fn test_send_vectored_fds_unix_stream() {
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
-    ancillary1.add_fds(&[s1.as_raw_fd()][..]).unwrap();
+    unsafe {
+        ancillary1.add_fds(&[s1.as_raw_fd()][..]).unwrap();
+    }
 
     let usize = or_panic!(s1.send_vectored_with_ancillary(&bufs_send, &mut ancillary1));
     assert_eq!(usize, 8);
@@ -608,7 +610,9 @@ fn test_send_vectored_with_ancillary_unix_datagram() {
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
-    ancillary1.add_fds(&[bsock1.as_raw_fd()][..]).unwrap();
+    unsafe {
+        ancillary1.add_fds(&[bsock1.as_raw_fd()][..]).unwrap();
+    }
 
     or_panic!(bsock1.connect(&path2));
     let usize = or_panic!(bsock1.send_vectored_with_ancillary(&bufs_send, &mut ancillary1));

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -490,7 +490,7 @@ fn test_send_vectored_fds_unix_stream() {
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
-    assert!(ancillary1.add_fds(&[s1.as_raw_fd()][..]));
+    ancillary1.add_fds(&[s1.as_raw_fd()][..]).unwrap();
 
     let usize = or_panic!(s1.send_vectored_with_ancillary(&bufs_send, &mut ancillary1));
     assert_eq!(usize, 8);
@@ -551,7 +551,7 @@ fn test_send_vectored_with_ancillary_to_unix_datagram() {
     cred1.set_pid(getpid());
     cred1.set_uid(getuid());
     cred1.set_gid(getgid());
-    assert!(ancillary1.add_creds(&[cred1.clone()][..]));
+    ancillary1.add_creds(&[cred1.clone()][..]).unwrap();
 
     let usize =
         or_panic!(bsock1.send_vectored_with_ancillary_to(&bufs_send, &mut ancillary1, &path2));
@@ -608,7 +608,7 @@ fn test_send_vectored_with_ancillary_unix_datagram() {
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
-    assert!(ancillary1.add_fds(&[bsock1.as_raw_fd()][..]));
+    ancillary1.add_fds(&[bsock1.as_raw_fd()][..]).unwrap();
 
     or_panic!(bsock1.connect(&path2));
     let usize = or_panic!(bsock1.send_vectored_with_ancillary(&bufs_send, &mut ancillary1));


### PR DESCRIPTION
This PR tweaks the API of the unix-specific `SocketAncillary` struct.

It does four things:
* Add `data()`, `buffer()`, `buffer_mut()` and `set_len()` to allow integration with manual syscalls, for example when implementing unsupported socket types outside of `std`.
* Switch to `&mut [MaybeUnit<u8>]` internally and add `new_uninit()`.
* Have `add_fds()` and `add_creds()` return a `Result` to indicate failure.
* Mark `add_fds()` unsafe.

The reason for making `add_fds()` unsafe is that no lifetimes are tracked, so the FD could be closed and re-assigned before the ancillary data is actually used. This would result in sending the wrong file descriptor which may end up messing with an otherwise safe memory mapping.