### PR TITLE
Warn about useless assignments of variables/fields to themselves

### DIFF
--- a/src/test/ui/issues/issue-3290.rs
+++ b/src/test/ui/issues/issue-3290.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![feature(box_syntax)]
+#![allow(dead_code)]
 
 pub fn main() {
    let mut x: Box<_> = box 3;

--- a/src/test/ui/lint/dead-code/self-assign.rs
+++ b/src/test/ui/lint/dead-code/self-assign.rs
@@ -1,0 +1,50 @@
+// Test that dead code warnings are issued for superfluous assignments of
+// fields or variables to themselves (issue #75356).
+
+// check-pass
+#![allow(unused_assignments)]
+#![warn(dead_code)]
+
+fn main() {
+    let mut x = 0;
+    x = x;
+    //~^ WARNING: useless assignment of variable of type `i32` to itself
+
+    x = (x);
+    //~^ WARNING: useless assignment of variable of type `i32` to itself
+
+    x = {x};
+    // block expressions don't count as self-assignments
+
+
+    struct S<'a> { f: &'a str }
+    let mut s = S { f: "abc" };
+    s = s;
+    //~^ WARNING: useless assignment of variable of type `S` to itself
+
+    s.f = s.f;
+    //~^ WARNING: useless assignment of field of type `&str` to itself
+
+
+    struct N0 { x: Box<i32> }
+    struct N1 { n: N0 }
+    struct N2(N1);
+    struct N3 { n: N2 };
+    let mut n3 = N3 { n: N2(N1 { n: N0 { x: Box::new(42) } }) };
+    n3.n.0.n.x = n3.n.0.n.x;
+    //~^ WARNING: useless assignment of field of type `Box<i32>` to itself
+
+    let mut t = (1, ((2, 3, (4, 5)),));
+    t.1.0.2.1 = t.1.0.2.1;
+    //~^ WARNING: useless assignment of field of type `i32` to itself
+
+
+    let mut y = 0;
+    macro_rules! assign_to_y {
+        ($cur:expr) => {{
+            y = $cur;
+        }};
+    }
+    assign_to_y!(y);
+    // self-assignments in macro expansions are not reported either
+}

--- a/src/test/ui/lint/dead-code/self-assign.stderr
+++ b/src/test/ui/lint/dead-code/self-assign.stderr
@@ -1,0 +1,44 @@
+warning: useless assignment of variable of type `i32` to itself
+  --> $DIR/self-assign.rs:10:5
+   |
+LL |     x = x;
+   |     ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/self-assign.rs:6:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: useless assignment of variable of type `i32` to itself
+  --> $DIR/self-assign.rs:13:5
+   |
+LL |     x = (x);
+   |     ^^^^^^^
+
+warning: useless assignment of variable of type `S` to itself
+  --> $DIR/self-assign.rs:22:5
+   |
+LL |     s = s;
+   |     ^^^^^
+
+warning: useless assignment of field of type `&str` to itself
+  --> $DIR/self-assign.rs:25:5
+   |
+LL |     s.f = s.f;
+   |     ^^^^^^^^^
+
+warning: useless assignment of field of type `Box<i32>` to itself
+  --> $DIR/self-assign.rs:34:5
+   |
+LL |     n3.n.0.n.x = n3.n.0.n.x;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: useless assignment of field of type `i32` to itself
+  --> $DIR/self-assign.rs:38:5
+   |
+LL |     t.1.0.2.1 = t.1.0.2.1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+warning: 6 warnings emitted
+

--- a/src/test/ui/nll/issue-50461-used-mut-from-moves.rs
+++ b/src/test/ui/nll/issue-50461-used-mut-from-moves.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![deny(unused_mut)]
+#![allow(dead_code)]
 
 struct Foo {
     pub value: i32

--- a/src/test/ui/self/self-re-assign.rs
+++ b/src/test/ui/self/self-re-assign.rs
@@ -3,6 +3,7 @@
 // that we do not glue_drop before we glue_take (#3290).
 
 #![feature(box_syntax)]
+#![allow(dead_code)]
 
 use std::rc::Rc;
 


### PR DESCRIPTION
This PR fixes #75356. Following @varkor's suggestion in https://github.com/rust-lang/rust/issues/75356#issuecomment-700339154, I have implemented this warning as part of the `dead_code` lint. Unlike the `-Wself-assign` implementation in [Clang](https://github.com/llvm/llvm-project/blob/56e6d4742e6909bd7d2db201cc5e0e3e77c6f282/clang/lib/Sema/SemaExpr.cpp#L13875-L13909), my implementation also warns about self-assignments of struct fields (`s.x = s.x`).

r? @varkor
