### PR TITLE
Fix type decl layout "overflow"

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -247,6 +247,9 @@ code, pre, a.test-arrow {
 pre {
 	padding: 14px;
 }
+.type-decl pre {
+	overflow-x: auto;
+}
 
 .source .content pre {
 	padding: 20px;

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -47,3 +47,10 @@ pub mod sub_mod {
     /// ```
     pub struct Foo;
 }
+
+pub mod long_trait {
+    use std::ops::DerefMut;
+
+    pub trait ALongNameBecauseItHelpsTestingTheCurrentProblem: DerefMut<Target = u32>
+        + From<u128> + Send + Sync + AsRef<str> + 'static {}
+}

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -1,0 +1,8 @@
+// This test ensures that the type declaration content overflow is handled inside the <pre> directly.
+goto: file://|DOC_PATH|/lib2/long_trait/trait.ALongNameBecauseItHelpsTestingTheCurrentProblem.html
+// We set a fixed size so there is no chance of "random" resize.
+size: (1100, 800)
+// Logically, the <body> scroll width should be the width of the window.
+assert-property: ("body", {"scrollWidth": "1100"})
+// However, since there is overflow in the type declaration, its scroll width is bigger.
+assert-property: (".type-decl pre", {"scrollWidth": "1324"})


### PR DESCRIPTION
Before:

![Screenshot from 2021-07-15 17-56-12](https://user-images.githubusercontent.com/3050060/125822644-c4595211-d75e-4dd7-ba44-183197ee836c.png)

After:

![Screenshot from 2021-07-15 17-56-17](https://user-images.githubusercontent.com/3050060/125822648-7b363847-e153-4ff3-9fba-59478e32eced.png)

cc @SergioBenitez 

r? @notriddle 