### PR TITLE
Add destructuring example of E0508

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0508.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0508.md
@@ -39,3 +39,16 @@ fn main() {
     let _value = array[0].clone();
 }
 ```
+
+If you really want to move the value out, you can use a destructuring array
+pattern to move it:
+
+```
+struct NonCopy;
+
+fn main() {
+    let array = [NonCopy; 1];
+    // Destructuring the array
+    let [_value] = array;
+}
+```


### PR DESCRIPTION
This adds an example that destructures the array to move the value, instead of taking a reference or cloning.