### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "libc",
  "merge",
  "num_cpus",
+ "once_cell",
  "opener",
  "pretty_assertions",
  "serde",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1749,6 +1749,7 @@ Language
 - [You can now use `#[repr(transparent)]` on univariant `enum`s.][68122] Meaning
   that you can create an enum that has the exact layout and ABI of the type
   it contains.
+- [You can now use outer attribute procedural macros on inline modules.][64273]  
 - [There are some *syntax-only* changes:][67131]
    - `default` is syntactically allowed before items in `trait` definitions.
    - Items in `impl`s (i.e. `const`s, `type`s, and `fn`s) may syntactically
@@ -1810,6 +1811,7 @@ Compatibility Notes
 [67935]: https://github.com/rust-lang/rust/pull/67935/
 [68339]: https://github.com/rust-lang/rust/pull/68339/
 [68122]: https://github.com/rust-lang/rust/pull/68122/
+[64273]: https://github.com/rust-lang/rust/pull/64273/
 [67712]: https://github.com/rust-lang/rust/pull/67712/
 [67887]: https://github.com/rust-lang/rust/pull/67887/
 [67131]: https://github.com/rust-lang/rust/pull/67131/

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -24,19 +24,18 @@ crate fn expand(
     annotatable: Annotatable,
 ) -> Vec<Annotatable> {
     check_builtin_macro_attribute(ecx, meta_item, sym::cfg_eval);
-    cfg_eval(ecx, annotatable)
+    vec![cfg_eval(ecx, annotatable)]
 }
 
-crate fn cfg_eval(ecx: &ExtCtxt<'_>, annotatable: Annotatable) -> Vec<Annotatable> {
-    let mut visitor = CfgEval {
+crate fn cfg_eval(ecx: &ExtCtxt<'_>, annotatable: Annotatable) -> Annotatable {
+    CfgEval {
         cfg: &mut StripUnconfigured {
             sess: ecx.sess,
             features: ecx.ecfg.features,
             config_tokens: true,
         },
-    };
-    let annotatable = visitor.configure_annotatable(annotatable);
-    vec![annotatable]
+    }
+    .configure_annotatable(annotatable)
 }
 
 struct CfgEval<'a, 'b> {

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -36,48 +36,48 @@ crate fn cfg_eval(ecx: &ExtCtxt<'_>, annotatable: Annotatable) -> Annotatable {
         },
     }
     .configure_annotatable(annotatable)
+    // Since the item itself has already been configured by the `InvocationCollector`,
+    // we know that fold result vector will contain exactly one element.
+    .unwrap()
 }
 
 struct CfgEval<'a, 'b> {
     cfg: &'a mut StripUnconfigured<'b>,
 }
 
-fn flat_map_annotatable(vis: &mut impl MutVisitor, annotatable: Annotatable) -> Annotatable {
-    // Since the item itself has already been configured by the InvocationCollector,
-    // we know that fold result vector will contain exactly one element
+fn flat_map_annotatable(
+    vis: &mut impl MutVisitor,
+    annotatable: Annotatable,
+) -> Option<Annotatable> {
     match annotatable {
-        Annotatable::Item(item) => Annotatable::Item(vis.flat_map_item(item).pop().unwrap()),
+        Annotatable::Item(item) => vis.flat_map_item(item).pop().map(Annotatable::Item),
         Annotatable::TraitItem(item) => {
-            Annotatable::TraitItem(vis.flat_map_trait_item(item).pop().unwrap())
+            vis.flat_map_trait_item(item).pop().map(Annotatable::TraitItem)
         }
         Annotatable::ImplItem(item) => {
-            Annotatable::ImplItem(vis.flat_map_impl_item(item).pop().unwrap())
+            vis.flat_map_impl_item(item).pop().map(Annotatable::ImplItem)
         }
         Annotatable::ForeignItem(item) => {
-            Annotatable::ForeignItem(vis.flat_map_foreign_item(item).pop().unwrap())
+            vis.flat_map_foreign_item(item).pop().map(Annotatable::ForeignItem)
         }
         Annotatable::Stmt(stmt) => {
-            Annotatable::Stmt(stmt.map(|stmt| vis.flat_map_stmt(stmt).pop().unwrap()))
+            vis.flat_map_stmt(stmt.into_inner()).pop().map(P).map(Annotatable::Stmt)
         }
-        Annotatable::Expr(mut expr) => Annotatable::Expr({
+        Annotatable::Expr(mut expr) => {
             vis.visit_expr(&mut expr);
-            expr
-        }),
-        Annotatable::Arm(arm) => Annotatable::Arm(vis.flat_map_arm(arm).pop().unwrap()),
+            Some(Annotatable::Expr(expr))
+        }
+        Annotatable::Arm(arm) => vis.flat_map_arm(arm).pop().map(Annotatable::Arm),
         Annotatable::ExprField(field) => {
-            Annotatable::ExprField(vis.flat_map_expr_field(field).pop().unwrap())
+            vis.flat_map_expr_field(field).pop().map(Annotatable::ExprField)
         }
-        Annotatable::PatField(fp) => {
-            Annotatable::PatField(vis.flat_map_pat_field(fp).pop().unwrap())
-        }
+        Annotatable::PatField(fp) => vis.flat_map_pat_field(fp).pop().map(Annotatable::PatField),
         Annotatable::GenericParam(param) => {
-            Annotatable::GenericParam(vis.flat_map_generic_param(param).pop().unwrap())
+            vis.flat_map_generic_param(param).pop().map(Annotatable::GenericParam)
         }
-        Annotatable::Param(param) => Annotatable::Param(vis.flat_map_param(param).pop().unwrap()),
-        Annotatable::FieldDef(sf) => {
-            Annotatable::FieldDef(vis.flat_map_field_def(sf).pop().unwrap())
-        }
-        Annotatable::Variant(v) => Annotatable::Variant(vis.flat_map_variant(v).pop().unwrap()),
+        Annotatable::Param(param) => vis.flat_map_param(param).pop().map(Annotatable::Param),
+        Annotatable::FieldDef(sf) => vis.flat_map_field_def(sf).pop().map(Annotatable::FieldDef),
+        Annotatable::Variant(v) => vis.flat_map_variant(v).pop().map(Annotatable::Variant),
     }
 }
 
@@ -122,11 +122,11 @@ impl CfgEval<'_, '_> {
         self.cfg.configure(node)
     }
 
-    pub fn configure_annotatable(&mut self, mut annotatable: Annotatable) -> Annotatable {
+    fn configure_annotatable(&mut self, mut annotatable: Annotatable) -> Option<Annotatable> {
         // Tokenizing and re-parsing the `Annotatable` can have a significant
         // performance impact, so try to avoid it if possible
         if !CfgFinder::has_cfg_or_cfg_attr(&annotatable) {
-            return annotatable;
+            return Some(annotatable);
         }
 
         // The majority of parsed attribute targets will never need to have early cfg-expansion

--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -26,6 +26,8 @@ impl MultiItemModifier for Expander {
             return ExpandResult::Ready(vec![item]);
         }
 
+        let item = cfg_eval(ecx, item);
+
         let result =
             ecx.resolver.resolve_derives(ecx.current_expansion.id, ecx.force_mode, &|| {
                 let template =
@@ -54,12 +56,12 @@ impl MultiItemModifier for Expander {
                         report_path_args(sess, &meta);
                         meta.path
                     })
-                    .map(|path| (path, None))
+                    .map(|path| (path, item.clone(), None))
                     .collect()
             });
 
         match result {
-            Ok(()) => ExpandResult::Ready(cfg_eval(ecx, item)),
+            Ok(()) => ExpandResult::Ready(vec![item]),
             Err(Indeterminate) => ExpandResult::Retry(item),
         }
     }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -835,7 +835,7 @@ impl SyntaxExtension {
 /// Error type that denotes indeterminacy.
 pub struct Indeterminate;
 
-pub type DeriveResolutions = Vec<(ast::Path, Option<Lrc<SyntaxExtension>>)>;
+pub type DeriveResolutions = Vec<(ast::Path, Annotatable, Option<Lrc<SyntaxExtension>>)>;
 
 pub trait ResolverExpand {
     fn next_node_id(&mut self) -> NodeId;

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -427,7 +427,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     pub fn fully_expand_fragment(&mut self, input_fragment: AstFragment) -> AstFragment {
         let orig_expansion_data = self.cx.current_expansion.clone();
         let orig_force_mode = self.cx.force_mode;
-        self.cx.current_expansion.depth = 0;
 
         // Collect all macro invocations and replace them with placeholders.
         let (mut fragment_with_placeholders, mut invocations) =
@@ -488,6 +487,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             };
 
             let ExpansionData { depth, id: expn_id, .. } = invoc.expansion_data;
+            let depth = depth - orig_expansion_data.depth;
             self.cx.current_expansion = invoc.expansion_data.clone();
             self.cx.force_mode = force;
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2817,6 +2817,27 @@ impl ItemKind<'_> {
             _ => return None,
         })
     }
+
+    pub fn descr(&self) -> &'static str {
+        match self {
+            ItemKind::ExternCrate(..) => "extern crate",
+            ItemKind::Use(..) => "`use` import",
+            ItemKind::Static(..) => "static item",
+            ItemKind::Const(..) => "constant item",
+            ItemKind::Fn(..) => "function",
+            ItemKind::Mod(..) => "module",
+            ItemKind::ForeignMod { .. } => "extern block",
+            ItemKind::GlobalAsm(..) => "global asm item",
+            ItemKind::TyAlias(..) => "type alias",
+            ItemKind::OpaqueTy(..) => "opaque type",
+            ItemKind::Enum(..) => "enum",
+            ItemKind::Struct(..) => "struct",
+            ItemKind::Union(..) => "union",
+            ItemKind::Trait(..) => "trait",
+            ItemKind::TraitAlias(..) => "trait alias",
+            ItemKind::Impl(..) => "implementation",
+        }
+    }
 }
 
 /// A reference from an trait to one of its associated items. This

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -380,7 +380,7 @@ impl<'a> ResolverExpand for Resolver<'a> {
             has_derive_copy: false,
         });
         let parent_scope = self.invocation_parent_scopes[&expn_id];
