### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), and
 ## Trademark
 
 The Rust programming language is an open source, community project governed
-by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”),
-which owns and protects the Rust and Cargo trademarks and logos
+by [the Rust Foundation][rust-foundation],
+which also owns and protects the Rust and Cargo trademarks and logos
 (the “Rust Trademarks”).
 
 If you want to use these names or brands, please read the [media guide][media-guide].
@@ -282,5 +282,6 @@ If you want to use these names or brands, please read the [media guide][media-gu
 Third-party logos may be subject to third-party copyrights and trademarks. See
 [Licenses][policies-licenses] for details.
 
+[rust-foundation]: https://foundation.rust-lang.org/
 [media-guide]: https://www.rust-lang.org/policies/media-guide
 [policies-licenses]: https://www.rust-lang.org/policies/licenses

--- a/README.md
+++ b/README.md
@@ -272,10 +272,8 @@ See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), and
 
 ## Trademark
 
-The Rust programming language is an open source, community project governed
-by [the Rust Foundation][rust-foundation],
-which also owns and protects the Rust and Cargo trademarks and logos
-(the “Rust Trademarks”).
+[The Rust Foundation][rust-foundation] owns and protects the Rust and Cargo
+trademarks and logos (the “Rust Trademarks”).
 
 If you want to use these names or brands, please read the [media guide][media-guide].
 

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -29,7 +29,7 @@ use rustc_middle::middle::cstore::MetadataLoader;
 use rustc_save_analysis as save;
 use rustc_save_analysis::DumpHandler;
 use rustc_serialize::json::{self, ToJson};
-use rustc_session::config::nightly_options;
+use rustc_session::config::{nightly_options, CG_OPTIONS, DB_OPTIONS};
 use rustc_session::config::{ErrorOutputType, Input, OutputType, PrintRequest, TrimmedDefPaths};
 use rustc_session::getopts;
 use rustc_session::lint::{Lint, LintId};
@@ -1017,9 +1017,18 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     for option in config::rustc_optgroups() {
         (option.apply)(&mut options);
     }
-    let matches = options
-        .parse(args)
-        .unwrap_or_else(|f| early_error(ErrorOutputType::default(), &f.to_string()));
+    let matches = options.parse(args).unwrap_or_else(|e| {
+        let msg = match e {
+            getopts::Fail::UnrecognizedOption(ref opt) => CG_OPTIONS
+                .iter()
+                .map(|&(name, ..)| ('C', name))
+                .chain(DB_OPTIONS.iter().map(|&(name, ..)| ('Z', name)))
+                .find(|&(_, name)| *opt == name.replace("_", "-"))
+                .map(|(flag, _)| format!("{}. Did you mean `-{} {}`?", e, flag, opt)),
+            _ => None,
+        };
+        early_error(ErrorOutputType::default(), &msg.unwrap_or_else(|| e.to_string()));
+    });
 
     // For all options we just parsed, we check a few aspects:
     //

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -361,6 +361,7 @@ E0626: include_str!("./error_codes/E0626.md"),
 E0627: include_str!("./error_codes/E0627.md"),
 E0628: include_str!("./error_codes/E0628.md"),
 E0631: include_str!("./error_codes/E0631.md"),
+E0632: include_str!("./error_codes/E0632.md"),
 E0633: include_str!("./error_codes/E0633.md"),
 E0634: include_str!("./error_codes/E0634.md"),
 E0635: include_str!("./error_codes/E0635.md"),
@@ -623,8 +624,6 @@ E0783: include_str!("./error_codes/E0783.md"),
 //  E0629, // missing 'feature' (rustc_const_unstable)
 //  E0630, // rustc_const_unstable attribute must be paired with stable/unstable
            // attribute
-    E0632, // cannot provide explicit generic arguments when `impl Trait` is
-           // used in argument position
     E0640, // infer outlives requirements
 //  E0645, // trait aliases not finished
     E0667, // `impl Trait` in projections

