### PR TITLE
Test cross-crate usage of `feature(const_trait_impl)`

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1223,7 +1223,12 @@ impl EncodeContext<'a, 'tcx> {
                 let fn_data = if let hir::ImplItemKind::Fn(ref sig, body) = ast_item.kind {
                     FnData {
                         asyncness: sig.header.asyncness,
-                        constness: sig.header.constness,
+                        // Can be inside `impl const Trait`, so using sig.header.constness is not reliable
+                        constness: if self.tcx.is_const_fn_raw(def_id) {
+                            hir::Constness::Const
+                        } else {
+                            hir::Constness::NotConst
+                        },
                         param_names: self.encode_fn_param_names_for_body(body),
                     }
                 } else {

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,0 +1,22 @@
+#![feature(const_trait_impl)]
+#![allow(incomplete_features)]
+
+pub trait MyTrait {
+    fn func(self);
+}
+
+pub struct NonConst;
+
+impl MyTrait for NonConst {
+    fn func(self) {
+
+    }
+}
+
+pub struct Const;
+
+impl const MyTrait for Const {
+    fn func(self) {
+
+    }
+}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.rs
@@ -1,0 +1,18 @@
+// aux-build: cross-crate.rs
+extern crate cross_crate;
+
+use cross_crate::*;
+
+fn non_const_context() {
+    NonConst.func();
+    Const.func();
+}
+
+const fn const_context() {
+    NonConst.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    Const.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.stderr
@@ -1,0 +1,15 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-disabled.rs:12:5
+   |
+LL |     NonConst.func();
+   |     ^^^^^^^^^^^^^^^
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-disabled.rs:14:5
+   |
+LL |     Const.func();
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.rs
@@ -1,0 +1,20 @@
+#![feature(const_trait_impl)]
+#![allow(incomplete_features)]
+
+// aux-build: cross-crate.rs
+extern crate cross_crate;
+
+use cross_crate::*;
+
+fn non_const_context() {
+    NonConst.func();
+    Const.func();
+}
+
+const fn const_context() {
+    NonConst.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    Const.func();
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.stderr
@@ -1,0 +1,9 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-enabled.rs:15:5
+   |
+LL |     NonConst.func();
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.


### PR DESCRIPTION
This PR does two things:

 - Fixes metadata not encoded properly for functions in const trait impls.
 - Adds tests for using const trait impls cross-crate with the feature gate on the user crate either enabled or disabled.

See #67792 for the tracking issue, cc @oli-obk 