### PR TITLE
Check node kind to avoid ICE in `check_expr_return()`

### DIFF
--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
@@ -12,6 +12,25 @@ const C: [(); 42] = {
     }]
 };
 
+struct S {}
+trait Tr {
+    fn foo();
+    fn bar() {
+    //~^ NOTE: ...not the enclosing function body
+        [(); return];
+        //~^ ERROR: return statement outside of function body [E0572]
+        //~| NOTE: the return is part of this body...
+    }
+}
+impl Tr for S {
+    fn foo() {
+    //~^ NOTE: ...not the enclosing function body
+        [(); return];
+        //~^ ERROR: return statement outside of function body [E0572]
+        //~| NOTE: the return is part of this body...
+    }
+}
+
 fn main() {
 //~^ NOTE: ...not the enclosing function body
     [(); return || {

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
@@ -9,7 +9,31 @@ LL | |     }]
    | |_____^
 
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-86188-return-not-in-fn-body.rs:17:10
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:20:14
+   |
+LL | /     fn bar() {
+LL | |
+LL | |         [(); return];
+   | |              ^^^^^^ the return is part of this body...
+LL | |
+LL | |
+LL | |     }
+   | |_____- ...not the enclosing function body
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:28:14
+   |
+LL | /     fn foo() {
+LL | |
+LL | |         [(); return];
+   | |              ^^^^^^ the return is part of this body...
+LL | |
+LL | |
+LL | |     }
+   | |_____- ...not the enclosing function body
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:36:10
    |
 LL |  / fn main() {
 LL |  |
@@ -23,6 +47,6 @@ LL | ||     }];
 LL |  | }
    |  |_- ...not the enclosing function body
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0572`.

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rev1.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rev1.stderr
@@ -1,5 +1,5 @@
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-86721-return-expr-ice.rs:6:22
+  --> $DIR/issue-86721-return-expr-ice.rs:9:22
    |
 LL |     const U: usize = return;
    |                      ^^^^^^

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rev2.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rev2.stderr
@@ -1,0 +1,9 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86721-return-expr-ice.rs:15:20
+   |
+LL |     fn foo(a: [(); return]);
+   |                    ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0572`.

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rs
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rs
@@ -1,8 +1,17 @@
 // Regression test for the ICE described in #86721.
 
+// revisions: rev1 rev2
+#![cfg_attr(any(), rev1, rev2)]
 #![crate_type="lib"]
 
+#[cfg(any(rev1))]
 trait T {
     const U: usize = return;
-    //~^ ERROR: return statement outside of function body [E0572]
+    //[rev1]~^ ERROR: return statement outside of function body [E0572]
+}
+
+#[cfg(any(rev2))]
+trait T2 {
+    fn foo(a: [(); return]);
+    //[rev2]~^ ERROR: return statement outside of function body [E0572]
 }

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rs
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rs
@@ -1,0 +1,8 @@
+// Regression test for the ICE described in #86721.
+
+#![crate_type="lib"]
+
+trait T {
+    const U: usize = return;
+    //~^ ERROR: return statement outside of function body [E0572]
+}

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.stderr
@@ -1,0 +1,9 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86721-return-expr-ice.rs:6:22
+   |
+LL |     const U: usize = return;
+   |                      ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0572`.


### PR DESCRIPTION
This PR fixes #86721. The ICE described there is apparently due to a misunderstanding:
https://github.com/rust-lang/rust/blob/e98897e5dc9898707bf4331c43b2e76ab7e282fe/compiler/rustc_typeck/src/check/expr.rs#L684-L685

Intuitively, one would think that calling `expect_item()` after `get_parent_item()` should succeed, but as it turns out, `get_parent_item()` can also return foreign, trait, and impl items as well as crates, whereas `expect_item()` specifically expects a `Node::Item`. I have therefore added an extra check to prevent this ICE.
