### PR TITLE
Cleanup handling of `crate_name` for doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -3,8 +3,8 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{ColorConfig, ErrorReported};
 use rustc_hir as hir;
-use rustc_hir::intravisit;
 use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_hir::intravisit;
 use rustc_hir::{HirId, CRATE_HIR_ID};
 use rustc_interface::interface;
 use rustc_middle::hir::map::Map;
@@ -14,6 +14,7 @@ use rustc_session::{lint, DiagnosticOutput, Session};
 use rustc_span::edition::Edition;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::sym;
+use rustc_span::Symbol;
 use rustc_span::{BytePos, FileName, Pos, Span, DUMMY_SP};
 use rustc_target::spec::TargetTriple;
 use tempfile::Builder as TempFileBuilder;
@@ -122,7 +123,7 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
                 opts.display_warnings |= options.display_warnings;
                 let enable_per_target_ignores = options.enable_per_target_ignores;
                 let mut collector = Collector::new(
-                    tcx.crate_name(LOCAL_CRATE).to_string(),
+                    tcx.crate_name(LOCAL_CRATE),
                     options,
                     false,
                     opts,
@@ -796,7 +797,7 @@ crate struct Collector {
     options: Options,
     use_headers: bool,
     enable_per_target_ignores: bool,
-    crate_name: String,
+    crate_name: Symbol,
     opts: TestOptions,
     position: Span,
     source_map: Option<Lrc<SourceMap>>,
@@ -808,7 +809,7 @@ crate struct Collector {
 
 impl Collector {
     crate fn new(
-        crate_name: String,
+        crate_name: Symbol,
         options: Options,
         use_headers: bool,
         opts: TestOptions,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -4,6 +4,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::{ColorConfig, ErrorReported};
 use rustc_hir as hir;
 use rustc_hir::intravisit;
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_hir::{HirId, CRATE_HIR_ID};
 use rustc_interface::interface;
 use rustc_middle::hir::map::Map;
@@ -111,8 +112,6 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
     let res = interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {
             let _lower_to_hir = queries.lower_to_hir()?;
-
-            let crate_name = queries.crate_name()?.peek().to_string();
             let mut global_ctxt = queries.global_ctxt()?.take();
 
             let collector = global_ctxt.enter(|tcx| {
@@ -123,7 +122,7 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
                 opts.display_warnings |= options.display_warnings;
                 let enable_per_target_ignores = options.enable_per_target_ignores;
                 let mut collector = Collector::new(
-                    crate_name,
+                    tcx.crate_name(LOCAL_CRATE).to_string(),
                     options,
                     false,
                     opts,

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use rustc_span::edition::Edition;
 use rustc_span::source_map::DUMMY_SP;
+use rustc_span::Symbol;
 
 use crate::config::{Options, RenderOptions};
 use crate::doctest::{Collector, TestOptions};
@@ -121,7 +122,7 @@ crate fn test(mut options: Options) -> Result<(), String> {
     opts.no_crate_inject = true;
     opts.display_warnings = options.display_warnings;
     let mut collector = Collector::new(
-        options.input.display().to_string(),
+        Symbol::intern(&options.input.display().to_string()),
         options.clone(),
         true,
         opts,


### PR DESCRIPTION
- Remove unnecessary reallocation
- Remove unnecessary messing around with `queries` for the crate name; it's simpler and faster to go through the TyCtxt instead
- Rename `cratename` -> `crate_name` for consistency with the rest of the compiler