### PR TITLE
Use #[track_caller] in const panic diagnostics.

### DIFF
--- a/compiler/rustc_mir/src/interpret/eval_context.rs
+++ b/compiler/rustc_mir/src/interpret/eval_context.rs
@@ -398,7 +398,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
     #[inline(always)]
     pub fn cur_span(&self) -> Span {
-        self.stack().last().map_or(self.tcx.span, |f| f.current_span())
+        self.stack()
+            .iter()
+            .rev()
+            .find(|frame| !frame.instance.def.requires_caller_location(*self.tcx))
+            .map_or(self.tcx.span, |f| f.current_span())
     }
 
     #[inline(always)]
@@ -927,7 +931,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     #[must_use]
     pub fn generate_stacktrace(&self) -> Vec<FrameInfo<'tcx>> {
         let mut frames = Vec::new();
-        for frame in self.stack().iter().rev() {
+        for frame in self
+            .stack()
+            .iter()
+            .rev()
+            .skip_while(|frame| frame.instance.def.requires_caller_location(*self.tcx))
+        {
             let lint_root = frame.current_source_info().and_then(|source_info| {
                 match &frame.body.source_scopes[source_info.scope].local_data {
                     mir::ClearCrossCrate::Set(data) => Some(data.lint_root),

--- a/src/test/ui/consts/const-eval/const_panic_track_caller.rs
+++ b/src/test/ui/consts/const-eval/const_panic_track_caller.rs
@@ -1,0 +1,23 @@
+#![feature(const_panic)]
+#![allow(non_fmt_panics)]
+#![crate_type = "lib"]
+
+#[track_caller]
+const fn a() -> u32 {
+    panic!("hey")
+}
+
+#[track_caller]
+const fn b() -> u32 {
+    a()
+}
+
+const fn c() -> u32 {
+    b()
+    //~^ ERROR evaluation of constant value failed
+    //~| NOTE the evaluated program panicked
+    //~| NOTE inside
+}
+
+const X: u32 = c();
+//~^ NOTE inside

--- a/src/test/ui/consts/const-eval/const_panic_track_caller.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_track_caller.stderr
@@ -1,0 +1,15 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_panic_track_caller.rs:16:5
+   |
+LL |     b()
+   |     ^^^
+   |     |
+   |     the evaluated program panicked at 'hey', $DIR/const_panic_track_caller.rs:16:5
+   |     inside `c` at $DIR/const_panic_track_caller.rs:16:5
+...
+LL | const X: u32 = c();
+   |                --- inside `X` at $DIR/const_panic_track_caller.rs:22:16
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-unwrap.rs
+++ b/src/test/ui/consts/const-unwrap.rs
@@ -4,9 +4,8 @@
 
 const FOO: i32 = Some(42i32).unwrap();
 
-// This causes an error, but it is attributed to the `panic` *inside* `Option::unwrap` (maybe due
-// to `track_caller`?). A note points to the originating `const`.
-const BAR: i32 = Option::<i32>::None.unwrap(); //~ NOTE
+const BAR: i32 = Option::<i32>::None.unwrap();
+//~^ERROR: evaluation of constant value failed
 
 fn main() {
     println!("{}", FOO);

--- a/src/test/ui/consts/const-unwrap.stderr
+++ b/src/test/ui/consts/const-unwrap.stderr
@@ -1,18 +1,8 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-LL |             None => panic!("called `Option::unwrap()` on a `None` value"),
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                     |
-   |                     the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:9:38
-   |                     inside `Option::<i32>::unwrap` at $SRC_DIR/core/src/panic.rs:LL:COL
-   | 
-  ::: $DIR/const-unwrap.rs:9:18
+  --> $DIR/const-unwrap.rs:7:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ---------------------------- inside `BAR` at $DIR/const-unwrap.rs:9:18
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:7:38
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This change stops const panic diagnostics from reporting inside #[track_caller] functions by skipping over them.