### PR TITLE
Add a doc alias for `adjacent_find`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -752,6 +752,7 @@ impl<T> [T] {
     /// assert!(iter.next().is_none());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "adjacent_find")]
     #[inline]
     pub fn windows(&self, size: usize) -> Windows<'_, T> {
         let size = NonZeroUsize::new(size).expect("size is zero");
@@ -1219,6 +1220,7 @@ impl<T> [T] {
     ///
     /// [`windows`]: slice::windows
     #[unstable(feature = "array_windows", issue = "75027")]
+    #[doc(alias = "adjacent_find")]
     #[inline]
     pub fn array_windows<const N: usize>(&self) -> ArrayWindows<'_, T, N> {
         assert_ne!(N, 0);


### PR DESCRIPTION
This should enable C++ programmers looking for [`std::adjacent_find`](https://en.cppreference.com/w/cpp/algorithm/adjacent_find) or [`std::ranges::adjacent_find`](https://en.cppreference.com/w/cpp/algorithm/ranges/adjacent_find) to find what they're looking for.

I've had pals coming from C++ ask me whether Rust exposed methods for this, and using the `windows` methods is the key component. Using various `Iterator` methods then allows you to define predicates with relative ease. Knowing about `slice::windows` is the first step in getting there, and having the docs point folks in the right direction would be helpful.

Thanks!