### PR TITLE
Use `copy_nonoverlapping` to copy `bytes` in `String::insert_bytes`

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1451,7 +1451,7 @@ impl String {
 
         unsafe {
             ptr::copy(self.vec.as_ptr().add(idx), self.vec.as_mut_ptr().add(idx + amt), len - idx);
-            ptr::copy(bytes.as_ptr(), self.vec.as_mut_ptr().add(idx), amt);
+            ptr::copy_nonoverlapping(bytes.as_ptr(), self.vec.as_mut_ptr().add(idx), amt);
             self.vec.set_len(len + amt);
         }
     }


### PR DESCRIPTION
The second copy could be made using `ptr::copy_nonoverlapping` instead of `ptr::copy`, since aliasing won't allow `self` and `bytes` to overlap. LLVM even seems to recognize this, [replacing the second `memmove` with a `memcopy`](https://rust.godbolt.org/z/Yoaa6rrGn), so this makes it so it's always applied.