### PR TITLE
Line numbers aligned with content

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -71,7 +71,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.3.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.4.0 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/rustdoc-gui/escape-key.goml
+++ b/src/test/rustdoc-gui/escape-key.goml
@@ -2,25 +2,25 @@ goto: file://|DOC_PATH|/test_docs/index.html
 // First, we check that the search results are hidden when the Escape key is pressed.
 write: (".search-input", "test")
 wait-for: "#search > h1" // The search element is empty before the first search 
-assert-attr: ("#search", {"class": "content"})
-assert-attr: ("#main", {"class": "content hidden"})
+assert-attribute: ("#search", {"class": "content"})
+assert-attribute: ("#main", {"class": "content hidden"})
 press-key: "Escape"
-assert-attr: ("#search", {"class": "content hidden"})
-assert-attr: ("#main", {"class": "content"})
+assert-attribute: ("#search", {"class": "content hidden"})
+assert-attribute: ("#main", {"class": "content"})
 
 // Check that focusing the search input brings back the search results
 focus: ".search-input"
-assert-attr: ("#search", {"class": "content"})
-assert-attr: ("#main", {"class": "content hidden"})
+assert-attribute: ("#search", {"class": "content"})
+assert-attribute: ("#main", {"class": "content hidden"})
 
 // Now let's check that when the help popup is displayed and we press Escape, it doesn't
 // hide the search results too.
 click: "#help-button"
-assert-attr: ("#help", {"class": ""})
+assert-attribute: ("#help", {"class": ""})
 press-key: "Escape"
-assert-attr: ("#help", {"class": "hidden"})
-assert-attr: ("#search", {"class": "content"})
-assert-attr: ("#main", {"class": "content hidden"})
+assert-attribute: ("#help", {"class": "hidden"})
+assert-attribute: ("#search", {"class": "content"})
+assert-attribute: ("#main", {"class": "content hidden"})
 
 // Check that Escape hides the search results when a search result is focused.
 focus: ".search-input"
@@ -29,6 +29,6 @@ press-key: "ArrowDown"
 assert-false: ".search-input:focus"
 assert: "#results a:focus"
 press-key: "Escape"
-assert-attr: ("#help", {"class": "hidden"})
-assert-attr: ("#search", {"class": "content hidden"})
-assert-attr: ("#main", {"class": "content"})
+assert-attribute: ("#help", {"class": "hidden"})
+assert-attribute: ("#search", {"class": "content hidden"})
+assert-attribute: ("#main", {"class": "content"})

--- a/src/test/rustdoc-gui/hash-item-expansion.goml
+++ b/src/test/rustdoc-gui/hash-item-expansion.goml
@@ -1,15 +1,15 @@
 // This test ensures that the element corresponding to the hash is displayed.
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.borrow
 // In the blanket implementations list, "Borrow" is the second one, hence the ":nth(2)".
-assert-attr: ("#blanket-implementations-list > details:nth-child(2)", {"open": ""})
+assert-attribute: ("#blanket-implementations-list > details:nth-child(2)", {"open": ""})
 // We first check that the impl block is open by default.
-assert-attr: ("#implementations + details", {"open": ""})
+assert-attribute: ("#implementations + details", {"open": ""})
 // We collapse it.
 click: "#implementations + details > summary"
 // We check that it was collapsed as expected.
-assert-attr-false: ("#implementations + details", {"open": ""})
+assert-attribute-false: ("#implementations + details", {"open": ""})
 // To ensure that we will click on the currently hidden method.
 assert-text: (".sidebar-links > a", "must_use")
 click: ".sidebar-links > a"
 // We check that the impl block was opened as expected so that we can see the method.
-assert-attr: ("#implementations + details", {"open": ""})
+assert-attribute: ("#implementations + details", {"open": ""})

--- a/src/test/rustdoc-gui/impl-default-expansion.goml
+++ b/src/test/rustdoc-gui/impl-default-expansion.goml
@@ -1,3 +1,3 @@
 // This test ensures that the impl blocks are open by default.
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
-assert-attr: ("#main > details.implementors-toggle", {"open": ""})
+assert-attribute: ("#main > details.implementors-toggle", {"open": ""})

--- a/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
+++ b/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
@@ -2,7 +2,7 @@ goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "Foo")
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-attr: ("#titles > button:nth-of-type(1)", {"class": "selected"})
+assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})
 
 // To go back to the original "state"
 goto: file://|DOC_PATH|/test_docs/index.html
@@ -10,7 +10,7 @@ write: (".search-input", "-> String")
 // Waiting for the search results to appear...
 wait-for: "#titles"
 // With this search, only the last tab shouldn't be empty so it should be selected.
-assert-attr: ("#titles > button:nth-of-type(3)", {"class": "selected"})
+assert-attribute: ("#titles > button:nth-of-type(3)", {"class": "selected"})
 
 // To go back to the original "state"
 goto: file://|DOC_PATH|/test_docs/index.html
