### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,17 +420,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fec17b16f1ac67908af82e47d0a90a7afd0e1827b181cd77504323d3263d35"
-dependencies = [
- "semver 0.10.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
@@ -4683,16 +4672,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
-dependencies = [
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
@@ -5230,7 +5209,7 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.11.1",
+ "cargo_metadata 0.12.0",
  "crossbeam-utils 0.8.3",
  "lazy_static",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
  "jobserver",
  "libc",
  "log",
- "miow 0.3.6",
+ "miow 0.3.7",
  "same-file",
  "shell-escape",
  "tempfile",
@@ -664,7 +664,7 @@ dependencies = [
  "glob",
  "lazy_static",
  "libc",
- "miow 0.3.6",
+ "miow 0.3.7",
  "regex",
  "rustfix 0.6.0",
  "serde",
@@ -688,7 +688,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "miow 0.3.6",
+ "miow 0.3.7",
  "regex",
  "rustfix 0.5.1",
  "serde",
@@ -856,24 +856,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.36"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bac9f84ca0977c4d9b8db998689de55b9e976656a6bc87fada2ca710d504c7"
+checksum = "003cb79c1c6d1c93344c7e1201bb51c2148f24ec2bd9c253709d6b2efb796515"
 dependencies = [
  "curl-sys",
  "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.0",
+ "socket2",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.42+curl-7.76.0"
+version = "0.4.44+curl-7.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4636d8d6109c842707018a104051436bffb8991ea20b2d1293db70b6e0ee4c7c"
+checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
 dependencies = [
  "cc",
  "libc",
@@ -2252,7 +2252,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.6",
+ "miow 0.3.7",
  "winapi 0.3.9",
 ]
 
@@ -2281,11 +2281,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -2514,7 +2513,7 @@ dependencies = [
  "libc",
  "log",
  "mio-named-pipes",
- "miow 0.3.6",
+ "miow 0.3.7",
  "rand 0.7.3",
  "tokio",
  "winapi 0.3.9",
@@ -4857,17 +4856,6 @@ name = "snap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "socket2"

--- a/compiler/rustc_error_codes/src/error_codes/E0716.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0716.md
@@ -14,14 +14,16 @@ Here, the expression `&foo()` is borrowing the expression `foo()`. As `foo()` is
 a call to a function, and not the name of a variable, this creates a
 **temporary** -- that temporary stores the return value from `foo()` so that it
 can be borrowed. You could imagine that `let p = bar(&foo());` is equivalent to
-this:
+the following, which uses an explicit temporary variable.
+
+Erroneous code example:
 
 ```compile_fail,E0597
 # fn foo() -> i32 { 22 }
 # fn bar(x: &i32) -> &i32 { x }
 let p = {
   let tmp = foo(); // the temporary
-  bar(&tmp)
+  bar(&tmp) // error: `tmp` does not live long enough
 }; // <-- tmp is freed as we exit this block
 let q = p;
 ```

--- a/compiler/rustc_mir/src/dataflow/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use self::drop_flag_effects::*;
 pub use self::framework::{
     fmt, lattice, visit_results, Analysis, AnalysisDomain, Backward, BorrowckFlowState,
     BorrowckResults, Engine, Forward, GenKill, GenKillAnalysis, JoinSemiLattice, Results,
-    ResultsCursor, ResultsRefCursor, ResultsVisitor,
+    ResultsCursor, ResultsRefCursor, ResultsVisitor, SwitchIntEdgeEffects,
 };
 
 use self::move_paths::MoveData;

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2769,33 +2769,31 @@ impl<'a> Drain<'a> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(string_drain_as_str)]
     /// let mut s = String::from("abc");
     /// let mut drain = s.drain(..);
     /// assert_eq!(drain.as_str(), "abc");
     /// let _ = drain.next().unwrap();
     /// assert_eq!(drain.as_str(), "bc");
     /// ```
-    #[unstable(feature = "string_drain_as_str", issue = "76905")] // Note: uncomment AsRef impls below when stabilizing.
+    #[stable(feature = "string_drain_as_str", since = "1.55.0")]
     pub fn as_str(&self) -> &str {
         self.iter.as_str()
     }
 }
 
-// Uncomment when stabilizing `string_drain_as_str`.
-// #[unstable(feature = "string_drain_as_str", issue = "76905")]
-// impl<'a> AsRef<str> for Drain<'a> {
-//     fn as_ref(&self) -> &str {
-//         self.as_str()
-//     }
-// }
-//
-// #[unstable(feature = "string_drain_as_str", issue = "76905")]
-// impl<'a> AsRef<[u8]> for Drain<'a> {
-//     fn as_ref(&self) -> &[u8] {
-//         self.as_str().as_bytes()
-//     }
-// }
+#[stable(feature = "string_drain_as_str", since = "1.55.0")]
+impl<'a> AsRef<str> for Drain<'a> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+#[stable(feature = "string_drain_as_str", since = "1.55.0")]
+impl<'a> AsRef<[u8]> for Drain<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl Iterator for Drain<'_> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1418,6 +1418,27 @@ pub trait Write {
     /// The default implementation calls [`write`] with either the first nonempty
     /// buffer provided, or an empty one if none exists.
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io::IoSlice;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let mut data1 = [1; 8];
+    ///     let mut data2 = [15; 8];
+    ///     let io_slice1 = IoSlice::new(&mut data1);
+    ///     let io_slice2 = IoSlice::new(&mut data2);
+    ///
+    ///     let mut buffer = File::create("foo.txt")?;
+    ///
+    ///     // Writes some prefix of the byte string, not necessarily all of it.
+    ///     buffer.write_vectored(&[io_slice1, io_slice2])?;
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
     /// [`write`]: Write::write
     #[stable(feature = "iovec", since = "1.36.0")]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -138,7 +138,7 @@ def unpack(tarball, tarball_suffix, dst, verbose=False, match=None):
     shutil.rmtree(os.path.join(dst, fname))
 
 
-def run(args, verbose=False, exception=False, **kwargs):
+def run(args, verbose=False, exception=False, is_bootstrap=False, **kwargs):
     """Run a child program in a new process"""
     if verbose:
         print("running: " + ' '.join(args))
@@ -151,7 +151,14 @@ def run(args, verbose=False, exception=False, **kwargs):
         err = "failed to run: " + ' '.join(args)
         if verbose or exception:
             raise RuntimeError(err)
-        sys.exit(err)
+        # For most failures, we definitely do want to print this error, or the user will have no
+        # idea what went wrong. But when we've successfully built bootstrap and it failed, it will
+        # have already printed an error above, so there's no need to print the exact command we're
+        # running.
+        if is_bootstrap:
+            sys.exit(1)
+        else:
+            sys.exit(err)
 
 
 def require(cmd, exit=True):
@@ -1170,7 +1177,7 @@ def bootstrap(help_triggered):
         env["BOOTSTRAP_CONFIG"] = toml_path
     if build.rustc_commit is not None:
         env["BOOTSTRAP_DOWNLOAD_RUSTC"] = '1'
-    run(args, env=env, verbose=build.verbose)
+    run(args, env=env, verbose=build.verbose, is_bootstrap=True)
 
 
 def main():

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1366,7 +1366,7 @@ pub fn stream_cargo(
 
     // Make sure Cargo actually succeeded after we read all of its stdout.
     let status = t!(child.wait());
-    if !status.success() {
+    if builder.is_verbose() && !status.success() {
         eprintln!(
             "command did not execute successfully: {:?}\n\
                   expected success, got: {}",

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -28,6 +28,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
+COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
@@ -37,6 +38,7 @@ ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
            python3 ../x.py test --stage 2 src/tools/tidy && \
            python3 ../x.py doc --stage 0 library/test && \
            /scripts/validate-toolstate.sh && \
+           /scripts/validate-error-codes.sh && \
            # Runs checks to ensure that there are no ES5 issues in our JS code.
            es-check es5 ../src/librustdoc/html/static/*.js && \
            eslint ../src/librustdoc/html/static/*.js

--- a/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Checks that no error code explanation is removed.
+
+set -euo pipefail
+
+echo "Check if an error code explanation was removed..."
+
+if (git diff "$BASE_COMMIT" --name-status | grep '^D' \
+        | grep --quiet "compiler/rustc_error_codes/src/error_codes/"); then
+    echo "Error code explanations should never be removed!"
+    echo "Take a look at E0001 to see how to handle it."
+    exit 1
+fi
+
+echo "No error code explanation was removed!"

--- a/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-error-codes.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Checks that no error code explanation is removed.
 
-set -euo pipefail
+set -eo pipefail
+
+if [[ -z "$BASE_COMMIT" ]]; then
+    echo "not checking error code explanations removal"
+    exit 0
+fi
 
 echo "Check if an error code explanation was removed..."
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -219,6 +219,10 @@ else
   command="/checkout/src/ci/run.sh"
 fi
 
+# Get some needed information for $BASE_COMMIT
+git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
+BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+
 docker \
   run \
   --workdir /checkout/obj \
@@ -237,6 +241,7 @@ docker \
   --env TOOLSTATE_PUBLISH \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
   --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
+  --env BASE_COMMIT="$BASE_COMMIT" \
   --init \
   --rm \
   rust-ci \

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -219,9 +219,13 @@ else
   command="/checkout/src/ci/run.sh"
 fi
 
-# Get some needed information for $BASE_COMMIT
-git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
-BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+if [ "$CI" != "" ]; then
+    # Get some needed information for $BASE_COMMIT
+    git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
+    BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+else
+    BASE_COMMIT=""
+fi
 
 docker \
   run \

--- a/src/test/ui/type-alias-impl-trait/issue-69323.full.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-69323.full.stderr
@@ -1,0 +1,11 @@
+warning: the feature `type_alias_impl_trait` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-69323.rs:5:27
+   |
+LL | #![cfg_attr(full, feature(type_alias_impl_trait))]
+   |                           ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/type-alias-impl-trait/issue-69323.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-69323.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+// revisions: min full
+#![feature(min_type_alias_impl_trait)]
+#![cfg_attr(full, feature(type_alias_impl_trait))]
+//[full]~^ WARN incomplete
+
+use std::iter::{once, Chain};
+
+fn test1<A: Iterator<Item = &'static str>>(x: A) -> Chain<A, impl Iterator<Item = &'static str>> {
+    x.chain(once(","))
+}
+
+type I<A> = Chain<A, impl Iterator<Item = &'static str>>;
+fn test2<A: Iterator<Item = &'static str>>(x: A) -> I<A> {
+    x.chain(once(","))
+}
+
+fn main() {}

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 autobins = false
 
 [dependencies]
-cargo_metadata = "0.11"
+cargo_metadata = "0.12"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"


### PR DESCRIPTION
Successful merges:

 - #86477 (E0716: clarify that equivalent code example is erroneous)
 - #86623 (Add check to ensure error code explanations are not removed anymore even if not emitted)
 - #86856 (Make x.py less verbose on failures)
 - #86858 (Stabilize `string_drain_as_str`)
 - #86859 (Add a regression test for issue-69323)
 - #86862 (re-export SwitchIntEdgeEffects)
 - #86864 (Add missing code example for Write::write_vectored)
 - #86874 (Bump deps)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86477,86623,86856,86858,86859,86862,86864,86874)
<!-- homu-ignore:end -->