### PR TITLE
Don't allow opaque ty aliases in ADT fields

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -515,6 +515,10 @@ fn check_fields_for_opaque_types(
         (None, None, None, None)
     }
 
+    if tcx.features().type_alias_impl_trait {
+        return;
+    }
+
     debug!("check_fields_of_opaque_types(adt_def: {:?}, span: {:?})", adt_def, span);
 
     let item_type = tcx.type_of(def_id);

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
@@ -6,6 +6,7 @@ type Foo = impl Debug;
 //~^ ERROR could not find defining uses
 
 struct Bar(Foo);
+//~^ ERROR type alias impl traits are not allowed as field types in structs
 fn define() -> Bar {
     Bar(42) //~ ERROR mismatched types
 }

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.rs
@@ -6,7 +6,7 @@ type Foo = impl Debug;
 //~^ ERROR could not find defining uses
 
 struct Bar(Foo);
-//~^ ERROR type alias impl traits are not allowed as field types in structs
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
 fn define() -> Bar {
     Bar(42) //~ ERROR mismatched types
 }

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:10:9
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:11:9
    |
 LL | type Foo = impl Debug;
    |            ---------- the expected opaque type
@@ -11,7 +11,7 @@ LL |     Bar(42)
                      found type `{integer}`
 
 error[E0658]: type alias impl trait is not permitted here
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:16:19
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:17:19
    |
 LL |     let x = || -> Foo2 { 42 };
    |                   ^^^^
@@ -20,7 +20,7 @@ LL |     let x = || -> Foo2 { 42 };
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:23:18
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:24:18
    |
 LL | type Foo3 = impl Debug;
    |             ---------- the found opaque type
@@ -34,7 +34,7 @@ LL |     let y: i32 = x;
            found opaque type `impl Debug`
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:26:13
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:27:13
    |
 LL | type Foo3 = impl Debug;
    |             ---------- the expected opaque type
@@ -46,7 +46,7 @@ LL |     define3(42)
                      found type `{integer}`
 
 error[E0658]: type alias impl trait is not permitted here
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:33:12
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:34:12
    |
 LL |     let y: Foo4 = 42;
    |            ^^^^
@@ -60,19 +60,30 @@ error: could not find defining uses
 LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
 
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:8:1
+   |
+LL | type Foo = impl Debug;
+   | ---------------------- type alias defined here
+...
+LL | struct Bar(Foo);
+   | ^^^^^^^^^^^---^^
+   |            |
+   |            this field contains a type alias impl trait
+
 error: could not find defining uses
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:19:13
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:20:13
    |
 LL | type Foo3 = impl Debug;
    |             ^^^^^^^^^^
 
 error: could not find defining uses
-  --> $DIR/feature-gate-type_alias_impl_trait.rs:29:13
+  --> $DIR/feature-gate-type_alias_impl_trait.rs:30:13
    |
 LL | type Foo4 = impl Debug;
    |             ^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_alias_impl_trait.stderr
@@ -60,7 +60,7 @@ error: could not find defining uses
 LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/feature-gate-type_alias_impl_trait.rs:8:1
    |
 LL | type Foo = impl Debug;
@@ -69,7 +69,8 @@ LL | type Foo = impl Debug;
 LL | struct Bar(Foo);
    | ^^^^^^^^^^^---^^
    |            |
-   |            this field contains a type alias impl trait
+   |            this field contains a type alias `Foo` of an `impl Trait`
+   |            this type is a type alias of an `impl Trait`
 
 error: could not find defining uses
   --> $DIR/feature-gate-type_alias_impl_trait.rs:20:13

--- a/src/test/ui/impl-trait/reject-opaque_types-in-fields.rs
+++ b/src/test/ui/impl-trait/reject-opaque_types-in-fields.rs
@@ -1,0 +1,42 @@
+#![feature(min_type_alias_impl_trait)]
+
+type ImplCopy = impl Copy;
+//~^ ERROR could not find defining uses
+
+enum Wrapper {
+//~^ ERROR type alias impl traits are not allowed as field types in enums
+    First(ImplCopy),
+    Second
+}
+
+type X = impl Iterator<Item = u64> + Unpin;
+//~^ ERROR could not find defining uses
+
+struct Foo(X);
+//~^ ERROR type alias impl traits are not allowed as field types in structs
+
+impl Foo {
+    fn new(z: Vec<u64>) -> Self {
+        Foo(z.into_iter())
+        //~^ ERROR mismatched types
+    }
+}
+
+struct Bar {a : X}
+//~^ ERROR type alias impl traits are not allowed as field types in structs
+
+impl Bar {
+  fn new(z: Vec<u64>) -> Self {
+    Bar {a: z.into_iter() }
+    //~^ ERROR mismatched types
+  }
+}
+
+union MyUnion {
+  //~^ ERROR type alias impl traits are not allowed as field types in unions
+  a: X,
+  //~^ ERROR unions may not contain fields that need dropping
+}
+
+
+fn main() {}

