### PR TITLE
Clear incremental cache when stage1 compiler is rebuilt

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1072,14 +1072,12 @@ impl<'a> Builder<'a> {
         let libdir = self.rustc_libdir(compiler);
 
         // Clear the output directory if the real rustc we're using has changed;
-        // Cargo cannot detect this as it thinks rustc is bootstrap/debug/rustc.
+        // Cargo usually cannot detect this because we use the same version string for all stage1
+        // builds, regardless of the git commit.
         //
         // Avoid doing this during dry run as that usually means the relevant
         // compiler is not yet linked/copied properly.
-        //
-        // Only clear out the directory if we're compiling std; otherwise, we
-        // should let Cargo take care of things for us (via depdep info)
-        if !self.config.dry_run && mode == Mode::Std && cmd == "build" {
+        if !self.config.dry_run && ["build", "check"].contains(&cmd) {
             self.clear_if_dirty(&out_dir, &self.rustc(compiler));
         }
 


### PR DESCRIPTION
Previously, this would cause ICEs because the stage1 compiler would see incremental state from a different compiler with a different ABI.

As a performance optimization, it might be possible to turn incremental off by default for stage1 builds, which would speed them up in the common case where the compiler is rebuilt. But that seems complicated and I don't have time to work on it at the moment.

Closes https://github.com/rust-lang/rust/issues/76720.

r? @Mark-Simulacrum

cc @rust-lang/compiler @rust-lang/compiler-contributors: this should allow you to see `incremental = true` unconditionally in config.toml, modulo any remaining bugs in incremental.