### PR TITLE
Warn when `rustdoc::` group is omitted from lint names

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -276,22 +276,6 @@ impl LintStore {
         }
     }
 
-    /// This lint should be available with either the old or the new name.
-    ///
-    /// Using the old name will not give a warning.
-    /// You must register a lint with the new name before calling this function.
-    #[track_caller]
-    pub fn register_alias(&mut self, old_name: &str, new_name: &str) {
-        let target = match self.by_name.get(new_name) {
-            Some(&Id(lint_id)) => lint_id,
-            _ => bug!("cannot add alias {} for lint {} that does not exist", old_name, new_name),
-        };
-        match self.by_name.insert(old_name.to_string(), Id(target)) {
-            None | Some(Ignored) => {}
-            Some(x) => bug!("duplicate specification of lint {} (was {:?})", old_name, x),
-        }
-    }
-
     /// This lint should give no warning and have no effect.
     ///
     /// This is used by rustc to avoid warning about old rustdoc lints before rustdoc registers them as tool lints.

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -193,7 +193,7 @@ crate fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
     );
     for lint in &*RUSTDOC_LINTS {
         let name = lint.name_lower();
-        lint_store.register_alias(&name.replace("rustdoc::", ""), &name);
+        lint_store.register_renamed(&name.replace("rustdoc::", ""), &name);
     }
     lint_store
         .register_renamed("intra_doc_link_resolution_failure", "rustdoc::broken_intra_doc_links");

--- a/src/test/rustdoc-ui/renamed-lint-still-applies.rs
+++ b/src/test/rustdoc-ui/renamed-lint-still-applies.rs
@@ -1,7 +1,6 @@
 // compile-args: --crate-type lib
 #![deny(broken_intra_doc_links)]
-// FIXME: the old names for rustdoc lints should warn by default once `rustdoc::` makes it to the
-// stable channel.
+//~^ WARNING renamed to `rustdoc::broken_intra_doc_links`
 //! [x]
 //~^ ERROR unresolved link
 

--- a/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
+++ b/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
@@ -1,13 +1,19 @@
-warning: lint `rustdoc::non_autolinks` has been renamed to `rustdoc::bare_urls`
-  --> $DIR/renamed-lint-still-applies.rs:8:9
+warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
+  --> $DIR/renamed-lint-still-applies.rs:2:9
    |
-LL | #![deny(rustdoc::non_autolinks)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::bare_urls`
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
+warning: lint `rustdoc::non_autolinks` has been renamed to `rustdoc::bare_urls`
+  --> $DIR/renamed-lint-still-applies.rs:7:9
+   |
+LL | #![deny(rustdoc::non_autolinks)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::bare_urls`
+
 error: unresolved link to `x`
-  --> $DIR/renamed-lint-still-applies.rs:5:6
+  --> $DIR/renamed-lint-still-applies.rs:4:6
    |
 LL | //! [x]
    |      ^ no item named `x` in scope
@@ -17,21 +23,20 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(broken_intra_doc_links)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: this URL is not a hyperlink
-  --> $DIR/renamed-lint-still-applies.rs:10:5
+  --> $DIR/renamed-lint-still-applies.rs:9:5
    |
 LL | //! http://example.com
    |     ^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://example.com>`
    |
 note: the lint level is defined here
-  --> $DIR/renamed-lint-still-applies.rs:8:9
+  --> $DIR/renamed-lint-still-applies.rs:7:9
    |
 LL | #![deny(rustdoc::non_autolinks)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
    = note: bare URLs are not automatically turned into clickable links
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/src/test/rustdoc-ui/unknown-renamed-lints.rs
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.rs
@@ -14,8 +14,7 @@
 //~^ ERROR renamed to `rustdoc::bare_urls`
 
 #![deny(private_doc_tests)]
-// FIXME: the old names for rustdoc lints should warn by default once `rustdoc::` makes it to the
-// stable channel.
+//~^ ERROR renamed to `rustdoc::private_doc_tests`
 
 #![deny(rustdoc)]
 //~^ ERROR removed: use `rustdoc::all` instead

--- a/src/test/rustdoc-ui/unknown-renamed-lints.stderr
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.stderr
@@ -40,19 +40,25 @@ error: lint `rustdoc::non_autolinks` has been renamed to `rustdoc::bare_urls`
 LL | #![deny(rustdoc::non_autolinks)]
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::bare_urls`
 
+error: lint `private_doc_tests` has been renamed to `rustdoc::private_doc_tests`
+  --> $DIR/unknown-renamed-lints.rs:16:9
+   |
+LL | #![deny(private_doc_tests)]
+   |         ^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::private_doc_tests`
+
 error: lint `rustdoc` has been removed: use `rustdoc::all` instead
-  --> $DIR/unknown-renamed-lints.rs:20:9
+  --> $DIR/unknown-renamed-lints.rs:19:9
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
 
 error: unknown lint: `rustdoc::intra_doc_link_resolution_failure`
-  --> $DIR/unknown-renamed-lints.rs:24:9
+  --> $DIR/unknown-renamed-lints.rs:23:9
    |
 LL | #![deny(rustdoc::intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Compilation failed, aborting rustdoc
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
When rustdoc lints were first made a tool lint, they gave an unconditional warning when you used the original name:
```
warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
  --> $DIR/renamed-lint-still-applies.rs:2:9
   |
LL | #![deny(broken_intra_doc_links)]
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default
```
That was reverted in https://github.com/rust-lang/rust/pull/83203 because adding `rustdoc::x` lints would cause the code to break on old versions of the compiler (due to https://github.com/rust-lang/rust/issues/66079#issuecomment-788589193, "fixed" in https://github.com/rust-lang/rust/pull/83216 in the sense that you can now opt-in to not breaking on nightly, which is not ideal but `register_tool` is a long way from stabilizing). Since https://github.com/rust-lang/rust/pull/80527 is now on 1.52.0 stable, we can re-enable the warning. For nightly users, they can change immediately and still have their code work on stable; for stable users, they can change their code in 12 weeks and still have it work up to 3 releases back (about 18 weeks). That seems reasonable to me.

r? @Manishearth cc @rust-lang/rustdoc