### PR TITLE
Improve error for missing -Z with debugging option

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -29,7 +29,7 @@ use rustc_middle::middle::cstore::MetadataLoader;
 use rustc_save_analysis as save;
 use rustc_save_analysis::DumpHandler;
 use rustc_serialize::json::{self, ToJson};
-use rustc_session::config::nightly_options;
+use rustc_session::config::{nightly_options, CG_OPTIONS, DB_OPTIONS};
 use rustc_session::config::{ErrorOutputType, Input, OutputType, PrintRequest, TrimmedDefPaths};
 use rustc_session::getopts;
 use rustc_session::lint::{Lint, LintId};
@@ -1017,9 +1017,18 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     for option in config::rustc_optgroups() {
         (option.apply)(&mut options);
     }
-    let matches = options
-        .parse(args)
-        .unwrap_or_else(|f| early_error(ErrorOutputType::default(), &f.to_string()));
+    let matches = options.parse(args).unwrap_or_else(|e| {
+        let msg = match e {
+            getopts::Fail::UnrecognizedOption(ref opt) => CG_OPTIONS
+                .iter()
+                .map(|&(name, ..)| ('C', name))
+                .chain(DB_OPTIONS.iter().map(|&(name, ..)| ('Z', name)))
+                .find(|&(_, name)| *opt == name.replace("_", "-"))
+                .map(|(flag, _)| format!("{}. Did you mean `-{} {}`?", e, flag, opt)),
+            _ => None,
+        };
+        early_error(ErrorOutputType::default(), &msg.unwrap_or_else(|| e.to_string()));
+    });
 
     // For all options we just parsed, we check a few aspects:
     //

--- a/src/test/ui/invalid-compile-flags/codegen-option-without-group.rs
+++ b/src/test/ui/invalid-compile-flags/codegen-option-without-group.rs
@@ -1,0 +1,1 @@
+// compile-flags: --llvm-args

--- a/src/test/ui/invalid-compile-flags/codegen-option-without-group.stderr
+++ b/src/test/ui/invalid-compile-flags/codegen-option-without-group.stderr
@@ -1,0 +1,2 @@
+error: Unrecognized option: 'llvm-args'. Did you mean `-C llvm-args`?
+

--- a/src/test/ui/invalid-compile-flags/debug-option-without-group.rs
+++ b/src/test/ui/invalid-compile-flags/debug-option-without-group.rs
@@ -1,0 +1,1 @@
+// compile-flags: --unpretty=hir

--- a/src/test/ui/invalid-compile-flags/debug-option-without-group.stderr
+++ b/src/test/ui/invalid-compile-flags/debug-option-without-group.stderr
@@ -1,0 +1,2 @@
+error: Unrecognized option: 'unpretty'. Did you mean `-Z unpretty`?
+


### PR DESCRIPTION
Before:
```text
❯ rustc --unpretty=hir
error: Unrecognized option: 'unpretty'
```
After:
```text
❯ rustc --unpretty=hir
error: Unrecognized option: 'unpretty'. Did you mean `-Z unpretty`?
```