### PR TITLE
Avoid cloning ExpnData to access Span edition

### DIFF
--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -644,7 +644,7 @@ impl SyntaxContext {
     }
 
     pub fn edition(self) -> Edition {
-        self.outer_expn_data().edition
+        HygieneData::with(|data| data.expn_data(data.outer_expn(self)).edition)
     }
 }
 


### PR DESCRIPTION
ExpnData is a fairly hefty structure to clone; cloning it may not be cheap. In
some cases this may get optimized out, but it's not clear that will always be
the case. Try to avoid that cost.

r? @ghost -- opening for a perf run to start with