@@ -18,4 +18,4 @@ write: (".search-input", "-> Something")
 // Waiting for the search results to appear...
 wait-for: "#titles"
 // With this search, all the tabs are empty so the first one should remain selected.
-assert-attr: ("#titles > button:nth-of-type(1)", {"class": "selected"})
+assert-attribute: ("#titles > button:nth-of-type(1)", {"class": "selected"})

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -3,11 +3,11 @@ goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 click: (40, 224) // This is the position of the span for line 4.
 // Unfortunately, "#4" isn't a valid query selector, so we have to go around that limitation
 // by instead getting the nth span.
-assert-attr: (".line-numbers > span:nth-child(4)", {"class": "line-highlighted"})
+assert-attribute: (".line-numbers > span:nth-child(4)", {"class": "line-highlighted"})
 // We now check that the good spans are highlighted
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html#4-6
-assert-attr-false: (".line-numbers > span:nth-child(3)", {"class": "line-highlighted"})
-assert-attr: (".line-numbers > span:nth-child(4)", {"class": "line-highlighted"})
-assert-attr: (".line-numbers > span:nth-child(5)", {"class": "line-highlighted"})
-assert-attr: (".line-numbers > span:nth-child(6)", {"class": "line-highlighted"})
-assert-attr-false: (".line-numbers > span:nth-child(7)", {"class": "line-highlighted"})
+assert-attribute-false: (".line-numbers > span:nth-child(3)", {"class": "line-highlighted"})
+assert-attribute: (".line-numbers > span:nth-child(4)", {"class": "line-highlighted"})
+assert-attribute: (".line-numbers > span:nth-child(5)", {"class": "line-highlighted"})
+assert-attribute: (".line-numbers > span:nth-child(6)", {"class": "line-highlighted"})
+assert-attribute-false: (".line-numbers > span:nth-child(7)", {"class": "line-highlighted"})

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -11,3 +11,5 @@ assert-attribute: (".line-numbers > span:nth-child(4)", {"class": "line-highligh
 assert-attribute: (".line-numbers > span:nth-child(5)", {"class": "line-highlighted"})
 assert-attribute: (".line-numbers > span:nth-child(6)", {"class": "line-highlighted"})
 assert-attribute-false: (".line-numbers > span:nth-child(7)", {"class": "line-highlighted"})
+// This is to ensure that the content is correctly align with the line numbers.
+compare-elements-position: ("//*[@id='1']", ".rust > span", ("y"))

--- a/src/test/rustdoc-gui/toggle-docs-mobile.goml
+++ b/src/test/rustdoc-gui/toggle-docs-mobile.goml
@@ -1,21 +1,21 @@
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 size: (433, 600)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})
 click: (4, 280) // This is the position of the top doc comment toggle
-assert-attr-false: (".top-doc", {"open": ""})
+assert-attribute-false: (".top-doc", {"open": ""})
 click: (4, 280)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})
 // To ensure that the toggle isn't over the text, we check that the toggle isn't clicked.
 click: (3, 280)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})
 
 // Now we do the same but with a little bigger width
 size: (600, 600)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})
 click: (4, 240) // New Y position since all search elements are back on one line.
-assert-attr-false: (".top-doc", {"open": ""})
+assert-attribute-false: (".top-doc", {"open": ""})
 click: (4, 240)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})
 // To ensure that the toggle isn't over the text, we check that the toggle isn't clicked.
 click: (3, 240)
-assert-attr: (".top-doc", {"open": ""})
+assert-attribute: (".top-doc", {"open": ""})

--- a/src/test/rustdoc-gui/toggle-docs.goml
+++ b/src/test/rustdoc-gui/toggle-docs.goml
@@ -1,10 +1,10 @@
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-attr: ("#main > details.top-doc", {"open": ""})
+assert-attribute: ("#main > details.top-doc", {"open": ""})
 click: "#toggle-all-docs"
 wait-for: 1000
 // This is now collapsed so there shouldn't be the "open" attribute on details.
-assert-attr-false: ("#main > details.top-doc", {"open": ""})
+assert-attribute-false: ("#main > details.top-doc", {"open": ""})
 click: "#toggle-all-docs"
 wait-for: 1000
 // Not collapsed anymore so the "open" attribute should be back.
-assert-attr: ("#main > details.top-doc", {"open": ""})
+assert-attribute: ("#main > details.top-doc", {"open": ""})

--- a/src/test/rustdoc-gui/toggled-open-implementations.goml
+++ b/src/test/rustdoc-gui/toggled-open-implementations.goml
@@ -2,4 +2,4 @@
 // has all the implementations toggled open by default, so users can
 // find method names in those implementations with Ctrl-F.
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
-assert-attr: (".rustdoc-toggle.implementors-toggle", {"open": ""})
+assert-attribute: (".rustdoc-toggle.implementors-toggle", {"open": ""})


### PR DESCRIPTION
We had the issue a few times in the past where the source code pages' content wasn't aligned with the line numbers but completely below. This test will prevent this change to go unnoticed.

The first commit comes from https://github.com/rust-lang/rust/pull/86541 so it needs it to be merged first.

r? @jsha 