### PR TITLE
Allow anyone to set `perf-regression` label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -4,6 +4,7 @@ allow-unauthenticated = [
     "D-*",
     "requires-nightly",
     "regression-*",
+    "perf-regression",
     # I-* without I-nominated
     "I-*", "!I-nominated",
     "AsyncAwait-OnDeck",


### PR DESCRIPTION
The main purpose is to allow the triage bot to set the label: https://github.com/rust-lang/rust/pull/86617#issuecomment-868450443

r? @Mark-Simulacrum 