### PR TITLE
Recover from `&dyn mut ...` parse errors

### DIFF
--- a/src/test/ui/parser/recover-ref-dyn-mut.rs
+++ b/src/test/ui/parser/recover-ref-dyn-mut.rs
@@ -1,0 +1,9 @@
+// Test that the parser detects `&dyn mut`, offers a help message, and
+// recovers.
+
+fn main() {
+    let r: &dyn mut Trait;
+    //~^ ERROR: `mut` must precede `dyn`
+    //~| HELP: place `mut` before `dyn`
+    //~| ERROR: cannot find trait `Trait` in this scope [E0405]
+}

--- a/src/test/ui/parser/recover-ref-dyn-mut.stderr
+++ b/src/test/ui/parser/recover-ref-dyn-mut.stderr
@@ -1,0 +1,15 @@
+error: `mut` must precede `dyn`
+  --> $DIR/recover-ref-dyn-mut.rs:5:12
+   |
+LL |     let r: &dyn mut Trait;
+   |            ^^^^^^^^ help: place `mut` before `dyn`: `&mut dyn`
+
+error[E0405]: cannot find trait `Trait` in this scope
+  --> $DIR/recover-ref-dyn-mut.rs:5:21
+   |
+LL |     let r: &dyn mut Trait;
+   |                     ^^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0405`.


### PR DESCRIPTION
Consider this example:
```rust
fn main() {
    let r: &dyn mut Trait;
}
```
This currently leads to:
```
error: expected one of `!`, `(`, `;`, `=`, `?`, `for`, lifetime, or path, found keyword `mut`
 --> src/main.rs:2:17
  |
2 |     let r: &dyn mut Trait;
  |                 ^^^ expected one of 8 possible tokens

error: aborting due to previous error
```
However, especially for beginners, I think it is easy to get `&dyn mut` and `&mut dyn` confused. With my changes, I get a help message, and the parser even recovers:
```
error: `mut` must precede `dyn`
 --> test.rs:2:12
  |
2 |     let r: &dyn mut Trait;
  |            ^^^^^^^^ help: place `mut` before `dyn`: `&mut dyn`

error[E0405]: cannot find trait `Trait` in this scope
 --> test.rs:2:21
  |
2 |     let r: &dyn mut Trait;
  |                     ^^^^^ not found in this scope

error: aborting due to 2 previous errors
```