### PR TITLE
Add check to ensure error code explanations are not removed anymore even if not emitted

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -28,6 +28,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
+COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
@@ -37,6 +38,7 @@ ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
            python3 ../x.py test --stage 2 src/tools/tidy && \
            python3 ../x.py doc --stage 0 library/test && \
            /scripts/validate-toolstate.sh && \
+           /scripts/validate-error-codes.sh && \
            # Runs checks to ensure that there are no ES5 issues in our JS code.
            es-check es5 ../src/librustdoc/html/static/*.js && \
            eslint ../src/librustdoc/html/static/*.js

--- a/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Checks that no error code explanation is removed.
+
+set -euo pipefail
+
+echo "Check if an error code explanation was removed..."
+
+if (git diff "$BASE_COMMIT" --name-status | grep '^D' \
+        | grep --quiet "compiler/rustc_error_codes/src/error_codes/"); then
+    echo "Error code explanations should never be removed!"
+    echo "Take a look at E0001 to see how to handle it."
+    exit 1
+fi
+
+echo "No error code explanation was removed!"

--- a/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Checks that no error code explanation is removed.
 
-set -euo pipefail
+set -eo pipefail
+
+if [[ -z "$BASE_COMMIT" ]]; then
+    echo "not checking error code explanations removal"
+    exit 0
+fi
 
 echo "Check if an error code explanation was removed..."
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -219,6 +219,10 @@ else
   command="/checkout/src/ci/run.sh"
 fi
 
+# Get some needed information for $BASE_COMMIT
+git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
+BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+
 docker \
   run \
   --workdir /checkout/obj \
@@ -237,6 +241,7 @@ docker \
   --env TOOLSTATE_PUBLISH \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
   --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
+  --env BASE_COMMIT="$BASE_COMMIT" \
   --init \
   --rm \
   rust-ci \

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -219,9 +219,13 @@ else
   command="/checkout/src/ci/run.sh"
 fi
 
-# Get some needed information for $BASE_COMMIT
-git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
-BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+if [ "$CI" != "" ]; then
+    # Get some needed information for $BASE_COMMIT
+    git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
+    BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+else
+    BASE_COMMIT=""
+fi
 
 docker \
   run \


### PR DESCRIPTION
The error explanations are useful in case you use older version of the compiler. Even more if they had an explanation. If they are not emitted, their explanations should be updated but not removed (as we did for a few of them, like E0001).

r? @Mark-Simulacrum 