### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -633,6 +633,7 @@ fn test_debugging_options_tracking_hash() {
     untracked!(dump_mir_graphviz, true);
     untracked!(emit_future_incompat_report, true);
     untracked!(emit_stack_sizes, true);
+    untracked!(future_incompat_test, true);
     untracked!(hir_stats, true);
     untracked!(identify_regions, true);
     untracked!(incremental_ignore_spans, true);

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -8,7 +8,7 @@ use rustc_hir::HirId;
 use rustc_index::vec::IndexVec;
 use rustc_session::lint::{
     builtin::{self, FORBIDDEN_LINT_GROUPS},
-    FutureIncompatibilityReason, FutureIncompatibleInfo, Level, Lint, LintId,
+    FutureIncompatibilityReason, Level, Lint, LintId,
 };
 use rustc_session::{DiagnosticMessageId, Session};
 use rustc_span::hygiene::MacroKind;
@@ -223,12 +223,12 @@ pub fn struct_lint_level<'s, 'd>(
         let lint_id = LintId::of(lint);
         let future_incompatible = lint.future_incompatible;
 
-        let has_future_breakage = matches!(
-            future_incompatible,
-            Some(FutureIncompatibleInfo {
-                reason: FutureIncompatibilityReason::FutureReleaseErrorReportNow,
-                ..
-            })
+        let has_future_breakage = future_incompatible.map_or(
+            // Default allow lints trigger too often for testing.
+            sess.opts.debugging_opts.future_incompat_test && lint.default_level != Level::Allow,
+            |incompat| {
+                matches!(incompat.reason, FutureIncompatibilityReason::FutureReleaseErrorReportNow)
+            },
         );
 
         let mut err = match (level, span) {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -502,14 +502,14 @@ impl<'a> Resolver<'a> {
 
                 err
             }
-            ResolutionError::SelfInTyParamDefault => {
+            ResolutionError::SelfInGenericParamDefault => {
                 let mut err = struct_span_err!(
                     self.session,
                     span,
                     E0735,
-                    "type parameters cannot use `Self` in their defaults"
+                    "generic parameters cannot use `Self` in their defaults"
                 );
-                err.span_label(span, "`Self` in type parameter default".to_string());
+                err.span_label(span, "`Self` in generic parameter default".to_string());
                 err
             }
             ResolutionError::UnreachableLabel { name, definition_span, suggestion } => {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -249,7 +249,7 @@ enum ResolutionError<'a> {
     /// This error is only emitted when using `min_const_generics`.
     ParamInNonTrivialAnonConst { name: Symbol, is_type: bool },
     /// Error E0735: generic parameters with a default cannot use `Self`
-    SelfInTyParamDefault,
+    SelfInGenericParamDefault,
     /// Error E0767: use of unreachable label
     UnreachableLabel { name: Symbol, definition_span: Span, suggestion: Option<LabelSuggestion> },
 }
@@ -2643,7 +2643,7 @@ impl<'a> Resolver<'a> {
         if let ForwardGenericParamBanRibKind = all_ribs[rib_index].kind {
             if record_used {
                 let res_error = if rib_ident.name == kw::SelfUpper {
-                    ResolutionError::SelfInTyParamDefault
+                    ResolutionError::SelfInGenericParamDefault
                 } else {
                     ResolutionError::ForwardDeclaredGenericParam
                 };

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1084,6 +1084,8 @@ options! {
         "set the optimization fuel quota for a crate"),
     function_sections: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "whether each function should go in its own section"),
+    future_incompat_test: bool = (false, parse_bool, [UNTRACKED],
+        "forces all lints to be future incompatible, used for internal testing (default: no)"),
     gcc_ld: Option<LdImpl> = (None, parse_gcc_ld, [TRACKED], "implementation of ld used by cc"),
     graphviz_dark_mode: bool = (false, parse_bool, [UNTRACKED],
         "use dark-themed colors in graphviz output (default: no)"),

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -489,6 +489,13 @@ impl<T> Arc<T> {
     pub fn pin(data: T) -> Pin<Arc<T>> {
         unsafe { Pin::new_unchecked(Arc::new(data)) }
     }
+    
+    /// Constructs a new `Pin<Arc<T>>, return an error if allocation fails.
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub fn try_pin(data: T) -> Result<Pin<Arc<T>>, AllocError> {
+        unsafe { Ok(Pin::new_unchecked(Arc::try_new(data)?)) }
+    }
 
     /// Constructs a new `Arc<T>`, returning an error if allocation fails.
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -489,7 +489,7 @@ impl<T> Arc<T> {
     pub fn pin(data: T) -> Pin<Arc<T>> {
         unsafe { Pin::new_unchecked(Arc::new(data)) }
     }
-    
+
     /// Constructs a new `Pin<Arc<T>>, return an error if allocation fails.
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[inline]

--- a/library/core/src/slice/rotate.rs
+++ b/library/core/src/slice/rotate.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-undocumented-unsafe
-
 use crate::cmp;
 use crate::mem::{self, MaybeUninit};
 use crate::ptr;
@@ -79,8 +77,10 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             // the way until about `left + right == 32`, but the worst case performance breaks even
             // around 16. 24 was chosen as middle ground. If the size of `T` is larger than 4
             // `usize`s, this algorithm also outperforms other algorithms.
+            // SAFETY: callers must ensure `mid - left` is valid for reading and writing.
             let x = unsafe { mid.sub(left) };
             // beginning of first round
+            // SAFETY: see previous comment.
             let mut tmp: T = unsafe { x.read() };
             let mut i = right;
             // `gcd` can be found before hand by calculating `gcd(left + right, right)`,
@@ -92,6 +92,21 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             // the very end. This is possibly due to the fact that swapping or replacing temporaries
             // uses only one memory address in the loop instead of needing to manage two.
             loop {
+                // [long-safety-expl]
+                // SAFETY: callers must ensure `[left, left+mid+right)` are all valid for reading and
+                // writing.
+                //
+                // - `i` start with `right` so `mid-left <= x+i = x+right = mid-left+right < mid+right`
+                // - `i <= left+right-1` is always true
+                //   - if `i < left`, `right` is added so `i < left+right` and on the next
+                //     iteration `left` is removed from `i` so it doesn't go further
+                //   - if `i >= left`, `left` is removed immediately and so it doesn't go further.
+                // - overflows cannot happen for `i` since the function's safety contract ask for
+                //   `mid+right-1 = x+left+right` to be valid for writing
+                // - underflows cannot happen because `i` must be bigger or equal to `left` for
+                //   a substraction of `left` to happen.
+                //
+                // So `x+i` is valid for reading and writing if the caller respected the contract
                 tmp = unsafe { x.add(i).replace(tmp) };
                 // instead of incrementing `i` and then checking if it is outside the bounds, we
                 // check if `i` will go outside the bounds on the next increment. This prevents
@@ -100,6 +115,8 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
                     i -= left;
                     if i == 0 {
                         // end of first round
+                        // SAFETY: tmp has been read from a valid source and x is valid for writing
+                        // according to the caller.
                         unsafe { x.write(tmp) };
                         break;
                     }
@@ -113,13 +130,24 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             }
             // finish the chunk with more rounds
             for start in 1..gcd {
+                // SAFETY: `gcd` is at most equal to `right` so all values in `1..gcd` are valid for
+                // reading and writing as per the function's safety contract, see [long-safety-expl]
+                // above
                 tmp = unsafe { x.add(start).read() };
+                // [safety-expl-addition]
+                //
+                // Here `start < gcd` so `start < right` so `i < right+right`: `right` being the
+                // greatest common divisor of `(left+right, right)` means that `left = right` so
+                // `i < left+right` so `x+i = mid-left+i` is always valid for reading and writing
+                // according to the function's safety contract.
                 i = start + right;
                 loop {
+                    // SAFETY: see [long-safety-expl] and [safety-expl-addition]
                     tmp = unsafe { x.add(i).replace(tmp) };
                     if i >= left {
                         i -= left;
                         if i == start {
+                            // SAFETY: see [long-safety-expl] and [safety-expl-addition]
                             unsafe { x.add(start).write(tmp) };
                             break;
                         }
@@ -135,14 +163,30 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             // The `[T; 0]` here is to ensure this is appropriately aligned for T
             let mut rawarray = MaybeUninit::<(BufType, [T; 0])>::uninit();
             let buf = rawarray.as_mut_ptr() as *mut T;
+            // SAFETY: `mid-left <= mid-left+right < mid+right`
             let dim = unsafe { mid.sub(left).add(right) };
             if left <= right {
+                // SAFETY:
+                //
+                // 1) The `else if` condition about the sizes ensures `[mid-left; left]` will fit in
+                //    `buf` without overflow and `buf` was created just above and so cannot be
+                //    overlapped with any value of `[mid-left; left]`
+                // 2) [mid-left, mid+right) are all valid for reading and writing and we don't care
+                //    about overlaps here.
+                // 3) The `if` condition about `left <= right` ensures writing `left` elements to
+                //    `dim = mid-left+right` is valid because:
+                //    - `buf` is valid and `left` elements were written in it in 1)
+                //    - `dim+left = mid-left+right+left = mid+right` and we write `[dim, dim+left)`
                 unsafe {
+                    // 1)
                     ptr::copy_nonoverlapping(mid.sub(left), buf, left);
+                    // 2)
                     ptr::copy(mid, mid.sub(left), right);
+                    // 3)
                     ptr::copy_nonoverlapping(buf, dim, left);
                 }
             } else {
+                // SAFETY: same reasoning as above but with `left` and `right` reversed
                 unsafe {
                     ptr::copy_nonoverlapping(mid, buf, right);
                     ptr::copy(mid.sub(left), dim, left);
@@ -156,6 +200,10 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
             // of this algorithm would be, and swapping using that last chunk instead of swapping
             // adjacent chunks like this algorithm is doing, but this way is still faster.
             loop {
+                // SAFETY:
+                // `left >= right` so `[mid-right, mid+right)` is valid for reading and writing
+                // Substracting `right` from `mid` each turn is counterbalanced by the addition and
+                // check after it.
                 unsafe {
                     ptr::swap_nonoverlapping(mid.sub(right), mid, right);
                     mid = mid.sub(right);
@@ -168,6 +216,10 @@ pub unsafe fn ptr_rotate<T>(mut left: usize, mut mid: *mut T, mut right: usize) 
         } else {
             // Algorithm 3, `left < right`
             loop {
+                // SAFETY: `[mid-left, mid+left)` is valid for reading and writing because
+                // `left < right` so `mid+left < mid+right`.
+                // Adding `left` to `mid` each turn is counterbalanced by the substraction and check
+                // after it.
                 unsafe {
                     ptr::swap_nonoverlapping(mid.sub(left), mid, left);
                     mid = mid.add(left);

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -1,7 +1,7 @@
 //! WASI-specific extensions to primitives in the `std::fs` module.
 
 #![deny(unsafe_op_in_unsafe_fn)]
-#![unstable(feature = "wasi_ext", issue = "none")]
+#![unstable(feature = "wasi_ext", issue = "71213")]
 
 use crate::ffi::OsStr;
 use crate::fs::{self, File, Metadata, OpenOptions};

--- a/library/std/src/os/wasi/io.rs
+++ b/library/std/src/os/wasi/io.rs
@@ -1,7 +1,7 @@
 //! WASI-specific extensions to general I/O primitives
 
 #![deny(unsafe_op_in_unsafe_fn)]
-#![unstable(feature = "wasi_ext", issue = "none")]
+#![unstable(feature = "wasi_ext", issue = "71213")]
 
 use crate::fs;
 use crate::io;

--- a/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.rs
+++ b/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.rs
@@ -1,0 +1,16 @@
+#![feature(const_generics_defaults)]
+
+struct Struct<const N: usize = { Self; 10 }>;
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
+
+enum Enum<const N: usize = { Self; 10 }> { }
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
+
+union Union<const N: usize = { Self; 10 }> { not_empty: () }
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
+
+fn main() {
+    let _: Struct;
+    let _: Enum;
+    let _: Union;
+}

--- a/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
+++ b/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
@@ -1,0 +1,21 @@
+error[E0735]: generic parameters cannot use `Self` in their defaults
+  --> $DIR/default-const-param-cannot-reference-self.rs:3:36
+   |
+LL | struct Snobound<const N: usize = { Self; 10 }>;
+   |                                    ^^^^ `Self` in generic parameter default
+
+error[E0735]: generic parameters cannot use `Self` in their defaults
+  --> $DIR/default-const-param-cannot-reference-self.rs:6:34
+   |
+LL | enum Enobound<const N: usize = { Self; 10 }> { }
+   |                                  ^^^^ `Self` in generic parameter default
+
+error[E0735]: generic parameters cannot use `Self` in their defaults
+  --> $DIR/default-const-param-cannot-reference-self.rs:9:35
+   |
+LL | union Unobound<const N: usize = { Self; 10 }> { not_empty: () }
+   |                                   ^^^^ `Self` in generic parameter default
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0735`.

--- a/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
+++ b/src/test/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
@@ -1,20 +1,20 @@
 error[E0735]: generic parameters cannot use `Self` in their defaults
-  --> $DIR/default-const-param-cannot-reference-self.rs:3:36
+  --> $DIR/default-const-param-cannot-reference-self.rs:3:34
    |
-LL | struct Snobound<const N: usize = { Self; 10 }>;
-   |                                    ^^^^ `Self` in generic parameter default
-
-error[E0735]: generic parameters cannot use `Self` in their defaults
-  --> $DIR/default-const-param-cannot-reference-self.rs:6:34
-   |
-LL | enum Enobound<const N: usize = { Self; 10 }> { }
+LL | struct Struct<const N: usize = { Self; 10 }>;
    |                                  ^^^^ `Self` in generic parameter default
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
-  --> $DIR/default-const-param-cannot-reference-self.rs:9:35
+  --> $DIR/default-const-param-cannot-reference-self.rs:6:30
    |
-LL | union Unobound<const N: usize = { Self; 10 }> { not_empty: () }
-   |                                   ^^^^ `Self` in generic parameter default
+LL | enum Enum<const N: usize = { Self; 10 }> { }
+   |                              ^^^^ `Self` in generic parameter default
+
+error[E0735]: generic parameters cannot use `Self` in their defaults
+  --> $DIR/default-const-param-cannot-reference-self.rs:9:32
+   |
+LL | union Union<const N: usize = { Self; 10 }> { not_empty: () }
+   |                                ^^^^ `Self` in generic parameter default
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generics/issue-61631-default-type-param-cannot-reference-self.rs
+++ b/src/test/ui/generics/issue-61631-default-type-param-cannot-reference-self.rs
@@ -11,25 +11,25 @@
 // compatibility concern.
 
 struct Snobound<'a, P = Self> { x: Option<&'a P> }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 enum Enobound<'a, P = Self> { A, B(Option<&'a P>) }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 union Unobound<'a, P = Self> { x: i32, y: Option<&'a P> }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 // Disallowing `Self` in defaults sidesteps need to check the bounds
 // on the defaults in cases like these.
 
 struct Ssized<'a, P: Sized = [Self]> { x: Option<&'a P> }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 enum Esized<'a, P: Sized = [Self]> { A, B(Option<&'a P>) }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 union Usized<'a, P: Sized = [Self]> { x: i32, y: Option<&'a P> }
-//~^ ERROR type parameters cannot use `Self` in their defaults [E0735]
+//~^ ERROR generic parameters cannot use `Self` in their defaults [E0735]
 
 fn demo_usages() {
     // An ICE means you only get the error from the first line of the

--- a/src/test/ui/generics/issue-61631-default-type-param-cannot-reference-self.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-cannot-reference-self.stderr
@@ -1,38 +1,38 @@
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:13:25
    |
 LL | struct Snobound<'a, P = Self> { x: Option<&'a P> }
-   |                         ^^^^ `Self` in type parameter default
+   |                         ^^^^ `Self` in generic parameter default
 
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:16:23
    |
 LL | enum Enobound<'a, P = Self> { A, B(Option<&'a P>) }
-   |                       ^^^^ `Self` in type parameter default
+   |                       ^^^^ `Self` in generic parameter default
 
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:19:24
    |
 LL | union Unobound<'a, P = Self> { x: i32, y: Option<&'a P> }
-   |                        ^^^^ `Self` in type parameter default
+   |                        ^^^^ `Self` in generic parameter default
 
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:25:31
    |
 LL | struct Ssized<'a, P: Sized = [Self]> { x: Option<&'a P> }
-   |                               ^^^^ `Self` in type parameter default
+   |                               ^^^^ `Self` in generic parameter default
 
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:28:29
    |
 LL | enum Esized<'a, P: Sized = [Self]> { A, B(Option<&'a P>) }
-   |                             ^^^^ `Self` in type parameter default
+   |                             ^^^^ `Self` in generic parameter default
 
-error[E0735]: type parameters cannot use `Self` in their defaults
+error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:31:30
    |
 LL | union Usized<'a, P: Sized = [Self]> { x: i32, y: Option<&'a P> }
-   |                              ^^^^ `Self` in type parameter default
+   |                              ^^^^ `Self` in generic parameter default
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/future-incompat-test.rs
+++ b/src/test/ui/lint/future-incompat-test.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Zfuture-incompat-test -Zemit-future-incompat-report
+// check-pass
+
+// The `-Zfuture-incompat-test flag causes any normal warning to be included
+// in the future-incompatible report. The stderr output here should mention
+// the future incompatible report (as extracted by compiletest).
+
+fn main() {
+    let x = 1;
+}

--- a/src/test/ui/lint/future-incompat-test.stderr
+++ b/src/test/ui/lint/future-incompat-test.stderr
@@ -1,0 +1,9 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: unused variable: `x`
+  --> $DIR/future-incompat-test.rs:9:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `-A unused-variables` implied by `-A unused`
+

--- a/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
+++ b/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
@@ -81,7 +81,7 @@ LL |     tuple_from_req!(Foo);
 
 warning: 5 warnings emitted
 
-Future incompatibility report: Future breakage date: None, diagnostic:
+Future incompatibility report: Future breakage diagnostic:
 warning: using an old version of `time-macros-impl`
   --> $DIR/time-macros-impl/src/lib.rs:5:32
    |
@@ -99,7 +99,7 @@ LL |     impl_macros!(Foo);
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
    = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Future breakage date: None, diagnostic:
+Future breakage diagnostic:
 warning: using an old version of `time-macros-impl`
   --> $DIR/time-macros-impl-0.1.0/src/lib.rs:5:32
    |
@@ -116,7 +116,7 @@ LL |     impl_macros!(Foo);
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
    = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Future breakage date: None, diagnostic:
+Future breakage diagnostic:
 warning: using an old version of `js-sys`
   --> $DIR/js-sys-0.3.17/src/lib.rs:5:32
    |
@@ -133,7 +133,7 @@ LL |     arrays!(Foo);
    = note: older versions of the `js-sys` crate will stop compiling in future versions of Rust; please update to `js-sys` v0.3.40 or above
    = note: this warning originates in the macro `arrays` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Future breakage date: None, diagnostic:
+Future breakage diagnostic:
 warning: using an old version of `actix-web`
   --> $DIR/actix-web/src/extract.rs:5:34
    |
@@ -150,7 +150,7 @@ LL |     tuple_from_req!(Foo);
    = note: the version of `actix-web` you are using might stop compiling in future versions of Rust; please update to the latest version of the `actix-web` crate to avoid breakage
    = note: this warning originates in the macro `tuple_from_req` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Future breakage date: None, diagnostic:
+Future breakage diagnostic:
 warning: using an old version of `actix-web`
   --> $DIR/actix-web-2.0.0/src/extract.rs:5:34
    |

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
@@ -11,7 +11,7 @@ LL | enum ProceduralMasqueradeDummyType {
 
 warning: 1 warning emitted
 
-Future incompatibility report: Future breakage date: None, diagnostic:
+Future incompatibility report: Future breakage diagnostic:
 warning: using `procedural-masquerade` crate
   --> $DIR/issue-73933-procedural-masquerade.rs:8:6
    |

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -43,7 +43,6 @@ struct FutureIncompatReport {
 
 #[derive(Deserialize)]
 struct FutureBreakageItem {
-    future_breakage_date: Option<String>,
     diagnostic: Diagnostic,
 }
 
@@ -104,9 +103,7 @@ pub fn extract_rendered(output: &str) -> String {
                                 .into_iter()
                                 .map(|item| {
                                     format!(
-                                        "Future breakage date: {}, diagnostic:\n{}",
-                                        item.future_breakage_date
-                                            .unwrap_or_else(|| "None".to_string()),
+                                        "Future breakage diagnostic:\n{}",
                                         item.diagnostic
                                             .rendered
                                             .unwrap_or_else(|| "Not rendered".to_string())


### PR DESCRIPTION
Successful merges:

 - #85579 (Added Arc::try_pin)
 - #86478 (Add -Zfuture-incompat-test to assist with testing future-incompat reports.)
 - #87081 (Add tracking issue number to `wasi_ext`)
 - #87127 (Add safety comments in private core::slice::rotate::ptr_rotate function)
 - #87134 (Make SelfInTyParamDefault wording not be specific to type defaults)
 - #87147 (Update cargo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85579,86478,87081,87127,87134,87147)
<!-- homu-ignore:end -->