### PR TITLE
Bump expat to 2.4.1

### DIFF
--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
@@ -644,7 +644,7 @@ CT_EXPAT_PATCH_GLOBAL=y
 CT_EXPAT_PATCH_ORDER="global"
 CT_EXPAT_V_2_2=y
 # CT_EXPAT_NO_VERSIONS is not set
-CT_EXPAT_VERSION="2.3.0"
+CT_EXPAT_VERSION="2.4.1"
 CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"


### PR DESCRIPTION
Temporary fix as expat 2.3.0 is now renamed, presumably due to https://github.com/libexpat/libexpat/blob/R_2_4_1/expat/Changes#L19. 

r? @pietroalbini 