### PR TITLE
Do not suggest adding a semicolon after `?`

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1456,11 +1456,15 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 expected.is_unit(),
                 pointing_at_return_type,
             ) {
-                // If the block is from an external macro, then do not suggest
-                // adding a semicolon, because there's nowhere to put it.
-                // See issue #81943.
+                // If the block is from an external macro or try (`?`) desugaring, then
+                // do not suggest adding a semicolon, because there's nowhere to put it.
+                // See issues #81943 and #87051.
                 if cond_expr.span.desugaring_kind().is_none()
                     && !in_external_macro(fcx.tcx.sess, cond_expr.span)
+                    && !matches!(
+                        cond_expr.kind,
+                        hir::ExprKind::Match(.., hir::MatchSource::TryDesugar)
+                    )
                 {
                     err.span_label(cond_expr.span, "expected this to be `()`");
                     if expr.can_have_side_effects() {

--- a/src/test/ui/suggestions/try-operator-dont-suggest-semicolon.rs
+++ b/src/test/ui/suggestions/try-operator-dont-suggest-semicolon.rs
@@ -1,0 +1,27 @@
+// Regression test for #87051, where a double semicolon was erroneously
+// suggested after a `?` operator.
+
+fn main() -> Result<(), ()> {
+    a(|| {
+        b()
+        //~^ ERROR: mismatched types [E0308]
+        //~| NOTE: expected `()`, found `i32`
+        //~| HELP: consider using a semicolon here
+    })?;
+
+    // Here, we do want to suggest a semicolon:
+    let x = Ok(42);
+    if true {
+    //~^ NOTE: expected this to be `()`
+        x?
+        //~^ ERROR: mismatched types [E0308]
+        //~| NOTE: expected `()`, found integer
+        //~| HELP: consider using a semicolon here
+    }
+    //~^ HELP: consider using a semicolon here
+
+    Ok(())
+}
+
+fn a<F>(f: F) -> Result<(), ()> where F: FnMut() { Ok(()) }
+fn b() -> i32 { 42 }

--- a/src/test/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
+++ b/src/test/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/try-operator-dont-suggest-semicolon.rs:6:9
+   |
+LL |         b()
+   |         ^^^- help: consider using a semicolon here: `;`
+   |         |
+   |         expected `()`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/try-operator-dont-suggest-semicolon.rs:16:9
+   |
+LL | /     if true {
+LL | |
+LL | |         x?
+   | |         ^^ expected `()`, found integer
+LL | |
+LL | |
+LL | |
+LL | |     }
+   | |_____- expected this to be `()`
+   |
+help: consider using a semicolon here
+   |
+LL |         x?;
+   |           ^
+help: consider using a semicolon here
+   |
+LL |     };
+   |      ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #87051. I have only modified `report_return_mismatched_types()`, i.e. my changes only affect suggestions to add `;` for return type mismatches, but this never makes sense after `?`, because the function cannot return `()` if `?` is used (it has to return a `Result` or an `Option`), and a semicolon won't help if the expected and actual `Err` types differ, even if the expected one is `()`.