### PR TITLE
rustc_span: Explicitly handle crates that differ from package names

### DIFF
--- a/compiler/rustc_span/Cargo.toml
+++ b/compiler/rustc_span/Cargo.toml
@@ -17,6 +17,6 @@ scoped-tls = "1.0"
 unicode-width = "0.1.4"
 cfg-if = "0.1.2"
 tracing = "0.1"
-sha-1 = "0.9"
+sha1 = { package = "sha-1", version = "0.9" }
 sha2 = "0.9"
-md-5 = "0.9"
+md5 = { package = "md-5", version = "0.9" }


### PR DESCRIPTION
The sha-1 and md-5 packages contain crates named sha1 and md5,
respectively. This discrepancy makes it somewhat more challenging to
automate detection of unused crates. Explicitly rename the packages to
the names of the crates they contain, to simplify such detection.
