### PR TITLE
Make disjoint_capture_migration an edition lint.

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3001,8 +3001,7 @@ declare_lint! {
 
 declare_lint! {
     /// The `disjoint_capture_migration` lint detects variables that aren't completely
-    /// captured when the feature `capture_disjoint_fields` is enabled and it affects the Drop
-    /// order of at least one path starting at this variable.
+    /// captured in Rust 2021 and affect the Drop order of at least one path starting at this variable.
     /// It can also detect when a variable implements a trait, but one of its field does not and
     /// the field is captured by a closure and used with the assumption that said field implements
     /// the same trait as the root variable.
@@ -3039,8 +3038,8 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// In the above example `p.y` will be dropped at the end of `f` instead of with `c` if
-    /// the feature `capture_disjoint_fields` is enabled.
+    /// In the above example, `p.y` will be dropped at the end of `f` instead of
+    /// with `c` in Rust 2021.
     ///
     /// ### Example of auto-trait
     ///
@@ -3048,7 +3047,7 @@ declare_lint! {
     /// #![deny(disjoint_capture_migration)]
     /// use std::thread;
     ///
-    /// struct Pointer (*mut i32);
+    /// struct Pointer(*mut i32);
     /// unsafe impl Send for Pointer {}
     ///
     /// fn main() {
@@ -3064,12 +3063,16 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// In the above example `fptr.0` is captured when feature `capture_disjoint_fields` is enabled.
+    /// In the above example, only `fptr.0` is captured in Rust 2021.
     /// The field is of type *mut i32 which doesn't implement Send, making the code invalid as the
     /// field cannot be sent between thread safely.
     pub DISJOINT_CAPTURE_MIGRATION,
     Allow,
-    "Drop reorder and auto traits error because of `capture_disjoint_fields`"
+    "detects closures affected by Rust 2021 changes",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2021),
+        explain_reason: false,
+    };
 }
 
 declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -145,6 +145,11 @@ pub struct FutureIncompatibleInfo {
     /// The reason for the lint used by diagnostics to provide
     /// the right help message
     pub reason: FutureIncompatibilityReason,
+    /// Whether to explain the reason to the user.
+    ///
+    /// Set to false for lints that already include a more detailed
+    /// explanation.
+    pub explain_reason: bool,
     /// Information about a future breakage, which will
     /// be emitted in JSON messages to be displayed by Cargo
     /// for upstream deps
@@ -185,6 +190,7 @@ impl FutureIncompatibleInfo {
         FutureIncompatibleInfo {
             reference: "",
             reason: FutureIncompatibilityReason::FutureReleaseError,
+            explain_reason: true,
             future_breakage: None,
         }
     }

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -398,9 +398,14 @@ pub fn struct_lint_level<'s, 'd>(
                  it will become a hard error in a future release!"
                     .to_owned()
             };
-            let citation = format!("for more information, see {}", future_incompatible.reference);
-            err.warn(&explanation);
-            err.note(&citation);
+            if future_incompatible.explain_reason {
+                err.warn(&explanation);
+            }
+            if !future_incompatible.reference.is_empty() {
+                let citation =
+                    format!("for more information, see {}", future_incompatible.reference);
+                err.note(&citation);
+            }
         }
 
         // Finally, run `decorate`. This function is also responsible for emitting the diagnostic.

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -494,11 +494,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 |lint| {
                     let mut diagnostics_builder = lint.build(
                         format!(
-                            "{} affected for closure because of `capture_disjoint_fields`",
+                            "{} will change in Rust 2021",
                             reasons
                         )
                         .as_str(),
                     );
+                    diagnostics_builder.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
                     let closure_body_span = self.tcx.hir().span(body_id.hir_id);
                     let (sugg, app) =
                         match self.tcx.sess.source_map().span_to_snippet(closure_body_span) {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -11,7 +11,7 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Send` trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
     } });
@@ -28,7 +28,7 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Sync`, `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Sync`, `Send` trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
     } });
@@ -49,7 +49,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
-        //~^ ERROR: `Clone` trait implementation, and drop order affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Clone` trait implementation, and drop order
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
         println!("{:?}", f_1.0);

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -11,7 +11,7 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Send` trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
     });
@@ -28,7 +28,7 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Sync`, `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Sync`, `Send` trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
     });
