### PR TITLE
Document rustdoc with `--document-private-items`

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -600,7 +600,7 @@ impl Step for Rustc {
 }
 
 macro_rules! tool_doc {
-    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?] $(, binary=$bin:expr)?) => {
+    ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?], binary=$bin:expr) => {
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct $tool {
             stage: u32,
@@ -669,9 +669,9 @@ macro_rules! tool_doc {
                     cargo.arg("-p").arg($krate);
                 )+
 
-                $(if !$bin {
+                if !$bin {
                     cargo.rustdocflag("--document-private-items");
-                })?
+                }
                 cargo.rustdocflag("--enable-index-page");
                 cargo.rustdocflag("--show-type-layout");
                 cargo.rustdocflag("-Zunstable-options");
@@ -681,7 +681,13 @@ macro_rules! tool_doc {
     }
 }
 
-tool_doc!(Rustdoc, "rustdoc-tool", "src/tools/rustdoc", ["rustdoc", "rustdoc-json-types"]);
+tool_doc!(
+    Rustdoc,
+    "rustdoc-tool",
+    "src/tools/rustdoc",
+    ["rustdoc", "rustdoc-json-types"],
+    binary = false
+);
 tool_doc!(
     Rustfmt,
     "rustfmt-nightly",


### PR DESCRIPTION
The `tool_doc` macro introduced in #86737 did not use `false` as the default value for `binary` when it is not provided, so the `if` is not even expanded and thus the argument is never provided if the `binary` argument isn't.

Resolves #86900

r? @Mark-Simulacrum