### PR TITLE
Fix ICE when misplaced visibility cannot be properly parsed

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1791,7 +1791,13 @@ impl<'a> Parser<'a> {
                     if self.check_keyword(kw::Pub) {
                         let sp = sp_start.to(self.prev_token.span);
                         if let Ok(snippet) = self.span_to_snippet(sp) {
-                            let vis = self.parse_visibility(FollowedByType::No)?;
+                            let vis = match self.parse_visibility(FollowedByType::No) {
+                                Ok(v) => v,
+                                Err(mut d) => {
+                                    d.cancel();
+                                    return Err(err);
+                                }
+                            };
                             let vs = pprust::vis_to_string(&vis);
                             let vs = vs.trim_end();
                             err.span_suggestion(

--- a/src/test/ui/parser/issue-86895.rs
+++ b/src/test/ui/parser/issue-86895.rs
@@ -1,0 +1,3 @@
+const pub () {}
+//~^ ERROR expected one of `async`, `extern`, `fn`, or `unsafe`
+pub fn main() {}

--- a/src/test/ui/parser/issue-86895.stderr
+++ b/src/test/ui/parser/issue-86895.stderr
@@ -1,0 +1,8 @@
+error: expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
+  --> $DIR/issue-86895.rs:1:7
+   |
+LL | const pub () {}
+   |       ^^^ expected one of `async`, `extern`, `fn`, or `unsafe`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #86895 

The issue was that a failure to parse the visibility was causing the original error to be dropped before being emitted. 

The resulting error isn't quite as nice as when the visibility is parsed properly, but I'm not sure which error to prioritize here. Displaying both errors might be too confusing. 

r? @estebank 