### PR TITLE
Handle non-integer const generic parameters in debuginfo type names.

### DIFF
--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -33,6 +33,13 @@
 // Generator
 // Generators don't seem to appear in GDB's symbol table.
 
+// Const generic parameter
+// gdb-command:info functions -q function_names::const_generic_fn.*
+// gdb-check:[...]static fn function_names::const_generic_fn_bool();
+// gdb-check:[...]static fn function_names::const_generic_fn_non_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_signed_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int();
+
 // === CDB TESTS ===================================================================================
 
 // Top-level function
@@ -49,9 +56,9 @@
 
 // Trait implementations
 // cdb-command:x a!function_names::*::trait_function*
-// cdb-check:[...] a!function_names::impl$6::trait_function<i32, 0x1> (void)
 // cdb-check:[...] a!function_names::impl$3::trait_function<i32> (void)
 // cdb-check:[...] a!function_names::impl$1::trait_function (void)
+// cdb-check:[...] a!function_names::impl$6::trait_function<i32, 1> (void)
 // cdb-check:[...] a!function_names::impl$5::trait_function3<function_names::TestStruct1> (void)
 // cdb-check:[...] a!function_names::Mod1::impl$1::trait_function (void)
 
@@ -65,10 +72,18 @@
 // cdb-command:x a!function_names::*::generator*
 // cdb-check:[...] a!function_names::main::generator$1 (void)
 
+// Const generic parameter
+// cdb-command:x a!function_names::const_generic_fn*
+// cdb-check:[...] a!function_names::const_generic_fn_bool<false> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_non_int<CONST$fe3cfa0214ac55c7> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_unsigned_int<14> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_signed_int<-7> (void)
+
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![feature(generators, generator_trait)]
+#![feature(const_generics, generators, generator_trait)]
+#![allow(incomplete_features)] // for const_generics
 
 use Mod1::TestTrait2;
 use std::ops::Generator;
@@ -97,6 +112,12 @@ fn main() {
     // Generator
     let mut generator = || { yield; return; };
     Pin::new(&mut generator).resume(());
+
+    // Const generic functions
+    const_generic_fn_bool::<false>();
+    const_generic_fn_non_int::<{()}>();
+    const_generic_fn_signed_int::<-7>();
+    const_generic_fn_unsigned_int::<14>();
 }
 
 struct TestStruct1;
@@ -173,3 +194,8 @@ fn generic_func<T>(value: T) -> T {
 
     value
 }
+
+fn const_generic_fn_bool<const C: bool>() {}
+fn const_generic_fn_non_int<const C: ()>() {}
+fn const_generic_fn_signed_int<const C: i64>() {}
+fn const_generic_fn_unsigned_int<const C: u32>() {}


### PR DESCRIPTION
This PR fixes an ICE introduced by https://github.com/rust-lang/rust/pull/85269 which started emitting const generic arguments for debuginfo names but did not cover the case where such an argument could not be evaluated to a flat string of bits.

The fix implemented in this PR is very basic: If `try_eval_bits()` fails for the constant in question, we fall back to generating a stable hash of the constant and emit that instead. This way we get a (virtually) unique name and side step the problem of generating a string representation of a potentially complex value.

The downside is that the generated name will be rather opaque. E.g. the regression test adds a function `const_generic_fn_non_int<()>` which is then rendered as `const_generic_fn_non_int<{CONST#fe3cfa0214ac55c7}>`. I think it's an open question how to deal with this more gracefully.

I'd be interested in ideas on how to do this better.

r? @wesleywiser 

cc @dpaoliello (do you see any problems with this approach?)
cc @Mark-Simulacrum & @nagisa (who I've seen comment on debuginfo issues recently -- anyone else?)

Fixes https://github.com/rust-lang/rust/issues/86893