### PR TITLE
Check that `#[cmse_nonsecure_entry]` is applied to a function definition

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -97,6 +97,7 @@ impl CheckAttrVisitor<'tcx> {
                 | sym::rustc_dirty
                 | sym::rustc_if_this_changed
                 | sym::rustc_then_this_would_need => self.check_rustc_dirty_clean(&attr),
+                sym::cmse_nonsecure_entry => self.check_cmse_nonsecure_entry(attr, span, target),
                 _ => true,
             };
             // lint-only checks
@@ -220,6 +221,25 @@ impl CheckAttrVisitor<'tcx> {
                 self.inline_attr_str_error_with_macro_def(hir_id, attr, "naked");
                 true
             }
+            _ => {
+                self.tcx
+                    .sess
+                    .struct_span_err(
+                        attr.span,
+                        "attribute should be applied to a function definition",
+                    )
+                    .span_label(*span, "not a function definition")
+                    .emit();
+                false
+            }
+        }
+    }
+
+    /// Checks if `#[cmse_nonsecure_entry]` is applied to a function definition.
+    fn check_cmse_nonsecure_entry(&self, attr: &Attribute, span: &Span, target: Target) -> bool {
+        match target {
+            Target::Fn
+            | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => true,
             _ => {
                 self.tcx
                     .sess

--- a/src/test/ui/cmse-nonsecure/cmse-nonsecure-entry/issue-83475.rs
+++ b/src/test/ui/cmse-nonsecure/cmse-nonsecure-entry/issue-83475.rs
@@ -1,0 +1,9 @@
+// Regression test for the ICE described in #83475.
+
+#![crate_type="lib"]
+
+#![feature(cmse_nonsecure_entry)]
+#[cmse_nonsecure_entry]
+//~^ ERROR: attribute should be applied to a function definition
+struct XEmpty2;
+//~^ NOTE: not a function definition

--- a/src/test/ui/cmse-nonsecure/cmse-nonsecure-entry/issue-83475.stderr
+++ b/src/test/ui/cmse-nonsecure/cmse-nonsecure-entry/issue-83475.stderr
@@ -1,0 +1,11 @@
+error: attribute should be applied to a function definition
+  --> $DIR/issue-83475.rs:6:1
+   |
+LL | #[cmse_nonsecure_entry]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct XEmpty2;
+   | --------------- not a function definition
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR fixes #83475. The compiler currently neglects to check whether `#[cmse_nonsecure_entry]` is applied to a function (and not, say, a struct) definition, leading to an ICE later on when the type checker attempts to retrieve the function signature. I have fixed this problem by adding an appropriate check to the `check_attr` pass, so that an error is reported instead of an ICE.