### PR TITLE
Remove `impl Clean for {Ident, Symbol}`

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -552,7 +552,7 @@ fn build_macro(cx: &mut DocContext<'_>, did: DefId, name: Symbol) -> clean::Item
 
                 let source = format!(
                     "macro_rules! {} {{\n{}}}",
-                    name.clean(cx),
+                    name,
                     utils::render_macro_arms(matchers, ";")
                 );
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1814,20 +1814,6 @@ impl Clean<PathSegment> for hir::PathSegment<'_> {
     }
 }
 
-impl Clean<String> for Ident {
-    #[inline]
-    fn clean(&self, cx: &mut DocContext<'_>) -> String {
-        self.name.clean(cx)
-    }
-}
-
-impl Clean<String> for Symbol {
-    #[inline]
-    fn clean(&self, _: &mut DocContext<'_>) -> String {
-        self.to_string()
-    }
-}
-
 impl Clean<BareFunctionDecl> for hir::BareFnTy<'_> {
     fn clean(&self, cx: &mut DocContext<'_>) -> BareFunctionDecl {
         let (generic_params, decl) = enter_impl_trait(cx, |cx| {


### PR DESCRIPTION
These were only used once, in a place where it was trivial to replace.
Also, it's unclear what 'clean' would mean for these, so it seems better
to be explicit.

Found while reviewing https://github.com/rust-lang/rust/pull/86841, which makes the same change to `build_macro`, so the two will conflict.

r? @GuillaumeGomez