### PR TITLE
Account for capture kind in auto traits migration

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/migrations/unpin_no_migration.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/unpin_no_migration.rs
@@ -1,0 +1,13 @@
+//run-pass
+#![deny(disjoint_capture_migration)]
+#![allow(unused_must_use)]
+
+fn filter_try_fold(
+    predicate: &mut impl FnMut() -> bool,
+) -> impl FnMut() -> bool + '_ {
+    move || predicate()
+}
+
+fn main() {
+    filter_try_fold(&mut || true);
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/unpin_no_migration.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/unpin_no_migration.rs
@@ -1,5 +1,5 @@
 //run-pass
-#![deny(disjoint_capture_migration)]
+#![deny(rust_2021_incompatible_closure_captures)]
 #![allow(unused_must_use)]
 
 fn filter_try_fold(


### PR DESCRIPTION
Modifies the current auto traits migration for RFC2229 so it takes into account capture kind

Closes https://github.com/rust-lang/project-rfc-2229/issues/51

r? @nikomatsakis