### PR TITLE
Inline implementation of lookup_line

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1552,13 +1552,11 @@ impl SourceFile {
     /// number. If the source_file is empty or the position is located before the
     /// first line, `None` is returned.
     pub fn lookup_line(&self, pos: BytePos) -> Option<usize> {
-        if self.lines.is_empty() {
-            return None;
+        match self.lines.binary_search(&pos) {
+            Ok(idx) => Some(idx),
+            Err(0) => None,
+            Err(idx) => Some(idx - 1),
         }
-
-        let line_index = lookup_line(&self.lines[..], pos);
-        assert!(line_index < self.lines.len() as isize);
-        if line_index >= 0 { Some(line_index as usize) } else { None }
     }
 
     pub fn line_bounds(&self, line_index: usize) -> Range<BytePos> {
@@ -1954,16 +1952,6 @@ pub struct InnerSpan {
 impl InnerSpan {
     pub fn new(start: usize, end: usize) -> InnerSpan {
         InnerSpan { start, end }
-    }
-}
-
-// Given a slice of line start positions and a position, returns the index of
-// the line the position is on. Returns -1 if the position is located before
-// the first line.
-fn lookup_line(lines: &[BytePos], pos: BytePos) -> isize {
-    match lines.binary_search(&pos) {
-        Ok(line) => line as isize,
-        Err(line) => line as isize - 1,
     }
 }
 

--- a/compiler/rustc_span/src/tests.rs
+++ b/compiler/rustc_span/src/tests.rs
@@ -2,18 +2,21 @@ use super::*;
 
 #[test]
 fn test_lookup_line() {
-    let lines = &[BytePos(3), BytePos(17), BytePos(28)];
+    let source = "abcdefghijklm\nabcdefghij\n...".to_owned();
+    let sf =
+        SourceFile::new(FileName::Anon(0), source, BytePos(3), SourceFileHashAlgorithm::Sha256);
+    assert_eq!(sf.lines.as_slice(), &[BytePos(3), BytePos(17), BytePos(28)]);
 
-    assert_eq!(lookup_line(lines, BytePos(0)), -1);
-    assert_eq!(lookup_line(lines, BytePos(3)), 0);
-    assert_eq!(lookup_line(lines, BytePos(4)), 0);
+    assert_eq!(sf.lookup_line(BytePos(0)), None);
+    assert_eq!(sf.lookup_line(BytePos(3)), Some(0));
+    assert_eq!(sf.lookup_line(BytePos(4)), Some(0));
 
-    assert_eq!(lookup_line(lines, BytePos(16)), 0);
-    assert_eq!(lookup_line(lines, BytePos(17)), 1);
-    assert_eq!(lookup_line(lines, BytePos(18)), 1);
+    assert_eq!(sf.lookup_line(BytePos(16)), Some(0));
+    assert_eq!(sf.lookup_line(BytePos(17)), Some(1));
+    assert_eq!(sf.lookup_line(BytePos(18)), Some(1));
 
-    assert_eq!(lookup_line(lines, BytePos(28)), 2);
-    assert_eq!(lookup_line(lines, BytePos(29)), 2);
+    assert_eq!(sf.lookup_line(BytePos(28)), Some(2));
+    assert_eq!(sf.lookup_line(BytePos(29)), Some(2));
 }
 
 #[test]


### PR DESCRIPTION
to avoid unnecessary conversions from `Option<usize>` to `isize` and back.