### PR TITLE
Add #[track_caller] for some function in core::mem.

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -619,6 +619,7 @@ impl<T> MaybeUninit<T> {
     #[rustc_const_unstable(feature = "const_maybe_uninit_assume_init", issue = "none")]
     #[inline(always)]
     #[rustc_diagnostic_item = "assume_init"]
+    #[track_caller]
     pub const unsafe fn assume_init(self) -> T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // This also means that `self` must be a `value` variant.
@@ -690,6 +691,7 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_extra", issue = "63567")]
     #[rustc_const_unstable(feature = "maybe_uninit_extra", issue = "63567")]
     #[inline(always)]
+    #[track_caller]
     pub const unsafe fn assume_init_read(&self) -> T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // Reading from `self.as_ptr()` is safe since `self` should be initialized.
@@ -937,6 +939,7 @@ impl<T> MaybeUninit<T> {
     /// ```
     #[unstable(feature = "maybe_uninit_array_assume_init", issue = "80908")]
     #[inline(always)]
+    #[track_caller]
     pub unsafe fn array_assume_init<const N: usize>(array: [Self; N]) -> [T; N] {
         // SAFETY:
         // * The caller guarantees that all elements of the array are initialized

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -622,6 +622,7 @@ pub const fn needs_drop<T>() -> bool {
 #[allow(deprecated_in_future)]
 #[allow(deprecated)]
 #[rustc_diagnostic_item = "mem_zeroed"]
+#[track_caller]
 pub unsafe fn zeroed<T>() -> T {
     // SAFETY: the caller must guarantee that an all-zero value is valid for `T`.
     unsafe {
@@ -657,6 +658,7 @@ pub unsafe fn zeroed<T>() -> T {
 #[allow(deprecated_in_future)]
 #[allow(deprecated)]
 #[rustc_diagnostic_item = "mem_uninitialized"]
+#[track_caller]
 pub unsafe fn uninitialized<T>() -> T {
     // SAFETY: the caller must guarantee that an unitialized value is valid for `T`.
     unsafe {

--- a/src/test/ui/consts/assume-type-intrinsics.stderr
+++ b/src/test/ui/consts/assume-type-intrinsics.stderr
@@ -1,17 +1,9 @@
 error: any use of this value will cause an error
-  --> $SRC_DIR/core/src/mem/maybe_uninit.rs:LL:COL
-   |
-LL |               intrinsics::assert_inhabited::<T>();
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |               |
-   |               aborted execution: attempted to instantiate uninhabited type `!`
-   |               inside `MaybeUninit::<!>::assume_init` at $SRC_DIR/core/src/mem/maybe_uninit.rs:LL:COL
-   |               inside `_BAD` at $DIR/assume-type-intrinsics.rs:11:9
-   | 
-  ::: $DIR/assume-type-intrinsics.rs:10:5
+  --> $DIR/assume-type-intrinsics.rs:11:9
    |
 LL | /     const _BAD: () = unsafe {
 LL | |         MaybeUninit::<!>::uninit().assume_init();
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ aborted execution: attempted to instantiate uninhabited type `!`
 LL | |     };
    | |______-
    |


### PR DESCRIPTION
These functions can panic for some types. This makes the panic point to the code that calls e.g. mem::uninitialized(), instead of inside the definition of mem::uninitialized.