### PR TITLE
stdlib: Fix typo in internal RefCell docs 

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -578,7 +578,7 @@ pub struct RefCell<T: ?Sized> {
     // Stores the location of the earliest currently active borrow.
     // This gets updated whenver we go from having zero borrows
     // to having a single borrow. When a borrow occurs, this gets included
-    // in the generated `BorroeError/`BorrowMutError`
+    // in the generated `BorrowError/`BorrowMutError`
     #[cfg(feature = "debug_refcell")]
     borrowed_at: Cell<Option<&'static crate::panic::Location<'static>>>,
     value: UnsafeCell<T>,


### PR DESCRIPTION
`BorroeError` => `BorrowError` in [cell.rs](https://github.com/rust-lang/rust/blob/master/library/core/src/cell.rs#L581)