### PR TITLE
Make x.py less verbose on failures

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -138,7 +138,7 @@ def unpack(tarball, tarball_suffix, dst, verbose=False, match=None):
     shutil.rmtree(os.path.join(dst, fname))
 
 
-def run(args, verbose=False, exception=False, **kwargs):
+def run(args, verbose=False, exception=False, is_bootstrap=False, **kwargs):
     """Run a child program in a new process"""
     if verbose:
         print("running: " + ' '.join(args))
@@ -151,7 +151,14 @@ def run(args, verbose=False, exception=False, **kwargs):
         err = "failed to run: " + ' '.join(args)
         if verbose or exception:
             raise RuntimeError(err)
-        sys.exit(err)
+        # For most failures, we definitely do want to print this error, or the user will have no
+        # idea what went wrong. But when we've successfully built bootstrap and it failed, it will
+        # have already printed an error above, so there's no need to print the exact command we're
+        # running.
+        if is_bootstrap:
+            sys.exit(1)
+        else:
+            sys.exit(err)
 
 
 def require(cmd, exit=True):
@@ -1170,7 +1177,7 @@ def bootstrap(help_triggered):
         env["BOOTSTRAP_CONFIG"] = toml_path
     if build.rustc_commit is not None:
         env["BOOTSTRAP_DOWNLOAD_RUSTC"] = '1'
-    run(args, env=env, verbose=build.verbose)
+    run(args, env=env, verbose=build.verbose, is_bootstrap=True)
 
 
 def main():

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1366,7 +1366,7 @@ pub fn stream_cargo(
 
     // Make sure Cargo actually succeeded after we read all of its stdout.
     let status = t!(child.wait());
-    if !status.success() {
+    if builder.is_verbose() && !status.success() {
         eprintln!(
             "command did not execute successfully: {:?}\n\
                   expected success, got: {}",


### PR DESCRIPTION
- Don't print the exact command run by rustbuild unless `--verbose` is set.
  This is almost always unhelpful, since it's just cargo with a lot of
  arguments (and you can't replicate it anyway unless you have the environment variables, which aren't printed by default).
- Don't print "Build completed unsuccessfully" unless --verbose is set.
  You can already tell the build failed by the errors above, and the
  time isn't particularly helpful.
- Don't print the full path to bootstrap. This is useless to everyone,
  even including when working on x.py itself. You can still opt-in to
  this being shown with `--verbose`, since it will throw an exception.

Before:

```
error[E0432]: unresolved import `x`
   --> library/std/src/lib.rs:343:5
    |
343 | use x;
    |     ^ no external crate `x`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `std`

To learn more, run the command again with --verbose.
command did not execute successfully: "/home/joshua/rustc4/build/x86_64-unknown-linux-gnu/stage0/bin/cargo" "check" "--target" "x86_64-unknown-linux-gnu" "-Zbinary-dep-depinfo" "-j" "8" "--release" "--features" "panic-unwind backtrace" "--manifest-path" "/home/joshua/rustc4/library/test/Cargo.toml" "--message-format" "json-render-diagnostics"
expected success, got: exit status: 101
failed to run: /home/joshua/rustc4/build/bootstrap/debug/bootstrap check
Build completed unsuccessfully in 0:00:13
```

After:

```
error[E0432]: unresolved import `x`
   --> library/std/src/lib.rs:343:5
    |
343 | use x;
    |     ^ no external crate `x`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `std`

To learn more, run the command again with --verbose.
```

cc https://github.com/rust-lang/rust/issues/86854, https://github.com/rust-lang/rust/pull/86022

r? @Mark-Simulacrum