### PR TITLE
Fix several ICEs related to malformed `#[repr(...)]` attributes

### DIFF
--- a/src/test/ui/attributes/nonterminal-expansion.rs
+++ b/src/test/ui/attributes/nonterminal-expansion.rs
@@ -2,7 +2,9 @@
 
 macro_rules! pass_nonterminal {
     ($n:expr) => {
-        #[repr(align($n))] //~ ERROR expected unsuffixed literal or identifier, found `n!()`
+        #[repr(align($n))]
+        //~^ ERROR expected unsuffixed literal or identifier, found `n!()`
+        //~| ERROR incorrect `repr(align)` attribute format
         struct S;
     };
 }

--- a/src/test/ui/attributes/nonterminal-expansion.stderr
+++ b/src/test/ui/attributes/nonterminal-expansion.stderr
@@ -9,5 +9,17 @@ LL | pass_nonterminal!(n!());
    |
    = note: this error originates in the macro `pass_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/nonterminal-expansion.rs:5:16
+   |
+LL |         #[repr(align($n))]
+   |                ^^^^^^^^^
+...
+LL | pass_nonterminal!(n!());
+   | ------------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `pass_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0693`.

--- a/src/test/ui/repr/issue-83921-ice.rs
+++ b/src/test/ui/repr/issue-83921-ice.rs
@@ -1,0 +1,34 @@
+// Regression test for various ICEs inspired by
+// https://github.com/rust-lang/rust/issues/83921#issuecomment-814640734
+
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
+#[repr(packed())]
+//~^ ERROR: incorrect `repr(packed)` attribute format
+struct S1;
+
+#[repr(align)]
+//~^ ERROR: invalid `repr(align)` attribute
+struct S2;
+
+#[repr(align(2, 4))]
+//~^ ERROR: incorrect `repr(align)` attribute format
+struct S3;
+
+#[repr(align())]
+//~^ ERROR: incorrect `repr(align)` attribute format
+struct S4;
+
+#[repr(i8())]
+//~^ ERROR: invalid representation hint
+enum E1 { A, B }
+
+#[repr(u32(42))]
+//~^ ERROR: invalid representation hint
+enum E2 { A, B }
+
+#[repr(i64 = 2)]
+//~^ ERROR: invalid representation hint
+enum E3 { A, B }
+
+fn main() {}

--- a/src/test/ui/repr/issue-83921-ice.stderr
+++ b/src/test/ui/repr/issue-83921-ice.stderr
@@ -1,0 +1,46 @@
+error[E0552]: incorrect `repr(packed)` attribute format: `packed` takes exactly one parenthesized argument, or no parentheses at all
+  --> $DIR/issue-83921-ice.rs:6:8
+   |
+LL | #[repr(packed())]
+   |        ^^^^^^^^
+
+error[E0589]: invalid `repr(align)` attribute: `align` needs an argument
+  --> $DIR/issue-83921-ice.rs:10:8
+   |
+LL | #[repr(align)]
+   |        ^^^^^ help: supply an argument here: `align(...)`
+
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/issue-83921-ice.rs:14:8
+   |
+LL | #[repr(align(2, 4))]
+   |        ^^^^^^^^^^^
+
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/issue-83921-ice.rs:18:8
+   |
+LL | #[repr(align())]
+   |        ^^^^^^^
+
+error[E0552]: invalid representation hint: `i8` does not take a parenthesized argument list
+  --> $DIR/issue-83921-ice.rs:22:8
+   |
+LL | #[repr(i8())]
+   |        ^^^^
+
+error[E0552]: invalid representation hint: `u32` does not take a parenthesized argument list
+  --> $DIR/issue-83921-ice.rs:26:8
+   |
+LL | #[repr(u32(42))]
+   |        ^^^^^^^
+
+error[E0552]: invalid representation hint: `i64` does not take a value
+  --> $DIR/issue-83921-ice.rs:30:8
+   |
+LL | #[repr(i64 = 2)]
+   |        ^^^^^^^
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0552, E0589, E0693.
+For more information about an error, try `rustc --explain E0552`.

--- a/src/test/ui/repr/issue-83921-pretty.normal.stderr
+++ b/src/test/ui/repr/issue-83921-pretty.normal.stderr
@@ -1,0 +1,9 @@
+error[E0565]: meta item in `repr` must be an identifier
+  --> $DIR/issue-83921-pretty.rs:10:8
+   |
+LL | #[repr("C")]
+   |        ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0565`.

--- a/src/test/ui/repr/issue-83921-pretty.pretty.stdout
+++ b/src/test/ui/repr/issue-83921-pretty.pretty.stdout
@@ -1,0 +1,19 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// Regression test for #83921. A `delay_span_bug()` call was issued, but the
+// error was never reported because the pass responsible for detecting and
+// reporting the error does not run in certain modes of pretty-printing.
+
+// Make sure the error is reported if we do not just pretty-print:
+// revisions: pretty normal
+// [pretty]compile-flags: -Zunpretty=everybody_loops
+// [pretty]check-pass
+#[repr("C")]
+struct A {
+}
+
+fn main() { loop { } }

--- a/src/test/ui/repr/issue-83921-pretty.rs
+++ b/src/test/ui/repr/issue-83921-pretty.rs
@@ -1,0 +1,14 @@
+// Regression test for #83921. A `delay_span_bug()` call was issued, but the
+// error was never reported because the pass responsible for detecting and
+// reporting the error does not run in certain modes of pretty-printing.
+
+// Make sure the error is reported if we do not just pretty-print:
+// revisions: pretty normal
+// [pretty]compile-flags: -Zunpretty=everybody_loops
+// [pretty]check-pass
+
+#[repr("C")]
+//[normal]~^ ERROR: meta item in `repr` must be an identifier [E0565]
+struct A {}
+
+fn main() {}


### PR DESCRIPTION
This PR fixes #83921. #83921 actually contains two related but distinct issues (one of them incorrectly reported as a duplicate in https://github.com/rust-lang/rust/issues/83921#issuecomment-814640734):

In the first, a call to `delay_span_bug` leads to an ICE when compiling with `-Zunpretty=everybody_loops` (and some other pretty-printing modes), because the corresponding error is emitted in a later pass, which does not run when only pretty-printing is requested.

The second issue is about parsing `#[repr(...)]` attributes. Currently, all of the following cause an ICE when applied to a struct/enum:
```rust
#[repr(packed())]
#[repr(align)]
#[repr(align(2, 4))]
#[repr(align())]
#[repr(i8())]
#[repr(u32(42))]
#[repr(i64 = 2)]
```
I have fixed this by expanding the well-formedness checks in `find_repr_attrs()`.