### PR TITLE
Mark some edition tests as check-pass

### DIFF
--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.fixed
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.fixed
@@ -3,7 +3,8 @@
 // to detect or fix uses of `dyn` under a macro. Since we are testing
 // this file via `rustfix`, we want the rustfix output to be
 // compilable; so the macros here carefully use `dyn` "correctly."
-
+//
+// edition:2015
 // run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.rs
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.rs
@@ -3,7 +3,8 @@
 // to detect or fix uses of `dyn` under a macro. Since we are testing
 // this file via `rustfix`, we want the rustfix output to be
 // compilable; so the macros here carefully use `dyn` "correctly."
-
+//
+// edition:2015
 // run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.stderr
@@ -1,11 +1,11 @@
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:13:13
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:14:13
    |
 LL |     pub mod dyn {
    |             ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
    |
 note: the lint level is defined here
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:10:9
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:11:9
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #![deny(keyword_idents)]
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:16:20
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:17:20
    |
 LL |         pub struct dyn;
    |                    ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -22,7 +22,7 @@ LL |         pub struct dyn;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:21:16
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:22:16
    |
 LL | use outer_mod::dyn::dyn;
    |                ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -31,7 +31,7 @@ LL | use outer_mod::dyn::dyn;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:21:21
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:22:21
    |
 LL | use outer_mod::dyn::dyn;
    |                     ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -40,7 +40,7 @@ LL | use outer_mod::dyn::dyn;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:28:11
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:29:11
    |
 LL |     match dyn { dyn => {} }
    |           ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -49,7 +49,7 @@ LL |     match dyn { dyn => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:28:17
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:29:17
    |
 LL |     match dyn { dyn => {} }
    |                 ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -58,7 +58,7 @@ LL |     match dyn { dyn => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:33:17
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:34:17
    |
 LL |     macro_defn::dyn();
    |                 ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -67,7 +67,7 @@ LL |     macro_defn::dyn();
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:43:18
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:44:18
    |
 LL |     macro_rules! dyn {
    |                  ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -76,7 +76,7 @@ LL |     macro_rules! dyn {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:12
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:52:12
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |            ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -85,7 +85,7 @@ LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:34
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:52:34
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |                                  ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -94,7 +94,7 @@ LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:51:39
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:52:39
    |
 LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    |                                       ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -103,7 +103,7 @@ LL |     pub fn dyn() -> ::outer_mod::dyn::dyn {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:58:22
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:59:22
    |
 LL |         ::outer_mod::dyn::dyn
    |                      ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -112,7 +112,7 @@ LL |         ::outer_mod::dyn::dyn
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:58:27
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:59:27
    |
 LL |         ::outer_mod::dyn::dyn
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
@@ -121,7 +121,7 @@ LL |         ::outer_mod::dyn::dyn
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `dyn` is a keyword in the 2018 edition
-  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:67:23
+  --> $DIR/dyn-2015-edition-keyword-ident-lint.rs:68:23
    |
 LL |     pub fn boxed() -> dyn!(
    |                       ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`

--- a/src/test/ui/dyn-keyword/dyn-2015-idents-in-decl-macros-unlinted.rs
+++ b/src/test/ui/dyn-keyword/dyn-2015-idents-in-decl-macros-unlinted.rs
@@ -1,11 +1,12 @@
-// build-pass (FIXME(62277): could be check-pass?)
-
 // Under the 2015 edition with the keyword_idents lint, `dyn` is
 // not entirely acceptable as an identifier.
 //
 // We currently do not attempt to detect or fix uses of `dyn` as an
 // identifier under a macro, including under the declarative `macro`
 // forms from macros 1.2 and macros 2.0.
+//
+// check-pass
+// edition:2015
 
 #![feature(decl_macro)]
 #![allow(non_camel_case_types)]

--- a/src/test/ui/dyn-keyword/dyn-2015-idents-in-macros-unlinted.rs
+++ b/src/test/ui/dyn-keyword/dyn-2015-idents-in-macros-unlinted.rs
@@ -1,10 +1,11 @@
-// build-pass (FIXME(62277): could be check-pass?)
-
 // Under the 2015 edition with the keyword_idents lint, `dyn` is
 // not entirely acceptable as an identifier.
 //
 // We currently do not attempt to detect or fix uses of `dyn` as an
 // identifier under a macro.
+//
+// check-pass
+// edition:2015
 
 #![allow(non_camel_case_types)]
 #![deny(keyword_idents)]

--- a/src/test/ui/dyn-keyword/dyn-2015-no-warnings-without-lints.rs
+++ b/src/test/ui/dyn-keyword/dyn-2015-no-warnings-without-lints.rs
@@ -1,7 +1,8 @@
 // Under the 2015 edition without the keyword_idents lint, `dyn` is
 // entirely acceptable as an identifier.
-
-// build-pass (FIXME(62277): could be check-pass?)
+//
+// check-pass
+// edition:2015
 
 #![allow(non_camel_case_types)]
 

--- a/src/test/ui/dyn-keyword/issue-56327-dyn-trait-in-macro-is-okay.rs
+++ b/src/test/ui/dyn-keyword/issue-56327-dyn-trait-in-macro-is-okay.rs
@@ -1,5 +1,6 @@
 // check-pass
-
+// edition:2015
+//
 // rust-lang/rust#56327: Some occurrences of `dyn` within a macro are
 // not instances of identifiers, and thus should *not* be caught by the
 // keyword_ident lint.

--- a/src/test/ui/editions/edition-feature-ok.rs
+++ b/src/test/ui/editions/edition-feature-ok.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rust_2018_preview)]
 

--- a/src/test/ui/editions/edition-imports-virtual-2015-ambiguity.rs
+++ b/src/test/ui/editions/edition-imports-virtual-2015-ambiguity.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // edition:2018
 // compile-flags:--extern edition_imports_2015
 // aux-build:edition-imports-2015.rs

--- a/src/test/ui/editions/edition-keywords-2015-2015-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2015-2015-expansion.rs
@@ -1,6 +1,6 @@
 // edition:2015
 // aux-build:edition-kw-macro-2015.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(keyword_idents)]
 

--- a/src/test/ui/editions/edition-keywords-2018-2015-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2015-expansion.rs
@@ -1,6 +1,6 @@
 // edition:2018
 // aux-build:edition-kw-macro-2015.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(keyword_idents)]
 


### PR DESCRIPTION
## Overview
This helps with #62277. In short, there are some tests that were marked as `build-pass` when it was unclear whether `check-pass` might be more appropriate. This PR marks some of those tests as `check-pass`, in addition to making some incidental formatting improvements.

## A brief explanation of why this is correct
These tests fall into a few buckets. 

`src/test/ui/dyn-keyword/dyn-2015-edition-keyword-ident-lint.rs`
`src/test/ui/dyn-keyword/dyn-2015-idents-in-decl-macros-unlinted.rs` 
`src/test/ui/dyn-keyword/dyn-2015-idents-in-macros-unlinted.rs`
`src/test/ui/dyn-keyword/dyn-2015-no-warnings-without-lints.rs`
`src/test/ui/dyn-keyword/issue-56327-dyn-trait-in-macro-is-okay.rs`

These test a lint for a keyword added in a new edition and the corresponding changes in keyword rules.

`src/test/ui/editions/edition-feature-ok.rs`
This checks that a feature related to an edition transition is valid.

`src/test/ui/editions/edition-imports-virtual-2015-ambiguity.rs`
This checks that imports between editions work correctly.

`src/test/ui/editions/edition-keywords-2015-2015-expansion.rs`
`src/test/ui/editions/edition-keywords-2018-2015-expansion.rs`
This checks the interaction between a change in keyword status over editions and macros.

All of the things being tested come before linking and codegen, so it is safe to use `check-pass` for them.