### PR TITLE
Make `fmt::Arguments::as_str` unstably const

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -444,8 +444,9 @@ impl<'a> Arguments<'a> {
     /// assert_eq!(format_args!("{}", 1).as_str(), None);
     /// ```
     #[stable(feature = "fmt_as_str", since = "1.52.0")]
+    #[rustc_const_unstable(feature = "const_arguments_as_str", issue = "none")]
     #[inline]
-    pub fn as_str(&self) -> Option<&'static str> {
+    pub const fn as_str(&self) -> Option<&'static str> {
         match (self.pieces, self.args) {
             ([], []) => Some(""),
             ([s], []) => Some(s),


### PR DESCRIPTION
Motivation: mostly to move "panic!() in const contexts" forward, making use of `as_str` was mentioned in https://github.com/rust-lang/rust/issues/85194#issuecomment-852345377 and seems like the simplest way forward.