### PR TITLE
Fix boldness (put it back where needed)

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -146,9 +146,15 @@ h1.fqn > .in-band > a:hover {
 h2, h3, h4 {
 	border-bottom: 1px solid;
 }
-.impl, .impl-items .method,
-.impl-items .type, .impl-items .associatedconstant,
-.impl-items .associatedtype {
+.impl,
+.impl-items .method,
+.methods .method,
+.impl-items .type,
+.methods .type,
+.impl-items .associatedconstant,
+.methods .associatedconstant,
+.impl-items .associatedtype,
+.methods .associatedtype {
 	flex-basis: 100%;
 	font-weight: 600;
 	margin-top: 16px;

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -5,3 +5,16 @@ assert-css: ("//*[@class='structfield small-section-header']//a[text()='Alias']"
 assert-css: ("#method\.a_method > code", {"font-weight": "600"})
 assert-css: ("#associatedtype\.X > code", {"font-weight": "600"})
 assert-css: ("#associatedconstant\.Y > code", {"font-weight": "600"})
+
+goto: file://|DOC_PATH|/test_docs/type.SomeType.html
+assert-css: (".top-doc .docblock p", {"font-weight": "400"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+assert-css: (".impl-items .method", {"font-weight": "600"}, ALL)
+
+goto: file://|DOC_PATH|/lib2/trait.Trait.html
+assert-count: (".methods .type", 1)
+assert-css: (".methods .type", {"font-weight": "600"})
+assert-count: (".methods .constant", 1)
+assert-css: (".methods .constant", {"font-weight": "600"})
+assert-css: (".methods .method", {"font-weight": "600"})

--- a/src/test/rustdoc-gui/src/lib2.rs
+++ b/src/test/rustdoc-gui/src/lib2.rs
@@ -23,6 +23,8 @@ impl Foo {
 pub trait Trait {
     type X;
     const Y: u32;
+
+    fn foo() {}
 }
 
 impl Trait for Foo {

--- a/src/test/rustdoc-gui/type-weight.rs
+++ b/src/test/rustdoc-gui/type-weight.rs
@@ -1,2 +1,0 @@
-goto: file://|DOC_PATH|/test_docs/type.SomeType.html
-assert-all: (".top-block .docblock p", {"font-weight": "400"})


### PR DESCRIPTION
I realized that I created a GUI test that wasn't run because it had ".rs" extension instead of ".goml" so I moved its content into `font-weight.goml` (since it was checking font weight).
