### PR TITLE
Improves migrations lint for RFC2229

### DIFF
--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -619,7 +619,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if auto_trait_reasons.len() > 0 && drop_reason {
-            reasons = format!("{}, and ", reasons);
+            reasons = format!("{} and ", reasons);
         }
 
         if drop_reason {
@@ -886,12 +886,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
 
             // Combine all the captures responsible for needing migrations into one HashSet
-            let mut capture_disagnostic = drop_reorder_diagnostic.clone();
+            let mut capture_diagnostic = drop_reorder_diagnostic.clone();
             for key in auto_trait_diagnostic.keys() {
-                capture_disagnostic.insert(key.clone());
+                capture_diagnostic.insert(key.clone());
             }
 
-            for captured_info in capture_disagnostic.iter() {
+            for captured_info in capture_diagnostic.iter() {
                 // Get the auto trait reasons of why migration is needed because of that capture, if there are any
                 let capture_trait_reasons =
                     if let Some(reasons) = auto_trait_diagnostic.get(captured_info) {
@@ -917,7 +917,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ));
             }
 
-            if capture_disagnostic.len() > 0 {
+            if capture_diagnostic.len() > 0 {
                 need_migrations.push((var_hir_id, responsible_captured_hir_ids));
             }
         }

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -535,6 +535,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 captured_names,
                             ));
                         }
+
+                        if reasons.contains("closure trait implementation") {
+                            let closure_body_span = self.tcx.hir().span(body_id.hir_id);
+                            let closure_ending_span = self.tcx.sess.source_map().guess_head_span(closure_body_span).shrink_to_lo();
+
+                            let missing_trait = &reasons[..reasons.find("closure trait implementation").unwrap() - 1];
+
+                            diagnostics_builder.span_label(closure_ending_span, format!("in Rust 2018, this closure would implement {} as `{}` implements {}, but in Rust 2021, this closure will no longer implement {} as {} does not implement {}",
+                                missing_trait,
+                                self.tcx.hir().name(*var_hir_id),
+                                missing_trait,
+                                missing_trait,
+                                captured_names,
+                                missing_trait,
+                            ));
+                        }
                     }
                     diagnostics_builder.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
                     let closure_body_span = self.tcx.hir().span(body_id.hir_id);

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -616,7 +616,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         reasons
     }
 
