### PR TITLE
Fix ICE with `-Zunpretty=hir,typed`

### DIFF
--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -293,18 +293,6 @@ struct TypedAnnotation<'tcx> {
     maybe_typeck_results: Cell<Option<&'tcx ty::TypeckResults<'tcx>>>,
 }
 
-impl<'tcx> TypedAnnotation<'tcx> {
-    /// Gets the type-checking results for the current body.
-    /// As this will ICE if called outside bodies, only call when working with
-    /// `Expr` or `Pat` nodes (they are guaranteed to be found only in bodies).
-    #[track_caller]
-    fn typeck_results(&self) -> &'tcx ty::TypeckResults<'tcx> {
-        self.maybe_typeck_results
-            .get()
-            .expect("`TypedAnnotation::typeck_results` called outside of body")
-    }
-}
-
 impl<'tcx> HirPrinterSupport<'tcx> for TypedAnnotation<'tcx> {
     fn sess(&self) -> &Session {
         &self.tcx.sess
@@ -336,10 +324,24 @@ impl<'tcx> pprust_hir::PpAnn for TypedAnnotation<'tcx> {
     }
     fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         if let pprust_hir::AnnNode::Expr(expr) = node {
-            s.s.space();
-            s.s.word("as");
-            s.s.space();
-            s.s.word(self.typeck_results().expr_ty(expr).to_string());
+            let typeck_results =
+                self.maybe_typeck_results.get().or_else(|| {
+                    if let Some(body_id) = self.tcx.hir().maybe_body_owned_by(
+                        self.tcx.hir().local_def_id_to_hir_id(expr.hir_id.owner),
+                    ) {
+                        Some(self.tcx.typeck_body(body_id))
+                    } else {
+                        None
+                    }
+                });
+
+            if let Some(typeck_results) = typeck_results {
+                s.s.space();
+                s.s.word("as");
+                s.s.space();
+                s.s.word(typeck_results.expr_ty(expr).to_string());
+            }
+
             s.pclose();
         }
     }

--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -324,16 +324,12 @@ impl<'tcx> pprust_hir::PpAnn for TypedAnnotation<'tcx> {
     }
     fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         if let pprust_hir::AnnNode::Expr(expr) = node {
-            let typeck_results =
-                self.maybe_typeck_results.get().or_else(|| {
-                    if let Some(body_id) = self.tcx.hir().maybe_body_owned_by(
-                        self.tcx.hir().local_def_id_to_hir_id(expr.hir_id.owner),
-                    ) {
-                        Some(self.tcx.typeck_body(body_id))
-                    } else {
-                        None
-                    }
-                });
+            let typeck_results = self.maybe_typeck_results.get().or_else(|| {
+                self.tcx
+                    .hir()
+                    .maybe_body_owned_by(self.tcx.hir().local_def_id_to_hir_id(expr.hir_id.owner))
+                    .map(|body_id| self.tcx.typeck_body(body_id))
+            });
 
             if let Some(typeck_results) = typeck_results {
                 s.s.space();

--- a/src/test/ui/unpretty-expr-fn-arg.rs
+++ b/src/test/ui/unpretty-expr-fn-arg.rs
@@ -1,0 +1,13 @@
+// Regression test for the ICE described in #82328. The pretty-printer for
+// compile-flags: -Zunpretty=hir,typed
+// would previously retrieve type-checking results when entering a body,
+// which means that type information was not available for expressions
+// occurring in function signatures, as in the `foo` example below, leading
+// to an ICE.
+
+// check-pass
+#![allow(dead_code)]
+
+fn main() {}
+
+fn foo(-128..=127: i8) {}

--- a/src/test/ui/unpretty-expr-fn-arg.rs
+++ b/src/test/ui/unpretty-expr-fn-arg.rs
@@ -1,11 +1,11 @@
 // Regression test for the ICE described in #82328. The pretty-printer for
-// compile-flags: -Zunpretty=hir,typed
-// would previously retrieve type-checking results when entering a body,
-// which means that type information was not available for expressions
-// occurring in function signatures, as in the `foo` example below, leading
-// to an ICE.
+// `-Zunpretty=hir,typed` would previously retrieve type-checking results
+// when entering a body, which means that type information was not available
+// for expressions occurring in function signatures, as in the `foo` example
+// below, leading to an ICE.
 
 // check-pass
+// compile-flags: -Zunpretty=hir,typed
 #![allow(dead_code)]
 
 fn main() {}

--- a/src/test/ui/unpretty-expr-fn-arg.stdout
+++ b/src/test/ui/unpretty-expr-fn-arg.stdout
@@ -1,11 +1,11 @@
 // Regression test for the ICE described in #82328. The pretty-printer for
-// compile-flags: -Zunpretty=hir,typed
-// would previously retrieve type-checking results when entering a body,
-// which means that type information was not available for expressions
-// occurring in function signatures, as in the `foo` example below, leading
-// to an ICE.
+// `-Zunpretty=hir,typed` would previously retrieve type-checking results
+// when entering a body, which means that type information was not available
+// for expressions occurring in function signatures, as in the `foo` example
+// below, leading to an ICE.
 
 // check-pass
+// compile-flags: -Zunpretty=hir,typed
 #![allow(dead_code)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/src/test/ui/unpretty-expr-fn-arg.stdout
+++ b/src/test/ui/unpretty-expr-fn-arg.stdout
@@ -1,0 +1,17 @@
+// Regression test for the ICE described in #82328. The pretty-printer for
+// compile-flags: -Zunpretty=hir,typed
+// would previously retrieve type-checking results when entering a body,
+// which means that type information was not available for expressions
+// occurring in function signatures, as in the `foo` example below, leading
+// to an ICE.
+
+// check-pass
+#![allow(dead_code)]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+
+fn main() ({ } as ())
+
+fn foo((-(128 as i8) as i8) ...(127 as i8): i8) ({ } as ())


### PR DESCRIPTION
This PR fixes #82328. The `-Zunpretty=hir,typed` pretty-printer maintains an `Option` with type-checking results and sets the `Option` to `Some` when entering a body. However, this leads to an ICE if an expression occurs in a function signature (i.e. outside of a body), such as `128` in
```rust
fn foo(-128..=127: i8) {}
```
This PR fixes the ICE by checking (if necessary) whether the expression's owner has a body, and retrieving type-checking results for that on the fly.