### PR TITLE
Use HTTPS links where possible

### DIFF
--- a/compiler/rustc_apfloat/tests/ieee.rs
+++ b/compiler/rustc_apfloat/tests/ieee.rs
@@ -552,7 +552,7 @@ fn fma() {
         assert!(f1.is_negative() && f1.is_zero());
     }
 
-    // Test x87 extended precision case from http://llvm.org/PR20728.
+    // Test x87 extended precision case from https://llvm.org/PR20728.
     {
         let mut m1 = X87DoubleExtended::from_u128(1).value;
         let m2 = X87DoubleExtended::from_u128(1).value;

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -606,7 +606,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 // According to LLVM [1] building a nontemporal store must
                 // *always* point to a metadata value of the integer 1.
                 //
-                // [1]: http://llvm.org/docs/LangRef.html#store-instruction
+                // [1]: https://llvm.org/docs/LangRef.html#store-instruction
                 let one = self.cx.const_i32(1);
                 let node = llvm::LLVMMDNodeInContext(self.cx.llcx, &one, 1);
                 llvm::LLVMSetMetadata(store, llvm::MD_nontemporal as c_uint, node);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -71,7 +71,7 @@ pub struct CodegenCx<'ll, 'tcx> {
     pub statics_to_rauw: RefCell<Vec<(&'ll Value, &'ll Value)>>,
 
     /// Statics that will be placed in the llvm.used variable
-    /// See <http://llvm.org/docs/LangRef.html#the-llvm-used-global-variable> for details
+    /// See <https://llvm.org/docs/LangRef.html#the-llvm-used-global-variable> for details
     pub used_statics: RefCell<Vec<&'ll Value>>,
 
     pub lltypes: RefCell<FxHashMap<(Ty<'tcx>, Option<VariantIdx>), &'ll Type>>,

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -102,7 +102,7 @@ pub fn SetFunctionCallConv(fn_: &'a Value, cc: CallConv) {
 // example happen for generics when using multiple codegen units. This function simply uses the
 // value's name as the comdat value to make sure that it is in a 1-to-1 relationship to the
 // function.
-// For more details on COMDAT sections see e.g., http://www.airs.com/blog/archives/52
+// For more details on COMDAT sections see e.g., https://www.airs.com/blog/archives/52
 pub fn SetUniqueComdat(llmod: &Module, val: &'a Value) {
     unsafe {
         let name = get_value_name(val);

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -1,11 +1,11 @@
-//! Generate files suitable for use with [Graphviz](http://www.graphviz.org/)
+//! Generate files suitable for use with [Graphviz](https://www.graphviz.org/)
 //!
 //! The `render` function generates output (e.g., an `output.dot` file) for
-//! use with [Graphviz](http://www.graphviz.org/) by walking a labeled
+//! use with [Graphviz](https://www.graphviz.org/) by walking a labeled
 //! graph. (Graphviz can then automatically lay out the nodes and edges
 //! of the graph, and also optionally render the graph as an image or
 //! other [output formats](
-//! http://www.graphviz.org/content/output-formats), such as SVG.)
+//! https://www.graphviz.org/content/output-formats), such as SVG.)
 //!
 //! Rather than impose some particular graph data structure on clients,
 //! this library exposes two traits that clients can implement on their
@@ -13,8 +13,8 @@
 //!
 //! Note: This library does not yet provide access to the full
 //! expressiveness of the [DOT language](
-//! http://www.graphviz.org/doc/info/lang.html). For example, there are
-//! many [attributes](http://www.graphviz.org/content/attrs) related to
+//! https://www.graphviz.org/doc/info/lang.html). For example, there are
+//! many [attributes](https://www.graphviz.org/content/attrs) related to
 //! providing layout hints (e.g., left-to-right versus top-down, which
 //! algorithm to use, etc). The current intention of this library is to
 //! emit a human-readable .dot file with very regular structure suitable
@@ -267,9 +267,9 @@
 //!
 //! # References
 //!
-//! * [Graphviz](http://www.graphviz.org/)
+//! * [Graphviz](https://www.graphviz.org/)
 //!
-//! * [DOT language](http://www.graphviz.org/doc/info/lang.html)
+//! * [DOT language](https://www.graphviz.org/doc/info/lang.html)
 
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
@@ -292,7 +292,7 @@ pub enum LabelText<'a> {
     LabelStr(Cow<'a, str>),
 
     /// This kind of label uses the graphviz label escString type:
-    /// <http://www.graphviz.org/content/attrs#kescString>
+    /// <https://www.graphviz.org/content/attrs#kescString>
     ///
     /// Occurrences of backslashes (`\`) are not escaped; instead they
     /// are interpreted as initiating an escString escape sequence.
@@ -307,12 +307,12 @@ pub enum LabelText<'a> {
     /// printed exactly as given, but between `<` and `>`. **No
     /// escaping is performed.**
     ///
-    /// [html]: http://www.graphviz.org/content/node-shapes#html
+    /// [html]: https://www.graphviz.org/content/node-shapes#html
     HtmlStr(Cow<'a, str>),
 }
 
 /// The style for a node or edge.
-/// See <http://www.graphviz.org/doc/info/attrs.html#k:style> for descriptions.
+/// See <https://www.graphviz.org/doc/info/attrs.html#k:style> for descriptions.
 /// Note that some of these are not valid for edges.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Style {
@@ -439,7 +439,7 @@ pub trait Labeller<'a> {
     /// Maps `n` to one of the [graphviz `shape` names][1]. If `None`
     /// is returned, no `shape` attribute is specified.
     ///
-    /// [1]: http://www.graphviz.org/content/node-shapes
+    /// [1]: https://www.graphviz.org/content/node-shapes
     fn node_shape(&'a self, _node: &Self::Node) -> Option<LabelText<'a>> {
         None
     }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -581,7 +581,7 @@ fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
 
 fn escape_dep_filename(filename: &String) -> String {
     // Apparently clang and gcc *only* escape spaces:
-    // http://llvm.org/klaus/clang/commit/9d50634cfc268ecc9a7250226dd5ca0e945240d4
+    // https://llvm.org/klaus/clang/commit/9d50634cfc268ecc9a7250226dd5ca0e945240d4
     filename.replace(" ", "\\ ")
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1370,8 +1370,8 @@ pub type Region<'tcx> = &'tcx RegionKind;
 /// happen, you can use `leak_check`. This is more clearly explained
 /// by the [rustc dev guide].
 ///
-/// [1]: http://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
-/// [2]: http://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
+/// [1]: https://smallcultfollowing.com/babysteps/blog/2013/10/29/intermingled-parameter-lists/
+/// [2]: https://smallcultfollowing.com/babysteps/blog/2013/11/04/intermingled-parameter-lists/
 /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
 #[derive(Clone, PartialEq, Eq, Hash, Copy, TyEncodable, TyDecodable, PartialOrd, Ord)]
 pub enum RegionKind {

--- a/compiler/rustc_mir/src/borrow_check/region_infer/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/region_infer/mod.rs
@@ -1380,7 +1380,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// terms that the "longer free region" `'a` outlived the "shorter free region" `'b`.
     ///
     /// More details can be found in this blog post by Niko:
-    /// <http://smallcultfollowing.com/babysteps/blog/2019/01/17/polonius-and-region-errors/>
+    /// <https://smallcultfollowing.com/babysteps/blog/2019/01/17/polonius-and-region-errors/>
     ///
     /// In the canonical example
     ///

--- a/compiler/rustc_parse/src/lexer/unicode_chars.rs
+++ b/compiler/rustc_parse/src/lexer/unicode_chars.rs
@@ -1,5 +1,5 @@
 // Characters and their corresponding confusables were collected from
-// http://www.unicode.org/Public/security/10.0.0/confusables.txt
+// https://www.unicode.org/Public/security/10.0.0/confusables.txt
 
 use super::StringReader;
 use crate::token;

--- a/compiler/rustc_target/src/abi/call/msp430.rs
+++ b/compiler/rustc_target/src/abi/call/msp430.rs
@@ -1,5 +1,5 @@
 // Reference: MSP430 Embedded Application Binary Interface
-// https://web.archive.org/web/20191221205752/http://www.ti.com/lit/an/slaa534/slaa534.pdf
+// https://www.ti.com/lit/an/slaa534a/slaa534a.pdf
 
 use crate::abi::call::{ArgAbi, FnAbi};
 

--- a/compiler/rustc_target/src/abi/call/msp430.rs
+++ b/compiler/rustc_target/src/abi/call/msp430.rs
@@ -1,5 +1,5 @@
 // Reference: MSP430 Embedded Application Binary Interface
-// http://www.ti.com/lit/an/slaa534/slaa534.pdf
+// https://web.archive.org/web/20191221205752/http://www.ti.com/lit/an/slaa534/slaa534.pdf
 
 use crate::abi::call::{ArgAbi, FnAbi};
 

--- a/compiler/rustc_target/src/abi/call/nvptx.rs
+++ b/compiler/rustc_target/src/abi/call/nvptx.rs
@@ -1,5 +1,5 @@
 // Reference: PTX Writer's Guide to Interoperability
-// http://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
+// https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
 
 use crate::abi::call::{ArgAbi, FnAbi};
 

--- a/compiler/rustc_target/src/abi/call/nvptx64.rs
+++ b/compiler/rustc_target/src/abi/call/nvptx64.rs
@@ -1,5 +1,5 @@
 // Reference: PTX Writer's Guide to Interoperability
-// http://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
+// https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability
 
 use crate::abi::call::{ArgAbi, FnAbi};
 

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -38,7 +38,7 @@ where
             // small structs are returned as integers.
             //
             // Some links:
-            // http://www.angelcode.com/dev/callconv/callconv.html
+            // https://www.angelcode.com/dev/callconv/callconv.html
             // Clang's ABI handling is in lib/CodeGen/TargetInfo.cpp
             let t = cx.target_spec();
             if t.abi_return_struct_as_int {

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -16,7 +16,7 @@ use rustc_span::Span;
 
 pub mod call;
 
-/// Parsed [Data layout](http://llvm.org/docs/LangRef.html#data-layout)
+/// Parsed [Data layout](https://llvm.org/docs/LangRef.html#data-layout)
 /// for a target, which contains everything needed to compute layouts.
 pub struct TargetDataLayout {
     pub endian: Endian,

--- a/compiler/rustc_target/src/spec/aarch64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/aarch64_linux_android.rs
@@ -6,7 +6,7 @@ use crate::spec::{SanitizerSet, Target, TargetOptions};
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.max_atomic_width = Some(128);
-    // As documented in http://developer.android.com/ndk/guides/cpu-features.html
+    // As documented in https://developer.android.com/ndk/guides/cpu-features.html
     // the neon (ASIMD) and FP must exist on all android aarch64 targets.
     base.features = "+neon,+fp-armv8".to_string();
     base.supported_sanitizers = SanitizerSet::HWADDRESS;

--- a/compiler/rustc_target/src/spec/i686_linux_android.rs
+++ b/compiler/rustc_target/src/spec/i686_linux_android.rs
@@ -8,7 +8,7 @@ pub fn target() -> Target {
 
     base.max_atomic_width = Some(64);
 
-    // http://developer.android.com/ndk/guides/abis.html#x86
+    // https://developer.android.com/ndk/guides/abis.html#x86
     base.cpu = "pentiumpro".to_string();
     base.features = "+mmx,+sse,+sse2,+sse3,+ssse3".to_string();
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! # Defining a new target
 //!
-//! Targets are defined using [JSON](http://json.org/). The `Target` struct in
+//! Targets are defined using [JSON](https://json.org/). The `Target` struct in
 //! this module defines the format the JSON file should take, though each
 //! underscore in the field names should be replaced with a hyphen (`-`) in the
 //! JSON file. Some fields are required in every target specification, such as
@@ -950,7 +950,7 @@ pub struct Target {
     /// Architecture to use for ABI considerations. Valid options include: "x86",
     /// "x86_64", "arm", "aarch64", "mips", "powerpc", "powerpc64", and others.
     pub arch: String,
-    /// [Data layout](http://llvm.org/docs/LangRef.html#data-layout) to pass to LLVM.
+    /// [Data layout](https://llvm.org/docs/LangRef.html#data-layout) to pass to LLVM.
     pub data_layout: String,
     /// Optional settings with defaults.
     pub options: TargetOptions,

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -8,7 +8,7 @@
 //! ## `Ty` lowering
 //! Much of the `Ty` lowering is 1:1 with Chalk. (Or will be eventually). A
 //! helpful table for what types lower to what can be found in the
-//! [Chalk book](http://rust-lang.github.io/chalk/book/types/rust_types.html).
+//! [Chalk book](https://rust-lang.github.io/chalk/book/types/rust_types.html).
 //! The most notable difference lies with `Param`s. To convert from rustc to
 //! Chalk, we eagerly and deeply convert `Param`s to placeholders (in goals) or
 //! bound variables (for clause generation through functions in `db`).

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -1042,7 +1042,7 @@ where
 }
 
 /// This merge sort borrows some (but not all) ideas from TimSort, which is described in detail
-/// [here](http://svn.python.org/projects/python/trunk/Objects/listsort.txt).
+/// [here](https://github.com/python/cpython/blob/main/Objects/listsort.txt).
 ///
 /// The algorithm identifies strictly descending and non-descending subsequences, which are called
 /// natural runs. There is a stack of pending runs yet to be merged. Each newly found run is pushed

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -396,7 +396,7 @@ impl str {
         return s;
 
         fn map_uppercase_sigma(from: &str, i: usize, to: &mut String) {
-            // See http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G33992
+            // See https://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G33992
             // for the definition of `Final_Sigma`.
             debug_assert!('Σ'.len_utf8() == 2);
             let is_word_final = case_ignoreable_then_cased(from[..i].chars().rev())

--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -45,7 +45,7 @@ fn bench_max_by_key(b: &mut Bencher) {
     })
 }
 
-// http://www.reddit.com/r/rust/comments/31syce/using_iterators_to_find_the_index_of_the_min_or/
+// https://www.reddit.com/r/rust/comments/31syce/using_iterators_to_find_the_index_of_the_min_or/
 #[bench]
 fn bench_max_by_key2(b: &mut Bencher) {
     fn max_index_iter(array: &[i32]) -> usize {

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -15,8 +15,8 @@ impl char {
     /// Point], but only ones within a certain range. `MAX` is the highest valid
     /// code point that's a valid [Unicode Scalar Value].
     ///
-    /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
-    /// [Code Point]: http://www.unicode.org/glossary/#code_point
+    /// [Unicode Scalar Value]: https://www.unicode.org/glossary/#unicode_scalar_value
+    /// [Code Point]: https://www.unicode.org/glossary/#code_point
     #[stable(feature = "assoc_char_consts", since = "1.52.0")]
     pub const MAX: char = '\u{10ffff}';
 
@@ -28,7 +28,7 @@ impl char {
     #[stable(feature = "assoc_char_consts", since = "1.52.0")]
     pub const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
 
-    /// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
+    /// The version of [Unicode](https://www.unicode.org/) that the Unicode parts of
     /// `char` and `str` methods are based on.
     ///
     /// New versions of Unicode are released regularly and subsequently all methods
@@ -1494,8 +1494,8 @@ impl char {
     /// before using this function.
     ///
     /// [infra-aw]: https://infra.spec.whatwg.org/#ascii-whitespace
-    /// [pct]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
-    /// [bfs]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+    /// [pct]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
+    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
     ///
     /// # Examples
     ///

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -5,8 +5,8 @@
 //! scalar value]', which is similar to, but not the same as, a '[Unicode code
 //! point]'.
 //!
-//! [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
-//! [Unicode code point]: http://www.unicode.org/glossary/#code_point
+//! [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+//! [Unicode code point]: https://www.unicode.org/glossary/#code_point
 //!
 //! This module exists for technical reasons, the primary documentation for
 //! `char` is directly on [the `char` primitive type][char] itself.
@@ -95,8 +95,8 @@ const MAX_THREE_B: u32 = 0x10000;
 /// Point], but only ones within a certain range. `MAX` is the highest valid
 /// code point that's a valid [Unicode Scalar Value].
 ///
-/// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
-/// [Code Point]: http://www.unicode.org/glossary/#code_point
+/// [Unicode Scalar Value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [Code Point]: https://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX: char = char::MAX;
 

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -145,7 +145,7 @@ impl_from! { i16, isize, #[stable(feature = "lossless_iusize_conv", since = "1.2
 
 // CHERI proposes 256-bit “capabilities”. Unclear if this would be relevant to usize/isize.
 // https://www.cl.cam.ac.uk/research/security/ctsrd/pdfs/20171017a-cheri-poster.pdf
-// http://www.csl.sri.com/users/neumann/2012resolve-cheri.pdf
+// https://www.csl.sri.com/users/neumann/2012resolve-cheri.pdf
 
 // Note: integers can only be represented with full precision in a float if
 // they fit in the significand, which is 24 bits in f32 and 53 bits in f64.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -25,7 +25,7 @@
 //! across other volatile intrinsics. See the LLVM documentation on
 //! [[volatile]].
 //!
-//! [volatile]: http://llvm.org/docs/LangRef.html#volatile-memory-accesses
+//! [volatile]: https://llvm.org/docs/LangRef.html#volatile-memory-accesses
 //!
 //! # Atomics
 //!
@@ -33,7 +33,7 @@
 //! words, with multiple possible memory orderings. They obey the same
 //! semantics as C++11. See the LLVM documentation on [[atomics]].
 //!
-//! [atomics]: http://llvm.org/docs/Atomics.html
+//! [atomics]: https://llvm.org/docs/Atomics.html
 //!
 //! A quick refresher on memory ordering:
 //!

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -33,7 +33,7 @@
 //!
 //! Primarily, this module and its children implement the algorithms described in:
 //! "How to Read Floating Point Numbers Accurately" by William D. Clinger,
-//! available online: <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.45.4152>
+//! available online: <https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.45.4152>
 //!
 //! In addition, there are numerous helper functions that are used in the paper but not available
 //! in Rust (or at least in core). Our version is additionally complicated by the need to handle

--- a/library/core/src/num/flt2dec/mod.rs
+++ b/library/core/src/num/flt2dec/mod.rs
@@ -49,7 +49,7 @@ the supplied buffer and let the algorithm to return.
 # Implementation overview
 
 It is easy to get the floating point printing correct but slow (Russ Cox has
-[demonstrated](http://research.swtch.com/ftoa) how it's easy), or incorrect but
+[demonstrated](https://research.swtch.com/ftoa) how it's easy), or incorrect but
 fast (naïve division and modulo). But it is surprisingly hard to print
 floating point numbers correctly *and* efficiently.
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -590,8 +590,8 @@ impl u8 {
     /// before using this function.
     ///
     /// [infra-aw]: https://infra.spec.whatwg.org/#ascii-whitespace
-    /// [pct]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
-    /// [bfs]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+    /// [pct]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
+    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
     ///
     /// # Examples
     ///

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -227,7 +227,7 @@ where
 /// Partitioning is performed block-by-block in order to minimize the cost of branching operations.
 /// This idea is presented in the [BlockQuicksort][pdf] paper.
 ///
-/// [pdf]: http://drops.dagstuhl.de/opus/volltexte/2016/6389/pdf/LIPIcs-ESA-2016-38.pdf
+/// [pdf]: https://drops.dagstuhl.de/opus/volltexte/2016/6389/pdf/LIPIcs-ESA-2016-38.pdf
 fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
 where
     F: FnMut(&T, &T) -> bool,

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod printable;
 mod unicode_data;
 
-/// The version of [Unicode](http://www.unicode.org/) that the Unicode parts of
+/// The version of [Unicode](https://www.unicode.org/) that the Unicode parts of
 /// `char` and `str` methods are based on.
 ///
 /// New versions of Unicode are released regularly and subsequently all methods

--- a/library/core/src/unicode/printable.py
+++ b/library/core/src/unicode/printable.py
@@ -130,7 +130,7 @@ def print_normal(normal, normalname):
     print("];")
 
 def main():
-    file = get_file("http://www.unicode.org/Public/UNIDATA/UnicodeData.txt")
+    file = get_file("https://www.unicode.org/Public/UNIDATA/UnicodeData.txt")
 
     codepoints = get_codepoints(file)
 

--- a/library/panic_unwind/src/dwarf/eh.rs
+++ b/library/panic_unwind/src/dwarf/eh.rs
@@ -1,9 +1,9 @@
 //! Parsing of GCC-style Language-Specific Data Area (LSDA)
 //! For details see:
-//!  * <http://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/ehframechpt.html>
-//!  * <http://mentorembedded.github.io/cxx-abi/exceptions.pdf>
-//!  * <http://www.airs.com/blog/archives/460>
-//!  * <http://www.airs.com/blog/archives/464>
+//!  * <https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/ehframechpt.html>
+//!  * <https://itanium-cxx-abi.github.io/cxx-abi/exceptions.pdf>
+//!  * <https://www.airs.com/blog/archives/460>
+//!  * <https://www.airs.com/blog/archives/464>
 //!
 //! A reference implementation may be found in the GCC source tree
 //! (`<root>/libgcc/unwind-c.c` as of this writing).

--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -5,8 +5,8 @@
 //! documents linked from it.
 //! These are also good reads:
 //!  * <https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html>
-//!  * <http://monoinfinito.wordpress.com/series/exception-handling-in-c/>
-//!  * <http://www.airs.com/blog/index.php?s=exception+frames>
+//!  * <https://monoinfinito.wordpress.com/series/exception-handling-in-c/>
+//!  * <https://www.airs.com/blog/index.php?s=exception+frames>
 //!
 //! ## A brief summary
 //!
@@ -94,7 +94,7 @@ fn rust_exception_class() -> uw::_Unwind_Exception_Class {
 // and TargetLowering::getExceptionSelectorRegister() for each architecture,
 // then mapped to DWARF register numbers via register definition tables
 // (typically <arch>RegisterInfo.td, search for "DwarfRegNum").
-// See also http://llvm.org/docs/WritingAnLLVMBackend.html#defining-a-register.
+// See also https://llvm.org/docs/WritingAnLLVMBackend.html#defining-a-register.
 
 #[cfg(target_arch = "x86")]
 const UNWIND_DATA_REG: (i32, i32) = (0, 2); // EAX, EDX
@@ -130,7 +130,7 @@ const UNWIND_DATA_REG: (i32, i32) = (10, 11); // x10, x11
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "arm", not(target_os = "ios"), not(target_os = "netbsd")))] {
         // ARM EHABI personality routine.
-        // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
+        // https://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
         //
         // iOS uses the default routine instead since it uses SjLj unwinding.
         #[lang = "eh_personality"]

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -42,7 +42,7 @@
 //!   of the `try` intrinsic.
 //!
 //! [win64]: https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64
-//! [llvm]: http://llvm.org/docs/ExceptionHandling.html#background-on-windows-exceptions
+//! [llvm]: https://llvm.org/docs/ExceptionHandling.html#background-on-windows-exceptions
 
 #![allow(nonstandard_style)]
 
@@ -100,7 +100,7 @@ struct Exception {
 // In any case, these structures are all constructed in a similar manner, and
 // it's just somewhat verbose for us.
 //
-// [1]: http://www.geoffchappell.com/studies/msvc/language/predefined/
+// [1]: https://www.geoffchappell.com/studies/msvc/language/predefined/
 
 #[cfg(target_arch = "x86")]
 #[macro_use]

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -305,7 +305,7 @@ impl Error for VarError {
 ///
 /// Discussion of this unsafety on Unix may be found in:
 ///
-///  - [Austin Group Bugzilla](http://austingroupbugs.net/view.php?id=188)
+///  - [Austin Group Bugzilla](https://austingroupbugs.net/view.php?id=188)
 ///  - [GNU C library Bugzilla](https://sourceware.org/bugzilla/show_bug.cgi?id=15607#c2)
 ///
 /// # Panics
@@ -344,7 +344,7 @@ fn _set_var(key: &OsStr, value: &OsStr) {
 ///
 /// Discussion of this unsafety on Unix may be found in:
 ///
-///  - [Austin Group Bugzilla](http://austingroupbugs.net/view.php?id=188)
+///  - [Austin Group Bugzilla](https://austingroupbugs.net/view.php?id=188)
 ///  - [GNU C library Bugzilla](https://sourceware.org/bugzilla/show_bug.cgi?id=15607#c2)
 ///
 /// # Panics

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -124,8 +124,8 @@
 //! method is an [`OsString`] which can be round-tripped to a Windows
 //! string losslessly.
 //!
-//! [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
-//! [Unicode code point]: http://www.unicode.org/glossary/#code_point
+//! [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+//! [Unicode code point]: https://www.unicode.org/glossary/#code_point
 //! [`env::set_var()`]: crate::env::set_var
 //! [`env::var_os()`]: crate::env::var_os
 //! [unix.OsStringExt]: crate::os::unix::ffi::OsStringExt

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -379,7 +379,7 @@ impl Ipv4Addr {
     /// This property is defined in _UNIX Network Programming, Second Edition_,
     /// W. Richard Stevens, p. 891; see also [ip7].
     ///
-    /// [ip7]: http://man7.org/linux/man-pages/man7/ip.7.html
+    /// [ip7]: https://man7.org/linux/man-pages/man7/ip.7.html
     ///
     /// # Examples
     ///

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -277,8 +277,8 @@ mod prim_never {}
 /// scalar value]', which is similar to, but not the same as, a '[Unicode code
 /// point]'.
 ///
-/// [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
-/// [Unicode code point]: http://www.unicode.org/glossary/#code_point
+/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [Unicode code point]: https://www.unicode.org/glossary/#code_point
 ///
 /// This documentation describes a number of methods and trait implementations on the
 /// `char` type. For technical reasons, there is additional, separate

--- a/library/std/src/sync/mpsc/mpsc_queue.rs
+++ b/library/std/src/sync/mpsc/mpsc_queue.rs
@@ -8,8 +8,8 @@
 //! method, and see the method for more information about it. Due to this
 //! caveat, this queue may not be appropriate for all use-cases.
 
-// http://www.1024cores.net/home/lock-free-algorithms
-//                         /queues/non-intrusive-mpsc-node-based-queue
+// https://www.1024cores.net/home/lock-free-algorithms
+//                          /queues/non-intrusive-mpsc-node-based-queue
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;

--- a/library/std/src/sync/mpsc/spsc_queue.rs
+++ b/library/std/src/sync/mpsc/spsc_queue.rs
@@ -4,7 +4,7 @@
 //! concurrently between two threads. This data structure is safe to use and
 //! enforces the semantics that there is one pusher and one popper.
 
-// http://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
+// https://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
 
 #[cfg(all(test, not(target_os = "emscripten")))]
 mod tests;

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -240,7 +240,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "macos")] {
         #[link(name = "System")]
         // res_init and friends require -lresolv on macOS/iOS.
-        // See #41582 and http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
+        // See #41582 and https://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
         #[link(name = "resolv")]
         extern "C" {}
     } else if #[cfg(target_os = "ios")] {

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -207,7 +207,7 @@ impl Command {
         // the remaining portion of this spawn in a mutex.
         //
         // For more information, msdn also has an article about this race:
-        // http://support.microsoft.com/kb/315939
+        // https://support.microsoft.com/kb/315939
         static CREATE_PROCESS_LOCK: StaticMutex = StaticMutex::new();
 
         let _guard = unsafe { CREATE_PROCESS_LOCK.lock() };

--- a/library/std/src/sys/windows/thread_local_key.rs
+++ b/library/std/src/sys/windows/thread_local_key.rs
@@ -35,7 +35,7 @@ pub type Dtor = unsafe extern "C" fn(*mut u8);
 //
 // For more details and nitty-gritty, see the code sections below!
 //
-// [1]: http://www.codeproject.com/Articles/8113/Thread-Local-Storage-The-C-Way
+// [1]: https://www.codeproject.com/Articles/8113/Thread-Local-Storage-The-C-Way
 // [2]: https://github.com/ChromiumWebApps/chromium/blob/master/base
 //                        /threading/thread_local_storage_win.cc#L42
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -168,7 +168,7 @@ pub struct Instant(time::Instant);
 ///
 /// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
 /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
-/// [gettimeofday]: http://man7.org/linux/man-pages/man2/gettimeofday.2.html
+/// [gettimeofday]: https://man7.org/linux/man-pages/man2/gettimeofday.2.html
 /// [clock_gettime (Realtime Clock)]: https://linux.die.net/man/3/clock_gettime
 /// [__wasi_clock_time_get (Realtime Clock)]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md#clock_time_get
 /// [GetSystemTimePreciseAsFileTime]: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime

--- a/library/test/src/stats.rs
+++ b/library/test/src/stats.rs
@@ -19,7 +19,7 @@ pub trait Stats {
     /// ["Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric
     /// Predicates"][paper]
     ///
-    /// [paper]: http://www.cs.cmu.edu/~quake-papers/robust-arithmetic.ps
+    /// [paper]: https://www.cs.cmu.edu/~quake-papers/robust-arithmetic.ps
     fn sum(&self) -> f64;
 
     /// Minimum value of the samples.

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -77,7 +77,7 @@ def download(path, url, probably_big, verbose):
 def _download(path, url, probably_big, verbose, exception):
     if probably_big or verbose:
         print("downloading {}".format(url))
-    # see http://serverfault.com/questions/301128/how-to-download
+    # see https://serverfault.com/questions/301128/how-to-download
     if sys.platform == 'win32':
         run(["PowerShell.exe", "/nologo", "-Command",
              "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;",

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -857,7 +857,7 @@ impl Build {
         }
 
         // Work around an apparently bad MinGW / GCC optimization,
-        // See: http://lists.llvm.org/pipermail/cfe-dev/2016-December/051980.html
+        // See: https://lists.llvm.org/pipermail/cfe-dev/2016-December/051980.html
         // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78936
         if &*target.triple == "i686-pc-windows-gnu" {
             base.push("-fno-omit-frame-pointer".into());

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -139,7 +139,7 @@ impl Step for Llvm {
         let _time = util::timeit(&builder);
         t!(fs::create_dir_all(&out_dir));
 
-        // http://llvm.org/docs/CMake.html
+        // https://llvm.org/docs/CMake.html
         let mut cfg = cmake::Config::new(builder.src.join(root));
 
         let profile = match (builder.config.llvm_optimize, builder.config.llvm_release_debuginfo) {
@@ -276,7 +276,7 @@ impl Step for Llvm {
             }
         }
 
-        // http://llvm.org/docs/HowToCrossCompileLLVM.html
+        // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if target != builder.config.build {
             builder.ensure(Llvm { target: builder.config.build });
             // FIXME: if the llvm root for the build triple is overridden then we

--- a/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
@@ -58,7 +58,7 @@ RUN curl https://www.busybox.net/downloads/busybox-1.32.1.tar.bz2 | tar xjf - &&
 # Download the ubuntu rootfs, which we'll use as a chroot for all our tests.
 WORKDIR /tmp
 RUN mkdir rootfs/ubuntu
-RUN curl http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-armhf.tar.gz | \
+RUN curl https://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-armhf.tar.gz | \
       tar xzf - -C rootfs/ubuntu && \
       cd rootfs && mkdir proc sys dev etc etc/init.d
 

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-dragonfly/build-toolchain.sh
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-dragonfly/build-toolchain.sh
@@ -39,7 +39,7 @@ rm -rf binutils
 
 # Next, download the DragonFly libc and relevant header files
 
-URL=http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.0.0_REL.iso.bz2
+URL=https://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.0.0_REL.iso.bz2
 mkdir dragonfly
 curl $URL | bzcat | bsdtar xf - -C dragonfly ./usr/include ./usr/lib ./lib
 

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no
   g++-8-arm-linux-gnueabi
 
 RUN apt-key adv --batch --yes --keyserver keyserver.ubuntu.com --recv-keys 74DA7924C5513486
-RUN add-apt-repository -y 'deb http://apt.dilos.org/dilos dilos2 main'
+RUN add-apt-repository -y 'deb https://apt.dilos.org/dilos dilos2 main'
 
 ENV \
     AR_x86_64_fuchsia=x86_64-fuchsia-ar \

--- a/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
@@ -7,7 +7,7 @@ target="x86_64-fortanix-unknown-sgx"
 
 install_prereq() {
     curl https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
-    add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+    add-apt-repository -y 'deb https://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
     apt-get update
     apt-get install -y --no-install-recommends \
             build-essential \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -22,7 +22,7 @@ cd gcc-$GCC
 # latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
 # instead here.
 #
-sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
+sed -i'' 's|ftp://gcc\.gnu\.org/|https://gcc.gnu.org/|g' ./contrib/download_prerequisites
 
 ./contrib/download_prerequisites
 mkdir ../gcc-build

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -22,7 +22,8 @@ cd gcc-$GCC
 # latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
 # instead here.
 #
-sed -i'' 's|ftp://gcc\.gnu\.org/|https://gcc.gnu.org/|g' ./contrib/download_prerequisites
+# FIXME: use HTTPS (see https://github.com/rust-lang/rust/pull/86586#issuecomment-868355356)
+sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
 
 ./contrib/download_prerequisites
 mkdir ../gcc-build

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -7,7 +7,7 @@
 
 export MIRRORS_BASE="https://ci-mirrors.rust-lang.org/rustc"
 
-# See http://unix.stackexchange.com/questions/82598
+# See https://unix.stackexchange.com/questions/82598
 # Duplicated in docker/dist-various-2/shared.sh
 function retry {
   echo "Attempting with retry:" "$@"

--- a/src/etc/installer/README.md
+++ b/src/etc/installer/README.md
@@ -18,7 +18,7 @@ prefix. You can display these options by running:
 
     $ sudo ./install.sh --help
 
-Read [The Book](http://doc.rust-lang.org/book/index.html) to learn how
+Read [The Book](https://doc.rust-lang.org/book/index.html) to learn how
 to use Rust.
 
 Rust is primarily distributed under the terms of both the MIT license

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -73,7 +73,7 @@ function removeEmptyStringsFromArray(x) {
  * Licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported
  * Full License can be found at http://creativecommons.org/licenses/by-sa/3.0/legalcode
  * This code is an unmodified version of the code written by Marco de Wit
- * and was found at http://stackoverflow.com/a/18514751/745719
+ * and was found at https://stackoverflow.com/a/18514751/745719
  */
 var levenshtein_row2 = [];
 function levenshtein(s1, s2) {

--- a/src/test/pretty/block-comment-wchar.pp
+++ b/src/test/pretty/block-comment-wchar.pp
@@ -90,7 +90,7 @@ fn f() {
 }
 
 fn main() {
-    // Taken from http://www.unicode.org/Public/UNIDATA/PropList.txt
+    // Taken from https://www.unicode.org/Public/UNIDATA/PropList.txt
     let chars =
         ['\x0A', '\x0B', '\x0C', '\x0D', '\x20', '\u{85}', '\u{A0}',
          '\u{1680}', '\u{2000}', '\u{2001}', '\u{2002}', '\u{2003}',

--- a/src/test/pretty/block-comment-wchar.rs
+++ b/src/test/pretty/block-comment-wchar.rs
@@ -86,7 +86,7 @@ fn f() {
 }
 
 fn main() {
-    // Taken from http://www.unicode.org/Public/UNIDATA/PropList.txt
+    // Taken from https://www.unicode.org/Public/UNIDATA/PropList.txt
     let chars =
         ['\x0A', '\x0B', '\x0C', '\x0D', '\x20', '\u{85}', '\u{A0}',
          '\u{1680}', '\u{2000}', '\u{2001}', '\u{2002}', '\u{2003}',

--- a/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
+++ b/src/test/run-make-fulldeps/extern-fn-with-packed-struct/test.c
@@ -1,4 +1,4 @@
-// Pragma needed cause of gcc bug on windows: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
+// Pragma needed cause of gcc bug on windows: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
 
 #include <assert.h>
 

--- a/src/test/ui/generic-associated-types/collections-project-default.rs
+++ b/src/test/ui/generic-associated-types/collections-project-default.rs
@@ -3,7 +3,7 @@
 #![feature(associated_type_defaults)]
 
 // A Collection trait and collection families. Based on
-// http://smallcultfollowing.com/babysteps/blog/2016/11/03/
+// https://smallcultfollowing.com/babysteps/blog/2016/11/03/
 // associated-type-constructors-part-2-family-traits/
 
 // check that we don't normalize with trait defaults.

--- a/src/test/ui/generic-associated-types/collections.rs
+++ b/src/test/ui/generic-associated-types/collections.rs
@@ -3,7 +3,7 @@
 #![feature(associated_type_defaults)]
 
 // A Collection trait and collection families. Based on
-// http://smallcultfollowing.com/babysteps/blog/2016/11/03/
+// https://smallcultfollowing.com/babysteps/blog/2016/11/03/
 // associated-type-constructors-part-2-family-traits/
 
 // run-pass

--- a/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.rs
+++ b/src/test/ui/moves/moves-based-on-type-no-recursive-stack-closure.rs
@@ -1,6 +1,6 @@
 // Tests correct kind-checking of the reason stack closures without the :Copy
 // bound must be noncopyable. For details see
-// http://smallcultfollowing.com/babysteps/blog/2013/04/30/the-case-of-the-recurring-closure/
+// https://smallcultfollowing.com/babysteps/blog/2013/04/30/the-case-of-the-recurring-closure/
 
 struct R<'a> {
     // This struct is needed to create the

--- a/src/test/ui/nullable-pointer-iotareduction.rs
+++ b/src/test/ui/nullable-pointer-iotareduction.rs
@@ -4,7 +4,7 @@
 
 // Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,
 // which "says that a destructor applied to an object built from a constructor
-// behaves as expected".  -- https://web.archive.org/web/20100531091244/http://coq.inria.fr/doc/Reference-Manual006.html
+// behaves as expected".  -- https://coq.inria.fr/doc/language/core/conversion.html#iota-reduction
 //
 // It's a little more complicated here, because of pointers and regions and
 // trying to get assert failure messages that at least identify which case

--- a/src/test/ui/nullable-pointer-iotareduction.rs
+++ b/src/test/ui/nullable-pointer-iotareduction.rs
@@ -4,7 +4,7 @@
 
 // Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,
 // which "says that a destructor applied to an object built from a constructor
-// behaves as expected".  -- http://coq.inria.fr/doc/Reference-Manual006.html
+// behaves as expected".  -- https://web.archive.org/web/20100531091244/http://coq.inria.fr/doc/Reference-Manual006.html
 //
 // It's a little more complicated here, because of pointers and regions and
 // trying to get assert failure messages that at least identify which case

--- a/src/test/ui/parser/parser-unicode-whitespace.rs
+++ b/src/test/ui/parser/parser-unicode-whitespace.rs
@@ -1,7 +1,7 @@
 // run-pass
 // Beware editing: it has numerous whitespace characters which are important.
 // It contains one ranges from the 'PATTERN_WHITE_SPACE' property outlined in
-// http://unicode.org/Public/UNIDATA/PropList.txt
+// https://unicode.org/Public/UNIDATA/PropList.txt
 //
 // The characters in the first expression of the assertion can be generated
 // from: "4\u{0C}+\n\t\r7\t*\u{20}2\u{85}/\u{200E}3\u{200F}*\u{2028}2\u{2029}"

--- a/src/test/ui/traits/reservation-impl/non-lattice-ok.rs
+++ b/src/test/ui/traits/reservation-impl/non-lattice-ok.rs
@@ -28,7 +28,7 @@
 // go with a known approach, we should go with a "marker trait overlap"-style
 // approach.
 //
-// [ii]: http://smallcultfollowing.com/babysteps/blog/2016/09/24/intersection-impls/
+// [ii]: https://smallcultfollowing.com/babysteps/blog/2016/09/24/intersection-impls/
 
 #![feature(rustc_attrs, never_type)]
 

--- a/src/test/ui/wait-forked-but-failed-child.rs
+++ b/src/test/ui/wait-forked-but-failed-child.rs
@@ -28,7 +28,7 @@ use std::process::Command;
 fn find_zombies() {
     let my_pid = unsafe { libc::getpid() };
 
-    // http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html
+    // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html
     let ps_cmd_output = Command::new("ps").args(&["-A", "-o", "pid,ppid,args"]).output().unwrap();
     let ps_output = String::from_utf8_lossy(&ps_cmd_output.stdout);
 


### PR DESCRIPTION
While looking at #86583, I wondered how many other (insecure) HTTP links were in `rustc`. This changes most other `http` links to `https`. While most of the links are in comments or documentation, there are a few other HTTP links that are used by CI that are changed to HTTPS.

Notes:
- I didn't change any to or in licences
- Some links don't support HTTPS :(
- Some `http` links were dead, in those cases I upgraded them to their new places (all of which used HTTPS)