### PR TITLE
Fix crate filter search reset

### DIFF
--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1442,6 +1442,10 @@ window.initSearch = function(rawSearchIndex) {
         if (selectCrate) {
             selectCrate.onchange = function() {
                 updateLocalStorage("rustdoc-saved-filter-crate", selectCrate.value);
+                // In case you "cut" the entry from the search input, then change the crate filter
+                // before paste back the previous search, you get the old search results without
+                // the filter. To prevent this, we need to remove the previous results.
+                currentResults = null;
                 search(undefined, true);
             };
         }

--- a/src/test/rustdoc-gui/search-filter.goml
+++ b/src/test/rustdoc-gui/search-filter.goml
@@ -1,0 +1,17 @@
+goto: file://|DOC_PATH|/test_docs/index.html
+write: (".search-input", "test")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert-text: ("#results .externcrate", "test_docs")
+text: (".search-input", "")
+// We now want to change the crate filter.
+click: "#crate-search"
+// We select "lib2" option then press enter to change the filter.
+press-key: "ArrowDown"
+press-key: "Enter"
+// We now make the search again.
+write: (".search-input", "test")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+// We check that there is no more "test_docs" appearing.
+assert-false: "#results .externcrate"


### PR DESCRIPTION
I found a fun bug when using rustdoc recently: I made a search, cut the search input content, changed the crate filter, pasted back the input content. To my surprise, the crate filter wasn't applied. It's because that our search input was empty when receiving the `<select>` "onchange" event. To fix this issue, I reset the `currentResults` variable to `null`.

It's using the first commit from #86542 so it needs to wait for it before getting merged.

r? @jsha 