--- a/src/test/ui/impl-trait/reject-opaque_types-in-fields.rs
+++ b/src/test/ui/impl-trait/reject-opaque_types-in-fields.rs
@@ -4,7 +4,7 @@ type ImplCopy = impl Copy;
 //~^ ERROR could not find defining uses
 
 enum Wrapper {
-//~^ ERROR type alias impl traits are not allowed as field types in enums
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in enums
     First(ImplCopy),
     Second
 }
@@ -13,7 +13,7 @@ type X = impl Iterator<Item = u64> + Unpin;
 //~^ ERROR could not find defining uses
 
 struct Foo(X);
-//~^ ERROR type alias impl traits are not allowed as field types in structs
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
 
 impl Foo {
     fn new(z: Vec<u64>) -> Self {
@@ -22,8 +22,11 @@ impl Foo {
     }
 }
 
+struct FooNested(Vec<X>);
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
+
 struct Bar {a : X}
-//~^ ERROR type alias impl traits are not allowed as field types in structs
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
 
 impl Bar {
   fn new(z: Vec<u64>) -> Self {
@@ -33,7 +36,7 @@ impl Bar {
 }
 
 union MyUnion {
-  //~^ ERROR type alias impl traits are not allowed as field types in unions
+  //~^ ERROR type aliases of `impl Trait` are not allowed as field types in unions
   a: X,
   //~^ ERROR unions may not contain fields that need dropping
 }

--- a/src/test/ui/impl-trait/reject-opaque_types-in-fields.stderr
+++ b/src/test/ui/impl-trait/reject-opaque_types-in-fields.stderr
@@ -1,0 +1,102 @@
+error[E0308]: mismatched types
+  --> $DIR/reject-opaque_types-in-fields.rs:20:13
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   |          --------------------------------- the expected opaque type
+...
+LL |         Foo(z.into_iter())
+   |             ^^^^^^^^^^^^^ expected opaque type, found struct `std::vec::IntoIter`
+   |
+   = note: expected opaque type `impl Iterator+Unpin`
+                   found struct `std::vec::IntoIter<u64>`
+
+error[E0308]: mismatched types
+  --> $DIR/reject-opaque_types-in-fields.rs:30:13
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   |          --------------------------------- the expected opaque type
+...
+LL |     Bar {a: z.into_iter() }
+   |             ^^^^^^^^^^^^^ expected opaque type, found struct `std::vec::IntoIter`
+   |
+   = note: expected opaque type `impl Iterator+Unpin`
+                   found struct `std::vec::IntoIter<u64>`
+
+error: could not find defining uses
+  --> $DIR/reject-opaque_types-in-fields.rs:3:17
+   |
+LL | type ImplCopy = impl Copy;
+   |                 ^^^^^^^^^
+
+error: type alias impl traits are not allowed as field types in enums
+  --> $DIR/reject-opaque_types-in-fields.rs:6:1
+   |
+LL |   type ImplCopy = impl Copy;
+   |   -------------------------- type alias defined here
+...
+LL | / enum Wrapper {
+LL | |
+LL | |     First(ImplCopy),
+   | |           -------- this field contains a type alias impl trait
+LL | |     Second
+LL | | }
+   | |_^
+
+error: could not find defining uses
+  --> $DIR/reject-opaque_types-in-fields.rs:12:10
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/reject-opaque_types-in-fields.rs:15:1
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   | ------------------------------------------- type alias defined here
+...
+LL | struct Foo(X);
+   | ^^^^^^^^^^^-^^
+   |            |
+   |            this field contains a type alias impl trait
+
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/reject-opaque_types-in-fields.rs:25:1
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   | ------------------------------------------- type alias defined here
+...
+LL | struct Bar {a : X}
+   | ^^^^^^^^^^^^-----^
+   |             |
+   |             this field contains a type alias impl trait
+
+error: type alias impl traits are not allowed as field types in unions
+  --> $DIR/reject-opaque_types-in-fields.rs:35:1
+   |
+LL |   type X = impl Iterator<Item = u64> + Unpin;
+   |   ------------------------------------------- type alias defined here
+...
+LL | / union MyUnion {
+LL | |
+LL | |   a: X,
+   | |   ---- this field contains a type alias impl trait
+LL | |
+LL | | }
+   | |_^
+
+error[E0740]: unions may not contain fields that need dropping
+  --> $DIR/reject-opaque_types-in-fields.rs:37:3
+   |
+LL |   a: X,
+   |   ^^^^
+   |
+note: `std::mem::ManuallyDrop` can be used to wrap the type
+  --> $DIR/reject-opaque_types-in-fields.rs:37:3
+   |
+LL |   a: X,
+   |   ^^^^
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0308, E0740.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/impl-trait/reject-opaque_types-in-fields.stderr
+++ b/src/test/ui/impl-trait/reject-opaque_types-in-fields.stderr
@@ -11,7 +11,7 @@ LL |         Foo(z.into_iter())
                    found struct `std::vec::IntoIter<u64>`
 
 error[E0308]: mismatched types
-  --> $DIR/reject-opaque_types-in-fields.rs:30:13
+  --> $DIR/reject-opaque_types-in-fields.rs:33:13
    |
 LL | type X = impl Iterator<Item = u64> + Unpin;
    |          --------------------------------- the expected opaque type
@@ -28,7 +28,7 @@ error: could not find defining uses
 LL | type ImplCopy = impl Copy;
    |                 ^^^^^^^^^
 
-error: type alias impl traits are not allowed as field types in enums
+error: type aliases of `impl Trait` are not allowed as field types in enums
   --> $DIR/reject-opaque_types-in-fields.rs:6:1
    |
 LL |   type ImplCopy = impl Copy;
@@ -37,7 +37,10 @@ LL |   type ImplCopy = impl Copy;
 LL | / enum Wrapper {
 LL | |
 LL | |     First(ImplCopy),
-   | |           -------- this field contains a type alias impl trait
+   | |           --------
+   | |           |
+   | |           this field contains a type alias `ImplCopy` of an `impl Trait`
+   | |           this type is a type alias of an `impl Trait`
 LL | |     Second
 LL | | }
    | |_^
@@ -48,7 +51,7 @@ error: could not find defining uses
 LL | type X = impl Iterator<Item = u64> + Unpin;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/reject-opaque_types-in-fields.rs:15:1
    |
 LL | type X = impl Iterator<Item = u64> + Unpin;
@@ -57,21 +60,35 @@ LL | type X = impl Iterator<Item = u64> + Unpin;
 LL | struct Foo(X);
    | ^^^^^^^^^^^-^^
    |            |
-   |            this field contains a type alias impl trait
+   |            this field contains a type alias `X` of an `impl Trait`
+   |            this type is a type alias of an `impl Trait`
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/reject-opaque_types-in-fields.rs:25:1
+   |
+LL | type X = impl Iterator<Item = u64> + Unpin;
+   | ------------------------------------------- type alias defined here
+...
+LL | struct FooNested(Vec<X>);
+   | ^^^^^^^^^^^^^^^^^------^^
+   |                  |   |
+   |                  |   this type is a type alias of an `impl Trait`
+   |                  this field contains a type alias `X` of an `impl Trait`
+
+error: type aliases of `impl Trait` are not allowed as field types in structs
+  --> $DIR/reject-opaque_types-in-fields.rs:28:1
    |
 LL | type X = impl Iterator<Item = u64> + Unpin;
    | ------------------------------------------- type alias defined here
 ...
 LL | struct Bar {a : X}
    | ^^^^^^^^^^^^-----^
-   |             |
-   |             this field contains a type alias impl trait
+   |             |   |
+   |             |   this type is a type alias of an `impl Trait`
+   |             this field contains a type alias `X` of an `impl Trait`
 
-error: type alias impl traits are not allowed as field types in unions
-  --> $DIR/reject-opaque_types-in-fields.rs:35:1
+error: type aliases of `impl Trait` are not allowed as field types in unions
+  --> $DIR/reject-opaque_types-in-fields.rs:38:1
    |
 LL |   type X = impl Iterator<Item = u64> + Unpin;
    |   ------------------------------------------- type alias defined here
@@ -79,24 +96,27 @@ LL |   type X = impl Iterator<Item = u64> + Unpin;
 LL | / union MyUnion {
 LL | |
 LL | |   a: X,
-   | |   ---- this field contains a type alias impl trait
+   | |   ----
+   | |   |  |
+   | |   |  this type is a type alias of an `impl Trait`
+   | |   this field contains a type alias `X` of an `impl Trait`
 LL | |
 LL | | }
    | |_^
 
 error[E0740]: unions may not contain fields that need dropping
-  --> $DIR/reject-opaque_types-in-fields.rs:37:3
+  --> $DIR/reject-opaque_types-in-fields.rs:40:3
    |
 LL |   a: X,
    |   ^^^^
    |
 note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/reject-opaque_types-in-fields.rs:37:3
+  --> $DIR/reject-opaque_types-in-fields.rs:40:3
    |
 LL |   a: X,
    |   ^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0308, E0740.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
@@ -7,18 +7,18 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: `extern` block uses type `impl Baz`, which is not FFI-safe
-  --> $DIR/lint-ctypes-73249-3.rs:21:25
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/lint-ctypes-73249-3.rs:16:1
    |
-LL |     pub fn lint_me() -> A;
-   |                         ^ not FFI-safe
-   |
-note: the lint level is defined here
-  --> $DIR/lint-ctypes-73249-3.rs:5:9
-   |
-LL | #![deny(improper_ctypes)]
-   |         ^^^^^^^^^^^^^^^
-   = note: opaque types have no C equivalent
+LL |   type Qux = impl Baz;
+   |   -------------------- type alias defined here
+...
+LL | / pub struct A {
+LL | |
+LL | |     x: Qux,
+   | |     ------ this field contains a type alias impl trait
+LL | | }
+   | |_^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
@@ -7,21 +7,18 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type aliases of `impl Trait` are not allowed as field types in structs
-  --> $DIR/lint-ctypes-73249-3.rs:16:1
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73249-3.rs:22:25
    |
-LL |   type Qux = impl Baz;
-   |   -------------------- type alias defined here
-...
-LL | / pub struct A {
-LL | |
-LL | |     x: Qux,
-   | |     ------
-   | |     |  |
-   | |     |  this type is a type alias of an `impl Trait`
-   | |     this field contains a type alias `Qux` of an `impl Trait`
-LL | | }
-   | |_^
+LL |     pub fn lint_me() -> A;
+   |                         ^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73249-3.rs:5:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.full_tait.stderr
@@ -7,7 +7,7 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/lint-ctypes-73249-3.rs:16:1
    |
 LL |   type Qux = impl Baz;
@@ -16,7 +16,10 @@ LL |   type Qux = impl Baz;
 LL | / pub struct A {
 LL | |
 LL | |     x: Qux,
-   | |     ------ this field contains a type alias impl trait
+   | |     ------
+   | |     |  |
+   | |     |  this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Qux` of an `impl Trait`
 LL | | }
    | |_^
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.min_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.min_tait.stderr
@@ -1,15 +1,15 @@
-error: `extern` block uses type `impl Baz`, which is not FFI-safe
-  --> $DIR/lint-ctypes-73249-3.rs:21:25
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/lint-ctypes-73249-3.rs:16:1
    |
-LL |     pub fn lint_me() -> A;
-   |                         ^ not FFI-safe
-   |
-note: the lint level is defined here
-  --> $DIR/lint-ctypes-73249-3.rs:5:9
-   |
-LL | #![deny(improper_ctypes)]
-   |         ^^^^^^^^^^^^^^^
-   = note: opaque types have no C equivalent
+LL |   type Qux = impl Baz;
+   |   -------------------- type alias defined here
+...
+LL | / pub struct A {
+LL | |
+LL | |     x: Qux,
+   | |     ------ this field contains a type alias impl trait
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.min_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-3.min_tait.stderr
@@ -1,4 +1,4 @@
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/lint-ctypes-73249-3.rs:16:1
    |
 LL |   type Qux = impl Baz;
@@ -7,7 +7,10 @@ LL |   type Qux = impl Baz;
 LL | / pub struct A {
 LL | |
 LL | |     x: Qux,
-   | |     ------ this field contains a type alias impl trait
+   | |     ------
+   | |     |  |
+   | |     |  this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Qux` of an `impl Trait`
 LL | | }
    | |_^
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-3.rs
@@ -14,11 +14,12 @@ fn assign() -> Qux { 3 }
 
 #[repr(C)]
 pub struct A {
+    //~^ ERROR type alias impl traits are not allowed as field types in structs
     x: Qux,
 }
 
 extern "C" {
-    pub fn lint_me() -> A; //~ ERROR: uses type `impl Baz`
+    pub fn lint_me() -> A;
 }
 
 fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-3.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-3.rs
@@ -14,7 +14,7 @@ fn assign() -> Qux { 3 }
 
 #[repr(C)]
 pub struct A {
-    //~^ ERROR type alias impl traits are not allowed as field types in structs
+    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     x: Qux,
 }
 

--- a/src/test/ui/lint/lint-ctypes-73249-3.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-3.rs
@@ -14,12 +14,13 @@ fn assign() -> Qux { 3 }
 
 #[repr(C)]
 pub struct A {
-    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
+    //[min_tait]~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     x: Qux,
 }
 
 extern "C" {
     pub fn lint_me() -> A;
+    //[full_tait]~^ ERROR `extern` block uses type `impl Baz`, which is not FFI-safe
 }
 
 fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
@@ -7,18 +7,18 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: `extern` block uses type `impl Baz`, which is not FFI-safe
-  --> $DIR/lint-ctypes-73249-5.rs:21:25
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/lint-ctypes-73249-5.rs:16:1
    |
-LL |     pub fn lint_me() -> A;
-   |                         ^ not FFI-safe
-   |
-note: the lint level is defined here
-  --> $DIR/lint-ctypes-73249-5.rs:5:9
-   |
-LL | #![deny(improper_ctypes)]
-   |         ^^^^^^^^^^^^^^^
-   = note: opaque types have no C equivalent
+LL |   type Qux = impl Baz;
+   |   -------------------- type alias defined here
+...
+LL | / pub struct A {
+LL | |
+LL | |     x: Qux,
+   | |     ------ this field contains a type alias impl trait
+LL | | }
+   | |_^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
@@ -7,21 +7,18 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type aliases of `impl Trait` are not allowed as field types in structs
-  --> $DIR/lint-ctypes-73249-5.rs:16:1
+error: `extern` block uses type `impl Baz`, which is not FFI-safe
+  --> $DIR/lint-ctypes-73249-5.rs:22:25
    |
-LL |   type Qux = impl Baz;
-   |   -------------------- type alias defined here
-...
-LL | / pub struct A {
-LL | |
-LL | |     x: Qux,
-   | |     ------
-   | |     |  |
-   | |     |  this type is a type alias of an `impl Trait`
-   | |     this field contains a type alias `Qux` of an `impl Trait`
-LL | | }
-   | |_^
+LL |     pub fn lint_me() -> A;
+   |                         ^ not FFI-safe
+   |
+note: the lint level is defined here
+  --> $DIR/lint-ctypes-73249-5.rs:5:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+   = note: opaque types have no C equivalent
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.full_tait.stderr
@@ -7,7 +7,7 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/lint-ctypes-73249-5.rs:16:1
    |
 LL |   type Qux = impl Baz;
@@ -16,7 +16,10 @@ LL |   type Qux = impl Baz;
 LL | / pub struct A {
 LL | |
 LL | |     x: Qux,
-   | |     ------ this field contains a type alias impl trait
+   | |     ------
+   | |     |  |
+   | |     |  this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Qux` of an `impl Trait`
 LL | | }
    | |_^
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.min_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.min_tait.stderr
@@ -1,15 +1,15 @@
-error: `extern` block uses type `impl Baz`, which is not FFI-safe
-  --> $DIR/lint-ctypes-73249-5.rs:21:25
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/lint-ctypes-73249-5.rs:16:1
    |
-LL |     pub fn lint_me() -> A;
-   |                         ^ not FFI-safe
-   |
-note: the lint level is defined here
-  --> $DIR/lint-ctypes-73249-5.rs:5:9
-   |
-LL | #![deny(improper_ctypes)]
-   |         ^^^^^^^^^^^^^^^
-   = note: opaque types have no C equivalent
+LL |   type Qux = impl Baz;
+   |   -------------------- type alias defined here
+...
+LL | / pub struct A {
+LL | |
+LL | |     x: Qux,
+   | |     ------ this field contains a type alias impl trait
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.min_tait.stderr
+++ b/src/test/ui/lint/lint-ctypes-73249-5.min_tait.stderr
@@ -1,4 +1,4 @@
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/lint-ctypes-73249-5.rs:16:1
    |
 LL |   type Qux = impl Baz;
@@ -7,7 +7,10 @@ LL |   type Qux = impl Baz;
 LL | / pub struct A {
 LL | |
 LL | |     x: Qux,
-   | |     ------ this field contains a type alias impl trait
+   | |     ------
+   | |     |  |
+   | |     |  this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Qux` of an `impl Trait`
 LL | | }
    | |_^
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-5.rs
@@ -14,11 +14,12 @@ fn assign() -> Qux { 3 }
 
 #[repr(transparent)]
 pub struct A {
+    //~^ ERROR type alias impl traits are not allowed as field types in structs
     x: Qux,
 }
 
 extern "C" {
-    pub fn lint_me() -> A; //~ ERROR: uses type `impl Baz`
+    pub fn lint_me() -> A;
 }
 
 fn main() {}

--- a/src/test/ui/lint/lint-ctypes-73249-5.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-5.rs
@@ -14,7 +14,7 @@ fn assign() -> Qux { 3 }
 
 #[repr(transparent)]
 pub struct A {
-    //~^ ERROR type alias impl traits are not allowed as field types in structs
+    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     x: Qux,
 }
 

--- a/src/test/ui/lint/lint-ctypes-73249-5.rs
+++ b/src/test/ui/lint/lint-ctypes-73249-5.rs
@@ -14,12 +14,13 @@ fn assign() -> Qux { 3 }
 
 #[repr(transparent)]
 pub struct A {
-    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
+    //[min_tait]~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     x: Qux,
 }
 
 extern "C" {
     pub fn lint_me() -> A;
+    //[full_tait]~^ ERROR `extern` block uses type `impl Baz`, which is not FFI-safe
 }
 
 fn main() {}

--- a/src/test/ui/mir/issue-75053.full_tait.stderr
+++ b/src/test/ui/mir/issue-75053.full_tait.stderr
@@ -16,18 +16,6 @@ LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: type aliases of `impl Trait` are not allowed as field types in structs
-  --> $DIR/issue-75053.rs:28:1
-   |
-LL | type DummyT<T> = impl F;
-   | ------------------------ type alias defined here
-...
-LL | struct Scope<T>(Phantom2<DummyT<T>>);
-   | ^^^^^^^^^^^^^^^^-------------------^^
-   |                 |        |
-   |                 |        this type is a type alias of an `impl Trait`
-   |                 this field contains a type alias `DummyT` of an `impl Trait`
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/mir/issue-75053.full_tait.stderr
+++ b/src/test/ui/mir/issue-75053.full_tait.stderr
@@ -8,7 +8,7 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
 error[E0658]: type alias impl trait is not permitted here
-  --> $DIR/issue-75053.rs:52:15
+  --> $DIR/issue-75053.rs:53:15
    |
 LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -16,6 +16,18 @@ LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: aborting due to previous error; 1 warning emitted
+error: type aliases of `impl Trait` are not allowed as field types in structs
+  --> $DIR/issue-75053.rs:28:1
+   |
+LL | type DummyT<T> = impl F;
+   | ------------------------ type alias defined here
+...
+LL | struct Scope<T>(Phantom2<DummyT<T>>);
+   | ^^^^^^^^^^^^^^^^-------------------^^
+   |                 |        |
+   |                 |        this type is a type alias of an `impl Trait`
+   |                 this field contains a type alias `DummyT` of an `impl Trait`
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/mir/issue-75053.in_bindings.stderr
+++ b/src/test/ui/mir/issue-75053.in_bindings.stderr
@@ -8,7 +8,7 @@ LL | #![cfg_attr(in_bindings, feature(impl_trait_in_bindings))]
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-75053.rs:52:38
+  --> $DIR/issue-75053.rs:53:38
    |
 LL |     type O;
    |     ------- `<Self as MyIndex<T>>::O` defined here
@@ -19,6 +19,18 @@ LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    |                                      this method call resolves to `<Self as MyIndex<T>>::O`
    |                                      cannot infer type for type parameter `T`
 
-error: aborting due to previous error; 1 warning emitted
+error: type aliases of `impl Trait` are not allowed as field types in structs
+  --> $DIR/issue-75053.rs:28:1
+   |
+LL | type DummyT<T> = impl F;
+   | ------------------------ type alias defined here
+...
+LL | struct Scope<T>(Phantom2<DummyT<T>>);
+   | ^^^^^^^^^^^^^^^^-------------------^^
+   |                 |        |
+   |                 |        this type is a type alias of an `impl Trait`
+   |                 this field contains a type alias `DummyT` of an `impl Trait`
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/mir/issue-75053.min_tait.stderr
+++ b/src/test/ui/mir/issue-75053.min_tait.stderr
@@ -1,5 +1,5 @@
 error[E0658]: type alias impl trait is not permitted here
-  --> $DIR/issue-75053.rs:52:15
+  --> $DIR/issue-75053.rs:53:15
    |
 LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -7,6 +7,18 @@ LL |     let _pos: Phantom1<DummyT<()>> = Scope::new().my_index();
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error: type aliases of `impl Trait` are not allowed as field types in structs
+  --> $DIR/issue-75053.rs:28:1
+   |
+LL | type DummyT<T> = impl F;
+   | ------------------------ type alias defined here
+...
+LL | struct Scope<T>(Phantom2<DummyT<T>>);
+   | ^^^^^^^^^^^^^^^^-------------------^^
+   |                 |        |
+   |                 |        this type is a type alias of an `impl Trait`
+   |                 this field contains a type alias `DummyT` of an `impl Trait`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/mir/issue-75053.rs
+++ b/src/test/ui/mir/issue-75053.rs
@@ -26,7 +26,7 @@ fn _dummy_t<T>() -> DummyT<T> {}
 struct Phantom1<T>(PhantomData<T>);
 struct Phantom2<T>(PhantomData<T>);
 struct Scope<T>(Phantom2<DummyT<T>>);
-//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
+//[min_tait,in_bindings]~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
 
 impl<T> Scope<T> {
     fn new() -> Self {

--- a/src/test/ui/mir/issue-75053.rs
+++ b/src/test/ui/mir/issue-75053.rs
@@ -26,6 +26,7 @@ fn _dummy_t<T>() -> DummyT<T> {}
 struct Phantom1<T>(PhantomData<T>);
 struct Phantom2<T>(PhantomData<T>);
 struct Scope<T>(Phantom2<DummyT<T>>);
+//~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
 
 impl<T> Scope<T> {
     fn new() -> Self {

--- a/src/test/ui/type-alias-impl-trait/cross_crate_ice.rs
+++ b/src/test/ui/type-alias-impl-trait/cross_crate_ice.rs
@@ -1,9 +1,9 @@
 // aux-build:cross_crate_ice.rs
-// build-pass (FIXME(62277): could be check-pass?)
 
 extern crate cross_crate_ice;
 
 struct Bar(cross_crate_ice::Foo);
+//~^ type alias impl traits are not allowed as field types in structs
 
 impl Bar {
     fn zero(&self) -> &cross_crate_ice::Foo {

--- a/src/test/ui/type-alias-impl-trait/cross_crate_ice.stderr
+++ b/src/test/ui/type-alias-impl-trait/cross_crate_ice.stderr
@@ -1,0 +1,8 @@
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/cross_crate_ice.rs:5:1
+   |
+LL | struct Bar(cross_crate_ice::Foo);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
@@ -1,5 +1,5 @@
 warning: the feature `type_alias_impl_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/type-alias-impl-trait-tuple.rs:5:32
+  --> $DIR/type-alias-impl-trait-tuple.rs:3:32
    |
 LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    |                                ^^^^^^^^^^^^^^^^^^^^^
@@ -7,5 +7,19 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-warning: 1 warning emitted
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/type-alias-impl-trait-tuple.rs:11:1
+   |
+LL | / struct Blah {
+LL | |
+LL | |     my_foo: Foo,
+   | |     ----------- this field contains a type alias impl trait
+LL | |     my_u8: u8
+LL | | }
+   | |_^
+...
+LL |   type Foo = impl MyTrait;
+   |   ------------------------ type alias defined here
+
+error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
@@ -7,13 +7,16 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/type-alias-impl-trait-tuple.rs:11:1
    |
 LL | / struct Blah {
 LL | |
 LL | |     my_foo: Foo,
-   | |     ----------- this field contains a type alias impl trait
+   | |     -----------
+   | |     |       |
+   | |     |       this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Foo` of an `impl Trait`
 LL | |     my_u8: u8
 LL | | }
    | |_^

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.full_tait.stderr
@@ -1,5 +1,5 @@
 warning: the feature `type_alias_impl_trait` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/type-alias-impl-trait-tuple.rs:3:32
+  --> $DIR/type-alias-impl-trait-tuple.rs:4:32
    |
 LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    |                                ^^^^^^^^^^^^^^^^^^^^^
@@ -7,22 +7,5 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
 
-error: type aliases of `impl Trait` are not allowed as field types in structs
-  --> $DIR/type-alias-impl-trait-tuple.rs:11:1
-   |
-LL | / struct Blah {
-LL | |
-LL | |     my_foo: Foo,
-   | |     -----------
-   | |     |       |
-   | |     |       this type is a type alias of an `impl Trait`
-   | |     this field contains a type alias `Foo` of an `impl Trait`
-LL | |     my_u8: u8
-LL | | }
-   | |_^
-...
-LL |   type Foo = impl MyTrait;
-   |   ------------------------ type alias defined here
-
-error: aborting due to previous error; 1 warning emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
@@ -1,0 +1,16 @@
+error: type alias impl traits are not allowed as field types in structs
+  --> $DIR/type-alias-impl-trait-tuple.rs:11:1
+   |
+LL | / struct Blah {
+LL | |
+LL | |     my_foo: Foo,
+   | |     ----------- this field contains a type alias impl trait
+LL | |     my_u8: u8
+LL | | }
+   | |_^
+...
+LL |   type Foo = impl MyTrait;
+   |   ------------------------ type alias defined here
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
@@ -1,10 +1,13 @@
-error: type alias impl traits are not allowed as field types in structs
+error: type aliases of `impl Trait` are not allowed as field types in structs
   --> $DIR/type-alias-impl-trait-tuple.rs:11:1
    |
 LL | / struct Blah {
 LL | |
 LL | |     my_foo: Foo,
-   | |     ----------- this field contains a type alias impl trait
+   | |     -----------
+   | |     |       |
+   | |     |       this type is a type alias of an `impl Trait`
+   | |     this field contains a type alias `Foo` of an `impl Trait`
 LL | |     my_u8: u8
 LL | | }
    | |_^

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.min_tait.stderr
@@ -1,5 +1,5 @@
 error: type aliases of `impl Trait` are not allowed as field types in structs
-  --> $DIR/type-alias-impl-trait-tuple.rs:11:1
+  --> $DIR/type-alias-impl-trait-tuple.rs:12:1
    |
 LL | / struct Blah {
 LL | |

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 // revisions: min_tait full_tait
 #![feature(min_type_alias_impl_trait)]
 #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
@@ -11,6 +9,7 @@ pub trait MyTrait {}
 impl MyTrait for bool {}
 
 struct Blah {
+    //~^ ERROR type alias impl traits are not allowed as field types in structs
     my_foo: Foo,
     my_u8: u8
 }

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
@@ -9,7 +9,7 @@ pub trait MyTrait {}
 impl MyTrait for bool {}
 
 struct Blah {
-    //~^ ERROR type alias impl traits are not allowed as field types in structs
+    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     my_foo: Foo,
     my_u8: u8
 }

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
@@ -1,4 +1,5 @@
 // revisions: min_tait full_tait
+//[full_tait] check-pass
 #![feature(min_type_alias_impl_trait)]
 #![cfg_attr(full_tait, feature(type_alias_impl_trait))]
 //[full_tait]~^ WARN incomplete
@@ -9,7 +10,7 @@ pub trait MyTrait {}
 impl MyTrait for bool {}
 
 struct Blah {
-    //~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
+    //[min_tait]~^ ERROR type aliases of `impl Trait` are not allowed as field types in structs
     my_foo: Foo,
     my_u8: u8
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/86732