### PR TITLE
Added Option::reduce

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1049,6 +1049,47 @@ impl<T> Option<T> {
     {
         Some(f(self?, other?))
     }
+
+    /// Zips `self` and another `Option` with function `f`, or returns `self.or(other)`.
+    ///
+    /// If `self` is `Some(s)` and `other` is `Some(o)`, this method returns `Some(f(s, o))`.
+    /// Otherwise, if `self` is `Some`, `self` is returned.
+    /// Otherwise, `other` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_or_zip_with)]
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Point {
+    ///     x: f64,
+    ///     y: f64,
+    /// }
+    ///
+    /// impl Point {
+    ///     fn new(x: f64, y: f64) -> Self {
+    ///         Self { x, y }
+    ///     }
+    /// }
+    ///
+    /// let x = Some(17.5);
+    /// let y = Some(42.7);
+    ///
+    /// assert_eq!(Some(2).or_zip_with(Some(3), |a, b| a + b), Some(5));
+    /// assert_eq!(Some(2).or_zip_with(None, |a, b| a + b), Some(2));
+    /// assert_eq!(None.or_zip_with(Some(3), |a, b| a + b), Some(3));
+    /// ```
+    #[unstable(feature = "option_or_zip_with", issue = "70086")]
+    pub fn or_zip_with<F>(self, other: Option<T>, f: F) -> Option<T>
+    where
+        F: FnOnce(T, T) -> T,
+    {
+        match (self, other) {
+            (Some(a), Some(b)) => Some(f(a, b)),
+            (a, b) => a.or(b),
+        }
+    }
 }
 
 impl<T: Copy> Option<&T> {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1050,38 +1050,27 @@ impl<T> Option<T> {
         Some(f(self?, other?))
     }
 
-    /// Zips `self` and another `Option` with function `f`, or returns `self.or(other)`.
+    /// Reduces `self` and another `Option` with function `f`, or returns `self.or(other)`.
     ///
-    /// If `self` is `Some(s)` and `other` is `Some(o)`, this method returns `Some(f(s, o))`.
-    /// Otherwise, if `self` is `Some`, `self` is returned.
-    /// Otherwise, `other` is returned.
+    /// If `self` is `Some(s)` and `other` is `Some(o)`, this reduces the two values
+    /// with the provided function, returning `Some(f(s, o))`.
+    /// Otherwise, the result of [`self.or(other)`] is returned.
     ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(option_or_zip_with)]
+    /// #![feature(option_reduce)]
     ///
-    /// #[derive(Debug, PartialEq)]
-    /// struct Point {
-    ///     x: f64,
-    ///     y: f64,
-    /// }
+    /// let x = Some(5);
+    /// let y = Some(7);
     ///
-    /// impl Point {
-    ///     fn new(x: f64, y: f64) -> Self {
-    ///         Self { x, y }
-    ///     }
-    /// }
-    ///
-    /// let x = Some(17.5);
-    /// let y = Some(42.7);
-    ///
-    /// assert_eq!(Some(2).or_zip_with(Some(3), |a, b| a + b), Some(5));
-    /// assert_eq!(Some(2).or_zip_with(None, |a, b| a + b), Some(2));
-    /// assert_eq!(None.or_zip_with(Some(3), |a, b| a + b), Some(3));
+    /// assert_eq!(x.reduce(y, i32::max), Some(7));
+    /// assert_eq!(x.reduce(None, i32::max), Some(5));
+    /// assert_eq!(x.reduce(y, |x, y| x + y), Some(12));
+    /// assert_eq!(None.reduce(y, |x, y| x + y), Some(7));
     /// ```
-    #[unstable(feature = "option_or_zip_with", issue = "70086")]
-    pub fn or_zip_with<F>(self, other: Option<T>, f: F) -> Option<T>
+    #[unstable(feature = "option_reduce", issue = "70086")]
+    pub fn reduce<F>(self, other: Option<T>, f: F) -> Option<T>
     where
         F: FnOnce(T, T) -> T,
     {


### PR DESCRIPTION
This PR adds a function that I and others have needed on a regular occurrence (more frequently than at least half of those on `Option` already) that does not have a concise inline alternative, nor can it seemingly be composed from existing functions on `Option`.

I've found this function to be particularly useful in the context of compiler development when one has to resolve two potentially non-existent values together, although it crops up in many other contexts. For example, two error values can be resolved like so:

```rust
err0.reduce(err1, |err0, err1| err0.merge_with(err1))
```

This expands to:

```rust
match (err0, err1) {
    (Some(err0), Some(err1)) => Some(err0.merge_with(err1)),
    (Some(err0), None) => Some(err0),
    (None, Some(err1)) => Some(err1),
    (None, None) => None,
}
```

(I've expanded this example for the sake of clarity)

Additionally, although not implemented in this PR, there is another, similar function that crops up almost as frequently:

```rs
impl<T> Option<T> {
    pub fn reduce<F>(self, other: T, f: F)
        where F: FnOnce(T, T) -> T
    {
        match self {
            Some(a) => f(a, other),
            None => other,
        }
    }
}
```

However, this is trivially emulated with `a.into_iter().reduce(b, f)`.