### PR TITLE
Fix ICE with `#[repr(simd)]` on enum

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -672,6 +672,15 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
             // SIMD vector types.
             ty::Adt(def, substs) if def.repr.simd() => {
+                if !def.is_struct() {
+                    // Should have yielded E0517 by now.
+                    tcx.sess.delay_span_bug(
+                        DUMMY_SP,
+                        "#[repr(simd)] was applied to an ADT that is not a struct",
+                    );
+                    return Err(LayoutError::Unknown(ty));
+                }
+
                 // Supported SIMD vectors are homogeneous ADTs with at least one field:
                 //
                 // * #[repr(simd)] struct S(T, T, T, T);

--- a/src/test/ui/repr/issue-83505-repr-simd.rs
+++ b/src/test/ui/repr/issue-83505-repr-simd.rs
@@ -1,0 +1,10 @@
+// Regression test for the ICE described in #83505.
+
+#![crate_type="lib"]
+
+#[repr(simd)]
+//~^ ERROR: attribute should be applied to a struct [E0517]
+//~| ERROR: unsupported representation for zero-variant enum [E0084]
+enum Es {}
+static CLs: Es;
+//~^ ERROR: free static item without body

--- a/src/test/ui/repr/issue-83505-repr-simd.stderr
+++ b/src/test/ui/repr/issue-83505-repr-simd.stderr
@@ -1,0 +1,30 @@
+error: free static item without body
+  --> $DIR/issue-83505-repr-simd.rs:9:1
+   |
+LL | static CLs: Es;
+   | ^^^^^^^^^^^^^^-
+   |               |
+   |               help: provide a definition for the static: `= <expr>;`
+
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/issue-83505-repr-simd.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ---------- not a struct
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> $DIR/issue-83505-repr-simd.rs:5:1
+   |
+LL | #[repr(simd)]
+   | ^^^^^^^^^^^^^
+...
+LL | enum Es {}
+   | ---------- zero-variant enum
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0084, E0517.
+For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
This pull request fixes #83505. `#[repr(simd)]` may only be applied to structs, which correctly causes `E0517` for the example given in #83505, but the compiler attempts to recover from this error, which leads to an ICE later, when `.non_enum_variant()` is called on the `AdtDef`. I have added a check that prevents this from happening.