### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -2,7 +2,7 @@
 name: Library Tracking Issue
 about: A tracking issue for an unstable library feature.
 title: Tracking Issue for XXX
-labels: C-tracking-issue, T-libs
+labels: C-tracking-issue, T-libs-api
 ---
 <!--
 Thank you for creating a tracking issue!
@@ -60,7 +60,7 @@ unresolved questions left, the feature might be ready for stabilization.
 If this feature didn't go through the RFC process, a final commenting period
 (FCP) is always needed before stabilization. This works as follows:
 
-A library team member can kick off the stabilization process, at which point
+A library API team member can kick off the stabilization process, at which point
 the rfcbot will ask all the team members to verify they agree with
 stabilization. Once enough members agree and there are no concerns, the final
 commenting period begins: this issue will be marked as such and will be listed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -672,6 +672,15 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
             // SIMD vector types.
             ty::Adt(def, substs) if def.repr.simd() => {
+                if !def.is_struct() {
+                    // Should have yielded E0517 by now.
+                    tcx.sess.delay_span_bug(
+                        DUMMY_SP,
+                        "#[repr(simd)] was applied to an ADT that is not a struct",
+                    );
+                    return Err(LayoutError::Unknown(ty));
+                }
+
                 // Supported SIMD vectors are homogeneous ADTs with at least one field:
                 //
                 // * #[repr(simd)] struct S(T, T, T, T);

--- a/compiler/rustc_mir/src/transform/const_prop.rs
+++ b/compiler/rustc_mir/src/transform/const_prop.rs
@@ -1205,12 +1205,9 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
                         let mut eval_to_int = |op| {
                             // This can be `None` if the lhs wasn't const propagated and we just
                             // triggered the assert on the value of the rhs.
-                            match self.eval_operand(op, source_info) {
-                                Some(op) => DbgVal::Val(
-                                    self.ecx.read_immediate(&op).unwrap().to_const_int(),
-                                ),
-                                None => DbgVal::Underscore,
-                            }
+                            self.eval_operand(op, source_info).map_or(DbgVal::Underscore, |op| {
+                                DbgVal::Val(self.ecx.read_immediate(&op).unwrap().to_const_int())
+                            })
                         };
                         let msg = match msg {
                             AssertKind::DivisionByZero(op) => {

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -488,6 +488,13 @@ impl<T: ?Sized> Cell<T> {
     /// This call borrows `Cell` mutably (at compile-time) which guarantees
     /// that we possess the only reference.
     ///
+    /// However be cautious: this method expects `self` to be mutable, which is
+    /// generally not the case when using a `Cell`. If you require interior
+    /// mutability by reference, consider using `RefCell` which provides
+    /// run-time checked mutable borrows through its [`borrow_mut`] method.
+    ///
+    /// [`borrow_mut`]: RefCell::borrow_mut()
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -578,7 +578,7 @@ pub struct RefCell<T: ?Sized> {
     // Stores the location of the earliest currently active borrow.
     // This gets updated whenver we go from having zero borrows
     // to having a single borrow. When a borrow occurs, this gets included
-    // in the generated `BorroeError/`BorrowMutError`
+    // in the generated `BorrowError/`BorrowMutError`
     #[cfg(feature = "debug_refcell")]
     borrowed_at: Cell<Option<&'static crate::panic::Location<'static>>>,
     value: UnsafeCell<T>,

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -707,7 +707,7 @@ impl Group {
     /// pub fn span_open(&self) -> Span {
     ///                 ^
     /// ```
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_group_span", since = "1.55.0")]
     pub fn span_open(&self) -> Span {
         Span(self.0.span_open())
     }
@@ -718,7 +718,7 @@ impl Group {
     /// pub fn span_close(&self) -> Span {
     ///                        ^
     /// ```
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_group_span", since = "1.55.0")]
     pub fn span_close(&self) -> Span {
         Span(self.0.span_close())
     }

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -79,7 +79,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
                          name=\"{}\" time=\"{}\">",
                         class_name,
                         test_name,
-                        duration.as_secs()
+                        duration.as_secs_f64()
                     ))?;
                     self.write_message("<failure type=\"assert\"/>")?;
                     self.write_message("</testcase>")?;
@@ -91,7 +91,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
                          name=\"{}\" time=\"{}\">",
                         class_name,
                         test_name,
-                        duration.as_secs()
+                        duration.as_secs_f64()
                     ))?;
                     self.write_message(&*format!("<failure message=\"{}\" type=\"assert\"/>", m))?;
                     self.write_message("</testcase>")?;
@@ -103,7 +103,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
                          name=\"{}\" time=\"{}\">",
                         class_name,
                         test_name,
-                        duration.as_secs()
+                        duration.as_secs_f64()
                     ))?;
                     self.write_message("<failure type=\"timeout\"/>")?;
                     self.write_message("</testcase>")?;
@@ -123,7 +123,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
                          name=\"{}\" time=\"{}\"/>",
                         class_name,
                         test_name,
-                        duration.as_secs()
+                        duration.as_secs_f64()
                     ))?;
                 }
             }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -979,7 +979,9 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 }
                 w.write_str(")");
             }
