### PR TITLE
Optimize fmt::PadAdapter::wrap

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -23,10 +23,7 @@ impl<'buf, 'state> PadAdapter<'buf, 'state> {
         slot: &'slot mut Option<Self>,
         state: &'state mut PadAdapterState,
     ) -> fmt::Formatter<'slot> {
-        fmt.wrap_buf(move |buf| {
-            *slot = Some(PadAdapter { buf, state });
-            slot.as_mut().unwrap()
-        })
+        fmt.wrap_buf(move |buf| slot.insert(PadAdapter { buf, state }))
     }
 }
 


### PR DESCRIPTION
After adding the first `write!` usage to my project and printing the result to the console, I noticed, that my binary contains the strings "called `Option::unwrap()` on a `None` value`" and more importantly "C:\Users\Patrick Fischer\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\fmt\builders.rs", with my release build being configured as follows:
```
[profile.release]
panic = "abort"
codegen-units = 1
strip = "symbols" # the important bit
lto = true
```
I am in a no_std environment and my custom panic handler is a simple `loop {}`. I did not expect the above information to be preserved. I heavily suspect the edited function to be the culprit. It contains the only direct use of `Option::unwrap` in the entire file and I tracked the symbols in the assembly to be used from the section `_ZN68_$LT$core..fmt..builders..PadAdapter$u20$as$u20$core..fmt..Write$GT$9write_str17ha1d5e5efe167202aE`.

Aside from me suspecting this function to be the culprit, the replaced code performs the same operation as `Option::insert`, but without the `unreachable_unchecked` optimization `Option::insert` provides. Therefore, it makes sense to me to use the more optimized version, instead.

As I don't change any semantics, I hope a simple pull request suffices.
