### PR TITLE
Optimize and improve the proc_macro RPC interface for cross-thread execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
  "rustc_span",
  "smallvec",
  "tracing",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,6 +3840,7 @@ dependencies = [
 name = "rustc_expand"
 version = "0.0.0"
 dependencies = [
+ "crossbeam-channel",
  "rustc_ast",
  "rustc_ast_passes",
  "rustc_ast_pretty",

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -25,3 +25,4 @@ rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_ast = { path = "../rustc_ast" }
+crossbeam-channel = "0.5.0"

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -26,3 +26,4 @@ rustc_session = { path = "../rustc_session" }
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_ast = { path = "../rustc_ast" }
 crossbeam-channel = "0.5.0"
+unicode-normalization = "0.1.11"

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -388,7 +388,10 @@ impl<'a> Rustc<'a> {
     }
 
     fn lit(&mut self, kind: token::LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Literal {
-        Literal { lit: token::Lit::new(kind, symbol, suffix), span: server::Span::call_site(self) }
+        Literal {
+            lit: token::Lit::new(kind, symbol, suffix),
+            span: server::Context::call_site(self),
+        }
     }
 }
 
@@ -484,7 +487,7 @@ impl server::Group for Rustc<'_> {
         Group {
             delimiter,
             stream,
-            span: DelimSpan::from_single(server::Span::call_site(self)),
+            span: DelimSpan::from_single(server::Context::call_site(self)),
             flatten: false,
         }
     }
@@ -510,7 +513,7 @@ impl server::Group for Rustc<'_> {
 
 impl server::Punct for Rustc<'_> {
     fn new(&mut self, ch: char, spacing: Spacing) -> Self::Punct {
-        Punct::new(ch, spacing == Spacing::Joint, server::Span::call_site(self))
+        Punct::new(ch, spacing == Spacing::Joint, server::Context::call_site(self))
     }
     fn as_char(&mut self, punct: Self::Punct) -> char {
         punct.ch
@@ -712,15 +715,6 @@ impl server::Span for Rustc<'_> {
             format!("{:?} bytes({}..{})", span.ctxt(), span.lo().0, span.hi().0)
         }
     }
-    fn def_site(&mut self) -> Self::Span {
-        self.def_site
-    }
-    fn call_site(&mut self) -> Self::Span {
-        self.call_site
-    }
-    fn mixed_site(&mut self) -> Self::Span {
-        self.mixed_site
-    }
     fn source_file(&mut self, span: Self::Span) -> Self::SourceFile {
         self.sess.source_map().lookup_char_pos(span.lo()).file
     }
@@ -798,6 +792,18 @@ impl server::Span for Rustc<'_> {
             // our current call site.
             raw_span.with_def_site_ctxt(expn_id)
         })
+    }
+}
+
+impl server::Context for Rustc<'_> {
+    fn def_site(&mut self) -> Self::Span {
+        self.def_site
+    }
+    fn call_site(&mut self) -> Self::Span {
+        self.call_site
+    }
+    fn mixed_site(&mut self) -> Self::Span {
+        self.mixed_site
     }
 }
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -3,7 +3,7 @@ use crate::base::{ExtCtxt, ResolverExpand};
 use rustc_ast as ast;
 use rustc_ast::token::{self, Nonterminal, NtIdent, TokenKind};
 use rustc_ast::tokenstream::{self, CanSynthesizeMissingTokens};
-use rustc_ast::tokenstream::{DelimSpan, Spacing::*, TokenStream, TreeAndSpacing};
+use rustc_ast::tokenstream::{Spacing::*, TokenStream};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
@@ -19,7 +19,7 @@ use rustc_span::hygiene::ExpnKind;
 use rustc_span::symbol::{self, kw, sym, Symbol};
 use rustc_span::{BytePos, FileName, MultiSpan, Pos, RealFileName, SourceFile, Span};
 
-use pm::bridge::{server, Punct, TokenTree};
+use pm::bridge::{server, DelimSpan, Group, Punct, TokenTree};
 use pm::{Delimiter, Level, LineColumn};
 use std::ops::Bound;
 use std::{ascii, panic};
@@ -54,160 +54,182 @@ impl ToInternal<token::DelimToken> for Delimiter {
     }
 }
 
