### PR TITLE
impl `Copy` for `fs::Permissions`

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -175,7 +175,7 @@ pub struct OpenOptions(fs_imp::OpenOptions);
 /// through the [`PermissionsExt`] trait.
 ///
 /// [`PermissionsExt`]: crate::os::unix::fs::PermissionsExt
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Permissions(fs_imp::FilePermissions);
 

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -96,6 +96,8 @@ impl Clone for FilePermissions {
     }
 }
 
+impl Copy for FilePermissions {}
+
 impl PartialEq for FilePermissions {
     fn eq(&self, _other: &FilePermissions) -> bool {
         self.0

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -229,7 +229,7 @@ pub struct OpenOptions {
     mode: mode_t,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FilePermissions {
     mode: mode_t,
 }

--- a/library/std/src/sys/unsupported/fs.rs
+++ b/library/std/src/sys/unsupported/fs.rs
@@ -72,6 +72,8 @@ impl Clone for FilePermissions {
     }
 }
 
+impl Copy for FilePermissions {}
+
 impl PartialEq for FilePermissions {
     fn eq(&self, _other: &FilePermissions) -> bool {
         self.0

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -56,7 +56,7 @@ pub struct OpenOptions {
     rights_inheriting: Option<wasi::Rights>,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FilePermissions {
     readonly: bool,
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -72,7 +72,7 @@ pub struct OpenOptions {
     security_attributes: usize, // FIXME: should be a reference
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct FilePermissions {
     attrs: c::DWORD,
 }


### PR DESCRIPTION
It is highly unlikely that a future platform use anything else that numbers/booleans for permissions, so `fs::Permissions` can be `Copy` without forward compatibility issues.

@rustbot modify labels: +T-libs