### PR TITLE
Optimize use of LocalDefId::to_def_id

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -272,7 +272,7 @@ fn add_unused_functions<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {
             if ignore_unused_generics && tcx.generics_of(def_id).requires_monomorphization(tcx) {
                 return None;
             }
-            Some(local_def_id.to_def_id())
+            Some(def_id)
         })
         .collect();
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1274,26 +1274,27 @@ impl EncodeContext<'a, 'tcx> {
             .collect::<Vec<_>>();
         // Sort everything to ensure a stable order for diagnotics.
         keys_and_jobs.sort_by_key(|&(def_id, _, _)| def_id);
-        for (def_id, encode_const, encode_opt) in keys_and_jobs.into_iter() {
+        for (local_def_id, encode_const, encode_opt) in keys_and_jobs.into_iter() {
             debug_assert!(encode_const || encode_opt);
 
-            debug!("EntryBuilder::encode_mir({:?})", def_id);
+            debug!("EntryBuilder::encode_mir({:?})", local_def_id);
+            let def_id = local_def_id.to_def_id();
             if encode_opt {
-                record!(self.tables.mir[def_id.to_def_id()] <- self.tcx.optimized_mir(def_id));
+                record!(self.tables.mir[def_id] <- self.tcx.optimized_mir(local_def_id));
             }
             if encode_const {
-                record!(self.tables.mir_for_ctfe[def_id.to_def_id()] <- self.tcx.mir_for_ctfe(def_id));
+                record!(self.tables.mir_for_ctfe[def_id] <- self.tcx.mir_for_ctfe(local_def_id));
 
-                let abstract_const = self.tcx.mir_abstract_const(def_id);
+                let abstract_const = self.tcx.mir_abstract_const(local_def_id);
                 if let Ok(Some(abstract_const)) = abstract_const {
-                    record!(self.tables.mir_abstract_consts[def_id.to_def_id()] <- abstract_const);
+                    record!(self.tables.mir_abstract_consts[def_id] <- abstract_const);
                 }
             }
-            record!(self.tables.promoted_mir[def_id.to_def_id()] <- self.tcx.promoted_mir(def_id));
+            record!(self.tables.promoted_mir[def_id] <- self.tcx.promoted_mir(local_def_id));
 
-            let unused = self.tcx.unused_generic_params(def_id);
+            let unused = self.tcx.unused_generic_params(local_def_id);
             if !unused.is_empty() {
-                record!(self.tables.unused_generic_params[def_id.to_def_id()] <- unused);
+                record!(self.tables.unused_generic_params[def_id] <- unused);
             }
         }
     }
@@ -1525,27 +1526,27 @@ impl EncodeContext<'a, 'tcx> {
         }
     }
 
-    fn encode_info_for_closure(&mut self, def_id: LocalDefId) {
-        debug!("EncodeContext::encode_info_for_closure({:?})", def_id);
+    fn encode_info_for_closure(&mut self, local_def_id: LocalDefId) {
+        debug!("EncodeContext::encode_info_for_closure({:?})", local_def_id);
 
         // NOTE(eddyb) `tcx.type_of(def_id)` isn't used because it's fully generic,
         // including on the signature, which is inferred in `typeck.
-        let hir_id = self.tcx.hir().local_def_id_to_hir_id(def_id);
-        let ty = self.tcx.typeck(def_id).node_type(hir_id);
-
+        let hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
+        let ty = self.tcx.typeck(local_def_id).node_type(hir_id);
+        let def_id = local_def_id.to_def_id();
         match ty.kind() {
             ty::Generator(..) => {
-                let data = self.tcx.generator_kind(def_id).unwrap();
-                record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::Generator(data));
+                let data = self.tcx.generator_kind(local_def_id).unwrap();
+                record!(self.tables.kind[def_id] <- EntryKind::Generator(data));
             }
 
             ty::Closure(..) => {
-                record!(self.tables.kind[def_id.to_def_id()] <- EntryKind::Closure);
+                record!(self.tables.kind[def_id] <- EntryKind::Closure);
             }
 
             _ => bug!("closure that is neither generator nor closure"),
         }
-        self.encode_item_type(def_id.to_def_id());
+        self.encode_item_type(def_id);
         if let ty::Closure(def_id, substs) = *ty.kind() {
             record!(self.tables.fn_sig[def_id] <- substs.as_closure().sig());
         }

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -649,7 +649,8 @@ impl<'tcx> DumpVisitor<'tcx> {
         methods: &'tcx [hir::TraitItemRef],
     ) {
         let name = item.ident.to_string();
-        let qualname = format!("::{}", self.tcx.def_path_str(item.def_id.to_def_id()));
+        let def_id = item.def_id.to_def_id();
+        let qualname = format!("::{}", self.tcx.def_path_str(def_id));
         let mut val = name.clone();
         if !generics.params.is_empty() {
             val.push_str(&generic_params_to_string(generics.params));
@@ -659,7 +660,7 @@ impl<'tcx> DumpVisitor<'tcx> {
             val.push_str(&bounds_to_string(trait_refs));
         }
         if !self.span.filter_generated(item.ident.span) {
-            let id = id_from_def_id(item.def_id.to_def_id());
+            let id = id_from_def_id(def_id);
             let span = self.span_from_span(item.ident.span);
             let children =
                 methods.iter().map(|i| id_from_def_id(i.id.def_id.to_def_id())).collect();

--- a/compiler/rustc_typeck/src/check/dropck.rs
+++ b/compiler/rustc_typeck/src/check/dropck.rs
@@ -82,8 +82,8 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
         let named_type = tcx.type_of(self_type_did);
 
         let drop_impl_span = tcx.def_span(drop_impl_did);
-        let fresh_impl_substs =
-            infcx.fresh_substs_for_item(drop_impl_span, drop_impl_did.to_def_id());
+        let drop_impl_did = drop_impl_did.to_def_id();
+        let fresh_impl_substs = infcx.fresh_substs_for_item(drop_impl_span, drop_impl_did);
         let fresh_impl_self_ty = drop_impl_ty.subst(tcx, fresh_impl_substs);
 
         let cause = &ObligationCause::misc(drop_impl_span, drop_impl_hir_id);
@@ -130,7 +130,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
         let outlives_env = OutlivesEnvironment::new(ty::ParamEnv::empty());
 
         infcx.resolve_regions_and_report_errors(
-            drop_impl_did.to_def_id(),
+            drop_impl_did,
             &outlives_env,
             RegionckMode::default(),
         );

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -985,6 +985,7 @@ fn convert_variant(
     adt_kind: ty::AdtKind,
     parent_did: LocalDefId,
 ) -> ty::VariantDef {
+    let parent_did = parent_did.to_def_id();
     let mut seen_fields: FxHashMap<Ident, Span> = Default::default();
     let fields = def
         .fields()
@@ -1017,9 +1018,9 @@ fn convert_variant(
         fields,
         CtorKind::from_hir(def),
         adt_kind,
-        parent_did.to_def_id(),
+        parent_did,
         recovered,
-        adt_kind == AdtKind::Struct && tcx.has_attr(parent_did.to_def_id(), sym::non_exhaustive)
+        adt_kind == AdtKind::Struct && tcx.has_attr(parent_did, sym::non_exhaustive)
             || variant_did.map_or(false, |variant_did| {
                 tcx.has_attr(variant_did.to_def_id(), sym::non_exhaustive)
             }),


### PR DESCRIPTION
multiple calls to `to_def_id` have been reduced to one.

I am not sure if this should get a perf run