### PR TITLE
Use clang 12.0.1 on dist-x86_64/i686-linux

### DIFF
--- a/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
@@ -69,8 +69,6 @@ COPY host-x86_64/dist-x86_64-linux/build-gcc.sh /tmp/
 RUN ./build-gcc.sh && apt-get remove -y gcc g++
 
 COPY host-x86_64/dist-x86_64-linux/build-python.sh /tmp/
-# Build Python 2.7 needed for Clang 10.
-RUN ./build-python.sh 2.7.12
 # Build Python 3 needed for LLVM 12.
 RUN ./build-python.sh 3.9.1
 
@@ -97,7 +95,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=i686-unknown-linux-gnu \
       --set llvm.ninja=false \
       --set rust.jemalloc
-ENV SCRIPT python2.7 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
+ENV SCRIPT python3 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This was added when we switched from gcc to clang. It's not clear why this is

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -69,8 +69,6 @@ COPY host-x86_64/dist-x86_64-linux/build-gcc.sh /tmp/
 RUN ./build-gcc.sh && apt-get remove -y gcc g++
 
 COPY host-x86_64/dist-x86_64-linux/build-python.sh /tmp/
-# Build Python 2.7 needed for Clang 10.
-RUN ./build-python.sh 2.7.12
 # Build Python 3 needed for LLVM 12.
 RUN ./build-python.sh 3.9.1
 
@@ -102,7 +100,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
       --set rust.jemalloc
-ENV SCRIPT ../src/ci/pgo.sh python2.7 ../x.py dist \
+ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \
     src/tools/build-manifest

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-binutils.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-binutils.sh
@@ -11,7 +11,7 @@ curl https://ftp.gnu.org/gnu/binutils/binutils-$VERSION.tar.bz2 | tar xfj -
 mkdir binutils-build
 cd binutils-build
 hide_output ../binutils-$VERSION/configure --prefix=/rustroot
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 
 cd ..

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-binutils.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-binutils.sh
@@ -4,14 +4,16 @@ set -ex
 
 source shared.sh
 
-curl https://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2 | tar xfj -
+VERSION=2.26.1
+
+curl https://ftp.gnu.org/gnu/binutils/binutils-$VERSION.tar.bz2 | tar xfj -
 
 mkdir binutils-build
 cd binutils-build
-hide_output ../binutils-2.25.1/configure --prefix=/rustroot
+hide_output ../binutils-$VERSION/configure --prefix=/rustroot
 hide_output make -j10
 hide_output make install
 
 cd ..
 rm -rf binutils-build
-rm -rf binutils-2.25.1
+rm -rf binutils-$VERSION

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -30,7 +30,7 @@ hide_output \
       -DLLVM_ENABLE_PROJECTS="clang;lld" \
       -DC_INCLUDE_DIRS="$INC"
 
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 
 cd ../..

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-10.0.0
+LLVM=llvmorg-12.0.1
 
 mkdir llvm-project
 cd llvm-project

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-cmake.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-cmake.sh
@@ -9,7 +9,7 @@ curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE.
 mkdir cmake-build
 cd cmake-build
 hide_output ../cmake-$CMAKE/configure --prefix=/rustroot
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 
 cd ..

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-curl.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-curl.sh
@@ -30,7 +30,7 @@ hide_output ../curl-$VERSION/configure \
       --disable-rtsp \
       --disable-ldaps \
       --disable-ldap
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 
 cd ..

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -32,7 +32,7 @@ hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
     --enable-languages=c,c++ \
     --disable-gnu-unique-object
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 ln -s gcc /rustroot/bin/cc
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-openssl.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-openssl.sh
@@ -14,7 +14,7 @@ curl $URL | tar xzf -
 
 cd openssl-$VERSION
 hide_output ./config --prefix=/rustroot shared -fPIC
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 cd ..
 rm -rf openssl-$VERSION

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-python.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-python.sh
@@ -14,7 +14,7 @@ cd python-build
 # than that fairly normal.
 CFLAGS='-I /rustroot/include' LDFLAGS='-L /rustroot/lib -L /rustroot/lib64' \
     hide_output ../Python-$VERSION/configure --prefix=/rustroot
-hide_output make -j10
+hide_output make -j$(nproc)
 hide_output make install
 
 cd ..

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 rm -rf /tmp/rustc-pgo
 
-python2.7 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
+python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --stage 2 library/std --rust-profile-generate=/tmp/rustc-pgo
 
 RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \


### PR DESCRIPTION
The LLD + ThinLTO __morestack bug has been fixed in 12.0.1, so
we can now update our clang version. This also means that we no
longer need to build Python 2.