### PR TITLE
Update compiler-builtins to 0.1.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69484e04eab372f5f345920e3a8c7a06e7dcbb75c0944eccdc3e3160aeee3c7"
+checksum = "fd4ed89e0a5c3e50b15c0045fbe1ff8567b703bc07544faf935ddff0aaa7b65f"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
  Bumped to `0.1.47` to resolve missing symbols on `aarch` when linking
  `cargo`. This was due to a recent change in a `cargo` dependency on
  `curl` (upstream C library added code that uses the uncommon `long
  double` type).

r? @tmandry 