### PR TITLE
Update reference.md

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1,4 +1,4 @@
 % The Rust Reference has moved
 
 We've split up the reference into chapters. Please find it at its new
-home [here](reference/index.html).
+home [here](https://doc.rust-lang.org/stable/reference/introduction.html).


### PR DESCRIPTION
I ran into a link to the outdated src/doc/reference.md here: https://users.rust-lang.org/t/conditional-compilation-for-debug-release/1098/6
Apparently the Rust reference has moved again, so the link gave a 404 error. This should fix it.