### PR TITLE
Don't run a publically reachable server in tests

### DIFF
--- a/src/test/ui/process-termination/process-termination-blocking-io.rs
+++ b/src/test/ui/process-termination/process-termination-blocking-io.rs
@@ -9,7 +9,7 @@ use std::{net::TcpListener, sync::mpsc, thread};
 fn main() {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let listen = TcpListener::bind("0.0.0.0:0").unwrap();
+        let listen = TcpListener::bind("127.0.0.1:0").unwrap();
         tx.send(()).unwrap();
         while let Ok(_) = listen.accept() {}
     });


### PR DESCRIPTION
This causes Windows Defender's firewall to pop up during tests to ask if I want to allow the test program to access the public Internet, since it was listening on `0.0.0.0` (the test passes regardless of how you respond to the modal, since the firewall only affects traffic outside of the computer, none of which actually happens in the test). The test server doesn't actually need to be publicly reachable, so this makes it so it is only reachable locally, which makes Windows Defender happy.