### PR TITLE
Add "some" as a doc alias for "any".

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2288,6 +2288,7 @@ pub trait Iterator {
     /// // we can still use `iter`, as there are more elements.
     /// assert_eq!(iter.next(), Some(&2));
     /// ```
+    #[doc(alias = "some")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn any<F>(&mut self, f: F) -> bool


### PR DESCRIPTION
This matches [Array#some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) in JavaScript.

See also #81697 for the alias between "every" and "all".