### PR TITLE
Constify implementations of `(Try)From` for int types

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -45,7 +45,8 @@ impl_float_to_int!(f64 => u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize);
 macro_rules! impl_from {
     ($Small: ty, $Large: ty, #[$attr:meta], $doc: expr) => {
         #[$attr]
-        impl From<$Small> for $Large {
+        #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+        impl const From<$Small> for $Large {
             // Rustdocs on the impl block show a "[+] show undocumented items" toggle.
             // Rustdocs on functions do not.
             #[doc = $doc]
@@ -172,7 +173,8 @@ impl_from! { f32, f64, #[stable(feature = "lossless_float_conv", since = "1.6.0"
 macro_rules! try_from_unbounded {
     ($source:ty, $($target:ty),*) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
-        impl TryFrom<$source> for $target {
+        #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+        impl const TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Try to create the target number type from a source
@@ -190,7 +192,8 @@ macro_rules! try_from_unbounded {
 macro_rules! try_from_lower_bounded {
     ($source:ty, $($target:ty),*) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
-        impl TryFrom<$source> for $target {
+        #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+        impl const TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Try to create the target number type from a source
@@ -212,7 +215,8 @@ macro_rules! try_from_lower_bounded {
 macro_rules! try_from_upper_bounded {
     ($source:ty, $($target:ty),*) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
-        impl TryFrom<$source> for $target {
+        #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+        impl const TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Try to create the target number type from a source
@@ -234,7 +238,8 @@ macro_rules! try_from_upper_bounded {
 macro_rules! try_from_both_bounded {
     ($source:ty, $($target:ty),*) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
-        impl TryFrom<$source> for $target {
+        #[rustc_const_unstable(feature = "const_num_from_num", issue = "87852")]
+        impl const TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Try to create the target number type from a source

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -99,6 +99,7 @@
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_slice_ptr_len)]
 #![feature(const_swap)]
+#![feature(const_trait_impl)]
 #![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_unreachable_unchecked)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -13,6 +13,8 @@
 #![feature(const_ptr_read)]
 #![feature(const_ptr_write)]
 #![feature(const_ptr_offset)]
+#![feature(const_trait_impl)]
+#![feature(const_num_from_num)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]

--- a/library/core/tests/num/const_from.rs
+++ b/library/core/tests/num/const_from.rs
@@ -1,0 +1,21 @@
+#[test]
+fn from() {
+    use core::convert::TryFrom;
+    use core::num::TryFromIntError;
+
+    // From
+    const FROM: i64 = i64::from(1i32);
+    assert_eq!(FROM, 1i64);
+
+    // Upper bounded
+    const U8_FROM_U16: Result<u8, TryFromIntError> = u8::try_from(1u16);
+    assert_eq!(U8_FROM_U16, Ok(1u8));
+
+    // Both bounded
+    const I8_FROM_I16: Result<i8, TryFromIntError> = i8::try_from(1i16);
+    assert_eq!(I8_FROM_I16, Ok(1i8));
+
+    // Lower bounded
+    const I16_FROM_U16: Result<i16, TryFromIntError> = i16::try_from(1u16);
+    assert_eq!(I16_FROM_U16, Ok(1i16));
+}

--- a/library/core/tests/num/const_from.rs
+++ b/library/core/tests/num/const_from.rs
@@ -7,6 +7,10 @@ fn from() {
     const FROM: i64 = i64::from(1i32);
     assert_eq!(FROM, 1i64);
 
+    // From int to float
+    const FROM_F64: f64 = f64::from(42u8);
+    assert_eq!(FROM_F64, 42f64);
+
     // Upper bounded
     const U8_FROM_U16: Result<u8, TryFromIntError> = u8::try_from(1u16);
     assert_eq!(U8_FROM_U16, Ok(1u8));

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -27,6 +27,8 @@ mod u64;
 mod u8;
 
 mod bignum;
+
+mod const_from;
 mod dec2flt;
 mod flt2dec;
 mod int_log;


### PR DESCRIPTION
I believe this to be one of the (many?) things blocking const (Range) iterators.

~~If this is to be merged maybe that should wait until `#![feature(const_trait_impl)]` no longer needs `#![allow(incomplete_features)]`?~~ - Done