-    /// Returns true if migration is needed for trait for the provided var_hir_id
+    /// Returns a tuple that contains the hir_id pointing to the use that resulted in the
+    /// corresponding place being captured and a String which contains the captured value's name
+    /// (i.e: a.b.c) if migration is needed for trait for the provided var_hir_id, otherwise returns None
     fn need_2229_migrations_for_trait(
         &self,
         min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
@@ -693,12 +695,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// captured by the closure when `capture_disjoint_fields` is enabled and auto-traits
     /// differ between the root variable and the captured paths.
     ///
-    /// The output list would include a root variable if:
-    /// - It would have been captured into the closure when `capture_disjoint_fields` wasn't
-    ///   enabled, **and**
-    /// - It wasn't completely captured by the closure, **and**
-    /// - One of the paths captured does not implement all the auto-traits its root variable
-    ///   implements.
+    /// Returns a tuple containing a HashSet of traits that not implemented by the captured fields
+    /// of a root variables that has the provided var_hir_id and a HashSet of tuples that contains
+    /// the hir_id pointing to the use that resulted in the corresponding place being captured and
+    /// a String which contains the captured value's name (i.e: a.b.c) if migration is needed for
+    /// trait for the provided var_hir_id, otherwise returns None
     fn compute_2229_migrations_for_trait(
         &self,
         min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
@@ -788,8 +789,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// - It wasn't completely captured by the closure, **and**
     /// - One of the paths starting at this root variable, that is not captured needs Drop.
     ///
-    /// This function only returns true for significant drops. A type is considerent to have a
-    /// significant drop if it's Drop implementation is not annotated by `rustc_insignificant_dtor`.
+    /// This function only returns a HashSet of tuples for significant drops. The returned HashSet
+    /// of tuples contains  the hir_id pointing to the use that resulted in the corresponding place
+    /// being captured anda String which contains the captured value's name (i.e: a.b.c)
     fn compute_2229_migrations_for_drop(
         &self,
         closure_def_id: DefId,
@@ -871,8 +873,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// - One of the paths captured does not implement all the auto-traits its root variable
     ///   implements.
     ///
-    /// Returns a tuple containing a vector of HirIds as well as a String containing the reason
-    /// why root variables whose HirId is contained in the vector should be fully captured.
+    /// Returns a tuple containing a vector of tuples of HirIds and a HashSet of tuples that contains
+    /// the hir_id pointing to the use that resulted in the corresponding place being captured and
+    /// a String which contains the captured value's name (i.e: a.b.c), as well as a String
+    /// containing the reason why root variables whose HirId is contained in the vector should
     fn compute_2229_migrations(
         &self,
         closure_def_id: DefId,

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -505,7 +505,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 |lint| {
                     let mut diagnostics_builder = lint.build(
                         format!(
-                            "{} will change in Rust 2021",
+                            "changes to closure capture in Rust 2021 will affect {}",
                             reasons
                         )
                         .as_str(),
@@ -567,7 +567,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if auto_trait_reasons.len() > 0 {
             reasons = format!(
-                "{} trait implementation",
+                "{} closure trait implementation",
                 auto_trait_reasons.clone().into_iter().collect::<Vec<&str>>().join(", ")
             );
         }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -56,7 +56,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -11,7 +11,7 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Send` trait implementation
+        //~^ ERROR: `Send` closure trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
     } });
@@ -28,7 +28,7 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Sync`, `Send` trait implementation
+        //~^ ERROR: `Sync`, `Send` closure trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
     } });
@@ -49,7 +49,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
-        //~^ ERROR: `Clone` trait implementation, and drop order
+        //~^ ERROR: `Clone` closure trait implementation, and drop order
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
         println!("{:?}", f_1.0);

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -13,6 +13,7 @@ fn test_send_trait() {
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || { let _ = &fptr; unsafe {
         //~^ ERROR: `Send` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
@@ -32,6 +33,7 @@ fn test_sync_trait() {
     let fptr = SyncPointer(f);
     thread::spawn(move || { let _ = &fptr; unsafe {
         //~^ ERROR: `Sync`, `Send` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
@@ -55,6 +57,7 @@ fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
         //~^ ERROR: `Clone` closure trait implementation, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 
 use std::thread;
 
@@ -12,8 +13,10 @@ fn test_send_trait() {
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || { let _ = &fptr; unsafe {
         //~^ ERROR: `Send` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
     } });
 }
 
@@ -29,8 +32,10 @@ fn test_sync_trait() {
     let fptr = SyncPointer(f);
     thread::spawn(move || { let _ = &fptr; unsafe {
         //~^ ERROR: `Sync`, `Send` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
     } });
 }
 
@@ -50,8 +55,10 @@ fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
         //~^ ERROR: `Clone` closure trait implementation, and drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
         println!("{:?}", f_1.0);
     };
 
@@ -59,6 +66,7 @@ fn test_clone_trait() {
 
     c_clone();
 }
+//~^ NOTE: in Rust 2018, `f` would be dropped here, but in Rust 2021, only `f.1` would be dropped here alongside the closure
 
 fn main() {
     test_send_trait();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -12,8 +12,8 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Send` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
+        //~^ ERROR: `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr.0` does not implement `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
@@ -32,8 +32,8 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || { let _ = &fptr; unsafe {
-        //~^ ERROR: `Sync`, `Send` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
+        //~^ ERROR: `Sync`, `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
@@ -56,8 +56,8 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || { let _ = &f; 
-        //~^ ERROR: `Clone` closure trait implementation, and drop order
-        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -12,8 +12,8 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Send` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
+        //~^ ERROR: `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr.0` does not implement `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
@@ -32,8 +32,8 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Sync`, `Send` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
+        //~^ ERROR: `Sync`, `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
@@ -56,8 +56,8 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
-        //~^ ERROR: `Clone` closure trait implementation, and drop order
-        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -13,6 +13,7 @@ fn test_send_trait() {
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || unsafe {
         //~^ ERROR: `Send` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
@@ -32,6 +33,7 @@ fn test_sync_trait() {
     let fptr = SyncPointer(f);
     thread::spawn(move || unsafe {
         //~^ ERROR: `Sync`, `Send` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
@@ -55,6 +57,7 @@ fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
         //~^ ERROR: `Clone` closure trait implementation, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -11,7 +11,7 @@ fn test_send_trait() {
     let mut f = 10;
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Send` trait implementation
+        //~^ ERROR: `Send` closure trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
     });
@@ -28,7 +28,7 @@ fn test_sync_trait() {
     let f = CustomInt(&mut f as *mut i32);
     let fptr = SyncPointer(f);
     thread::spawn(move || unsafe {
-        //~^ ERROR: `Sync`, `Send` trait implementation
+        //~^ ERROR: `Sync`, `Send` closure trait implementation
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
     });
@@ -49,7 +49,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
-        //~^ ERROR: `Clone` trait implementation, and drop order
+        //~^ ERROR: `Clone` closure trait implementation, and drop order
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
         println!("{:?}", f_1.0);

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -56,7 +56,7 @@ impl Clone for U {
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 
 use std::thread;
 
@@ -12,8 +13,10 @@ fn test_send_trait() {
     let fptr = SendPointer(&mut f as *mut i32);
     thread::spawn(move || unsafe {
         //~^ ERROR: `Send` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
     });
 }
 
@@ -29,8 +32,10 @@ fn test_sync_trait() {
     let fptr = SyncPointer(f);
     thread::spawn(move || unsafe {
         //~^ ERROR: `Sync`, `Send` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `fptr` to be fully captured
         *fptr.0.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
     });
 }
 
@@ -50,8 +55,10 @@ fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
     let c = || {
         //~^ ERROR: `Clone` closure trait implementation, and drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         let f_1 = f.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
         println!("{:?}", f_1.0);
     };
 
@@ -59,6 +66,7 @@ fn test_clone_trait() {
 
     c_clone();
 }
+//~^ NOTE: in Rust 2018, `f` would be dropped here, but in Rust 2021, only `f.1` would be dropped here alongside the closure
 
 fn main() {
     test_send_trait();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -43,7 +43,7 @@ LL |
 LL |         *fptr.0.0 = 20;
  ...
 
-error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure and drop order
   --> $DIR/auto_traits.rs:58:13
    |
 LL |     let c = || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -1,4 +1,4 @@
-error: `Send` trait implementation will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect `Send` closure trait implementation
   --> $DIR/auto_traits.rs:13:19
    |
 LL |       thread::spawn(move || unsafe {
@@ -25,7 +25,7 @@ LL |         *fptr.0 = 20;
 LL |     } });
    |
 
-error: `Sync`, `Send` trait implementation will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` closure trait implementation
   --> $DIR/auto_traits.rs:30:19
    |
 LL |       thread::spawn(move || unsafe {
@@ -47,7 +47,7 @@ LL |         *fptr.0.0 = 20;
 LL |     } });
    |
 
-error: `Clone` trait implementation, and drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect `Clone` closure trait implementation, and drop order
   --> $DIR/auto_traits.rs:51:13
    |
 LL |       let c = || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -6,6 +6,7 @@ LL |       thread::spawn(move || unsafe {
 LL | |
 LL | |
 LL | |         *fptr.0 = 20;
+   | |         ------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
 LL | |     });
    | |_____^
    |
@@ -32,6 +33,7 @@ LL |       thread::spawn(move || unsafe {
 LL | |
 LL | |
 LL | |         *fptr.0.0 = 20;
+   | |         --------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
 LL | |     });
    | |_____^
    |
@@ -53,6 +55,7 @@ LL |       let c = || {
 LL | |
 LL | |
 LL | |         let f_1 = f.1;
+   | |                   --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
 LL | |         println!("{:?}", f_1.0);
 LL | |     };
    | |_____^

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -2,7 +2,10 @@ error: changes to closure capture in Rust 2021 will affect `Send` closure trait 
   --> $DIR/auto_traits.rs:14:19
    |
 LL |       thread::spawn(move || unsafe {
-   |  ___________________^
+   |                     ^       - in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
+   |  ___________________|
+   | |
+LL | |
 LL | |
 LL | |
 LL | |
@@ -24,15 +27,18 @@ LL |     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
 LL |
 LL |
-LL |         *fptr.0 = 20;
 LL |
+LL |         *fptr.0 = 20;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` closure trait implementation
-  --> $DIR/auto_traits.rs:33:19
+  --> $DIR/auto_traits.rs:34:19
    |
 LL |       thread::spawn(move || unsafe {
-   |  ___________________^
+   |                     ^       - in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
+   |  ___________________|
+   | |
+LL | |
 LL | |
 LL | |
 LL | |
@@ -49,15 +55,18 @@ LL |     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
 LL |
 LL |
-LL |         *fptr.0.0 = 20;
 LL |
+LL |         *fptr.0.0 = 20;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Clone` closure trait implementation, and drop order
-  --> $DIR/auto_traits.rs:56:13
+  --> $DIR/auto_traits.rs:58:13
    |
 LL |       let c = || {
-   |  _____________^
+   |               ^  - in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
+   |  _____________|
+   | |
+LL | |
 LL | |
 LL | |
 LL | |
@@ -78,8 +87,8 @@ LL |     let c = || { let _ = &f;
 LL |
 LL |
 LL |
-LL |         let f_1 = f.1;
 LL |
+LL |         let f_1 = f.1;
  ...
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -1,12 +1,14 @@
 error: changes to closure capture in Rust 2021 will affect `Send` closure trait implementation
-  --> $DIR/auto_traits.rs:13:19
+  --> $DIR/auto_traits.rs:14:19
    |
 LL |       thread::spawn(move || unsafe {
    |  ___________________^
 LL | |
 LL | |
+LL | |
 LL | |         *fptr.0 = 20;
    | |         ------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
+LL | |
 LL | |     });
    | |_____^
    |
@@ -21,19 +23,22 @@ help: add a dummy let to cause `fptr` to be fully captured
 LL |     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
 LL |
+LL |
 LL |         *fptr.0 = 20;
-LL |     } });
-   |
+LL |
+ ...
 
 error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` closure trait implementation
-  --> $DIR/auto_traits.rs:30:19
+  --> $DIR/auto_traits.rs:33:19
    |
 LL |       thread::spawn(move || unsafe {
    |  ___________________^
 LL | |
 LL | |
+LL | |
 LL | |         *fptr.0.0 = 20;
    | |         --------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
+LL | |
 LL | |     });
    | |_____^
    |
@@ -43,22 +48,28 @@ help: add a dummy let to cause `fptr` to be fully captured
 LL |     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
 LL |
+LL |
 LL |         *fptr.0.0 = 20;
-LL |     } });
-   |
+LL |
+ ...
 
 error: changes to closure capture in Rust 2021 will affect `Clone` closure trait implementation, and drop order
-  --> $DIR/auto_traits.rs:51:13
+  --> $DIR/auto_traits.rs:56:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
+LL | |
 LL | |         let f_1 = f.1;
    | |                   --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
+LL | |
 LL | |         println!("{:?}", f_1.0);
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `f` would be dropped here, but in Rust 2021, only `f.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
@@ -66,10 +77,10 @@ help: add a dummy let to cause `f` to be fully captured
 LL |     let c = || { let _ = &f; 
 LL |
 LL |
+LL |
 LL |         let f_1 = f.1;
-LL |         println!("{:?}", f_1.0);
-LL |     };
-   |
+LL |
+ ...
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -1,19 +1,11 @@
-error: changes to closure capture in Rust 2021 will affect `Send` closure trait implementation
+error: changes to closure capture in Rust 2021 will affect `Send` trait implementation for closure
   --> $DIR/auto_traits.rs:14:19
    |
-LL |       thread::spawn(move || unsafe {
-   |                     ^       - in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure will no longer implement `Send` as `fptr.0` does not implement `Send`
-   |  ___________________|
-   | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         *fptr.0 = 20;
-   | |         ------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
-LL | |
-LL | |     });
-   | |_____^
+LL |     thread::spawn(move || unsafe {
+   |                   ^^^^^^^^^^^^^^ in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr.0` does not implement `Send`
+...
+LL |         *fptr.0 = 20;
+   |         ------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
    |
 note: the lint level is defined here
   --> $DIR/auto_traits.rs:2:9
@@ -31,22 +23,14 @@ LL |
 LL |         *fptr.0 = 20;
  ...
 
-error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` closure trait implementation
+error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` trait implementation for closure
   --> $DIR/auto_traits.rs:34:19
    |
-LL |       thread::spawn(move || unsafe {
-   |                     ^       - in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure will no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
-   |  ___________________|
-   | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         *fptr.0.0 = 20;
-   | |         --------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
-LL | |
-LL | |     });
-   | |_____^
+LL |     thread::spawn(move || unsafe {
+   |                   ^^^^^^^^^^^^^^ in Rust 2018, this closure would implement `Sync`, `Send` as `fptr` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr.0.0` does not implement `Sync`, `Send`
+...
+LL |         *fptr.0.0 = 20;
+   |         --------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0.0`
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
@@ -59,26 +43,17 @@ LL |
 LL |         *fptr.0.0 = 20;
  ...
 
-error: changes to closure capture in Rust 2021 will affect `Clone` closure trait implementation, and drop order
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
   --> $DIR/auto_traits.rs:58:13
    |
-LL |       let c = || {
-   |               ^  - in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure will no longer implement `Clone` as `f.1` does not implement `Clone`
-   |  _____________|
-   | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         let f_1 = f.1;
-   | |                   --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
-LL | |
-LL | |         println!("{:?}", f_1.0);
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^ in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
 ...
-LL |   }
-   |   - in Rust 2018, `f` would be dropped here, but in Rust 2021, only `f.1` would be dropped here alongside the closure
+LL |         let f_1 = f.1;
+   |                   --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.1`
+...
+LL | }
+   | - in Rust 2018, `f` would be dropped here, but in Rust 2021, only `f.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -27,6 +27,9 @@ fn test1_all_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
 
 // String implements drop and therefore should be migrated.
 // But in this test cases, `t2` is completely captured and when it is dropped won't be affected
@@ -48,6 +51,8 @@ fn test2_only_precise_paths_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
 
 // If a variable would've not been captured by value then it would've not been
 // dropped with the closure and therefore doesn't need migration.
@@ -65,6 +70,7 @@ fn test3_only_by_value_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Copy types get copied into the closure instead of move. Therefore we don't need to
 // migrate then as their drop order isn't tied to the closure.
@@ -85,6 +91,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn test5_only_drop_types_need_migration() {
     struct S(i32, i32);
@@ -105,6 +112,7 @@ fn test5_only_drop_types_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Since we are using a move closure here, both `t` and `t1` get moved
 // even though they are being used by ref inside the closure.
@@ -122,6 +130,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
 
 // Test migration analysis in case of Drop + Non Drop aggregates.
 // Note we need migration here only because the non-copy (because Drop type) is captured,
@@ -139,6 +149,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn main() {
     test1_all_need_migration();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -18,8 +18,11 @@ fn test1_all_need_migration() {
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
     };
 
     c();
@@ -37,7 +40,9 @@ fn test2_only_precise_paths_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2;
     };
 
@@ -54,6 +59,7 @@ fn test3_only_by_value_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         println!("{}", t1.1);
     };
 
@@ -73,6 +79,7 @@ fn test4_only_non_copy_types_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
     };
 
@@ -92,6 +99,7 @@ fn test5_only_drop_types_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _s = s.0;
     };
 
@@ -108,6 +116,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+        //~| NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
     };
 
     c();
@@ -124,6 +134,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -27,6 +27,9 @@ fn test1_all_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
 
 // String implements drop and therefore should be migrated.
 // But in this test cases, `t2` is completely captured and when it is dropped won't be affected
@@ -48,6 +51,8 @@ fn test2_only_precise_paths_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
 
 // If a variable would've not been captured by value then it would've not been
 // dropped with the closure and therefore doesn't need migration.
@@ -65,6 +70,7 @@ fn test3_only_by_value_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Copy types get copied into the closure instead of move. Therefore we don't need to
 // migrate then as their drop order isn't tied to the closure.
@@ -85,6 +91,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn test5_only_drop_types_need_migration() {
     struct S(i32, i32);
@@ -105,6 +112,7 @@ fn test5_only_drop_types_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Since we are using a move closure here, both `t` and `t1` get moved
 // even though they are being used by ref inside the closure.
@@ -122,6 +130,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+//~| in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
 
 // Test migration analysis in case of Drop + Non Drop aggregates.
 // Note we need migration here only because the non-copy (because Drop type) is captured,
@@ -139,6 +149,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn main() {
     test1_all_need_migration();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -18,8 +18,11 @@ fn test1_all_need_migration() {
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
     };
 
     c();
@@ -37,7 +40,9 @@ fn test2_only_precise_paths_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2;
     };
 
@@ -54,6 +59,7 @@ fn test3_only_by_value_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         println!("{}", t1.1);
     };
 
@@ -73,6 +79,7 @@ fn test4_only_non_copy_types_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
     };
 
@@ -92,6 +99,7 @@ fn test5_only_drop_types_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _s = s.0;
     };
 
@@ -108,6 +116,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+        //~| NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
     };
 
     c();
@@ -124,6 +134,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -18,6 +18,13 @@ LL | |         let _t2 = t2.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/insignificant_drop.rs:3:9
@@ -36,7 +43,7 @@ LL |         let _t = t.0;
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:38:13
+  --> $DIR/insignificant_drop.rs:41:13
    |
 LL |       let c = || {
    |  _____________^
@@ -52,6 +59,12 @@ LL | |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
@@ -65,7 +78,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:57:13
+  --> $DIR/insignificant_drop.rs:62:13
    |
 LL |       let c = || {
    |  _____________^
@@ -78,6 +91,9 @@ LL | |
 LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -91,7 +107,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:77:13
+  --> $DIR/insignificant_drop.rs:83:13
    |
 LL |       let c = || {
    |  _____________^
@@ -104,6 +120,9 @@ LL | |
 LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -117,7 +136,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:97:13
+  --> $DIR/insignificant_drop.rs:104:13
    |
 LL |       let c = || {
    |  _____________^
@@ -130,6 +149,9 @@ LL | |
 LL | |         let _s = s.0;
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -143,7 +165,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:114:13
+  --> $DIR/insignificant_drop.rs:122:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -158,6 +180,12 @@ LL | |
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
@@ -171,7 +199,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop.rs:132:13
+  --> $DIR/insignificant_drop.rs:142:13
    |
 LL |       let c = || {
    |  _____________^
@@ -183,6 +211,9 @@ LL | |         let _t = t.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,4 +1,4 @@
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:15:13
    |
 LL |       let c = || {
@@ -35,7 +35,7 @@ LL |
 LL |         let _t = t.0;
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:38:13
    |
 LL |       let c = || {
@@ -64,7 +64,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:57:13
    |
 LL |       let c = || {
@@ -90,7 +90,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:77:13
    |
 LL |       let c = || {
@@ -116,7 +116,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:97:13
    |
 LL |       let c = || {
@@ -142,7 +142,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:114:13
    |
 LL |       let c = move || {
@@ -170,7 +170,7 @@ LL |         println!("{} {}", t1.1, t.1);
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:132:13
    |
 LL |       let c = || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,30 +1,24 @@
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:15:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _t1 = t1.0;
-   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
-LL | |
-LL | |         let _t2 = t2.0;
-   | |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL |
+LL |         let _t1 = t1.0;
+   |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL |
+LL |         let _t2 = t2.0;
+   |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+   | in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/insignificant_drop.rs:3:9
@@ -45,26 +39,20 @@ LL |         let _t = t.0;
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:41:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _t1 = t1.0;
-   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
-LL | |
-LL | |         let _t2 = t2;
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL |
+LL |         let _t1 = t1.0;
+   |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
@@ -80,20 +68,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:62:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         println!("{}", t1.1);
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -109,20 +91,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:83:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _t1 = t1.0;
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -138,20 +114,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:104:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _s = s.0;
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -167,25 +137,19 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:122:13
    |
-LL |       let c = move || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         println!("{} {}", t1.1, t.1);
-   | |                           ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
-   | |                           |
-   | |                           in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
-LL | |
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = move || {
+   |             ^^^^^^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+LL |         println!("{} {}", t1.1, t.1);
+   |                           ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+   |                           |
+   |                           in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
@@ -201,19 +165,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:142:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -6,8 +6,16 @@ LL |       let c = || {
 LL | |
 LL | |
 LL | |
-...  |
+LL | |
+LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
+LL | |         let _t1 = t1.0;
+   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL | |
 LL | |         let _t2 = t2.0;
+   | |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -28,14 +36,19 @@ LL |         let _t = t.0;
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:35:13
+  --> $DIR/insignificant_drop.rs:38:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
 LL | |
-...  |
+LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
+LL | |         let _t1 = t1.0;
+   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL | |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
@@ -48,11 +61,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _t1 = t1.0;
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:52:13
+  --> $DIR/insignificant_drop.rs:57:13
    |
 LL |       let c = || {
    |  _____________^
@@ -60,6 +73,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
@@ -72,11 +87,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         println!("{}", t1.1);
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:71:13
+  --> $DIR/insignificant_drop.rs:77:13
    |
 LL |       let c = || {
    |  _____________^
@@ -84,6 +99,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
@@ -96,11 +113,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _t1 = t1.0;
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:90:13
+  --> $DIR/insignificant_drop.rs:97:13
    |
 LL |       let c = || {
    |  _____________^
@@ -108,6 +125,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |         let _s = s.0;
 LL | |     };
    | |_____^
@@ -120,11 +139,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _s = s.0;
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:106:13
+  --> $DIR/insignificant_drop.rs:114:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -132,6 +151,11 @@ LL | |
 LL | |
 LL | |
 LL | |         println!("{} {}", t1.1, t.1);
+   | |                           ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+   | |                           |
+   | |                           in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+LL | |
+LL | |
 LL | |     };
    | |_____^
    |
@@ -143,11 +167,11 @@ LL |
 LL |
 LL |
 LL |         println!("{} {}", t1.1, t.1);
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop.rs:122:13
+  --> $DIR/insignificant_drop.rs:132:13
    |
 LL |       let c = || {
    |  _____________^
@@ -155,6 +179,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -166,8 +192,8 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     };
-   |
+LL |
+ ...
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -39,6 +39,7 @@ fn significant_drop_needs_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -57,6 +58,7 @@ fn generic_struct_with_significant_drop_needs_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -44,6 +44,7 @@ fn significant_drop_needs_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Even if a type implements an insignificant drop, if it's
 // elements have a significant drop then the overall type is
@@ -63,6 +64,7 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
 
 fn main() {
     significant_drop_needs_migration();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
@@ -39,6 +39,7 @@ fn significant_drop_needs_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -57,6 +58,7 @@ fn generic_struct_with_significant_drop_needs_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
@@ -44,6 +44,7 @@ fn significant_drop_needs_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Even if a type implements an insignificant drop, if it's
 // elements have a significant drop then the overall type is
@@ -63,6 +64,7 @@ fn generic_struct_with_significant_drop_needs_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
 
 fn main() {
     significant_drop_needs_migration();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -7,6 +7,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -23,11 +25,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/insignificant_drop_attr_migrations.rs:55:13
+  --> $DIR/insignificant_drop_attr_migrations.rs:56:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -35,6 +37,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.1;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -46,8 +50,8 @@ LL |
 LL |
 LL |
 LL |         let _t = t.1;
-LL |     };
-   |
+LL |
+ ...
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -1,4 +1,4 @@
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop_attr_migrations.rs:37:13
    |
 LL |       let c = || {
@@ -28,7 +28,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop_attr_migrations.rs:56:13
    |
 LL |       let c = move || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -1,19 +1,14 @@
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop_attr_migrations.rs:37:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/insignificant_drop_attr_migrations.rs:3:9
@@ -34,19 +29,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop_attr_migrations.rs:57:13
    |
-LL |       let c = move || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.1;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = move || {
+   |             ^^^^^^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+LL |         let _t = t.1;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -11,6 +11,9 @@ LL | |         let _t = t.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/insignificant_drop_attr_migrations.rs:3:9
@@ -29,7 +32,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/insignificant_drop_attr_migrations.rs:56:13
+  --> $DIR/insignificant_drop_attr_migrations.rs:57:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -41,6 +44,9 @@ LL | |         let _t = t.1;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -22,11 +22,11 @@ fn closure_contains_block() {
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
@@ -38,6 +38,7 @@ fn closure_doesnt_contain_block() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn main() {
     closure_contains_block();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -21,6 +21,8 @@ fn closure_contains_block() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+
     };
 
     c();
@@ -30,6 +32,7 @@ fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || { let _ = &t; t.0 };
     //~^ ERROR: drop order
+    //~| NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -22,11 +22,11 @@ fn closure_contains_block() {
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
@@ -38,6 +38,7 @@ fn closure_doesnt_contain_block() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 fn main() {
     closure_contains_block();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -21,6 +21,8 @@ fn closure_contains_block() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+
     };
 
     c();
@@ -30,6 +32,7 @@ fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || t.0;
     //~^ ERROR: drop order
+    //~| NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     //~| NOTE: for more information, see
     //~| HELP: add a dummy let to cause `t` to be fully captured
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -1,4 +1,4 @@
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/migrations_rustfix.rs:19:13
    |
 LL |       let c = || {
@@ -29,7 +29,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/migrations_rustfix.rs:33:13
    |
 LL |     let c = || t.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -1,19 +1,14 @@
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/migrations_rustfix.rs:19:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/migrations_rustfix.rs:2:9

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -9,9 +9,11 @@ LL | |
 LL | |         let _t = t.0;
    | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
 LL | |
-LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/migrations_rustfix.rs:2:9
@@ -36,6 +38,9 @@ LL |     let c = || t.0;
    |             ^^^---
    |                |
    |                in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -7,6 +7,9 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
+LL | |
 LL | |     };
    | |_____^
    |
@@ -23,14 +26,16 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/migrations_rustfix.rs:31:13
+  --> $DIR/migrations_rustfix.rs:33:13
    |
 LL |     let c = || t.0;
-   |             ^^^^^^
+   |             ^^^---
+   |                |
+   |                in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -18,8 +18,8 @@ where
 {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure would no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -19,6 +19,7 @@ where
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -17,7 +17,7 @@ where
 {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
     });

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 // ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
@@ -18,8 +19,10 @@ where
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || { let _ = &f; 
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
+        //~^ NOTE: in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
     });
     if let Ok(..) = result {
         panic!("diverging function returned");

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -19,6 +19,7 @@ where
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
+        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -17,7 +17,7 @@ where
 {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
     });

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 // ignore-wasm32-bare compiled with panic=abort by default
 #![feature(fn_traits)]
 #![feature(never_type)]
@@ -18,8 +19,10 @@ where
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()
+        //~^ NOTE: in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
     });
     if let Ok(..) = result {
         panic!("diverging function returned");

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -18,8 +18,8 @@ where
 {
     let f = panic::AssertUnwindSafe(f);
     let result = panic::catch_unwind(move || {
-        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` closure trait implementation
-        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
+        //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure would no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f` to be fully captured
         f.0()

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,19 +1,11 @@
-error: changes to closure capture in Rust 2021 will affect `UnwindSafe`, `RefUnwindSafe` closure trait implementation
+error: changes to closure capture in Rust 2021 will affect `UnwindSafe`, `RefUnwindSafe` trait implementation for closure
   --> $DIR/mir_calls_to_shims.rs:20:38
    |
-LL |       let result = panic::catch_unwind(move || {
-   |                                        ^       - in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
-   |  ______________________________________|
-   | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         f.0()
-   | |         --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
-LL | |
-LL | |     });
-   | |_____^
+LL |     let result = panic::catch_unwind(move || {
+   |                                      ^^^^^^^ in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure would no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
+...
+LL |         f.0()
+   |         --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
    |
 note: the lint level is defined here
   --> $DIR/mir_calls_to_shims.rs:3:9

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,12 +1,14 @@
 error: changes to closure capture in Rust 2021 will affect `UnwindSafe`, `RefUnwindSafe` closure trait implementation
-  --> $DIR/mir_calls_to_shims.rs:19:38
+  --> $DIR/mir_calls_to_shims.rs:20:38
    |
 LL |       let result = panic::catch_unwind(move || {
    |  ______________________________________^
 LL | |
 LL | |
+LL | |
 LL | |         f.0()
    | |         --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
+LL | |
 LL | |     });
    | |_____^
    |
@@ -21,9 +23,10 @@ help: add a dummy let to cause `f` to be fully captured
 LL |     let result = panic::catch_unwind(move || { let _ = &f; 
 LL |
 LL |
+LL |
 LL |         f.0()
-LL |     });
-   |
+LL |
+ ...
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,4 +1,4 @@
-error: `UnwindSafe`, `RefUnwindSafe` trait implementation will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect `UnwindSafe`, `RefUnwindSafe` closure trait implementation
   --> $DIR/mir_calls_to_shims.rs:19:38
    |
 LL |       let result = panic::catch_unwind(move || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -6,6 +6,7 @@ LL |       let result = panic::catch_unwind(move || {
 LL | |
 LL | |
 LL | |         f.0()
+   | |         --- in Rust 2018, closure captures all of `f`, but in Rust 2021, it only captures `f.0`
 LL | |     });
    | |_____^
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -2,7 +2,10 @@ error: changes to closure capture in Rust 2021 will affect `UnwindSafe`, `RefUnw
   --> $DIR/mir_calls_to_shims.rs:20:38
    |
 LL |       let result = panic::catch_unwind(move || {
-   |  ______________________________________^
+   |                                        ^       - in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure will no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
+   |  ______________________________________|
+   | |
+LL | |
 LL | |
 LL | |
 LL | |
@@ -24,8 +27,8 @@ LL |     let result = panic::catch_unwind(move || { let _ = &f;
 LL |
 LL |
 LL |
-LL |         f.0()
 LL |
+LL |         f.0()
  ...
 
 error: aborting due to previous error

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
@@ -21,7 +21,7 @@ fn test_multi_issues() {
     let f1 = U(S(String::from("foo")), T(0));
     let f2 = U(S(String::from("bar")), T(0));
     let c = || { let _ = (&f1, &f2); 
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f1`, `f2` to be fully captured
@@ -84,7 +84,7 @@ fn test_capturing_several_disjoint_fields_individually_1() {
 fn test_capturing_several_disjoint_fields_individually_2() {
     let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
     let c = || { let _ = &f1; 
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f1` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
@@ -1,0 +1,138 @@
+// run-rustfix
+#![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
+
+use std::thread;
+
+struct S(String);
+
+#[derive(Clone)]
+struct T(i32);
+
+struct U(S, T);
+
+impl Clone for U {
+    fn clone(&self) -> Self {
+        U(S(String::from("Hello World")), T(0))
+    }
+}
+
+fn test_multi_issues() {
+    let f1 = U(S(String::from("foo")), T(0));
+    let f2 = U(S(String::from("bar")), T(0));
+    let c = || { let _ = (&f1, &f2); 
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1`, `f2` to be fully captured
+        let _f_1 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f2.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f2`, but in Rust 2021, it only captures `f2.1`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+//~^ NOTE: in Rust 2018, `f2` would be dropped here, but in Rust 2021, only `f2.1` would be dropped here alongside the closure
+
+fn test_capturing_all_disjoint_fields_individually() {
+    let f1 = U(S(String::from("foo")), T(0));
+    let c = || { let _ = &f1; 
+        //~^ ERROR: `Clone` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_1 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f1.1;
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+
+struct U1(S, T, S);
+
+impl Clone for U1 {
+    fn clone(&self) -> Self {
+        U1(S(String::from("foo")), T(0), S(String::from("bar")))
+    }
+}
+
+fn test_capturing_several_disjoint_fields_individually_1() {
+    let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
+    let c = || { let _ = &f1; 
+        //~^ ERROR: `Clone` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.2` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_0 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f1.2;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.2`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+
+fn test_capturing_several_disjoint_fields_individually_2() {
+    let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
+    let c = || { let _ = &f1; 
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_0 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_1 = f1.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.1`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+//~^ NOTE: in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
+
+struct SendPointer(*mut i32);
+unsafe impl Send for SendPointer {}
+
+struct CustomInt(*mut i32);
+struct SyncPointer(CustomInt);
+unsafe impl Sync for SyncPointer {}
+unsafe impl Send for CustomInt {}
+
+fn test_multi_traits_issues() {
+    let mut f1 = 10;
+    let f1 = CustomInt(&mut f1 as *mut i32);
+    let fptr1 = SyncPointer(f1);
+
+    let mut f2 = 10;
+    let fptr2 = SendPointer(&mut f2 as *mut i32);
+    thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
+        //~^ ERROR: `Sync`, `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr1` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr1.0.0` does not implement `Sync`, `Send`
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr2` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr2.0` does not implement `Send`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
+        *fptr1.0.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr1`, but in Rust 2021, it only captures `fptr1.0.0`
+        *fptr2.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr2`, but in Rust 2021, it only captures `fptr2.0`
+    } });
+}
+
+fn main() {
+    test_multi_issues();
+    test_capturing_all_disjoint_fields_individually();
+    test_capturing_several_disjoint_fields_individually_1();
+    test_capturing_several_disjoint_fields_individually_2();
+    test_multi_traits_issues();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
@@ -1,0 +1,138 @@
+// run-rustfix
+#![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
+
+use std::thread;
+
+struct S(String);
+
+#[derive(Clone)]
+struct T(i32);
+
+struct U(S, T);
+
+impl Clone for U {
+    fn clone(&self) -> Self {
+        U(S(String::from("Hello World")), T(0))
+    }
+}
+
+fn test_multi_issues() {
+    let f1 = U(S(String::from("foo")), T(0));
+    let f2 = U(S(String::from("bar")), T(0));
+    let c = || {
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1`, `f2` to be fully captured
+        let _f_1 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f2.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f2`, but in Rust 2021, it only captures `f2.1`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+//~^ NOTE: in Rust 2018, `f2` would be dropped here, but in Rust 2021, only `f2.1` would be dropped here alongside the closure
+
+fn test_capturing_all_disjoint_fields_individually() {
+    let f1 = U(S(String::from("foo")), T(0));
+    let c = || {
+        //~^ ERROR: `Clone` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_1 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f1.1;
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+
+struct U1(S, T, S);
+
+impl Clone for U1 {
+    fn clone(&self) -> Self {
+        U1(S(String::from("foo")), T(0), S(String::from("bar")))
+    }
+}
+
+fn test_capturing_several_disjoint_fields_individually_1() {
+    let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
+    let c = || {
+        //~^ ERROR: `Clone` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.2` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_0 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_2 = f1.2;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.2`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+
+fn test_capturing_several_disjoint_fields_individually_2() {
+    let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
+    let c = || {
+        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `f1` to be fully captured
+        let _f_0 = f1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+        let _f_1 = f1.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.1`
+    };
+
+    let c_clone = c.clone();
+
+    c_clone();
+}
+//~^ NOTE: in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
+
+struct SendPointer(*mut i32);
+unsafe impl Send for SendPointer {}
+
+struct CustomInt(*mut i32);
+struct SyncPointer(CustomInt);
+unsafe impl Sync for SyncPointer {}
+unsafe impl Send for CustomInt {}
+
+fn test_multi_traits_issues() {
+    let mut f1 = 10;
+    let f1 = CustomInt(&mut f1 as *mut i32);
+    let fptr1 = SyncPointer(f1);
+
+    let mut f2 = 10;
+    let fptr2 = SendPointer(&mut f2 as *mut i32);
+    thread::spawn(move || unsafe {
+        //~^ ERROR: `Sync`, `Send` trait implementation for closure
+        //~| NOTE: in Rust 2018, this closure would implement `Sync`, `Send` as `fptr1` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr1.0.0` does not implement `Sync`, `Send`
+        //~| NOTE: in Rust 2018, this closure would implement `Send` as `fptr2` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr2.0` does not implement `Send`
+        //~| NOTE: for more information, see
+        //~| HELP: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
+        *fptr1.0.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr1`, but in Rust 2021, it only captures `fptr1.0.0`
+        *fptr2.0 = 20;
+        //~^ NOTE: in Rust 2018, closure captures all of `fptr2`, but in Rust 2021, it only captures `fptr2.0`
+    });
+}
+
+fn main() {
+    test_multi_issues();
+    test_capturing_all_disjoint_fields_individually();
+    test_capturing_several_disjoint_fields_individually_1();
+    test_capturing_several_disjoint_fields_individually_2();
+    test_multi_traits_issues();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
@@ -21,7 +21,7 @@ fn test_multi_issues() {
     let f1 = U(S(String::from("foo")), T(0));
     let f2 = U(S(String::from("bar")), T(0));
     let c = || {
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f1`, `f2` to be fully captured
@@ -84,7 +84,7 @@ fn test_capturing_several_disjoint_fields_individually_1() {
 fn test_capturing_several_disjoint_fields_individually_2() {
     let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
     let c = || {
-        //~^ ERROR: `Clone` trait implementation for closure, and drop order
+        //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `f1` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -1,4 +1,4 @@
-error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure and drop order
   --> $DIR/multi_diagnostics.rs:23:13
    |
 LL |     let c = || {
@@ -75,7 +75,7 @@ LL |
 LL |
  ...
 
-error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure and drop order
   --> $DIR/multi_diagnostics.rs:86:13
    |
 LL |     let c = || {
@@ -90,8 +90,8 @@ LL |         let _f_1 = f1.1;
 LL | }
    | -
    | |
-   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
    | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
+   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -90,8 +90,8 @@ LL |         let _f_1 = f1.1;
 LL | }
    | -
    | |
-   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
    | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
+   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -1,0 +1,134 @@
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
+  --> $DIR/multi_diagnostics.rs:23:13
+   |
+LL |     let c = || {
+   |             ^^ in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+...
+LL |         let _f_1 = f1.0;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+LL |
+LL |         let _f_2 = f2.1;
+   |                    ---- in Rust 2018, closure captures all of `f2`, but in Rust 2021, it only captures `f2.1`
+...
+LL | }
+   | - in Rust 2018, `f2` would be dropped here, but in Rust 2021, only `f2.1` would be dropped here alongside the closure
+   |
+note: the lint level is defined here
+  --> $DIR/multi_diagnostics.rs:2:9
+   |
+LL | #![deny(rust_2021_incompatible_closure_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `f1`, `f2` to be fully captured
+   |
+LL |     let c = || { let _ = (&f1, &f2); 
+LL |
+LL |
+LL |
+LL |
+LL |         let _f_1 = f1.0;
+ ...
+
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
+  --> $DIR/multi_diagnostics.rs:42:13
+   |
+LL |     let c = || {
+   |             ^^ in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+...
+LL |         let _f_1 = f1.0;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `f1` to be fully captured
+   |
+LL |     let c = || { let _ = &f1; 
+LL |
+LL |
+LL |
+LL |
+LL |         let _f_1 = f1.0;
+ ...
+
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
+  --> $DIR/multi_diagnostics.rs:67:13
+   |
+LL |     let c = || {
+   |             ^^
+   |             |
+   |             in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+   |             in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.2` does not implement `Clone`
+...
+LL |         let _f_0 = f1.0;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+LL |
+LL |         let _f_2 = f1.2;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.2`
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `f1` to be fully captured
+   |
+LL |     let c = || { let _ = &f1; 
+LL |
+LL |
+LL |
+LL |
+LL |
+ ...
+
+error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure, and drop order
+  --> $DIR/multi_diagnostics.rs:86:13
+   |
+LL |     let c = || {
+   |             ^^ in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
+...
+LL |         let _f_0 = f1.0;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.0`
+LL |
+LL |         let _f_1 = f1.1;
+   |                    ---- in Rust 2018, closure captures all of `f1`, but in Rust 2021, it only captures `f1.1`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.0` would be dropped here alongside the closure
+   | in Rust 2018, `f1` would be dropped here, but in Rust 2021, only `f1.1` would be dropped here alongside the closure
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `f1` to be fully captured
+   |
+LL |     let c = || { let _ = &f1; 
+LL |
+LL |
+LL |
+LL |
+LL |         let _f_0 = f1.0;
+ ...
+
+error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` trait implementation for closure
+  --> $DIR/multi_diagnostics.rs:119:19
+   |
+LL |     thread::spawn(move || unsafe {
+   |                   ^^^^^^^^^^^^^^
+   |                   |
+   |                   in Rust 2018, this closure would implement `Sync`, `Send` as `fptr1` implements `Sync`, `Send`, but in Rust 2021, this closure would no longer implement `Sync`, `Send` as `fptr1.0.0` does not implement `Sync`, `Send`
+   |                   in Rust 2018, this closure would implement `Send` as `fptr2` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr2.0` does not implement `Send`
+...
+LL |         *fptr1.0.0 = 20;
+   |         ---------- in Rust 2018, closure captures all of `fptr1`, but in Rust 2021, it only captures `fptr1.0.0`
+LL |
+LL |         *fptr2.0 = 20;
+   |         -------- in Rust 2018, closure captures all of `fptr2`, but in Rust 2021, it only captures `fptr2.0`
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
+   |
+LL |     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
+LL |
+LL |
+LL |
+LL |
+LL |
+ ...
+
+error: aborting due to 5 previous errors
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 
 #[derive(Debug)]
 struct Foo(i32);
@@ -18,13 +19,16 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
     let c = || { let _ = &t; 
         //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t = &t.1;
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 struct S;
 impl Drop for S {
@@ -40,14 +44,22 @@ fn test_precise_analysis_long_path_missing() {
 
     let c = || { let _ = &u; 
         //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
         let _x = u.0.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
         let _x = u.1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.1.0` would be dropped here alongside the closure
+
 
 fn main() {
     test_precise_analysis_drop_paths_not_captured_by_move();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(rust_2021_incompatible_closure_captures)]
+//~^ NOTE: the lint level is defined here
 
 #[derive(Debug)]
 struct Foo(i32);
@@ -18,13 +19,16 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
     let c = || {
         //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t = &t.1;
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 struct S;
 impl Drop for S {
@@ -40,14 +44,22 @@ fn test_precise_analysis_long_path_missing() {
 
     let c = || {
         //~^ ERROR: drop order
+        //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
         let _x = u.0.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
         let _x = u.1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
     };
 
     c();
 }
+//~^ NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.1.0` would be dropped here alongside the closure
+
 
 fn main() {
     test_precise_analysis_drop_paths_not_captured_by_move();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -44,8 +44,8 @@ LL |         let _x = u.1.0;
 LL | }
    | -
    | |
-   | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1` would be dropped here alongside the closure
    | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.0` would be dropped here alongside the closure
+   | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1` would be dropped here alongside the closure
    | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -6,6 +6,7 @@ LL |       let c = || {
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
 LL | |         let _t = &t.1;
 LL | |     };
    | |_____^
@@ -34,8 +35,11 @@ LL |       let c = || {
 LL | |
 LL | |
 LL | |         let _x = u.0.0;
+   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
 LL | |         let _x = u.0.1;
+   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
 LL | |         let _x = u.1.0;
+   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
 LL | |     };
    | |_____^
    |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -10,6 +10,9 @@ LL | |         let _t = t.0;
 LL | |         let _t = &t.1;
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/precise.rs:3:9
@@ -42,6 +45,9 @@ LL | |         let _x = u.1.0;
    | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1`, `u.0.0`, `u.1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/precise.rs:19:13
+  --> $DIR/precise.rs:20:13
    |
 LL |     let c = || {
    |             ^^
@@ -21,26 +21,32 @@ help: add a dummy let to cause `t` to be fully captured
 LL |     let c = || { let _ = &t; 
 LL |
 LL |
+LL |
 LL |         let _t = t.0;
-LL |         let _t = &t.1;
-LL |     };
-   |
+LL |
+ ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/precise.rs:41:13
+  --> $DIR/precise.rs:45:13
    |
 LL |     let c = || {
    |             ^^
 ...
 LL |         let _x = u.0.0;
    |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
+LL |
 LL |         let _x = u.0.1;
    |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
+LL |
 LL |         let _x = u.1.0;
    |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
 ...
 LL | }
-   | - in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1`, `u.0.0`, `u.1.0` would be dropped here alongside the closure
+   | -
+   | |
+   | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1` would be dropped here alongside the closure
+   | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.0` would be dropped here alongside the closure
+   | in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured
@@ -48,9 +54,9 @@ help: add a dummy let to cause `u` to be fully captured
 LL |     let c = || { let _ = &u; 
 LL |
 LL |
+LL |
 LL |         let _x = u.0.0;
-LL |         let _x = u.0.1;
-LL |         let _x = u.1.0;
+LL |
  ...
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -1,4 +1,4 @@
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/precise.rs:19:13
    |
 LL |       let c = || {
@@ -27,7 +27,7 @@ LL |         let _t = &t.1;
 LL |     };
    |
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/precise.rs:41:13
    |
 LL |       let c = || {

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -1,18 +1,14 @@
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/precise.rs:19:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |         let _t = &t.1;
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/precise.rs:3:9
@@ -33,21 +29,18 @@ LL |     };
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/precise.rs:41:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |         let _x = u.0.0;
-   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
-LL | |         let _x = u.0.1;
-   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
-LL | |         let _x = u.1.0;
-   | |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1`, `u.0.0`, `u.1.0` would be dropped here alongside the closure
+LL |         let _x = u.0.0;
+   |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.0`
+LL |         let _x = u.0.1;
+   |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.0.1`
+LL |         let _x = u.1.0;
+   |                  ----- in Rust 2018, closure captures all of `u`, but in Rust 2021, it only captures `u.1.0`
+...
+LL | }
+   | - in Rust 2018, `u` would be dropped here, but in Rust 2021, only `u.0.1`, `u.0.0`, `u.1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -36,6 +36,9 @@ fn test1_all_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
 
 // String implements drop and therefore should be migrated.
 // But in this test cases, `t2` is completely captured and when it is dropped won't be affected
@@ -57,6 +60,8 @@ fn test2_only_precise_paths_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
 
 // If a variable would've not been captured by value then it would've not been
 // dropped with the closure and therefore doesn't need migration.
@@ -74,6 +79,7 @@ fn test3_only_by_value_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // The root variable might not implement drop themselves but some path starting
 // at the root variable might implement Drop.
@@ -92,6 +98,7 @@ fn test4_type_contains_drop_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Test migration analysis in case of Drop + Non Drop aggregates.
 // Note we need migration here only because the non-copy (because Drop type) is captured,
@@ -109,6 +116,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Test migration analysis in case of Significant and Insignificant Drop aggregates.
 fn test6_significant_insignificant_drop_aggregate_need_migration() {
@@ -124,6 +132,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
 
 // Since we are using a move closure here, both `t` and `t1` get moved
 // even though they are being used by ref inside the closure.
@@ -142,6 +151,47 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+
+
+fn test8_drop_order_and_blocks() {
+    {
+        let tuple =
+          (String::from("foo"), String::from("bar"));
+        {
+            let c = || { let _ = &tuple; 
+                //~^ ERROR: drop order
+                //~| NOTE: for more information, see
+                //~| HELP: add a dummy let to cause `tuple` to be fully captured
+                tuple.0;
+                //~^ NOTE: in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+            };
+
+            c();
+        }
+        //~^ NOTE: in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+    }
+}
+
+fn test9_drop_order_and_nested_closures() {
+    let tuple =
+        (String::from("foo"), String::from("bar"));
+    let b = || {
+        let c = || { let _ = &tuple; 
+            //~^ ERROR: drop order
+            //~| NOTE: for more information, see
+            //~| HELP: add a dummy let to cause `tuple` to be fully captured
+            tuple.0;
+            //~^ NOTE: in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+        };
+
+        c();
+    };
+    //~^ NOTE: in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+
+    b();
+}
 
 fn main() {
     test1_all_need_migration();
@@ -151,4 +201,6 @@ fn main() {
     test5_drop_non_drop_aggregate_need_migration();
     test6_significant_insignificant_drop_aggregate_need_migration();
     test7_move_closures_non_copy_types_might_need_migration();
+    test8_drop_order_and_blocks();
+    test9_drop_order_and_nested_closures();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -27,8 +27,11 @@ fn test1_all_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
     };
 
     c();
@@ -46,7 +49,9 @@ fn test2_only_precise_paths_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2;
     };
 
@@ -63,6 +68,7 @@ fn test3_only_by_value_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         println!("{:?}", t1.1);
     };
 
@@ -81,6 +87,7 @@ fn test4_type_contains_drop_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -97,6 +104,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -111,6 +119,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();
@@ -127,6 +136,8 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+        //~| NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -36,6 +36,9 @@ fn test1_all_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
 
 // String implements drop and therefore should be migrated.
 // But in this test cases, `t2` is completely captured and when it is dropped won't be affected
@@ -57,6 +60,8 @@ fn test2_only_precise_paths_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
 
 // If a variable would've not been captured by value then it would've not been
 // dropped with the closure and therefore doesn't need migration.
@@ -74,6 +79,7 @@ fn test3_only_by_value_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // The root variable might not implement drop themselves but some path starting
 // at the root variable might implement Drop.
@@ -92,6 +98,7 @@ fn test4_type_contains_drop_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Test migration analysis in case of Drop + Non Drop aggregates.
 // Note we need migration here only because the non-copy (because Drop type) is captured,
@@ -109,6 +116,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
 
 // Test migration analysis in case of Significant and Insignificant Drop aggregates.
 fn test6_significant_insignificant_drop_aggregate_need_migration() {
@@ -124,6 +132,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
 
 // Since we are using a move closure here, both `t` and `t1` get moved
 // even though they are being used by ref inside the closure.
@@ -142,6 +151,47 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     c();
 }
+//~^ NOTE: in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+//~| NOTE: in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+
+
+fn test8_drop_order_and_blocks() {
+    {
+        let tuple =
+          (String::from("foo"), String::from("bar"));
+        {
+            let c = || {
+                //~^ ERROR: drop order
+                //~| NOTE: for more information, see
+                //~| HELP: add a dummy let to cause `tuple` to be fully captured
+                tuple.0;
+                //~^ NOTE: in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+            };
+
+            c();
+        }
+        //~^ NOTE: in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+    }
+}
+
+fn test9_drop_order_and_nested_closures() {
+    let tuple =
+        (String::from("foo"), String::from("bar"));
+    let b = || {
+        let c = || {
+            //~^ ERROR: drop order
+            //~| NOTE: for more information, see
+            //~| HELP: add a dummy let to cause `tuple` to be fully captured
+            tuple.0;
+            //~^ NOTE: in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+        };
+
+        c();
+    };
+    //~^ NOTE: in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+
+    b();
+}
 
 fn main() {
     test1_all_need_migration();
@@ -151,4 +201,6 @@ fn main() {
     test5_drop_non_drop_aggregate_need_migration();
     test6_significant_insignificant_drop_aggregate_need_migration();
     test7_move_closures_non_copy_types_might_need_migration();
+    test8_drop_order_and_blocks();
+    test9_drop_order_and_nested_closures();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -27,8 +27,11 @@ fn test1_all_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
     };
 
     c();
@@ -46,7 +49,9 @@ fn test2_only_precise_paths_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         let _t1 = t1.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
         let _t2 = t2;
     };
 
@@ -63,6 +68,7 @@ fn test3_only_by_value_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
         println!("{:?}", t1.1);
     };
 
@@ -81,6 +87,7 @@ fn test4_type_contains_drop_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -97,6 +104,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
     };
 
     c();
@@ -111,6 +119,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
+        //~^ NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();
@@ -127,6 +136,8 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
+        //~^ NOTE: in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+        //~| NOTE: in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,29 +1,24 @@
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:25:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _t1 = t1.0;
-   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
-LL | |
-LL | |         let _t2 = t2.0;
-   | |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL |
+LL |         let _t1 = t1.0;
+   |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL |
+LL |         let _t2 = t2.0;
+   |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+   | in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/significant_drop.rs:2:9
@@ -44,26 +39,20 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:50:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         let _t1 = t1.0;
-   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
-LL | |
-LL | |         let _t2 = t2;
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL |
+LL |         let _t1 = t1.0;
+   |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
@@ -79,20 +68,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:71:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |         println!("{:?}", t1.1);
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -108,19 +91,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:91:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -136,19 +114,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:109:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.0;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+LL |         let _t = t.0;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -164,19 +137,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:125:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         let _t = t.1;
-   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = || {
+   |             ^^
 ...
-LL |   }
-   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+LL |         let _t = t.1;
+   |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+...
+LL | }
+   | - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -192,25 +160,19 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:143:13
    |
-LL |       let c = move || {
-   |  _____________^
-LL | |
-LL | |
-LL | |
-LL | |         println!("{:?} {:?}", t1.1, t.1);
-   | |                               ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
-   | |                               |
-   | |                               in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
-LL | |
-LL | |
-LL | |     };
-   | |_____^
+LL |     let c = move || {
+   |             ^^^^^^^
 ...
-LL |   }
-   |   -
-   |   |
-   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
-   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
+LL |         println!("{:?} {:?}", t1.1, t.1);
+   |                               ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+   |                               |
+   |                               in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+...
+LL | }
+   | -
+   | |
+   | in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+   | in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
@@ -226,19 +188,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:163:21
    |
-LL |               let c = || {
-   |  _____________________^
-LL | |
-LL | |
-LL | |
-LL | |                 tuple.0;
-   | |                 ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
-LL | |
-LL | |             };
-   | |_____________^
+LL |             let c = || {
+   |                     ^^
 ...
-LL |           }
-   |           - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+LL |                 tuple.0;
+   |                 ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+...
+LL |         }
+   |         - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
@@ -254,19 +211,14 @@ LL |
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:181:17
    |
-LL |           let c = || {
-   |  _________________^
-LL | |
-LL | |
-LL | |
-LL | |             tuple.0;
-   | |             ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
-LL | |
-LL | |         };
-   | |_________^
+LL |         let c = || {
+   |                 ^^
 ...
-LL |       };
-   |       - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+LL |             tuple.0;
+   |             ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+...
+LL |     };
+   |     - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -17,6 +17,13 @@ LL | |         let _t2 = t2.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t2` would be dropped here, but in Rust 2021, only `t2.0` would be dropped here alongside the closure
    |
 note: the lint level is defined here
   --> $DIR/significant_drop.rs:2:9
@@ -35,7 +42,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:47:13
+  --> $DIR/significant_drop.rs:50:13
    |
 LL |       let c = || {
    |  _____________^
@@ -51,6 +58,12 @@ LL | |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
@@ -64,7 +77,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:66:13
+  --> $DIR/significant_drop.rs:71:13
    |
 LL |       let c = || {
    |  _____________^
@@ -77,6 +90,9 @@ LL | |
 LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -90,7 +106,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:85:13
+  --> $DIR/significant_drop.rs:91:13
    |
 LL |       let c = || {
    |  _____________^
@@ -102,6 +118,9 @@ LL | |         let _t = t.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -115,7 +134,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:102:13
+  --> $DIR/significant_drop.rs:109:13
    |
 LL |       let c = || {
    |  _____________^
@@ -127,6 +146,9 @@ LL | |         let _t = t.0;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.0` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -140,7 +162,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:117:13
+  --> $DIR/significant_drop.rs:125:13
    |
 LL |       let c = || {
    |  _____________^
@@ -152,6 +174,9 @@ LL | |         let _t = t.1;
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   - in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
@@ -165,7 +190,7 @@ LL |
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
-  --> $DIR/significant_drop.rs:134:13
+  --> $DIR/significant_drop.rs:143:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -180,6 +205,12 @@ LL | |
 LL | |
 LL | |     };
    | |_____^
+...
+LL |   }
+   |   -
+   |   |
+   |   in Rust 2018, `t1` would be dropped here, but in Rust 2021, only `t1.1` would be dropped here alongside the closure
+   |   in Rust 2018, `t` would be dropped here, but in Rust 2021, only `t.1` would be dropped here alongside the closure
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
@@ -192,5 +223,61 @@ LL |         println!("{:?} {:?}", t1.1, t.1);
 LL |
  ...
 
-error: aborting due to 7 previous errors
+error: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/significant_drop.rs:163:21
+   |
+LL |               let c = || {
+   |  _____________________^
+LL | |
+LL | |
+LL | |
+LL | |                 tuple.0;
+   | |                 ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+LL | |
+LL | |             };
+   | |_____________^
+...
+LL |           }
+   |           - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `tuple` to be fully captured
+   |
+LL |             let c = || { let _ = &tuple; 
+LL |
+LL |
+LL |
+LL |                 tuple.0;
+LL |
+ ...
+
+error: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/significant_drop.rs:181:17
+   |
+LL |           let c = || {
+   |  _________________^
+LL | |
+LL | |
+LL | |
+LL | |             tuple.0;
+   | |             ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
+LL | |
+LL | |         };
+   | |_________^
+...
+LL |       };
+   |       - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+help: add a dummy let to cause `tuple` to be fully captured
+   |
+LL |         let c = || { let _ = &tuple; 
+LL |
+LL |
+LL |
+LL |             tuple.0;
+LL |
+ ...
+
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -6,8 +6,15 @@ LL |       let c = || {
 LL | |
 LL | |
 LL | |
-...  |
+LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
+LL | |         let _t1 = t1.0;
+   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL | |
 LL | |         let _t2 = t2.0;
+   | |                   ---- in Rust 2018, closure captures all of `t2`, but in Rust 2021, it only captures `t2.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -24,18 +31,23 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _t1 = t1.0;
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:44:13
+  --> $DIR/significant_drop.rs:47:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
 LL | |
-...  |
+LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
+LL | |         let _t1 = t1.0;
+   | |                   ---- in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.0`
+LL | |
 LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
@@ -48,11 +60,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _t1 = t1.0;
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:61:13
+  --> $DIR/significant_drop.rs:66:13
    |
 LL |       let c = || {
    |  _____________^
@@ -60,6 +72,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
@@ -72,11 +86,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         println!("{:?}", t1.1);
+LL |
  ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:79:13
+  --> $DIR/significant_drop.rs:85:13
    |
 LL |       let c = || {
    |  _____________^
@@ -84,6 +98,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -95,11 +111,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:95:13
+  --> $DIR/significant_drop.rs:102:13
    |
 LL |       let c = || {
    |  _____________^
@@ -107,6 +123,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.0;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.0`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -118,11 +136,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:109:13
+  --> $DIR/significant_drop.rs:117:13
    |
 LL |       let c = || {
    |  _____________^
@@ -130,6 +148,8 @@ LL | |
 LL | |
 LL | |
 LL | |         let _t = t.1;
+   | |                  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+LL | |
 LL | |     };
    | |_____^
    |
@@ -141,11 +161,11 @@ LL |
 LL |
 LL |
 LL |         let _t = t.1;
-LL |     };
-   |
+LL |
+ ...
 
 error: drop order will change in Rust 2021
-  --> $DIR/significant_drop.rs:125:13
+  --> $DIR/significant_drop.rs:134:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -153,6 +173,11 @@ LL | |
 LL | |
 LL | |
 LL | |         println!("{:?} {:?}", t1.1, t.1);
+   | |                               ----  --- in Rust 2018, closure captures all of `t`, but in Rust 2021, it only captures `t.1`
+   | |                               |
+   | |                               in Rust 2018, closure captures all of `t1`, but in Rust 2021, it only captures `t1.1`
+LL | |
+LL | |
 LL | |     };
    | |_____^
    |
@@ -164,8 +189,8 @@ LL |
 LL |
 LL |
 LL |         println!("{:?} {:?}", t1.1, t.1);
-LL |     };
-   |
+LL |
+ ...
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,4 +1,4 @@
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:25:13
    |
 LL |       let c = || {
@@ -34,7 +34,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:47:13
    |
 LL |       let c = || {
@@ -63,7 +63,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:66:13
    |
 LL |       let c = || {
@@ -89,7 +89,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:85:13
    |
 LL |       let c = || {
@@ -114,7 +114,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:102:13
    |
 LL |       let c = || {
@@ -139,7 +139,7 @@ LL |         let _t = t.0;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:117:13
    |
 LL |       let c = || {
@@ -164,7 +164,7 @@ LL |         let _t = t.1;
 LL |
  ...
 
-error: drop order will change in Rust 2021
+error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:134:13
    |
 LL |       let c = move || {


### PR DESCRIPTION
This PR improves the current disjoint capture migration lint by providing more information on why drop order or auto trait implementation for a closure is impacted by the use of the new feature.

The drop order migration lint will now look something like this:
```
error: changes to closure capture in Rust 2021 will affect drop order
  --> $DIR/significant_drop.rs:163:21
   |
LL |             let c = || {
   |                     ^^
...
LL |                 tuple.0;
   |                 ------- in Rust 2018, closure captures all of `tuple`, but in Rust 2021, it only captures `tuple.0`
...
LL |         }
   |         - in Rust 2018, `tuple` would be dropped here, but in Rust 2021, only `tuple.0` would be dropped here alongside the closure
```

The auto trait migration lint will now look something like this:
```
error: changes to closure capture in Rust 2021 will affect `Send` trait implementation for closure
  --> $DIR/auto_traits.rs:14:19
   |
LL |     thread::spawn(move || unsafe {
   |                   ^^^^^^^^^^^^^^ in Rust 2018, this closure would implement `Send` as `fptr` implements `Send`, but in Rust 2021, this closure would no longer implement `Send` as `fptr.0` does not implement `Send`
...
LL |         *fptr.0 = 20;
   |         ------- in Rust 2018, closure captures all of `fptr`, but in Rust 2021, it only captures `fptr.0`
```

r? @nikomatsakis 

Closes https://github.com/rust-lang/project-rfc-2229/issues/54