### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -9,7 +9,7 @@ test = false
 
 [dependencies]
 bitflags = "1.2.1"
-cc = "1.0.68"
+cc = "1.0.69"
 itertools = "0.9"
 tracing = "0.1"
 libc = "0.2.50"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -13,4 +13,4 @@ libc = "0.2.73"
 
 [build-dependencies]
 build_helper = { path = "../../src/build_helper" }
-cc = "1.0.68"
+cc = "1.0.69"

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -903,8 +903,8 @@ impl<T> BTreeSet<T> {
         self.map.append(&mut other.map);
     }
 
-    /// Splits the collection into two at the given key. Returns everything after the given key,
-    /// including the key.
+    /// Splits the collection into two at the given value. Returns everything after the given value,
+    /// including the value.
     ///
     /// # Examples
     ///
@@ -933,11 +933,11 @@ impl<T> BTreeSet<T> {
     /// assert!(b.contains(&41));
     /// ```
     #[stable(feature = "btree_split_off", since = "1.11.0")]
-    pub fn split_off<Q: ?Sized + Ord>(&mut self, key: &Q) -> Self
+    pub fn split_off<Q: ?Sized + Ord>(&mut self, value: &Q) -> Self
     where
         T: Borrow<Q> + Ord,
     {
-        BTreeSet { map: self.map.split_off(key) }
+        BTreeSet { map: self.map.split_off(value) }
     }
 
     /// Creates an iterator that visits all values in ascending order and uses a closure

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -14,4 +14,4 @@ core = { path = "../core" }
 compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
-cc = "1.0.68"
+cc = "1.0.69"

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -21,7 +21,7 @@ compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"
 
 [build-dependencies]
-cc = "1.0.68"
+cc = "1.0.69"
 
 [features]
 

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -40,7 +40,7 @@ cmake = "0.1.38"
 filetime = "0.2"
 num_cpus = "1.0"
 getopts = "0.2.19"
-cc = "1.0.68"
+cc = "1.0.69"
 libc = "0.2"
 serde = { version = "1.0.8", features = ["derive"] }
 serde_json = "1.0.2"

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -161,7 +161,7 @@ pre, .rustdoc.source .example-wrap {
 .search-results a {
 	color: #0096cf;
 }
-.search-results a span.desc {
+.search-results a div.desc {
 	color: #c5c5c5;
 }
 

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -286,7 +286,7 @@ details.undocumented > summary::before {
 	color: grey;
 }
 
-tr.result span.primitive::after, tr.result span.keyword::after {
+.result-name .primitive > i, .result-name .keyword > i {
 	color: #788797;
 }
 

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -247,7 +247,7 @@ details.undocumented > summary::before {
 	color: grey;
 }
 
-tr.result span.primitive::after, tr.result span.keyword::after {
+.result-name .primitive > i, .result-name .keyword > i {
 	color: #ddd;
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -237,7 +237,7 @@ details.undocumented > summary::before {
 	color: grey;
 }
 
-tr.result span.primitive::after, tr.result span.keyword::after {
+.result-name .primitive > i, .result-name .keyword > i {
 	color: black;
 }
 

--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -33,6 +33,13 @@
 // Generator
 // Generators don't seem to appear in GDB's symbol table.
 
+// Const generic parameter
+// gdb-command:info functions -q function_names::const_generic_fn.*
+// gdb-check:[...]static fn function_names::const_generic_fn_bool();
+// gdb-check:[...]static fn function_names::const_generic_fn_non_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_signed_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int();
+
 // === CDB TESTS ===================================================================================
 
 // Top-level function
@@ -65,10 +72,18 @@
 // cdb-command:x a!function_names::*::generator*
 // cdb-check:[...] a!function_names::main::generator$1 (void)
 
+// Const generic parameter
+// cdb-command:x a!function_names::const_generic_fn*
+// cdb-check:[...] a!function_names::const_generic_fn_bool<false> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_non_int<CONST$fe3cfa0214ac55c7> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_signed_int<-7> (void)
+// cdb-check:[...] a!function_names::const_generic_fn_unsigned_int<14> (void)
+
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
-#![feature(generators, generator_trait)]
+#![feature(const_generics, generators, generator_trait)]
+#![allow(incomplete_features)] // for const_generics
 
 use Mod1::TestTrait2;
 use std::ops::Generator;
@@ -97,6 +112,12 @@ fn main() {
     // Generator
     let mut generator = || { yield; return; };
     Pin::new(&mut generator).resume(());
+
+    // Const generic functions
+    const_generic_fn_bool::<false>();
+    const_generic_fn_non_int::<{()}>();
+    const_generic_fn_signed_int::<-7>();
+    const_generic_fn_unsigned_int::<14>();
 }
 
 struct TestStruct1;
@@ -173,3 +194,8 @@ fn generic_func<T>(value: T) -> T {
 
     value
 }
+
+fn const_generic_fn_bool<const C: bool>() {}
+fn const_generic_fn_non_int<const C: ()>() {}
+fn const_generic_fn_signed_int<const C: i64>() {}
+fn const_generic_fn_unsigned_int<const C: u32>() {}

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -13,6 +13,9 @@ wait-for: "#titles"
 assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(197, 197, 197)"})
 assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 150, 207)"})
 
+// Checking the color for "keyword".
+assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(120, 135, 151)"})
+
 // Dark theme
 local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
 reload:
@@ -22,6 +25,9 @@ wait-for: "#titles"
 assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(221, 221, 221)"})
 assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(221, 221, 221)"})
 
+// Checking the color for "keyword".
+assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(221, 221, 221)"})
+
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 reload:
@@ -30,3 +36,6 @@ reload:
 wait-for: "#titles"
 assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(0, 0, 0)"})
 assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 0, 0)"})
+
+// Checking the color for "keyword".
+assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(0, 0, 0)"})

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -1,0 +1,32 @@
+// The goal of this test is to ensure the color of the text is the one expected.
+goto: file://|DOC_PATH|/test_docs/index.html?search=coo
+
+// This is needed so that the text color is computed.
+show-text: true
+
+// Ayu theme
+local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+reload:
+
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(197, 197, 197)"})
+assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 150, 207)"})
+
+// Dark theme
+local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+reload:
+
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(221, 221, 221)"})
+assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(221, 221, 221)"})
+
+// Light theme
+local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
+reload:
+
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(0, 0, 0)"})
+assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 0, 0)"})

--- a/src/test/rustdoc-gui/search-result-go-to-first.goml
+++ b/src/test/rustdoc-gui/search-result-go-to-first.goml
@@ -1,0 +1,20 @@
+// This test ensures that the "go_to_first" feature is working as expected.
+
+// First, we check that the first page doesn't have the string we're looking for to ensure
+// that the feature is changing page as expected.
+goto: file://|DOC_PATH|/test_docs/index.html
+assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+
+// We now check that we land on the search result page if "go_to_first" isn't set.
+goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert-text-false: (".fqn .in-band", "Struct test_docs::Foo")
+// Ensure that the search results are displayed, not the "normal" content.
+assert-css: ("#main", {"display": "none"})
+
+// Now we can check that the feature is working as expected!
+goto: file://|DOC_PATH|/test_docs/index.html?search=struct%3AFoo&go_to_first=true
+// Waiting for the page to load...
+wait-for: 500
+assert-text: (".fqn .in-band", "Struct test_docs::Foo")

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -101,6 +101,7 @@ pub enum AnEnum {
 }
 
 #[doc(keyword = "CookieMonster")]
+/// Some keyword.
 pub mod keyword {}
 
 /// Just some type alias.

--- a/src/test/ui/issues/issue-20427.rs
+++ b/src/test/ui/issues/issue-20427.rs
@@ -7,7 +7,6 @@
 #![allow(deprecated, deprecated_in_future)]
 
 // aux-build:i8.rs
-// ignore-pretty issue #37201
 
 extern crate i8;
 use std::string as i16;

--- a/src/test/ui/issues/issue-22992.rs
+++ b/src/test/ui/issues/issue-22992.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-pretty issue #37201
 
 struct X { val: i32 }
 impl std::ops::Deref for X {

--- a/src/test/ui/issues/issue-23338-ensure-param-drop-order.rs
+++ b/src/test/ui/issues/issue-23338-ensure-param-drop-order.rs
@@ -1,8 +1,6 @@
 // run-pass
 #![allow(non_upper_case_globals)]
 
-// ignore-pretty issue #37201
-
 // This test is ensuring that parameters are indeed dropped after
 // temporaries in a fn body.
 

--- a/src/test/ui/issues/issue-27401-dropflag-reinit.rs
+++ b/src/test/ui/issues/issue-27401-dropflag-reinit.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-pretty issue #37201
 
 // Check that when a `let`-binding occurs in a loop, its associated
 // drop-flag is reinitialized (to indicate "needs-drop" at the end of


### PR DESCRIPTION
Successful merges:

 - #87082 (Handle non-integer const generic parameters in debuginfo type names.)
 - #87085 (Search result colors)
 - #87090 (Make BTreeSet::split_off name elements like other set methods do)
 - #87098 (Unignore some pretty printing tests)
 - #87099 (Upgrade `cc` crate to 1.0.69)
 - #87102 (Add GUI test for "go to first" feature)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87082,87085,87090,87098,87099,87102)
<!-- homu-ignore:end -->