### PR TITLE
Defuse the bomb that is `mem::uninitialized`

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -163,6 +163,7 @@
 #![feature(slice_ptr_get)]
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
+#![feature(cfg_sanitize)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(or_patterns_back_compat)]
 

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -105,7 +105,7 @@ fn main() {
         // Types that do not like zero-initialziation
         test_panic_msg(
             || mem::uninitialized::<fn()>(),
-            "attempted to leave type `fn()` uninitialized, which is invalid"
+            "attempted to zero-initialize type `fn()`, which is invalid"
         );
         test_panic_msg(
             || mem::zeroed::<fn()>(),
@@ -114,7 +114,7 @@ fn main() {
 
         test_panic_msg(
             || mem::uninitialized::<*const dyn Send>(),
-            "attempted to leave type `*const dyn std::marker::Send` uninitialized, which is invalid"
+            "attempted to zero-initialize type `*const dyn std::marker::Send`, which is invalid"
         );
         test_panic_msg(
             || mem::zeroed::<*const dyn Send>(),
@@ -145,7 +145,7 @@ fn main() {
 
         test_panic_msg(
             || mem::uninitialized::<(NonNull<u32>, u32, u32)>(),
-            "attempted to leave type `(std::ptr::NonNull<u32>, u32, u32)` uninitialized, \
+            "attempted to zero-initialize type `(std::ptr::NonNull<u32>, u32, u32)`, \
                 which is invalid"
         );
         test_panic_msg(
@@ -156,7 +156,7 @@ fn main() {
 
         test_panic_msg(
             || mem::uninitialized::<OneVariant_NonZero>(),
-            "attempted to leave type `OneVariant_NonZero` uninitialized, \
+            "attempted to zero-initialize type `OneVariant_NonZero`, \
                 which is invalid"
         );
         test_panic_msg(
@@ -167,27 +167,13 @@ fn main() {
 
         test_panic_msg(
             || mem::uninitialized::<NoNullVariant>(),
-            "attempted to leave type `NoNullVariant` uninitialized, \
+            "attempted to zero-initialize type `NoNullVariant`, \
                 which is invalid"
         );
         test_panic_msg(
             || mem::zeroed::<NoNullVariant>(),
             "attempted to zero-initialize type `NoNullVariant`, \
                 which is invalid"
-        );
-
-        // Types that can be zero, but not uninit.
-        test_panic_msg(
-            || mem::uninitialized::<bool>(),
-            "attempted to leave type `bool` uninitialized, which is invalid"
-        );
-        test_panic_msg(
-            || mem::uninitialized::<LR>(),
-            "attempted to leave type `LR` uninitialized, which is invalid"
-        );
-        test_panic_msg(
-            || mem::uninitialized::<ManuallyDrop<LR>>(),
-            "attempted to leave type `std::mem::ManuallyDrop<LR>` uninitialized, which is invalid"
         );
 
         // Some things that should work.


### PR DESCRIPTION
EDIT: I think for now it makes sense to withdraw this PR while we wait for #66151 to explore tightening intrinsics::assert_zero_valid. I could also imagine an even better version of this PR that uses some value other than 0 (amusingly, 1 might be the most permissive/safe value?). Furthermore, while I still think mem::uninitialized deserves to be as discouraged as we can possibly make it, I am slightly less dim on its existence now that I understand the model of uninitialized memory better and that it actually is possible to use this function safely in some contrived circumstances (let x: () = mem::uninitialized();), which means that it isn't completely ridiculous to expect a hypothetical Rust specification to specify its behavior.

Original below:

---

The deficiencies with `mem::uninitialized` have long been [well-known](https://github.com/rust-lang/rfcs/pull/1892). It has been long since replaced by `mem::MaybeUninit`, and was officially deprecated in November 2019.

The problem with `mem::unitialized` is that, as originally conceived, it is fundamentally incompatible with Rust's stance on memory safety. The API as of Rust 1.0 presented a promise that this function *could* be safe; however, that promise could not be kept. There is no safe way for something with this API to safely provide uninitialized memory.

We can see this contradiction reflected in the current implementation: the return value is simply `MaybeUninit::uninit().assume_init()`. And yet if we look at the `MaybeUninit` docs, we see the following listed as a misuse of the API:

> `let x: i32 = unsafe { MaybeUninit::uninit().assume_init() }; // undefined behavior!`

It isn't safe to use uninitialized memory like this, and yet the API of `mem::uninitialized` makes it unavoidable.

When a function is marked `unsafe` in Rust, that does *not* mean that that function is fundamentally memory-unsafe; it means that the caller must manually uphold certain invariants in order to ensure memory safety. This is why all `unsafe` functions in libstd are supposed to have a "Safety" section in their documentation to inform the user how the function may be safely used. And yet for `mem::uninitialized` there is no "Safety" section, because, as implemented, the caller-upheld invariant is essentially this: *the return value of this function must never be used*.

So at best this function is "just" useless. And when it is not just useless, it is immediate undefined behavior.

Rust's stability guarantee permits breakage in the event of unsoundness. In fact, a year prior to the deprecation of `mem::uninitialized`, a check was added that guarantees that the function will panic at runtime when used with many types that are known to have uninhabited values. This caused some breakage in the wild, and yet it was not sufficient to totally solve the issue (self-evidently, as otherwise `MaybeUninit` would not have later been stabilized and this function would not have been deprecated).

However, although it is arguably within Rust's right to outright remove this function from the stdlib for the sake of soundness, it is possible to be more conservative. Since we must choose between being unsafe and being safe-but-useless, this PR chooses the latter.

This PR replaces the internals of `mem::uninitialized` with a call to `mem::zeroed`. Semantically this is legal: if your code was written to expect any imaginable value, then it must work with any *specific* value ([relevant XKCD](https://xkcd.com/221/)). Philosophically this is also defensible: although this new implementation not strictly "uninitialized", the alternative is undefined behavior; since undefined behavior allows any behavior at all, up to and including nasal demons, an interpretation of undefined behavior wherein your uninitialized memory is replaced with initialized memory is legal.

This PR has three chief advantages:

1. Any program using `mem::uninitialized` that has not been updated since the introduction of `MaybeUninit` is no longer all-but guaranteed to exhibit undefined behavior.
2. Because we can safely remove the guaranteed-to-panic-on-types-with-uninhabited-values check, this means that legacy libraries that stopped working because of that check may now be usable once more. (`mem::zeroed` has its own, more narrowly-scoped check that rejects a subset of the types of the current check.)
3. In a hypothetical future where Rust has a language specification, this interpretation of the contract of this function (transitioning from "this returns an uninitialized value" to "this returns an unspecified value") is possible to reasonably specify (even if it's not guaranteed to ever be useful).

This PR does **not** remove the `unsafe` marker on this function, nor does it reverse its deprecation, nor does it suggest that either of those ever be done. We're just building the sarcophagus on Chernobyl here.

[This was discussed in #libs on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/disarming.20mem.3A.3Auninitialized/near/244030355), and there were no outright objections (although some desired to just see this removed from std entirely).