-impl FromInternal<(TreeAndSpacing, &'_ mut Vec<Self>, &mut Rustc<'_>)>
-    for TokenTree<Span, Group, Ident, Literal>
+impl FromInternal<(TokenStream, &mut Rustc<'_>)>
+    for Vec<TokenTree<TokenStream, Span, Ident, Literal>>
 {
-    fn from_internal(
-        ((tree, spacing), stack, rustc): (TreeAndSpacing, &mut Vec<Self>, &mut Rustc<'_>),
-    ) -> Self {
+    fn from_internal((stream, rustc): (TokenStream, &mut Rustc<'_>)) -> Self {
         use rustc_ast::token::*;
 
-        let joint = spacing == Joint;
-        let Token { kind, span } = match tree {
-            tokenstream::TokenTree::Delimited(span, delim, tts) => {
-                let delimiter = Delimiter::from_internal(delim);
-                return TokenTree::Group(Group { delimiter, stream: tts, span, flatten: false });
-            }
-            tokenstream::TokenTree::Token(token) => token,
-        };
+        let mut cursor = stream.into_trees();
+        let mut trees = Vec::new();
 
-        macro_rules! tt {
-            ($ty:ident { $($field:ident $(: $value:expr)*),+ $(,)? }) => (
-                TokenTree::$ty(self::$ty {
-                    $($field $(: $value)*,)+
-                    span,
-                })
-            );
-            ($ty:ident::$method:ident($($value:expr),*)) => (
-                TokenTree::$ty(self::$ty::$method($($value,)* span))
-            );
-        }
-        macro_rules! op {
-            ($a:expr) => {
-                tt!(Punct { ch: $a, joint })
+        while let Some((tree, spacing)) = cursor.next_with_spacing() {
+            let joint = spacing == Joint;
+            let Token { kind, span } = match tree {
+                tokenstream::TokenTree::Delimited(span, delim, tts) => {
+                    let delimiter = Delimiter::from_internal(delim);
+                    trees.push(TokenTree::Group(Group {
+                        delimiter,
+                        stream: Some(tts),
+                        span: DelimSpan {
+                            open: span.open,
+                            close: span.close,
+                            entire: span.entire(),
+                        },
+                    }));
+                    continue;
+                }
+                tokenstream::TokenTree::Token(token) => token,
             };
-            ($a:expr, $b:expr) => {{
-                stack.push(tt!(Punct { ch: $b, joint }));
-                tt!(Punct { ch: $a, joint: true })
-            }};
-            ($a:expr, $b:expr, $c:expr) => {{
-                stack.push(tt!(Punct { ch: $c, joint }));
-                stack.push(tt!(Punct { ch: $b, joint: true }));
-                tt!(Punct { ch: $a, joint: true })
-            }};
-        }
 
-        match kind {
-            Eq => op!('='),
-            Lt => op!('<'),
-            Le => op!('<', '='),
-            EqEq => op!('=', '='),
-            Ne => op!('!', '='),
-            Ge => op!('>', '='),
-            Gt => op!('>'),
-            AndAnd => op!('&', '&'),
-            OrOr => op!('|', '|'),
-            Not => op!('!'),
-            Tilde => op!('~'),
-            BinOp(Plus) => op!('+'),
-            BinOp(Minus) => op!('-'),
-            BinOp(Star) => op!('*'),
-            BinOp(Slash) => op!('/'),
-            BinOp(Percent) => op!('%'),
-            BinOp(Caret) => op!('^'),
-            BinOp(And) => op!('&'),
-            BinOp(Or) => op!('|'),
-            BinOp(Shl) => op!('<', '<'),
-            BinOp(Shr) => op!('>', '>'),
-            BinOpEq(Plus) => op!('+', '='),
-            BinOpEq(Minus) => op!('-', '='),
-            BinOpEq(Star) => op!('*', '='),
-            BinOpEq(Slash) => op!('/', '='),
-            BinOpEq(Percent) => op!('%', '='),
-            BinOpEq(Caret) => op!('^', '='),
-            BinOpEq(And) => op!('&', '='),
-            BinOpEq(Or) => op!('|', '='),
-            BinOpEq(Shl) => op!('<', '<', '='),
-            BinOpEq(Shr) => op!('>', '>', '='),
-            At => op!('@'),
-            Dot => op!('.'),
-            DotDot => op!('.', '.'),
-            DotDotDot => op!('.', '.', '.'),
-            DotDotEq => op!('.', '.', '='),
-            Comma => op!(','),
-            Semi => op!(';'),
-            Colon => op!(':'),
-            ModSep => op!(':', ':'),
-            RArrow => op!('-', '>'),
-            LArrow => op!('<', '-'),
-            FatArrow => op!('=', '>'),
-            Pound => op!('#'),
-            Dollar => op!('$'),
-            Question => op!('?'),
-            SingleQuote => op!('\''),
-
-            Ident(name, false) if name == kw::DollarCrate => tt!(Ident::dollar_crate()),
-            Ident(name, is_raw) => tt!(Ident::new(rustc.sess, name, is_raw)),
-            Lifetime(name) => {
-                let ident = symbol::Ident::new(name, span).without_first_quote();
-                stack.push(tt!(Ident::new(rustc.sess, ident.name, false)));
-                tt!(Punct { ch: '\'', joint: true })
+            macro_rules! tt {
+                ($ty:ident { $($field:ident $(: $value:expr)*),+ $(,)? }) => (
+                    trees.push(TokenTree::$ty(self::$ty {
+                        $($field $(: $value)*,)+
+                        span,
+                    }))
+                );
+                ($ty:ident::$method:ident($($value:expr),*)) => (
+                    trees.push(TokenTree::$ty(self::$ty::$method($($value,)* span)))
+                );
             }
-            Literal(lit) => tt!(Literal { lit }),
-            DocComment(_, attr_style, data) => {
-                let mut escaped = String::new();
-                for ch in data.as_str().chars() {
-                    escaped.extend(ch.escape_debug());
-                }
-                let stream = vec![
-                    Ident(sym::doc, false),
-                    Eq,
-                    TokenKind::lit(token::Str, Symbol::intern(&escaped), None),
-                ]
-                .into_iter()
-                .map(|kind| tokenstream::TokenTree::token(kind, span))
-                .collect();
-                stack.push(TokenTree::Group(Group {
-                    delimiter: Delimiter::Bracket,
-                    stream,
-                    span: DelimSpan::from_single(span),
-                    flatten: false,
-                }));
-                if attr_style == ast::AttrStyle::Inner {
-                    stack.push(tt!(Punct { ch: '!', joint: false }));
-                }
-                tt!(Punct { ch: '#', joint: false })
+            macro_rules! op {
+                ($a:expr) => {{
+                    tt!(Punct { ch: $a, joint });
+                }};
+                ($a:expr, $b:expr) => {{
+                    tt!(Punct { ch: $a, joint: true });
+                    tt!(Punct { ch: $b, joint });
+                }};
+                ($a:expr, $b:expr, $c:expr) => {{
+                    tt!(Punct { ch: $a, joint: true });
+                    tt!(Punct { ch: $b, joint: true });
+                    tt!(Punct { ch: $c, joint });
+                }};
             }
 
-            Interpolated(nt) => {
-                if let Some((name, is_raw)) = ident_name_compatibility_hack(&nt, span, rustc) {
-                    TokenTree::Ident(Ident::new(rustc.sess, name.name, is_raw, name.span))
-                } else {
-                    let stream = nt_to_tokenstream(&nt, rustc.sess, CanSynthesizeMissingTokens::No);
-                    TokenTree::Group(Group {
-                        delimiter: Delimiter::None,
-                        stream,
+            match kind {
+                Eq => op!('='),
+                Lt => op!('<'),
+                Le => op!('<', '='),
+                EqEq => op!('=', '='),
+                Ne => op!('!', '='),
+                Ge => op!('>', '='),
+                Gt => op!('>'),
+                AndAnd => op!('&', '&'),
+                OrOr => op!('|', '|'),
+                Not => op!('!'),
+                Tilde => op!('~'),
+                BinOp(Plus) => op!('+'),
+                BinOp(Minus) => op!('-'),
+                BinOp(Star) => op!('*'),
+                BinOp(Slash) => op!('/'),
+                BinOp(Percent) => op!('%'),
+                BinOp(Caret) => op!('^'),
+                BinOp(And) => op!('&'),
+                BinOp(Or) => op!('|'),
+                BinOp(Shl) => op!('<', '<'),
+                BinOp(Shr) => op!('>', '>'),
+                BinOpEq(Plus) => op!('+', '='),
+                BinOpEq(Minus) => op!('-', '='),
+                BinOpEq(Star) => op!('*', '='),
+                BinOpEq(Slash) => op!('/', '='),
+                BinOpEq(Percent) => op!('%', '='),
+                BinOpEq(Caret) => op!('^', '='),
+                BinOpEq(And) => op!('&', '='),
+                BinOpEq(Or) => op!('|', '='),
+                BinOpEq(Shl) => op!('<', '<', '='),
+                BinOpEq(Shr) => op!('>', '>', '='),
+                At => op!('@'),
+                Dot => op!('.'),
+                DotDot => op!('.', '.'),
+                DotDotDot => op!('.', '.', '.'),
+                DotDotEq => op!('.', '.', '='),
+                Comma => op!(','),
+                Semi => op!(';'),
+                Colon => op!(':'),
+                ModSep => op!(':', ':'),
+                RArrow => op!('-', '>'),
+                LArrow => op!('<', '-'),
+                FatArrow => op!('=', '>'),
+                Pound => op!('#'),
+                Dollar => op!('$'),
+                Question => op!('?'),
+                SingleQuote => op!('\''),
+
+                Ident(name, false) if name == kw::DollarCrate => tt!(Ident::dollar_crate()),
+                Ident(name, is_raw) => tt!(Ident::new(rustc.sess, name, is_raw)),
+                Lifetime(name) => {
+                    let ident = symbol::Ident::new(name, span).without_first_quote();
+                    tt!(Punct { ch: '\'', joint: true });
+                    tt!(Ident::new(rustc.sess, ident.name, false));
+                }
+                Literal(lit) => tt!(Literal { lit }),
+                DocComment(_, attr_style, data) => {
+                    let mut escaped = String::new();
+                    for ch in data.as_str().chars() {
+                        escaped.extend(ch.escape_debug());
+                    }
+                    let stream = vec![
+                        Ident(sym::doc, false),
+                        Eq,
+                        TokenKind::lit(token::Str, Symbol::intern(&escaped), None),
+                    ]
+                    .into_iter()
+                    .map(|kind| tokenstream::TokenTree::token(kind, span))
+                    .collect();
+                    tt!(Punct { ch: '#', joint: false });
+                    if attr_style == ast::AttrStyle::Inner {
+                        tt!(Punct { ch: '!', joint: false });
+                    }
+                    trees.push(TokenTree::Group(Group {
+                        delimiter: Delimiter::Bracket,
+                        stream: Some(stream),
                         span: DelimSpan::from_single(span),
-                        flatten: crate::base::pretty_printing_compatibility_hack(&nt, rustc.sess),
-                    })
+                    }));
                 }
-            }
 
-            OpenDelim(..) | CloseDelim(..) => unreachable!(),
-            Eof => unreachable!(),
+                Interpolated(nt) => {
+                    if let Some((name, is_raw)) = ident_name_compatibility_hack(&nt, span, rustc) {
+                        trees.push(TokenTree::Ident(Ident::new(
+                            rustc.sess, name.name, is_raw, name.span,
+                        )));
+                    } else {
+                        let stream =
+                            nt_to_tokenstream(&nt, rustc.sess, CanSynthesizeMissingTokens::No);
+                        if crate::base::pretty_printing_compatibility_hack(&nt, rustc.sess) {
+                            cursor.append(stream);
+                        } else {
+                            trees.push(TokenTree::Group(Group {
+                                delimiter: Delimiter::None,
+                                stream: Some(stream),
+                                span: DelimSpan::from_single(span),
+                            }))
+                        }
+                    }
+                }
+
+                OpenDelim(..) | CloseDelim(..) => unreachable!(),
+                Eof => unreachable!(),
+            }
         }
+        trees
     }
 }
 
-impl ToInternal<TokenStream> for TokenTree<Span, Group, Ident, Literal> {
+impl ToInternal<TokenStream> for TokenTree<TokenStream, Span, Ident, Literal> {
     fn to_internal(self) -> TokenStream {
         use rustc_ast::token::*;
 
         let (ch, joint, span) = match self {
             TokenTree::Punct(Punct { ch, joint, span }) => (ch, joint, span),
-            TokenTree::Group(Group { delimiter, stream, span, .. }) => {
-                return tokenstream::TokenTree::Delimited(span, delimiter.to_internal(), stream)
-                    .into();
+            TokenTree::Group(Group { delimiter, stream, span: DelimSpan { open, close, .. } }) => {
+                return tokenstream::TokenTree::Delimited(
+                    tokenstream::DelimSpan { open, close },
+                    delimiter.to_internal(),
+                    stream.unwrap_or_default(),
+                )
+                .into();
             }
             TokenTree::Ident(self::Ident { sym, is_raw, span }) => {
                 return tokenstream::TokenTree::token(Ident(sym, is_raw), span).into();
@@ -283,17 +305,6 @@ impl ToInternal<rustc_errors::Level> for Level {
 }
 
 pub struct FreeFunctions;
-
-#[derive(Clone)]
-pub struct Group {
-    delimiter: Delimiter,
-    stream: TokenStream,
-    span: DelimSpan,
-    /// A hack used to pass AST fragments to attribute and derive macros
-    /// as a single nonterminal token instead of a token stream.
-    /// FIXME: It needs to be removed, but there are some compatibility issues (see #73345).
-    flatten: bool,
-}
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
@@ -371,7 +382,6 @@ impl<'a> Rustc<'a> {
 impl server::Types for Rustc<'_> {
     type FreeFunctions = FreeFunctions;
     type TokenStream = TokenStream;
-    type Group = Group;
     type Ident = Ident;
     type Literal = Literal;
     type SourceFile = Lrc<SourceFile>;
@@ -403,14 +413,14 @@ impl server::TokenStream for Rustc<'_> {
     }
     fn from_token_tree(
         &mut self,
-        tree: TokenTree<Self::Span, Self::Group, Self::Ident, Self::Literal>,
+        tree: TokenTree<Self::TokenStream, Self::Span, Self::Ident, Self::Literal>,
     ) -> Self::TokenStream {
         tree.to_internal()
     }
     fn concat_trees(
         &mut self,
         base: Option<Self::TokenStream>,
-        trees: Vec<TokenTree<Self::Span, Self::Group, Self::Ident, Self::Literal>>,
+        trees: Vec<TokenTree<Self::TokenStream, Self::Span, Self::Ident, Self::Literal>>,
     ) -> Self::TokenStream {
         let mut builder = tokenstream::TokenStreamBuilder::new();
         if let Some(base) = base {
@@ -438,64 +448,8 @@ impl server::TokenStream for Rustc<'_> {
     fn into_iter(
         &mut self,
         stream: Self::TokenStream,
-    ) -> Vec<TokenTree<Self::Span, Self::Group, Self::Ident, Self::Literal>> {
-        // XXX: This is a raw port of the previous approach, and can probably be
-        // optimized.
-        let mut cursor = stream.trees();
-        let mut stack = Vec::new();
-        let mut tts = Vec::new();
-        loop {
-            let next = stack.pop().or_else(|| {
-                let next = cursor.next_with_spacing()?;
-                Some(TokenTree::from_internal((next, &mut stack, self)))
-            });
-            match next {
-                Some(TokenTree::Group(group)) => {
-                    // A hack used to pass AST fragments to attribute and derive
-                    // macros as a single nonterminal token instead of a token
-                    // stream.  Such token needs to be "unwrapped" and not
-                    // represented as a delimited group.
-                    // FIXME: It needs to be removed, but there are some
-                    // compatibility issues (see #73345).
-                    if group.flatten {
-                        cursor.append(group.stream);
-                        continue;
-                    }
-                    tts.push(TokenTree::Group(group));
-                }
-                Some(tt) => tts.push(tt),
-                None => return tts,
-            }
-        }
-    }
-}
-
-impl server::Group for Rustc<'_> {
-    fn new(&mut self, delimiter: Delimiter, stream: Option<Self::TokenStream>) -> Self::Group {
-        Group {
-            delimiter,
-            stream: stream.unwrap_or_default(),
-            span: DelimSpan::from_single(server::Context::call_site(self)),
-            flatten: false,
-        }
-    }
-    fn delimiter(&mut self, group: &Self::Group) -> Delimiter {
-        group.delimiter
-    }
-    fn stream(&mut self, group: &Self::Group) -> Self::TokenStream {
-        group.stream.clone()
-    }
-    fn span(&mut self, group: &Self::Group) -> Self::Span {
-        group.span.entire()
-    }
-    fn span_open(&mut self, group: &Self::Group) -> Self::Span {
-        group.span.open
-    }
-    fn span_close(&mut self, group: &Self::Group) -> Self::Span {
-        group.span.close
-    }
-    fn set_span(&mut self, group: &mut Self::Group, span: Self::Span) {
-        group.span = DelimSpan::from_single(span);
+    ) -> Vec<TokenTree<Self::TokenStream, Self::Span, Self::Ident, Self::Literal>> {
+        FromInternal::from_internal((stream, self))
     }
 }
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -285,12 +285,6 @@ impl ToInternal<rustc_errors::Level> for Level {
 pub struct FreeFunctions;
 
 #[derive(Clone)]
-pub struct TokenStreamIter {
-    cursor: tokenstream::Cursor,
-    stack: Vec<TokenTree<Group, Punct, Ident, Literal>>,
-}
-
-#[derive(Clone)]
 pub struct Group {
     delimiter: Delimiter,
     stream: TokenStream,
@@ -398,8 +392,6 @@ impl<'a> Rustc<'a> {
 impl server::Types for Rustc<'_> {
     type FreeFunctions = FreeFunctions;
     type TokenStream = TokenStream;
-    type TokenStreamBuilder = tokenstream::TokenStreamBuilder;
-    type TokenStreamIter = TokenStreamIter;
     type Group = Group;
     type Punct = Punct;
     type Ident = Ident;
@@ -417,9 +409,6 @@ impl server::FreeFunctions for Rustc<'_> {
 }
 
 impl server::TokenStream for Rustc<'_> {
-    fn new(&mut self) -> Self::TokenStream {
-        TokenStream::default()
-    }
     fn is_empty(&mut self, stream: &Self::TokenStream) -> bool {
         stream.is_empty()
     }
@@ -440,53 +429,74 @@ impl server::TokenStream for Rustc<'_> {
     ) -> Self::TokenStream {
         tree.to_internal()
     }
-    fn into_iter(&mut self, stream: Self::TokenStream) -> Self::TokenStreamIter {
-        TokenStreamIter { cursor: stream.trees(), stack: vec![] }
-    }
-}
-
-impl server::TokenStreamBuilder for Rustc<'_> {
-    fn new(&mut self) -> Self::TokenStreamBuilder {
-        tokenstream::TokenStreamBuilder::new()
-    }
-    fn push(&mut self, builder: &mut Self::TokenStreamBuilder, stream: Self::TokenStream) {
-        builder.push(stream);
-    }
-    fn build(&mut self, builder: Self::TokenStreamBuilder) -> Self::TokenStream {
+    fn concat_trees(
+        &mut self,
+        base: Option<Self::TokenStream>,
+        trees: Vec<TokenTree<Self::Group, Self::Punct, Self::Ident, Self::Literal>>,
+    ) -> Self::TokenStream {
+        let mut builder = tokenstream::TokenStreamBuilder::new();
+        if let Some(base) = base {
+            builder.push(base);
+        }
+        for tree in trees {
+            builder.push(tree.to_internal());
+        }
         builder.build()
     }
-}
-
-impl server::TokenStreamIter for Rustc<'_> {
-    fn next(
+    fn concat_streams(
         &mut self,
-        iter: &mut Self::TokenStreamIter,
-    ) -> Option<TokenTree<Self::Group, Self::Punct, Self::Ident, Self::Literal>> {
+        base: Option<Self::TokenStream>,
+        streams: Vec<Self::TokenStream>,
+    ) -> Self::TokenStream {
+        let mut builder = tokenstream::TokenStreamBuilder::new();
+        if let Some(base) = base {
+            builder.push(base);
+        }
+        for stream in streams {
+            builder.push(stream);
+        }
+        builder.build()
+    }
+    fn into_iter(
+        &mut self,
+        stream: Self::TokenStream,
+    ) -> Vec<TokenTree<Self::Group, Self::Punct, Self::Ident, Self::Literal>> {
+        // XXX: This is a raw port of the previous approach, and can probably be
+        // optimized.
+        let mut cursor = stream.trees();
+        let mut stack = Vec::new();
+        let mut tts = Vec::new();
         loop {
-            let tree = iter.stack.pop().or_else(|| {
-                let next = iter.cursor.next_with_spacing()?;
-                Some(TokenTree::from_internal((next, &mut iter.stack, self)))
-            })?;
-            // A hack used to pass AST fragments to attribute and derive macros
-            // as a single nonterminal token instead of a token stream.
-            // Such token needs to be "unwrapped" and not represented as a delimited group.
-            // FIXME: It needs to be removed, but there are some compatibility issues (see #73345).
-            if let TokenTree::Group(ref group) = tree {
-                if group.flatten {
-                    iter.cursor.append(group.stream.clone());
-                    continue;
+            let next = stack.pop().or_else(|| {
+                let next = cursor.next_with_spacing()?;
+                Some(TokenTree::from_internal((next, &mut stack, self)))
+            });
+            match next {
+                Some(TokenTree::Group(group)) => {
+                    // A hack used to pass AST fragments to attribute and derive
+                    // macros as a single nonterminal token instead of a token
+                    // stream.  Such token needs to be "unwrapped" and not
+                    // represented as a delimited group.
+                    // FIXME: It needs to be removed, but there are some
+                    // compatibility issues (see #73345).
+                    if group.flatten {
+                        cursor.append(group.stream);
+                        continue;
+                    }
+                    tts.push(TokenTree::Group(group));
                 }
+                Some(tt) => tts.push(tt),
+                None => return tts,
             }
-            return Some(tree);
         }
     }
 }
 
 impl server::Group for Rustc<'_> {
-    fn new(&mut self, delimiter: Delimiter, stream: Self::TokenStream) -> Self::Group {
+    fn new(&mut self, delimiter: Delimiter, stream: Option<Self::TokenStream>) -> Self::Group {
         Group {
             delimiter,
-            stream,
+            stream: stream.unwrap_or_default(),
             span: DelimSpan::from_single(server::Context::call_site(self)),
             flatten: false,
         }
@@ -519,7 +529,11 @@ impl server::Punct for Rustc<'_> {
         punct.ch
     }
     fn spacing(&mut self, punct: Self::Punct) -> Spacing {
-        if punct.joint { Spacing::Joint } else { Spacing::Alone }
+        if punct.joint {
+            Spacing::Joint
+        } else {
+            Spacing::Alone
+        }
     }
     fn span(&mut self, punct: Self::Punct) -> Self::Span {
         punct.span

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1207,6 +1207,8 @@ options! {
         "print layout information for each type encountered (default: no)"),
     proc_macro_backtrace: bool = (false, parse_bool, [UNTRACKED],
          "show backtraces for panics during proc-macro execution (default: no)"),
+    proc_macro_cross_thread: bool = (false, parse_bool, [UNTRACKED],
+        "run proc-macro code on a separate thread (default: no)"),
     profile: bool = (false, parse_bool, [TRACKED],
         "insert profiling code (default: no)"),
     profile_closures: bool = (false, parse_no_flag, [UNTRACKED],

--- a/library/proc_macro/src/bridge/buffer.rs
+++ b/library/proc_macro/src/bridge/buffer.rs
@@ -6,6 +6,35 @@ use std::ops::{Deref, DerefMut};
 use std::slice;
 
 #[repr(C)]
+pub struct Slice<'a, T> {
+    data: &'a [T; 0],
+    len: usize,
+}
+
+unsafe impl<'a, T: Sync> Sync for Slice<'a, T> {}
+unsafe impl<'a, T: Sync> Send for Slice<'a, T> {}
+
+impl<T> Copy for Slice<'a, T> {}
+impl<T> Clone for Slice<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> From<&'a [T]> for Slice<'a, T> {
+    fn from(xs: &'a [T]) -> Self {
+        Slice { data: unsafe { &*(xs.as_ptr() as *const [T; 0]) }, len: xs.len() }
+    }
+}
+
+impl<T> Deref for Slice<'a, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.data.as_ptr(), self.len) }
+    }
+}
+
+#[repr(C)]
 pub struct Buffer<T: Copy> {
     data: *mut T,
     len: usize,

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -312,7 +312,11 @@ macro_rules! client_send_impl {
 
             b = bridge.dispatch.call(b);
 
-            let r = Result::<(), PanicMessage>::decode(&mut &b[..], &mut ());
+            let r = if b.len() > 0 {
+                Result::<(), PanicMessage>::decode(&mut &b[..], &mut ())
+            } else {
+                Ok(())
+            };
 
             bridge.cached_buffer = b;
 

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -196,7 +196,6 @@ define_handles! {
     'owned:
     FreeFunctions,
     TokenStream,
-    Literal,
     SourceFile,
     MultiSpan,
     Diagnostic,
@@ -214,25 +213,6 @@ define_handles! {
 impl Clone for TokenStream {
     fn clone(&self) -> Self {
         self.clone()
-    }
-}
-
-impl Clone for Literal {
-    fn clone(&self) -> Self {
-        self.clone()
-    }
-}
-
-impl fmt::Debug for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Literal")
-            // format the kind without quotes, as in `kind: Float`
-            .field("kind", &format_args!("{}", &self.debug_kind()))
-            .field("symbol", &self.symbol())
-            // format `Some("...")` on one line even in {:#?} mode
-            .field("suffix", &format_args!("{:?}", &self.suffix()))
-            .field("span", &self.span())
-            .finish()
     }
 }
 
@@ -267,6 +247,11 @@ impl fmt::Debug for Span {
 pub(crate) struct Symbol(handle::Handle);
 
 impl Symbol {
+    /// Intern a new `Symbol`
+    pub(crate) fn new(string: &str) -> Self {
+        Symbol(Bridge::with(|bridge| bridge.symbols.alloc(string)))
+    }
+
     /// Create a new `Symbol` for an identifier.
     ///
     /// Validates and normalizes before converting it to a symbol.

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -202,7 +202,6 @@ define_handles! {
     Diagnostic,
 
     'interned:
-    Punct,
     Ident,
     Span,
 }

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -195,7 +195,6 @@ define_handles! {
     'owned:
     FreeFunctions,
     TokenStream,
-    Group,
     Literal,
     SourceFile,
     MultiSpan,
@@ -213,12 +212,6 @@ define_handles! {
 // instead of pattern matching on methods, here and in server decl.
 
 impl Clone for TokenStream {
-    fn clone(&self) -> Self {
-        self.clone()
-    }
-}
-
-impl Clone for Group {
     fn clone(&self) -> Self {
         self.clone()
     }

--- a/library/proc_macro/src/bridge/handle.rs
+++ b/library/proc_macro/src/bridge/handle.rs
@@ -27,8 +27,12 @@ impl<T> OwnedStore<T> {
     pub(super) fn alloc(&mut self, x: T) -> Handle {
         let counter = self.counter.fetch_add(1, Ordering::SeqCst);
         let handle = Handle::new(counter as u32).expect("`proc_macro` handle counter overflowed");
-        assert!(self.data.insert(handle, x).is_none());
+        self.init(handle, x);
         handle
+    }
+
+    pub(super) fn init(&mut self, h: Handle, x: T) {
+        assert!(self.data.insert(h, x).is_none());
     }
 
     pub(super) fn take(&mut self, h: Handle) -> T {

--- a/library/proc_macro/src/bridge/handle.rs
+++ b/library/proc_macro/src/bridge/handle.rs
@@ -1,9 +1,11 @@
 //! Server-side handles and storage for per-handle data.
 
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::num::NonZeroU32;
 use std::ops::{Index, IndexMut};
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(super) type Handle = NonZeroU32;
@@ -53,22 +55,60 @@ impl<T> IndexMut<Handle> for OwnedStore<T> {
     }
 }
 
+pub(super) trait FromKey<Q: ?Sized> {
+    fn from_key(key: &Q) -> Self;
+}
+
+impl<T: Clone> FromKey<T> for T {
+    fn from_key(key: &T) -> T {
+        key.clone()
+    }
+}
+
+impl<T: ?Sized> FromKey<T> for Rc<T>
+where
+    Rc<T>: for<'a> From<&'a T>,
+{
+    fn from_key(key: &T) -> Rc<T> {
+        key.into()
+    }
+}
+
 pub(super) struct InternedStore<T: 'static> {
     owned: OwnedStore<T>,
     interner: HashMap<T, Handle>,
 }
 
-impl<T: Copy + Eq + Hash> InternedStore<T> {
+impl<T: Clone + Eq + Hash> InternedStore<T> {
     pub(super) fn new(counter: &'static AtomicUsize) -> Self {
         InternedStore { owned: OwnedStore::new(counter), interner: HashMap::new() }
     }
 
-    pub(super) fn alloc(&mut self, x: T) -> Handle {
+    pub(super) fn alloc<'a, Q: ?Sized>(&mut self, x: &'a Q) -> Handle
+    where
+        T: Borrow<Q> + FromKey<Q>,
+        Q: Hash + Eq,
+    {
         let owned = &mut self.owned;
-        *self.interner.entry(x).or_insert_with(|| owned.alloc(x))
+        *self
+            .interner
+            .raw_entry_mut()
+            .from_key(x)
+            .or_insert_with(|| {
+                let own = T::from_key(x);
+                (own.clone(), owned.alloc(own))
+            })
+            .1
     }
 
     pub(super) fn copy(&mut self, h: Handle) -> T {
-        self.owned[h]
+        self.owned[h].clone()
+    }
+}
+
+impl<T> Index<Handle> for InternedStore<T> {
+    type Output = T;
+    fn index(&self, h: Handle) -> &T {
+        self.owned.index(h)
     }
 }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -329,6 +329,21 @@ impl<T: Unmark, E: Unmark> Unmark for Result<T, E> {
     }
 }
 
+impl<T: Mark> Mark for Vec<T> {
+    type Unmarked = Vec<T::Unmarked>;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        // Should be a no-op due to std's in-place collect optimizations.
+        unmarked.into_iter().map(T::mark).collect()
+    }
+}
+impl<T: Unmark> Unmark for Vec<T> {
+    type Unmarked = Vec<T::Unmarked>;
+    fn unmark(self) -> Self::Unmarked {
+        // Should be a no-op due to std's in-place collect optimizations.
+        self.into_iter().map(T::unmark).collect()
+    }
+}
+
 macro_rules! mark_noop {
     ($($ty:ty),* $(,)?) => {
         $(

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -152,9 +152,6 @@ macro_rules! with_api {
             },
             Span {
                 fn debug($self: $S::Span) -> String;
-                fn def_site() -> $S::Span;
-                fn call_site() -> $S::Span;
-                fn mixed_site() -> $S::Span;
                 fn source_file($self: $S::Span) -> $S::SourceFile;
                 fn parent($self: $S::Span) -> Option<$S::Span>;
                 fn source($self: $S::Span) -> $S::Span;
@@ -210,16 +207,15 @@ use buffer::Buffer;
 pub use rpc::PanicMessage;
 use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
 
-/// An active connection between a server and a client.
-/// The server creates the bridge (`Bridge::run_server` in `server.rs`),
-/// then passes it to the client through the function pointer in the `run`
-/// field of `client::Client`. The client holds its copy of the `Bridge`
+/// Configuration for establishing an active connection between a server and a
+/// client.  The server creates the bridge config (`run_server` in `server.rs`),
+/// then passes it to the client through the function pointer in the `run` field
+/// of `client::Client`. The client constructs a local `Bridge` from the config
 /// in TLS during its execution (`Bridge::{enter, with}` in `client.rs`).
 #[repr(C)]
-pub struct Bridge<'a> {
-    /// Reusable buffer (only `clear`-ed, never shrunk), primarily
-    /// used for making requests, but also for passing input to client.
-    cached_buffer: Buffer<u8>,
+pub struct BridgeConfig<'a> {
+    /// Buffer used to pass initial input to the client.
+    input: Buffer<u8>,
 
     /// Server-side function that the client uses to make requests.
     dispatch: closure::Closure<'a, Buffer<u8>, Buffer<u8>>,
@@ -228,8 +224,8 @@ pub struct Bridge<'a> {
     force_show_panics: bool,
 }
 
-impl<'a> !Sync for Bridge<'a> {}
-impl<'a> !Send for Bridge<'a> {}
+impl<'a> !Sync for BridgeConfig<'a> {}
+impl<'a> !Send for BridgeConfig<'a> {}
 
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]
@@ -468,4 +464,17 @@ compound_traits!(
         Ident(tt),
         Literal(tt),
     }
+);
+
+/// Context provided alongside the initial inputs for a macro expansion.
+/// Provides values such as spans which are used frequently to avoid RPC.
+#[derive(Clone)]
+struct ExpnContext<S> {
+    def_site: S,
+    call_site: S,
+    mixed_site: S,
+}
+
+compound_traits!(
+    struct ExpnContext<Sp> { def_site, call_site, mixed_site }
 );

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -69,11 +69,11 @@ macro_rules! with_api {
                 wait fn from_str(src: &str) -> $S::TokenStream;
                 wait fn to_string($self: &$S::TokenStream) -> String;
                 nowait fn from_token_tree(
-                    tree: TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>,
+                    tree: TokenTree<$S::Span, $S::Group, $S::Ident, $S::Literal>,
                 ) -> $S::TokenStream;
                 nowait fn concat_trees(
                     base: Option<$S::TokenStream>,
-                    trees: Vec<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>,
+                    trees: Vec<TokenTree<$S::Span, $S::Group, $S::Ident, $S::Literal>>,
                 ) -> $S::TokenStream;
                 nowait fn concat_streams(
                     base: Option<$S::TokenStream>,
@@ -81,7 +81,7 @@ macro_rules! with_api {
                 ) -> $S::TokenStream;
                 wait fn into_iter(
                     $self: $S::TokenStream
-                ) -> Vec<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>;
+                ) -> Vec<TokenTree<$S::Span, $S::Group, $S::Ident, $S::Literal>>;
             },
             Group {
                 nowait fn drop($self: $S::Group);
@@ -93,13 +93,6 @@ macro_rules! with_api {
                 wait fn span_open($self: &$S::Group) -> $S::Span;
                 wait fn span_close($self: &$S::Group) -> $S::Span;
                 nowait fn set_span($self: &mut $S::Group, span: $S::Span);
-            },
-            Punct {
-                wait fn new(ch: char, spacing: Spacing) -> $S::Punct;
-                wait fn as_char($self: $S::Punct) -> char;
-                wait fn spacing($self: $S::Punct) -> Spacing;
-                wait fn span($self: $S::Punct) -> $S::Span;
-                wait fn with_span($self: $S::Punct, span: $S::Span) -> $S::Punct;
             },
             Ident {
                 wait fn new(string: &str, span: $S::Span, is_raw: bool) -> $S::Ident;
@@ -471,15 +464,24 @@ macro_rules! compound_traits {
 }
 
 #[derive(Clone)]
-pub enum TokenTree<G, P, I, L> {
+pub struct Punct<S> {
+    pub ch: char,
+    pub joint: bool,
+    pub span: S,
+}
+
+compound_traits!(struct Punct<Sp> { ch, joint, span });
+
+#[derive(Clone)]
+pub enum TokenTree<S, G, I, L> {
     Group(G),
-    Punct(P),
+    Punct(Punct<S>),
     Ident(I),
     Literal(L),
 }
 
 compound_traits!(
-    enum TokenTree<G, P, I, L> {
+    enum TokenTree<Sp, G, I, L> {
         Group(tt),
         Punct(tt),
         Ident(tt),

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -65,32 +65,28 @@ macro_rules! with_api {
             TokenStream {
                 nowait fn drop($self: $S::TokenStream);
                 nowait fn clone($self: &$S::TokenStream) -> $S::TokenStream;
-                nowait fn new() -> $S::TokenStream;
                 wait fn is_empty($self: &$S::TokenStream) -> bool;
                 wait fn from_str(src: &str) -> $S::TokenStream;
                 wait fn to_string($self: &$S::TokenStream) -> String;
                 nowait fn from_token_tree(
                     tree: TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>,
                 ) -> $S::TokenStream;
-                nowait fn into_iter($self: $S::TokenStream) -> $S::TokenStreamIter;
-            },
-            TokenStreamBuilder {
-                nowait fn drop($self: $S::TokenStreamBuilder);
-                nowait fn new() -> $S::TokenStreamBuilder;
-                nowait fn push($self: &mut $S::TokenStreamBuilder, stream: $S::TokenStream);
-                nowait fn build($self: $S::TokenStreamBuilder) -> $S::TokenStream;
-            },
-            TokenStreamIter {
-                nowait fn drop($self: $S::TokenStreamIter);
-                nowait fn clone($self: &$S::TokenStreamIter) -> $S::TokenStreamIter;
-                wait fn next(
-                    $self: &mut $S::TokenStreamIter,
-                ) -> Option<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>;
+                nowait fn concat_trees(
+                    base: Option<$S::TokenStream>,
+                    trees: Vec<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>,
+                ) -> $S::TokenStream;
+                nowait fn concat_streams(
+                    base: Option<$S::TokenStream>,
+                    trees: Vec<$S::TokenStream>,
+                ) -> $S::TokenStream;
+                wait fn into_iter(
+                    $self: $S::TokenStream
+                ) -> Vec<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>;
             },
             Group {
                 nowait fn drop($self: $S::Group);
                 nowait fn clone($self: &$S::Group) -> $S::Group;
-                nowait fn new(delimiter: Delimiter, stream: $S::TokenStream) -> $S::Group;
+                nowait fn new(delimiter: Delimiter, stream: Option<$S::TokenStream>) -> $S::Group;
                 wait fn delimiter($self: &$S::Group) -> Delimiter;
                 nowait fn stream($self: &$S::Group) -> $S::TokenStream;
                 wait fn span($self: &$S::Group) -> $S::Span;

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -401,6 +401,58 @@ rpc_encode_decode!(
     }
 );
 
+macro_rules! mark_compound {
+    (struct $name:ident <$($T:ident),+> { $($field:ident),* $(,)? }) => {
+        impl<$($T: Mark),+> Mark for $name <$($T),+> {
+            type Unmarked = $name <$($T::Unmarked),+>;
+            fn mark(unmarked: Self::Unmarked) -> Self {
+                $name {
+                    $($field: Mark::mark(unmarked.$field)),*
+                }
+            }
+        }
+
+        impl<$($T: Unmark),+> Unmark for $name <$($T),+> {
+            type Unmarked = $name <$($T::Unmarked),+>;
+            fn unmark(self) -> Self::Unmarked {
+                $name {
+                    $($field: Unmark::unmark(self.$field)),*
+                }
+            }
+        }
+    };
+    (enum $name:ident <$($T:ident),+> { $($variant:ident $(($field:ident))?),* $(,)? }) => {
+        impl<$($T: Mark),+> Mark for $name <$($T),+> {
+            type Unmarked = $name <$($T::Unmarked),+>;
+            fn mark(unmarked: Self::Unmarked) -> Self {
+                match unmarked {
+                    $($name::$variant $(($field))? => {
+                        $name::$variant $((Mark::mark($field)))?
+                    })*
+                }
+            }
+        }
+
+        impl<$($T: Unmark),+> Unmark for $name <$($T),+> {
+            type Unmarked = $name <$($T::Unmarked),+>;
+            fn unmark(self) -> Self::Unmarked {
+                match self {
+                    $($name::$variant $(($field))? => {
+                        $name::$variant $((Unmark::unmark($field)))?
+                    })*
+                }
+            }
+        }
+    }
+}
+
+macro_rules! compound_traits {
+    ($($t:tt)*) => {
+        rpc_encode_decode!($($t)*);
+        mark_compound!($($t)*);
+    };
+}
+
 #[derive(Clone)]
 pub enum TokenTree<G, P, I, L> {
     Group(G),
@@ -409,30 +461,7 @@ pub enum TokenTree<G, P, I, L> {
     Literal(L),
 }
 
-impl<G: Mark, P: Mark, I: Mark, L: Mark> Mark for TokenTree<G, P, I, L> {
-    type Unmarked = TokenTree<G::Unmarked, P::Unmarked, I::Unmarked, L::Unmarked>;
-    fn mark(unmarked: Self::Unmarked) -> Self {
-        match unmarked {
-            TokenTree::Group(tt) => TokenTree::Group(G::mark(tt)),
-            TokenTree::Punct(tt) => TokenTree::Punct(P::mark(tt)),
-            TokenTree::Ident(tt) => TokenTree::Ident(I::mark(tt)),
-            TokenTree::Literal(tt) => TokenTree::Literal(L::mark(tt)),
-        }
-    }
-}
-impl<G: Unmark, P: Unmark, I: Unmark, L: Unmark> Unmark for TokenTree<G, P, I, L> {
-    type Unmarked = TokenTree<G::Unmarked, P::Unmarked, I::Unmarked, L::Unmarked>;
-    fn unmark(self) -> Self::Unmarked {
-        match self {
-            TokenTree::Group(tt) => TokenTree::Group(tt.unmark()),
-            TokenTree::Punct(tt) => TokenTree::Punct(tt.unmark()),
-            TokenTree::Ident(tt) => TokenTree::Ident(tt.unmark()),
-            TokenTree::Literal(tt) => TokenTree::Literal(tt.unmark()),
-        }
-    }
-}
-
-rpc_encode_decode!(
+compound_traits!(
     enum TokenTree<G, P, I, L> {
         Group(tt),
         Punct(tt),

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -248,6 +248,26 @@ impl<S> DecodeMut<'_, '_, S> for String {
     }
 }
 
+impl<S, T: Encode<S>> Encode<S> for Vec<T> {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.len().encode(w, s);
+        for x in self {
+            x.encode(w, s);
+        }
+    }
+}
+
+impl<S, T: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S> for Vec<T> {
+    fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
+        let len = usize::decode(r, s);
+        let mut vec = Vec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(T::decode(r, s));
+        }
+        vec
+    }
+}
+
 /// Simplified version of panic payloads, ignoring
 /// types other than `&'static str` and `String`.
 pub enum PanicMessage {

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -128,6 +128,7 @@ impl<S> DecodeMut<'_, '_, S> for u8 {
     }
 }
 
+rpc_encode_decode!(le u16);
 rpc_encode_decode!(le u32);
 rpc_encode_decode!(le usize);
 

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -43,15 +43,17 @@ macro_rules! rpc_encode_decode {
             }
         }
     };
-    (struct $name:ident { $($field:ident),* $(,)? }) => {
-        impl<S> Encode<S> for $name {
+    (struct $name:ident $(<$($T:ident),+>)? { $($field:ident),* $(,)? }) => {
+        impl<S, $($($T: Encode<S>),+)?> Encode<S> for $name $(<$($T),+>)? {
             fn encode(self, w: &mut Writer, s: &mut S) {
                 $(self.$field.encode(w, s);)*
             }
         }
 
-        impl<S> DecodeMut<'_, '_, S> for $name {
-            fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        impl<S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+            for $name $(<$($T),+>)?
+        {
+            fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
                 $name {
                     $($field: DecodeMut::decode(r, s)),*
                 }

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -16,8 +16,6 @@ macro_rules! associated_item {
         (type TokenStream: 'static + Clone;);
     (type Group) =>
         (type Group: 'static + Clone;);
-    (type Punct) =>
-        (type Punct: 'static + Copy + Eq + Hash;);
     (type Ident) =>
         (type Ident: 'static + Copy + Eq + Hash;);
     (type Literal) =>

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -14,10 +14,6 @@ macro_rules! associated_item {
         (type FreeFunctions: 'static;);
     (type TokenStream) =>
         (type TokenStream: 'static + Clone;);
-    (type TokenStreamBuilder) =>
-        (type TokenStreamBuilder: 'static;);
-    (type TokenStreamIter) =>
-        (type TokenStreamIter: 'static + Clone;);
     (type Group) =>
         (type Group: 'static + Clone;);
     (type Punct) =>

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -14,8 +14,6 @@ macro_rules! associated_item {
         (type FreeFunctions: 'static;);
     (type TokenStream) =>
         (type TokenStream: 'static + Clone;);
-    (type Group) =>
-        (type Group: 'static + Clone;);
     (type Ident) =>
         (type Ident: 'static + Copy + Eq + Hash;);
     (type Literal) =>

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -14,8 +14,6 @@ macro_rules! associated_item {
         (type FreeFunctions: 'static;);
     (type TokenStream) =>
         (type TokenStream: 'static + Clone;);
-    (type Literal) =>
-        (type Literal: 'static + Clone;);
     (type SourceFile) =>
         (type SourceFile: 'static + Clone;);
     (type MultiSpan) =>

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -63,7 +63,7 @@ use std::{error, fmt, iter, mem};
 /// inside of a procedural macro, false if invoked from any other binary.
 #[unstable(feature = "proc_macro_is_available", issue = "71436")]
 pub fn is_available() -> bool {
-    bridge::Bridge::is_available()
+    bridge::client::is_available()
 }
 
 /// The main type provided by this crate, representing an abstract stream of

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -46,7 +46,7 @@ use std::cmp::Ordering;
 use std::ops::RangeBounds;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{error, fmt, iter, mem};
+use std::{error, fmt, iter};
 
 /// Determines whether proc_macro has been made accessible to the currently
 /// running program.
@@ -75,7 +75,7 @@ pub fn is_available() -> bool {
 /// and `#[proc_macro_derive]` definitions.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 #[derive(Clone)]
-pub struct TokenStream(bridge::client::TokenStream);
+pub struct TokenStream(Option<bridge::client::TokenStream>);
 
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Send for TokenStream {}
@@ -113,13 +113,13 @@ impl TokenStream {
     /// Returns an empty `TokenStream` containing no token trees.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn new() -> TokenStream {
-        TokenStream(bridge::client::TokenStream::new())
+        TokenStream(None)
     }
 
     /// Checks if this `TokenStream` is empty.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.0.as_ref().map(|h| h.is_empty()).unwrap_or(true)
     }
 }
 
@@ -135,7 +135,7 @@ impl FromStr for TokenStream {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
-        Ok(TokenStream(bridge::client::TokenStream::from_str(src)))
+        Ok(TokenStream(Some(bridge::client::TokenStream::from_str(src))))
     }
 }
 
@@ -144,7 +144,7 @@ impl FromStr for TokenStream {
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl ToString for TokenStream {
     fn to_string(&self) -> String {
-        self.0.to_string()
+        self.0.as_ref().map(|t| t.to_string()).unwrap_or_default()
     }
 }
 
@@ -177,16 +177,27 @@ impl Default for TokenStream {
 #[unstable(feature = "proc_macro_quote", issue = "54722")]
 pub use quote::{quote, quote_span};
 
+fn tree_to_bridge_tree(
+    tree: TokenTree,
+) -> bridge::TokenTree<
+    bridge::client::Group,
+    bridge::client::Punct,
+    bridge::client::Ident,
+    bridge::client::Literal,
+> {
+    match tree {
+        TokenTree::Group(tt) => bridge::TokenTree::Group(tt.0),
+        TokenTree::Punct(tt) => bridge::TokenTree::Punct(tt.0),
+        TokenTree::Ident(tt) => bridge::TokenTree::Ident(tt.0),
+        TokenTree::Literal(tt) => bridge::TokenTree::Literal(tt.0),
+    }
+}
+
 /// Creates a token stream containing a single token tree.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl From<TokenTree> for TokenStream {
     fn from(tree: TokenTree) -> TokenStream {
-        TokenStream(bridge::client::TokenStream::from_token_tree(match tree {
-            TokenTree::Group(tt) => bridge::TokenTree::Group(tt.0),
-            TokenTree::Punct(tt) => bridge::TokenTree::Punct(tt.0),
-            TokenTree::Ident(tt) => bridge::TokenTree::Ident(tt.0),
-            TokenTree::Literal(tt) => bridge::TokenTree::Literal(tt.0),
-        }))
+        TokenStream(Some(bridge::client::TokenStream::from_token_tree(tree_to_bridge_tree(tree))))
     }
 }
 
@@ -194,7 +205,10 @@ impl From<TokenTree> for TokenStream {
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl iter::FromIterator<TokenTree> for TokenStream {
     fn from_iter<I: IntoIterator<Item = TokenTree>>(trees: I) -> Self {
-        trees.into_iter().map(TokenStream::from).collect()
+        TokenStream(Some(bridge::client::TokenStream::concat_trees(
+            None,
+            trees.into_iter().map(tree_to_bridge_tree).collect(),
+        )))
     }
 }
 
@@ -203,24 +217,30 @@ impl iter::FromIterator<TokenTree> for TokenStream {
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl iter::FromIterator<TokenStream> for TokenStream {
     fn from_iter<I: IntoIterator<Item = TokenStream>>(streams: I) -> Self {
-        let mut builder = bridge::client::TokenStreamBuilder::new();
-        streams.into_iter().for_each(|stream| builder.push(stream.0));
-        TokenStream(builder.build())
+        TokenStream(Some(bridge::client::TokenStream::concat_streams(
+            None,
+            streams.into_iter().filter_map(|stream| stream.0).collect(),
+        )))
     }
 }
 
 #[stable(feature = "token_stream_extend", since = "1.30.0")]
 impl Extend<TokenTree> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, trees: I) {
-        self.extend(trees.into_iter().map(TokenStream::from));
+        *self = TokenStream(Some(bridge::client::TokenStream::concat_trees(
+            self.0.take(),
+            trees.into_iter().map(|tree| tree_to_bridge_tree(tree)).collect(),
+        )));
     }
 }
 
 #[stable(feature = "token_stream_extend", since = "1.30.0")]
 impl Extend<TokenStream> for TokenStream {
     fn extend<I: IntoIterator<Item = TokenStream>>(&mut self, streams: I) {
-        // FIXME(eddyb) Use an optimized implementation if/when possible.
-        *self = iter::once(mem::replace(self, Self::new())).chain(streams).collect();
+        *self = TokenStream(Some(bridge::client::TokenStream::concat_streams(
+            self.0.take(),
+            streams.into_iter().filter_map(|stream| stream.0).collect(),
+        )));
     }
 }
 
@@ -234,7 +254,16 @@ pub mod token_stream {
     /// and returns whole groups as token trees.
     #[derive(Clone)]
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-    pub struct IntoIter(bridge::client::TokenStreamIter);
+    pub struct IntoIter(
+        std::vec::IntoIter<
+            bridge::TokenTree<
+                bridge::client::Group,
+                bridge::client::Punct,
+                bridge::client::Ident,
+                bridge::client::Literal,
+            >,
+        >,
+    );
 
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     impl Iterator for IntoIter {
@@ -256,7 +285,7 @@ pub mod token_stream {
         type IntoIter = IntoIter;
 
         fn into_iter(self) -> IntoIter {
-            IntoIter(self.0.into_iter())
+            IntoIter(self.0.map(|v| v.into_iter()).unwrap_or_default().into_iter())
         }
     }
 }
@@ -685,7 +714,7 @@ impl Group {
     /// returned above.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn stream(&self) -> TokenStream {
-        TokenStream(self.0.stream())
+        TokenStream(Some(self.0.stream()))
     }
 
     /// Returns the span for the delimiters of this token stream, spanning the

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(restricted_std)]
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
+#![feature(hash_raw_entry)]
 #![recursion_limit = "256"]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]
@@ -182,7 +183,7 @@ fn tree_to_bridge_tree(
 ) -> bridge::TokenTree<
     bridge::client::TokenStream,
     bridge::client::Span,
-    bridge::client::Ident,
+    bridge::client::Symbol,
     bridge::client::Literal,
 > {
     match tree {
@@ -259,7 +260,7 @@ pub mod token_stream {
             bridge::TokenTree<
                 bridge::client::TokenStream,
                 bridge::client::Span,
-                bridge::client::Ident,
+                bridge::client::Symbol,
                 bridge::client::Literal,
             >,
         >,
@@ -911,7 +912,7 @@ impl PartialEq<Punct> for char {
 /// An identifier (`ident`).
 #[derive(Clone)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-pub struct Ident(bridge::client::Ident);
+pub struct Ident(bridge::Ident<bridge::client::Span, bridge::client::Symbol>);
 
 impl Ident {
     /// Creates a new `Ident` with the given `string` as well as the specified
@@ -935,7 +936,11 @@ impl Ident {
     /// tokens, requires a `Span` to be specified at construction.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn new(string: &str, span: Span) -> Ident {
-        Ident(bridge::client::Ident::new(string, span.0, false))
+        Ident(bridge::Ident {
+            sym: bridge::client::Symbol::new_ident(string, false),
+            is_raw: false,
+            span: span.0,
+        })
     }
 
     /// Same as `Ident::new`, but creates a raw identifier (`r#ident`).
@@ -944,29 +949,24 @@ impl Ident {
     /// (e.g. `self`, `super`) are not supported, and will cause a panic.
     #[stable(feature = "proc_macro_raw_ident", since = "1.47.0")]
     pub fn new_raw(string: &str, span: Span) -> Ident {
-        Ident(bridge::client::Ident::new(string, span.0, true))
+        Ident(bridge::Ident {
+            sym: bridge::client::Symbol::new_ident(string, true),
+            is_raw: true,
+            span: span.0,
+        })
     }
 
     /// Returns the span of this `Ident`, encompassing the entire string returned
     /// by [`to_string`](Self::to_string).
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn span(&self) -> Span {
-        Span(self.0.span())
+        Span(self.0.span)
     }
 
     /// Configures the span of this `Ident`, possibly changing its hygiene context.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn set_span(&mut self, span: Span) {
-        self.0 = self.0.with_span(span.0);
-    }
-}
-
-// N.B., the bridge only provides `to_string`, implement `fmt::Display`
-// based on it (the reverse of the usual relationship between the two).
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
-impl ToString for Ident {
-    fn to_string(&self) -> String {
-        TokenStream::from(TokenTree::from(self.clone())).to_string()
+        self.0.span = span.0;
     }
 }
 
@@ -975,7 +975,7 @@ impl ToString for Ident {
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        if self.0.is_raw { write!(f, "r#{}", self.0.sym) } else { write!(f, "{}", self.0.sym) }
     }
 }
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -180,12 +180,7 @@ pub use quote::{quote, quote_span};
 
 fn tree_to_bridge_tree(
     tree: TokenTree,
-) -> bridge::TokenTree<
-    bridge::client::TokenStream,
-    bridge::client::Span,
-    bridge::client::Symbol,
-    bridge::client::Literal,
-> {
+) -> bridge::TokenTree<bridge::client::TokenStream, bridge::client::Span, bridge::client::Symbol> {
     match tree {
         TokenTree::Group(tt) => bridge::TokenTree::Group(tt.0),
         TokenTree::Punct(tt) => bridge::TokenTree::Punct(tt.0),
@@ -261,7 +256,6 @@ pub mod token_stream {
                 bridge::client::TokenStream,
                 bridge::client::Span,
                 bridge::client::Symbol,
-                bridge::client::Literal,
             >,
         >,
     );
@@ -995,7 +989,7 @@ impl fmt::Debug for Ident {
 /// Boolean literals like `true` and `false` do not belong here, they are `Ident`s.
 #[derive(Clone)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
-pub struct Literal(bridge::client::Literal);
+pub struct Literal(bridge::Literal<bridge::client::Span, bridge::client::Symbol>);
 
 macro_rules! suffixed_int_literals {
     ($($name:ident => $kind:ident,)*) => ($(
@@ -1012,7 +1006,12 @@ macro_rules! suffixed_int_literals {
         /// below.
         #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
         pub fn $name(n: $kind) -> Literal {
-            Literal(bridge::client::Literal::typed_integer(&n.to_string(), stringify!($kind)))
+            Literal(bridge::Literal {
+                kind: bridge::LitKind::Integer,
+                symbol: bridge::client::Symbol::new(&n.to_string()),
+                suffix: Some(bridge::client::Symbol::new(stringify!($kind))),
+                span: Span::call_site().0,
+            })
         }
     )*)
 }
@@ -1034,12 +1033,26 @@ macro_rules! unsuffixed_int_literals {
         /// below.
         #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
         pub fn $name(n: $kind) -> Literal {
-            Literal(bridge::client::Literal::integer(&n.to_string()))
+            Literal(bridge::Literal {
+                kind: bridge::LitKind::Integer,
+                symbol: bridge::client::Symbol::new(&n.to_string()),
+                suffix: None,
+                span: Span::call_site().0,
+            })
         }
     )*)
 }
 
 impl Literal {
+    fn new(kind: bridge::LitKind, value: &str, suffix: Option<&str>) -> Self {
+        Literal(bridge::Literal {
+            kind,
+            symbol: bridge::client::Symbol::new(value),
+            suffix: suffix.map(bridge::client::Symbol::new),
+            span: Span::call_site().0,
+        })
+    }
+
     suffixed_int_literals! {
         u8_suffixed => u8,
         u16_suffixed => u16,
@@ -1087,7 +1100,7 @@ impl Literal {
         if !n.is_finite() {
             panic!("Invalid float literal {}", n);
         }
-        Literal(bridge::client::Literal::float(&n.to_string()))
+        Literal::new(bridge::LitKind::Float, &n.to_string(), None)
     }
 
     /// Creates a new suffixed floating-point literal.
@@ -1108,7 +1121,7 @@ impl Literal {
         if !n.is_finite() {
             panic!("Invalid float literal {}", n);
         }
-        Literal(bridge::client::Literal::f32(&n.to_string()))
+        Literal::new(bridge::LitKind::Float, &n.to_string(), Some("f32"))
     }
 
     /// Creates a new unsuffixed floating-point literal.
@@ -1128,7 +1141,7 @@ impl Literal {
         if !n.is_finite() {
             panic!("Invalid float literal {}", n);
         }
-        Literal(bridge::client::Literal::float(&n.to_string()))
+        Literal::new(bridge::LitKind::Float, &n.to_string(), None)
     }
 
     /// Creates a new suffixed floating-point literal.
@@ -1149,37 +1162,49 @@ impl Literal {
         if !n.is_finite() {
             panic!("Invalid float literal {}", n);
         }
-        Literal(bridge::client::Literal::f64(&n.to_string()))
+        Literal::new(bridge::LitKind::Float, &n.to_string(), Some("f64"))
     }
 
     /// String literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn string(string: &str) -> Literal {
-        Literal(bridge::client::Literal::string(string))
+        let mut escaped = String::new();
+        for ch in string.chars() {
+            escaped.extend(ch.escape_debug());
+        }
+        Literal::new(bridge::LitKind::Str, &escaped, None)
     }
 
     /// Character literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn character(ch: char) -> Literal {
-        Literal(bridge::client::Literal::character(ch))
+        let mut escaped = String::new();
+        escaped.extend(ch.escape_unicode());
+        Literal::new(bridge::LitKind::Char, &escaped, None)
     }
 
     /// Byte string literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn byte_string(bytes: &[u8]) -> Literal {
-        Literal(bridge::client::Literal::byte_string(bytes))
+        let string = bytes
+            .iter()
+            .cloned()
+            .flat_map(std::ascii::escape_default)
+            .map(Into::<char>::into)
+            .collect::<String>();
+        Literal::new(bridge::LitKind::ByteStr, &string, None)
     }
 
     /// Returns the span encompassing this literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn span(&self) -> Span {
-        Span(self.0.span())
+        Span(self.0.span)
     }
 
     /// Configures the span associated for this literal.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn set_span(&mut self, span: Span) {
-        self.0.set_span(span.0);
+        self.0.span = span.0;
     }
 
     /// Returns a `Span` that is a subset of `self.span()` containing only the
@@ -1195,7 +1220,12 @@ impl Literal {
     // was 'c' or whether it was '\u{63}'.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn subspan<R: RangeBounds<usize>>(&self, range: R) -> Option<Span> {
-        self.0.subspan(range.start_bound().cloned(), range.end_bound().cloned()).map(Span)
+        bridge::client::FreeFunctions::literal_subspan(
+            self.0.clone(),
+            range.start_bound().cloned(),
+            range.end_bound().cloned(),
+        )
+        .map(Span)
     }
 }
 
@@ -1214,19 +1244,10 @@ impl FromStr for Literal {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<Self, LexError> {
-        match bridge::client::Literal::from_str(src) {
+        match bridge::client::FreeFunctions::literal_from_str(src) {
             Ok(literal) => Ok(Literal(literal)),
             Err(()) => Err(LexError::new()),
         }
-    }
-}
-
-// N.B., the bridge only provides `to_string`, implement `fmt::Display`
-// based on it (the reverse of the usual relationship between the two).
-#[stable(feature = "proc_macro_lib", since = "1.15.0")]
-impl ToString for Literal {
-    fn to_string(&self) -> String {
-        TokenStream::from(TokenTree::from(self.clone())).to_string()
     }
 }
 
@@ -1235,14 +1256,44 @@ impl ToString for Literal {
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // Based on `literal_to_string` from `pprust/state.rs`
+        match self.0.kind {
+            bridge::LitKind::Byte => write!(f, "b'{}'", self.0.symbol)?,
+            bridge::LitKind::Char => write!(f, "'{}'", self.0.symbol)?,
+            bridge::LitKind::Str => write!(f, "\"{}\"", self.0.symbol)?,
+            bridge::LitKind::StrRaw(n) => write!(
+                f,
+                "r{delim}\"{string}\"{delim}",
+                delim = "#".repeat(n as usize),
+                string = self.0.symbol
+            )?,
+            bridge::LitKind::ByteStr => write!(f, "b\"{}\"", self.0.symbol)?,
+            bridge::LitKind::ByteStrRaw(n) => write!(
+                f,
+                "br{delim}\"{string}\"{delim}",
+                delim = "#".repeat(n as usize),
+                string = self.0.symbol
+            )?,
+            _ => write!(f, "{}", self.0.symbol)?,
+        }
+        if let Some(suffix) = self.0.suffix {
+            write!(f, "{}", suffix)?;
+        }
+        Ok(())
     }
 }
 
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl fmt::Debug for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        f.debug_struct("Literal")
+            // format the kind without quotes, as in `kind: Float`
+            .field("kind", &self.0.kind)
+            .field("symbol", &self.0.symbol)
+            // format `Some("...")` on one line even in {:#?} mode
+            .field("suffix", &format_args!("{:?}", &self.0.suffix))
+            .field("span", &self.0.span)
+            .finish()
     }
 }
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -97,6 +97,7 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "compiler_builtins",
     "cpuid-bool",
     "crc32fast",
+    "crossbeam-channel",
     "crossbeam-deque",
     "crossbeam-epoch",
     "crossbeam-queue",


### PR DESCRIPTION
This series of patches performs various changes to the RPC interface used by `proc_macro` to improve its performance. From my local testing (which involved doing `check --test` runs on serde's test suite, based on https://github.com/rust-lang/rust/pull/49219#issuecomment-439648025) these pages have small improvements to same-thread execution, and significant improvements to cross-thread execution.

Some of the major changes include:
* Stash frequently accessed interned values (`Span::{def,call,mixed}_site`) in the client bridge, so no RPC is required to access them,
* Support non-blocking messaging to the server for calls which can be handled async (such as `TokenStream::clone()` or composing `Token{Tree,Stream}`s together),
* Reduce the number of messages required for common `TokenStream` operations (removes `TokenStreamBuilder`, `TokenStreamIter` in favour of passing `Vec<TokenTree>` over RPC),
* Store an `Option<bridge::client::TokenStream>` in the `TokenStream` type to avoid `TokenStream::new()` call overhead,
* Add a local symbol interner within the client bridge to hold `Symbol`s in the client, along with support to serialize them over RPC,
* Decompose the token types `Group`, `Punct`, `Ident`, and `Literal` into struct types around more primitive handles (`TokenStream`, `Symbol`, and `Span`), meaning that common operations on these types, such as accessing `.span()` or `.delimiter()` require no RPC calls,
* Use `crossbeam-channel` for cross-thread message passing, to avoid `mpsc::channel`'s overhead,
* Added a flag (`-Z proc_macro_cross_thread`) to turn on the `CrossThread` execution strategy for proc macros without rebuilding.

The PR is organized into a sequence of commits which build on top of one another, and could be reviewed independently.

Some example times from my machine (there's unfortunately variation in times run-to-run, but I tried to pick representative examples):

<details>
<summary>PR (SameThread)</summary>

```sh
~/src/serde/test_suite$ ( export RUSTFLAGS="-Z proc_macro_cross_thread=no"; cargo +dev check --tests && rm -f ../target/debug/deps/libtest_*.rmeta && time cargo +dev check --tests )
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
    Checking serde_test_suite v0.0.0 (/home/nika/src/serde/test_suite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.76s

real	0m0.779s
user	0m2.256s
sys	0m0.459s
```
</details>

<details>
<summary>PR (CrossThread)</summary>

```sh
~/src/serde/test_suite$ ( export RUSTFLAGS="-Z proc_macro_cross_thread=yes"; cargo +dev check --tests && rm -f ../target/debug/deps/libtest_*.rmeta && time cargo +dev check --tests )
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
    Checking serde_test_suite v0.0.0 (/home/nika/src/serde/test_suite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.83s

real	0m0.847s
user	0m2.971s
sys	0m0.579s
```
</details>

<details>
<summary>HEAD (SameThread)</summary>

```sh
~/src/serde/test_suite$ cargo +dev check --tests && rm -f ../target/debug/deps/libtest_*.rmeta && time cargo +dev check --tests
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
    Checking serde_test_suite v0.0.0 (/home/nika/src/serde/test_suite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.85s

real	0m0.866s
user	0m2.608s
sys	0m0.395s
```
</details>

<details>
<summary>HEAD (CrossThread2)</summary>

```sh
~/src/serde/test_suite$ cargo +dev check --tests && rm -f ../target/debug/deps/libtest_*.rmeta && time cargo +dev check --tests
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
    Checking serde_test_suite v0.0.0 (/home/nika/src/serde/test_suite)
    Finished dev [unoptimized + debuginfo] target(s) in 7.49s

real	0m7.504s
user	0m8.036s
sys	0m13.600s
```
</details>

(note: there will likely be changes required to RA to support these changes as well, however this patch currently includes no changes to RA or it's copy of the `proc_macro` crate)