### PR TITLE
Fix autoborrowing when coercing to a mutable raw pointer

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -18,6 +18,7 @@ use rustc_hir::{ExprKind, GenericArg, Node, QPath, TyKind};
 use rustc_infer::infer::canonical::{Canonical, OriginalQueryValues, QueryResponse};
 use rustc_infer::infer::error_reporting::TypeAnnotationNeeded::E0282;
 use rustc_infer::infer::{InferOk, InferResult};
+use rustc_middle::mir::Mutability;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, AutoBorrowMutability};
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::subst::{
@@ -282,7 +283,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             matches!(
                 adj,
                 &Adjustment {
-                    kind: Adjust::Borrow(AutoBorrow::Ref(_, AutoBorrowMutability::Mut { .. })),
+                    kind: Adjust::Borrow(
+                        AutoBorrow::Ref(_, AutoBorrowMutability::Mut { .. })
+                            | AutoBorrow::RawPtr(Mutability::Mut)
+                    ),
                     ..
                 }
             )

--- a/src/test/ui/coercion/issue-86262-autoborrow-mut-ptr.rs
+++ b/src/test/ui/coercion/issue-86262-autoborrow-mut-ptr.rs
@@ -1,0 +1,20 @@
+// Regression test for #86262. Previously, the code below would incorrectly
+// give E0596 (cannot borrow `this.slot` as mutable) because autoborrowing
+// did not handle coercions to mutable raw pointers correctly.
+
+// check-pass
+#![crate_type="lib"]
+#![allow(unused_mut)]
+
+use std::mem::ManuallyDrop;
+
+pub struct RefWrapper<'a, T: ?Sized> {
+    slot: &'a mut T,
+}
+
+impl<'a, T: ?Sized> RefWrapper<'a, T> {
+    pub fn into_raw(this: Self) -> *mut T {
+        let mut this = ManuallyDrop::new(this);
+        this.slot as *mut T /* location of former error */
+    }
+}


### PR DESCRIPTION
This PR fixes #86262. Essentially, the problem is that `apply_adjustments()` in `FnCtxt` currently only takes mutability of references into account for automatic borrows, while it should also consider mutable raw pointers. I have fixed this, so that the example in #86262 compiles with my changes.