### PR TITLE
do not promote floating point division by 0

### DIFF
--- a/src/test/ui/consts/promote-not.rs
+++ b/src/test/ui/consts/promote-not.rs
@@ -51,4 +51,9 @@ fn main() {
     let _val: &'static _ = &(1%0); //~ ERROR temporary value dropped while borrowed
     let _val: &'static _ = &(1%(1-1)); //~ ERROR temporary value dropped while borrowed
     let _val: &'static _ = &([1,2,3][4]+1); //~ ERROR temporary value dropped while borrowed
+
+    // No promotion of NaN-generating operations.
+    let _val: &'static _ = &(1.0/0.0); //~ ERROR temporary value dropped while borrowed
+    const NEG0: f32 = -0.0;
+    let _val: &'static _ = &(1.0/NEG0); //~ ERROR temporary value dropped while borrowed
 }

--- a/src/test/ui/consts/promote-not.stderr
+++ b/src/test/ui/consts/promote-not.stderr
@@ -120,7 +120,7 @@ LL |     let _val: &'static _ = &(1%(1-1));
    |               ----------    ^^^^^^^^^ creates a temporary which is freed while still in use
    |               |
    |               type annotation requires that borrow lasts for `'static`
-LL |     let _val: &'static _ = &([1,2,3][4]+1);
+...
 LL | }
    | - temporary value is freed at the end of this statement
 
@@ -131,9 +131,31 @@ LL |     let _val: &'static _ = &([1,2,3][4]+1);
    |               ----------    ^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
    |               |
    |               type annotation requires that borrow lasts for `'static`
+...
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 13 previous errors
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-not.rs:56:29
+   |
+LL |     let _val: &'static _ = &(1.0/0.0);
+   |               ----------    ^^^^^^^^^ creates a temporary which is freed while still in use
+   |               |
+   |               type annotation requires that borrow lasts for `'static`
+...
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-not.rs:58:29
+   |
+LL |     let _val: &'static _ = &(1.0/NEG0);
+   |               ----------    ^^^^^^^^^^ creates a temporary which is freed while still in use
+   |               |
+   |               type annotation requires that borrow lasts for `'static`
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
NaNs during CTFE cause [all sorts of fun issues](https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/NaNs.20during.20CTFE). This patch attempts to ensure that CTFE of promoted values will never produce new NaNs, by rejecting divisions when the RHS might be zero. This is akin to what we already do for integer division (there it is absolutely crucial as division by zero would lead to a CTFE error).

This will need a crater run, and might need T-lang approval.
r? @oli-obk 