### PR TITLE
Change linked tracking issue for more_qualified_paths

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -685,7 +685,7 @@ declare_features! (
     (incomplete, unnamed_fields, "1.53.0", Some(49804), None),
 
     /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
-    (active, more_qualified_paths, "1.54.0", Some(80080), None),
+    (active, more_qualified_paths, "1.54.0", Some(86935), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/test/ui/feature-gates/feature-gate-more-qualified-paths.stderr
+++ b/src/test/ui/feature-gates/feature-gate-more-qualified-paths.stderr
@@ -4,7 +4,7 @@ error[E0658]: usage of qualified paths in this context is experimental
 LL |     let <Foo as A>::Assoc { br } = StructStruct { br: 2 };
    |         ^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #80080 <https://github.com/rust-lang/rust/issues/80080> for more information
+   = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
 
 error[E0658]: usage of qualified paths in this context is experimental
@@ -13,7 +13,7 @@ error[E0658]: usage of qualified paths in this context is experimental
 LL |     let _ = <Foo as A>::Assoc { br: 2 };
    |             ^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #80080 <https://github.com/rust-lang/rust/issues/80080> for more information
+   = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
 
 error[E0658]: usage of qualified paths in this context is experimental
@@ -22,7 +22,7 @@ error[E0658]: usage of qualified paths in this context is experimental
 LL |     let <E>::V(..) = E::V(0);
    |         ^^^^^^
    |
-   = note: see issue #80080 <https://github.com/rust-lang/rust/issues/80080> for more information
+   = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
This updates the linked tracking issue for the `more_qualified_paths` feature from the implementation PR #80080 to an actual tracking issue #86935. 