### PR TITLE
alloc: `RawVec<T, A>::shrink` can be in `no_global_oom_handling`.

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -463,7 +463,6 @@ impl<T, A: Allocator> RawVec<T, A> {
         Ok(())
     }
 
-    #[cfg(not(no_global_oom_handling))]
     fn shrink(&mut self, amount: usize) -> Result<(), TryReserveError> {
         assert!(amount <= self.capacity(), "Tried to shrink to a larger capacity");
 


### PR DESCRIPTION
Found in https://github.com/Rust-for-Linux/linux/pull/402.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>