### PR TITLE
Reuse CrateNum for proc-macro crates even when cross-compiling

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -598,7 +598,11 @@ impl<'a> CrateLoader<'a> {
         // don't want to match a host crate against an equivalent target one
         // already loaded.
         let root = library.metadata.get_root();
-        Ok(Some(if locator.triple == self.sess.opts.target_triple {
+        // FIXME: why is this condition necessary? It was adding in #33625 but I
+        // don't know why and the original author doesn't remember ...
+        let can_reuse_cratenum =
+            locator.triple == self.sess.opts.target_triple || locator.is_proc_macro == Some(true);
+        Ok(Some(if can_reuse_cratenum {
             let mut result = LoadResult::Loaded(library);
             self.cstore.iter_crate_data(|cnum, data| {
                 if data.name() == root.name() && root.hash() == data.hash() {

--- a/src/test/ui/crate-loading/auxiliary/proc-macro.rs
+++ b/src/test/ui/crate-loading/auxiliary/proc-macro.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+#![crate_name = "reproduction"]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn mac(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/ui/crate-loading/cross-compiled-proc-macro.rs
+++ b/src/test/ui/crate-loading/cross-compiled-proc-macro.rs
@@ -1,0 +1,8 @@
+// edition:2018
+// compile-flags:--extern reproduction
+// aux-build:proc-macro.rs
+// check-pass
+
+reproduction::mac!();
+
+fn main() {}


### PR DESCRIPTION
Proc-macros are always compiled for the host, so this should be the same
in every way as recompiling the crate.

I am not sure why the previous code special-cased the target, since the
compiler properly gives an error when trying to load a crate for a
different host:

```
error[E0461]: couldn't find crate `dependency` with expected target triple x86_64-unknown-linux-gnu
  --> /home/joshua/rustc4/src/test/ui/cfg-dependent.rs:8:2
   |
LL |     dependency::is_64();
   |     ^^^^^^^^^^
   |
   = note: the following crate versions were found:
           crate `dependency`, target triple i686-unknown-linux-gnu: /home/joshua/rustc4/build/x86_64-unknown-linux-gnu/test/ui/cfg-dependent/auxiliary/libdependency.so
```

I think another possible fix is to remove the check altogether. But I'm
not sure, and this fix works, so I'm not making the larger change here.

Fixes https://github.com/rust-lang/rust/issues/56935.

r? @petrochenkov cc @alexcrichton