### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "merge",
  "num_cpus",
  "once_cell",
- "opener",
+ "opener 0.5.0",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -195,7 +195,9 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -253,7 +255,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -288,11 +290,10 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "opener",
+ "opener 0.5.0",
  "openssl",
  "percent-encoding 2.1.0",
  "pretty_env_logger",
- "rand 0.8.3",
  "rustc-workspace-hack",
  "rustfix 0.6.0",
  "semver 1.0.3",
@@ -375,10 +376,12 @@ dependencies = [
  "flate2",
  "git2",
  "glob",
+ "itertools 0.10.0",
  "lazy_static",
  "remove_dir_all",
  "serde_json",
  "tar",
+ "termcolor",
  "toml",
  "url 2.2.2",
 ]
@@ -575,7 +578,7 @@ dependencies = [
  "bytecount",
  "clap",
  "itertools 0.9.0",
- "opener",
+ "opener 0.4.1",
  "regex",
  "shell-escape",
  "walkdir",
@@ -2415,6 +2418,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
 dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "opener"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
+dependencies = [
+ "bstr",
  "winapi 0.3.9",
 ]
 
@@ -5158,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,6 +3571,7 @@ dependencies = [
 name = "rustc-workspace-hack"
 version = "1.0.0"
 dependencies = [
+ "bstr",
  "byteorder",
  "crossbeam-utils 0.8.3",
  "libc",

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -48,7 +48,7 @@ toml = "0.5"
 lazy_static = "1.3.0"
 time = "0.1"
 ignore = "0.4.10"
-opener = "0.4"
+opener = "0.5"
 merge = "0.1.0"
 once_cell = "1.7.2"
 

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -61,6 +61,7 @@ features = [
 ]
 
 [dependencies]
+bstr = { version = "0.2.13", features = ["default"] }
 byteorder = { version = "1", features = ['default', 'std'] }
 curl-sys = { version = "0.4.13", features = ["http2", "libnghttp2-sys"], optional = true }
 crossbeam-utils = { version = "0.8.0", features = ["nightly"] }


### PR DESCRIPTION
This also updates `opener` used in bootstrap (to try to keep dependencies unified).

18 commits in 44456677b5d1d82fe981c955dc5c67734b31f340..9233aa06c801801cff75df65df718d70905a235e
2021-06-12 18:00:01 +0000 to 2021-06-22 21:32:55 +0000
- Detect incorrectly named cargo.toml (rust-lang/cargo#9607)
- Unify weak and namespaced features. (rust-lang/cargo#9574)
- Change `rustc-cdylib-link-arg` error to a warning. (rust-lang/cargo#9563)
- Updates to future-incompatible reporting. (rust-lang/cargo#9606)
- Add a compatibility notice for diesel and the new resolver. (rust-lang/cargo#9602)
- Don't allow config env to modify vars set by cargo (rust-lang/cargo#9579)
- Disambiguate is_symlink. (rust-lang/cargo#9604)
- Update opener requirement from 0.4 to 0.5 (rust-lang/cargo#9583)
- Avoid quadratic complexity when splitting output into lines (rust-lang/cargo#9586)
- Bump to 0.56.0, update changelog (rust-lang/cargo#9597)
- Fix dep-info files including non-local build script paths. (rust-lang/cargo#9596)
- Relax doc collision error. (rust-lang/cargo#9595)
- Handle "jobs = 0" case in cargo config files (rust-lang/cargo#9584)
- Enhancements to testsuite error output. (rust-lang/cargo#9589)
- Fix typo (rust-lang/cargo#9590)
- Enable support for fix --edition for 2021. (rust-lang/cargo#9588)
- Add more details for installing git repository errors (rust-lang/cargo#9582)
- More information for links conflicting (rust-lang/cargo#9568)