### PR TITLE
Recover from a misplaced inner doc comment

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -64,7 +64,14 @@ impl<'a> Parser<'a> {
                 }
                 self.bump();
                 just_parsed_doc_comment = true;
-                Some(attr::mk_doc_comment(comment_kind, attr_style, data, self.prev_token.span))
+                // Always make an outer attribute - this allows us to recover from a misplaced
+                // inner attribute.
+                Some(attr::mk_doc_comment(
+                    comment_kind,
+                    ast::AttrStyle::Outer,
+                    data,
+                    self.prev_token.span,
+                ))
             } else {
                 None
             };

--- a/src/test/ui/proc-macro/issue-86781-bad-inner-doc.rs
+++ b/src/test/ui/proc-macro/issue-86781-bad-inner-doc.rs
@@ -1,0 +1,11 @@
+// aux-build:test-macros.rs
+
+#[macro_use]
+extern crate test_macros;
+
+//! Inner doc comment
+//~^ ERROR expected outer doc comment
+#[derive(Empty)]
+pub struct Foo;
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-86781-bad-inner-doc.stderr
+++ b/src/test/ui/proc-macro/issue-86781-bad-inner-doc.stderr
@@ -1,0 +1,11 @@
+error[E0753]: expected outer doc comment
+  --> $DIR/issue-86781-bad-inner-doc.rs:6:1
+   |
+LL | //! Inner doc comment
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0753`.


### PR DESCRIPTION
Fixes #86781