### PR TITLE
Fix misuse of rev attribute on <a> tag

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -621,8 +621,7 @@ impl<'a, I: Iterator<Item = SpannedEvent<'a>>> Iterator for Footnotes<'a, I> {
                                 is_paragraph = true;
                             }
                             html::push_html(&mut ret, content.into_iter());
-                            write!(ret, "&nbsp;<a href=\"#fnref{}\" rev=\"footnote\">↩</a>", id)
-                                .unwrap();
+                            write!(ret, "&nbsp;<a href=\"#fnref{}\">↩</a>", id).unwrap();
                             if is_paragraph {
                                 ret.push_str("</p>");
                             }


### PR DESCRIPTION
The `rev` attribute is supposed to talk about "ownership" as far as I could found out. This attribute seems not very well defined in the HTML spec and its usage in rustdoc is suboptimal.

It was found out in https://github.com/rust-lang/rust/pull/87149.

r? @JohnTitor 