### PR TITLE
Convert `debug_assert!` to `assert!` in `Binder::dummy`

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -965,7 +965,7 @@ where
     /// binder. This is commonly used to 'inject' a value T into a
     /// different binding level.
     pub fn dummy(value: T) -> Binder<'tcx, T> {
-        debug_assert!(!value.has_escaping_bound_vars());
+        assert!(!value.has_escaping_bound_vars());
         Binder(value, ty::List::empty())
     }
 


### PR DESCRIPTION
This is needed for #85350 not to be passed.
r? @jackh726 