### PR TITLE
Fix `future_prelude_collision` false positive

### DIFF
--- a/compiler/rustc_typeck/src/check/method/prelude2021.rs
+++ b/compiler/rustc_typeck/src/check/method/prelude2021.rs
@@ -57,6 +57,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             {
                 return;
             }
+
+            // if it's an inherent `self` method (not `&self` or `&mut self`), it will take
+            // precedence over the `TryInto` impl, and thus won't break in 2021 edition
+            if pick.autoderefs == 0 && pick.autoref_or_ptr_adjustment.is_none() {
+                return;
+            }
+
             // Inherent impls only require not relying on autoref and autoderef in order to
             // ensure that the trait implementation won't be used
             self.tcx.struct_span_lint_hir(

--- a/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
@@ -1,0 +1,16 @@
+// edition:2018
+// check-pass
+#![allow(unused)]
+#![deny(future_prelude_collision)]
+
+struct S;
+
+impl S {
+    fn try_into(self) -> S { S }
+}
+
+// See https://github.com/rust-lang/rust/issues/86633
+fn main() {
+    let s = S;
+    let s2 = s.try_into();
+}


### PR DESCRIPTION
Fixes #86633

The lint for checking if method resolution of methods named `try_into` will fail in 2021 edition previously would fire on all inherent methods, however for inherent methods that consume `self`, this takes priority over `TryInto::try_into` due to being inherent, while trait method and methods that take `&self` or `&mut self` don't take priority, and thus aren't affected by this false positive.

This fix is rather simple: simply checking if the inherent method doesn't auto-deref or auto-ref (and thus takes `self`) and if so, prevents the lint from firing. 