-        for (i, (path, opt_ext)) in entry.resolutions.iter_mut().enumerate() {
+        for (i, (path, _, opt_ext)) in entry.resolutions.iter_mut().enumerate() {
             if opt_ext.is_none() {
                 *opt_ext = Some(
                     match self.resolve_macro_path(

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2418,6 +2418,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 visitor.0,
                 true,
                 hir_ty,
+                "function",
             );
         }
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -808,6 +808,14 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             match it.kind {
                 hir::ItemKind::Fn(..) => tcx.ensure().fn_sig(def_id),
                 hir::ItemKind::OpaqueTy(..) => tcx.ensure().item_bounds(def_id),
+                hir::ItemKind::Const(ty, ..) | hir::ItemKind::Static(ty, ..) => {
+                    // (#75889): Account for `const C: dyn Fn() -> _ = "";`
+                    if let hir::TyKind::TraitObject(..) = ty.kind {
+                        let mut visitor = PlaceholderHirTyCollector::default();
+                        visitor.visit_item(it);
+                        placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+                    }
+                }
                 _ => (),
             }
         }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -145,6 +145,7 @@ crate fn placeholder_type_error(
     placeholder_types: Vec<Span>,
     suggest: bool,
     hir_ty: Option<&hir::Ty<'_>>,
+    kind: &'static str,
 ) {
     if placeholder_types.is_empty() {
         return;
@@ -174,7 +175,7 @@ crate fn placeholder_type_error(
         ));
     }
 
-    let mut err = bad_placeholder_type(tcx, placeholder_types);
+    let mut err = bad_placeholder_type(tcx, placeholder_types, kind);
 
     // Suggest, but only if it is not a function in const or static
     if suggest {
@@ -236,7 +237,15 @@ fn reject_placeholder_type_signatures_in_item(tcx: TyCtxt<'tcx>, item: &'tcx hir
     let mut visitor = PlaceholderHirTyCollector::default();
     visitor.visit_item(item);
 
-    placeholder_type_error(tcx, Some(generics.span), generics.params, visitor.0, suggest, None);
+    placeholder_type_error(
+        tcx,
+        Some(generics.span),
+        generics.params,
+        visitor.0,
+        suggest,
+        None,
+        item.kind.descr(),
+    );
 }
 
 impl Visitor<'tcx> for CollectItemTypesVisitor<'tcx> {
@@ -302,13 +311,17 @@ impl Visitor<'tcx> for CollectItemTypesVisitor<'tcx> {
 fn bad_placeholder_type(
     tcx: TyCtxt<'tcx>,
     mut spans: Vec<Span>,
+    kind: &'static str,
 ) -> rustc_errors::DiagnosticBuilder<'tcx> {
+    let kind = if kind.ends_with('s') { format!("{}es", kind) } else { format!("{}s", kind) };
+
     spans.sort();
     let mut err = struct_span_err!(
         tcx.sess,
         spans.clone(),
         E0121,
-        "the type placeholder `_` is not allowed within types on item signatures",
+        "the type placeholder `_` is not allowed within types on item signatures for {}",
+        kind
     );
     for span in spans {
         err.span_label(span, "not allowed in type signatures");
@@ -382,7 +395,7 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
         _: Option<&ty::GenericParamDef>,
         span: Span,
     ) -> &'tcx Const<'tcx> {
-        bad_placeholder_type(self.tcx(), vec![span]).emit();
+        bad_placeholder_type(self.tcx(), vec![span], "generic").emit();
         // Typeck doesn't expect erased regions to be returned from `type_of`.
         let ty = self.tcx.fold_regions(ty, &mut false, |r, _| match r {
             ty::ReErased => self.tcx.lifetimes.re_static,
@@ -746,7 +759,15 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                     hir::ForeignItemKind::Static(..) => {
                         let mut visitor = PlaceholderHirTyCollector::default();
                         visitor.visit_foreign_item(item);
-                        placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+                        placeholder_type_error(
+                            tcx,
+                            None,
+                            &[],
+                            visitor.0,
+                            false,
+                            None,
+                            "static variable",
+                        );
                     }
                     _ => (),
                 }
@@ -838,7 +859,7 @@ fn convert_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             // Account for `const C: _;`.
             let mut visitor = PlaceholderHirTyCollector::default();
             visitor.visit_trait_item(trait_item);
-            placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+            placeholder_type_error(tcx, None, &[], visitor.0, false, None, "constant");
         }
 
         hir::TraitItemKind::Type(_, Some(_)) => {
@@ -847,7 +868,7 @@ fn convert_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             // Account for `type T = _;`.
             let mut visitor = PlaceholderHirTyCollector::default();
             visitor.visit_trait_item(trait_item);
-            placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+            placeholder_type_error(tcx, None, &[], visitor.0, false, None, "associated type");
         }
 
         hir::TraitItemKind::Type(_, None) => {
@@ -857,7 +878,7 @@ fn convert_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             let mut visitor = PlaceholderHirTyCollector::default();
             visitor.visit_trait_item(trait_item);
 
-            placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+            placeholder_type_error(tcx, None, &[], visitor.0, false, None, "associated type");
         }
     };
 
@@ -879,7 +900,7 @@ fn convert_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
             let mut visitor = PlaceholderHirTyCollector::default();
             visitor.visit_impl_item(impl_item);
 
-            placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+            placeholder_type_error(tcx, None, &[], visitor.0, false, None, "associated type");
         }
         hir::ImplItemKind::Const(..) => {}
     }
@@ -1703,7 +1724,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
 
                     let mut visitor = PlaceholderHirTyCollector::default();
                     visitor.visit_ty(ty);
-                    let mut diag = bad_placeholder_type(tcx, visitor.0);
+                    let mut diag = bad_placeholder_type(tcx, visitor.0, "return type");
                     let ret_ty = fn_sig.output();
                     if ret_ty != tcx.ty_error() {
                         if !ret_ty.is_closure() {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -35,8 +35,10 @@ use self::Ordering::*;
 /// so floating point types implement `PartialEq` but not [`trait@Eq`].
 ///
 /// Implementations must ensure that `eq` and `ne` are consistent with each other:
-/// `a != b` if and only if `!(a == b)`.
-/// This is ensured by the default implementation of `ne`.
+///
+/// - `a != b` if and only if `!(a == b)`
+///   (ensured by the default implementation).
+///
 /// If [`PartialOrd`] or [`Ord`] are also implemented for `Self` and `Rhs`, their methods must also
 /// be consistent with `PartialEq` (see the documentation of those traits for the exact
 /// requirememts). It's easy to accidentally make them disagree by deriving some of the traits and
@@ -633,22 +635,25 @@ impl<T: Clone> Clone for Reverse<T> {
 
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 ///
-/// An order is a total order if it is (for all `a`, `b` and `c`):
+/// Implementations must ensure to be consistent with the [`PartialOrd`] implementation, and that
+/// `max`, `min`, and `clamp` are consistent with `cmp`:
 ///
-/// - total and asymmetric: exactly one of `a < b`, `a == b` or `a > b` is true; and
-/// - transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+/// - `partial_cmp(a, b) == Some(cmp(a, b))`.
+/// - `max(a, b) == max_by(a, b, cmp)` (ensured by the default implementation).
+/// - `min(a, b) == min_by(a, b, cmp)` (ensured by the default implementation).
+/// - For `a.clamp(min, max)`, see the [method docs](#method.clamp)
+///   (ensured by the default implementation).
 ///
-/// Implementations of [`PartialEq`], [`PartialOrd`], and `Ord` *must* agree with each other (for
-/// all `a` and `b`):
-///
-/// - `a.partial_cmp(b) == Some(a.cmp(b))`
-/// - `a.cmp(b) == Ordering::Equal` if and only if `a == b`
-///   (already follows from the above and the requirements of `PartialOrd`)
-///
-/// It's easy to accidentally make them disagree by
+/// It's easy to accidentally make `cmp` and `partial_cmp` disagree by
 /// deriving some of the traits and manually implementing others.
 ///
-/// Furthermore, the `max`, `min`, and `clamp` methods of this trait must be consistent with `cmp`.
+/// ## Corollaries
+///
+/// From the above and the requirements of `PartialOrd`, it follows that `<` defines a strict total order.
+/// This means that for all `a`, `b` and `c`:
+///
+/// - exactly one of `a < b`, `a == b` or `a > b` is true; and
+/// - `<` is transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
 ///
 /// ## Derivable
 ///
@@ -839,10 +844,14 @@ impl PartialOrd for Ordering {
 /// the following sense:
 ///
 /// - `a == b` if and only if `partial_cmp(a, b) == Some(Equal)`.
-/// - `a < b` if and only if `partial_cmp(a, b) == Some(Less)`.
-/// - `a > b` if and only if `partial_cmp(a, b) == Some(Greater)`.
-/// - `a <= b` if and only if `a < b || a == b`.
-/// - `a >= b` if and only if `a > b || a == b`.
+/// - `a < b` if and only if `partial_cmp(a, b) == Some(Less)`
+///   (ensured by the default implementation).
+/// - `a > b` if and only if `partial_cmp(a, b) == Some(Greater)`
+///   (ensured by the default implementation).
+/// - `a <= b` if and only if `a < b || a == b`
+///   (ensured by the default implementation).
+/// - `a >= b` if and only if `a > b || a == b`
+///   (ensured by the default implementation).
 /// - `a != b` if and only if `!(a == b)` (already part of `PartialEq`).
 ///
 /// If [`Ord`] is also implemented for `Self` and `Rhs`, it must also be consistent with

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -27,12 +27,23 @@ use self::Ordering::*;
 /// Trait for equality comparisons which are [partial equivalence
 /// relations](https://en.wikipedia.org/wiki/Partial_equivalence_relation).
 ///
+/// `x.eq(y)` can also be written `x == y`, and `x.ne(y)` can be written `x != y`.
+/// We use the easier-to-read infix notation in the remainder of this documentation.
+///
 /// This trait allows for partial equality, for types that do not have a full
 /// equivalence relation. For example, in floating point numbers `NaN != NaN`,
 /// so floating point types implement `PartialEq` but not [`trait@Eq`].
 ///
-/// Formally, the equality must be (for all `a`, `b`, `c` of type `A`, `B`,
-/// `C`):
+/// Implementations must ensure that `eq` and `ne` are consistent with each other:
+/// `a != b` if and only if `!(a == b)`.
+/// This is ensured by the default implementation of `ne`.
+/// If [`PartialOrd`] or [`Ord`] are also implemented for `Self` and `Rhs`, their methods must also
+/// be consistent with `PartialEq` (see the documentation of those traits for the exact
+/// requirememts). It's easy to accidentally make them disagree by deriving some of the traits and
+/// manually implementing others.
+///
+/// The equality relation `==` must satisfy the following conditions
+/// (for all `a`, `b`, `c` of type `A`, `B`, `C`):
 ///
 /// - **Symmetric**: if `A: PartialEq<B>` and `B: PartialEq<A>`, then **`a == b`
 ///   implies `b == a`**; and
@@ -52,15 +63,6 @@ use self::Ordering::*;
 /// and not equal to the other variants.
 ///
 /// ## How can I implement `PartialEq`?
-///
-/// `PartialEq` only requires the [`eq`] method to be implemented; [`ne`] is defined
-/// in terms of it by default. Any manual implementation of [`ne`] *must* respect
-/// the rule that [`eq`] is a strict inverse of [`ne`]; that is, `!(a == b)` if and
-/// only if `a != b`.
-///
-/// Implementations of `PartialEq`, [`PartialOrd`], and [`Ord`] *must* agree with
-/// each other. It's easy to accidentally make them disagree by deriving some
-/// of the traits and manually implementing others.
 ///
 /// An example implementation for a domain in which two books are considered
 /// the same book if their ISBN matches, even if the formats differ:
@@ -634,7 +636,19 @@ impl<T: Clone> Clone for Reverse<T> {
 /// An order is a total order if it is (for all `a`, `b` and `c`):
 ///
 /// - total and asymmetric: exactly one of `a < b`, `a == b` or `a > b` is true; and
-/// - transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+/// - transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+///
+/// Implementations of [`PartialEq`], [`PartialOrd`], and `Ord` *must* agree with each other (for
+/// all `a` and `b`):
+///
+/// - `a.partial_cmp(b) == Some(a.cmp(b))`
+/// - `a.cmp(b) == Ordering::Equal` if and only if `a == b`
+///   (already follows from the above and the requirements of `PartialOrd`)
+///
+/// It's easy to accidentally make them disagree by
+/// deriving some of the traits and manually implementing others.
+///
+/// Furthermore, the `max`, `min`, and `clamp` methods of this trait must be consistent with `cmp`.
 ///
 /// ## Derivable
 ///
@@ -658,12 +672,6 @@ impl<T: Clone> Clone for Reverse<T> {
 ///
 /// Then you must define an implementation for [`cmp`]. You may find it useful to use
 /// [`cmp`] on your type's fields.
-///
-/// Implementations of [`PartialEq`], [`PartialOrd`], and `Ord` *must*
-/// agree with each other. That is, `a.cmp(b) == Ordering::Equal` if
-/// and only if `a == b` and `Some(a.cmp(b)) == a.partial_cmp(b)` for
-/// all `a` and `b`. It's easy to accidentally make them disagree by
-/// deriving some of the traits and manually implementing others.
 ///
 /// Here's an example where you want to sort people by height only, disregarding `id`
 /// and `name`:
@@ -824,14 +832,40 @@ impl PartialOrd for Ordering {
 
 /// Trait for values that can be compared for a sort-order.
 ///
+/// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using
+/// the `<`, `<=`, `>`, and `>=` operators, respectively.
+///
+/// The methods of this trait must be consistent with each other and with those of `PartialEq` in
+/// the following sense:
+///
+/// - `a == b` if and only if `partial_cmp(a, b) == Some(Equal)`.
+/// - `a < b` if and only if `partial_cmp(a, b) == Some(Less)`.
+/// - `a > b` if and only if `partial_cmp(a, b) == Some(Greater)`.
+/// - `a <= b` if and only if `a < b || a == b`.
+/// - `a >= b` if and only if `a > b || a == b`.
+/// - `a != b` if and only if `!(a == b)` (already part of `PartialEq`).
+///
+/// If [`Ord`] is also implemented for `Self` and `Rhs`, it must also be consistent with
+/// `partial_cmp` (see the documentation of that trait for the exact requirements). It's
+/// easy to accidentally make them disagree by deriving some of the traits and manually
+/// implementing others.
+///
 /// The comparison must satisfy, for all `a`, `b` and `c`:
 ///
-/// - asymmetry: if `a < b` then `!(a > b)`, as well as `a > b` implying `!(a < b)`; and
 /// - transitivity: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+/// - duality: `a < b` if and only if `b > a`.
 ///
 /// Note that these requirements mean that the trait itself must be implemented symmetrically and
 /// transitively: if `T: PartialOrd<U>` and `U: PartialOrd<V>` then `U: PartialOrd<T>` and `T:
 /// PartialOrd<V>`.
+///
+/// ## Corollaries
+///
+/// The following corollaries follow from the above requirements:
+///
+/// - irreflexivity of `<` and `>`: `!(a < a)`, `!(a > a)`
+/// - transitivity of `>`: if `a > b` and `b > c` then `a > c`
+/// - duality of `partial_cmp`: `partial_cmp(a, b) == partial_cmp(b, a).map(Ordering::reverse)`
 ///
 /// ## Derivable
 ///
@@ -849,10 +883,6 @@ impl PartialOrd for Ordering {
 /// false` (cf. IEEE 754-2008 section 5.11).
 ///
 /// `PartialOrd` requires your type to be [`PartialEq`].
-///
-/// Implementations of [`PartialEq`], `PartialOrd`, and [`Ord`] *must* agree with each other. It's
-/// easy to accidentally make them disagree by deriving some of the traits and manually
-/// implementing others.
 ///
 /// If your type is [`Ord`], you can implement [`partial_cmp`] by using [`cmp`]:
 ///

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -635,7 +635,7 @@ impl<T: Clone> Clone for Reverse<T> {
 
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 ///
-/// Implementations must ensure to be consistent with the [`PartialOrd`] implementation, and that
+/// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure
 /// `max`, `min`, and `clamp` are consistent with `cmp`:
 ///
 /// - `partial_cmp(a, b) == Some(cmp(a, b))`.

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -295,9 +295,10 @@ where
                 let sz_a = self.a.size();
                 if A::MAY_HAVE_SIDE_EFFECT && sz_a > self.len {
                     for _ in 0..sz_a - self.len {
+                        self.a_len -= 1;
                         self.a.next_back();
                     }
-                    self.a_len = self.len;
+                    debug_assert_eq!(self.a_len, self.len);
                 }
                 let sz_b = self.b.size();
                 if B::MAY_HAVE_SIDE_EFFECT && sz_b > self.len {

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -1,7 +1,5 @@
 use super::*;
 use core::iter::*;
-use std::panic::catch_unwind;
-use std::panic::AssertUnwindSafe;
 
 #[test]
 fn test_zip_nth() {
@@ -235,7 +233,11 @@ fn test_zip_trusted_random_access_composition() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn test_zip_trusted_random_access_next_back_drop() {
+    use std::panic::catch_unwind;
+    use std::panic::AssertUnwindSafe;
+
     let mut counter = 0;
 
     let it = [42].iter().map(|e| {

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -1,5 +1,7 @@
 use super::*;
 use core::iter::*;
+use std::panic::catch_unwind;
+use std::panic::AssertUnwindSafe;
 
 #[test]
 fn test_zip_nth() {
@@ -230,6 +232,29 @@ fn test_zip_trusted_random_access_composition() {
     fn assert_trusted_random_access<T: TrustedRandomAccess>(_a: &T) {}
     assert_trusted_random_access(&z2);
     assert_eq!(z2.next().unwrap(), ((1, 1), 1));
+}
+
+#[test]
+fn test_zip_trusted_random_access_next_back_drop() {
+    let mut counter = 0;
+
+    let it = [42].iter().map(|e| {
+        let c = counter;
+        counter += 1;
+        if c == 0 {
+            panic!("bomb");
+        }
+
+        e
+    });
+    let it2 = [(); 0].iter();
+    let mut zip = it.zip(it2);
+    catch_unwind(AssertUnwindSafe(|| {
+        zip.next_back();
+    }))
+    .unwrap_err();
+    assert!(zip.next().is_none());
+    assert_eq!(counter, 1);
 }
 
 #[test]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -50,6 +50,7 @@ time = "0.1"
 ignore = "0.4.10"
 opener = "0.4"
 merge = "0.1.0"
+once_cell = "1.7.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -29,6 +29,8 @@ use crate::util::{self, add_dylib_path, add_link_lib_path, exe, libdir};
 use crate::{Build, DocTests, GitRepo, Mode};
 
 pub use crate::Compiler;
+// FIXME: replace with std::lazy after it gets stabilized and reaches beta
+use once_cell::sync::Lazy;
 
 pub struct Builder<'a> {
     pub build: &'a Build,
@@ -195,7 +197,7 @@ impl StepDescription {
 
         if paths.is_empty() || builder.config.include_default_paths {
             for (desc, should_run) in v.iter().zip(&should_runs) {
-                if desc.default && should_run.is_really_default {
+                if desc.default && should_run.is_really_default() {
                     for pathset in &should_run.paths {
                         desc.maybe_run(builder, pathset);
                     }
@@ -228,7 +230,11 @@ impl StepDescription {
     }
 }
 
-#[derive(Clone)]
+enum ReallyDefault<'a> {
+    Bool(bool),
+    Lazy(Lazy<bool, Box<dyn Fn() -> bool + 'a>>),
+}
+
 pub struct ShouldRun<'a> {
     pub builder: &'a Builder<'a>,
     // use a BTreeSet to maintain sort order
@@ -236,7 +242,7 @@ pub struct ShouldRun<'a> {
 
     // If this is a default rule, this is an additional constraint placed on
     // its run. Generally something like compiler docs being enabled.
-    is_really_default: bool,
+    is_really_default: ReallyDefault<'a>,
 }
 
 impl<'a> ShouldRun<'a> {
@@ -244,13 +250,25 @@ impl<'a> ShouldRun<'a> {
         ShouldRun {
             builder,
             paths: BTreeSet::new(),
-            is_really_default: true, // by default no additional conditions
+            is_really_default: ReallyDefault::Bool(true), // by default no additional conditions
         }
     }
 
     pub fn default_condition(mut self, cond: bool) -> Self {
-        self.is_really_default = cond;
+        self.is_really_default = ReallyDefault::Bool(cond);
         self
+    }
+
+    pub fn lazy_default_condition(mut self, lazy_cond: Box<dyn Fn() -> bool + 'a>) -> Self {
+        self.is_really_default = ReallyDefault::Lazy(Lazy::new(lazy_cond));
+        self
+    }
+
+    pub fn is_really_default(&self) -> bool {
+        match &self.is_really_default {
+            ReallyDefault::Bool(val) => *val,
+            ReallyDefault::Lazy(lazy) => *lazy.deref(),
+        }
     }
 
     /// Indicates it should run if the command-line selects the given crate or

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -613,9 +613,14 @@ mod dist {
         // Note that the stages here are +1 than what they actually are because
         // Rustdoc::run swaps out the compiler with stage minus 1 if --stage is
         // not 0.
+        //
+        // The stage 0 copy is the one downloaded for bootstrapping. It is
+        // (currently) needed to run "cargo test" on the linkchecker, and
+        // should be relatively "free".
         assert_eq!(
             first(builder.cache.all::<tool::Rustdoc>()),
             &[
+                tool::Rustdoc { compiler: Compiler { host: a, stage: 0 } },
                 tool::Rustdoc { compiler: Compiler { host: a, stage: 1 } },
                 tool::Rustdoc { compiler: Compiler { host: a, stage: 2 } },
             ]

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -124,8 +124,25 @@ You can skip linkcheck with --exclude src/tools/linkchecker"
 
         builder.info(&format!("Linkcheck ({})", host));
 
+        // Test the linkchecker itself.
+        let bootstrap_host = builder.config.build;
+        let compiler = builder.compiler(0, bootstrap_host);
+        let cargo = tool::prepare_tool_cargo(
+            builder,
+            compiler,
+            Mode::ToolBootstrap,
+            bootstrap_host,
+            "test",
+            "src/tools/linkchecker",
+            SourceType::InTree,
+            &[],
+        );
+        try_run(builder, &mut cargo.into());
+
+        // Build all the default documentation.
         builder.default_doc(&[]);
 
+        // Run the linkchecker.
         let _time = util::timeit(&builder);
         try_run(
             builder,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -806,15 +806,15 @@ impl Step for RustdocGUI {
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         let run = run.suite_path("src/test/rustdoc-gui");
-        run.default_condition(
+        run.lazy_default_condition(Box::new(move || {
             builder.config.nodejs.is_some()
                 && builder
                     .config
                     .npm
                     .as_ref()
                     .map(|p| check_if_browser_ui_test_is_installed(p))
-                    .unwrap_or(false),
-        )
+                    .unwrap_or(false)
+        }))
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -16,7 +16,7 @@ type D = (u8, u8)::AssocTy;
 
 type E = _::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
-//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures for type aliases
 
 type F = &'static (u8)::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
@@ -47,37 +47,37 @@ type I = ty!()::AssocTy;
 
 trait K<A, B> {}
 fn foo<X: K<_, _>>(x: X) {}
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn bar<F>(_: F) where F: Fn() -> _ {}
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn baz<F: Fn() -> _>(_: F) {}
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 struct L<F>(F) where F: Fn() -> _;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for structs
 struct M<F> where F: Fn() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for structs
     a: F,
 }
 enum N<F> where F: Fn() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for enums
     Foo(F),
 }
 
 union O<F> where F: Fn() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for unions
     foo: F,
 }
 
 trait P<F> where F: Fn() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for traits
 }
 
 trait Q {
     fn foo<F>(_: F) where F: Fn() -> _ {}
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 }
 
 fn main() {}

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -81,7 +81,7 @@ error[E0223]: ambiguous associated type
 LL | type D = (u8, u8)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<(u8, u8) as Trait>::AssocTy`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for type aliases
   --> $DIR/bad-assoc-ty.rs:17:10
    |
 LL | type E = _::AssocTy;
@@ -122,7 +122,7 @@ error[E0223]: ambiguous associated type
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/bad-assoc-ty.rs:49:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
@@ -135,7 +135,7 @@ help: use type parameters instead
 LL | fn foo<X: K<T, T>, T>(x: X) {}
    |             ^  ^ ^^^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/bad-assoc-ty.rs:52:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
@@ -146,7 +146,7 @@ help: use type parameters instead
 LL | fn bar<F, T>(_: F) where F: Fn() -> T {}
    |         ^^^                         ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/bad-assoc-ty.rs:55:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
@@ -157,7 +157,7 @@ help: use type parameters instead
 LL | fn baz<F: Fn() -> T, T>(_: F) {}
    |                   ^^^^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/bad-assoc-ty.rs:58:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
@@ -168,7 +168,7 @@ help: use type parameters instead
 LL | struct L<F, T>(F) where F: Fn() -> T;
    |           ^^^                      ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/bad-assoc-ty.rs:60:30
    |
 LL | struct M<F> where F: Fn() -> _ {
@@ -179,7 +179,7 @@ help: use type parameters instead
 LL | struct M<F, T> where F: Fn() -> T {
    |           ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for enums
   --> $DIR/bad-assoc-ty.rs:64:28
    |
 LL | enum N<F> where F: Fn() -> _ {
@@ -190,7 +190,7 @@ help: use type parameters instead
 LL | enum N<F, T> where F: Fn() -> T {
    |         ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for unions
   --> $DIR/bad-assoc-ty.rs:69:29
    |
 LL | union O<F> where F: Fn() -> _ {
@@ -201,7 +201,7 @@ help: use type parameters instead
 LL | union O<F, T> where F: Fn() -> T {
    |          ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for traits
   --> $DIR/bad-assoc-ty.rs:74:29
    |
 LL | trait P<F> where F: Fn() -> _ {
@@ -212,7 +212,7 @@ help: use type parameters instead
 LL | trait P<F, T> where F: Fn() -> T {
    |          ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/bad-assoc-ty.rs:79:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}

--- a/src/test/ui/error-codes/E0121.rs
+++ b/src/test/ui/error-codes/E0121.rs
@@ -2,5 +2,4 @@ fn foo() -> _ { 5 } //~ ERROR E0121
 
 static BAR: _ = "test"; //~ ERROR E0121
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/E0121.rs:1:13
    |
 LL | fn foo() -> _ { 5 }
@@ -7,7 +7,7 @@ LL | fn foo() -> _ { 5 }
    |             not allowed in type signatures
    |             help: replace with the correct return type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/E0121.rs:3:13
    |
 LL | static BAR: _ = "test";

--- a/src/test/ui/fn/issue-80179.rs
+++ b/src/test/ui/fn/issue-80179.rs
@@ -8,7 +8,7 @@ fn returns_i32() -> i32 {
 }
 
 fn returns_fn_ptr() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures [E0121]
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types [E0121]
 //~| NOTE not allowed in type signatures
 //~| HELP replace with the correct return type
 //~| SUGGESTION fn() -> i32
@@ -16,7 +16,7 @@ fn returns_fn_ptr() -> _ {
 }
 
 fn returns_closure() -> _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures [E0121]
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types [E0121]
 //~| NOTE not allowed in type signatures
 //~| HELP consider using an `Fn`, `FnMut`, or `FnOnce` trait bound
 //~| NOTE for more information on `Fn` traits and closure types, see

--- a/src/test/ui/fn/issue-80179.stderr
+++ b/src/test/ui/fn/issue-80179.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80179.rs:10:24
    |
 LL | fn returns_fn_ptr() -> _ {
@@ -7,7 +7,7 @@ LL | fn returns_fn_ptr() -> _ {
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `fn() -> i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80179.rs:18:25
    |
 LL | fn returns_closure() -> _ {

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.rs
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.rs
@@ -4,7 +4,7 @@ macro_rules! suite {
             const A = "A".$fn();
             //~^ ERROR the name `A` is defined multiple times
             //~| ERROR missing type for `const` item
-            //~| ERROR the type placeholder `_` is not allowed within types
+            //~| ERROR the type placeholder `_` is not allowed within types on item signatures for constants
         )*
     }
 }

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -20,7 +20,7 @@ error: missing type for `const` item
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
    |
 LL |               const A = "A".$fn();
-   |                     ^ help: provide a type for the item: `A: usize`
+   |                     ^ help: provide a type for the constant: `A: usize`
 ...
 LL | / suite! {
 LL | |     len;
@@ -30,7 +30,7 @@ LL | | }
    |
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
    |
 LL |               const A = "A".$fn();

--- a/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.rs
+++ b/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.rs
@@ -1,0 +1,16 @@
+// Regression test for #84632: Recursion limit is ignored
+// for builtin macros that eagerly expands.
+
+#![recursion_limit = "15"]
+macro_rules! a {
+    () => ("");
+    (A) => (concat!("", a!()));
+    (A, $($A:ident),*) => (concat!("", a!($($A),*)))
+    //~^ ERROR recursion limit reached
+    //~| HELP consider adding
+}
+
+fn main() {
+    a!(A, A, A, A, A);
+    a!(A, A, A, A, A, A, A, A, A, A, A);
+}

--- a/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.stderr
+++ b/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.stderr
@@ -1,0 +1,14 @@
+error: recursion limit reached while expanding `concat!`
+  --> $DIR/issue-84632-eager-expansion-recursion-limit.rs:8:28
+   |
+LL |     (A, $($A:ident),*) => (concat!("", a!($($A),*)))
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     a!(A, A, A, A, A, A, A, A, A, A, A);
+   |     ------------------------------------ in this macro invocation
+   |
+   = help: consider adding a `#![recursion_limit="30"]` attribute to your crate (`issue_84632_eager_expansion_recursion_limit`)
+   = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/self/self-infer.rs
+++ b/src/test/ui/self/self-infer.rs
@@ -1,8 +1,8 @@
 struct S;
 
 impl S {
-    fn f(self: _) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
-    fn g(self: &_) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
+    fn f(self: _) {} //~ERROR the type placeholder `_` is not allowed within types on item signatures for functions
+    fn g(self: &_) {} //~ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 }
 
 fn main() {}

--- a/src/test/ui/self/self-infer.stderr
+++ b/src/test/ui/self/self-infer.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/self-infer.rs:4:16
    |
 LL |     fn f(self: _) {}
@@ -9,7 +9,7 @@ help: use type parameters instead
 LL |     fn f<T>(self: T) {}
    |         ^^^       ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/self-infer.rs:5:17
    |
 LL |     fn g(self: &_) {}

--- a/src/test/ui/suggestions/const-no-type.rs
+++ b/src/test/ui/suggestions/const-no-type.rs
@@ -32,20 +32,20 @@ static mut SM2 = "abc";
 
 const C = 42;
 //~^ ERROR missing type for `const` item
-//~| HELP provide a type for the item
+//~| HELP provide a type for the constant
 //~| SUGGESTION C: i32
 
 const D = &&42;
 //~^ ERROR missing type for `const` item
-//~| HELP provide a type for the item
+//~| HELP provide a type for the constant
 //~| SUGGESTION D: &&i32
 
 static S = Vec::<String>::new();
 //~^ ERROR missing type for `static` item
-//~| HELP provide a type for the item
+//~| HELP provide a type for the static variable
 //~| SUGGESTION S: Vec<String>
 
 static mut SM = "abc";
 //~^ ERROR missing type for `static mut` item
-//~| HELP provide a type for the item
+//~| HELP provide a type for the static variable
 //~| SUGGESTION &str

--- a/src/test/ui/suggestions/const-no-type.stderr
+++ b/src/test/ui/suggestions/const-no-type.stderr
@@ -2,25 +2,25 @@ error: missing type for `const` item
   --> $DIR/const-no-type.rs:33:7
    |
 LL | const C = 42;
-   |       ^ help: provide a type for the item: `C: i32`
+   |       ^ help: provide a type for the constant: `C: i32`
 
 error: missing type for `const` item
   --> $DIR/const-no-type.rs:38:7
    |
 LL | const D = &&42;
-   |       ^ help: provide a type for the item: `D: &&i32`
+   |       ^ help: provide a type for the constant: `D: &&i32`
 
 error: missing type for `static` item
   --> $DIR/const-no-type.rs:43:8
    |
 LL | static S = Vec::<String>::new();
-   |        ^ help: provide a type for the item: `S: Vec<String>`
+   |        ^ help: provide a type for the static variable: `S: Vec<String>`
 
 error: missing type for `static mut` item
   --> $DIR/const-no-type.rs:48:12
    |
 LL | static mut SM = "abc";
-   |            ^^ help: provide a type for the item: `SM: &str`
+   |            ^^ help: provide a type for the static variable: `SM: &str`
 
 error: missing type for `const` item
   --> $DIR/const-no-type.rs:14:7

--- a/src/test/ui/suggestions/unnamable-types.rs
+++ b/src/test/ui/suggestions/unnamable-types.rs
@@ -5,17 +5,17 @@
 
 const A = 5;
 //~^ ERROR: missing type for `const` item
-//~| HELP: provide a type for the item
+//~| HELP: provide a type for the constant
 
 static B: _ = "abc";
-//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for static variables
 //~| NOTE: not allowed in type signatures
 //~| HELP: replace with the correct type
 
 
 // FIXME: this should also suggest a function pointer, as the closure is non-capturing
 const C: _ = || 42;
-//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for constants
 //~| NOTE: not allowed in type signatures
 //~| NOTE: however, the inferred type
 
@@ -28,10 +28,10 @@ const D = S { t: { let i = 0; move || -> i32 { i } } };
 fn foo() -> i32 { 42 }
 const E = foo;
 //~^ ERROR: missing type for `const` item
-//~| HELP: provide a type for the item
+//~| HELP: provide a type for the constant
 const F = S { t: foo };
 //~^ ERROR: missing type for `const` item
-//~| HELP: provide a type for the item
+//~| HELP: provide a type for the constant
 
 
 const G = || -> i32 { yield 0; return 1; };

--- a/src/test/ui/suggestions/unnamable-types.stderr
+++ b/src/test/ui/suggestions/unnamable-types.stderr
@@ -2,9 +2,9 @@ error: missing type for `const` item
   --> $DIR/unnamable-types.rs:6:7
    |
 LL | const A = 5;
-   |       ^ help: provide a type for the item: `A: i32`
+   |       ^ help: provide a type for the constant: `A: i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/unnamable-types.rs:10:11
    |
 LL | static B: _ = "abc";
@@ -13,7 +13,7 @@ LL | static B: _ = "abc";
    |           not allowed in type signatures
    |           help: replace with the correct type: `&str`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/unnamable-types.rs:17:10
    |
 LL | const C: _ = || 42;
@@ -41,13 +41,13 @@ error: missing type for `const` item
   --> $DIR/unnamable-types.rs:29:7
    |
 LL | const E = foo;
-   |       ^ help: provide a type for the item: `E: fn() -> i32`
+   |       ^ help: provide a type for the constant: `E: fn() -> i32`
 
 error: missing type for `const` item
   --> $DIR/unnamable-types.rs:32:7
    |
 LL | const F = S { t: foo };
-   |       ^ help: provide a type for the item: `F: S<fn() -> i32>`
+   |       ^ help: provide a type for the constant: `F: S<fn() -> i32>`
 
 error: missing type for `const` item
   --> $DIR/unnamable-types.rs:37:7

--- a/src/test/ui/typeck/issue-74086.rs
+++ b/src/test/ui/typeck/issue-74086.rs
@@ -1,4 +1,4 @@
 fn main() {
     static BUG: fn(_) -> u8 = |_| 8;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures [E0121]
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions [E0121]
 }

--- a/src/test/ui/typeck/issue-74086.stderr
+++ b/src/test/ui/typeck/issue-74086.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/issue-74086.rs:2:20
    |
 LL |     static BUG: fn(_) -> u8 = |_| 8;

--- a/src/test/ui/typeck/issue-75883.rs
+++ b/src/test/ui/typeck/issue-75883.rs
@@ -5,7 +5,7 @@ pub struct UI {}
 impl UI {
     pub fn run() -> Result<_> {
         //~^ ERROR: this enum takes 2 generic arguments but 1 generic argument was supplied
-        //~| ERROR: the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR: the type placeholder `_` is not allowed within types on item signatures for return types
         let mut ui = UI {};
         ui.interact();
 
@@ -14,7 +14,7 @@ impl UI {
 
     pub fn interact(&mut self) -> Result<_> {
         //~^ ERROR: this enum takes 2 generic arguments but 1 generic argument was supplied
-        //~| ERROR: the type placeholder `_` is not allowed within types on item signatures
+        //~| ERROR: the type placeholder `_` is not allowed within types on item signatures for return types
         unimplemented!();
     }
 }

--- a/src/test/ui/typeck/issue-75883.stderr
+++ b/src/test/ui/typeck/issue-75883.stderr
@@ -34,13 +34,13 @@ help: add missing generic argument
 LL |     pub fn interact(&mut self) -> Result<_, E> {
    |                                           ^^^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-75883.rs:15:42
    |
 LL |     pub fn interact(&mut self) -> Result<_> {
    |                                          ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-75883.rs:6:28
    |
 LL |     pub fn run() -> Result<_> {

--- a/src/test/ui/typeck/issue-75889.rs
+++ b/src/test/ui/typeck/issue-75889.rs
@@ -1,0 +1,6 @@
+// Regression test for #75889.
+
+const FOO: dyn Fn() -> _ = ""; //~ ERROR E0121
+static BOO: dyn Fn() -> _ = ""; //~ ERROR E0121
+
+fn main() {}

--- a/src/test/ui/typeck/issue-75889.stderr
+++ b/src/test/ui/typeck/issue-75889.stderr
@@ -1,0 +1,15 @@
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/issue-75889.rs:3:24
+   |
+LL | const FOO: dyn Fn() -> _ = "";
+   |                        ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/issue-75889.rs:4:25
+   |
+LL | static BOO: dyn Fn() -> _ = "";
+   |                         ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/typeck/issue-80779.rs
+++ b/src/test/ui/typeck/issue-80779.rs
@@ -3,11 +3,11 @@
 pub struct T<'a>(&'a str);
 
 pub fn f<'a>(val: T<'a>) -> _ {
-    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for return types
     g(val)
 }
 
 pub fn g(_: T<'static>) -> _ {}
-//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for return types
 
 fn main() {}

--- a/src/test/ui/typeck/issue-80779.stderr
+++ b/src/test/ui/typeck/issue-80779.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80779.rs:10:28
    |
 LL | pub fn g(_: T<'static>) -> _ {}
@@ -7,7 +7,7 @@ LL | pub fn g(_: T<'static>) -> _ {}
    |                            not allowed in type signatures
    |                            help: replace with the correct return type: `()`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-80779.rs:5:29
    |
 LL | pub fn f<'a>(val: T<'a>) -> _ {

--- a/src/test/ui/typeck/issue-81885.rs
+++ b/src/test/ui/typeck/issue-81885.rs
@@ -1,10 +1,8 @@
 const TEST4: fn() -> _ = 42;
-                  //~^ ERROR the type placeholder `_` is not allowed within types on item
-                  //signatures
+                  //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn main() {
     const TEST5: fn() -> _ = 42;
-                      //~^ ERROR the type placeholder `_` is not allowed within types on item
-                      //signatures
+                      //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 }

--- a/src/test/ui/typeck/issue-81885.stderr
+++ b/src/test/ui/typeck/issue-81885.stderr
@@ -1,11 +1,11 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/issue-81885.rs:1:22
    |
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/issue-81885.rs:6:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/issue-81885.rs:5:26
    |
 LL |     const TEST5: fn() -> _ = 42;
    |                          ^ not allowed in type signatures

--- a/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
+++ b/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/issue-83621-placeholder-static-in-extern.rs:4:15
    |
 LL |     static x: _;

--- a/src/test/ui/typeck/type-placeholder-fn-in-const.rs
+++ b/src/test/ui/typeck/type-placeholder-fn-in-const.rs
@@ -2,13 +2,13 @@ struct MyStruct;
 
 trait Test {
     const TEST: fn() -> _;
-    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures [E0121]
-    //~| ERROR: the type placeholder `_` is not allowed within types on item signatures [E0121]
+    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for functions [E0121]
+    //~| ERROR: the type placeholder `_` is not allowed within types on item signatures for constants [E0121]
 }
 
 impl Test for MyStruct {
     const TEST: fn() -> _ = 42;
-    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures [E0121]
+    //~^ ERROR: the type placeholder `_` is not allowed within types on item signatures for functions [E0121]
 }
 
 fn main() {}

--- a/src/test/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/src/test/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -1,16 +1,16 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
 LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
 LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/type-placeholder-fn-in-const.rs:10:25
    |
 LL |     const TEST: fn() -> _ = 42;

--- a/src/test/ui/typeck/typeck_type_placeholder_item.full_tait.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.full_tait.stderr
@@ -1,35 +1,35 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:158:18
+  --> $DIR/typeck_type_placeholder_item.rs:157:18
    |
 LL | struct BadStruct<_>(_);
    |                  ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:161:16
+  --> $DIR/typeck_type_placeholder_item.rs:160:16
    |
 LL | trait BadTrait<_> {}
    |                ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:171:19
+  --> $DIR/typeck_type_placeholder_item.rs:170:19
    |
 LL | struct BadStruct1<_, _>(_);
    |                   ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:171:22
+  --> $DIR/typeck_type_placeholder_item.rs:170:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                      ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:176:19
+  --> $DIR/typeck_type_placeholder_item.rs:175:19
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:209:5
+  --> $DIR/typeck_type_placeholder_item.rs:208:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -37,7 +37,7 @@ LL |     const C: _;
    |               help: provide a definition for the constant: `= <expr>;`
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/typeck_type_placeholder_item.rs:171:22
+  --> $DIR/typeck_type_placeholder_item.rs:170:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                   -  ^ already used
@@ -53,7 +53,7 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:10:14
    |
 LL | fn test() -> _ { 5 }
@@ -62,7 +62,7 @@ LL | fn test() -> _ { 5 }
    |              not allowed in type signatures
    |              help: replace with the correct return type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:13:16
    |
 LL | fn test2() -> (_, _) { (5, 5) }
@@ -72,7 +72,7 @@ LL | fn test2() -> (_, _) { (5, 5) }
    |               |not allowed in type signatures
    |               help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:16:15
    |
 LL | static TEST3: _ = "test";
@@ -81,7 +81,7 @@ LL | static TEST3: _ = "test";
    |               not allowed in type signatures
    |               help: replace with the correct type: `&str`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:19:15
    |
 LL | static TEST4: _ = 145;
@@ -90,13 +90,13 @@ LL | static TEST4: _ = 145;
    |               not allowed in type signatures
    |               help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:22:15
    |
 LL | static TEST5: (_, _) = (1, 2);
    |               ^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:25:13
    |
 LL | fn test6(_: _) { }
@@ -107,7 +107,7 @@ help: use type parameters instead
 LL | fn test6<T>(_: T) { }
    |         ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:28:18
    |
 LL | fn test6_b<T>(_: _, _: T) { }
@@ -118,7 +118,7 @@ help: use type parameters instead
 LL | fn test6_b<T, U>(_: U, _: T) { }
    |             ^^^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:31:30
    |
 LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
@@ -129,7 +129,7 @@ help: use type parameters instead
 LL | fn test6_c<T, K, L, A, B, U>(_: U, _: (T, K, L, A, B)) { }
    |                         ^^^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:34:13
    |
 LL | fn test7(x: _) { let _x: usize = x; }
@@ -140,7 +140,7 @@ help: use type parameters instead
 LL | fn test7<T>(x: T) { let _x: usize = x; }
    |         ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:37:22
    |
 LL | fn test8(_f: fn() -> _) { }
@@ -149,7 +149,7 @@ LL | fn test8(_f: fn() -> _) { }
    |                      not allowed in type signatures
    |                      help: use type parameters instead: `T`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:37:22
    |
 LL | fn test8(_f: fn() -> _) { }
@@ -160,7 +160,7 @@ help: use type parameters instead
 LL | fn test8<T>(_f: fn() -> T) { }
    |         ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:51:26
    |
 LL | fn test11(x: &usize) -> &_ {
@@ -169,7 +169,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         |not allowed in type signatures
    |                         help: replace with the correct return type: `&'static &'static usize`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:56:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
@@ -178,7 +178,7 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      |             not allowed in type signatures
    |                                      help: replace with the correct return type: `*const *const usize`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/typeck_type_placeholder_item.rs:70:8
    |
 LL |     a: _,
@@ -201,9 +201,9 @@ error: missing type for `static` item
   --> $DIR/typeck_type_placeholder_item.rs:76:12
    |
 LL |     static A = 42;
-   |            ^ help: provide a type for the item: `A: i32`
+   |            ^ help: provide a type for the static variable: `A: i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:78:15
    |
 LL |     static B: _ = 42;
@@ -212,14 +212,14 @@ LL |     static B: _ = 42;
    |               not allowed in type signatures
    |               help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:80:15
    |
 LL |     static C: Option<_> = Some(42);
    |               ^^^^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:83:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:82:21
    |
 LL |     fn fn_test() -> _ { 5 }
    |                     ^
@@ -227,8 +227,8 @@ LL |     fn fn_test() -> _ { 5 }
    |                     not allowed in type signatures
    |                     help: replace with the correct return type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:86:23
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:85:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      -^--^-
@@ -237,8 +237,8 @@ LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      |not allowed in type signatures
    |                      help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:89:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:88:22
    |
 LL |     static FN_TEST3: _ = "test";
    |                      ^
@@ -246,8 +246,8 @@ LL |     static FN_TEST3: _ = "test";
    |                      not allowed in type signatures
    |                      help: replace with the correct type: `&str`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:92:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:91:22
    |
 LL |     static FN_TEST4: _ = 145;
    |                      ^
@@ -255,14 +255,14 @@ LL |     static FN_TEST4: _ = 145;
    |                      not allowed in type signatures
    |                      help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:95:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:94:22
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
    |                      ^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:98:20
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:97:20
    |
 LL |     fn fn_test6(_: _) { }
    |                    ^ not allowed in type signatures
@@ -272,8 +272,8 @@ help: use type parameters instead
 LL |     fn fn_test6<T>(_: T) { }
    |                ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:101:20
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:100:20
    |
 LL |     fn fn_test7(x: _) { let _x: usize = x; }
    |                    ^ not allowed in type signatures
@@ -283,8 +283,8 @@ help: use type parameters instead
 LL |     fn fn_test7<T>(x: T) { let _x: usize = x; }
    |                ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:104:29
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:103:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^
@@ -292,8 +292,8 @@ LL |     fn fn_test8(_f: fn() -> _) { }
    |                             not allowed in type signatures
    |                             help: use type parameters instead: `T`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:104:29
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:103:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
@@ -303,8 +303,8 @@ help: use type parameters instead
 LL |     fn fn_test8<T>(_f: fn() -> T) { }
    |                ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:127:12
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:126:12
    |
 LL |         a: _,
    |            ^ not allowed in type signatures
@@ -323,21 +323,21 @@ LL |         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:132:18
+  --> $DIR/typeck_type_placeholder_item.rs:131:18
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                  ^ cannot infer type
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:132:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:131:28
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            ^  ^ not allowed in type signatures
    |                            |
    |                            not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:136:30
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:135:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             -^--^-
@@ -346,8 +346,8 @@ LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             |not allowed in type signatures
    |                             help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:139:33
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:138:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           ------^-
@@ -355,8 +355,8 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:158:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:157:21
    |
 LL | struct BadStruct<_>(_);
    |                     ^ not allowed in type signatures
@@ -366,8 +366,8 @@ help: use type parameters instead
 LL | struct BadStruct<T>(T);
    |                  ^  ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:163:15
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/typeck_type_placeholder_item.rs:162:15
    |
 LL | impl BadTrait<_> for BadStruct<_> {}
    |               ^                ^ not allowed in type signatures
@@ -379,14 +379,14 @@ help: use type parameters instead
 LL | impl<T> BadTrait<T> for BadStruct<T> {}
    |     ^^^          ^                ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:166:34
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:165:34
    |
 LL | fn impl_trait() -> impl BadTrait<_> {
    |                                  ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:171:25
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:170:25
    |
 LL | struct BadStruct1<_, _>(_);
    |                         ^ not allowed in type signatures
@@ -396,8 +396,8 @@ help: use type parameters instead
 LL | struct BadStruct1<T, _>(T);
    |                   ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:176:25
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:175:25
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                         ^ not allowed in type signatures
@@ -407,20 +407,20 @@ help: use type parameters instead
 LL | struct BadStruct2<U, T>(U, T);
    |                   ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:180:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for type aliases
+  --> $DIR/typeck_type_placeholder_item.rs:179:14
    |
 LL | type X = Box<_>;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:186:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:185:21
    |
 LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:220:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:219:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -428,8 +428,8 @@ LL | fn value() -> Option<&'static _> {
    |               |               not allowed in type signatures
    |               help: replace with the correct return type: `Option<&'static u8>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:225:10
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:224:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -437,8 +437,8 @@ LL | const _: Option<_> = map(value);
    |          not allowed in type signatures
    |          help: replace with the correct type: `Option<u8>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:144:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:143:31
    |
 LL |     fn method_test1(&self, x: _);
    |                               ^ not allowed in type signatures
@@ -448,8 +448,8 @@ help: use type parameters instead
 LL |     fn method_test1<T>(&self, x: T);
    |                    ^^^           ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:146:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:145:31
    |
 LL |     fn method_test2(&self, x: _) -> _;
    |                               ^     ^ not allowed in type signatures
@@ -461,8 +461,8 @@ help: use type parameters instead
 LL |     fn method_test2<T>(&self, x: T) -> T;
    |                    ^^^           ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:148:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:147:31
    |
 LL |     fn method_test3(&self) -> _;
    |                               ^ not allowed in type signatures
@@ -472,8 +472,8 @@ help: use type parameters instead
 LL |     fn method_test3<T>(&self) -> T;
    |                    ^^^           ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:150:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:149:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
@@ -483,8 +483,8 @@ help: use type parameters instead
 LL |     fn assoc_fn_test1<T>(x: T);
    |                      ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:152:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:151:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
    |                          ^     ^ not allowed in type signatures
@@ -496,8 +496,8 @@ help: use type parameters instead
 LL |     fn assoc_fn_test2<T>(x: T) -> T;
    |                      ^^^    ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:154:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:153:28
    |
 LL |     fn assoc_fn_test3() -> _;
    |                            ^ not allowed in type signatures
@@ -507,20 +507,20 @@ help: use type parameters instead
 LL |     fn assoc_fn_test3<T>() -> T;
    |                      ^^^      ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:194:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:193:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:196:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:195:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:198:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:197:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -528,13 +528,13 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:201:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:200:26
    |
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:44:24
    |
 LL |     fn test9(&self) -> _ { () }
@@ -543,7 +543,7 @@ LL |     fn test9(&self) -> _ { () }
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `()`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:47:27
    |
 LL |     fn test10(&self, _x : _) { }
@@ -554,7 +554,7 @@ help: use type parameters instead
 LL |     fn test10<T>(&self, _x : T) { }
    |              ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:62:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
@@ -563,7 +563,7 @@ LL |     fn clone(&self) -> _ { Test9 }
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `Test9`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:65:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
@@ -574,8 +574,8 @@ help: use type parameters instead
 LL |     fn clone_from<T>(&mut self, other: T) { *self = Test9; }
    |                  ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:111:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:110:31
    |
 LL |         fn fn_test9(&self) -> _ { () }
    |                               ^
@@ -583,8 +583,8 @@ LL |         fn fn_test9(&self) -> _ { () }
    |                               not allowed in type signatures
    |                               help: replace with the correct return type: `()`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:114:34
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:113:34
    |
 LL |         fn fn_test10(&self, _x : _) { }
    |                                  ^ not allowed in type signatures
@@ -594,8 +594,8 @@ help: use type parameters instead
 LL |         fn fn_test10<T>(&self, _x : T) { }
    |                     ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:119:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:118:28
    |
 LL |         fn clone(&self) -> _ { FnTest9 }
    |                            ^
@@ -603,8 +603,8 @@ LL |         fn clone(&self) -> _ { FnTest9 }
    |                            not allowed in type signatures
    |                            help: replace with the correct return type: `FnTest9`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:122:41
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:121:41
    |
 LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
    |                                         ^ not allowed in type signatures
@@ -614,26 +614,26 @@ help: use type parameters instead
 LL |         fn clone_from<T>(&mut self, other: T) { *self = FnTest9; }
    |                      ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:207:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:209:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:208:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:212:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:211:14
    |
 LL |     const D: _ = 42;
    |              ^

--- a/src/test/ui/typeck/typeck_type_placeholder_item.min_tait.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.min_tait.stderr
@@ -1,35 +1,35 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:158:18
+  --> $DIR/typeck_type_placeholder_item.rs:157:18
    |
 LL | struct BadStruct<_>(_);
    |                  ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:161:16
+  --> $DIR/typeck_type_placeholder_item.rs:160:16
    |
 LL | trait BadTrait<_> {}
    |                ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:171:19
+  --> $DIR/typeck_type_placeholder_item.rs:170:19
    |
 LL | struct BadStruct1<_, _>(_);
    |                   ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:171:22
+  --> $DIR/typeck_type_placeholder_item.rs:170:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                      ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:176:19
+  --> $DIR/typeck_type_placeholder_item.rs:175:19
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:209:5
+  --> $DIR/typeck_type_placeholder_item.rs:208:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -37,14 +37,14 @@ LL |     const C: _;
    |               help: provide a definition for the constant: `= <expr>;`
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/typeck_type_placeholder_item.rs:171:22
+  --> $DIR/typeck_type_placeholder_item.rs:170:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                   -  ^ already used
    |                   |
    |                   first use of `_`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:10:14
    |
 LL | fn test() -> _ { 5 }
@@ -53,7 +53,7 @@ LL | fn test() -> _ { 5 }
    |              not allowed in type signatures
    |              help: replace with the correct return type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:13:16
    |
 LL | fn test2() -> (_, _) { (5, 5) }
@@ -63,7 +63,7 @@ LL | fn test2() -> (_, _) { (5, 5) }
    |               |not allowed in type signatures
    |               help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:16:15
    |
 LL | static TEST3: _ = "test";
@@ -72,7 +72,7 @@ LL | static TEST3: _ = "test";
    |               not allowed in type signatures
    |               help: replace with the correct type: `&str`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:19:15
    |
 LL | static TEST4: _ = 145;
@@ -81,13 +81,13 @@ LL | static TEST4: _ = 145;
    |               not allowed in type signatures
    |               help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:22:15
    |
 LL | static TEST5: (_, _) = (1, 2);
    |               ^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:25:13
    |
 LL | fn test6(_: _) { }
@@ -98,7 +98,7 @@ help: use type parameters instead
 LL | fn test6<T>(_: T) { }
    |         ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:28:18
    |
 LL | fn test6_b<T>(_: _, _: T) { }
@@ -109,7 +109,7 @@ help: use type parameters instead
 LL | fn test6_b<T, U>(_: U, _: T) { }
    |             ^^^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:31:30
    |
 LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
@@ -120,7 +120,7 @@ help: use type parameters instead
 LL | fn test6_c<T, K, L, A, B, U>(_: U, _: (T, K, L, A, B)) { }
    |                         ^^^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:34:13
    |
 LL | fn test7(x: _) { let _x: usize = x; }
@@ -131,7 +131,7 @@ help: use type parameters instead
 LL | fn test7<T>(x: T) { let _x: usize = x; }
    |         ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:37:22
    |
 LL | fn test8(_f: fn() -> _) { }
@@ -140,7 +140,7 @@ LL | fn test8(_f: fn() -> _) { }
    |                      not allowed in type signatures
    |                      help: use type parameters instead: `T`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:37:22
    |
 LL | fn test8(_f: fn() -> _) { }
@@ -151,7 +151,7 @@ help: use type parameters instead
 LL | fn test8<T>(_f: fn() -> T) { }
    |         ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:51:26
    |
 LL | fn test11(x: &usize) -> &_ {
@@ -160,7 +160,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         |not allowed in type signatures
    |                         help: replace with the correct return type: `&'static &'static usize`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:56:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
@@ -169,7 +169,7 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      |             not allowed in type signatures
    |                                      help: replace with the correct return type: `*const *const usize`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/typeck_type_placeholder_item.rs:70:8
    |
 LL |     a: _,
@@ -192,9 +192,9 @@ error: missing type for `static` item
   --> $DIR/typeck_type_placeholder_item.rs:76:12
    |
 LL |     static A = 42;
-   |            ^ help: provide a type for the item: `A: i32`
+   |            ^ help: provide a type for the static variable: `A: i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:78:15
    |
 LL |     static B: _ = 42;
@@ -203,14 +203,14 @@ LL |     static B: _ = 42;
    |               not allowed in type signatures
    |               help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:80:15
    |
 LL |     static C: Option<_> = Some(42);
    |               ^^^^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:83:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:82:21
    |
 LL |     fn fn_test() -> _ { 5 }
    |                     ^
@@ -218,8 +218,8 @@ LL |     fn fn_test() -> _ { 5 }
    |                     not allowed in type signatures
    |                     help: replace with the correct return type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:86:23
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:85:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      -^--^-
@@ -228,8 +228,8 @@ LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      |not allowed in type signatures
    |                      help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:89:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:88:22
    |
 LL |     static FN_TEST3: _ = "test";
    |                      ^
@@ -237,8 +237,8 @@ LL |     static FN_TEST3: _ = "test";
    |                      not allowed in type signatures
    |                      help: replace with the correct type: `&str`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:92:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:91:22
    |
 LL |     static FN_TEST4: _ = 145;
    |                      ^
@@ -246,14 +246,14 @@ LL |     static FN_TEST4: _ = 145;
    |                      not allowed in type signatures
    |                      help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:95:22
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/typeck_type_placeholder_item.rs:94:22
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
    |                      ^^^^^^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:98:20
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:97:20
    |
 LL |     fn fn_test6(_: _) { }
    |                    ^ not allowed in type signatures
@@ -263,8 +263,8 @@ help: use type parameters instead
 LL |     fn fn_test6<T>(_: T) { }
    |                ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:101:20
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:100:20
    |
 LL |     fn fn_test7(x: _) { let _x: usize = x; }
    |                    ^ not allowed in type signatures
@@ -274,8 +274,8 @@ help: use type parameters instead
 LL |     fn fn_test7<T>(x: T) { let _x: usize = x; }
    |                ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:104:29
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:103:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^
@@ -283,8 +283,8 @@ LL |     fn fn_test8(_f: fn() -> _) { }
    |                             not allowed in type signatures
    |                             help: use type parameters instead: `T`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:104:29
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:103:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
@@ -294,8 +294,8 @@ help: use type parameters instead
 LL |     fn fn_test8<T>(_f: fn() -> T) { }
    |                ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:127:12
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:126:12
    |
 LL |         a: _,
    |            ^ not allowed in type signatures
@@ -314,21 +314,21 @@ LL |         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:132:18
+  --> $DIR/typeck_type_placeholder_item.rs:131:18
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                  ^ cannot infer type
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:132:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:131:28
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            ^  ^ not allowed in type signatures
    |                            |
    |                            not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:136:30
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:135:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             -^--^-
@@ -337,8 +337,8 @@ LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             |not allowed in type signatures
    |                             help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:139:33
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:138:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           ------^-
@@ -346,8 +346,8 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:158:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:157:21
    |
 LL | struct BadStruct<_>(_);
    |                     ^ not allowed in type signatures
@@ -357,8 +357,8 @@ help: use type parameters instead
 LL | struct BadStruct<T>(T);
    |                  ^  ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:163:15
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/typeck_type_placeholder_item.rs:162:15
    |
 LL | impl BadTrait<_> for BadStruct<_> {}
    |               ^                ^ not allowed in type signatures
@@ -370,14 +370,14 @@ help: use type parameters instead
 LL | impl<T> BadTrait<T> for BadStruct<T> {}
    |     ^^^          ^                ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:166:34
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:165:34
    |
 LL | fn impl_trait() -> impl BadTrait<_> {
    |                                  ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:171:25
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:170:25
    |
 LL | struct BadStruct1<_, _>(_);
    |                         ^ not allowed in type signatures
@@ -387,8 +387,8 @@ help: use type parameters instead
 LL | struct BadStruct1<T, _>(T);
    |                   ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:176:25
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:175:25
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                         ^ not allowed in type signatures
@@ -398,20 +398,20 @@ help: use type parameters instead
 LL | struct BadStruct2<U, T>(U, T);
    |                   ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:180:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for type aliases
+  --> $DIR/typeck_type_placeholder_item.rs:179:14
    |
 LL | type X = Box<_>;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:186:21
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:185:21
    |
 LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:220:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:219:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -419,8 +419,8 @@ LL | fn value() -> Option<&'static _> {
    |               |               not allowed in type signatures
    |               help: replace with the correct return type: `Option<&'static u8>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:225:10
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:224:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -428,8 +428,8 @@ LL | const _: Option<_> = map(value);
    |          not allowed in type signatures
    |          help: replace with the correct type: `Option<u8>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:144:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:143:31
    |
 LL |     fn method_test1(&self, x: _);
    |                               ^ not allowed in type signatures
@@ -439,8 +439,8 @@ help: use type parameters instead
 LL |     fn method_test1<T>(&self, x: T);
    |                    ^^^           ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:146:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:145:31
    |
 LL |     fn method_test2(&self, x: _) -> _;
    |                               ^     ^ not allowed in type signatures
@@ -452,8 +452,8 @@ help: use type parameters instead
 LL |     fn method_test2<T>(&self, x: T) -> T;
    |                    ^^^           ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:148:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:147:31
    |
 LL |     fn method_test3(&self) -> _;
    |                               ^ not allowed in type signatures
@@ -463,8 +463,8 @@ help: use type parameters instead
 LL |     fn method_test3<T>(&self) -> T;
    |                    ^^^           ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:150:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:149:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
@@ -474,8 +474,8 @@ help: use type parameters instead
 LL |     fn assoc_fn_test1<T>(x: T);
    |                      ^^^    ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:152:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:151:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
    |                          ^     ^ not allowed in type signatures
@@ -487,8 +487,8 @@ help: use type parameters instead
 LL |     fn assoc_fn_test2<T>(x: T) -> T;
    |                      ^^^    ^     ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:154:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:153:28
    |
 LL |     fn assoc_fn_test3() -> _;
    |                            ^ not allowed in type signatures
@@ -498,20 +498,20 @@ help: use type parameters instead
 LL |     fn assoc_fn_test3<T>() -> T;
    |                      ^^^      ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:194:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:193:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:196:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:195:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:198:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:197:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -519,13 +519,13 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:201:26
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:200:26
    |
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:44:24
    |
 LL |     fn test9(&self) -> _ { () }
@@ -534,7 +534,7 @@ LL |     fn test9(&self) -> _ { () }
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `()`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:47:27
    |
 LL |     fn test10(&self, _x : _) { }
@@ -545,7 +545,7 @@ help: use type parameters instead
 LL |     fn test10<T>(&self, _x : T) { }
    |              ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:62:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
@@ -554,7 +554,7 @@ LL |     fn clone(&self) -> _ { Test9 }
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `Test9`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:65:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
@@ -565,8 +565,8 @@ help: use type parameters instead
 LL |     fn clone_from<T>(&mut self, other: T) { *self = Test9; }
    |                  ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:111:31
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:110:31
    |
 LL |         fn fn_test9(&self) -> _ { () }
    |                               ^
@@ -574,8 +574,8 @@ LL |         fn fn_test9(&self) -> _ { () }
    |                               not allowed in type signatures
    |                               help: replace with the correct return type: `()`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:114:34
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:113:34
    |
 LL |         fn fn_test10(&self, _x : _) { }
    |                                  ^ not allowed in type signatures
@@ -585,8 +585,8 @@ help: use type parameters instead
 LL |         fn fn_test10<T>(&self, _x : T) { }
    |                     ^^^             ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:119:28
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:118:28
    |
 LL |         fn clone(&self) -> _ { FnTest9 }
    |                            ^
@@ -594,8 +594,8 @@ LL |         fn clone(&self) -> _ { FnTest9 }
    |                            not allowed in type signatures
    |                            help: replace with the correct return type: `FnTest9`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:122:41
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:121:41
    |
 LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
    |                                         ^ not allowed in type signatures
@@ -605,26 +605,26 @@ help: use type parameters instead
 LL |         fn clone_from<T>(&mut self, other: T) { *self = FnTest9; }
    |                      ^^^                   ^
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:207:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:209:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:208:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
-  --> $DIR/typeck_type_placeholder_item.rs:212:14
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:211:14
    |
 LL |     const D: _ = 42;
    |              ^

--- a/src/test/ui/typeck/typeck_type_placeholder_item.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.rs
@@ -8,67 +8,67 @@
 // inference by using the `_` type placeholder.
 
 fn test() -> _ { 5 }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
 fn test2() -> (_, _) { (5, 5) }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
 static TEST3: _ = "test";
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
 static TEST4: _ = 145;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
 static TEST5: (_, _) = (1, 2);
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
 fn test6(_: _) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn test6_b<T>(_: _, _: T) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn test7(x: _) { let _x: usize = x; }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 fn test8(_f: fn() -> _) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
-//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
+//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 struct Test9;
 
 impl Test9 {
     fn test9(&self) -> _ { () }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
     fn test10(&self, _x : _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 }
 
 fn test11(x: &usize) -> &_ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
     &x
 }
 
 unsafe fn test12(x: *const usize) -> *const *const _ {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
     &x
 }
 
 impl Clone for Test9 {
     fn clone(&self) -> _ { Test9 }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
     fn clone_from(&mut self, other: _) { *self = Test9; }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 }
 
 struct Test10 {
     a: _,
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for structs
     b: (_, _),
 }
 
@@ -76,95 +76,94 @@ pub fn main() {
     static A = 42;
     //~^ ERROR missing type for `static` item
     static B: _ = 42;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
     static C: Option<_> = Some(42);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
-
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
     fn fn_test() -> _ { 5 }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
     fn fn_test2() -> (_, _) { (5, 5) }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
     static FN_TEST3: _ = "test";
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
     static FN_TEST4: _ = 145;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
     static FN_TEST5: (_, _) = (1, 2);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for static variables
 
     fn fn_test6(_: _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
     fn fn_test7(x: _) { let _x: usize = x; }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
     fn fn_test8(_f: fn() -> _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
-    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
+    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
     struct FnTest9;
 
     impl FnTest9 {
         fn fn_test9(&self) -> _ { () }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
         fn fn_test10(&self, _x : _) { }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     }
 
     impl Clone for FnTest9 {
         fn clone(&self) -> _ { FnTest9 }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
         fn clone_from(&mut self, other: _) { *self = FnTest9; }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     }
 
     struct FnTest10 {
         a: _,
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for structs
         b: (_, _),
     }
 
     fn fn_test11(_: _) -> (_, _) { panic!() }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
     //~| ERROR type annotations needed
 
     fn fn_test12(x: i32) -> (_, _) { (x, x) }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
     fn fn_test13(x: _) -> (i32, _) { (x, x) }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 }
 
 trait T {
     fn method_test1(&self, x: _);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     fn method_test2(&self, x: _) -> _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     fn method_test3(&self) -> _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test1(x: _);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test2(x: _) -> _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test3() -> _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 }
 
 struct BadStruct<_>(_);
 //~^ ERROR expected identifier, found reserved identifier `_`
-//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures for structs
 trait BadTrait<_> {}
 //~^ ERROR expected identifier, found reserved identifier `_`
 impl BadTrait<_> for BadStruct<_> {}
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for implementations
 
 fn impl_trait() -> impl BadTrait<_> {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for opaque types
     unimplemented!()
 }
 
@@ -172,19 +171,19 @@ struct BadStruct1<_, _>(_);
 //~^ ERROR expected identifier, found reserved identifier `_`
 //~| ERROR expected identifier, found reserved identifier `_`
 //~| ERROR the name `_` is already used
-//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures for structs
 struct BadStruct2<_, T>(_, T);
 //~^ ERROR expected identifier, found reserved identifier `_`
-//~| ERROR the type placeholder `_` is not allowed within types on item signatures
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures for structs
 
 type X = Box<_>;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for type aliases
 
 struct Struct;
 trait Trait<T> {}
 impl Trait<usize> for Struct {}
 type Y = impl Trait<_>;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for opaque types
 fn foo() -> Y {
     Struct
 }
@@ -192,25 +191,25 @@ fn foo() -> Y {
 trait Qux {
     type A;
     type B = _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for associated types
     const C: _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
     const D: _ = 42;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
     // type E: _; // FIXME: make the parser propagate the existence of `B`
     type F: std::ops::Fn(_);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
     type A = _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for associated types
     type B = _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for associated types
     const C: _;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
     //~| ERROR associated constant in `impl` without body
     const D: _ = 42;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
 }
 
 fn map<T>(_: fn() -> Option<&'static T>) -> Option<T> {
@@ -218,9 +217,9 @@ fn map<T>(_: fn() -> Option<&'static T>) -> Option<T> {
 }
 
 fn value() -> Option<&'static _> {
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
     Option::<&'static u8>::None
 }
 
 const _: Option<_> = map(value);
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -2,27 +2,27 @@
 // using the `_` type placeholder.
 
 fn test1() -> _ { Some(42) }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for return types
 
 const TEST2: _ = 42u32;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
 
 const TEST3: _ = Some(42);
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
 
 const TEST4: fn() -> _ = 42;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
 
 trait Test5 {
     const TEST5: _ = 42;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
 }
 
 struct Test6;
 
 impl Test6 {
     const TEST6: _ = 13;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for constants
 }
 
 pub fn main() {

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item_help.rs:4:15
    |
 LL | fn test1() -> _ { Some(42) }
@@ -7,7 +7,7 @@ LL | fn test1() -> _ { Some(42) }
    |               not allowed in type signatures
    |               help: replace with the correct return type: `Option<i32>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:7:14
    |
 LL | const TEST2: _ = 42u32;
@@ -16,7 +16,7 @@ LL | const TEST2: _ = 42u32;
    |              not allowed in type signatures
    |              help: replace with the correct type: `u32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:10:14
    |
 LL | const TEST3: _ = Some(42);
@@ -25,13 +25,13 @@ LL | const TEST3: _ = Some(42);
    |              not allowed in type signatures
    |              help: replace with the correct type: `Option<i32>`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
    |
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:17:18
    |
 LL |     const TEST5: _ = 42;
@@ -40,7 +40,7 @@ LL |     const TEST5: _ = 42;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:24:18
    |
 LL |     const TEST6: _ = 13;

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -347,7 +347,7 @@ impl Checker {
                 } else {
                     report.errors += 1;
                     print!("{}:{}: broken link fragment ", pretty_path, i + 1);
-                    println!("`#{}` pointing to `{}`", fragment, pretty_path);
+                    println!("`#{}` pointing to `{}`", fragment, target_pretty_path);
                 };
             }
         });

--- a/src/tools/linkchecker/tests/broken_redir/redir-bad.html
+++ b/src/tools/linkchecker/tests/broken_redir/redir-bad.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="refresh" content="0;URL=sometarget">
+    <title>Redirection</title>
 </head>
 <body>
     <p>Redirecting to <a href="sometarget">sometarget</a>...</p>

--- a/src/tools/linkchecker/tests/checks.rs
+++ b/src/tools/linkchecker/tests/checks.rs
@@ -15,7 +15,7 @@ fn run(dirname: &str) -> (ExitStatus, String, String) {
 fn broken_test(dirname: &str, expected: &str) {
     let (status, stdout, stderr) = run(dirname);
     assert!(!status.success());
-    if !stdout.contains(expected) {
+    if !contains(expected, &stdout) {
         panic!(
             "stdout did not contain expected text: {}\n\
             --- stdout:\n\
@@ -25,6 +25,25 @@ fn broken_test(dirname: &str, expected: &str) {
             expected, stdout, stderr
         );
     }
+}
+
+fn contains(expected: &str, actual: &str) -> bool {
+    // Normalize for Windows paths.
+    let actual = actual.replace('\\', "/");
+    actual.lines().any(|mut line| {
+        for (i, part) in expected.split("[..]").enumerate() {
+            match line.find(part) {
+                Some(j) => {
+                    if i == 0 && j != 0 {
+                        return false;
+                    }
+                    line = &line[j + part.len()..];
+                }
+                None => return false,
+            }
+        }
+        line.is_empty() || expected.ends_with("[..]")
+    })
 }
 
 fn valid_test(dirname: &str) {
@@ -48,30 +67,46 @@ fn valid() {
 
 #[test]
 fn basic_broken() {
-    broken_test("basic_broken", "bar.html");
+    broken_test("basic_broken", "foo.html:3: broken link - `bar.html`");
 }
 
 #[test]
 fn broken_fragment_local() {
-    broken_test("broken_fragment_local", "#somefrag");
+    broken_test(
+        "broken_fragment_local",
+        "foo.html:3: broken link fragment `#somefrag` pointing to `foo.html`",
+    );
 }
 
 #[test]
 fn broken_fragment_remote() {
-    broken_test("broken_fragment_remote/inner", "#somefrag");
+    broken_test(
+        "broken_fragment_remote/inner",
+        "foo.html:3: broken link fragment `#somefrag` pointing to `foo.html`",
+    );
 }
 
 #[test]
 fn broken_redir() {
-    broken_test("broken_redir", "sometarget");
+    broken_test(
+        "broken_redir",
+        "foo.html:3: broken redirect from `redir-bad.html` to `sometarget`",
+    );
 }
 
 #[test]
 fn directory_link() {
-    broken_test("directory_link", "somedir");
+    broken_test(
+        "directory_link",
+        "foo.html:3: directory link to `somedir` (directory links should use index.html instead)",
+    );
 }
 
 #[test]
 fn redirect_loop() {
-    broken_test("redirect_loop", "redir-bad.html");
+    broken_test(
+        "redirect_loop",
+        "foo.html:3: redirect from `redir-bad.html` to `[..]redirect_loop/redir-bad.html` \
+         which is also a redirect (not supported)",
+    );
 }

--- a/src/tools/linkchecker/tests/checks.rs
+++ b/src/tools/linkchecker/tests/checks.rs
@@ -82,7 +82,8 @@ fn broken_fragment_local() {
 fn broken_fragment_remote() {
     broken_test(
         "broken_fragment_remote/inner",
-        "foo.html:3: broken link fragment `#somefrag` pointing to `foo.html`",
+        "foo.html:3: broken link fragment `#somefrag` pointing to \
+         `[..]/broken_fragment_remote/bar.html`",
     );
 }
 

--- a/src/tools/linkchecker/tests/redirect_loop/redir-bad.html
+++ b/src/tools/linkchecker/tests/redirect_loop/redir-bad.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="refresh" content="0;URL=redir-bad.html">
+    <title>Redirection</title>
 </head>
 <body>
     <p>Redirecting to <a href="redir-bad.html">redir-bad.html</a>...</p>

--- a/src/tools/linkchecker/tests/valid/inner/redir-bad.html
+++ b/src/tools/linkchecker/tests/valid/inner/redir-bad.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="refresh" content="0;URL=xxx">
+    <title>Redirection</title>
 </head>
 <body>
     <p>Redirecting to <a href="xxx">xxx</a>...</p>

--- a/src/tools/linkchecker/tests/valid/inner/redir.html
+++ b/src/tools/linkchecker/tests/valid/inner/redir.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="refresh" content="0;URL=redir-target.html">
+    <title>Redirection</title>
 </head>
 <body>
     <p>Redirecting to <a href="redir-target.html">redir-target.html</a>...</p>


### PR DESCRIPTION
Successful merges:

 - #83739 (Account for bad placeholder errors on consts/statics with trait objects)
 - #85637 (document PartialEq, PartialOrd, Ord requirements more explicitly)
 - #86152 (Lazify is_really_default condition in the RustdocGUI bootstrap step)
 - #86156 (Fix a bug in the linkchecker)
 - #86223 (Specify the kind of the item for E0121)
 - #86427 (Updated release note)
 - #86452 (fix panic-safety in specialized Zip::next_back)
 - #86484 (Do not set depth to 0 in fully_expand_fragment)
 - #86491 (expand: Move some more derive logic to rustc_builtin_macros)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83739,85637,86152,86156,86223,86427,86452,86484,86491)
<!-- homu-ignore:end -->