### PR TITLE
Constify ?-operator for Result and Option

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -532,7 +532,7 @@ where
 
 // From implies Into
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T, U> const Into<U> for T
 where
     U: ~const From<T>,
@@ -544,7 +544,7 @@ where
 
 // From (and thus Into) is reflexive
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T> const From<T> for T {
     fn from(t: T) -> T {
         t

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -535,7 +535,7 @@ where
 #[rustc_const_unstable(feature = "const_convert", issue = "none")]
 impl<T, U> const Into<U> for T
 where
-    U: From<T>,
+    U: ~const From<T>,
 {
     fn into(self) -> U {
         U::from(self)

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -532,7 +532,8 @@ where
 
 // From implies Into
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, U> Into<U> for T
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T, U> const Into<U> for T
 where
     U: From<T>,
 {
@@ -543,7 +544,8 @@ where
 
 // From (and thus Into) is reflexive
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> From<T> for T {
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T> const From<T> for T {
     fn from(t: T) -> T {
         t
     }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -82,6 +82,7 @@
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 #![feature(const_heap)]
+#![feature(const_convert)]
 #![feature(const_inherent_unchecked_arith)]
 #![feature(const_int_unchecked_arith)]
 #![feature(const_intrinsic_copy)]

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2010,7 +2010,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T> const ops::Try for Option<T> {
     type Output = T;
     type Residual = Option<convert::Infallible>;
@@ -2030,7 +2030,7 @@ impl<T> const ops::Try for Option<T> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T> const ops::FromResidual for Option<T> {
     #[inline]
     fn from_residual(residual: Option<convert::Infallible>) -> Self {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2010,7 +2010,8 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<T> ops::Try for Option<T> {
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T> const ops::Try for Option<T> {
     type Output = T;
     type Residual = Option<convert::Infallible>;
 
@@ -2029,7 +2030,8 @@ impl<T> ops::Try for Option<T> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<T> ops::FromResidual for Option<T> {
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T> const ops::FromResidual for Option<T> {
     #[inline]
     fn from_residual(residual: Option<convert::Infallible>) -> Self {
         match residual {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1910,7 +1910,9 @@ impl<T, E> const ops::Try for Result<T, E> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 #[rustc_const_unstable(feature = "const_convert", issue = "88674")]
-impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
+impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible, E>>
+    for Result<T, F>
+{
     #[inline]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1910,7 +1910,7 @@ impl<T, E> const ops::Try for Result<T, E> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 #[rustc_const_unstable(feature = "const_convert", issue = "none")]
-impl<T, E, F: From<E>> const ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
+impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
     #[inline]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1889,7 +1889,8 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<T, E> ops::Try for Result<T, E> {
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T, E> const ops::Try for Result<T, E> {
     type Output = T;
     type Residual = Result<convert::Infallible, E>;
 
@@ -1908,7 +1909,8 @@ impl<T, E> ops::Try for Result<T, E> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
+#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+impl<T, E, F: From<E>> const ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
     #[inline]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1889,7 +1889,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T, E> const ops::Try for Result<T, E> {
     type Output = T;
     type Residual = Result<convert::Infallible, E>;
@@ -1909,7 +1909,7 @@ impl<T, E> const ops::Try for Result<T, E> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-#[rustc_const_unstable(feature = "const_convert", issue = "none")]
+#[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
     #[inline]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {

--- a/library/core/tests/convert.rs
+++ b/library/core/tests/convert.rs
@@ -1,9 +1,5 @@
-// run-pass
-
-#![feature(const_trait_impl)]
-#![feature(const_identity_convert)]
-
-fn main() {
+#[test]
+fn convert() {
     const fn from(x: i32) -> i32 {
         i32::from(x)
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -9,12 +9,13 @@
 #![feature(cfg_target_has_atomic)]
 #![feature(const_assume)]
 #![feature(const_cell_into_inner)]
+#![feature(const_convert)]
 #![feature(const_maybe_uninit_assume_init)]
+#![feature(const_num_from_num)]
 #![feature(const_ptr_read)]
 #![feature(const_ptr_write)]
 #![feature(const_ptr_offset)]
 #![feature(const_trait_impl)]
-#![feature(const_num_from_num)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
@@ -84,6 +85,7 @@ mod char;
 mod clone;
 mod cmp;
 mod const_ptr;
+mod convert;
 mod fmt;
 mod hash;
 mod intrinsics;

--- a/src/test/ui/consts/convert.rs
+++ b/src/test/ui/consts/convert.rs
@@ -1,0 +1,20 @@
+// run-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_identity_convert)]
+
+fn main() {
+    const fn from(x: i32) -> i32 {
+        i32::from(x)
+    }
+
+    const FOO: i32 = from(42);
+    assert_eq!(FOO, 42);
+
+    const fn into(x: Vec<String>) -> Vec<String> {
+        x.into()
+    }
+
+    const BAR: Vec<String> = into(Vec::new());
+    assert_eq!(BAR, Vec::<String>::new());
+}

--- a/src/test/ui/consts/try-operator.rs
+++ b/src/test/ui/consts/try-operator.rs
@@ -6,11 +6,18 @@
 #![feature(const_convert)]
 
 fn main() {
-    const fn foo() -> Result<bool, ()> {
+    const fn result() -> Result<bool, ()> {
         Err(())?;
         Ok(true)
     }
 
-    const FOO: Result<bool, ()> = foo();
+    const FOO: Result<bool, ()> = result();
     assert_eq!(Err(()), FOO);
+
+    const fn option() -> Option<()> {
+        None?;
+        Some(())
+    }
+    const BAR: Option<()> = option();
+    assert_eq!(None, BAR);
 }

--- a/src/test/ui/consts/try-operator.rs
+++ b/src/test/ui/consts/try-operator.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+#![feature(try_trait_v2)]
+#![feature(const_trait_impl)]
+#![feature(const_try)]
+#![feature(const_convert)]
+
+fn main() {
+    const fn foo() -> Result<bool, ()> {
+        Err(())?;
+        Ok(true)
+    }
+
+    const FOO: Result<bool, ()> = foo();
+    assert_eq!(Err(()), FOO);
+}


### PR DESCRIPTION
Try to make `?`-operator usable in `const fn` with `Result` and `Option`, see #74935 . Note that the try-operator itself was constified in #87237.

TODO
* [x] Add tests for const T -> T conversions
* [x] cleanup commits
* [x] Remove `#![allow(incomplete_features)]`
* [?] Await decision in #86808 - I'm not sure
* [x] Await support for parsing `~const` in bootstrapping compiler
* [x] Tracking issue(s)? - #88674