### PR TITLE
Fix multiple-definitions test

### DIFF
--- a/src/test/ui/rfc-2627-raw-dylib/multiple-definitions.stderr
+++ b/src/test/ui/rfc-2627-raw-dylib/multiple-definitions.stderr
@@ -10,8 +10,7 @@ LL | #![feature(raw_dylib)]
 error: multiple definitions of external function `f` from library `foo.dll` have different calling conventions
   --> $DIR/multiple-definitions.rs:8:5
    |
-LL |     fn f(x: i32);
-   |     ^^^^^^^^^^^^^
+LL |         fn f(x: i32);
 
 error: aborting due to previous error; 1 warning emitted
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/86419#issuecomment-877848693

This test fails and blocks merging these PRs: (tell bors to retry them after this lands)
#86922 #86857 

r? @joshtriplett 