--- a/compiler/rustc_error_codes/src/error_codes/E0632.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0632.md
@@ -1,0 +1,25 @@
+An explicit generic argument was provided when calling a function that
+uses `impl Trait` in argument position.
+
+Erroneous code example:
+
+```compile_fail,E0632
+fn foo<T: Copy>(a: T, b: impl Clone) {}
+
+foo::<i32>(0i32, "abc".to_string());
+```
+
+Either all generic arguments should be inferred at the call site, or
+the function definition should use an explicit generic type parameter
+instead of `impl Trait`. Example:
+
+```
+fn foo<T: Copy>(a: T, b: impl Clone) {}
+fn bar<T: Copy, U: Clone>(a: T, b: U) {}
+
+foo(0i32, "abc".to_string());
+
+bar::<i32, String>(0i32, "abc".to_string());
+bar::<_, _>(0i32, "abc".to_string());
+bar(0i32, "abc".to_string());
+```

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1084,7 +1084,7 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// An function with generics must have its symbol mangled to accommodate
+    /// A function with generics must have its symbol mangled to accommodate
     /// the generic parameter. The [`no_mangle` attribute] has no effect in
     /// this situation, and should be removed.
     ///

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1223,7 +1223,12 @@ impl EncodeContext<'a, 'tcx> {
                 let fn_data = if let hir::ImplItemKind::Fn(ref sig, body) = ast_item.kind {
                     FnData {
                         asyncness: sig.header.asyncness,
-                        constness: sig.header.constness,
+                        // Can be inside `impl const Trait`, so using sig.header.constness is not reliable
+                        constness: if self.tcx.is_const_fn_raw(def_id) {
+                            hir::Constness::Const
+                        } else {
+                            hir::Constness::NotConst
+                        },
                         param_names: self.encode_fn_param_names_for_body(body),
                     }
                 } else {

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -463,7 +463,6 @@ impl<T, A: Allocator> RawVec<T, A> {
         Ok(())
     }
 
-    #[cfg(not(no_global_oom_handling))]
     fn shrink(&mut self, amount: usize) -> Result<(), TryReserveError> {
         assert!(amount <= self.capacity(), "Tried to shrink to a larger capacity");
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -400,12 +400,12 @@ impl Step for Rustc {
 
             // Copy over lld if it's there
             if builder.config.lld_enabled {
-                let exe = exe("rust-lld", compiler.host);
-                builder.copy(&src_dir.join(&exe), &dst_dir.join(&exe));
+                let rust_lld = exe("rust-lld", compiler.host);
+                builder.copy(&src_dir.join(&rust_lld), &dst_dir.join(&rust_lld));
                 // for `-Z gcc-ld=lld`
                 let gcc_lld_dir = dst_dir.join("gcc-ld");
                 t!(fs::create_dir(&gcc_lld_dir));
-                builder.copy(&src_dir.join(&exe), &gcc_lld_dir.join(&exe));
+                builder.copy(&src_dir.join(&rust_lld), &gcc_lld_dir.join(exe("ld", compiler.host)));
             }
 
             // Copy over llvm-dwp if it's there

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -801,7 +801,8 @@ window.initSearch = function(rawSearchIndex) {
                     results_returned[fullId].lev =
                         Math.min(results_returned[fullId].lev, returned);
                 }
-                if (index !== -1 || lev <= MAX_LEV_DISTANCE) {
+                if (typePassesFilter(typeFilter, ty.ty) &&
+                        (index !== -1 || lev <= MAX_LEV_DISTANCE)) {
                     if (index !== -1 && paths.length < 2) {
                         lev = 0;
                     }

--- a/src/test/rustdoc-js-std/typed-query.js
+++ b/src/test/rustdoc-js-std/typed-query.js
@@ -1,0 +1,12 @@
+// exact-check
+
+const QUERY = 'macro:print';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'std', 'name': 'print' },
+        { 'path': 'std', 'name': 'eprint' },
+        { 'path': 'std', 'name': 'println' },
+        { 'path': 'std', 'name': 'eprintln' },
+    ],
+};

--- a/src/test/ui/const-generics/impl-trait-with-const-arguments.full.stderr
+++ b/src/test/ui/const-generics/impl-trait-with-const-arguments.full.stderr
@@ -6,3 +6,4 @@ LL |     assert_eq!(f::<4usize>(Usizable), 20usize);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/const-generics/impl-trait-with-const-arguments.min.stderr
+++ b/src/test/ui/const-generics/impl-trait-with-const-arguments.min.stderr
@@ -6,3 +6,4 @@ LL |     assert_eq!(f::<4usize>(Usizable), 20usize);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -6,3 +6,4 @@ LL |     foo::<String>('a');
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
@@ -8,3 +8,4 @@ LL |     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/invalid-compile-flags/codegen-option-without-group.rs
+++ b/src/test/ui/invalid-compile-flags/codegen-option-without-group.rs
@@ -1,0 +1,1 @@
+// compile-flags: --llvm-args

--- a/src/test/ui/invalid-compile-flags/codegen-option-without-group.stderr
+++ b/src/test/ui/invalid-compile-flags/codegen-option-without-group.stderr
@@ -1,0 +1,2 @@
+error: Unrecognized option: 'llvm-args'. Did you mean `-C llvm-args`?
+

--- a/src/test/ui/invalid-compile-flags/debug-option-without-group.rs
+++ b/src/test/ui/invalid-compile-flags/debug-option-without-group.rs
@@ -1,0 +1,1 @@
+// compile-flags: --unpretty=hir

--- a/src/test/ui/invalid-compile-flags/debug-option-without-group.stderr
+++ b/src/test/ui/invalid-compile-flags/debug-option-without-group.stderr
@@ -1,0 +1,2 @@
+error: Unrecognized option: 'unpretty'. Did you mean `-Z unpretty`?
+

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.rs
@@ -12,6 +12,25 @@ const C: [(); 42] = {
     }]
 };
 
+struct S {}
+trait Tr {
+    fn foo();
+    fn bar() {
+    //~^ NOTE: ...not the enclosing function body
+        [(); return];
+        //~^ ERROR: return statement outside of function body [E0572]
+        //~| NOTE: the return is part of this body...
+    }
+}
+impl Tr for S {
+    fn foo() {
+    //~^ NOTE: ...not the enclosing function body
+        [(); return];
+        //~^ ERROR: return statement outside of function body [E0572]
+        //~| NOTE: the return is part of this body...
+    }
+}
+
 fn main() {
 //~^ NOTE: ...not the enclosing function body
     [(); return || {

--- a/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
+++ b/src/test/ui/return/issue-86188-return-not-in-fn-body.stderr
@@ -9,7 +9,31 @@ LL | |     }]
    | |_____^
 
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-86188-return-not-in-fn-body.rs:17:10
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:20:14
+   |
+LL | /     fn bar() {
+LL | |
+LL | |         [(); return];
+   | |              ^^^^^^ the return is part of this body...
+LL | |
+LL | |
+LL | |     }
+   | |_____- ...not the enclosing function body
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:28:14
+   |
+LL | /     fn foo() {
+LL | |
+LL | |         [(); return];
+   | |              ^^^^^^ the return is part of this body...
+LL | |
+LL | |
+LL | |     }
+   | |_____- ...not the enclosing function body
+
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86188-return-not-in-fn-body.rs:36:10
    |
 LL |  / fn main() {
 LL |  |
@@ -23,6 +47,6 @@ LL | ||     }];
 LL |  | }
    |  |_- ...not the enclosing function body
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0572`.

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,0 +1,22 @@
+#![feature(const_trait_impl)]
+#![allow(incomplete_features)]
+
+pub trait MyTrait {
+    fn func(self);
+}
+
+pub struct NonConst;
+
+impl MyTrait for NonConst {
+    fn func(self) {
+
+    }
+}
+
+pub struct Const;
+
+impl const MyTrait for Const {
+    fn func(self) {
+
+    }
+}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.rs
@@ -1,0 +1,18 @@
+// aux-build: cross-crate.rs
+extern crate cross_crate;
+
+use cross_crate::*;
+
+fn non_const_context() {
+    NonConst.func();
+    Const.func();
+}
+
+const fn const_context() {
+    NonConst.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    Const.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-disabled.stderr
@@ -1,0 +1,15 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-disabled.rs:12:5
+   |
+LL |     NonConst.func();
+   |     ^^^^^^^^^^^^^^^
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-disabled.rs:14:5
+   |
+LL |     Const.func();
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.rs
@@ -1,0 +1,20 @@
+#![feature(const_trait_impl)]
+#![allow(incomplete_features)]
+
+// aux-build: cross-crate.rs
+extern crate cross_crate;
+
+use cross_crate::*;
+
+fn non_const_context() {
+    NonConst.func();
+    Const.func();
+}
+
+const fn const_context() {
+    NonConst.func();
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    Const.func();
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-feature-enabled.stderr
@@ -1,0 +1,9 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/cross-crate-feature-enabled.rs:15:5
+   |
+LL |     NonConst.func();
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/synthetic-param.stderr
+++ b/src/test/ui/synthetic-param.stderr
@@ -18,3 +18,4 @@ LL |     Bar::<i8>::func::<u8>(42);
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0632`.

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rev1.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rev1.stderr
@@ -1,5 +1,5 @@
 error[E0572]: return statement outside of function body
