### PR TITLE
Remove & from Command::args calls in documentation

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -451,7 +451,7 @@ impl fmt::Debug for ChildStderr {
 ///
 /// let output = if cfg!(target_os = "windows") {
 ///     Command::new("cmd")
-///             .args(&["/C", "echo hello"])
+///             .args(["/C", "echo hello"])
 ///             .output()
 ///             .expect("failed to execute process")
 /// } else {
@@ -608,7 +608,7 @@ impl Command {
     /// use std::process::Command;
     ///
     /// Command::new("ls")
-    ///         .args(&["-l", "-a"])
+    ///         .args(["-l", "-a"])
     ///         .spawn()
     ///         .expect("ls command failed to start");
     /// ```


### PR DESCRIPTION
Now that arrays implement `IntoIterator`, using `&` is no longer necessary. This makes examples easier to understand.