### PR TITLE
Use existing declaration of rust_eh_personality

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -937,8 +937,12 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         pers_fn: &'ll Value,
         num_clauses: usize,
     ) -> &'ll Value {
+        // Use LLVMSetPersonalityFn to set the personality. It supports arbitrary Consts while,
+        // LLVMBuildLandingPad requires the argument to be a Function (as of LLVM 12). The
+        // personality lives on the parent function anyway.
+        self.set_personality_fn(pers_fn);
         unsafe {
-            llvm::LLVMBuildLandingPad(self.llbuilder, ty, pers_fn, num_clauses as c_uint, UNNAMED)
+            llvm::LLVMBuildLandingPad(self.llbuilder, ty, None, num_clauses as c_uint, UNNAMED)
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -385,11 +385,16 @@ impl MiscMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 } else {
                     "rust_eh_personality"
                 };
-                let fty = self.type_variadic_func(&[], self.type_i32());
-                self.declare_cfn(name, llvm::UnnamedAddr::Global, fty)
+                if let Some(llfn) = self.get_declared_value(name) {
+                    llfn
+                } else {
+                    let fty = self.type_variadic_func(&[], self.type_i32());
+                    let llfn = self.declare_cfn(name, llvm::UnnamedAddr::Global, fty);
+                    attributes::apply_target_cpu_attr(self, llfn);
+                    llfn
+                }
             }
         };
-        attributes::apply_target_cpu_attr(self, llfn);
         self.eh_personality.set(Some(llfn));
         llfn
     }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1165,7 +1165,7 @@ extern "C" {
     pub fn LLVMBuildLandingPad(
         B: &Builder<'a>,
         Ty: &'a Type,
-        PersFn: &'a Value,
+        PersFn: Option<&'a Value>,
         NumClauses: c_uint,
         Name: *const c_char,
     ) -> &'a Value;

--- a/src/test/ui/panic-runtime/incompatible-type.rs
+++ b/src/test/ui/panic-runtime/incompatible-type.rs
@@ -1,0 +1,24 @@
+// Check that rust_eh_personality can have a different type signature than the
+// one hardcoded in the compiler.  Regression test for #70117. Used to fail with:
+//
+// Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
+//
+// build-pass
+// compile-flags: --crate-type=lib -Ccodegen-units=1
+#![no_std]
+#![panic_runtime]
+#![feature(panic_runtime)]
+#![feature(rustc_attrs)]
+
+pub struct DropMe;
+
+impl Drop for DropMe {
+    fn drop(&mut self) {}
+}
+
+pub fn test(_: DropMe) {
+    unreachable!();
+}
+
+#[rustc_std_internal_symbol]
+pub unsafe extern "C" fn rust_eh_personality() {}


### PR DESCRIPTION
If crate declares `rust_eh_personality`, re-use existing declaration
as otherwise attempts to set function attributes that follow the
declaration will fail (unless it happens to have exactly the same
type signature as the one predefined in the compiler).

Fixes #70117.
Fixes https://github.com/rust-lang/rust/pull/81469#issuecomment-809428126; probably.

