### PR TITLE
Improve error reporting for modifications behind `&` references

### DIFF
--- a/src/test/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*s.pointer` which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL | fn a(s: &S) {
@@ -6,7 +6,7 @@ LL | fn a(s: &S) {
 LL |     *s.pointer += 1;
    |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*s.pointer` which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL | fn c(s: & &mut S) {

--- a/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `**t1` which is behind a `&` reference
+error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     let t1 = t0;

--- a/src/test/ui/borrowck/borrowck-issue-14498.stderr
+++ b/src/test/ui/borrowck/borrowck-issue-14498.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `***p` which is behind a `&` reference
+error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     let p = &y;

--- a/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*item` which is behind a `&` reference
+error[E0594]: cannot assign to `*item`, which is behind a `&` reference
   --> $DIR/issue-69789-iterator-mut-suggestion.rs:7:9
    |
 LL |     for item in &mut std::iter::empty::<&'static ()>() {

--- a/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -9,7 +9,7 @@ fn main() {
     for v in Query.iter_mut() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
-        //~^ ERROR cannot assign to `*v` which is behind a `&` reference
+        //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
         //~| NOTE `v` is a `&` reference, so the data it refers to cannot be written
     }
 }

--- a/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*v` which is behind a `&` reference
+error[E0594]: cannot assign to `*v`, which is behind a `&` reference
   --> $DIR/issue-83309-ice-immut-in-for-loop.rs:11:9
    |
 LL |     for v in Query.iter_mut() {

--- a/src/test/ui/borrowck/issue-85765.rs
+++ b/src/test/ui/borrowck/issue-85765.rs
@@ -5,4 +5,11 @@ fn main() {
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
     //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+
+    let mut mutvar = 42;
+    let r = &mutvar;
+    //~^ HELP consider changing this to be a mutable reference
+    *r = 0;
+    //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
+    //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
 }

--- a/src/test/ui/borrowck/issue-85765.stderr
+++ b/src/test/ui/borrowck/issue-85765.stderr
@@ -7,6 +7,16 @@ LL |
 LL |     rofl.push(Vec::new());
    |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
-error: aborting due to previous error
+error[E0594]: cannot assign to `*r`, which is behind a `&` reference
+  --> $DIR/issue-85765.rs:12:5
+   |
+LL |     let r = &mutvar;
+   |             ------- help: consider changing this to be a mutable reference: `&mut mutvar`
+LL |
+LL |     *r = 0;
+   |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
 
-For more information about this error, try `rustc --explain E0596`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/borrowck/mutability-errors.stderr
+++ b/src/test/ui/borrowck/mutability-errors.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL | fn named_ref(x: &(i32,)) {
@@ -6,7 +6,7 @@ LL | fn named_ref(x: &(i32,)) {
 LL |     *x = (1,);
    |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `x.0` which is behind a `&` reference
+error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL | fn named_ref(x: &(i32,)) {
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |     &mut f().0;
    |     ^^^^^^^^^^ cannot borrow as mutable
 
-error[E0594]: cannot assign to `*x` which is behind a `*const` pointer
+error[E0594]: cannot assign to `*x`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:23:5
    |
 LL | unsafe fn named_ptr(x: *const (i32,)) {
@@ -65,7 +65,7 @@ LL | unsafe fn named_ptr(x: *const (i32,)) {
 LL |     *x = (1,);
    |     ^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `x.0` which is behind a `*const` pointer
+error[E0594]: cannot assign to `x.0`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:24:5
    |
 LL | unsafe fn named_ptr(x: *const (i32,)) {

--- a/src/test/ui/did_you_mean/issue-39544.rs
+++ b/src/test/ui/did_you_mean/issue-39544.rs
@@ -46,5 +46,5 @@ pub fn with_tuple() {
     let mut y = 0;
     let x = (&y,);
     *x.0 = 1;
-    //~^ ERROR cannot assign to `*x.0` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*x.0`, which is behind a `&` reference
 }

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -90,7 +90,7 @@ LL |     let _ = &mut z.x;
 LL |     let _ = &mut w.x;
    |             ^^^^^^^^ `w` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
-error[E0594]: cannot assign to `*x.0` which is behind a `&` reference
+error[E0594]: cannot assign to `*x.0`, which is behind a `&` reference
   --> $DIR/issue-39544.rs:48:5
    |
 LL |     *x.0 = 1;

--- a/src/test/ui/error-codes/E0389.rs
+++ b/src/test/ui/error-codes/E0389.rs
@@ -5,6 +5,6 @@ struct FancyNum {
 fn main() {
     let mut fancy = FancyNum{ num: 5 };
     let fancy_ref = &(&mut fancy);
-    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num` which is behind a `&` reference
+    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num`, which is behind a `&` reference
     println!("{}", fancy_ref.num);
 }

--- a/src/test/ui/error-codes/E0389.stderr
+++ b/src/test/ui/error-codes/E0389.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num` which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     let fancy_ref = &(&mut fancy);

--- a/src/test/ui/issues/issue-51244.rs
+++ b/src/test/ui/issues/issue-51244.rs
@@ -1,4 +1,4 @@
 fn main() {
     let ref my_ref @ _ = 0;
-    *my_ref = 0; //~ ERROR cannot assign to `*my_ref` which is behind a `&` reference [E0594]
+    *my_ref = 0; //~ ERROR cannot assign to `*my_ref`, which is behind a `&` reference [E0594]
 }

--- a/src/test/ui/issues/issue-51244.stderr
+++ b/src/test/ui/issues/issue-51244.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
+error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     let ref my_ref @ _ = 0;

--- a/src/test/ui/issues/issue-51515.rs
+++ b/src/test/ui/issues/issue-51515.rs
@@ -3,10 +3,10 @@ fn main() {
     //~^ HELP consider changing this to be a mutable reference
     //~| SUGGESTION &mut 16
     *foo = 32;
-    //~^ ERROR cannot assign to `*foo` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*foo`, which is behind a `&` reference
     let bar = foo;
     //~^ HELP consider changing this to be a mutable reference
     //~| SUGGESTION &mut i32
     *bar = 64;
-    //~^ ERROR cannot assign to `*bar` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*bar`, which is behind a `&` reference
 }

--- a/src/test/ui/issues/issue-51515.stderr
+++ b/src/test/ui/issues/issue-51515.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*foo` which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:5:5
    |
 LL |     let foo = &16;
@@ -7,7 +7,7 @@ LL |     let foo = &16;
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*bar` which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:10:5
    |
 LL |     let bar = foo;

--- a/src/test/ui/mut/mutable-class-fields-2.stderr
+++ b/src/test/ui/mut/mutable-class-fields-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.how_hungry` which is behind a `&` reference
+error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` reference
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |   pub fn eat(&self) {

--- a/src/test/ui/nll/issue-47388.stderr
+++ b/src/test/ui/nll/issue-47388.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num` which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     let fancy_ref = &(&mut fancy);

--- a/src/test/ui/nll/issue-51244.rs
+++ b/src/test/ui/nll/issue-51244.rs
@@ -1,5 +1,5 @@
 fn main() {
     let ref my_ref @ _ = 0;
     *my_ref = 0;
-    //~^ ERROR cannot assign to `*my_ref` which is behind a `&` reference [E0594]
+    //~^ ERROR cannot assign to `*my_ref`, which is behind a `&` reference [E0594]
 }

--- a/src/test/ui/nll/issue-51244.stderr
+++ b/src/test/ui/nll/issue-51244.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
+error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     let ref my_ref @ _ = 0;

--- a/src/test/ui/nll/issue-57989.rs
+++ b/src/test/ui/nll/issue-57989.rs
@@ -2,7 +2,7 @@
 
 fn f(x: &i32) {
     let g = &x;
-    *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+    *x = 0;     //~ ERROR cannot assign to `*x`, which is behind a `&` reference
                 //~| ERROR cannot assign to `*x` because it is borrowed
     g;
 }

--- a/src/test/ui/nll/issue-57989.stderr
+++ b/src/test/ui/nll/issue-57989.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL | fn f(x: &i32) {

--- a/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
+++ b/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
@@ -23,8 +23,8 @@ fn tuple() {
     _x1 = U; //~ ERROR cannot assign twice to immutable variable
     let _x0_hold = &mut tup.0; //~ ERROR cannot borrow `tup.0` as mutable because it is also
     let (ref mut _x0_hold, ..) = tup; //~ ERROR cannot borrow `tup.0` as mutable because it is also
-    *_x0 = U; //~ ERROR cannot assign to `*_x0` which is behind a `&` reference
-    *_x2 = U; //~ ERROR cannot assign to `*_x2` which is behind a `&` reference
+    *_x0 = U; //~ ERROR cannot assign to `*_x0`, which is behind a `&` reference
+    *_x2 = U; //~ ERROR cannot assign to `*_x2`, which is behind a `&` reference
     drop(tup.1); //~ ERROR use of moved value: `tup.1`
     let _x1_hold = &tup.1; //~ ERROR borrow of moved value: `tup.1`
     let (.., ref mut _x3) = tup;

--- a/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -101,7 +101,7 @@ LL |     let (ref mut _x0_hold, ..) = tup;
 LL |     *_x0 = U;
    |     -------- immutable borrow later used here
 
-error[E0594]: cannot assign to `*_x0` which is behind a `&` reference
+error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     let (ref _x0, _x1, ref _x2, ..) = tup;
@@ -110,7 +110,7 @@ LL |     let (ref _x0, _x1, ref _x2, ..) = tup;
 LL |     *_x0 = U;
    |     ^^^^^^^^ `_x0` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*_x2` which is behind a `&` reference
+error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     let (ref _x0, _x1, ref _x2, ..) = tup;

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.rs
@@ -6,17 +6,17 @@ use Wrapper::Wrap;
 
 pub fn main() {
     let Wrap(x) = &Wrap(3);
-    *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+    *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
 
 
     if let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
     } else {
         panic!();
     }
 
     while let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
         break;
     }
 }

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
    |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
    |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.rs
@@ -4,7 +4,7 @@
 fn main() {
     match &&Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},
@@ -12,7 +12,7 @@ fn main() {
 
     match &mut &Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},
@@ -20,7 +20,7 @@ fn main() {
 
     match &&mut Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;

--- a/src/test/ui/suggestions/issue-68049-1.stderr
+++ b/src/test/ui/suggestions/issue-68049-1.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;

--- a/src/test/ui/suggestions/issue-68049-2.stderr
+++ b/src/test/ui/suggestions/issue-68049-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*input` which is behind a `&` reference
+error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |   fn example(&self, input: &i32); // should suggest here
@@ -7,7 +7,7 @@ LL |   fn example(&self, input: &i32); // should suggest here
 LL |       *input = self.0;
    |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |   fn example(&self, input: &i32); // should suggest here

--- a/src/test/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/src/test/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `t.v` which is behind a `&` reference
+error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop.rs:14:9
    |
 LL |     for mut t in buzz.values() {

--- a/src/test/ui/suggestions/suggest-ref-mut.stderr
+++ b/src/test/ui/suggestions/suggest-ref-mut.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |     fn zap(&self) {
@@ -7,7 +7,7 @@ LL |     fn zap(&self) {
 LL |         self.0 = 32;
    |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*foo` which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:16:5
    |
 LL |     let ref foo = 16;
@@ -16,7 +16,7 @@ LL |     let ref foo = 16;
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*bar` which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:21:9
    |
 LL |     if let Some(ref bar) = Some(16) {
@@ -25,7 +25,7 @@ LL |     if let Some(ref bar) = Some(16) {
 LL |         *bar = 32;
    |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*quo` which is behind a `&` reference
+error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:25:22
    |
 LL |         ref quo => { *quo = 32; },


### PR DESCRIPTION
I had a look at #84210 and noticed that #85823 has effectively already fixed #84210.

However, the string matching in #85823 is _very_ crude and already breaks down when a variable name starts with `mut`. I have made this a bit more robust; further improvements could definitely be made but are complicated by the lack of information provided by an earlier pass:
https://github.com/rust-lang/rust/blob/ce331ee6ee010438d1a58c7da8ced4f26d69a20e/compiler/rustc_mir_build/src/build/matches/mod.rs#L2103-L2107

I have also fixed a missing comma in the error message.
