### PR TITLE
chore(rustdoc): remove JS code that uses nonexistent GENERICS_DATA

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -257,7 +257,7 @@ function loadSearchJsAndIndex(searchJs, searchIndex, storageJs, crate) {
 
     var arraysToLoad = ["itemTypes"];
     var variablesToLoad = ["MAX_LEV_DISTANCE", "MAX_RESULTS", "NO_TYPE_FILTER",
-                           "GENERICS_DATA", "NAME", "INPUTS_DATA", "OUTPUT_DATA",
+                           "NAME", "INPUTS_DATA", "OUTPUT_DATA",
                            "TY_PRIMITIVE", "TY_KEYWORD",
                            "levenshtein_row2"];
     // execQuery first parameter is built in getQuery (which takes in the search input).


### PR DESCRIPTION
The search index stopped including this data back with b9167e6c7d09, which changed the format of function i/o types from `[name, generics]` to `[name, kind]` (since TypeWithKind directly serializes the name, and does not serialize the generics data).