### PR TITLE
impl Default, Copy, Clone for std::io::Sink and Empty

### DIFF
--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -14,6 +14,7 @@ use crate::io::{
 /// the documentation of [`empty()`] for more details.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[non_exhaustive]
+#[derive(Copy, Clone, Default)]
 pub struct Empty;
 
 /// Constructs a new handle to an empty reader.
@@ -172,6 +173,7 @@ impl fmt::Debug for Repeat {
 /// see the documentation of [`sink()`] for more details.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[non_exhaustive]
+#[derive(Copy, Clone, Default)]
 pub struct Sink;
 
 /// Creates an instance of a writer which will successfully consume all data.


### PR DESCRIPTION
The omission of `Sink: Default` is causing me a slight inconvenience in a test harness.  There seems little reason for this and `Empty` not to be `Clone` and `Copy` too.

I have made all three of these insta-stable, because:

AIUI `Copy` can only be derived, and I was not able to find any examples of how to unstably derive it.  I think it is probably not possible.

I hunted through the git history for precedent and found

> 79b8ad84c84481a43704213cd0948d2ba0ea63b4
> Implement `Copy` for `IoSlice`
> https://github.com/rust-lang/rust/pull/69403

which was also insta-stable.