### PR TITLE
Ignore failures of RLS on aarch64 Windows

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1033,7 +1033,15 @@ impl Step for Rls {
         let rls = builder
             .ensure(tool::Rls { compiler, target, extra_features: Vec::new() })
             .or_else(|| {
-                missing_tool("RLS", builder.build.config.missing_tools);
+                // We ignore failure on aarch64 Windows because RLS currently
+                // fails to build, due to winapi 0.2 not supporting aarch64.
+                //
+                // FIXME(#86606): we shouldn't be failing to build RLS.
+                missing_tool(
+                    "RLS",
+                    builder.build.config.missing_tools
+                        || (target.triple.contains("aarch64") && target.triple.contains("windows")),
+                );
                 None
             })?;
 


### PR DESCRIPTION
We've been putting this patch on beta/stable for multiple cycles now, it likely makes sense to just put it on master as well to avoid the extra cherry pick on each beta promotion. I've filed #86606 to track actually fixing this but I somewhat doubt it'll happen in the short term.

r? @pietroalbini 