### PR TITLE
Enable the tests developed with #86594

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.4.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.4.1 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/rustdoc-gui/label-next-to-symbol.goml
+++ b/src/test/rustdoc-gui/label-next-to-symbol.goml
@@ -13,12 +13,12 @@ assert-css: (".item-table .item-left .stab.portability", { "background-color": "
 
 // table like view
 assert-css: (".item-right.docblock-short", { "padding-left": "0px" })
-// Requires new function: https://github.com/GuillaumeGomez/browser-UI-test/pull/202
-//compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", ("y"))
+compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 2})
 compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
 
 // Ensure no wrap
-//compare-elements-position: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", ("y"))
+compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 2})
+// compare parent elements
 compare-elements-position: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
 
 
@@ -26,11 +26,11 @@ compare-elements-position: ("//*[@class='item-left module-item']//a[text()='repl
 size: (600, 600)
 // staggered layout with 2em spacing
 assert-css: (".item-right.docblock-short", { "padding-left": "32px" })
-// Requires new function: https://github.com/GuillaumeGomez/browser-UI-test/pull/202
-//compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", ("y"))
+compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 1})
 compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
 
 // Ensure wrap
-compare-elements-position-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", ("y"))
+compare-elements-position-near-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 12})
+// compare parent elements
 compare-elements-position-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
 compare-elements-position-false: (".item-left .stab.deprecated", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", ("y"))


### PR DESCRIPTION
This PR requires `browser-ui-test@0.4.1`. Can we centralise the version number somehow and maybe automatically install it when tests are run?

r? @GuillaumeGomez 