@@ -49,7 +49,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
-        //~^ ERROR: `Clone` trait implementation, and drop order affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `Clone` trait implementation, and drop order
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
         println!("{:?}", f_1.0);

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -1,4 +1,4 @@
-error: `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+error: `Send` trait implementation will change in Rust 2021
   --> $DIR/auto_traits.rs:13:19
    |
 LL |       thread::spawn(move || unsafe {
@@ -14,6 +14,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL |     thread::spawn(move || { let _ = &fptr; unsafe {
@@ -23,7 +24,7 @@ LL |         *fptr.0 = 20;
 LL |     } });
    |
 
-error: `Sync`, `Send` trait implementation affected for closure because of `capture_disjoint_fields`
+error: `Sync`, `Send` trait implementation will change in Rust 2021
   --> $DIR/auto_traits.rs:30:19
    |
 LL |       thread::spawn(move || unsafe {
@@ -34,6 +35,7 @@ LL | |         *fptr.0.0 = 20;
 LL | |     });
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL |     thread::spawn(move || { let _ = &fptr; unsafe {
@@ -43,7 +45,7 @@ LL |         *fptr.0.0 = 20;
 LL |     } });
    |
 
-error: `Clone` trait implementation, and drop order affected for closure because of `capture_disjoint_fields`
+error: `Clone` trait implementation, and drop order will change in Rust 2021
   --> $DIR/auto_traits.rs:51:13
    |
 LL |       let c = || {
@@ -55,6 +57,7 @@ LL | |         println!("{:?}", f_1.0);
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
 LL |     let c = || { let _ = &f; 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -13,7 +13,8 @@ fn test1_all_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || { let _ = (&t, &t1, &t2); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
@@ -32,7 +33,8 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || { let _ = (&t, &t1); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -48,7 +50,8 @@ fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
@@ -66,7 +69,8 @@ fn test4_only_non_copy_types_need_migration() {
     let t1 = (0i32, 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -84,7 +88,8 @@ fn test5_only_drop_types_need_migration() {
     let s = S(0i32, 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
@@ -99,7 +104,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = move || { let _ = (&t1, &t); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
@@ -114,7 +120,8 @@ fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -13,7 +13,8 @@ fn test1_all_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
@@ -32,7 +33,8 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -48,7 +50,8 @@ fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
@@ -66,7 +69,8 @@ fn test4_only_non_copy_types_need_migration() {
     let t1 = (0i32, 0i32);
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -84,7 +88,8 @@ fn test5_only_drop_types_need_migration() {
     let s = S(0i32, 0i32);
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
@@ -99,7 +104,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = move || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
@@ -114,7 +120,8 @@ fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,4 +1,4 @@
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/insignificant_drop.rs:15:13
    |
 LL |       let c = || {
@@ -16,44 +16,47 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
 LL |
+LL |
 LL | 
 LL |         let _t = t.0;
-LL |         let _t1 = t1.0;
  ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:34:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:35:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
-LL | |         let _t = t.0;
-LL | |         let _t1 = t1.0;
+LL | |
+...  |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1); 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         let _t1 = t1.0;
-LL |         let _t2 = t2;
  ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:50:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:52:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -61,21 +64,23 @@ LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         println!("{}", t1.1);
-LL |     };
-   |
+ ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:68:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:71:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -83,21 +88,23 @@ LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         let _t1 = t1.0;
-LL |     };
-   |
+ ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:86:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:90:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -105,50 +112,57 @@ LL | |         let _s = s.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         let _s = s.0;
-LL |     };
-   |
+ ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:101:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:106:13
    |
 LL |       let c = move || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         println!("{} {}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL |     let c = move || { let _ = (&t1, &t); 
+LL |
 LL |
 LL |
 LL |         println!("{} {}", t1.1, t.1);
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:116:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop.rs:122:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -36,7 +36,8 @@ fn significant_drop_needs_migration() {
     let t = (SigDrop {}, SigDrop {});
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -53,7 +54,8 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     // move is used to force i32 to be copied instead of being a ref
     let c = move || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
@@ -36,7 +36,8 @@ fn significant_drop_needs_migration() {
     let t = (SigDrop {}, SigDrop {});
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -53,7 +54,8 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     // move is used to force i32 to be copied instead of being a ref
     let c = move || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -1,8 +1,9 @@
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/insignificant_drop_attr_migrations.rs:38:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -14,29 +15,34 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop_attr_migrations.rs:55:13
+error: drop order will change in Rust 2021
+  --> $DIR/insignificant_drop_attr_migrations.rs:56:13
    |
 LL |       let c = move || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = move || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -17,7 +17,8 @@ impl Drop for Foo {
 fn closure_contains_block() {
     let t = (Foo(0), Foo(0));
     let c = || { let _ = &t; 
-        //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -28,7 +29,8 @@ fn closure_contains_block() {
 fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || { let _ = &t; t.0 };
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -17,7 +17,8 @@ impl Drop for Foo {
 fn closure_contains_block() {
     let t = (Foo(0), Foo(0));
     let c = || {
-        //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -28,7 +29,8 @@ fn closure_contains_block() {
 fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || t.0;
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -1,8 +1,9 @@
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/migrations_rustfix.rs:19:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -14,21 +15,24 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/migrations_rustfix.rs:30:13
+error: drop order will change in Rust 2021
+  --> $DIR/migrations_rustfix.rs:31:13
    |
 LL |     let c = || t.0;
    |             ^^^^^^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; t.0 };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -13,7 +13,7 @@ fn foo_diverges() -> ! { panic!() }
 fn assert_panics<F>(f: F) where F: FnOnce() {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
     });

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -13,7 +13,7 @@ fn foo_diverges() -> ! { panic!() }
 fn assert_panics<F>(f: F) where F: FnOnce() {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation affected for closure because of `capture_disjoint_fields`
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
     });

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,4 +1,4 @@
-error: `UnwindSafe`, `RefUnwindSafe` trait implementation affected for closure because of `capture_disjoint_fields`
+error: `UnwindSafe`, `RefUnwindSafe` trait implementation will change in Rust 2021
   --> $DIR/mir_calls_to_shims.rs:15:38
    |
 LL |       let result = panic::catch_unwind(move || {
@@ -14,6 +14,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
 LL |     let result = panic::catch_unwind(move || { let _ = &f; 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -17,7 +17,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
@@ -40,7 +40,7 @@ fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
     let c = || { let _ = &u; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
     //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
@@ -17,7 +17,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
@@ -40,7 +40,7 @@ fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
     //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -1,4 +1,4 @@
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/precise.rs:19:13
    |
 LL |       let c = || {
@@ -15,6 +15,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
@@ -25,7 +26,7 @@ LL |         let _t = &t.1;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/precise.rs:42:13
    |
 LL |       let c = || {
@@ -38,6 +39,7 @@ LL | |         let _x = u.1.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured
    |
 LL |     let c = || { let _ = &u; 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -23,7 +23,8 @@ fn test1_all_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || { let _ = (&t, &t1, &t2); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -41,7 +42,8 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || { let _ = (&t, &t1); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -57,7 +59,8 @@ fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
@@ -74,7 +77,8 @@ fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -89,7 +93,8 @@ fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -102,7 +107,8 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
@@ -117,7 +123,8 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t1 = (Foo(0), Foo(0), Foo(0));
 
     let c = move || { let _ = (&t1, &t); 
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -23,7 +23,8 @@ fn test1_all_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -41,7 +42,8 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
@@ -57,7 +59,8 @@ fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
@@ -74,7 +77,8 @@ fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -89,7 +93,8 @@ fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
@@ -102,7 +107,8 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
     let c = || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
@@ -117,7 +123,8 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t1 = (Foo(0), Foo(0), Foo(0));
 
     let c = move || {
-    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~^ ERROR: drop order
+    //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,12 +1,12 @@
-error: drop order affected for closure because of `capture_disjoint_fields`
+error: drop order will change in Rust 2021
   --> $DIR/significant_drop.rs:25:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
-LL | |         let _t = t.0;
-LL | |         let _t1 = t1.0;
+LL | |
+...  |
 LL | |         let _t2 = t2.0;
 LL | |     };
    | |_____^
@@ -16,44 +16,47 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_migration)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         let _t1 = t1.0;
-LL |         let _t2 = t2.0;
  ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:43:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:44:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
-LL | |         let _t = t.0;
-LL | |         let _t1 = t1.0;
+LL | |
+...  |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1); 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
 LL |         let _t1 = t1.0;
-LL |         let _t2 = t2;
  ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:59:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:61:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
@@ -61,90 +64,103 @@ LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;
 LL |         println!("{:?}", t1.1);
-LL |     };
-   |
+ ...
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:76:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:79:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:91:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:95:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.0;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:104:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:109:13
    |
 LL |       let c = || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
+LL |
 LL |
 LL |
 LL |         let _t = t.1;
 LL |     };
    |
 
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:119:13
+error: drop order will change in Rust 2021
+  --> $DIR/significant_drop.rs:125:13
    |
 LL |       let c = move || {
    |  _____________^
+LL | |
 LL | |
 LL | |
 LL | |         println!("{:?} {:?}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL |     let c = move || { let _ = (&t1, &t); 
+LL |
 LL |
 LL |
 LL |         println!("{:?} {:?}", t1.1, t.1);


### PR DESCRIPTION
This turns the disjoint capture lint into an edition lint, and changes all the wording to refer to the edition.

This includes the same first commit as https://github.com/rust-lang/rust/pull/86671. See https://github.com/rust-lang/rust/pull/86671.

Fixes most of https://github.com/rust-lang/project-rfc-2229/issues/43#issuecomment-869188197