### PR TITLE
fix panic-safety in specialized Zip::next_back

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -295,9 +295,10 @@ where
                 let sz_a = self.a.size();
                 if A::MAY_HAVE_SIDE_EFFECT && sz_a > self.len {
                     for _ in 0..sz_a - self.len {
+                        self.a_len -= 1;
                         self.a.next_back();
                     }
-                    self.a_len = self.len;
+                    debug_assert_eq!(self.a_len, self.len);
                 }
                 let sz_b = self.b.size();
                 if B::MAY_HAVE_SIDE_EFFECT && sz_b > self.len {

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -1,7 +1,5 @@
 use super::*;
 use core::iter::*;
-use std::panic::catch_unwind;
-use std::panic::AssertUnwindSafe;
 
 #[test]
 fn test_zip_nth() {
@@ -235,7 +233,11 @@ fn test_zip_trusted_random_access_composition() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn test_zip_trusted_random_access_next_back_drop() {
+    use std::panic::catch_unwind;
+    use std::panic::AssertUnwindSafe;
+
     let mut counter = 0;
 
     let it = [42].iter().map(|e| {

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -1,5 +1,7 @@
 use super::*;
 use core::iter::*;
+use std::panic::catch_unwind;
+use std::panic::AssertUnwindSafe;
 
 #[test]
 fn test_zip_nth() {
@@ -230,6 +232,29 @@ fn test_zip_trusted_random_access_composition() {
     fn assert_trusted_random_access<T: TrustedRandomAccess>(_a: &T) {}
     assert_trusted_random_access(&z2);
     assert_eq!(z2.next().unwrap(), ((1, 1), 1));
+}
+
+#[test]
+fn test_zip_trusted_random_access_next_back_drop() {
+    let mut counter = 0;
+
+    let it = [42].iter().map(|e| {
+        let c = counter;
+        counter += 1;
+        if c == 0 {
+            panic!("bomb");
+        }
+
+        e
+    });
+    let it2 = [(); 0].iter();
+    let mut zip = it.zip(it2);
+    catch_unwind(AssertUnwindSafe(|| {
+        zip.next_back();
+    }))
+    .unwrap_err();
+    assert!(zip.next().is_none());
+    assert_eq!(counter, 1);
 }
 
 #[test]


### PR DESCRIPTION
This was unsound since a panic in a.next_back() would result in the
length not being updated which would then lead to the same element
being revisited in the side-effect preserving code.

fixes #86443