### PR TITLE
Fix type: `'satic` -> `'static`

### DIFF
--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -284,7 +284,7 @@ impl Inliner<'tcx> {
         &self,
         callsite: &CallSite<'tcx>,
         callee_attrs: &CodegenFnAttrs,
-    ) -> Result<(), &'satic str> {
+    ) -> Result<(), &'static str> {
         if let InlineAttr::Never = callee_attrs.inline {
             return Err("never inline hint");
         }


### PR DESCRIPTION
Pointed out on discord: https://discord.com/channels/273534239310479360/490356824420122645/863434443170250793

~~The fact that this compiles is probably a bug.~~ Nope it's `#![feature(in_band_lifetimes)]` (Thanks to [floppy](https://discord.com/channels/273534239310479360/490356824420122645/863437381671059486)

~~[The docs](https://doc.rust-lang.org/stable/nightly-rustc/rustc_mir/transform/inline/struct.Inliner.html#method.check_codegen_attributes) seem to indicate rust thinks this function is generic over the lifetime `'satic`~~ This is because of `in_band_lifetimes`