### PR TITLE
Rustdoc: suggest removing disambiguator if linking to field

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1610,6 +1610,8 @@ impl Disambiguator {
             return Suggestion::Macro;
         } else if kind == DefKind::Fn || kind == DefKind::AssocFn {
             return Suggestion::Function;
+        } else if kind == DefKind::Field {
+            return Suggestion::RemoveDisambiguator;
         }
 
         let prefix = match kind {
@@ -1674,6 +1676,8 @@ enum Suggestion {
     Function,
     /// `m!`
     Macro,
+    /// `foo` without any disambiguator
+    RemoveDisambiguator,
 }
 
 impl Suggestion {
@@ -1682,6 +1686,7 @@ impl Suggestion {
             Self::Prefix(x) => format!("prefix with `{}@`", x).into(),
             Self::Function => "add parentheses".into(),
             Self::Macro => "add an exclamation mark".into(),
+            Self::RemoveDisambiguator => "remove the disambiguator".into(),
         }
     }
 
@@ -1691,6 +1696,7 @@ impl Suggestion {
             Self::Prefix(prefix) => format!("{}@{}", prefix, path_str),
             Self::Function => format!("{}()", path_str),
             Self::Macro => format!("{}!", path_str),
+            Self::RemoveDisambiguator => path_str.into(),
         }
     }
 }

--- a/src/test/rustdoc-ui/intra-doc/field-ice.rs
+++ b/src/test/rustdoc-ui/intra-doc/field-ice.rs
@@ -1,0 +1,11 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+//~^NOTE the lint level is defined here
+
+/// [`Foo::bar`]
+/// [`Foo::bar()`]
+//~^ERROR incompatible link kind for `Foo::bar`
+//~|HELP to link to the field, remove the disambiguator
+//~|NOTE this link resolved to a field, which is not a function
+pub struct Foo {
+    pub bar: u8
+}

--- a/src/test/rustdoc-ui/intra-doc/field-ice.stderr
+++ b/src/test/rustdoc-ui/intra-doc/field-ice.stderr
@@ -1,0 +1,15 @@
+error: incompatible link kind for `Foo::bar`
+  --> $DIR/field-ice.rs:5:6
+   |
+LL | /// [`Foo::bar()`]
+   |      ^^^^^^^^^^^^ help: to link to the field, remove the disambiguator: ``Foo::bar``
+   |
+note: the lint level is defined here
+  --> $DIR/field-ice.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this link resolved to a field, which is not a function
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This fixes #85615.

@rustbot label T-rustdoc