### PR TITLE
"x.py install" does not honor prefix for "/etc".

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -32,7 +32,7 @@ fn install_sh(
     builder.info(&format!("Install {} stage{} ({:?})", package, stage, host));
 
     let prefix = default_path(&builder.config.prefix, "/usr/local");
-    let sysconfdir = prefix.join(default_path(&builder.config.sysconfdir, "/etc"));
+    let sysconfdir = prefix.join(default_path(&builder.config.sysconfdir, "etc"));
     let datadir = prefix.join(default_path(&builder.config.datadir, "share"));
     let docdir = prefix.join(default_path(&builder.config.docdir, "share/doc/rust"));
     let mandir = prefix.join(default_path(&builder.config.mandir, "share/man"));


### PR DESCRIPTION
`x.py install` throws `/etc/bash_completion.d: Permission denied` with a custom install path. This is because `prefix` is not honored in `src/bootstrap/install.rs` which always uses `/etc`. Changing the string to `etc` fixes it.

Here's a portion of the logs that shows the error:

```
Install cargo stage2 (Some(TargetSelection { triple: "x86_64-apple-darwin", file: None }))
install: uninstalling component 'cargo'
install: creating uninstall script at <my install directory>/lib/rustlib/uninstall.sh
install: installing component 'cargo'
mkdir: /etc/bash_completion.d: Permission denied
install: error: directory creation failed. see logs at '<my install directory>/lib/rustlib/install.log'
```