### PR TITLE
2229: Capture box completely in move closures

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.rs
@@ -141,7 +141,7 @@ fn truncate_box_derefs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", b.0);
-        //~^ NOTE: Capturing b[] -> ByValue
+        //~^ NOTE: Capturing b[Deref,(0, 0)] -> ByValue
         //~| NOTE: Min Capture b[] -> ByValue
     };
 
@@ -158,7 +158,7 @@ fn truncate_box_derefs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", t.1.0);
-        //~^ NOTE: Capturing t[(1, 0)] -> ByValue
+        //~^ NOTE: Capturing t[(1, 0),Deref,(0, 0)] -> ByValue
         //~| NOTE: Min Capture t[(1, 0)] -> ByValue
     };
 }

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.rs
@@ -114,8 +114,9 @@ fn struct_contains_ref_to_another_struct_3() {
 fn truncate_box_derefs() {
     struct S(i32);
 
-    let b = Box::new(S(10));
 
+    // Content within the box is moved within the closure
+    let b = Box::new(S(10));
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
@@ -129,6 +130,37 @@ fn truncate_box_derefs() {
     };
 
     c();
+
+    // Content within the box is used by a shared ref and the box is the root variable
+    let b = Box::new(S(10));
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    move || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        println!("{}", b.0);
+        //~^ NOTE: Capturing b[] -> ByValue
+        //~| NOTE: Min Capture b[] -> ByValue
+    };
+
+    c();
+
+    // Content within the box is used by a shared ref and the box is not the root variable
+    let b = Box::new(S(10));
+    let t = (0, b);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    move || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        println!("{}", t.1.0);
+        //~^ NOTE: Capturing t[(1, 0)] -> ByValue
+        //~| NOTE: Min Capture t[(1, 0)] -> ByValue
+    };
 }
 
 fn main() {

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -317,7 +317,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing b[] -> ByValue
+note: Capturing b[Deref,(0, 0)] -> ByValue
   --> $DIR/move_closure.rs:143:24
    |
 LL |         println!("{}", b.0);
@@ -353,7 +353,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(1, 0)] -> ByValue
+note: Capturing t[(1, 0),Deref,(0, 0)] -> ByValue
   --> $DIR/move_closure.rs:160:24
    |
 LL |         println!("{}", t.1.0);

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -44,7 +44,25 @@ LL |     let mut c = #[rustc_capture_analysis]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:119:13
+  --> $DIR/move_closure.rs:120:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:137:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:154:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,7 +265,7 @@ LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:122:5
+  --> $DIR/move_closure.rs:123:5
    |
 LL | /     move || {
 LL | |
@@ -259,18 +277,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[Deref,(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:125:18
+  --> $DIR/move_closure.rs:126:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 note: Capturing b[] -> ByValue
-  --> $DIR/move_closure.rs:125:18
+  --> $DIR/move_closure.rs:126:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:122:5
+  --> $DIR/move_closure.rs:123:5
    |
 LL | /     move || {
 LL | |
@@ -282,11 +300,83 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[] -> ByValue
-  --> $DIR/move_closure.rs:125:18
+  --> $DIR/move_closure.rs:126:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
-error: aborting due to 18 previous errors; 1 warning emitted
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:140:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         println!("{}", b.0);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing b[] -> ByValue
+  --> $DIR/move_closure.rs:143:24
+   |
+LL |         println!("{}", b.0);
+   |                        ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:140:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         println!("{}", b.0);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture b[] -> ByValue
+  --> $DIR/move_closure.rs:143:24
+   |
+LL |         println!("{}", b.0);
+   |                        ^^^
+
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:157:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         println!("{}", t.1.0);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing t[(1, 0)] -> ByValue
+  --> $DIR/move_closure.rs:160:24
+   |
+LL |         println!("{}", t.1.0);
+   |                        ^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:157:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         println!("{}", t.1.0);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture t[(1, 0)] -> ByValue
+  --> $DIR/move_closure.rs:160:24
+   |
+LL |         println!("{}", t.1.0);
+   |                        ^^^^^
+
+error: aborting due to 24 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Even if the content from box is used in a sharef-ref context,
we capture the box entirerly.

This is motivated by:
1) We only capture data that is on the stack.
2) Capturing data from within the box might end up moving more data than
the user anticipated.

Closes https://github.com/rust-lang/project-rfc-2229/issues/50

r? @nikomatsakis 