### PR TITLE
Fix codeblocks overflow

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -435,7 +435,7 @@ nav.sub {
 	border-bottom-left-radius: 5px;
 }
 
-.rustdoc:not(.source) .example-wrap > pre.rust {
+.rustdoc:not(.source) .example-wrap > pre:not(.line-number) {
 	width: 100%;
 	overflow-x: auto;
 }

--- a/src/test/rustdoc-gui/code-blocks-overflow.goml
+++ b/src/test/rustdoc-gui/code-blocks-overflow.goml
@@ -1,0 +1,8 @@
+// This test ensures that codeblocks content don't overflow.
+goto: file://|DOC_PATH|/lib2/sub_mod/struct.Foo.html
+size: (1080, 600)
+// There should be two codeblocks: a rust one and a non-rust one.
+assert-count: (".docblock > .example-wrap", 2)
+assert: ".docblock > .example-wrap > .language-txt"
+assert: ".docblock > .example-wrap > .rust-example-rendered"
+assert-css: (".docblock > .example-wrap > pre", {"width": "796px", "overflow-x": "auto"}, ALL)

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 pub mod module {
     pub mod sub_module {
         pub mod sub_sub_module {
@@ -32,4 +34,16 @@ impl Trait for Foo {
     const Y: u32 = 0;
 }
 
+
 impl implementors::Whatever for Foo {}
+
+pub mod sub_mod {
+    /// ```txt
+    /// aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    /// ```
+    ///
+    /// ```
+    /// aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    /// ```
+    pub struct Foo;
+}


### PR DESCRIPTION
Fixes #87043.

Instead of completely relying on `pulldown-cmark` (and its potential changes), I decided to move the generation of codeblocks HTML directly in rustdoc so we can unify the DOM and the CSS classes.

r? @Nemo157 