### PR TITLE
Make `--force-warns` a normal lint level option

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -135,7 +135,6 @@ top_level_options!(
         debuginfo: DebugInfo [TRACKED],
         lint_opts: Vec<(String, lint::Level)> [TRACKED_NO_CRATE_HASH],
         lint_cap: Option<lint::Level> [TRACKED_NO_CRATE_HASH],
-        force_warns: Vec<String> [TRACKED_NO_CRATE_HASH],
         describe_lints: bool [UNTRACKED],
         output_types: OutputTypes [TRACKED],
         search_paths: Vec<SearchPath> [UNTRACKED],

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -628,7 +628,7 @@ impl Options {
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
         let show_type_layout = matches.opt_present("show-type-layout");
 
-        let (lint_opts, describe_lints, lint_cap, _) =
+        let (lint_opts, describe_lints, lint_cap) =
             get_cmd_lint_options(matches, error_format, &debugging_opts);
 
         Ok(Options {

--- a/src/test/ui/lint/cli-lint-override.forbid_warn.stderr
+++ b/src/test/ui/lint/cli-lint-override.forbid_warn.stderr
@@ -1,0 +1,11 @@
+error: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `-F missing-abi`
+   = help: the default ABI is C
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/cli-lint-override.force_warn_deny.stderr
+++ b/src/test/ui/lint/cli-lint-override.force_warn_deny.stderr
@@ -1,0 +1,11 @@
+warning: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `--force-warns missing-abi`
+   = help: the default ABI is C
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/cli-lint-override.rs
+++ b/src/test/ui/lint/cli-lint-override.rs
@@ -1,0 +1,17 @@
+// Tests that subsequent lints specified via the command line override
+// each other, except for ForceWarn and Forbid, which cannot be overriden.
+//
+// revisions: warn_deny forbid_warn force_warn_deny
+//
+//[warn_deny] compile-flags: --warn missing_abi --deny missing_abi
+//[forbid_warn] compile-flags: --warn missing_abi --forbid missing_abi
+//[force_warn_deny] compile-flags: -Z unstable-options --force-warns missing_abi --allow missing_abi
+//[force_warn_deny] check-pass
+
+
+extern fn foo() {}
+//[warn_deny]~^ ERROR extern declarations without an explicit ABI are deprecated
+//[forbid_warn]~^^ ERROR extern declarations without an explicit ABI are deprecated
+//[force_warn_deny]~^^^ WARN extern declarations without an explicit ABI are deprecated
+
+fn main() {}

--- a/src/test/ui/lint/cli-lint-override.warn_deny.stderr
+++ b/src/test/ui/lint/cli-lint-override.warn_deny.stderr
@@ -1,0 +1,11 @@
+error: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `-D missing-abi`
+   = help: the default ABI is C
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/cli-unknown-force-warn.rs
+++ b/src/test/ui/lint/cli-unknown-force-warn.rs
@@ -1,0 +1,7 @@
+// Checks that rustc correctly errors when passed an invalid lint with
+// `--force-warns`. This is a regression test for issue #86958.
+//
+// compile-flags: -Z unstable-options --force-warns foo-qux
+// error-pattern: unknown lint: `foo_qux`
+
+fn main() {}

--- a/src/test/ui/lint/cli-unknown-force-warn.stderr
+++ b/src/test/ui/lint/cli-unknown-force-warn.stderr
@@ -1,0 +1,15 @@
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0602`.


### PR DESCRIPTION
Now that `ForceWarn` is a lint level, there's no reason `--force-warns` should be treated differently from other options that set lint levels. This merges the `ForceWarn` handling in with the other lint level command line options. It also unifies all of the relevant selection logic in `compiler/rustc_lint/src/levels.rs`, rather than having some of it weirdly elsewhere.

Fixes #86958, which arose from the special-cased handling of `ForceWarn` having had an error in it.