### PR TITLE
Don't normalize xform_ret_ty during method candidate assembly 

### DIFF
--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
@@ -6,7 +6,6 @@ LL |     let _result = &Some(42).as_deref();
    |
    = note: the following trait bounds were not satisfied:
            `{integer}: Deref`
-           `<{integer} as Deref>::Target = _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.stderr
@@ -6,7 +6,7 @@ LL |     let _result = &mut Some(42).as_deref_mut();
    |
    = note: the following trait bounds were not satisfied:
            `{integer}: DerefMut`
-           `<{integer} as Deref>::Target = _`
+           `{integer}: Deref`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
@@ -6,7 +6,6 @@ LL |     let _result = &Ok(42).as_deref();
    |
    = note: the following trait bounds were not satisfied:
            `{integer}: Deref`
-           `<{integer} as Deref>::Target = _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
@@ -6,7 +6,7 @@ LL |     let _result = &mut Ok(42).as_deref_mut();
    |
    = note: the following trait bounds were not satisfied:
            `{integer}: DerefMut`
-           `<{integer} as Deref>::Target = _`
+           `{integer}: Deref`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-85671.rs
+++ b/src/test/ui/resolve/issue-85671.rs
@@ -1,0 +1,37 @@
+// check-pass
+
+// Some trait with a function that returns a slice:
+pub trait AsSlice {
+    type Element;
+    fn as_slice(&self) -> &[Self::Element];
+}
+
+// Some type
+pub struct A<Cont>(Cont);
+
+// Here we say that if A wraps a slice, then it implements AsSlice
+impl<'a, Element> AsSlice for A<&'a [Element]> {
+    type Element = Element;
+    fn as_slice(&self) -> &[Self::Element] {
+        self.0
+    }
+}
+
+impl<Cont> A<Cont> {
+    // We want this function to work
+    pub fn failing<Coef>(&self)
+    where
+        Self: AsSlice<Element = Coef>,
+    {
+        self.as_ref_a().as_ref_a();
+    }
+
+    pub fn as_ref_a<Coef>(&self) -> A<&[<Self as AsSlice>::Element]>
+    where
+        Self: AsSlice<Element = Coef>,
+    {
+        A(self.as_slice())
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85671

Normalizing the return type of a method candidate together with the expected receiver type of the method can lead to valid method candidates being rejected during probing. Specifically in the example of the fixed issue we have a `self_ty` of the form `&A<&[Coef]>` whereas the `impl_ty` of the method would be `&A<_>`, if we normalize the projection in the return type we unify the inference variable with `Cont`, which will lead us to reject the candidate in the sup type check in `consider_probe`. Since we don't actually need the normalized return type during candidate assembly, we postpone the normalization until we consider candidates in `consider_probe`.