### PR TITLE
Fix rustdoc query type filter

### DIFF
--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -801,7 +801,8 @@ window.initSearch = function(rawSearchIndex) {
                     results_returned[fullId].lev =
                         Math.min(results_returned[fullId].lev, returned);
                 }
-                if (index !== -1 || lev <= MAX_LEV_DISTANCE) {
+                if (typePassesFilter(typeFilter, ty.ty) &&
+                        (index !== -1 || lev <= MAX_LEV_DISTANCE)) {
                     if (index !== -1 && paths.length < 2) {
                         lev = 0;
                     }

--- a/src/test/rustdoc-js-std/typed-query.js
+++ b/src/test/rustdoc-js-std/typed-query.js
@@ -1,0 +1,12 @@
+// exact-check
+
+const QUERY = 'macro:print';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'std', 'name': 'print' },
+        { 'path': 'std', 'name': 'eprint' },
+        { 'path': 'std', 'name': 'println' },
+        { 'path': 'std', 'name': 'eprintln' },
+    ],
+};


### PR DESCRIPTION
I realized while reviewing #86659 that the type filter was broken on search so I'd prefer it to get merged before merging #86659.

r? @notriddle 