### PR TITLE
Fix garbled suggestion for missing lifetime specifier

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1962,6 +1962,8 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                                 hir::GenericParamKind::Type {
                                     synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
                                     ..
+                                } | hir::GenericParamKind::Lifetime {
+                                    kind: hir::LifetimeParamKind::Elided
                                 }
                             )
                         }) {

--- a/src/test/ui/suggestions/issue-86667.rs
+++ b/src/test/ui/suggestions/issue-86667.rs
@@ -1,0 +1,16 @@
+// Regression test for #86667, where a garbled suggestion was issued for
+// a missing named lifetime parameter.
+
+// compile-flags: --edition 2018
+
+async fn a(s1: &str, s2: &str) -> &str {
+//~^ ERROR: missing lifetime specifier [E0106]
+    s1
+}
+
+fn b(s1: &str, s2: &str) -> &str {
+//~^ ERROR: missing lifetime specifier [E0106]
+    s1
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-86667.stderr
+++ b/src/test/ui/suggestions/issue-86667.stderr
@@ -1,0 +1,27 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-86667.rs:6:35
+   |
+LL | async fn a(s1: &str, s2: &str) -> &str {
+   |                ----      ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `s1` or `s2`
+help: consider introducing a named lifetime parameter
+   |
+LL | async fn a<'a>(s1: &'a str, s2: &'a str) -> &'a str {
+   |           ^^^^     ^^^^^^^      ^^^^^^^     ^^^
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-86667.rs:11:29
+   |
+LL | fn b(s1: &str, s2: &str) -> &str {
+   |          ----      ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `s1` or `s2`
+help: consider introducing a named lifetime parameter
+   |
+LL | fn b<'a>(s1: &'a str, s2: &'a str) -> &'a str {
+   |     ^^^^     ^^^^^^^      ^^^^^^^     ^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
This PR fixes #86667. The suggestion code currently checks whether there is a generic parameter that is not a synthetic `impl Trait` parameter and, if so, suggests to insert a new lifetime `'a` before that generic parameter. However, it does not make sense to insert `'a` in front of an elided lifetime parameter, since these are synthetic as well, which leads to the garbled suggestion in #86667.
