### PR TITLE
tests: add failing tests for `type_changing_struct_update` feature flag

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -666,7 +666,7 @@ declare_features! (
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
     (active, more_qualified_paths, "1.54.0", Some(80080), None),
 
-    /// Allows creation of instances of a struct by moving fields that have 
+    /// Allows creation of instances of a struct by moving fields that have
     /// not changed from prior instances of the same struct (RFC #2528)
     (active, type_changing_struct_update, "1.55.0", Some(86618), None)
 

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -666,6 +666,10 @@ declare_features! (
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
     (active, more_qualified_paths, "1.54.0", Some(80080), None),
 
+    /// Allows creation of instances of a struct by moving fields that have 
+    /// not changed from prior instances of the same struct (RFC #2528)
+    (active, type_changing_struct_update, "1.55.0", Some(86618), None)
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/test/ui/type_changing_struct_update_rfc_2528/basic_tests_setup.rs
+++ b/src/test/ui/type_changing_struct_update_rfc_2528/basic_tests_setup.rs
@@ -1,0 +1,39 @@
+// gate-test-type_changing_struct_update
+
+/// Here, we're documenting the current state of affairs related to
+/// FRU (functional record update)
+
+#![feature(type_changing_struct_update)]
+
+struct Machine<S> {
+    state: S,
+    common_field1: &'static str,
+    common_field2: i32,
+}
+
+struct State1;
+struct State2;
+
+impl Machine<State1> {
+    fn into_state2(self) -> Machine<State2> {
+        // do stuff
+        Machine {
+            state: State2,
+            ..self
+        }
+    }
+}
+
+#[test]
+#[should_panic]  // NOTE: this would be fixed by the implementation of the RFC
+fn update_to_state2() {
+    let m1: Machine<State1> = Machine {
+        state: State1,
+        common_field1: "hello",
+        common_field2: 2,
+    };
+    let m2: Machine<State2> = m1.into_state2();
+    assert_eq!(State2, m2.state);
+}
+
+fn main() {}

--- a/src/test/ui/type_changing_struct_update_rfc_2528/basic_tests_setup.stderr
+++ b/src/test/ui/type_changing_struct_update_rfc_2528/basic_tests_setup.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> $DIR/basic_tests_setup.rs:19:15
+   |
+LL |             ..self
+   |               ^^^^ expected struct `State2`, found struct `State1`
+   |
+   = note: expected struct `Machine<State2>`
+              found struct `Machine<State1>`


### PR DESCRIPTION
This PR adds failing tests for the feature flag `type_changing_struct_update`. 

The requirement for the same can be found in the following comment: https://github.com/rust-lang/rust/issues/86618#issuecomment-868976781

Related Issue: https://github.com/rust-lang/rust/issues/86618

Please keep in mind that PR: https://github.com/rust-lang/rust/pull/86646 has to be merged before the merge of this PR.
