### PR TITLE
E0716: clarify that equivalent code example is erroneous

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0716.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0716.md
@@ -14,14 +14,16 @@ Here, the expression `&foo()` is borrowing the expression `foo()`. As `foo()` is
 a call to a function, and not the name of a variable, this creates a
 **temporary** -- that temporary stores the return value from `foo()` so that it
 can be borrowed. You could imagine that `let p = bar(&foo());` is equivalent to
-this:
+the following, which uses an explicit temporary variable.
+
+Erroneous code example:
 
 ```compile_fail,E0597
 # fn foo() -> i32 { 22 }
 # fn bar(x: &i32) -> &i32 { x }
 let p = {
   let tmp = foo(); // the temporary
-  bar(&tmp)
+  bar(&tmp) // error: `tmp` does not live long enough
 }; // <-- tmp is freed as we exit this block
 let q = p;
 ```


### PR DESCRIPTION
In E0716, there is a code block that is equivalent to the erroneous
code example. Especially when viewed with `rustc --explain`, it's
not obvious that it is also erroneous, and some users have been
confused when they try to change their code to match the erroneous
equivalent.

@rustbot label +A-diagnostics +D-newcomer-roadblock +T-compiler