### PR TITLE
Rename some Rust 2021 lints to better names 

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -18,7 +18,9 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_feature::Features;
-use rustc_lint_defs::builtin::{OR_PATTERNS_BACK_COMPAT, SEMICOLON_IN_EXPRESSIONS_FROM_MACROS};
+use rustc_lint_defs::builtin::{
+    RUST_2021_INCOMPATIBLE_OR_PATTERNS, SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+};
 use rustc_lint_defs::BuiltinLintDiagnostics;
 use rustc_parse::parser::Parser;
 use rustc_session::parse::ParseSess;
@@ -975,7 +977,7 @@ fn check_matcher_core(
                             Some(NonterminalKind::PatParam { inferred: false }),
                         ));
                         sess.buffer_lint_with_diagnostic(
-                            &OR_PATTERNS_BACK_COMPAT,
+                            &RUST_2021_INCOMPATIBLE_OR_PATTERNS,
                             span,
                             ast::CRATE_NODE_ID,
                             "the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro",

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -327,6 +327,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("safe_packed_borrows", "unaligned_references");
     store.register_renamed("disjoint_capture_migration", "rust_2021_incompatible_closure_captures");
     store.register_renamed("or_patterns_back_compat", "rust_2021_incompatible_or_patterns");
+    store.register_renamed("non_fmt_panic", "non_fmt_panics");
 
     // These were moved to tool lints, but rustc still sees them when compiling normally, before
     // tool lints are registered, so `check_tool_name_for_backwards_compat` doesn't work. Use

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -325,6 +325,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("redundant_semicolon", "redundant_semicolons");
     store.register_renamed("overlapping_patterns", "overlapping_range_endpoints");
     store.register_renamed("safe_packed_borrows", "unaligned_references");
+    store.register_renamed("disjoint_capture_migration", "rust_2021_incompatible_closure_captures");
 
     // These were moved to tool lints, but rustc still sees them when compiling normally, before
     // tool lints are registered, so `check_tool_name_for_backwards_compat` doesn't work. Use

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -326,6 +326,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("overlapping_patterns", "overlapping_range_endpoints");
     store.register_renamed("safe_packed_borrows", "unaligned_references");
     store.register_renamed("disjoint_capture_migration", "rust_2021_incompatible_closure_captures");
+    store.register_renamed("or_patterns_back_compat", "rust_2021_incompatible_or_patterns");
 
     // These were moved to tool lints, but rustc still sees them when compiling normally, before
     // tool lints are registered, so `check_tool_name_for_backwards_compat` doesn't work. Use

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -9,7 +9,7 @@ use rustc_span::edition::Edition;
 use rustc_span::{hygiene, sym, symbol::kw, symbol::SymbolStr, InnerSpan, Span, Symbol};
 
 declare_lint! {
-    /// The `non_fmt_panic` lint detects `panic!(..)` invocations where the first
+    /// The `non_fmt_panics` lint detects `panic!(..)` invocations where the first
     /// argument is not a formatting string.
     ///
     /// ### Example
@@ -29,7 +29,7 @@ declare_lint! {
     /// an `i32` as message.
     ///
     /// Rust 2021 always interprets the first argument as format string.
-    NON_FMT_PANIC,
+    NON_FMT_PANICS,
     Warn,
     "detect single-argument panic!() invocations in which the argument is not a format string",
     @future_incompatible = FutureIncompatibleInfo {
@@ -39,7 +39,7 @@ declare_lint! {
     report_in_external_macro
 }
 
-declare_lint_pass!(NonPanicFmt => [NON_FMT_PANIC]);
+declare_lint_pass!(NonPanicFmt => [NON_FMT_PANICS]);
 
 impl<'tcx> LateLintPass<'tcx> for NonPanicFmt {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
@@ -91,7 +91,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
         arg_span = expn.call_site;
     }
 
-    cx.struct_span_lint(NON_FMT_PANIC, arg_span, |lint| {
+    cx.struct_span_lint(NON_FMT_PANICS, arg_span, |lint| {
         let mut l = lint.build("panic message is not a string literal");
         l.note("this usage of panic!() is deprecated; it will be a hard error in Rust 2021");
         l.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>");
@@ -174,7 +174,7 @@ fn check_panic_str<'tcx>(
             [] => vec![fmt_span],
             v => v.iter().map(|span| fmt_span.from_inner(*span)).collect(),
         };
-        cx.struct_span_lint(NON_FMT_PANIC, arg_spans, |lint| {
+        cx.struct_span_lint(NON_FMT_PANICS, arg_spans, |lint| {
             let mut l = lint.build(match n_arguments {
                 1 => "panic message contains an unused formatting placeholder",
                 _ => "panic message contains unused formatting placeholders",
@@ -208,7 +208,7 @@ fn check_panic_str<'tcx>(
             Some(v) if v.len() == 1 => "panic message contains a brace",
             _ => "panic message contains braces",
         };
-        cx.struct_span_lint(NON_FMT_PANIC, brace_spans.unwrap_or_else(|| vec![span]), |lint| {
+        cx.struct_span_lint(NON_FMT_PANICS, brace_spans.unwrap_or_else(|| vec![span]), |lint| {
             let mut l = lint.build(msg);
             l.note("this message is not used as a format string, but will be in Rust 2021");
             if span.contains(arg.span) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2972,7 +2972,7 @@ declare_lint_pass! {
         PROC_MACRO_BACK_COMPAT,
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
-        FUTURE_PRELUDE_COLLISION,
+        FUTURE_PRELUDE_COLLISIONS,
         RESERVED_PREFIX,
         UNSUPPORTED_CALLING_CONVENTIONS,
     ]
@@ -3221,13 +3221,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `future_prelude_collision` lint detects the usage of trait methods which are ambiguous
+    /// The `future_prelude_collisions` lint detects the usage of trait methods which are ambiguous
     /// with traits added to the prelude in future editions.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(future_prelude_collision)]
+    /// #![deny(future_prelude_collisions)]
     ///
     /// trait Foo {
     ///     fn try_into(self) -> Result<String, !>;
@@ -3259,7 +3259,7 @@ declare_lint! {
     ///  is called directly on a type.
     ///
     /// [prelude changes]: https://blog.rust-lang.org/inside-rust/2021/03/04/planning-rust-2021.html#prelude-changes
-    pub FUTURE_PRELUDE_COLLISION,
+    pub FUTURE_PRELUDE_COLLISIONS,
     Allow,
     "detects the usage of trait methods which are ambiguous with traits added to the \
         prelude in future editions",

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2973,7 +2973,7 @@ declare_lint_pass! {
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
         RUST_2021_PRELUDE_COLLISIONS,
-        RUST_2021_TOKEN_PREFIXES,
+        RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX,
         UNSUPPORTED_CALLING_CONVENTIONS,
     ]
 }
@@ -3270,13 +3270,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `rust_2021_token_prefixes` lint detects identifiers that will be parsed as a
+    /// The `rust_2021_prefixes_incompatible_syntax` lint detects identifiers that will be parsed as a
     /// prefix instead in Rust 2021.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(rust_2021_token_prefixes)]
+    /// #![deny(rust_2021_prefixes_incompatible_syntax)]
     ///
     /// macro_rules! m {
     ///     (z $x:expr) => ();
@@ -3295,7 +3295,7 @@ declare_lint! {
     ///
     /// This lint suggests to add whitespace between the `z` and `"hey"` tokens
     /// to keep them separated in Rust 2021.
-    pub RUST_2021_TOKEN_PREFIXES,
+    pub RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX,
     Allow,
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2973,7 +2973,7 @@ declare_lint_pass! {
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
         FUTURE_PRELUDE_COLLISIONS,
-        RESERVED_PREFIXES,
+        RUST_2021_TOKEN_PREFIXES,
         UNSUPPORTED_CALLING_CONVENTIONS,
     ]
 }
@@ -3270,13 +3270,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `reserved_prefixes` lint detects identifiers that will be parsed as a
+    /// The `rust_2021_token_prefixes` lint detects identifiers that will be parsed as a
     /// prefix instead in Rust 2021.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(reserved_prefixes)]
+    /// #![deny(rust_2021_token_prefixes)]
     ///
     /// macro_rules! m {
     ///     (z $x:expr) => ();
@@ -3295,7 +3295,7 @@ declare_lint! {
     ///
     /// This lint suggests to add whitespace between the `z` and `"hey"` tokens
     /// to keep them separated in Rust 2021.
-    pub RESERVED_PREFIXES,
+    pub RUST_2021_TOKEN_PREFIXES,
     Allow,
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2967,7 +2967,7 @@ declare_lint_pass! {
         MISSING_ABI,
         INVALID_DOC_ATTRIBUTES,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
-        DISJOINT_CAPTURE_MIGRATION,
+        RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
         LEGACY_DERIVE_HELPERS,
         PROC_MACRO_BACK_COMPAT,
         OR_PATTERNS_BACK_COMPAT,
@@ -3002,7 +3002,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `disjoint_capture_migration` lint detects variables that aren't completely
+    /// The `rust_2021_incompatible_closure_captures` lint detects variables that aren't completely
     /// captured in Rust 2021 and affect the Drop order of at least one path starting at this variable.
     /// It can also detect when a variable implements a trait, but one of its field does not and
     /// the field is captured by a closure and used with the assumption that said field implements
@@ -3011,7 +3011,7 @@ declare_lint! {
     /// ### Example of drop reorder
     ///
     /// ```rust,compile_fail
-    /// # #![deny(disjoint_capture_migration)]
+    /// # #![deny(rust_2021_incompatible_closure_captures)]
     /// # #![allow(unused)]
     /// struct FancyInteger(i32);
     ///
@@ -3046,7 +3046,7 @@ declare_lint! {
     /// ### Example of auto-trait
     ///
     /// ```rust,compile_fail
-    /// #![deny(disjoint_capture_migration)]
+    /// #![deny(rust_2021_incompatible_closure_captures)]
     /// use std::thread;
     ///
     /// struct Pointer(*mut i32);
@@ -3068,7 +3068,7 @@ declare_lint! {
     /// In the above example, only `fptr.0` is captured in Rust 2021.
     /// The field is of type *mut i32 which doesn't implement Send, making the code invalid as the
     /// field cannot be sent between thread safely.
-    pub DISJOINT_CAPTURE_MIGRATION,
+    pub RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
     Allow,
     "detects closures affected by Rust 2021 changes",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2973,7 +2973,7 @@ declare_lint_pass! {
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
         FUTURE_PRELUDE_COLLISIONS,
-        RESERVED_PREFIX,
+        RESERVED_PREFIXES,
         UNSUPPORTED_CALLING_CONVENTIONS,
     ]
 }
@@ -3270,13 +3270,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `reserved_prefix` lint detects identifiers that will be parsed as a
+    /// The `reserved_prefixes` lint detects identifiers that will be parsed as a
     /// prefix instead in Rust 2021.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(reserved_prefix)]
+    /// #![deny(reserved_prefixes)]
     ///
     /// macro_rules! m {
     ///     (z $x:expr) => ();
@@ -3295,7 +3295,7 @@ declare_lint! {
     ///
     /// This lint suggests to add whitespace between the `z` and `"hey"` tokens
     /// to keep them separated in Rust 2021.
-    pub RESERVED_PREFIX,
+    pub RESERVED_PREFIXES,
     Allow,
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2970,7 +2970,7 @@ declare_lint_pass! {
         RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
         LEGACY_DERIVE_HELPERS,
         PROC_MACRO_BACK_COMPAT,
-        OR_PATTERNS_BACK_COMPAT,
+        RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
         FUTURE_PRELUDE_COLLISION,
         RESERVED_PREFIX,
@@ -3183,12 +3183,12 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `or_patterns_back_compat` lint detects usage of old versions of or-patterns.
+    /// The `rust_2021_incompatible_or_patterns` lint detects usage of old versions of or-patterns.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(or_patterns_back_compat)]
+    /// #![deny(rust_2021_incompatible_or_patterns)]
     /// macro_rules! match_any {
     ///     ( $expr:expr , $( $( $pat:pat )|+ => $expr_arm:expr ),+ ) => {
     ///         match $expr {
@@ -3211,7 +3211,7 @@ declare_lint! {
     /// ### Explanation
     ///
     /// In Rust 2021, the pat matcher will match new patterns, which include the | character.
-    pub OR_PATTERNS_BACK_COMPAT,
+    pub RUST_2021_INCOMPATIBLE_OR_PATTERNS,
     Allow,
     "detects usage of old versions of or-patterns",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2972,7 +2972,7 @@ declare_lint_pass! {
         PROC_MACRO_BACK_COMPAT,
         RUST_2021_INCOMPATIBLE_OR_PATTERNS,
         LARGE_ASSIGNMENTS,
-        FUTURE_PRELUDE_COLLISIONS,
+        RUST_2021_PRELUDE_COLLISIONS,
         RUST_2021_TOKEN_PREFIXES,
         UNSUPPORTED_CALLING_CONVENTIONS,
     ]
@@ -3221,13 +3221,13 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `future_prelude_collisions` lint detects the usage of trait methods which are ambiguous
+    /// The `rust_2021_prelude_collisions` lint detects the usage of trait methods which are ambiguous
     /// with traits added to the prelude in future editions.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(future_prelude_collisions)]
+    /// #![deny(rust_2021_prelude_collisions)]
     ///
     /// trait Foo {
     ///     fn try_into(self) -> Result<String, !>;
@@ -3259,7 +3259,7 @@ declare_lint! {
     ///  is called directly on a type.
     ///
     /// [prelude changes]: https://blog.rust-lang.org/inside-rust/2021/03/04/planning-rust-2021.html#prelude-changes
-    pub FUTURE_PRELUDE_COLLISIONS,
+    pub RUST_2021_PRELUDE_COLLISIONS,
     Allow,
     "detects the usage of trait methods which are ambiguous with traits added to the \
         prelude in future editions",

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -4,7 +4,7 @@ use rustc_ast::tokenstream::{Spacing, TokenStream};
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, FatalError, PResult};
 use rustc_lexer::unescape::{self, Mode};
 use rustc_lexer::{Base, DocStyle, RawStrError};
-use rustc_session::lint::builtin::RESERVED_PREFIX;
+use rustc_session::lint::builtin::RESERVED_PREFIXES;
 use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::parse::ParseSess;
 use rustc_span::symbol::{sym, Symbol};
@@ -526,7 +526,7 @@ impl<'a> StringReader<'a> {
         } else {
             // Before Rust 2021, only emit a lint for migration.
             self.sess.buffer_lint_with_diagnostic(
-                &RESERVED_PREFIX,
+                &RESERVED_PREFIXES,
                 prefix_span,
                 ast::CRATE_NODE_ID,
                 &msg,

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -4,7 +4,7 @@ use rustc_ast::tokenstream::{Spacing, TokenStream};
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, FatalError, PResult};
 use rustc_lexer::unescape::{self, Mode};
 use rustc_lexer::{Base, DocStyle, RawStrError};
-use rustc_session::lint::builtin::RUST_2021_TOKEN_PREFIXES;
+use rustc_session::lint::builtin::RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX;
 use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::parse::ParseSess;
 use rustc_span::symbol::{sym, Symbol};
@@ -526,7 +526,7 @@ impl<'a> StringReader<'a> {
         } else {
             // Before Rust 2021, only emit a lint for migration.
             self.sess.buffer_lint_with_diagnostic(
-                &RUST_2021_TOKEN_PREFIXES,
+                &RUST_2021_PREFIXES_INCOMPATIBLE_SYNTAX,
                 prefix_span,
                 ast::CRATE_NODE_ID,
                 &msg,

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -4,7 +4,7 @@ use rustc_ast::tokenstream::{Spacing, TokenStream};
 use rustc_errors::{error_code, Applicability, DiagnosticBuilder, FatalError, PResult};
 use rustc_lexer::unescape::{self, Mode};
 use rustc_lexer::{Base, DocStyle, RawStrError};
-use rustc_session::lint::builtin::RESERVED_PREFIXES;
+use rustc_session::lint::builtin::RUST_2021_TOKEN_PREFIXES;
 use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::parse::ParseSess;
 use rustc_span::symbol::{sym, Symbol};
@@ -526,7 +526,7 @@ impl<'a> StringReader<'a> {
         } else {
             // Before Rust 2021, only emit a lint for migration.
             self.sess.buffer_lint_with_diagnostic(
-                &RESERVED_PREFIXES,
+                &RUST_2021_TOKEN_PREFIXES,
                 prefix_span,
                 ast::CRATE_NODE_ID,
                 &msg,

--- a/compiler/rustc_typeck/src/check/method/prelude2021.rs
+++ b/compiler/rustc_typeck/src/check/method/prelude2021.rs
@@ -5,7 +5,7 @@ use rustc_ast::Mutability;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_middle::ty::{Ref, Ty};
-use rustc_session::lint::builtin::FUTURE_PRELUDE_COLLISIONS;
+use rustc_session::lint::builtin::RUST_2021_PRELUDE_COLLISIONS;
 use rustc_span::symbol::kw::Underscore;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::Span;
@@ -67,7 +67,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Inherent impls only require not relying on autoref and autoderef in order to
             // ensure that the trait implementation won't be used
             self.tcx.struct_span_lint_hir(
-                FUTURE_PRELUDE_COLLISIONS,
+                RUST_2021_PRELUDE_COLLISIONS,
                 self_expr.hir_id,
                 self_expr.span,
                 |lint| {
@@ -128,7 +128,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // trait implementations require full disambiguation to not clash with the new prelude
             // additions (i.e. convert from dot-call to fully-qualified call)
             self.tcx.struct_span_lint_hir(
-                FUTURE_PRELUDE_COLLISIONS,
+                RUST_2021_PRELUDE_COLLISIONS,
                 call_expr.hir_id,
                 call_expr.span,
                 |lint| {
@@ -212,7 +212,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
-        self.tcx.struct_span_lint_hir(FUTURE_PRELUDE_COLLISIONS, expr_id, span, |lint| {
+        self.tcx.struct_span_lint_hir(RUST_2021_PRELUDE_COLLISIONS, expr_id, span, |lint| {
             // "type" refers to either a type or, more likely, a trait from which
             // the associated function or method is from.
             let trait_path = self.trait_path_or_bare_name(span, expr_id, pick.item.container.id());

--- a/compiler/rustc_typeck/src/check/method/prelude2021.rs
+++ b/compiler/rustc_typeck/src/check/method/prelude2021.rs
@@ -5,7 +5,7 @@ use rustc_ast::Mutability;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_middle::ty::{Ref, Ty};
-use rustc_session::lint::builtin::FUTURE_PRELUDE_COLLISION;
+use rustc_session::lint::builtin::FUTURE_PRELUDE_COLLISIONS;
 use rustc_span::symbol::kw::Underscore;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::Span;
@@ -67,7 +67,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Inherent impls only require not relying on autoref and autoderef in order to
             // ensure that the trait implementation won't be used
             self.tcx.struct_span_lint_hir(
-                FUTURE_PRELUDE_COLLISION,
+                FUTURE_PRELUDE_COLLISIONS,
                 self_expr.hir_id,
                 self_expr.span,
                 |lint| {
@@ -128,7 +128,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // trait implementations require full disambiguation to not clash with the new prelude
             // additions (i.e. convert from dot-call to fully-qualified call)
             self.tcx.struct_span_lint_hir(
-                FUTURE_PRELUDE_COLLISION,
+                FUTURE_PRELUDE_COLLISIONS,
                 call_expr.hir_id,
                 call_expr.span,
                 |lint| {
@@ -212,7 +212,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
-        self.tcx.struct_span_lint_hir(FUTURE_PRELUDE_COLLISION, expr_id, span, |lint| {
+        self.tcx.struct_span_lint_hir(FUTURE_PRELUDE_COLLISIONS, expr_id, span, |lint| {
             // "type" refers to either a type or, more likely, a trait from which
             // the associated function or method is from.
             let trait_path = self.trait_path_or_bare_name(span, expr_id, pick.item.container.id());

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1829,7 +1829,10 @@ fn var_name(tcx: TyCtxt<'_>, var_hir_id: hir::HirId) -> Symbol {
     tcx.hir().name(var_hir_id)
 }
 
-fn should_do_rust_2021_incompatible_closure_captures_analysis(tcx: TyCtxt<'_>, closure_id: hir::HirId) -> bool {
+fn should_do_rust_2021_incompatible_closure_captures_analysis(
+    tcx: TyCtxt<'_>,
+    closure_id: hir::HirId,
+) -> bool {
     let (level, _) =
         tcx.lint_level_at_node(lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES, closure_id);
 

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -173,7 +173,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let closure_hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
 
-        if should_do_disjoint_capture_migration_analysis(self.tcx, closure_hir_id) {
+        if should_do_rust_2021_incompatible_closure_captures_analysis(self.tcx, closure_hir_id) {
             self.perform_2229_migration_anaysis(closure_def_id, body_id, capture_clause, span);
         }
 
@@ -505,7 +505,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let local_def_id = closure_def_id.expect_local();
             let closure_hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
             self.tcx.struct_span_lint_hir(
-                lint::builtin::DISJOINT_CAPTURE_MIGRATION,
+                lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
                 closure_hir_id,
                 span,
                 |lint| {
@@ -1829,8 +1829,9 @@ fn var_name(tcx: TyCtxt<'_>, var_hir_id: hir::HirId) -> Symbol {
     tcx.hir().name(var_hir_id)
 }
 
-fn should_do_disjoint_capture_migration_analysis(tcx: TyCtxt<'_>, closure_id: hir::HirId) -> bool {
-    let (level, _) = tcx.lint_level_at_node(lint::builtin::DISJOINT_CAPTURE_MIGRATION, closure_id);
+fn should_do_rust_2021_incompatible_closure_captures_analysis(tcx: TyCtxt<'_>, closure_id: hir::HirId) -> bool {
+    let (level, _) =
+        tcx.lint_level_at_node(lint::builtin::RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES, closure_id);
 
     !matches!(level, lint::Level::Allow)
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -164,6 +164,7 @@
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
 #![deny(unsafe_op_in_unsafe_fn)]
+#![allow(renamed_and_removed_lints)]
 #![deny(or_patterns_back_compat)]
 
 // allow using `core::` in intra-doc links

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -164,8 +164,8 @@
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
 #![deny(unsafe_op_in_unsafe_fn)]
-#![allow(renamed_and_removed_lints)]
-#![deny(or_patterns_back_compat)]
+#![cfg_attr(bootstrap, deny(or_patterns_back_compat))]
+#![cfg_attr(not(bootstrap), deny(rust_2021_incompatible_or_patterns))]
 
 // allow using `core::` in intra-doc links
 #[allow(unused_extern_crates)]

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -1,10 +1,10 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 
 use std::thread;
 
 /* Test Send Trait Migration */
-struct SendPointer (*mut i32);
+struct SendPointer(*mut i32);
 unsafe impl Send for SendPointer {}
 
 fn test_send_trait() {
@@ -18,8 +18,8 @@ fn test_send_trait() {
 }
 
 /* Test Sync Trait Migration */
-struct CustomInt (*mut i32);
-struct SyncPointer (CustomInt);
+struct CustomInt(*mut i32);
+struct SyncPointer(CustomInt);
 unsafe impl Sync for SyncPointer {}
 unsafe impl Send for CustomInt {}
 
@@ -38,7 +38,7 @@ fn test_sync_trait() {
 struct S(String);
 struct T(i32);
 
-struct U(S,T);
+struct U(S, T);
 
 impl Clone for U {
     fn clone(&self) -> Self {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -1,10 +1,10 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 
 use std::thread;
 
 /* Test Send Trait Migration */
-struct SendPointer (*mut i32);
+struct SendPointer(*mut i32);
 unsafe impl Send for SendPointer {}
 
 fn test_send_trait() {
@@ -18,8 +18,8 @@ fn test_send_trait() {
 }
 
 /* Test Sync Trait Migration */
-struct CustomInt (*mut i32);
-struct SyncPointer (CustomInt);
+struct CustomInt(*mut i32);
+struct SyncPointer(CustomInt);
 unsafe impl Sync for SyncPointer {}
 unsafe impl Send for CustomInt {}
 
@@ -38,7 +38,7 @@ fn test_sync_trait() {
 struct S(String);
 struct T(i32);
 
-struct U(S,T);
+struct U(S, T);
 
 impl Clone for U {
     fn clone(&self) -> Self {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -12,8 +12,8 @@ LL | |     });
 note: the lint level is defined here
   --> $DIR/auto_traits.rs:2:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test cases for types that implement a insignificant drop (stlib defined)
@@ -13,9 +13,9 @@ fn test1_all_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || { let _ = (&t, &t1, &t2); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
@@ -33,9 +33,9 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || { let _ = (&t, &t1); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -50,9 +50,9 @@ fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -69,9 +69,9 @@ fn test4_only_non_copy_types_need_migration() {
     let t1 = (0i32, 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -88,9 +88,9 @@ fn test5_only_drop_types_need_migration() {
     let s = S(0i32, 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
     };
@@ -104,9 +104,9 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = move || { let _ = (&t1, &t); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
 
@@ -120,9 +120,9 @@ fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test cases for types that implement a insignificant drop (stlib defined)
@@ -13,9 +13,9 @@ fn test1_all_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
@@ -33,9 +33,9 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (String::new(), String::new());
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -50,9 +50,9 @@ fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -69,9 +69,9 @@ fn test4_only_non_copy_types_need_migration() {
     let t1 = (0i32, 0i32);
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -88,9 +88,9 @@ fn test5_only_drop_types_need_migration() {
     let s = S(0i32, 0i32);
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
     };
@@ -104,9 +104,9 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
     let c = move || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
 
@@ -120,9 +120,9 @@ fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -14,8 +14,8 @@ LL | |     };
 note: the lint level is defined here
   --> $DIR/insignificant_drop.rs:3:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -1,8 +1,7 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-
 #![feature(rustc_attrs)]
 #![allow(unused)]
 
@@ -36,9 +35,9 @@ fn significant_drop_needs_migration() {
     let t = (SigDrop {}, SigDrop {});
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -54,9 +53,9 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     // move is used to force i32 to be copied instead of being a ref
     let c = move || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
@@ -1,8 +1,7 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
-
 #![feature(rustc_attrs)]
 #![allow(unused)]
 
@@ -36,9 +35,9 @@ fn significant_drop_needs_migration() {
     let t = (SigDrop {}, SigDrop {});
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -54,9 +53,9 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     // move is used to force i32 to be copied instead of being a ref
     let c = move || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -1,5 +1,5 @@
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop_attr_migrations.rs:38:13
+  --> $DIR/insignificant_drop_attr_migrations.rs:37:13
    |
 LL |       let c = || {
    |  _____________^
@@ -13,8 +13,8 @@ LL | |     };
 note: the lint level is defined here
   --> $DIR/insignificant_drop_attr_migrations.rs:3:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
@@ -27,7 +27,7 @@ LL |     };
    |
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop_attr_migrations.rs:56:13
+  --> $DIR/insignificant_drop_attr_migrations.rs:55:13
    |
 LL |       let c = move || {
    |  _____________^

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_no_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_no_migrations.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 #![feature(rustc_attrs)]
 #![allow(unused)]
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
@@ -1,10 +1,10 @@
 // run-pass
 
-#![warn(disjoint_capture_migration)]
+#![warn(rust_2021_incompatible_closure_captures)]
 
 fn main() {
     if let a = "" {
-    //~^ WARNING: irrefutable `if let` pattern
+        //~^ WARNING: irrefutable `if let` pattern
         drop(|_: ()| drop(a));
     }
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test the two possible cases for automated migartion using rustfix

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test the two possible cases for automated migartion using rustfix

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -13,8 +13,8 @@ LL | |     };
 note: the lint level is defined here
   --> $DIR/migrations_rustfix.rs:2:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -1,16 +1,20 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 // ignore-wasm32-bare compiled with panic=abort by default
-
 #![feature(fn_traits)]
 #![feature(never_type)]
 
 use std::panic;
 
-fn foo_diverges() -> ! { panic!() }
+fn foo_diverges() -> ! {
+    panic!()
+}
 
-fn assert_panics<F>(f: F) where F: FnOnce() {
+fn assert_panics<F>(f: F)
+where
+    F: FnOnce(),
+{
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
@@ -23,7 +27,8 @@ fn assert_panics<F>(f: F) where F: FnOnce() {
 }
 
 fn test_fn_ptr_panic<T>(mut t: T)
-    where T: Fn() -> !
+where
+    T: Fn() -> !,
 {
     let as_fn = <T as Fn<()>>::call;
     assert_panics(|| as_fn(&t, ()));

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -1,16 +1,20 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 // ignore-wasm32-bare compiled with panic=abort by default
-
 #![feature(fn_traits)]
 #![feature(never_type)]
 
 use std::panic;
 
-fn foo_diverges() -> ! { panic!() }
+fn foo_diverges() -> ! {
+    panic!()
+}
 
-fn assert_panics<F>(f: F) where F: FnOnce() {
+fn assert_panics<F>(f: F)
+where
+    F: FnOnce(),
+{
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
@@ -23,7 +27,8 @@ fn assert_panics<F>(f: F) where F: FnOnce() {
 }
 
 fn test_fn_ptr_panic<T>(mut t: T)
-    where T: Fn() -> !
+where
+    T: Fn() -> !,
 {
     let as_fn = <T as Fn<()>>::call;
     assert_panics(|| as_fn(&t, ()));

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: `UnwindSafe`, `RefUnwindSafe` trait implementation will change in Rust 2021
-  --> $DIR/mir_calls_to_shims.rs:15:38
+  --> $DIR/mir_calls_to_shims.rs:19:38
    |
 LL |       let result = panic::catch_unwind(move || {
    |  ______________________________________^
@@ -12,8 +12,8 @@ LL | |     });
 note: the lint level is defined here
   --> $DIR/mir_calls_to_shims.rs:3:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
@@ -2,8 +2,7 @@
 
 // Set of test cases that don't need migrations
 
-#![deny(disjoint_capture_migration)]
-
+#![deny(rust_2021_incompatible_closure_captures)]
 
 // Copy types as copied by the closure instead of being moved into the closure
 // Therefore their drop order isn't tied to the closure and won't be requiring any
@@ -53,7 +52,6 @@ fn test4_insignificant_drop_non_drop_aggregate() {
     c();
 }
 
-
 struct Foo(i32);
 impl Drop for Foo {
     fn drop(&mut self) {
@@ -80,5 +78,4 @@ fn main() {
     test3_only_copy_types_move_closure();
     test4_insignificant_drop_non_drop_aggregate();
     test5_significant_drop_non_drop_aggregate();
-
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/old_name.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/old_name.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+// Ensure that the old name for `rust_2021_incompatible_closure_captures` is still
+// accepted by the compiler
+
+#![allow(disjoint_capture_migration)]
+//~^ WARN lint `disjoint_capture_migration` has been renamed
+
+fn main() {}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/old_name.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/old_name.stderr
@@ -1,0 +1,10 @@
+warning: lint `disjoint_capture_migration` has been renamed to `rust_2021_incompatible_closure_captures`
+  --> $DIR/old_name.rs:6:10
+   |
+LL | #![allow(disjoint_capture_migration)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rust_2021_incompatible_closure_captures`
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 
 #[derive(Debug)]
 struct Foo(i32);
@@ -17,8 +17,8 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
     };
@@ -28,8 +28,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
 struct S;
 impl Drop for S {
-    fn drop(&mut self) {
-    }
+    fn drop(&mut self) {}
 }
 
 struct T(S, S);
@@ -40,8 +39,8 @@ fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
     let c = || { let _ = &u; 
-    //~^ ERROR: drop order
-    //~| HELP: add a dummy let to cause `u` to be fully captured
+        //~^ ERROR: drop order
+        //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 
 #[derive(Debug)]
 struct Foo(i32);
@@ -17,8 +17,8 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
     };
@@ -28,8 +28,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
 struct S;
 impl Drop for S {
-    fn drop(&mut self) {
-    }
+    fn drop(&mut self) {}
 }
 
 struct T(S, S);
@@ -40,8 +39,8 @@ fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| HELP: add a dummy let to cause `u` to be fully captured
+        //~^ ERROR: drop order
+        //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -13,8 +13,8 @@ LL | |     };
 note: the lint level is defined here
   --> $DIR/precise.rs:3:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
@@ -27,7 +27,7 @@ LL |     };
    |
 
 error: drop order will change in Rust 2021
-  --> $DIR/precise.rs:42:13
+  --> $DIR/precise.rs:41:13
    |
 LL |       let c = || {
    |  _____________^

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise_no_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise_no_migrations.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 
 #[derive(Debug)]
 struct Foo(i32);
@@ -73,8 +73,7 @@ fn test_precise_analysis_parent_captured_2() {
 
 struct S;
 impl Drop for S {
-    fn drop(&mut self) {
-    }
+    fn drop(&mut self) {}
 }
 
 struct T(S, S);

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test cases for types that implement a significant drop (user defined)
@@ -23,9 +23,9 @@ fn test1_all_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || { let _ = (&t, &t1, &t2); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -42,9 +42,9 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || { let _ = (&t, &t1); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -59,9 +59,9 @@ fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -77,9 +77,9 @@ fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -93,9 +93,9 @@ fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -107,9 +107,9 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
     let c = || { let _ = &t; 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 
@@ -123,9 +123,9 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t1 = (Foo(0), Foo(0), Foo(0));
 
     let c = move || { let _ = (&t1, &t); 
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here
 
 // Test cases for types that implement a significant drop (user defined)
@@ -23,9 +23,9 @@ fn test1_all_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -42,9 +42,9 @@ fn test2_only_precise_paths_need_migration() {
     let t2 = (Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -59,9 +59,9 @@ fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -77,9 +77,9 @@ fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -93,9 +93,9 @@ fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -107,9 +107,9 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
     let c = || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 
@@ -123,9 +123,9 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t1 = (Foo(0), Foo(0), Foo(0));
 
     let c = move || {
-    //~^ ERROR: drop order
-    //~| NOTE: for more information, see
-    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
+        //~^ ERROR: drop order
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -14,8 +14,8 @@ LL | |     };
 note: the lint level is defined here
   --> $DIR/significant_drop.rs:2:9
    |
-LL | #![deny(disjoint_capture_migration)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |

--- a/src/test/ui/consts/const-eval/const_panic.rs
+++ b/src/test/ui/consts/const-eval/const_panic.rs
@@ -1,5 +1,5 @@
 #![feature(const_panic)]
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 #![crate_type = "lib"]
 
 const MSG: &str = "hello";

--- a/src/test/ui/fmt/format-args-capture.rs
+++ b/src/test/ui/fmt/format-args-capture.rs
@@ -16,13 +16,13 @@ fn main() {
 
 fn named_argument_takes_precedence_to_captured() {
     let foo = "captured";
-    let s = format!("{foo}", foo="named");
+    let s = format!("{foo}", foo = "named");
     assert_eq!(&s, "named");
 
-    let s = format!("{foo}-{foo}-{foo}", foo="named");
+    let s = format!("{foo}-{foo}-{foo}", foo = "named");
     assert_eq!(&s, "named-named-named");
 
-    let s = format!("{}-{bar}-{foo}", "positional", bar="named");
+    let s = format!("{}-{bar}-{foo}", "positional", bar = "named");
     assert_eq!(&s, "positional-named-captured");
 }
 
@@ -42,10 +42,11 @@ fn panic_with_single_argument_does_not_get_formatted() {
     // RFC #2795 suggests that this may need to change so that captured arguments are formatted.
     // For stability reasons this will need to part of an edition change.
 
-    #[allow(non_fmt_panic)]
+    #[allow(non_fmt_panics)]
     let msg = std::panic::catch_unwind(|| {
         panic!("{foo}");
-    }).unwrap_err();
+    })
+    .unwrap_err();
 
     assert_eq!(msg.downcast_ref::<&str>(), Some(&"{foo}"))
 }
@@ -55,8 +56,9 @@ fn panic_with_multiple_arguments_is_formatted() {
     let foo = "captured";
 
     let msg = std::panic::catch_unwind(|| {
-        panic!("{}-{bar}-{foo}", "positional", bar="named");
-    }).unwrap_err();
+        panic!("{}-{bar}-{foo}", "positional", bar = "named");
+    })
+    .unwrap_err();
 
     assert_eq!(msg.downcast_ref::<String>(), Some(&"positional-named-captured".to_string()))
 }

--- a/src/test/ui/macros/assert-macro-owned.rs
+++ b/src/test/ui/macros/assert-macro-owned.rs
@@ -2,7 +2,7 @@
 // error-pattern:panicked at 'test-assert-owned'
 // ignore-emscripten no processes
 
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 
 fn main() {
     assert!(false, "test-assert-owned".to_string());

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -14,11 +14,12 @@
 // revisions: std core
 
 // ignore-wasm32-bare compiled with panic=abort by default
-
 #![cfg_attr(core, no_std)]
 
-#[cfg(std)] use std::fmt;
-#[cfg(core)] use core::fmt;
+#[cfg(core)]
+use core::fmt;
+#[cfg(std)]
+use std::fmt;
 
 // an easy mistake in the implementation of 'assert!'
 // would cause this to say "explicit panic"
@@ -57,7 +58,7 @@ fn writeln_1arg() {
 //
 // (Example: Issue #48042)
 #[test]
-#[allow(non_fmt_panic)]
+#[allow(non_fmt_panics)]
 fn to_format_or_not_to_format() {
     // ("{}" is the easiest string to test because if this gets
     // sent to format_args!, it'll simply fail to compile.
@@ -80,13 +81,17 @@ fn to_format_or_not_to_format() {
     // format!("{}",); // see check-fail
     // format_args!("{}",); // see check-fail
 
-    if falsum() { panic!("{}",); }
+    if falsum() {
+        panic!("{}",);
+    }
 
     // print!("{}",); // see check-fail
     // println!("{}",); // see check-fail
     // unimplemented!("{}",); // see check-fail
 
-    if falsum() { unreachable!("{}",); }
+    if falsum() {
+        unreachable!("{}",);
+    }
 
     // write!(&mut stdout, "{}",); // see check-fail
     // writeln!(&mut stdout, "{}",); // see check-fail

--- a/src/test/ui/macros/macro-or-patterns-back-compat.fixed
+++ b/src/test/ui/macros/macro-or-patterns-back-compat.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // aux-build:or-pattern.rs
 
-#![deny(or_patterns_back_compat)]
+#![deny(rust_2021_incompatible_or_patterns)]
 #![allow(unused_macros)]
 
 #[macro_use]

--- a/src/test/ui/macros/macro-or-patterns-back-compat.rs
+++ b/src/test/ui/macros/macro-or-patterns-back-compat.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // aux-build:or-pattern.rs
 
-#![deny(or_patterns_back_compat)]
+#![deny(rust_2021_incompatible_or_patterns)]
 #![allow(unused_macros)]
 
 #[macro_use]

--- a/src/test/ui/macros/macro-or-patterns-back-compat.stderr
+++ b/src/test/ui/macros/macro-or-patterns-back-compat.stderr
@@ -7,8 +7,8 @@ LL | macro_rules! foo { ($x:pat | $y:pat) => {} }
 note: the lint level is defined here
   --> $DIR/macro-or-patterns-back-compat.rs:4:9
    |
-LL | #![deny(or_patterns_back_compat)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rust_2021_incompatible_or_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see issue #84869 <https://github.com/rust-lang/rust/issues/84869>
 

--- a/src/test/ui/non-fmt-panic.stderr
+++ b/src/test/ui/non-fmt-panic.stderr
@@ -4,7 +4,7 @@ warning: panic message contains a brace
 LL |     panic!("here's a brace: {");
    |                             ^
    |
-   = note: `#[warn(non_fmt_panic)]` on by default
+   = note: `#[warn(non_fmt_panics)]` on by default
    = note: this message is not used as a format string, but will be in Rust 2021
 help: add a "{}" format string to use the message literally
    |

--- a/src/test/ui/panics/explicit-panic-msg.rs
+++ b/src/test/ui/panics/explicit-panic-msg.rs
@@ -1,6 +1,6 @@
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 
 // run-fail
 // error-pattern:wooooo

--- a/src/test/ui/panics/panic-macro-any-wrapped.rs
+++ b/src/test/ui/panics/panic-macro-any-wrapped.rs
@@ -2,7 +2,7 @@
 // error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 
 fn main() {
     panic!(Box::new(612_i64));

--- a/src/test/ui/panics/panic-macro-any.rs
+++ b/src/test/ui/panics/panic-macro-any.rs
@@ -3,7 +3,7 @@
 // ignore-emscripten no processes
 
 #![feature(box_syntax)]
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 
 fn main() {
     panic!(box 413 as Box<dyn std::any::Any + Send>);

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -7,8 +7,8 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-imported.rs:4:9
    |
-LL | #![warn(future_prelude_collisions)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -7,8 +7,8 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-imported.rs:4:9
    |
-LL | #![warn(future_prelude_collision)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(future_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/future-prelude-collision-shadow.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-shadow.rs
@@ -1,5 +1,5 @@
 // edition:2018
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-shadow.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-shadow.rs
@@ -1,5 +1,5 @@
 // edition:2018
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
@@ -1,7 +1,7 @@
 // edition:2018
 // check-pass
 #![allow(unused)]
-#![deny(future_prelude_collisions)]
+#![deny(rust_2021_prelude_collisions)]
 
 struct S;
 

--- a/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-unneeded.rs
@@ -1,12 +1,14 @@
 // edition:2018
 // check-pass
 #![allow(unused)]
-#![deny(future_prelude_collision)]
+#![deny(future_prelude_collisions)]
 
 struct S;
 
 impl S {
-    fn try_into(self) -> S { S }
+    fn try_into(self) -> S {
+        S
+    }
 }
 
 // See https://github.com/rust-lang/rust/issues/86633

--- a/src/test/ui/rust-2021/future-prelude-collision.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/future-prelude-collision.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/future-prelude-collision.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/future-prelude-collision.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // edition:2018
 // check-pass
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/future-prelude-collision.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision.stderr
@@ -7,8 +7,8 @@ LL |     let _: u32 = 3u8.try_into().unwrap();
 note: the lint level is defined here
   --> $DIR/future-prelude-collision.rs:4:9
    |
-LL | #![warn(future_prelude_collisions)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/future-prelude-collision.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision.stderr
@@ -7,8 +7,8 @@ LL |     let _: u32 = 3u8.try_into().unwrap();
 note: the lint level is defined here
   --> $DIR/future-prelude-collision.rs:4:9
    |
-LL | #![warn(future_prelude_collision)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(future_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/generic-type-collision.fixed
+++ b/src/test/ui/rust-2021/generic-type-collision.fixed
@@ -1,7 +1,7 @@
 // check-pass
 // run-rustfix
 // edition 2018
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait MyTrait<A> {
     fn from_iter(x: Option<A>);

--- a/src/test/ui/rust-2021/generic-type-collision.fixed
+++ b/src/test/ui/rust-2021/generic-type-collision.fixed
@@ -1,7 +1,7 @@
 // check-pass
 // run-rustfix
 // edition 2018
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait MyTrait<A> {
     fn from_iter(x: Option<A>);

--- a/src/test/ui/rust-2021/generic-type-collision.rs
+++ b/src/test/ui/rust-2021/generic-type-collision.rs
@@ -1,7 +1,7 @@
 // check-pass
 // run-rustfix
 // edition 2018
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait MyTrait<A> {
     fn from_iter(x: Option<A>);

--- a/src/test/ui/rust-2021/generic-type-collision.rs
+++ b/src/test/ui/rust-2021/generic-type-collision.rs
@@ -1,7 +1,7 @@
 // check-pass
 // run-rustfix
 // edition 2018
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait MyTrait<A> {
     fn from_iter(x: Option<A>);

--- a/src/test/ui/rust-2021/generic-type-collision.stderr
+++ b/src/test/ui/rust-2021/generic-type-collision.stderr
@@ -7,8 +7,8 @@ LL |     <Vec<i32>>::from_iter(None);
 note: the lint level is defined here
   --> $DIR/generic-type-collision.rs:4:9
    |
-LL | #![warn(future_prelude_collisions)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/generic-type-collision.stderr
+++ b/src/test/ui/rust-2021/generic-type-collision.stderr
@@ -7,8 +7,8 @@ LL |     <Vec<i32>>::from_iter(None);
 note: the lint level is defined here
   --> $DIR/generic-type-collision.rs:4:9
    |
-LL | #![warn(future_prelude_collision)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(future_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/inherent-dyn-collision.fixed
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.fixed
@@ -5,7 +5,7 @@
 // run-rustfix
 // edition:2018
 
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(&self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/inherent-dyn-collision.fixed
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.fixed
@@ -5,7 +5,7 @@
 // run-rustfix
 // edition:2018
 
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(&self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/inherent-dyn-collision.rs
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.rs
@@ -5,7 +5,7 @@
 // run-rustfix
 // edition:2018
 
-#![warn(future_prelude_collision)]
+#![warn(future_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(&self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/inherent-dyn-collision.rs
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.rs
@@ -5,7 +5,7 @@
 // run-rustfix
 // edition:2018
 
-#![warn(future_prelude_collisions)]
+#![warn(rust_2021_prelude_collisions)]
 
 trait TryIntoU32 {
     fn try_into(&self) -> Result<u32, ()>;

--- a/src/test/ui/rust-2021/inherent-dyn-collision.stderr
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.stderr
@@ -7,8 +7,8 @@ LL |         get_dyn_trait().try_into().unwrap()
 note: the lint level is defined here
   --> $DIR/inherent-dyn-collision.rs:8:9
    |
-LL | #![warn(future_prelude_collisions)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/inherent-dyn-collision.stderr
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.stderr
@@ -7,8 +7,8 @@ LL |         get_dyn_trait().try_into().unwrap()
 note: the lint level is defined here
   --> $DIR/inherent-dyn-collision.rs:8:9
    |
-LL | #![warn(future_prelude_collision)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(future_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
 

--- a/src/test/ui/rust-2021/inherent-method-collision.rs
+++ b/src/test/ui/rust-2021/inherent-method-collision.rs
@@ -2,7 +2,7 @@
 //
 // check-pass
 
-#![deny(future_prelude_collision)]
+#![deny(future_prelude_collisions)]
 
 pub struct MySeq {}
 

--- a/src/test/ui/rust-2021/inherent-method-collision.rs
+++ b/src/test/ui/rust-2021/inherent-method-collision.rs
@@ -2,7 +2,7 @@
 //
 // check-pass
 
-#![deny(future_prelude_collisions)]
+#![deny(rust_2021_prelude_collisions)]
 
 pub struct MySeq {}
 

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(reserved_prefixes)]
+#![warn(rust_2021_token_prefixes)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z "hey");
-    //~^ WARNING prefix `z` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `z` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m2!(prefix "hey");
-    //~^ WARNING prefix `prefix` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `prefix` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey #123);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey #hey);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind #value
-    //~^ WARNING prefix `kind` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `kind` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(rust_2021_token_prefixes)]
+#![warn(rust_2021_prefixes_incompatible_syntax)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z "hey");
-    //~^ WARNING prefix `z` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `z` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m2!(prefix "hey");
-    //~^ WARNING prefix `prefix` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `prefix` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m3!(hey #123);
-    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m3!(hey #hey);
-    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind #value
-    //~^ WARNING prefix `kind` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `kind` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(reserved_prefix)]
+#![warn(reserved_prefixes)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z "hey");
-    //~^ WARNING prefix `z` is unknown [reserved_prefix]
+    //~^ WARNING prefix `z` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m2!(prefix "hey");
-    //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
+    //~^ WARNING prefix `prefix` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey #123);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey #hey);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind #value
-    //~^ WARNING prefix `kind` is unknown [reserved_prefix]
+    //~^ WARNING prefix `kind` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(reserved_prefix)]
+#![warn(reserved_prefixes)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z"hey");
-    //~^ WARNING prefix `z` is unknown [reserved_prefix]
+    //~^ WARNING prefix `z` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m2!(prefix"hey");
-    //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
+    //~^ WARNING prefix `prefix` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey#123);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey#hey);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind#value
-    //~^ WARNING prefix `kind` is unknown [reserved_prefix]
+    //~^ WARNING prefix `kind` is unknown [reserved_prefixes]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(rust_2021_token_prefixes)]
+#![warn(rust_2021_prefixes_incompatible_syntax)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z"hey");
-    //~^ WARNING prefix `z` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `z` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m2!(prefix"hey");
-    //~^ WARNING prefix `prefix` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `prefix` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m3!(hey#123);
-    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
     m3!(hey#hey);
-    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind#value
-    //~^ WARNING prefix `kind` is unknown [rust_2021_token_prefixes]
+    //~^ WARNING prefix `kind` is unknown [rust_2021_prefixes_incompatible_syntax]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -2,7 +2,7 @@
 // run-rustfix
 // compile-flags: -Z unstable-options --edition 2018
 
-#![warn(reserved_prefixes)]
+#![warn(rust_2021_token_prefixes)]
 
 macro_rules! m2 {
     ($a:tt $b:tt) => {};
@@ -14,16 +14,16 @@ macro_rules! m3 {
 
 fn main() {
     m2!(z"hey");
-    //~^ WARNING prefix `z` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `z` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m2!(prefix"hey");
-    //~^ WARNING prefix `prefix` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `prefix` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey#123);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
     m3!(hey#hey);
-    //~^ WARNING prefix `hey` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `hey` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
 }
 
@@ -33,6 +33,6 @@ macro_rules! quote {
 
 quote! {
     #name = #kind#value
-    //~^ WARNING prefix `kind` is unknown [reserved_prefixes]
+    //~^ WARNING prefix `kind` is unknown [rust_2021_token_prefixes]
     //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -7,8 +7,8 @@ LL |     m2!(z"hey");
 note: the lint level is defined here
   --> $DIR/reserved-prefixes-migration.rs:5:9
    |
-LL | #![warn(reserved_prefix)]
-   |         ^^^^^^^^^^^^^^^
+LL | #![warn(reserved_prefixes)]
+   |         ^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -7,8 +7,8 @@ LL |     m2!(z"hey");
 note: the lint level is defined here
   --> $DIR/reserved-prefixes-migration.rs:5:9
    |
-LL | #![warn(reserved_prefixes)]
-   |         ^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_token_prefixes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -7,8 +7,8 @@ LL |     m2!(z"hey");
 note: the lint level is defined here
   --> $DIR/reserved-prefixes-migration.rs:5:9
    |
-LL | #![warn(rust_2021_token_prefixes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![warn(rust_2021_prefixes_incompatible_syntax)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021

--- a/src/tools/clippy/CHANGELOG.md
+++ b/src/tools/clippy/CHANGELOG.md
@@ -592,7 +592,7 @@ Released 2021-02-11
 
 * Previously deprecated [`str_to_string`] and [`string_to_string`] have been un-deprecated
   as `restriction` lints [#6333](https://github.com/rust-lang/rust-clippy/pull/6333)
-* Deprecate `panic_params` lint. This is now available in rustc as `non_fmt_panic`
+* Deprecate `panic_params` lint. This is now available in rustc as `non_fmt_panics`
   [#6351](https://github.com/rust-lang/rust-clippy/pull/6351)
 * Move [`map_err_ignore`] to `restriction`
   [#6416](https://github.com/rust-lang/rust-clippy/pull/6416)

--- a/src/tools/clippy/clippy_lints/src/lib.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.rs
@@ -2171,7 +2171,7 @@ pub fn register_renamed(ls: &mut rustc_lint::LintStore) {
     ls.register_renamed("clippy::unused_label", "unused_labels");
     ls.register_renamed("clippy::drop_bounds", "drop_bounds");
     ls.register_renamed("clippy::temporary_cstring_as_ptr", "temporary_cstring_as_ptr");
-    ls.register_renamed("clippy::panic_params", "non_fmt_panic");
+    ls.register_renamed("clippy::panic_params", "non_fmt_panics");
     ls.register_renamed("clippy::unknown_clippy_lints", "unknown_lints");
 }
 

--- a/src/tools/clippy/tests/ui/assertions_on_constants.rs
+++ b/src/tools/clippy/tests/ui/assertions_on_constants.rs
@@ -1,4 +1,4 @@
-#![allow(non_fmt_panic)]
+#![allow(non_fmt_panics)]
 
 macro_rules! assert_const {
     ($len:expr) => {

--- a/src/tools/clippy/tests/ui/deprecated.stderr
+++ b/src/tools/clippy/tests/ui/deprecated.stderr
@@ -60,11 +60,11 @@ error: lint `clippy::temporary_cstring_as_ptr` has been renamed to `temporary_cs
 LL | #[warn(clippy::temporary_cstring_as_ptr)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `temporary_cstring_as_ptr`
 
-error: lint `clippy::panic_params` has been renamed to `non_fmt_panic`
+error: lint `clippy::panic_params` has been renamed to `non_fmt_panics`
   --> $DIR/deprecated.rs:11:8
    |
 LL | #[warn(clippy::panic_params)]
-   |        ^^^^^^^^^^^^^^^^^^^^ help: use the new name: `non_fmt_panic`
+   |        ^^^^^^^^^^^^^^^^^^^^ help: use the new name: `non_fmt_panics`
 
 error: lint `clippy::unknown_clippy_lints` has been renamed to `unknown_lints`
   --> $DIR/deprecated.rs:12:8

--- a/src/tools/lint-docs/src/lib.rs
+++ b/src/tools/lint-docs/src/lib.rs
@@ -467,7 +467,9 @@ fn lint_name(line: &str) -> Result<String, &'static str> {
                 return Err("lint name should end with comma");
             }
             let name = &name[..name.len() - 1];
-            if !name.chars().all(|ch| ch.is_uppercase() || ch == '_') || name.is_empty() {
+            if !name.chars().all(|ch| ch.is_uppercase() || ch.is_ascii_digit() || ch == '_')
+                || name.is_empty()
+            {
                 return Err("lint name did not have expected format");
             }
             Ok(name.to_lowercase().to_string())


### PR DESCRIPTION
Based on conversation in https://github.com/rust-lang/rust/issues/85894.

Rename a bunch of Rust 2021 related lints:

Lints that are officially renamed because they are already in beta or stable:
* `disjoint_capture_migration` => `rust_2021_incompatible_closure_captures`
* `or_patterns_back_compat` => `rust_2021_incompatible_or_patterns`
* `non_fmt_panic` => `non_fmt_panics`

Lints that are renamed but don't require any back -compat work since they aren't yet in stable:
* `future_prelude_collision` => `rust_2021_prelude_collisions`
* `reserved_prefix` => `rust_2021_token_prefixes`

Lints that have been discussed but that I did not rename:
* ~`non_fmt_panic` and `bare_trait_object`: is making this plural worth the headache we might cause users?~
* `array_into_iter`: I'm unsure of a good name and whether bothering users with a name change is worth it. 

r? @nikomatsakis 
