### PR TITLE
Fix small headers display

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1027,7 +1027,7 @@ fn render_assoc_items(
                 write!(
                     w,
                     "<h2 id=\"deref-methods\" class=\"small-section-header\">\
-                         Methods from {trait_}&lt;Target = {type_}&gt;\
+                         <span>Methods from {trait_}&lt;Target = {type_}&gt;</span>\
                          <a href=\"#deref-methods\" class=\"anchor\"></a>\
                      </h2>",
                     trait_ = trait_.print(cx),

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1092,11 +1092,6 @@ a.test-arrow:hover{
 	left: -10px;
 }
 
-#main > .variant, #main > .structfield {
-	display: block;
-}
-
-
 :target > code {
 	opacity: 1;
 }


### PR DESCRIPTION
You can see it on the `IoSlice` or on the `ErrorKind` pages.

Before:

![Screenshot from 2021-07-06 15-26-33](https://user-images.githubusercontent.com/3050060/124610344-b50a8100-de70-11eb-8ab4-ac5de8adf18f.png)
![Screenshot from 2021-07-08 17-51-43](https://user-images.githubusercontent.com/3050060/124953436-7235de00-e015-11eb-9f99-b361c7eb41a9.png)

After:

![Screenshot from 2021-07-08 17-48-42](https://user-images.githubusercontent.com/3050060/124953042-12d7ce00-e015-11eb-8132-1ae4552dd969.png)
![Screenshot from 2021-07-08 17-48-47](https://user-images.githubusercontent.com/3050060/124953052-13706480-e015-11eb-89f8-dab96c2f0f63.png)

r? @Nemo157 