### PR TITLE
rustdoc: Unify external_paths and paths cache map

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -18,7 +18,7 @@ use crate::clean::{
     self, utils, Attributes, AttributesExt, GetDefId, ItemId, NestedAttributesExt, Type,
 };
 use crate::core::DocContext;
-use crate::formats::item_type::ItemType;
+use crate::formats::{cache::CachedPath, item_type::ItemType};
 
 use super::{Clean, Visibility};
 
@@ -189,7 +189,7 @@ crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) 
     if did.is_local() {
         cx.cache.exact_paths.insert(did, fqn);
     } else {
-        cx.cache.external_paths.insert(did, (fqn, kind));
+        cx.cache.paths.insert(did, CachedPath::Extern(fqn, kind));
     }
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -21,7 +21,7 @@ use rustc_target::spec::abi::Abi;
 use crate::clean::{
     self, utils::find_nearest_parent_module, ExternalCrate, GetDefId, ItemId, PrimitiveType,
 };
-use crate::formats::item_type::ItemType;
+use crate::formats::{cache::CachedPath, item_type::ItemType};
 use crate::html::escape::Escape;
 use crate::html::render::cache::ExternalLocation;
 use crate::html::render::Context;
@@ -483,13 +483,12 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Option<(String, ItemType, Vec<Str
         return None;
     }
 
-    let (fqp, shortty, mut url_parts) = match cache.paths.get(&did) {
-        Some(&(ref fqp, shortty)) => (fqp, shortty, {
+    let (fqp, shortty, mut url_parts) = match *cache.paths.get(&did)? {
+        CachedPath::Local(ref fqp, shortty) => (fqp, shortty, {
             let module_fqp = to_module_fqp(shortty, fqp);
             href_relative_parts(module_fqp, relative_to)
         }),
-        None => {
-            let &(ref fqp, shortty) = cache.external_paths.get(&did)?;
+        CachedPath::Extern(ref fqp, shortty) => {
             let module_fqp = to_module_fqp(shortty, fqp);
             (
                 fqp,

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -9,7 +9,7 @@ use crate::clean;
 use crate::clean::types::{
     FnDecl, FnRetTy, GenericBound, Generics, GetDefId, Type, WherePredicate,
 };
-use crate::formats::cache::Cache;
+use crate::formats::cache::{Cache, CachedPath};
 use crate::formats::item_type::ItemType;
 use crate::html::markdown::short_markdown_summary;
 use crate::html::render::{IndexItem, IndexItemFunctionType, RenderType, TypeWithKind};
@@ -33,7 +33,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
     // Attach all orphan items to the type's definition if the type
     // has since been learned.
     for &(did, ref item) in &cache.orphan_impl_items {
-        if let Some(&(ref fqp, _)) = cache.paths.get(&did) {
+        if let Some(CachedPath::Local(fqp, _)) = cache.paths.get(&did) {
             let desc = item
                 .doc_value()
                 .map_or_else(String::new, |s| short_markdown_summary(&s, &item.link_names(&cache)));
@@ -90,7 +90,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
                 defid_to_pathid.insert(defid, pathid);
                 lastpathid += 1;
 
-                if let Some(&(ref fqp, short)) = paths.get(&defid) {
+                if let Some(&CachedPath::Local(ref fqp, short)) = paths.get(&defid) {
                     crate_paths.push((short, fqp.last().unwrap().clone()));
                     Some(pathid)
                 } else {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -24,7 +24,7 @@ use crate::clean::ExternalCrate;
 use crate::config::RenderOptions;
 use crate::docfs::{DocFS, PathError};
 use crate::error::Error;
-use crate::formats::cache::Cache;
+use crate::formats::cache::{Cache, CachedPath};
 use crate::formats::item_type::ItemType;
 use crate::formats::FormatRenderer;
 use crate::html::escape::Escape;
@@ -230,7 +230,9 @@ impl<'tcx> Context<'tcx> {
                 &self.shared.style_files,
             )
         } else {
-            if let Some(&(ref names, ty)) = self.cache.paths.get(&it.def_id.expect_def_id()) {
+            if let Some(&CachedPath::Local(ref names, ty)) =
+                self.cache.paths.get(&it.def_id.expect_def_id())
+            {
                 let mut path = String::new();
                 for name in &names[..names.len() - 1] {
                     path.push_str(name);

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -16,6 +16,7 @@ use crate::clean::Crate;
 use crate::config::{EmitType, RenderOptions};
 use crate::docfs::PathError;
 use crate::error::Error;
+use crate::formats::cache::CachedPath;
 use crate::html::{layout, static_files};
 
 static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| {
@@ -488,12 +489,9 @@ pub(super) fn write_shared(
         //
         // FIXME: this is a vague explanation for why this can't be a `get`, in
         //        theory it should be...
-        let &(ref remote_path, remote_item_type) = match cx.cache.paths.get(&did) {
-            Some(p) => p,
-            None => match cx.cache.external_paths.get(&did) {
-                Some(p) => p,
-                None => continue,
-            },
+        let (remote_path, remote_item_type) = match cx.cache.paths.get(&did) {
+            Some(&CachedPath::Local(ref a, b) | &CachedPath::Extern(ref a, b)) => (a, b),
+            None => continue,
         };
 
         #[derive(Serialize)]
@@ -528,7 +526,8 @@ pub(super) fn write_shared(
         // Only create a js file if we have impls to add to it. If the trait is
         // documented locally though we always create the file to avoid dead
         // links.
-        if implementors.is_empty() && !cx.cache.paths.contains_key(&did) {
+        if implementors.is_empty() && cx.cache.paths.get(&did).map_or(false, CachedPath::is_extern)
+        {
             continue;
         }
 


### PR DESCRIPTION
The `formats::cache::Cache` fields `paths` and `external_paths` are now
unified to a single `paths` map, which makes it easier to manage the
paths and avoids using local paths as extern and vice versa.

The `paths` map maps a `DefId` to an enum which can be either `Local` or
`Extern` so there can't be any misusing.

Resolves #86798

r? @jyn514 