### PR TITLE
Nellshamrell/improve async error

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1489,7 +1489,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
                             err.span_label(
                                 *sp,
-                                format!("{}", "calling an async function returns a future"),
+                                format!("{}", "async functions return futures"),
                             );
                         } else {
                             err.span_label(

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1487,10 +1487,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     let mut returned_async_output_error = false;
                     for sp in values {
                         if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
-                            err.span_label(
-                                *sp,
-                                format!("{}", "async functions return futures"),
-                            );
+                            err.span_label(*sp, format!("{}", "async functions return futures"));
                         } else {
                             err.span_label(
                                 *sp,

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1481,11 +1481,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 target: &str,
                 types: &FxHashMap<TyCategory, FxHashSet<Span>>,
             ) {
-                for (key, values) in types.iter() {
-                    let count = values.len();
-                    let kind = key.descr();
+                for (ty_category, spans) in types.iter() {
+                    let count = spans.len();
+                    let kind = ty_category.descr();
                     let mut returned_async_output_error = false;
-                    for sp in values {
+                    for sp in spans {
                         if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
                             err.span_label(*sp, format!("{}", "async functions return futures"));
                             err.note("while checking the return type of the `async fn`");

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1488,6 +1488,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     for sp in values {
                         if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
                             err.span_label(*sp, format!("{}", "async functions return futures"));
+                            err.note("while checking the return type of the `async fn`");
+                            returned_async_output_error = true;
                         } else {
                             err.span_label(
                                 *sp,
@@ -1500,12 +1502,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                     pluralize!(count),
                                 ),
                             );
-                        }
-                        if sp.is_desugaring(DesugaringKind::Async)
-                            && returned_async_output_error == false
-                        {
-                            err.note("while checking the return type of the `async fn`");
-                            returned_async_output_error = true;
                         }
                     }
                 }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2523,7 +2523,7 @@ impl<'tcx> ObligationCauseExt<'tcx> for ObligationCause<'tcx> {
 
 /// This is a bare signal of what kind of type we're dealing with. `ty::TyKind` tracks
 /// extra information about each type, but we only care about the category.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TyCategory {
     Closure,
     Opaque,

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1486,25 +1486,24 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     let kind = key.descr();
                     let mut returned_async_output_error = false;
                     for sp in values {
-                        err.span_label(
-                            *sp,
-                            format!(
-                                "{}{}{} {}{}",
-                                if sp.is_desugaring(DesugaringKind::Async)
-                                    && !returned_async_output_error
-                                {
-                                    "checked the `Output` of this `async fn`, "
-                                } else if count == 1 {
-                                    "the "
-                                } else {
-                                    ""
-                                },
-                                if count > 1 { "one of the " } else { "" },
-                                target,
-                                kind,
-                                pluralize!(count),
-                            ),
-                        );
+                        if sp.is_desugaring(DesugaringKind::Async) && !returned_async_output_error {
+                            err.span_label(
+                                *sp,
+                                format!("{}", "calling an async function returns a future"),
+                            );
+                        } else {
+                            err.span_label(
+                                *sp,
+                                format!(
+                                    "{}{}{} {}{}",
+                                    if count == 1 { "the " } else { "" },
+                                    if count > 1 { "one of the " } else { "" },
+                                    target,
+                                    kind,
+                                    pluralize!(count),
+                                ),
+                            );
+                        }
                         if sp.is_desugaring(DesugaringKind::Async)
                             && returned_async_output_error == false
                         {
@@ -1768,7 +1767,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         if let ObligationCauseCode::CompareImplMethodObligation { .. } = &cause.code {
             return;
         }
-
         match (
             self.get_impl_future_output_ty(exp_found.expected),
             self.get_impl_future_output_ty(exp_found.found),
@@ -2525,7 +2523,7 @@ impl<'tcx> ObligationCauseExt<'tcx> for ObligationCause<'tcx> {
 
 /// This is a bare signal of what kind of type we're dealing with. `ty::TyKind` tracks
 /// extra information about each type, but we only care about the category.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum TyCategory {
     Closure,
     Opaque,

--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-missing-await.rs:14:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- checked the `Output` of this `async fn`, found opaque type
+   |                        --- calling an async function returns a future
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type

--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-missing-await.rs:14:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- calling an async function returns a future
+   |                        --- async functions return futures
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -13,9 +13,9 @@ error[E0308]: mismatched types
   --> $DIR/generator-desc.rs:12:16
    |
 LL | async fn one() {}
-   |                - checked the `Output` of this `async fn`, expected opaque type
+   |                - calling an async function returns a future
 LL | async fn two() {}
-   |                - checked the `Output` of this `async fn`, found opaque type
+   |                - calling an async function returns a future
 ...
 LL |     fun(one(), two());
    |                ^^^^^ expected opaque type, found a different opaque type

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -13,9 +13,9 @@ error[E0308]: mismatched types
   --> $DIR/generator-desc.rs:12:16
    |
 LL | async fn one() {}
-   |                - calling an async function returns a future
+   |                - async functions return futures
 LL | async fn two() {}
-   |                - calling an async function returns a future
+   |                - async functions return futures
 ...
 LL |     fun(one(), two());
    |                ^^^^^ expected opaque type, found a different opaque type

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -56,7 +56,7 @@ async fn struct_() -> Struct {
 }
 
 async fn tuple() -> Tuple {
-    //~^ NOTE checked the `Output` of this `async fn`, expected opaque type
+    //~^ NOTE calling an async function returns a future
     Tuple(1i32)
 }
 

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -56,7 +56,7 @@ async fn struct_() -> Struct {
 }
 
 async fn tuple() -> Tuple {
-    //~^ NOTE calling an async function returns a future
+    //~^ NOTE async functions return futures
     Tuple(1i32)
 }
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -61,7 +61,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-61076.rs:92:9
    |
 LL | async fn tuple() -> Tuple {
-   |                     ----- checked the `Output` of this `async fn`, expected opaque type
+   |                     ----- calling an async function returns a future
 ...
 LL |         Tuple(_) => {}
    |         ^^^^^^^^ expected opaque type, found struct `Tuple`

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -61,7 +61,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-61076.rs:92:9
    |
 LL | async fn tuple() -> Tuple {
-   |                     ----- calling an async function returns a future
+   |                     ----- async functions return futures
 ...
 LL |         Tuple(_) => {}
    |         ^^^^^^^^ expected opaque type, found struct `Tuple`

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await-closure.rs:16:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- checked the `Output` of this `async fn`, found opaque type
+   |                        --- calling an async function returns a future
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await-closure.rs:16:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- calling an async function returns a future
+   |                        --- async functions return futures
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:12:14
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- checked the `Output` of this `async fn`, found opaque type
+   |                        --- calling an async function returns a future
 ...
 LL |     take_u32(x)
    |              ^ expected `u32`, found opaque type
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:22:5
    |
 LL | async fn dummy() {}
-   |                  - checked the `Output` of this `async fn`, found opaque type
+   |                  - calling an async function returns a future
 ...
 LL |     dummy()
    |     ^^^^^^^ expected `()`, found opaque type

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:12:14
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- calling an async function returns a future
+   |                        --- async functions return futures
 ...
 LL |     take_u32(x)
    |              ^ expected `u32`, found opaque type
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:22:5
    |
 LL | async fn dummy() {}
-   |                  - calling an async function returns a future
+   |                  - async functions return futures
 ...
 LL |     dummy()
    |     ^^^^^^^ expected `()`, found opaque type

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -189,7 +189,7 @@ LL |         async fn ft1();
 LL |         async fn ft1() {}
    |                        ^
    |                        |
-   |                        checked the `Output` of this `async fn`, found opaque type
+   |                        calling an async function returns a future
    |                        expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`
@@ -205,7 +205,7 @@ LL |         const async unsafe extern "C" fn ft5();
 LL |         const async unsafe extern "C" fn ft5() {}
    |                                                ^
    |                                                |
-   |                                                checked the `Output` of this `async fn`, found opaque type
+   |                                                calling an async function returns a future
    |                                                expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -189,7 +189,7 @@ LL |         async fn ft1();
 LL |         async fn ft1() {}
    |                        ^
    |                        |
-   |                        calling an async function returns a future
+   |                        async functions return futures
    |                        expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`
@@ -205,7 +205,7 @@ LL |         const async unsafe extern "C" fn ft5();
 LL |         const async unsafe extern "C" fn ft5() {}
    |                                                ^
    |                                                |
-   |                                                calling an async function returns a future
+   |                                                async functions return futures
    |                                                expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -53,7 +53,7 @@ LL |     async fn associated();
 LL |     async fn associated();
    |                          ^
    |                          |
-   |                          checked the `Output` of this `async fn`, found opaque type
+   |                          calling an async function returns a future
    |                          expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -53,7 +53,7 @@ LL |     async fn associated();
 LL |     async fn associated();
    |                          ^
    |                          |
-   |                          calling an async function returns a future
+   |                          async functions return futures
    |                          expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -17,7 +17,7 @@ LL | |     }
   ::: $DIR/auxiliary/issue-81839.rs:6:49
    |
 LL |       pub async fn answer_str(&self, _s: &str) -> Test {
-   |                                                   ---- checked the `Output` of this `async fn`, found opaque type
+   |                                                   ---- calling an async function returns a future
    |
    = note: while checking the return type of the `async fn`
    = note:     expected type `()`

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -17,7 +17,7 @@ LL | |     }
   ::: $DIR/auxiliary/issue-81839.rs:6:49
    |
 LL |       pub async fn answer_str(&self, _s: &str) -> Test {
-   |                                                   ---- calling an async function returns a future
+   |                                                   ---- async functions return futures
    |
    = note: while checking the return type of the `async fn`
    = note:     expected type `()`

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -13,9 +13,9 @@ fn extra_semicolon() {
     };
 }
 
-async fn async_dummy() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-async fn async_dummy2() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
-//~| NOTE checked the `Output` of this `async fn`, found opaque type
+async fn async_dummy() {} //~ NOTE calling an async function returns a future
+async fn async_dummy2() {} //~ NOTE calling an async function returns a future
+//~| NOTE calling an async function returns a future
 
 async fn async_extra_semicolon_same() {
     let _ = match true { //~ NOTE `match` arms have incompatible types

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -13,9 +13,9 @@ fn extra_semicolon() {
     };
 }
 
-async fn async_dummy() {} //~ NOTE calling an async function returns a future
-async fn async_dummy2() {} //~ NOTE calling an async function returns a future
-//~| NOTE calling an async function returns a future
+async fn async_dummy() {} //~ NOTE async functions return futures
+async fn async_dummy2() {} //~ NOTE async functions return futures
+//~| NOTE async functions return futures
 
 async fn async_extra_semicolon_same() {
     let _ = match true { //~ NOTE `match` arms have incompatible types

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -2,7 +2,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:26:18
    |
 LL |   async fn async_dummy() {}
-   |                          - checked the `Output` of this `async fn`, found opaque type
+   |                          - calling an async function returns a future
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -34,7 +34,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:40:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - checked the `Output` of this `async fn`, found opaque type
+   |                           - calling an async function returns a future
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -69,7 +69,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:52:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - checked the `Output` of this `async fn`, found opaque type
+   |                           - calling an async function returns a future
 ...
 LL |       let _ = match true {
    |  _____________-

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -2,7 +2,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:26:18
    |
 LL |   async fn async_dummy() {}
-   |                          - calling an async function returns a future
+   |                          - async functions return futures
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -34,7 +34,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:40:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - calling an async function returns a future
+   |                           - async functions return futures
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -69,7 +69,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:52:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - calling an async function returns a future
+   |                           - async functions return futures
 ...
 LL |       let _ = match true {
    |  _____________-


### PR DESCRIPTION
This is at least a partial fix for #80658

Prior to this fix, when someone attempted to compile this code:

```rust
fn main() {

}

fn foo() -> u8 {
    async fn async_fn() -> u8 {  22 }

    async_fn()
}
```

The would receive this output:

```bash
error[E0308]: mismatched types
 --> src/lib.rs:4:5
  |
1 | fn foo() -> u8 {
  |             -- expected `u8` because of return type
2 |     async fn async_fn() -> u8 {  22 }
  |                            -- the `Output` of this `async fn`'s found opaque type
3 |     
4 |     async_fn()
  |     ^^^^^^^^^^ expected `u8`, found opaque type
  |
  = note:     expected type `u8`
          found opaque type `impl std::future::Future`
```

If this change is merged, someone compiling the same code will then get this output instead:

```bash
error[E0308]: mismatched types
 --> src/lib.rs:8:5
  |
5 | fn foo() -> u8 {
  |             -- expected `u8` because of return type
6 |     async fn async_fn() -> u8 {  22 }
  |                            -- calling an async function returns a future
7 |
8 |     async_fn()
  |     ^^^^^^^^^^ expected `u8`, found opaque type
  |
  = note: while checking the return type of the `async fn`
  = note:     expected type `u8`
          found opaque type `impl Future`
help: consider `await`ing on the `Future`
  |
8 |     async_fn().await
  |               ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
```