-  --> $DIR/issue-86721-return-expr-ice.rs:6:22
+  --> $DIR/issue-86721-return-expr-ice.rs:9:22
    |
 LL |     const U: usize = return;
    |                      ^^^^^^

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rev2.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rev2.stderr
@@ -1,0 +1,9 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86721-return-expr-ice.rs:15:20
+   |
+LL |     fn foo(a: [(); return]);
+   |                    ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0572`.

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rs
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rs
@@ -1,8 +1,17 @@
 // Regression test for the ICE described in #86721.
 
+// revisions: rev1 rev2
+#![cfg_attr(any(), rev1, rev2)]
 #![crate_type="lib"]
 
+#[cfg(any(rev1))]
 trait T {
     const U: usize = return;
-    //~^ ERROR: return statement outside of function body [E0572]
+    //[rev1]~^ ERROR: return statement outside of function body [E0572]
+}
+
+#[cfg(any(rev2))]
+trait T2 {
+    fn foo(a: [(); return]);
+    //[rev2]~^ ERROR: return statement outside of function body [E0572]
 }

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.rs
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.rs
@@ -1,0 +1,8 @@
+// Regression test for the ICE described in #86721.
+
+#![crate_type="lib"]
+
+trait T {
+    const U: usize = return;
+    //~^ ERROR: return statement outside of function body [E0572]
+}

--- a/src/test/ui/typeck/issue-86721-return-expr-ice.stderr
+++ b/src/test/ui/typeck/issue-86721-return-expr-ice.stderr
@@ -1,0 +1,9 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-86721-return-expr-ice.rs:6:22
+   |
+LL |     const U: usize = return;
+   |                      ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0572`.


### PR DESCRIPTION
Successful merges:

 - #85504 (the foundation owns rust trademarks)
 - #85520 (Fix typo and improve documentation for E0632)
 - #86680 (Improve error for missing -Z with debugging option)
 - #86728 (Check node kind to avoid ICE in `check_expr_return()`)
 - #86740 (copy rust-lld as ld in dist)
 - #86746 (Fix rustdoc query type filter)
 - #86750 (Test cross-crate usage of `feature(const_trait_impl)`)
 - #86755 (alloc: `RawVec<T, A>::shrink` can be in `no_global_oom_handling`.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85504,85520,86680,86728,86740,86746,86750,86755)
<!-- homu-ignore:end -->