### PR TITLE
feature flag: add feature flag `type_changing_struct_update` for implementation of RFC #2528

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -666,7 +666,7 @@ declare_features! (
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
     (active, more_qualified_paths, "1.54.0", Some(80080), None),
 
-    /// Allows creation of instances of a struct by moving fields that have 
+    /// Allows creation of instances of a struct by moving fields that have
     /// not changed from prior instances of the same struct (RFC #2528)
     (active, type_changing_struct_update, "1.55.0", Some(86618), None)
 

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -666,6 +666,10 @@ declare_features! (
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
     (active, more_qualified_paths, "1.54.0", Some(80080), None),
 
+    /// Allows creation of instances of a struct by moving fields that have 
+    /// not changed from prior instances of the same struct (RFC #2528)
+    (active, type_changing_struct_update, "1.55.0", Some(86618), None)
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a feature flag: `type_changing_struct_update` with regards to the implementation of RFC https://github.com/rust-lang/rfcs/pull/2528.

The implementation issue can be found here: https://github.com/rust-lang/rust/issues/86618