-            w.write_str("</code></div>");
+            w.write_str("</code>");
+            render_stability_since(w, variant, it, cx.tcx());
+            w.write_str("</div>");
             document(w, cx, variant, Some(it));
             document_non_exhaustive(w, variant);
 
@@ -1021,7 +1023,6 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 w.write_str("</div></div>");
                 toggle_close(w);
             }
-            render_stability_since(w, variant, it, cx.tcx());
         }
     }
     let def_id = it.def_id.expect_real();

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -654,6 +654,12 @@ a {
 	background: transparent;
 }
 
+.small-section-header {
+	display: flex;
+	justify-content: space-between;
+	position: relative;
+}
+
 .small-section-header:hover > .anchor {
 	display: initial;
 }

--- a/src/test/ui/repr/issue-83505-repr-simd.rs
+++ b/src/test/ui/repr/issue-83505-repr-simd.rs
@@ -1,0 +1,10 @@
+// Regression test for the ICE described in #83505.
+
+#![crate_type="lib"]
+
+#[repr(simd)]
+//~^ ERROR: attribute should be applied to a struct [E0517]
+//~| ERROR: unsupported representation for zero-variant enum [E0084]
+enum Es {}
+static CLs: Es;
+//~^ ERROR: free static item without body

--- a/src/test/ui/repr/issue-83505-repr-simd.stderr
+++ b/src/test/ui/repr/issue-83505-repr-simd.stderr
@@ -1,0 +1,30 @@
+error: free static item without body
+  --> $DIR/issue-83505-repr-simd.rs:9:1
+   |
+LL | static CLs: Es;
+   | ^^^^^^^^^^^^^^-
+   |               |
+   |               help: provide a definition for the static: `= <expr>;`
+
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/issue-83505-repr-simd.rs:5:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+...
+LL | enum Es {}
+   | ---------- not a struct
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> $DIR/issue-83505-repr-simd.rs:5:1
+   |
+LL | #[repr(simd)]
+   | ^^^^^^^^^^^^^
+...
+LL | enum Es {}
+   | ---------- zero-variant enum
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0084, E0517.
+For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
Successful merges:

 - #86136 (Stabilize span_open() and span_close().)
 - #86359 (Use as_secs_f64 in JunitFormatter)
 - #86370 (Fix rustdoc stabilized versions layout)
 - #86397 (Alter std::cell::Cell::get_mut documentation)
 - #86407 (Use `map_or` instead of open-coding it)
 - #86425 (Update rustversion to 1.0.5)
 - #86440 (Update library tracking issue for libs-api rename.)
 - #86444 (Fix ICE with `#[repr(simd)]` on enum)
 - #86453 (stdlib: Fix typo in internal RefCell docs )

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86136,86359,86370,86397,86407,86425,86440,86444,86453)
<!-- homu-ignore:end -->