### PR TITLE
Fix misleading "impl Trait" error

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1481,6 +1481,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     expected,
                     found,
                     can_suggest,
+                    fcx.tcx.hir().get_parent_item(id),
                 );
             }
             if !pointing_at_return_type {

--- a/src/test/ui/extern/extern-types-distinct-types.stderr
+++ b/src/test/ui/extern/extern-types-distinct-types.stderr
@@ -6,6 +6,8 @@ LL |     type A;
 LL |     type B;
    |     ------- the expected foreign type
 ...
+LL | fn foo(r: &A) -> &B {
+   |                  -- expected `&B` because of return type
 LL |     r
    |     ^ expected extern type `B`, found extern type `A`
    |

--- a/src/test/ui/retslot-cast.stderr
+++ b/src/test/ui/retslot-cast.stderr
@@ -1,6 +1,9 @@
 error[E0308]: mismatched types
   --> $DIR/retslot-cast.rs:13:5
    |
+LL |             -> Option<&Iterator<Item=()>> {
+   |                -------------------------- expected `Option<&dyn Iterator<Item = ()>>` because of return type
+...
 LL |     inner(x)
    |     ^^^^^^^^ expected trait `Iterator<Item = ()>`, found trait `Iterator<Item = ()> + Send`
    |

--- a/src/test/ui/typeck/issue-84160.rs
+++ b/src/test/ui/typeck/issue-84160.rs
@@ -1,0 +1,9 @@
+fn mismatched_types_with_reference(x: &u32) -> &u32 {
+    if false {
+        return x;
+    }
+    return "test";
+    //~^ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-84160.stderr
+++ b/src/test/ui/typeck/issue-84160.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-84160.rs:5:12
+   |
+LL | fn mismatched_types_with_reference(x: &u32) -> &u32 {
+   |                                                ---- expected `&u32` because of return type
+...
+LL |     return "test";
+   |            ^^^^^^ expected `u32`, found `str`
+   |
+   = note: expected reference `&u32`
+              found reference `&'static str`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The kinds can't be compared directly, as types with references are treated as different because the lifetimes aren't bound in ty, but are in expected.
Closes #84160