### PR TITLE
Add fast path for Path::cmp that skips over long shared prefixes

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2686,7 +2686,7 @@ impl fmt::Display for Display<'_> {
 impl cmp::PartialEq for Path {
     #[inline]
     fn eq(&self, other: &Path) -> bool {
-        self.components().eq(other.components())
+        self.components() == other.components()
     }
 }
 

--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1395,6 +1395,23 @@ fn into_rc() {
     assert_eq!(&*arc2, path);
 }
 
+#[test]
+fn test_ord() {
+    macro_rules! ord(
+        ($ord:ident, $left:expr, $right:expr) => ( {
+            assert_eq!(Path::new($left).cmp(&Path::new($right)), core::cmp::Ordering::$ord);
+        });
+    );
+
+    ord!(Less, "1", "2");
+    ord!(Less, "/foo/bar", "/foo./bar");
+    ord!(Less, "foo/bar", "foo/bar.");
+    ord!(Equal, "foo/./bar", "foo/bar/");
+    ord!(Equal, "foo/bar", "foo/bar/");
+    ord!(Equal, "foo/bar", "foo/bar/.");
+    ord!(Equal, "foo/bar", "foo/bar//");
+}
+
 #[bench]
 fn bench_path_cmp_fast_path_buf_sort(b: &mut test::Bencher) {
     let prefix = "my/home";


### PR DESCRIPTION

```
# before
test path::tests::bench_path_cmp_fast_path_buf_sort               ... bench:      60,811 ns/iter (+/- 865)
test path::tests::bench_path_cmp_fast_path_long                   ... bench:       6,459 ns/iter (+/- 275)
test path::tests::bench_path_cmp_fast_path_short                  ... bench:       1,777 ns/iter (+/- 34)

# after
test path::tests::bench_path_cmp_fast_path_buf_sort               ... bench:      38,140 ns/iter (+/- 211)
test path::tests::bench_path_cmp_fast_path_long                   ... bench:       1,471 ns/iter (+/- 24)
test path::tests::bench_path_cmp_fast_path_short                  ... bench:       1,106 ns/iter (+/- 9)
```