### PR TITLE
Windows: Fix `fs::canonicalize`  to work with legacy drivers

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -229,6 +229,7 @@ pub struct ipv6_mreq {
 }
 
 pub const VOLUME_NAME_DOS: DWORD = 0x0;
+pub const VOLUME_NAME_NT: DWORD = 0x2;
 pub const MOVEFILE_REPLACE_EXISTING: DWORD = 1;
 
 pub const FILE_BEGIN: DWORD = 0;

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -865,10 +865,37 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
 }
 
 fn get_path(f: &File) -> io::Result<PathBuf> {
+    get_path_with_flags(f, c::VOLUME_NAME_DOS).or_else(|error| {
+        if error.raw_os_error() == Some(c::ERROR_INVALID_FUNCTION as i32) {
+            // This should normally be unreachable. See comment below.
+            get_path_fallback(f)
+        } else {
+            Err(error)
+        }
+    })
+}
+
+// Unfortunately some third party filesystem drivers don't implement the
+// volume manager interface that the kernel requires. This breaks a number of
+// things, including resolving the win32 path from a file handle.
+//
+// To workaround these broken drivers, this function instead gets the NT kernel
+// path (which is always available) and then uses the magic win32 prefix
+// `\\?\GLOBALROOT` so that the NT path can be used in win32 code.
+//
+// A downside to this is that it produces weird paths that users may find
+// strange.
+fn get_path_fallback(f: &File) -> io::Result<PathBuf> {
+    get_path_with_flags(f, c::VOLUME_NAME_NT).map(|nt_path| {
+        let mut win32_path: OsString = r"\\?\GLOBALROOT".into();
+        win32_path.push(nt_path);
+        win32_path.into()
+    })
+}
+
+fn get_path_with_flags(f: &File, flags: u32) -> io::Result<PathBuf> {
     super::fill_utf16_buf(
-        |buf, sz| unsafe {
-            c::GetFinalPathNameByHandleW(f.handle.as_raw_handle(), buf, sz, c::VOLUME_NAME_DOS)
-        },
+        |buf, sz| unsafe { c::GetFinalPathNameByHandleW(f.handle.as_raw_handle(), buf, sz, flags) },
         |buf| PathBuf::from(OsString::from_wide(buf)),
     )
 }


### PR DESCRIPTION
Attempts to fix: #59392, #79449, #59107, #54875, #52440, #52377, #48249, #74327, #55812

(sorry if I missed any)

# The problem

On Windows, certain virtual drives (e.g. legacy RAM drives) manually create drive letter associations and mount points rather than going through the system Mount Manager (either directly or indirectly). The result of this means that volume management functions may fail. Unfortunately these functions include looking up the drive name, which in turn means that `std::fs::canonicalize` won't work.

# The workaround

The solution presented here is to detect when querying the drive name fails and fallback to using the NT kernel path. This can be used in win32 by prepending `\\?\GLOBALROOT` to the kernel path ([as documented here](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#nt-namespaces)). The downside of this solution is that it produces "weird" looking paths that a user may not recognise and other applications may not be able to use.

E.g. this path:

    R:\path\to\file.txt

May be canonicalized like so:

    \\?\GLOBALROOT\Device\ImDisk0\path\to\file.txt

But it is at least usable by `std::fs` and it's perhaps better than having the crashes reported in some of the issues above.

# Conclusion

Working in the presence of these drivers can be tricky and normally I would just suggest this isn't Rust's problem (which it technically isn't). However, these drivers seem widespread enough that I think it makes sense to try to workaround them, at least in this specific case.