### PR TITLE
Remove `missing_docs` lint on private 2.0 macros

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -571,6 +571,11 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
         self.check_missing_docs_attrs(cx, hir::CRATE_HIR_ID, krate.item.inner, "the", "crate");
 
         for macro_def in krate.exported_macros {
+            // Non exported MBE 2.0 macros should be skipped
+            if !macro_def.ast.macro_rules && !cx.access_levels.is_exported(macro_def.hir_id()) {
+                continue;
+            }
+
             let attrs = cx.tcx.hir().attrs(macro_def.hir_id());
             let has_doc = attrs.iter().any(|a| has_doc(cx.sess(), a));
             if !has_doc {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -571,8 +571,9 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
         self.check_missing_docs_attrs(cx, hir::CRATE_HIR_ID, krate.item.inner, "the", "crate");
 
         for macro_def in krate.exported_macros {
-            // Non exported MBE 2.0 macros should be skipped
-            if !macro_def.ast.macro_rules && !cx.access_levels.is_exported(macro_def.hir_id()) {
+            // Non exported macros should be skipped, since `missing_docs` only
+            // applies to externally visible items.
+            if !cx.access_levels.is_exported(macro_def.hir_id()) {
                 continue;
             }
 

--- a/src/test/ui/lint/missing-doc-private-macro.rs
+++ b/src/test/ui/lint/missing-doc-private-macro.rs
@@ -1,0 +1,43 @@
+// Checks that undocumented private macros will not generate `missing_docs`
+// lints, but public ones will.
+//
+// This is a regression test for issue #57569
+#![deny(missing_docs)]
+#![feature(decl_macro)]
+//! Empty documentation.
+
+macro new_style_private_macro {
+    () => ()
+}
+
+pub(crate) macro new_style_crate_macro {
+    () => ()
+}
+
+macro_rules! old_style_private_macro {
+    () => ()
+}
+
+mod submodule {
+    pub macro new_style_macro_in_private_module {
+        () => ()
+    }
+
+    macro_rules! old_style_mod_private_macro {
+        () => ()
+    }
+
+    #[macro_export]
+    macro_rules! exported_to_top_level {
+        //~^ ERROR missing documentation for macro
+        () => ()
+    }
+}
+
+pub macro top_level_pub_macro {
+    //~^ ERROR missing documentation for macro
+    () => ()
+}
+
+/// Empty documentation.
+pub fn main() {}

--- a/src/test/ui/lint/missing-doc-private-macro.stderr
+++ b/src/test/ui/lint/missing-doc-private-macro.stderr
@@ -1,0 +1,20 @@
+error: missing documentation for macro
+  --> $DIR/missing-doc-private-macro.rs:31:5
+   |
+LL |     macro_rules! exported_to_top_level {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/missing-doc-private-macro.rs:5:9
+   |
+LL | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
+
+error: missing documentation for macro
+  --> $DIR/missing-doc-private-macro.rs:37:1
+   |
+LL | pub macro top_level_pub_macro {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/798baebde1fe77e5a660490ec64e727a5d79970d/compiler/rustc_lint/src/builtin.rs#L573-L584

This code is the source of #57569. The problem is subtle, so let me point it out. This code makes the mistake of assuming that all of the macros in `krate.exported_macros` are exported.

...Yeah. For some historical reason, all `macro` macros are marked as exported, regardless of whether they actually are, which is dreadfully confusing. It would be more accurate to say that `exported_macros` currently contains only macros that have paths. 

This PR renames `exported_macros` to `importable_macros`, since these macros can be imported with `use` while others cannot. It also fixes the code above to no longer lint on private `macro` macros, since the `missing_docs` lint should only appear on exported items.

Fixes #57569.