### PR TITLE
[draft] Store the path in io::Error without extra allocations.

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -1,7 +1,9 @@
+#![allow(unreachable_patterns)] // For empty OsWithPath on some platforms.
+
 #[cfg(test)]
 mod tests;
 
-use crate::convert::From;
+use crate::convert::{From, TryInto};
 use crate::error;
 use crate::fmt;
 use crate::result;
@@ -68,9 +70,19 @@ impl fmt::Debug for Error {
 
 enum Repr {
     Os(i32),
+
+    // i16 to make sure the whole Repr remains two words in size.
+    // All known error codes fit in a i16.
+    // If for some reason it wouldn't fit, we just don't add the path and use
+    // Os(code) instead.
+    #[allow(dead_code)]
+    OsWithPath(i16, sys::fs::OsPathBuf),
+
     Simple(ErrorKind),
+
     // &str is a fat pointer, but &&str is a thin pointer.
     SimpleMessage(ErrorKind, &'static &'static str),
+
     Custom(Box<Custom>),
 }
 
@@ -337,6 +349,16 @@ impl Error {
         Error { repr: Repr::Os(code) }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn with_path(self, path: sys::fs::OsPathBuf) -> Self {
+        if let Repr::Os(code) = self.repr {
+            if let Ok(code) = code.try_into() {
+                return Self { repr: Repr::OsWithPath(code, path) };
+            }
+        }
+        self
+    }
+
     /// Returns the OS error that this error represents (if any).
     ///
     /// If this [`Error`] was constructed via [`last_os_error`] or
@@ -371,6 +393,7 @@ impl Error {
     pub fn raw_os_error(&self) -> Option<i32> {
         match self.repr {
             Repr::Os(i) => Some(i),
+            Repr::OsWithPath(i, _) => Some(i.into()),
             Repr::Custom(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
@@ -409,6 +432,7 @@ impl Error {
     pub fn get_ref(&self) -> Option<&(dyn error::Error + Send + Sync + 'static)> {
         match self.repr {
             Repr::Os(..) => None,
+            Repr::OsWithPath(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => Some(&*c.error),
@@ -482,6 +506,7 @@ impl Error {
     pub fn get_mut(&mut self) -> Option<&mut (dyn error::Error + Send + Sync + 'static)> {
         match self.repr {
             Repr::Os(..) => None,
+            Repr::OsWithPath(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
             Repr::Custom(ref mut c) => Some(&mut *c.error),
@@ -520,6 +545,7 @@ impl Error {
     pub fn into_inner(self) -> Option<Box<dyn error::Error + Send + Sync>> {
         match self.repr {
             Repr::Os(..) => None,
+            Repr::OsWithPath(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
             Repr::Custom(c) => Some(c.error),
@@ -549,6 +575,7 @@ impl Error {
     pub fn kind(&self) -> ErrorKind {
         match self.repr {
             Repr::Os(code) => sys::decode_error_kind(code),
+            Repr::OsWithPath(code, _) => sys::decode_error_kind(code.into()),
             Repr::Custom(ref c) => c.kind,
             Repr::Simple(kind) => kind,
             Repr::SimpleMessage(kind, _) => kind,
@@ -564,6 +591,13 @@ impl fmt::Debug for Repr {
                 .field("code", &code)
                 .field("kind", &sys::decode_error_kind(code))
                 .field("message", &sys::os::error_string(code))
+                .finish(),
+            Repr::OsWithPath(code, ref path) => fmt
+                .debug_struct("Os")
+                .field("code", &code)
+                .field("kind", &sys::decode_error_kind(code.into()))
+                .field("message", &sys::os::error_string(code.into()))
+                .field("path", path)
                 .finish(),
             Repr::Custom(ref c) => fmt::Debug::fmt(&c, fmt),
             Repr::Simple(kind) => fmt.debug_tuple("Kind").field(&kind).finish(),
@@ -582,6 +616,9 @@ impl fmt::Display for Error {
                 let detail = sys::os::error_string(code);
                 write!(fmt, "{} (os error {})", detail, code)
             }
+            Repr::OsWithPath(code, _) => {
+                fmt::Display::fmt(&Self::from_raw_os_error(code.into()), fmt)
+            }
             Repr::Custom(ref c) => c.error.fmt(fmt),
             Repr::Simple(kind) => write!(fmt, "{}", kind.as_str()),
             Repr::SimpleMessage(_, &msg) => msg.fmt(fmt),
@@ -594,7 +631,7 @@ impl error::Error for Error {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         match self.repr {
-            Repr::Os(..) | Repr::Simple(..) => self.kind().as_str(),
+            Repr::Os(..) | Repr::OsWithPath(..) | Repr::Simple(..) => self.kind().as_str(),
             Repr::SimpleMessage(_, &msg) => msg,
             Repr::Custom(ref c) => c.error.description(),
         }
@@ -604,6 +641,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match self.repr {
             Repr::Os(..) => None,
+            Repr::OsWithPath(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => c.error.cause(),
@@ -613,6 +651,7 @@ impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.repr {
             Repr::Os(..) => None,
+            Repr::OsWithPath(..) => None,
             Repr::Simple(..) => None,
             Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => c.error.source(),

--- a/library/std/src/sys/unix/fs/ospathbuf.rs
+++ b/library/std/src/sys/unix/fs/ospathbuf.rs
@@ -1,0 +1,98 @@
+use crate::alloc;
+use crate::ffi::CStr;
+use crate::fmt;
+use crate::io;
+use crate::mem;
+use crate::ops::Deref;
+use crate::os::unix::ffi::OsStrExt;
+use crate::path::Path;
+use crate::ptr;
+use crate::slice;
+use crate::sys_common::memchr;
+
+/// A heap-allocated C-string for doing syscalls with.
+///
+/// Unlike CString, this is only one pointer in size, as the size is stored
+/// on the heap right before the data.
+///
+/// That means it's not trivially convertible to and from Vec<u8> or String,
+/// but we don't need that.
+///
+/// Because it is so small, it can be stored inside io::Error.
+pub struct OsPathBuf {
+    ptr: ptr::NonNull<u8>,
+}
+
+unsafe impl Send for OsPathBuf {}
+unsafe impl Sync for OsPathBuf {}
+
+impl OsPathBuf {
+    pub fn new(path: &Path) -> io::Result<Self> {
+        if memchr::memchr(0, path.as_os_str().as_bytes()).is_some() {
+            return Err(io::Error::new_const(
+                io::ErrorKind::InvalidInput,
+                &"path contains interior nul byte",
+            ));
+        }
+        let path_len = path.as_os_str().len();
+        let layout = layout_for_len(path_len);
+        let ptr = ptr::NonNull::new(unsafe { alloc::alloc(layout) })
+            .unwrap_or_else(|| alloc::handle_alloc_error(layout));
+        unsafe {
+            ptr.cast::<usize>().as_ptr().write(path_len);
+            ptr.as_ptr()
+                .add(mem::size_of::<usize>())
+                .copy_from_nonoverlapping(path.as_os_str().as_bytes().as_ptr(), path_len);
+            ptr.as_ptr().add(mem::size_of::<usize>() + path_len).write(0);
+        }
+        Ok(Self { ptr })
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { self.ptr.cast::<usize>().as_ptr().read() }
+    }
+
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        unsafe { self.ptr.as_ptr().add(mem::size_of::<usize>()) as *const _ }
+    }
+
+    pub fn as_cstr(&self) -> &CStr {
+        unsafe {
+            CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(
+                self.as_ptr() as *const u8,
+                self.len() + 1,
+            ))
+        }
+    }
+}
+
+impl Deref for OsPathBuf {
+    type Target = CStr;
+
+    fn deref(&self) -> &CStr {
+        self.as_cstr()
+    }
+}
+
+impl fmt::Debug for OsPathBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_cstr(), f)
+    }
+}
+
+impl Drop for OsPathBuf {
+    fn drop(&mut self) {
+        unsafe {
+            alloc::dealloc(self.ptr.as_ptr(), layout_for_len(self.len()));
+        }
+    }
+}
+
+fn layout_for_len(path_len: usize) -> alloc::Layout {
+    unsafe {
+        alloc::Layout::from_size_align_unchecked(
+            mem::size_of::<usize>() + path_len + 1,
+            mem::align_of::<usize>(),
+        )
+    }
+}

--- a/library/std/src/sys/unsupported/fs.rs
+++ b/library/std/src/sys/unsupported/fs.rs
@@ -1,10 +1,13 @@
-use crate::ffi::OsString;
+use crate::ffi::{CStr, OsString};
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::unsupported;
+
+#[derive(Debug)]
+pub enum OsPathBuf {}
 
 pub struct File(!);
 

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -15,6 +15,9 @@ use crate::sys_common::FromInner;
 
 use super::to_u16s;
 
+#[derive(Debug)]
+pub enum OsPathBuf {}
+
 pub struct File {
     handle: Handle,
 }


### PR DESCRIPTION
This stores the path of the file/directory in io::Error, without doing any allocations and without increasing the size of io::Error.

We need to allocate for doing a syscall on a path anyway, so this just keeps that allocation around in the io::Error if the syscall fails.

This implements it only on unix. But it can work similarly on other platforms as well.

It does not store the path for the rename and (sym)link operations, as they involve two paths, and you can't really tell which of the two paths caused the error.

This only shows the path in the Debug implementation of io::Error. It's not clear what else we should do with it. Putting it in Display will make many programs show the path twice, and have less control over the output format. Adding a .path() accessor to io::Error is also not great, because it'll have to be a Option, and won't be accessible through the Error triat.