### PR TITLE
Reject octal zeros in IPv4 addresses

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -74,6 +74,7 @@ pub enum IpAddr {
 /// assert_eq!("127.0.0.1".parse(), Ok(localhost));
 /// assert_eq!(localhost.is_loopback(), true);
 /// assert!("012.004.002.000".parse::<Ipv4Addr>().is_err()); // all octets are in octal
+/// assert!("0000000.0.0.0".parse::<Ipv4Addr>().is_err()); // first octet is a zero in octal
 /// assert!("0xcb.0x0.0x71.0x00".parse::<Ipv4Addr>().is_err()); // all octets are in hex
 /// ```
 #[derive(Copy)]

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -59,7 +59,8 @@ pub enum IpAddr {
 ///
 /// `Ipv4Addr` provides a [`FromStr`] implementation. The four octets are in decimal
 /// notation, divided by `.` (this is called "dot-decimal notation").
-/// Notably, octal numbers and hexadecimal numbers are not allowed per [IETF RFC 6943].
+/// Notably, octal numbers (which are indicated with a leading `0`) and hexadecimal numbers (which
+/// are indicated with a leading `0x`) are not allowed per [IETF RFC 6943].
 ///
 /// [IETF RFC 6943]: https://tools.ietf.org/html/rfc6943#section-3.1.1
 /// [`FromStr`]: crate::str::FromStr
@@ -72,6 +73,8 @@ pub enum IpAddr {
 /// let localhost = Ipv4Addr::new(127, 0, 0, 1);
 /// assert_eq!("127.0.0.1".parse(), Ok(localhost));
 /// assert_eq!(localhost.is_loopback(), true);
+/// assert!("012.004.002.000".parse::<Ipv4Addr>().is_err()); // all octets are in octal
+/// assert!("0xcb.0x0.0x71.0x00".parse::<Ipv4Addr>().is_err()); // all octets are in hex
 /// ```
 #[derive(Copy)]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/net/ip/tests.rs
+++ b/library/std/src/net/ip/tests.rs
@@ -20,6 +20,14 @@ fn test_from_str_ipv4() {
     // no number between dots
     let none: Option<Ipv4Addr> = "255.0..1".parse().ok();
     assert_eq!(None, none);
+    // octal
+    let none: Option<Ipv4Addr> = "255.0.0.01".parse().ok();
+    assert_eq!(None, none);
+    // octal zero
+    let none: Option<Ipv4Addr> = "255.0.0.00".parse().ok();
+    assert_eq!(None, none);
+    let none: Option<Ipv4Addr> = "255.0.00.0".parse().ok();
+    assert_eq!(None, none);
 }
 
 #[test]

--- a/library/std/src/net/parser.rs
+++ b/library/std/src/net/parser.rs
@@ -148,7 +148,7 @@ impl<'a> Parser<'a> {
                 *slot = p.read_separator('.', i, |p| {
                     // Disallow octal number in IP string.
                     // https://tools.ietf.org/html/rfc6943#section-3.1.1
-                    p.read_number(10, None, false)
+                    p.read_number(10, Some(3), false)
                 })?;
             }
 

--- a/library/std/src/net/parser.rs
+++ b/library/std/src/net/parser.rs
@@ -289,7 +289,12 @@ impl FromStr for IpAddr {
 impl FromStr for Ipv4Addr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
-        Parser::new(s).parse_with(|p| p.read_ipv4_addr())
+        // don't try to parse if too long
+        if s.len() > 15 {
+            Err(AddrParseError(()))
+        } else {
+            Parser::new(s).parse_with(|p| p.read_ipv4_addr())
+        }
     }
 }
 

--- a/library/std/src/net/parser.rs
+++ b/library/std/src/net/parser.rs
@@ -12,7 +12,7 @@ use crate::fmt;
 use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use crate::str::FromStr;
 
-trait ReadNumberHelper: crate::marker::Sized + crate::cmp::PartialEq {
+trait ReadNumberHelper: crate::marker::Sized {
     const ZERO: Self;
     fn checked_mul(&self, other: u32) -> Option<Self>;
     fn checked_add(&self, other: u32) -> Option<Self>;
@@ -131,10 +131,7 @@ impl<'a> Parser<'a> {
 
             if digit_count == 0 {
                 None
-            } else if !allow_zero_prefix
-                && has_leading_zero
-                && (result != T::ZERO || result == T::ZERO && digit_count > 1)
-            {
+            } else if !allow_zero_prefix && has_leading_zero && digit_count > 1 {
                 None
             } else {
                 Some(result)


### PR DESCRIPTION
This fixes #86964 by rejecting octal zeros in IP addresses, such that `192.168.00.00000000` is rejected with a parse error, since having leading zeros in front of another zero indicates it is a zero written in octal notation, which is not allowed in the strict mode specified by RFC 6943 3.1.1. Octal rejection was implemented in #83652, but due to the way it was implemented octal zeros were still allowed.