### PR TITLE
Fix CI to fetch master on beta channel

### DIFF
--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -31,7 +31,7 @@ mkdir "$CACHE_DIR"
 
 # On the beta channel we'll be automatically calculating the prerelease version
 # via the git history, so unshallow our shallow clone from CI.
-if grep -q RUST_RELEASE_CHANNEL=beta src/ci/run.sh; then
+if [ "$(releaseChannel)" = "beta" ]; then
   git fetch origin --unshallow beta master
 fi
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -65,11 +65,7 @@ fi
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting
 # master, beta, or stable with a build to determine whether to run some checks (notably toolstate).
-if [[ -z "${RUST_CI_OVERRIDE_RELEASE_CHANNEL+x}" ]]; then
-    export RUST_RELEASE_CHANNEL="$(cat "${ci_dir}/channel")"
-else
-    export RUST_RELEASE_CHANNEL="${RUST_CI_OVERRIDE_RELEASE_CHANNEL}"
-fi
+export RUST_RELEASE_CHANNEL=$(releaseChannel)
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
 
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -141,3 +141,11 @@ function ciCommandSetEnv {
         exit 1
     fi
 }
+
+function releaseChannel {
+    if [[ -z "${RUST_CI_OVERRIDE_RELEASE_CHANNEL+x}" ]]; then
+        cat "${ci_dir}/channel"
+    else
+        echo $RUST_CI_OVERRIDE_RELEASE_CHANNEL
+    fi
+}


### PR DESCRIPTION
This forward-ports a fix from the beta channel (landing in #86413, hopefully) to master so that we don't need to apply it on each round of backports.

This bug also demonstrates that our channel-checking is a bit insufficient -- stable is checked, but beta has some of its own peculiarities currently and isn't checked. But this does not attempt to adjust for that; we likely can't afford to run both beta and stable channels by CI and the current state here seems OK for now.

r? @pietroalbini 