### PR TITLE
Show triangle on the "Details" disclosure element in all cases

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -199,6 +199,11 @@ summary {
 	outline: none;
 }
 
+details:not(.rustdoc-toggle) summary {
+	margin-bottom: .6em;
+	display: list-item;
+}
+
 code, pre, a.test-arrow {
 	font-family: "Source Code Pro", monospace;
 }
@@ -875,10 +880,6 @@ body.blur > :not(#help) {
 }
 .stab p {
 	display: inline;
-}
-
-.stab summary {
-	display: list-item;
 }
 
 .stab .emoji {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -199,6 +199,7 @@ summary {
 	outline: none;
 }
 
+/* FIXME: Remove after normalize.css is either upgraded or removed (#86629) */
 details:not(.rustdoc-toggle) summary {
 	margin-bottom: .6em;
 	display: list-item;


### PR DESCRIPTION
Re-submission of #82805, fixes the style issue by applying the same margin as `<p>`.

<details><summary>Before</summary>

![before 1](https://user-images.githubusercontent.com/25030997/123215032-e4c99880-d502-11eb-9ccc-6df58f3a6b0b.png)
![before 2](https://user-images.githubusercontent.com/25030997/123215035-e5622f00-d502-11eb-9275-6c6dfcfdf72e.png)
</details>

<details><summary>After</summary>

![after 1](https://user-images.githubusercontent.com/25030997/123215037-e5fac580-d502-11eb-9b49-c99d1eafb1b4.png)
![after 2](https://user-images.githubusercontent.com/25030997/123215040-e5fac580-d502-11eb-8afc-ab713d3dc658.png)
</details>

r? @GuillaumeGomez 
