### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1950,7 +1950,6 @@ impl<'a> State<'a> {
                     self.word_space(":");
                 }
                 self.head("loop");
-                self.s.space();
                 self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Match(ref expr, ref arms) => {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1538,7 +1538,6 @@ impl<'a> State<'a> {
                     self.word_space(":");
                 }
                 self.head("loop");
-                self.s.space();
                 self.print_block(&blk);
             }
             hir::ExprKind::Match(ref expr, arms, _) => {

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -674,7 +674,39 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Ty<'tcx> {
         if self.ret_coercion.is_none() {
-            self.tcx.sess.emit_err(ReturnStmtOutsideOfFnBody { span: expr.span });
+            let mut err = ReturnStmtOutsideOfFnBody {
+                span: expr.span,
+                encl_body_span: None,
+                encl_fn_span: None,
+            };
+
+            let encl_item_id = self.tcx.hir().get_parent_item(expr.hir_id);
+            let encl_item = self.tcx.hir().expect_item(encl_item_id);
+
+            if let hir::ItemKind::Fn(..) = encl_item.kind {
+                // We are inside a function body, so reporting "return statement
+                // outside of function body" needs an explanation.
+
+                let encl_body_owner_id = self.tcx.hir().enclosing_body_owner(expr.hir_id);
+
+                // If this didn't hold, we would not have to report an error in
+                // the first place.
+                assert_ne!(encl_item_id, encl_body_owner_id);
+
+                let encl_body_id = self.tcx.hir().body_owned_by(encl_body_owner_id);
+                let encl_body = self.tcx.hir().body(encl_body_id);
+
+                err.encl_body_span = Some(encl_body.value.span);
+                err.encl_fn_span = Some(encl_item.span);
+            }
+
+            self.tcx.sess.emit_err(err);
+
+            if let Some(e) = expr_opt {
+                // We still have to type-check `e` (issue #86188), but calling
+                // `check_return_expr` only works inside fn bodies.
+                self.check_expr(e);
+            }
         } else if let Some(e) = expr_opt {
             if self.ret_coercion_span.get().is_none() {
                 self.ret_coercion_span.set(Some(e.span));

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -147,6 +147,10 @@ pub struct TypeofReservedKeywordUsed {
 pub struct ReturnStmtOutsideOfFnBody {
     #[message = "return statement outside of function body"]
     pub span: Span,
+    #[label = "the return is part of this body..."]
+    pub encl_body_span: Option<Span>,
+    #[label = "...not the enclosing function body"]
+    pub encl_fn_span: Option<Span>,
 }
 
 #[derive(SessionDiagnostic)]

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1171,6 +1171,9 @@ impl Step for Miri {
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
+        if !builder.build.unstable_features() {
+            return None;
+        }
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1072,6 +1072,12 @@ impl Step for RustAnalyzer {
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
+        // This prevents rust-analyzer from being built for "dist" or "install"
+        // on the stable/beta channels. It is a nightly-only tool and should
+        // not be included.
+        if !builder.build.unstable_features() {
+            return None;
+        }
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
@@ -1171,6 +1177,9 @@ impl Step for Miri {
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
+        // This prevents miri from being built for "dist" or "install"
+        // on the stable/beta channels. It is a nightly-only tool and should
+        // not be included.
         if !builder.build.unstable_features() {
             return None;
         }

--- a/src/test/pretty/ast-stmt-expr-attr.rs
+++ b/src/test/pretty/ast-stmt-expr-attr.rs
@@ -39,7 +39,7 @@ fn syntax() {
                     #![attr]
                 };
     let _ =
-        #[attr] loop  {
+        #[attr] loop {
                     #![attr]
                 };
     let _ =

--- a/src/test/pretty/hir-pretty-loop.pp
+++ b/src/test/pretty/hir-pretty-loop.pp
@@ -1,0 +1,9 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:hir-pretty-loop.pp
+
+pub fn foo() { loop { break ; } }

--- a/src/test/pretty/hir-pretty-loop.rs
+++ b/src/test/pretty/hir-pretty-loop.rs
@@ -1,0 +1,9 @@
+// pretty-compare-only
+// pretty-mode:hir
+// pp-exact:hir-pretty-loop.pp
+
+pub fn foo(){
+    loop{
+        break;
+    }
+}

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -159,9 +159,8 @@ fn _11() {
         #[rustc_dummy] for _ in 0..0 {
                            #![rustc_dummy]
                        };
-    // FIXME: pp bug, two spaces after the loop
     let _ =
-        #[rustc_dummy] loop  {
+        #[rustc_dummy] loop {
                            #![rustc_dummy]
                        };
     let _ = #[rustc_dummy] match false { _ => (), };

--- a/src/test/ui/issues/issue-51714.rs
+++ b/src/test/ui/issues/issue-51714.rs
@@ -1,13 +1,21 @@
 fn main() {
+//~^ NOTE: not the enclosing function body
+//~| NOTE: not the enclosing function body
+//~| NOTE: not the enclosing function body
+//~| NOTE: not the enclosing function body
     |_:  [_; return || {}] | {};
-    //~^ ERROR return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 
     [(); return || {}];
-    //~^ ERROR return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 
     [(); return |ice| {}];
-    //~^ ERROR return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 
     [(); return while let Some(n) = Some(0) {}];
-    //~^ ERROR return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 }

--- a/src/test/ui/issues/issue-51714.stderr
+++ b/src/test/ui/issues/issue-51714.stderr
@@ -1,26 +1,62 @@
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-51714.rs:2:14
+  --> $DIR/issue-51714.rs:6:14
    |
-LL |     |_:  [_; return || {}] | {};
-   |              ^^^^^^^^^^^^
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+LL | |
+LL | |     |_:  [_; return || {}] | {};
+   | |              ^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
 
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-51714.rs:5:10
+  --> $DIR/issue-51714.rs:10:10
    |
-LL |     [(); return || {}];
-   |          ^^^^^^^^^^^^
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     [(); return || {}];
+   | |          ^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
 
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-51714.rs:8:10
+  --> $DIR/issue-51714.rs:14:10
    |
-LL |     [(); return |ice| {}];
-   |          ^^^^^^^^^^^^^^^
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     [(); return |ice| {}];
+   | |          ^^^^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
 
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-51714.rs:11:10
+  --> $DIR/issue-51714.rs:18:10
    |
-LL |     [(); return while let Some(n) = Some(0) {}];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     [(); return while let Some(n) = Some(0) {}];
+   | |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the return is part of this body...
+LL | |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
@@ -1,0 +1,22 @@
+// Due to a compiler bug, if a return occurs outside of a function body
+// (e.g. in an AnonConst body), the return value expression would not be
+// type-checked, leading to an ICE. This test checks that the ICE no
+// longer happens, and that an appropriate error message is issued that
+// also explains why the return is considered "outside of a function body"
+// if it seems to be inside one, as in the main function below.
+
+const C: [(); 42] = {
+    [(); return || {
+    //~^ ERROR: return statement outside of function body [E0572]
+        let tx;
+    }]
+};
+
+fn main() {
+//~^ NOTE: ...not the enclosing function body
+    [(); return || {
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
+        let tx;
+    }];
+}

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
@@ -1,0 +1,28 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:9:10
+   |
+LL |       [(); return || {
+   |  __________^
+LL | |
+LL | |         let tx;
+LL | |     }]
+   | |_____^
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:17:10
+   |
+LL |  / fn main() {
+LL |  |
+LL |  |     [(); return || {
+   |  |__________^
+LL | ||
+LL | ||
+LL | ||         let tx;
+LL | ||     }];
+   | ||_____^ the return is part of this body...
+LL |  | }
+   |  |_- ...not the enclosing function body
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0572`.

--- a/src/test/ui/return/return-match-array-const.rs
+++ b/src/test/ui/return/return-match-array-const.rs
@@ -1,10 +1,19 @@
 fn main() {
+//~^ NOTE: not the enclosing function body
+//~| NOTE: not the enclosing function body
+//~| NOTE: not the enclosing function body
     [(); return match 0 { n => n }];
-    //~^ ERROR: return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 
     [(); return match 0 { 0 => 0 }];
-    //~^ ERROR: return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
 
     [(); return match () { 'a' => 0, _ => 0 }];
-    //~^ ERROR: return statement outside of function body
+    //~^ ERROR: return statement outside of function body [E0572]
+    //~| NOTE: the return is part of this body...
+    //~| ERROR: mismatched types [E0308]
+    //~| NOTE: expected `()`, found `char`
+    //~| NOTE: this expression has type `()`
 }

--- a/src/test/ui/return/return-match-array-const.stderr
+++ b/src/test/ui/return/return-match-array-const.stderr
@@ -1,21 +1,56 @@
 error[E0572]: return statement outside of function body
-  --> $DIR/return-match-array-const.rs:2:10
-   |
-LL |     [(); return match 0 { n => n }];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0572]: return statement outside of function body
   --> $DIR/return-match-array-const.rs:5:10
    |
-LL |     [(); return match 0 { 0 => 0 }];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+LL | |     [(); return match 0 { n => n }];
+   | |          ^^^^^^^^^^^^^^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
 
 error[E0572]: return statement outside of function body
-  --> $DIR/return-match-array-const.rs:8:10
+  --> $DIR/return-match-array-const.rs:9:10
+   |
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     [(); return match 0 { 0 => 0 }];
+   | |          ^^^^^^^^^^^^^^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
+
+error[E0572]: return statement outside of function body
+  --> $DIR/return-match-array-const.rs:13:10
+   |
+LL | / fn main() {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     [(); return match () { 'a' => 0, _ => 0 }];
+   | |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the return is part of this body...
+...  |
+LL | |
+LL | | }
+   | |_- ...not the enclosing function body
+
+error[E0308]: mismatched types
+  --> $DIR/return-match-array-const.rs:13:28
    |
 LL |     [(); return match () { 'a' => 0, _ => 0 }];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       --   ^^^ expected `()`, found `char`
+   |                       |
+   |                       this expression has type `()`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0572`.
+Some errors have detailed explanations: E0308, E0572.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-impl-trait/issue-65384.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.rs
@@ -1,0 +1,16 @@
+#![feature(min_type_alias_impl_trait)]
+#![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
+
+trait MyTrait {}
+
+impl MyTrait for () {}
+
+type Bar = impl MyTrait;
+
+impl MyTrait for Bar {}
+//~^ ERROR: cannot implement trait on type alias impl trait
+
+fn bazr() -> Bar { }
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-65384.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.stderr
@@ -1,0 +1,14 @@
+error: cannot implement trait on type alias impl trait
+  --> $DIR/issue-65384.rs:11:1
+   |
+LL | impl MyTrait for Bar {}
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/issue-65384.rs:9:12
+   |
+LL | type Bar = impl MyTrait;
+   |            ^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -4,6 +4,7 @@ allow-unauthenticated = [
     "D-*",
     "requires-nightly",
     "regression-*",
+    "perf-regression",
     # I-* without I-nominated
     "I-*", "!I-nominated",
     "AsyncAwait-OnDeck",


### PR DESCRIPTION
Successful merges:

 - #86206 (Fix type checking of return expressions outside of function bodies)
 - #86358 (fix pretty print for `loop`)
 - #86568 (Don't dist miri or rust-analyzer on stable or beta.)
 - #86683 (:arrow_up: rust-analyzer)
 - #86687 (Allow anyone to set `perf-regression` label)
 - #86688 (Add a regression test for issue-65384)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86206,86358,86568,86683,86687,86688)
<!-- homu-ignore:end -->