### PR TITLE
Only include lint in future_incompatible lint group if not an edition lint

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -220,17 +220,17 @@ impl LintStore {
                         })
                         .lint_ids
                         .push(id);
+                } else {
+                    self.lint_groups
+                        .entry("future_incompatible")
+                        .or_insert(LintGroup {
+                            lint_ids: vec![],
+                            from_plugin: lint.is_plugin,
+                            depr: None,
+                        })
+                        .lint_ids
+                        .push(id);
                 }
-
-                self.lint_groups
-                    .entry("future_incompatible")
-                    .or_insert(LintGroup {
-                        lint_ids: vec![],
-                        from_plugin: lint.is_plugin,
-                        depr: None,
-                    })
-                    .lint_ids
-                    .push(id);
             }
         }
     }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -221,6 +221,9 @@ impl LintStore {
                         .lint_ids
                         .push(id);
                 } else {
+                    // Lints belonging to the `future_incompatible` lint group are lints where a
+                    // future version of rustc will cause existing code to stop compiling.
+                    // Lints tied to an edition don't count because they are opt-in.
                     self.lint_groups
                         .entry("future_incompatible")
                         .or_insert(LintGroup {

--- a/src/test/ui/future-incompatible-lint-group.rs
+++ b/src/test/ui/future-incompatible-lint-group.rs
@@ -1,8 +1,18 @@
+// Ensure that the future_incompatible lint group only includes
+// lints for changes that are not tied to an edition
 #![deny(future_incompatible)]
 
 trait Tr {
-    fn f(u8) {} //~ ERROR anonymous parameters are deprecated
-                //~^ WARN this is accepted in the current edition
+    // Warn only since this is not a `future_incompatible` lint
+    fn f(u8) {} //~ WARN anonymous parameters are deprecated
+                //~| WARN this is accepted in the current edition
+}
+
+pub mod submodule {
+    // Error since this is a `future_incompatible` lint
+    #![doc(test(some_test))]
+        //~^ ERROR this attribute can only be applied at the crate level
+        //~| WARN this was previously accepted by the compiler
 }
 
 fn main() {}

--- a/src/test/ui/future-incompatible-lint-group.stderr
+++ b/src/test/ui/future-incompatible-lint-group.stderr
@@ -1,17 +1,28 @@
-error: anonymous parameters are deprecated and will be removed in the next edition.
-  --> $DIR/future-incompatible-lint-group.rs:4:10
+warning: anonymous parameters are deprecated and will be removed in the next edition.
+  --> $DIR/future-incompatible-lint-group.rs:7:10
    |
 LL |     fn f(u8) {}
    |          ^^ help: try naming the parameter or explicitly ignoring it: `_: u8`
    |
-note: the lint level is defined here
-  --> $DIR/future-incompatible-lint-group.rs:1:9
-   |
-LL | #![deny(future_incompatible)]
-   |         ^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(anonymous_parameters)]` implied by `#[deny(future_incompatible)]`
+   = note: `#[warn(anonymous_parameters)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
-error: aborting due to previous error
+error: this attribute can only be applied at the crate level
+  --> $DIR/future-incompatible-lint-group.rs:13:12
+   |
+LL |     #![doc(test(some_test))]
+   |            ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/future-incompatible-lint-group.rs:3:9
+   |
+LL | #![deny(future_incompatible)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(future_incompatible)]`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+   = note: read https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level for more information
+
+error: aborting due to previous error; 1 warning emitted
 


### PR DESCRIPTION
A follow up to #86330 - this only includes lints annotated with `FutureIncompatibleInfo` in the `future_incompatibile` lint group if the future compatibility is not tied to an edition.

We probably want to rename `FutureIncompatibleInfo` to something else since this type is now used to indicate future breakages of all kinds (even those that happen in editions). I'd prefer to do that in a separate PR though. 

r? @nikomatsakis 