### PR TITLE
Migrate `cpu-usage-over-time.py` to Python 3

### DIFF
--- a/src/ci/cpu-usage-over-time.py
+++ b/src/ci/cpu-usage-over-time.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ignore-tidy-linelength
 
 # This is a small script that we use on CI to collect CPU usage statistics of
@@ -37,7 +37,10 @@ import datetime
 import sys
 import time
 
-if sys.platform == 'linux2':
+# Python 3.3 changed the value of `sys.platform` on Linux from "linux2" to just
+# "linux". We check here with `.startswith` to keep compatibility with older
+# Python versions (especially Python 2.7).
+if sys.platform.startswith('linux'):
     class State:
         def __init__(self):
             with open('/proc/stat', 'r') as file:

--- a/src/ci/scripts/collect-cpu-stats.sh
+++ b/src/ci/scripts/collect-cpu-stats.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-python src/ci/cpu-usage-over-time.py &> cpu-usage.csv &
+python3 src/ci/cpu-usage-over-time.py &> cpu-usage.csv &


### PR DESCRIPTION
The only change here is a fix for `sys.platform` on Linux. Python 3.3 changed the API to return `"linux"` instead of `"linux2"`/`"linux3"`, so this PR uses `.startswith("linux")` to make the code work on Python 3 without breaking Python 2.