### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -588,10 +588,17 @@ impl<'a, 'tcx> DeferredCallResolution<'tcx> {
                 fcx.write_method_call(self.call_expr.hir_id, method_callee);
             }
             None => {
-                span_bug!(
+                // This can happen if `#![no_core]` is used and the `fn/fn_mut/fn_once`
+                // lang items are not defined (issue #86238).
+                let mut err = fcx.inh.tcx.sess.struct_span_err(
                     self.call_expr.span,
-                    "failed to find an overloaded call trait for closure call"
+                    "failed to find an overloaded call trait for closure call",
                 );
+                err.help(
+                    "make sure the `fn`/`fn_mut`/`fn_once` lang items are defined \
+                     and have an associated `call`/`call_mut`/`call_once` function",
+                );
+                err.emit();
             }
         }
     }

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -596,7 +596,7 @@ impl<'a, 'tcx> DeferredCallResolution<'tcx> {
                 );
                 err.help(
                     "make sure the `fn`/`fn_mut`/`fn_once` lang items are defined \
-                     and have an associated `call`/`call_mut`/`call_once` function",
+                     and have associated `call`/`call_mut`/`call_once` functions",
                 );
                 err.emit();
             }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -12,7 +12,7 @@ impl bool {
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    #[unstable(feature = "bool_to_option", issue = "64260")]
+    #[unstable(feature = "bool_to_option", issue = "80967")]
     #[inline]
     pub fn then_some<T>(self, t: T) -> Option<T> {
         if self { Some(t) } else { None }

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -99,6 +99,10 @@ pub(crate) fn update_llvm_submodule(build: &Build) {
         t!(std::fs::read_dir(dir)).next().is_none()
     }
 
+    if !build.config.submodules {
+        return;
+    }
+
     // NOTE: The check for the empty directory is here because when running x.py
     // the first time, the llvm submodule won't be checked out. Check it out
     // now so we can build it.

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1,4 +1,4 @@
 % The Rust Reference has moved
 
 We've split up the reference into chapters. Please find it at its new
-home [here](reference/index.html).
+home [here](https://doc.rust-lang.org/stable/reference/introduction.html).

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -289,13 +289,6 @@ window.initSearch = function(rawSearchIndex) {
             };
         }
 
-        function getObjectNameFromId(id) {
-            if (typeof id === "number") {
-                return searchIndex[id].name;
-            }
-            return id;
-        }
-
         function checkGenerics(obj, val) {
             // The names match, but we need to be sure that all generics kinda
             // match as well.
@@ -306,10 +299,10 @@ window.initSearch = function(rawSearchIndex) {
                     var elems = Object.create(null);
                     var elength = obj[GENERICS_DATA].length;
                     for (var x = 0; x < elength; ++x) {
-                        if (!elems[getObjectNameFromId(obj[GENERICS_DATA][x])]) {
-                            elems[getObjectNameFromId(obj[GENERICS_DATA][x])] = 0;
+                        if (!elems[obj[GENERICS_DATA][x]]) {
+                            elems[obj[GENERICS_DATA][x]] = 0;
                         }
-                        elems[getObjectNameFromId(obj[GENERICS_DATA][x])] += 1;
+                        elems[obj[GENERICS_DATA][x]] += 1;
                     }
                     var total = 0;
                     var done = 0;
@@ -318,7 +311,7 @@ window.initSearch = function(rawSearchIndex) {
                     var vlength = val.generics.length;
                     for (x = 0; x < vlength; ++x) {
                         var lev = MAX_LEV_DISTANCE + 1;
-                        var firstGeneric = getObjectNameFromId(val.generics[x]);
+                        var firstGeneric = val.generics[x];
                         var match = null;
                         if (elems[firstGeneric]) {
                             match = firstGeneric;
@@ -361,16 +354,16 @@ window.initSearch = function(rawSearchIndex) {
                             var elems = Object.create(null);
                             len = obj[GENERICS_DATA].length;
                             for (x = 0; x < len; ++x) {
-                                if (!elems[getObjectNameFromId(obj[GENERICS_DATA][x])]) {
-                                    elems[getObjectNameFromId(obj[GENERICS_DATA][x])] = 0;
+                                if (!elems[obj[GENERICS_DATA][x]]) {
+                                    elems[obj[GENERICS_DATA][x]] = 0;
                                 }
-                                elems[getObjectNameFromId(obj[GENERICS_DATA][x])] += 1;
+                                elems[obj[GENERICS_DATA][x]] += 1;
                             }
 
                             var allFound = true;
                             len = val.generics.length;
                             for (x = 0; x < len; ++x) {
-                                firstGeneric = getObjectNameFromId(val.generics[x]);
+                                firstGeneric = val.generics[x];
                                 if (elems[firstGeneric]) {
                                     elems[firstGeneric] -= 1;
                                 } else {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -582,9 +582,9 @@ fn opts() -> Vec<RustcOptGroup> {
         unstable("test-builder", |o| {
             o.optopt("", "test-builder", "The rustc-like binary to use as the test builder", "PATH")
         }),
-        unstable("check", |o| o.optflag("", "check", "Run rustdoc checks")),
+        unstable("check", |o| o.optflagmulti("", "check", "Run rustdoc checks")),
         unstable("generate-redirect-map", |o| {
-            o.optflag(
+            o.optflagmulti(
                 "",
                 "generate-redirect-map",
                 "Generate JSON file at the top level instead of generating HTML redirection files",
@@ -598,9 +598,11 @@ fn opts() -> Vec<RustcOptGroup> {
                 "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific]",
             )
         }),
-        unstable("no-run", |o| o.optflag("", "no-run", "Compile doctests without running them")),
+        unstable("no-run", |o| {
+            o.optflagmulti("", "no-run", "Compile doctests without running them")
+        }),
         unstable("show-type-layout", |o| {
-            o.optflag("", "show-type-layout", "Include the memory layout of types in the docs")
+            o.optflagmulti("", "show-type-layout", "Include the memory layout of types in the docs")
         }),
     ]
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -269,9 +269,9 @@ fn opts() -> Vec<RustcOptGroup> {
     let stable: fn(_, fn(&mut getopts::Options) -> &mut _) -> _ = RustcOptGroup::stable;
     let unstable: fn(_, fn(&mut getopts::Options) -> &mut _) -> _ = RustcOptGroup::unstable;
     vec![
-        stable("h", |o| o.optflag("h", "help", "show this help message")),
-        stable("V", |o| o.optflag("V", "version", "print rustdoc's version")),
-        stable("v", |o| o.optflag("v", "verbose", "use verbose output")),
+        stable("h", |o| o.optflagmulti("h", "help", "show this help message")),
+        stable("V", |o| o.optflagmulti("V", "version", "print rustdoc's version")),
+        stable("v", |o| o.optflagmulti("v", "verbose", "use verbose output")),
         stable("r", |o| {
             o.optopt("r", "input-format", "the input type of the specified file", "[rust]")
         }),
@@ -309,14 +309,14 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         stable("plugins", |o| o.optmulti("", "plugins", "removed", "PLUGINS")),
-        stable("no-default", |o| o.optflag("", "no-defaults", "don't run the default passes")),
+        stable("no-default", |o| o.optflagmulti("", "no-defaults", "don't run the default passes")),
         stable("document-private-items", |o| {
-            o.optflag("", "document-private-items", "document private items")
+            o.optflagmulti("", "document-private-items", "document private items")
         }),
         unstable("document-hidden-items", |o| {
-            o.optflag("", "document-hidden-items", "document items that have doc(hidden)")
+            o.optflagmulti("", "document-hidden-items", "document items that have doc(hidden)")
         }),
-        stable("test", |o| o.optflag("", "test", "run code examples as tests")),
+        stable("test", |o| o.optflagmulti("", "test", "run code examples as tests")),
         stable("test-args", |o| {
             o.optmulti("", "test-args", "arguments to pass to the test runner", "ARGS")
         }),
@@ -386,7 +386,7 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optopt("", "markdown-playground-url", "URL to send code snippets to", "URL")
         }),
         stable("markdown-no-toc", |o| {
-            o.optflag("", "markdown-no-toc", "don't include table of contents")
+            o.optflagmulti("", "markdown-no-toc", "don't include table of contents")
         }),
         stable("e", |o| {
             o.optopt(
@@ -412,13 +412,13 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("display-warnings", |o| {
-            o.optflag("", "display-warnings", "to print code warnings when testing doc")
+            o.optflagmulti("", "display-warnings", "to print code warnings when testing doc")
         }),
         stable("crate-version", |o| {
             o.optopt("", "crate-version", "crate version to print into documentation", "VERSION")
         }),
         unstable("sort-modules-by-appearance", |o| {
-            o.optflag(
+            o.optflagmulti(
                 "",
                 "sort-modules-by-appearance",
                 "sort modules by where they appear in the program, rather than alphabetically",
@@ -495,7 +495,7 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optopt("", "json", "Configure the structure of JSON diagnostics", "CONFIG")
         }),
         unstable("disable-minification", |o| {
-            o.optflag("", "disable-minification", "Disable minification applied on JS files")
+            o.optflagmulti("", "disable-minification", "Disable minification applied on JS files")
         }),
         stable("warn", |o| o.optmulti("W", "warn", "Set lint warnings", "OPT")),
         stable("allow", |o| o.optmulti("A", "allow", "Set lint allowed", "OPT")),
@@ -523,7 +523,7 @@ fn opts() -> Vec<RustcOptGroup> {
             o.optopt("", "index-page", "Markdown file to be used as index page", "PATH")
         }),
         unstable("enable-index-page", |o| {
-            o.optflag("", "enable-index-page", "To enable generation of the index page")
+            o.optflagmulti("", "enable-index-page", "To enable generation of the index page")
         }),
         unstable("static-root-path", |o| {
             o.optopt(
@@ -535,7 +535,7 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("disable-per-crate-search", |o| {
-            o.optflag(
+            o.optflagmulti(
                 "",
                 "disable-per-crate-search",
                 "disables generating the crate selector on the search box",
@@ -550,14 +550,14 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("show-coverage", |o| {
-            o.optflag(
+            o.optflagmulti(
                 "",
                 "show-coverage",
                 "calculate percentage of public items with documentation",
             )
         }),
         unstable("enable-per-target-ignores", |o| {
-            o.optflag(
+            o.optflagmulti(
                 "",
                 "enable-per-target-ignores",
                 "parse ignore-foo for ignoring doctests on a per-target basis",

--- a/src/test/rustdoc/duplicate-flags.rs
+++ b/src/test/rustdoc/duplicate-flags.rs
@@ -1,0 +1,4 @@
+// compile-flags: --document-private-items --document-private-items
+
+// @has duplicate_flags/struct.Private.html
+struct Private;

--- a/src/test/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-to-andmut-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*s.pointer` which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:9:5
    |
 LL | fn a(s: &S) {
@@ -6,7 +6,7 @@ LL | fn a(s: &S) {
 LL |     *s.pointer += 1;
    |     ^^^^^^^^^^^^^^^ `s` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*s.pointer` which is behind a `&` reference
+error[E0594]: cannot assign to `*s.pointer`, which is behind a `&` reference
   --> $DIR/borrowck-assign-to-andmut-in-aliasable-loc.rs:17:5
    |
 LL | fn c(s: & &mut S) {

--- a/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-mut-base-ptr-in-aliasable-loc.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `**t1` which is behind a `&` reference
+error[E0594]: cannot assign to `**t1`, which is behind a `&` reference
   --> $DIR/borrowck-borrow-mut-base-ptr-in-aliasable-loc.rs:9:5
    |
 LL |     let t1 = t0;

--- a/src/test/ui/borrowck/borrowck-issue-14498.stderr
+++ b/src/test/ui/borrowck/borrowck-issue-14498.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `***p` which is behind a `&` reference
+error[E0594]: cannot assign to `***p`, which is behind a `&` reference
   --> $DIR/borrowck-issue-14498.rs:16:5
    |
 LL |     let p = &y;

--- a/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
+++ b/src/test/ui/borrowck/issue-69789-iterator-mut-suggestion.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*item` which is behind a `&` reference
+error[E0594]: cannot assign to `*item`, which is behind a `&` reference
   --> $DIR/issue-69789-iterator-mut-suggestion.rs:7:9
    |
 LL |     for item in &mut std::iter::empty::<&'static ()>() {

--- a/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
+++ b/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.rs
@@ -9,7 +9,7 @@ fn main() {
     for v in Query.iter_mut() {
         //~^ NOTE this iterator yields `&` references
         *v -= 1;
-        //~^ ERROR cannot assign to `*v` which is behind a `&` reference
+        //~^ ERROR cannot assign to `*v`, which is behind a `&` reference
         //~| NOTE `v` is a `&` reference, so the data it refers to cannot be written
     }
 }

--- a/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
+++ b/src/test/ui/borrowck/issue-83309-ice-immut-in-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*v` which is behind a `&` reference
+error[E0594]: cannot assign to `*v`, which is behind a `&` reference
   --> $DIR/issue-83309-ice-immut-in-for-loop.rs:11:9
    |
 LL |     for v in Query.iter_mut() {

--- a/src/test/ui/borrowck/issue-85765.rs
+++ b/src/test/ui/borrowck/issue-85765.rs
@@ -5,4 +5,11 @@ fn main() {
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
     //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+
+    let mut mutvar = 42;
+    let r = &mutvar;
+    //~^ HELP consider changing this to be a mutable reference
+    *r = 0;
+    //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
+    //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
 }

--- a/src/test/ui/borrowck/issue-85765.stderr
+++ b/src/test/ui/borrowck/issue-85765.stderr
@@ -7,6 +7,16 @@ LL |
 LL |     rofl.push(Vec::new());
    |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
-error: aborting due to previous error
+error[E0594]: cannot assign to `*r`, which is behind a `&` reference
+  --> $DIR/issue-85765.rs:12:5
+   |
+LL |     let r = &mutvar;
+   |             ------- help: consider changing this to be a mutable reference: `&mut mutvar`
+LL |
+LL |     *r = 0;
+   |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
 
-For more information about this error, try `rustc --explain E0596`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/borrowck/mutability-errors.stderr
+++ b/src/test/ui/borrowck/mutability-errors.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:9:5
    |
 LL | fn named_ref(x: &(i32,)) {
@@ -6,7 +6,7 @@ LL | fn named_ref(x: &(i32,)) {
 LL |     *x = (1,);
    |     ^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `x.0` which is behind a `&` reference
+error[E0594]: cannot assign to `x.0`, which is behind a `&` reference
   --> $DIR/mutability-errors.rs:10:5
    |
 LL | fn named_ref(x: &(i32,)) {
@@ -57,7 +57,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |     &mut f().0;
    |     ^^^^^^^^^^ cannot borrow as mutable
 
-error[E0594]: cannot assign to `*x` which is behind a `*const` pointer
+error[E0594]: cannot assign to `*x`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:23:5
    |
 LL | unsafe fn named_ptr(x: *const (i32,)) {
@@ -65,7 +65,7 @@ LL | unsafe fn named_ptr(x: *const (i32,)) {
 LL |     *x = (1,);
    |     ^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `x.0` which is behind a `*const` pointer
+error[E0594]: cannot assign to `x.0`, which is behind a `*const` pointer
   --> $DIR/mutability-errors.rs:24:5
    |
 LL | unsafe fn named_ptr(x: *const (i32,)) {

--- a/src/test/ui/did_you_mean/issue-39544.rs
+++ b/src/test/ui/did_you_mean/issue-39544.rs
@@ -46,5 +46,5 @@ pub fn with_tuple() {
     let mut y = 0;
     let x = (&y,);
     *x.0 = 1;
-    //~^ ERROR cannot assign to `*x.0` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*x.0`, which is behind a `&` reference
 }

--- a/src/test/ui/did_you_mean/issue-39544.stderr
+++ b/src/test/ui/did_you_mean/issue-39544.stderr
@@ -90,7 +90,7 @@ LL |     let _ = &mut z.x;
 LL |     let _ = &mut w.x;
    |             ^^^^^^^^ `w` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
-error[E0594]: cannot assign to `*x.0` which is behind a `&` reference
+error[E0594]: cannot assign to `*x.0`, which is behind a `&` reference
   --> $DIR/issue-39544.rs:48:5
    |
 LL |     *x.0 = 1;

--- a/src/test/ui/error-codes/E0389.rs
+++ b/src/test/ui/error-codes/E0389.rs
@@ -5,6 +5,6 @@ struct FancyNum {
 fn main() {
     let mut fancy = FancyNum{ num: 5 };
     let fancy_ref = &(&mut fancy);
-    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num` which is behind a `&` reference
+    fancy_ref.num = 6; //~ ERROR cannot assign to `fancy_ref.num`, which is behind a `&` reference
     println!("{}", fancy_ref.num);
 }

--- a/src/test/ui/error-codes/E0389.stderr
+++ b/src/test/ui/error-codes/E0389.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num` which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/E0389.rs:8:5
    |
 LL |     let fancy_ref = &(&mut fancy);

--- a/src/test/ui/issues/issue-51244.rs
+++ b/src/test/ui/issues/issue-51244.rs
@@ -1,4 +1,4 @@
 fn main() {
     let ref my_ref @ _ = 0;
-    *my_ref = 0; //~ ERROR cannot assign to `*my_ref` which is behind a `&` reference [E0594]
+    *my_ref = 0; //~ ERROR cannot assign to `*my_ref`, which is behind a `&` reference [E0594]
 }

--- a/src/test/ui/issues/issue-51244.stderr
+++ b/src/test/ui/issues/issue-51244.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
+error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     let ref my_ref @ _ = 0;

--- a/src/test/ui/issues/issue-51515.rs
+++ b/src/test/ui/issues/issue-51515.rs
@@ -3,10 +3,10 @@ fn main() {
     //~^ HELP consider changing this to be a mutable reference
     //~| SUGGESTION &mut 16
     *foo = 32;
-    //~^ ERROR cannot assign to `*foo` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*foo`, which is behind a `&` reference
     let bar = foo;
     //~^ HELP consider changing this to be a mutable reference
     //~| SUGGESTION &mut i32
     *bar = 64;
-    //~^ ERROR cannot assign to `*bar` which is behind a `&` reference
+    //~^ ERROR cannot assign to `*bar`, which is behind a `&` reference
 }

--- a/src/test/ui/issues/issue-51515.stderr
+++ b/src/test/ui/issues/issue-51515.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*foo` which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:5:5
    |
 LL |     let foo = &16;
@@ -7,7 +7,7 @@ LL |     let foo = &16;
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*bar` which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/issue-51515.rs:10:5
    |
 LL |     let bar = foo;

--- a/src/test/ui/lang-items/issue-86238.rs
+++ b/src/test/ui/lang-items/issue-86238.rs
@@ -1,0 +1,16 @@
+// Regression test for the ICE described in issue #86238.
+
+#![feature(lang_items)]
+#![feature(no_core)]
+
+#![no_core]
+fn main() {
+    let one = || {};
+    one()
+    //~^ ERROR: failed to find an overloaded call trait for closure call
+    //~| HELP: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined
+}
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}

--- a/src/test/ui/lang-items/issue-86238.stderr
+++ b/src/test/ui/lang-items/issue-86238.stderr
@@ -1,0 +1,10 @@
+error: failed to find an overloaded call trait for closure call
+  --> $DIR/issue-86238.rs:9:5
+   |
+LL |     one()
+   |     ^^^^^
+   |
+   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have an associated `call`/`call_mut`/`call_once` function
+
+error: aborting due to previous error
+

--- a/src/test/ui/lang-items/issue-86238.stderr
+++ b/src/test/ui/lang-items/issue-86238.stderr
@@ -4,7 +4,7 @@ error: failed to find an overloaded call trait for closure call
 LL |     one()
    |     ^^^^^
    |
-   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have an associated `call`/`call_mut`/`call_once` function
+   = help: make sure the `fn`/`fn_mut`/`fn_once` lang items are defined and have associated `call`/`call_mut`/`call_once` functions
 
 error: aborting due to previous error
 

--- a/src/test/ui/mut/mutable-class-fields-2.stderr
+++ b/src/test/ui/mut/mutable-class-fields-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.how_hungry` which is behind a `&` reference
+error[E0594]: cannot assign to `self.how_hungry`, which is behind a `&` reference
   --> $DIR/mutable-class-fields-2.rs:9:5
    |
 LL |   pub fn eat(&self) {

--- a/src/test/ui/nll/issue-47388.stderr
+++ b/src/test/ui/nll/issue-47388.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `fancy_ref.num` which is behind a `&` reference
+error[E0594]: cannot assign to `fancy_ref.num`, which is behind a `&` reference
   --> $DIR/issue-47388.rs:8:5
    |
 LL |     let fancy_ref = &(&mut fancy);

--- a/src/test/ui/nll/issue-51244.rs
+++ b/src/test/ui/nll/issue-51244.rs
@@ -1,5 +1,5 @@
 fn main() {
     let ref my_ref @ _ = 0;
     *my_ref = 0;
-    //~^ ERROR cannot assign to `*my_ref` which is behind a `&` reference [E0594]
+    //~^ ERROR cannot assign to `*my_ref`, which is behind a `&` reference [E0594]
 }

--- a/src/test/ui/nll/issue-51244.stderr
+++ b/src/test/ui/nll/issue-51244.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*my_ref` which is behind a `&` reference
+error[E0594]: cannot assign to `*my_ref`, which is behind a `&` reference
   --> $DIR/issue-51244.rs:3:5
    |
 LL |     let ref my_ref @ _ = 0;

--- a/src/test/ui/nll/issue-57989.rs
+++ b/src/test/ui/nll/issue-57989.rs
@@ -2,7 +2,7 @@
 
 fn f(x: &i32) {
     let g = &x;
-    *x = 0;     //~ ERROR cannot assign to `*x` which is behind a `&` reference
+    *x = 0;     //~ ERROR cannot assign to `*x`, which is behind a `&` reference
                 //~| ERROR cannot assign to `*x` because it is borrowed
     g;
 }

--- a/src/test/ui/nll/issue-57989.stderr
+++ b/src/test/ui/nll/issue-57989.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/issue-57989.rs:5:5
    |
 LL | fn f(x: &i32) {

--- a/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
+++ b/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
@@ -23,8 +23,8 @@ fn tuple() {
     _x1 = U; //~ ERROR cannot assign twice to immutable variable
     let _x0_hold = &mut tup.0; //~ ERROR cannot borrow `tup.0` as mutable because it is also
     let (ref mut _x0_hold, ..) = tup; //~ ERROR cannot borrow `tup.0` as mutable because it is also
-    *_x0 = U; //~ ERROR cannot assign to `*_x0` which is behind a `&` reference
-    *_x2 = U; //~ ERROR cannot assign to `*_x2` which is behind a `&` reference
+    *_x0 = U; //~ ERROR cannot assign to `*_x0`, which is behind a `&` reference
+    *_x2 = U; //~ ERROR cannot assign to `*_x2`, which is behind a `&` reference
     drop(tup.1); //~ ERROR use of moved value: `tup.1`
     let _x1_hold = &tup.1; //~ ERROR borrow of moved value: `tup.1`
     let (.., ref mut _x3) = tup;

--- a/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/src/test/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -101,7 +101,7 @@ LL |     let (ref mut _x0_hold, ..) = tup;
 LL |     *_x0 = U;
    |     -------- immutable borrow later used here
 
-error[E0594]: cannot assign to `*_x0` which is behind a `&` reference
+error[E0594]: cannot assign to `*_x0`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:26:5
    |
 LL |     let (ref _x0, _x1, ref _x2, ..) = tup;
@@ -110,7 +110,7 @@ LL |     let (ref _x0, _x1, ref _x2, ..) = tup;
 LL |     *_x0 = U;
    |     ^^^^^^^^ `_x0` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*_x2` which is behind a `&` reference
+error[E0594]: cannot assign to `*_x2`, which is behind a `&` reference
   --> $DIR/borrowck-move-ref-pattern.rs:27:5
    |
 LL |     let (ref _x0, _x1, ref _x2, ..) = tup;

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.rs
@@ -6,17 +6,17 @@ use Wrapper::Wrap;
 
 pub fn main() {
     let Wrap(x) = &Wrap(3);
-    *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+    *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
 
 
     if let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
     } else {
         panic!();
     }
 
     while let Some(x) = &Some(3) {
-        *x += 1; //~ ERROR cannot assign to `*x` which is behind a `&` reference
+        *x += 1; //~ ERROR cannot assign to `*x`, which is behind a `&` reference
         break;
     }
 }

--- a/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/enum.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:9:5
    |
 LL |     *x += 1;
    |     ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:13:9
    |
 LL |         *x += 1;
    |         ^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*x` which is behind a `&` reference
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
   --> $DIR/enum.rs:19:9
    |
 LL |         *x += 1;

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.rs
@@ -4,7 +4,7 @@
 fn main() {
     match &&Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},
@@ -12,7 +12,7 @@ fn main() {
 
     match &mut &Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},
@@ -20,7 +20,7 @@ fn main() {
 
     match &&mut Some(5i32) {
         Some(n) => {
-            *n += 1; //~ ERROR cannot assign to `*n` which is behind a `&` reference
+            *n += 1; //~ ERROR cannot assign to `*n`, which is behind a `&` reference
             let _ = n;
         }
         None => {},

--- a/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/explicit-mut.stderr
@@ -1,16 +1,16 @@
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:7:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:15:13
    |
 LL |             *n += 1;
    |             ^^^^^^^ `n` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*n` which is behind a `&` reference
+error[E0594]: cannot assign to `*n`, which is behind a `&` reference
   --> $DIR/explicit-mut.rs:23:13
    |
 LL |             *n += 1;

--- a/src/test/ui/suggestions/issue-68049-1.stderr
+++ b/src/test/ui/suggestions/issue-68049-1.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-1.rs:7:9
    |
 LL |         self.0 += 1;

--- a/src/test/ui/suggestions/issue-68049-2.stderr
+++ b/src/test/ui/suggestions/issue-68049-2.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `*input` which is behind a `&` reference
+error[E0594]: cannot assign to `*input`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:9:7
    |
 LL |   fn example(&self, input: &i32); // should suggest here
@@ -7,7 +7,7 @@ LL |   fn example(&self, input: &i32); // should suggest here
 LL |       *input = self.0;
    |       ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/issue-68049-2.rs:17:5
    |
 LL |   fn example(&self, input: &i32); // should suggest here

--- a/src/test/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/src/test/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `t.v` which is behind a `&` reference
+error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop.rs:14:9
    |
 LL |     for mut t in buzz.values() {

--- a/src/test/ui/suggestions/suggest-ref-mut.stderr
+++ b/src/test/ui/suggestions/suggest-ref-mut.stderr
@@ -1,4 +1,4 @@
-error[E0594]: cannot assign to `self.0` which is behind a `&` reference
+error[E0594]: cannot assign to `self.0`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:7:9
    |
 LL |     fn zap(&self) {
@@ -7,7 +7,7 @@ LL |     fn zap(&self) {
 LL |         self.0 = 32;
    |         ^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*foo` which is behind a `&` reference
+error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:16:5
    |
 LL |     let ref foo = 16;
@@ -16,7 +16,7 @@ LL |     let ref foo = 16;
 LL |     *foo = 32;
    |     ^^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*bar` which is behind a `&` reference
+error[E0594]: cannot assign to `*bar`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:21:9
    |
 LL |     if let Some(ref bar) = Some(16) {
@@ -25,7 +25,7 @@ LL |     if let Some(ref bar) = Some(16) {
 LL |         *bar = 32;
    |         ^^^^^^^^^ `bar` is a `&` reference, so the data it refers to cannot be written
 
-error[E0594]: cannot assign to `*quo` which is behind a `&` reference
+error[E0594]: cannot assign to `*quo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:25:22
    |
 LL |         ref quo => { *quo = 32; },


### PR DESCRIPTION
Successful merges:

 - #73936 (Rustdoc: Change all 'optflag' arguments to 'optflagmulti')
 - #86249 (Report an error if resolution of closure call functions failed)
 - #86815 (Improve error reporting for modifications behind `&` references)
 - #87031 (Update reference.md)
 - #87037 (cleanup(rustdoc): remove unused function getObjectNameById)
 - #87045 (Fix tracking issue for `bool_to_option`)
 - #87049 (Account for `submodules = false` in config.toml when updating LLVM submodule)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=73936,86249,86815,87031,87037,87045,87049)
<!-- homu-ignore:end -->