### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -104,20 +104,15 @@ impl<'s> LintLevelsBuilder<'s> {
                 Err(_) => continue, // errors handled in check_lint_name_cmdline above
             };
             for id in ids {
+                // ForceWarn and Forbid cannot be overriden
+                match specs.get(&id) {
+                    Some((Level::ForceWarn | Level::Forbid, _)) => continue,
+                    _ => (),
+                }
+
                 self.check_gated_lint(id, DUMMY_SP);
                 let src = LintLevelSource::CommandLine(lint_flag_val, orig_level);
                 specs.insert(id, (level, src));
-            }
-        }
-
-        for lint_name in &sess.opts.force_warns {
-            store.check_lint_name_cmdline(sess, lint_name, Level::ForceWarn, self.crate_attrs);
-            let lints = store
-                .find_lints(lint_name)
-                .unwrap_or_else(|_| bug!("A valid lint failed to produce a lint ids"));
-            for id in lints {
-                let src = LintLevelSource::CommandLine(Symbol::intern(lint_name), Level::ForceWarn);
-                specs.insert(id, (Level::ForceWarn, src));
             }
         }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -677,7 +677,6 @@ impl Default for Options {
             optimize: OptLevel::No,
             debuginfo: DebugInfo::None,
             lint_opts: Vec::new(),
-            force_warns: Vec::new(),
             lint_cap: None,
             describe_lints: false,
             output_types: OutputTypes(BTreeMap::new()),
@@ -1170,20 +1169,20 @@ pub fn get_cmd_lint_options(
     matches: &getopts::Matches,
     error_format: ErrorOutputType,
     debugging_opts: &DebuggingOptions,
-) -> (Vec<(String, lint::Level)>, bool, Option<lint::Level>, Vec<String>) {
+) -> (Vec<(String, lint::Level)>, bool, Option<lint::Level>) {
     let mut lint_opts_with_position = vec![];
     let mut describe_lints = false;
 
-    for level in [lint::Allow, lint::Warn, lint::Deny, lint::Forbid] {
-        for (passed_arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
-            let arg_pos = if let lint::Forbid = level {
-                // HACK: forbid is always specified last, so it can't be overridden.
-                // FIXME: remove this once <https://github.com/rust-lang/rust/issues/70819> is
-                // fixed and `forbid` works as expected.
-                usize::MAX
-            } else {
-                passed_arg_pos
-            };
+    if !debugging_opts.unstable_options && matches.opt_present("force-warns") {
+        early_error(
+            error_format,
+            "the `-Z unstable-options` flag must also be passed to enable \
+            the flag `--force-warns=lints`",
+        );
+    }
+
+    for level in [lint::Allow, lint::Warn, lint::ForceWarn, lint::Deny, lint::Forbid] {
+        for (arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
             if lint_name == "help" {
                 describe_lints = true;
             } else {
@@ -1204,18 +1203,7 @@ pub fn get_cmd_lint_options(
             .unwrap_or_else(|| early_error(error_format, &format!("unknown lint level: `{}`", cap)))
     });
 
-    if !debugging_opts.unstable_options && matches.opt_present("force-warns") {
-        early_error(
-            error_format,
-            "the `-Z unstable-options` flag must also be passed to enable \
-            the flag `--force-warns=lints`",
-        );
-    }
-
-    let force_warns =
-        matches.opt_strs("force-warns").into_iter().map(|name| name.replace('-', "_")).collect();
-
-    (lint_opts, describe_lints, lint_cap, force_warns)
+    (lint_opts, describe_lints, lint_cap)
 }
 
 /// Parses the `--color` flag.
@@ -1953,7 +1941,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         .unwrap_or_else(|e| early_error(error_format, &e[..]));
 
     let mut debugging_opts = DebuggingOptions::build(matches, error_format);
-    let (lint_opts, describe_lints, lint_cap, force_warns) =
+    let (lint_opts, describe_lints, lint_cap) =
         get_cmd_lint_options(matches, error_format, &debugging_opts);
 
     check_debug_option_stability(&debugging_opts, error_format, json_rendered);
@@ -2127,7 +2115,6 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         optimize: opt_level,
         debuginfo,
         lint_opts,
-        force_warns,
         lint_cap,
         describe_lints,
         output_types,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -135,7 +135,6 @@ top_level_options!(
         debuginfo: DebugInfo [TRACKED],
         lint_opts: Vec<(String, lint::Level)> [TRACKED],
         lint_cap: Option<lint::Level> [TRACKED],
-        force_warns: Vec<String> [TRACKED],
         describe_lints: bool [UNTRACKED],
         output_types: OutputTypes [TRACKED],
         search_paths: Vec<SearchPath> [UNTRACKED],

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1535,10 +1535,9 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
             place_with_id, diag_expr_id, mode
         );
 
-        // Copy type being used as ByValue are equivalent to ImmBorrow and don't require any
-        // escalation.
+        // Copy types in ByValue scenarios need should be treated as ImmBorrows
         match mode {
-            euv::ConsumeMode::Copy => return,
+            euv::ConsumeMode::Copy => unreachable!(),
             euv::ConsumeMode::Move => {}
         };
 

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1528,19 +1528,11 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
         &mut self,
         place_with_id: &PlaceWithHirId<'tcx>,
         diag_expr_id: hir::HirId,
-        mode: euv::ConsumeMode,
     ) {
         debug!(
-            "adjust_upvar_borrow_kind_for_consume(place_with_id={:?}, diag_expr_id={:?}, mode={:?})",
-            place_with_id, diag_expr_id, mode
+            "adjust_upvar_borrow_kind_for_consume(place_with_id={:?}, diag_expr_id={:?})",
+            place_with_id, diag_expr_id
         );
-
-        // Copy types in ByValue scenarios need should be treated as ImmBorrows
-        match mode {
-            euv::ConsumeMode::Copy => unreachable!(),
-            euv::ConsumeMode::Move => {}
-        };
-
         let tcx = self.fcx.tcx;
         let upvar_id = if let PlaceBase::Upvar(upvar_id) = place_with_id.place.base {
             upvar_id
@@ -1715,22 +1707,14 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'tcx> {
         }
     }
 
-    fn consume(
-        &mut self,
-        place_with_id: &PlaceWithHirId<'tcx>,
-        diag_expr_id: hir::HirId,
-        mode: euv::ConsumeMode,
-    ) {
-        debug!(
-            "consume(place_with_id={:?}, diag_expr_id={:?}, mode={:?})",
-            place_with_id, diag_expr_id, mode
-        );
+    fn consume(&mut self, place_with_id: &PlaceWithHirId<'tcx>, diag_expr_id: hir::HirId) {
+        debug!("consume(place_with_id={:?}, diag_expr_id={:?})", place_with_id, diag_expr_id);
 
         if !self.capture_information.contains_key(&place_with_id.place) {
             self.init_capture_info_for_place(&place_with_id, diag_expr_id);
         }
 
-        self.adjust_upvar_borrow_kind_for_consume(&place_with_id, diag_expr_id, mode);
+        self.adjust_upvar_borrow_kind_for_consume(&place_with_id, diag_expr_id);
     }
 
     fn borrow(

--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -30,7 +30,9 @@ pub trait Delegate<'tcx> {
     // on `mode`. Where `diag_expr_id` is the id used for diagnostics for `place`.
     //
     // Use of a `Copy` type in a ByValue context is considered a use
-    // by `ImmBorrow` and `borrow` is called instead.
+    // by `ImmBorrow` and `borrow` is called instead. This is because
+    // a shared borrow is the "minimum access" that would be needed
+    // to perform a copy.
     //
     //
     // The parameter `diag_expr_id` indicates the HIR id that ought to be used for

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="str">
-    <DisplayString>{data_ptr,[length]s8}</DisplayString>
-    <StringView>data_ptr,[length]s8</StringView>
+    <DisplayString>{(char*)data_ptr,[length]s8}</DisplayString>
+    <StringView>(char*)data_ptr,[length]s8</StringView>
     <Expand>
       <Item Name="[len]" ExcludeView="simple">length</Item>
       <Synthetic Name="[chars]">

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -48,6 +48,7 @@
       <Item Name="[len]" ExcludeView="simple">vec.len</Item>
       <Item Name="[capacity]" ExcludeView="simple">vec.buf.cap</Item>
       <Synthetic Name="[chars]">
+        <DisplayString>{(char*)vec.buf.ptr.pointer,[vec.len]s8}</DisplayString>
         <Expand>
           <ArrayItems>
             <Size>vec.len</Size>

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -57,16 +57,26 @@
       </Synthetic>
     </Expand>
   </Type>
+
   <Type Name="alloc::rc::Rc&lt;*&gt;">
+    <DisplayString>{ptr.pointer->value}</DisplayString>
+    <Expand>
+      <ExpandedItem>ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]">ptr.pointer->strong</Item>
+    </Expand>
+  </Type>
+  <Type Name="alloc::rc::Weak&lt;*&gt;">
     <DisplayString>{ptr.pointer->value}</DisplayString>
     <Expand>
       <ExpandedItem>ptr.pointer->value</ExpandedItem>
     </Expand>
   </Type>
+
   <Type Name="alloc::sync::Arc&lt;*&gt;">
     <DisplayString>{ptr.pointer->data}</DisplayString>
     <Expand>
       <ExpandedItem>ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]">ptr.pointer->strong</Item>
     </Expand>
   </Type>
   <Type Name="alloc::sync::Weak&lt;*&gt;">

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -64,12 +64,15 @@
     <Expand>
       <ExpandedItem>ptr.pointer->value</ExpandedItem>
       <Item Name="[Reference count]">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
     </Expand>
   </Type>
   <Type Name="alloc::rc::Weak&lt;*&gt;">
     <DisplayString>{ptr.pointer->value}</DisplayString>
     <Expand>
       <ExpandedItem>ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
     </Expand>
   </Type>
 
@@ -78,12 +81,15 @@
     <Expand>
       <ExpandedItem>ptr.pointer->data</ExpandedItem>
       <Item Name="[Reference count]">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
     </Expand>
   </Type>
   <Type Name="alloc::sync::Weak&lt;*&gt;">
     <DisplayString>{ptr.pointer->data}</DisplayString>
     <Expand>
       <ExpandedItem>ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
     </Expand>
   </Type>
   <Type Name="alloc::borrow::Cow&lt;*&gt;">

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -156,8 +156,8 @@
   <Type Name="core::time::Duration">
     <DisplayString>{secs,d}s {nanos,d}ns</DisplayString>
     <Expand>
-      <Item Name="seconds">secs</Item>
-      <Item Name="nanoseconds">nanos</Item>
+      <Item Name="seconds">secs,d</Item>
+      <Item Name="nanoseconds">nanos,d</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -1,5 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="core::num::nonzero::NonZeroI8">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroI16">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroI32">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroI64">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroI128">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroIsize">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroU8">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroU16">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroU32">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroU64">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroU128">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+  <Type Name="core::num::nonzero::NonZeroUsize">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+
+  <Type Name="core::num::wrapping::Wrapping&lt;*&gt;">
+    <DisplayString>{__0}</DisplayString>
+  </Type>
+
   <Type Name="core::ptr::Unique&lt;*&gt;">
     <DisplayString>{{ Unique {pointer} }}</DisplayString>
     <Expand>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -61,4 +61,38 @@
       <Item Name="[value]">*pointer</Item>
     </Expand>
   </Type>
+
+  <Type Name="core::sync::atomic::AtomicBool">
+    <DisplayString>{(bool)v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicI8">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicI16">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicI32">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicI64">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicIsize">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+    <Type Name="core::sync::atomic::AtomicU8">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicU16">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicU32">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicU64">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
+  <Type Name="core::sync::atomic::AtomicUsize">
+    <DisplayString>{v.value}</DisplayString>
+  </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -75,6 +75,22 @@
     <DisplayString>{__0}</DisplayString>
   </Type>
 
+  <Type Name="core::ops::range::Range&lt;*&gt;">
+    <DisplayString>({start}..{end})</DisplayString>
+  </Type>
+  <Type Name="core::ops::range::RangeFrom&lt;*&gt;">
+    <DisplayString>({start}..)</DisplayString>
+  </Type>
+  <Type Name="core::ops::range::RangeInclusive&lt;*&gt;">
+    <DisplayString>({start}..={end})</DisplayString>
+  </Type>
+  <Type Name="core::ops::range::RangeTo&lt;*&gt;">
+    <DisplayString>(..{end})</DisplayString>
+  </Type>
+  <Type Name="core::ops::range::RangeToInclusive&lt;*&gt;">
+    <DisplayString>(..={end})</DisplayString>
+  </Type>
+
   <Type Name="core::ptr::non_null::NonNull&lt;*&gt;">
     <DisplayString>NonNull({(void*) pointer}: {pointer})</DisplayString>
     <Expand>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -75,24 +75,17 @@
     <DisplayString>{__0}</DisplayString>
   </Type>
 
-  <Type Name="core::ptr::Unique&lt;*&gt;">
-    <DisplayString>{{ Unique {pointer} }}</DisplayString>
-    <Expand>
-      <Item Name="[ptr]">pointer</Item>
-    </Expand>
-  </Type>
-
-  <Type Name="core::ptr::Shared&lt;*&gt;">
-    <DisplayString>{{ Shared {pointer} }}</DisplayString>
-    <Expand>
-      <Item Name="[ptr]">pointer</Item>
-    </Expand>
-  </Type>
-
   <Type Name="core::ptr::non_null::NonNull&lt;*&gt;">
-    <DisplayString>{(void*) pointer}</DisplayString>
+    <DisplayString>NonNull({(void*) pointer}: {pointer})</DisplayString>
     <Expand>
-      <Item Name="[value]">*pointer</Item>
+      <ExpandedItem>pointer</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <Type Name="core::ptr::unique::Unique&lt;*&gt;">
+    <DisplayString>Unique({(void*)pointer}: {pointer})</DisplayString>
+    <Expand>
+      <ExpandedItem>pointer</ExpandedItem>
     </Expand>
   </Type>
 

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="core::cell::Cell&lt;*&gt;">
+    <DisplayString>{value.value}</DisplayString>
+    <Expand>
+      <ExpandedItem>value.value</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="core::cell::Ref&lt;*&gt;">
+    <DisplayString>{value}</DisplayString>
+    <Expand>
+      <ExpandedItem>value</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="core::cell::RefMut&lt;*&gt;">
+    <DisplayString>{value}</DisplayString>
+    <Expand>
+      <ExpandedItem>value</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="core::cell::RefCell&lt;*&gt;">
+    <DisplayString>{value.value}</DisplayString>
+    <Expand>
+      <Item Name="[Borrow state]" Condition="borrow.value.value == 0">"Unborrowed",sb</Item>
+      <Item Name="[Borrow state]" Condition="borrow.value.value &gt; 0">"Immutably borrowed",sb</Item>
+      <Item Name="[Borrow state]" Condition="borrow.value.value &lt; 0">"Mutably borrowed",sb</Item>
+      <ExpandedItem>value.value</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="core::cell::UnsafeCell&lt;*&gt;">
+    <DisplayString>{value}</DisplayString>
+    <Expand>
+      <ExpandedItem>value</ExpandedItem>
+    </Expand>
+  </Type>
+
   <Type Name="core::num::nonzero::NonZeroI8">
     <DisplayString>{__0}</DisplayString>
   </Type>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -34,6 +34,13 @@
     </Expand>
   </Type>
 
+  <Type Name="core::mem::manually_drop::ManuallyDrop&lt;*&gt;">
+    <DisplayString>{value}</DisplayString>
+    <Expand>
+      <ExpandedItem>value</ExpandedItem>
+    </Expand>
+  </Type>
+
   <Type Name="core::num::nonzero::NonZeroI8">
     <DisplayString>{__0}</DisplayString>
   </Type>
@@ -91,6 +98,13 @@
     <DisplayString>(..={end})</DisplayString>
   </Type>
 
+  <Type Name="core::pin::Pin&lt;*&gt;">
+    <DisplayString>Pin({(void*)pointer}: {pointer})</DisplayString>
+    <Expand>
+      <ExpandedItem>pointer</ExpandedItem>
+    </Expand>
+  </Type>
+
   <Type Name="core::ptr::non_null::NonNull&lt;*&gt;">
     <DisplayString>NonNull({(void*) pointer}: {pointer})</DisplayString>
     <Expand>
@@ -137,5 +151,13 @@
   </Type>
   <Type Name="core::sync::atomic::AtomicUsize">
     <DisplayString>{v.value}</DisplayString>
+  </Type>
+
+  <Type Name="core::time::Duration">
+    <DisplayString>{secs,d}s {nanos,d}ns</DisplayString>
+    <Expand>
+      <Item Name="seconds">secs</Item>
+      <Item Name="nanoseconds">nanos</Item>
+    </Expand>
   </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -77,6 +77,7 @@
     <DisplayString>{(char*)inner.data_ptr}</DisplayString>
     <Expand>
       <Synthetic Name="[chars]">
+        <DisplayString>{(char*)inner.data_ptr}</DisplayString>
         <Expand>
           <ArrayItems>
             <Size>inner.length</Size>
@@ -106,6 +107,7 @@
     <DisplayString>{(char*)inner.inner.bytes.buf.ptr.pointer,[inner.inner.bytes.len]}</DisplayString>
     <Expand>
       <Synthetic Name="[chars]">
+        <DisplayString>{(char*)inner.inner.bytes.buf.ptr.pointer,[inner.inner.bytes.len]}</DisplayString>
         <Expand>
           <ArrayItems>
             <Size>inner.inner.bytes.len</Size>

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -74,7 +74,7 @@
   </Type>
 
   <Type Name="std::ffi::c_str::CString">
-    <DisplayString>{inner.data_ptr,s}</DisplayString>
+    <DisplayString>{(char*)inner.data_ptr}</DisplayString>
     <Expand>
       <Synthetic Name="[chars]">
         <Expand>
@@ -96,6 +96,20 @@
           <ArrayItems>
             <Size>strlen((char *) inner) + 1</Size>
             <ValuePointer>(char*)inner</ValuePointer>
+          </ArrayItems>
+        </Expand>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="std::ffi::os_str::OsString">
+    <DisplayString>{(char*)inner.inner.bytes.buf.ptr.pointer,[inner.inner.bytes.len]}</DisplayString>
+    <Expand>
+      <Synthetic Name="[chars]">
+        <Expand>
+          <ArrayItems>
+            <Size>inner.inner.bytes.len</Size>
+            <ValuePointer>(char*)inner.inner.bytes.buf.ptr.pointer</ValuePointer>
           </ArrayItems>
         </Expand>
       </Synthetic>

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -628,7 +628,7 @@ impl Options {
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
         let show_type_layout = matches.opt_present("show-type-layout");
 
-        let (lint_opts, describe_lints, lint_cap, _) =
+        let (lint_opts, describe_lints, lint_cap) =
             get_cmd_lint_options(matches, error_format, &debugging_opts);
 
         Ok(Options {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -247,6 +247,9 @@ code, pre, a.test-arrow {
 pre {
 	padding: 14px;
 }
+.type-decl pre {
+	overflow-x: auto;
+}
 
 .source .content pre {
 	padding: 20px;

--- a/src/test/debuginfo/duration-type.rs
+++ b/src/test/debuginfo/duration-type.rs
@@ -1,0 +1,22 @@
+// only-cdb
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx duration
+// cdb-check:duration         : 5s 12ns [Type: core::time::Duration]
+// cdb-check:    [<Raw View>]     [Type: core::time::Duration]
+// cdb-check:    seconds          : 0x5 [Type: unsigned __int64]
+// cdb-check:    nanoseconds      : 0xc [Type: unsigned int]
+
+use std::time::Duration;
+
+fn main() {
+    let duration = Duration::new(5, 12);
+
+    zzz(); // #break
+}
+
+fn zzz() { }

--- a/src/test/debuginfo/duration-type.rs
+++ b/src/test/debuginfo/duration-type.rs
@@ -8,8 +8,8 @@
 // cdb-command: dx duration
 // cdb-check:duration         : 5s 12ns [Type: core::time::Duration]
 // cdb-check:    [<Raw View>]     [Type: core::time::Duration]
-// cdb-check:    seconds          : 0x5 [Type: unsigned __int64]
-// cdb-check:    nanoseconds      : 0xc [Type: unsigned int]
+// cdb-check:    seconds          : 5 [Type: unsigned __int64]
+// cdb-check:    nanoseconds      : 12 [Type: unsigned int]
 
 use std::time::Duration;
 

--- a/src/test/debuginfo/marker-types.rs
+++ b/src/test/debuginfo/marker-types.rs
@@ -17,8 +17,8 @@
 // cdb-command: dx pin
 // cdb-check:pin              : Pin(0x[...]: "this") [Type: core::pin::Pin<ref_mut$<alloc::string::String> >]
 // cdb-check:    [<Raw View>]     [Type: core::pin::Pin<ref_mut$<alloc::string::String> >]
-// cdb-check:    [len]            : 0x4 [Type: unsigned __int64]
-// cdb-check:    [capacity]       : 0x4 [Type: unsigned __int64]
+// cdb-check:    [len]            : 0x4 [Type: unsigned [...]]
+// cdb-check:    [capacity]       : 0x4 [Type: unsigned [...]]
 // cdb-check:    [chars]          : "this"
 
 // cdb-command: dx unique

--- a/src/test/debuginfo/marker-types.rs
+++ b/src/test/debuginfo/marker-types.rs
@@ -1,0 +1,21 @@
+// only-cdb
+// compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+
+// cdb-command: dx nonnull
+// cdb-check:nonnull          : NonNull(0x[...]: 0xc) [Type: core::ptr::non_null::NonNull<u32>]
+// cdb-check:    [<Raw View>]     [Type: core::ptr::non_null::NonNull<u32>]
+// cdb-checK:    0xc [Type: unsigned int]
+
+use std::ptr::NonNull;
+
+fn main() {
+    let nonnull: NonNull<_> = (&12u32).into();
+
+    zzz(); // #break
+}
+
+fn zzz() { }

--- a/src/test/debuginfo/marker-types.rs
+++ b/src/test/debuginfo/marker-types.rs
@@ -8,7 +8,7 @@
 // cdb-command: dx nonnull
 // cdb-check:nonnull          : NonNull(0x[...]: 0xc) [Type: core::ptr::non_null::NonNull<u32>]
 // cdb-check:    [<Raw View>]     [Type: core::ptr::non_null::NonNull<u32>]
-// cdb-checK:    0xc [Type: unsigned int]
+// cdb-check:    0xc [Type: unsigned int]
 
 // cdb-command: dx manuallydrop
 // cdb-check:manuallydrop     : 12345 [Type: core::mem::manually_drop::ManuallyDrop<i32>]
@@ -19,7 +19,7 @@
 // cdb-check:    [<Raw View>]     [Type: core::pin::Pin<ref_mut$<alloc::string::String> >]
 // cdb-check:    [len]            : 0x4 [Type: unsigned __int64]
 // cdb-check:    [capacity]       : 0x4 [Type: unsigned __int64]
-// cdb-check:    [chars]
+// cdb-check:    [chars]          : "this"
 
 use std::mem::ManuallyDrop;
 use std::pin::Pin;

--- a/src/test/debuginfo/marker-types.rs
+++ b/src/test/debuginfo/marker-types.rs
@@ -10,10 +10,28 @@
 // cdb-check:    [<Raw View>]     [Type: core::ptr::non_null::NonNull<u32>]
 // cdb-checK:    0xc [Type: unsigned int]
 
+// cdb-command: dx manuallydrop
+// cdb-check:manuallydrop     : 12345 [Type: core::mem::manually_drop::ManuallyDrop<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::mem::manually_drop::ManuallyDrop<i32>]
+
+// cdb-command: dx pin
+// cdb-check:pin              : Pin(0x[...]: "this") [Type: core::pin::Pin<ref_mut$<alloc::string::String> >]
+// cdb-check:    [<Raw View>]     [Type: core::pin::Pin<ref_mut$<alloc::string::String> >]
+// cdb-check:    [len]            : 0x4 [Type: unsigned __int64]
+// cdb-check:    [capacity]       : 0x4 [Type: unsigned __int64]
+// cdb-check:    [chars]
+
+use std::mem::ManuallyDrop;
+use std::pin::Pin;
 use std::ptr::NonNull;
 
 fn main() {
     let nonnull: NonNull<_> = (&12u32).into();
+
+    let manuallydrop = ManuallyDrop::new(12345i32);
+
+    let mut s = "this".to_string();
+    let pin = Pin::new(&mut s);
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/marker-types.rs
+++ b/src/test/debuginfo/marker-types.rs
@@ -21,9 +21,17 @@
 // cdb-check:    [capacity]       : 0x4 [Type: unsigned __int64]
 // cdb-check:    [chars]          : "this"
 
+// cdb-command: dx unique
+// cdb-check:unique           : Unique(0x[...]: (0x2a, 4321)) [Type: core::ptr::unique::Unique<tuple$<u64,i32> >]
+// cdb-check:    [<Raw View>]     [Type: core::ptr::unique::Unique<tuple$<u64,i32> >]
+// cdb-check:    [0]              : 0x2a [Type: unsigned __int64]
+// cdb-check:    [1]              : 4321 [Type: int]
+
+#![feature(ptr_internals)]
+
 use std::mem::ManuallyDrop;
 use std::pin::Pin;
-use std::ptr::NonNull;
+use std::ptr::{NonNull, Unique};
 
 fn main() {
     let nonnull: NonNull<_> = (&12u32).into();
@@ -32,6 +40,8 @@ fn main() {
 
     let mut s = "this".to_string();
     let pin = Pin::new(&mut s);
+
+    let unique: Unique<_> = (&mut (42u64, 4321i32)).into();
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/mutable-locs.rs
+++ b/src/test/debuginfo/mutable-locs.rs
@@ -9,26 +9,64 @@
 // cdb-command: g
 
 // cdb-command:dx static_c,d
-// cdb-check:static_c,d       [Type: core::cell::Cell<i32>]
-// cdb-check:    [...] value            [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:static_c,d       : 10 [Type: core::cell::Cell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::Cell<i32>]
 
 // cdb-command: dx static_c.value,d
-// cdb-check:static_c.value,d [Type: core::cell::UnsafeCell<i32>]
-// cdb-check:    [...] value            : 10 [Type: int]
+// cdb-check:static_c.value,d : 10 [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::UnsafeCell<i32>]
 
 // cdb-command:  dx dynamic_c,d
-// cdb-check:dynamic_c,d      [Type: core::cell::RefCell<i32>]
-// cdb-check:    [...] borrow           [Type: core::cell::Cell<isize>]
-// cdb-check:    [...] value            [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:dynamic_c,d      : 15 [Type: core::cell::RefCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefCell<i32>]
+// cdb-check:    [Borrow state]   : Unborrowed
 
 // cdb-command: dx dynamic_c.value,d
-// cdb-check:dynamic_c.value,d [Type: core::cell::UnsafeCell<i32>]
-// cdb-check:    [...] value            : 15 [Type: int]
+// cdb-check:dynamic_c.value,d : 15 [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::UnsafeCell<i32>]
 
 // cdb-command: dx b,d
-// cdb-check:b,d              [Type: core::cell::RefMut<i32>]
-// cdb-check:    [...] value            : [...] : 42 [Type: int *]
-// cdb-check:    [...] borrow           [Type: core::cell::BorrowRefMut]
+// cdb-check:b,d              : 42 [Type: core::cell::RefMut<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefMut<i32>]
+// cdb-check:    42 [Type: int]
+
+// cdb-command: g
+
+// cdb-command: dx dynamic_c,d
+// cdb-check:dynamic_c,d      : 15 [Type: core::cell::RefCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefCell<i32>]
+// cdb-check:    [Borrow state]   : Immutably borrowed
+
+// cdb-command: dx r_borrow,d
+// cdb-check:r_borrow,d       : 15 [Type: core::cell::Ref<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::Ref<i32>]
+// cdb-check:    15 [Type: int]
+
+// cdb-command: g
+
+// cdb-command: dx dynamic_c,d
+// cdb-check:dynamic_c,d      : 15 [Type: core::cell::RefCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefCell<i32>]
+// cdb-check:    [Borrow state]   : Unborrowed
+
+// cdb-command: g
+
+// cdb-command: dx dynamic_c,d
+// cdb-check:dynamic_c,d      : 15 [Type: core::cell::RefCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefCell<i32>]
+// cdb-check:    [Borrow state]   : Mutably borrowed
+
+// cdb-command: dx r_borrow_mut,d
+// cdb-check:r_borrow_mut,d   : 15 [Type: core::cell::RefMut<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefMut<i32>]
+// cdb-check:    15 [Type: int]
+
+// cdb-command: g
+
+// cdb-command: dx dynamic_c,d
+// cdb-check:dynamic_c,d      : 15 [Type: core::cell::RefCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::RefCell<i32>]
+// cdb-check:    [Borrow state]   : Unborrowed
 
 #![allow(unused_variables)]
 
@@ -44,6 +82,21 @@ fn main() {
     let dynamic_c_0 = RefCell::new(15);
     let mut b = dynamic_c_0.borrow_mut();
     *b = 42;
+
+    zzz(); // #break
+
+    // Check that `RefCell`'s borrow state visualizes correctly
+    {
+        let r_borrow = dynamic_c.borrow();
+        zzz(); // #break
+    }
+
+    zzz(); // #break
+
+    {
+        let r_borrow_mut = dynamic_c.borrow_mut();
+        zzz(); // #break
+    }
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/numeric-types.rs
+++ b/src/test/debuginfo/numeric-types.rs
@@ -1,0 +1,142 @@
+// only-cdb
+// compile-flags:-g
+
+// Tests the visualizations for `NonZero{I,U}{8,16,32,64,128,size}` and `Wrapping<T>` in
+// `libcore.natvis`.
+
+// === CDB TESTS ==================================================================================
+// cdb-command: g
+
+// cdb-command: dx nz_i8
+// cdb-check:nz_i8            : 11 [Type: core::num::nonzero::NonZeroI8]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroI8]
+
+// cdb-command: dx nz_i16
+// cdb-check:nz_i16           : 22 [Type: core::num::nonzero::NonZeroI16]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroI16]
+
+// cdb-command: dx nz_i32
+// cdb-check:nz_i32           : 33 [Type: core::num::nonzero::NonZeroI32]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroI32]
+
+// cdb-command: dx nz_i64
+// cdb-check:nz_i64           : 44 [Type: core::num::nonzero::NonZeroI64]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroI64]
+
+// 128-bit integers don't seem to work in CDB
+// cdb-command: dx nz_i128
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroI128]
+
+// cdb-command: dx nz_isize
+// cdb-check:nz_isize         : 66 [Type: core::num::nonzero::NonZeroIsize]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroIsize]
+
+// cdb-command: dx nz_u8
+// cdb-check:nz_u8            : 0x4d [Type: core::num::nonzero::NonZeroU8]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroU8]
+
+// cdb-command: dx nz_u16
+// cdb-check:nz_u16           : 0x58 [Type: core::num::nonzero::NonZeroU16]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroU16]
+
+// cdb-command: dx nz_u32
+// cdb-check:nz_u32           : 0x63 [Type: core::num::nonzero::NonZeroU32]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroU32]
+
+// cdb-command: dx nz_u64
+// cdb-check:nz_u64           : 0x64 [Type: core::num::nonzero::NonZeroU64]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroU64]
+
+// 128-bit integers don't seem to work in CDB
+// cdb-command: dx nz_u128
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroU128]
+
+// cdb-command: dx nz_usize
+// cdb-check:nz_usize         : 0x7a [Type: core::num::nonzero::NonZeroUsize]
+// cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZeroUsize]
+
+// cdb-command: dx w_i8
+// cdb-check:w_i8             : 10 [Type: core::num::wrapping::Wrapping<i8>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i8>]
+
+// cdb-command: dx w_i16
+// cdb-check:w_i16            : 20 [Type: core::num::wrapping::Wrapping<i16>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i16>]
+
+// cdb-command: dx w_i32
+// cdb-check:w_i32            : 30 [Type: core::num::wrapping::Wrapping<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i32>]
+
+// cdb-command: dx w_i64
+// cdb-check:w_i64            : 40 [Type: core::num::wrapping::Wrapping<i64>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i64>]
+
+// 128-bit integers don't seem to work in CDB
+// cdb-command: dx w_i128
+// cdb-check:w_i128           [Type: core::num::wrapping::Wrapping<i128>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i128>]
+
+// cdb-command: dx w_isize
+// cdb-check:w_isize          : 60 [Type: core::num::wrapping::Wrapping<isize>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<isize>]
+
+// cdb-command: dx w_u8
+// cdb-check:w_u8             : 0x46 [Type: core::num::wrapping::Wrapping<u8>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u8>]
+
+// cdb-command: dx w_u16
+// cdb-check:w_u16            : 0x50 [Type: core::num::wrapping::Wrapping<u16>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u16>]
+
+// cdb-command: dx w_u32
+// cdb-check:w_u32            : 0x5a [Type: core::num::wrapping::Wrapping<u32>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u32>]
+
+// cdb-command: dx w_u64
+// cdb-check:w_u64            : 0x64 [Type: core::num::wrapping::Wrapping<u64>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u64>]
+
+// 128-bit integers don't seem to work in CDB
+// cdb-command: dx w_u128
+// cdb-check:w_u128           [Type: core::num::wrapping::Wrapping<u128>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u128>]
+
+// cdb-command: dx w_usize
+// cdb-check:w_usize          : 0x78 [Type: core::num::wrapping::Wrapping<usize>]
+// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<usize>]
+
+use std::num::*;
+
+fn main() {
+    let nz_i8 = NonZeroI8::new(11).unwrap();
+    let nz_i16 = NonZeroI16::new(22).unwrap();
+    let nz_i32 = NonZeroI32::new(33).unwrap();
+    let nz_i64 = NonZeroI64::new(44).unwrap();
+    let nz_i128 = NonZeroI128::new(55).unwrap();
+    let nz_isize = NonZeroIsize::new(66).unwrap();
+
+    let nz_u8 = NonZeroU8::new(77).unwrap();
+    let nz_u16 = NonZeroU16::new(88).unwrap();
+    let nz_u32 = NonZeroU32::new(99).unwrap();
+    let nz_u64 = NonZeroU64::new(100).unwrap();
+    let nz_u128 = NonZeroU128::new(111).unwrap();
+    let nz_usize = NonZeroUsize::new(122).unwrap();
+
+    let w_i8 = Wrapping(10i8);
+    let w_i16 = Wrapping(20i16);
+    let w_i32 = Wrapping(30i32);
+    let w_i64 = Wrapping(40i64);
+    let w_i128 = Wrapping(50i128);
+    let w_isize = Wrapping(60isize);
+
+    let w_u8 = Wrapping(70u8);
+    let w_u16 = Wrapping(80u16);
+    let w_u32 = Wrapping(90u32);
+    let w_u64 = Wrapping(100u64);
+    let w_u128 = Wrapping(110u128);
+    let w_usize = Wrapping(120usize);
+
+    zzz(); // #break
+}
+
+fn zzz() { }

--- a/src/test/debuginfo/numeric-types.rs
+++ b/src/test/debuginfo/numeric-types.rs
@@ -1,8 +1,8 @@
 // only-cdb
 // compile-flags:-g
 
-// Tests the visualizations for `NonZero{I,U}{8,16,32,64,128,size}` and `Wrapping<T>` in
-// `libcore.natvis`.
+// Tests the visualizations for `NonZero{I,U}{8,16,32,64,128,size}`, `Wrapping<T>` and
+// `Atomic{Bool,I8,I16,I32,I64,Isize,U8,U16,U32,U64,Usize}` located in `libcore.natvis`.
 
 // === CDB TESTS ==================================================================================
 // cdb-command: g
@@ -105,7 +105,56 @@
 // cdb-check:w_usize          : 0x78 [Type: core::num::wrapping::Wrapping<usize>]
 // cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<usize>]
 
+// cdb-command: dx a_bool_t
+// cdb-check:a_bool_t         : true [Type: core::sync::atomic::AtomicBool]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicBool]
+
+// cdb-command: dx a_bool_f
+// cdb-check:a_bool_f         : false [Type: core::sync::atomic::AtomicBool]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicBool]
+
+// cdb-command: dx a_i8
+// cdb-check:a_i8             : 2 [Type: core::sync::atomic::AtomicI8]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI8]
+
+// cdb-command: dx a_i16
+// cdb-check:a_i16            : 4 [Type: core::sync::atomic::AtomicI16]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI16]
+
+// cdb-command: dx a_i32
+// cdb-check:a_i32            : 8 [Type: core::sync::atomic::AtomicI32]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI32]
+
+// cdb-command: dx a_i64
+// cdb-check:a_i64            : 16 [Type: core::sync::atomic::AtomicI64]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI64]
+
+// cdb-command: dx a_isize
+// cdb-check:a_isize          : 32 [Type: core::sync::atomic::AtomicIsize]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicIsize]
+
+// cdb-command: dx a_u8
+// cdb-check:a_u8             : 0x40 [Type: core::sync::atomic::AtomicU8]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU8]
+
+// cdb-command: dx a_u16
+// cdb-check:a_u16            : 0x80 [Type: core::sync::atomic::AtomicU16]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU16]
+
+// cdb-command: dx a_u32
+// cdb-check:a_u32            : 0x100 [Type: core::sync::atomic::AtomicU32]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU32]
+
+// cdb-command: dx a_u64
+// cdb-check:a_u64            : 0x200 [Type: core::sync::atomic::AtomicU64]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU64]
+
+// cdb-command: dx a_usize
+// cdb-check:a_usize          : 0x400 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicUsize]
+
 use std::num::*;
+use std::sync::atomic::*;
 
 fn main() {
     let nz_i8 = NonZeroI8::new(11).unwrap();
@@ -135,6 +184,21 @@ fn main() {
     let w_u64 = Wrapping(100u64);
     let w_u128 = Wrapping(110u128);
     let w_usize = Wrapping(120usize);
+
+    let a_bool_t = AtomicBool::new(true);
+    let a_bool_f = AtomicBool::new(false);
+
+    let a_i8 = AtomicI8::new(2);
+    let a_i16 = AtomicI16::new(4);
+    let a_i32 = AtomicI32::new(8);
+    let a_i64 = AtomicI64::new(16);
+    let a_isize = AtomicIsize::new(32);
+
+    let a_u8 = AtomicU8::new(64);
+    let a_u16 = AtomicU16::new(128);
+    let a_u32 = AtomicU32::new(256);
+    let a_u64 = AtomicU64::new(512);
+    let a_usize = AtomicUsize::new(1024);
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -113,7 +113,7 @@
 // cdb-command: dx os_string
 // cdb-check:os_string        : "IAMA OS string 😃" [Type: std::ffi::os_str::OsString]
 // cdb-check:    [<Raw View>]     [Type: std::ffi::os_str::OsString]
-// cdb-check:    [chars]
+// cdb-check:    [chars]          : "IAMA OS string 😃"
 
 // cdb-command: dx some
 // cdb-check:some             : Some [Type: enum$<core::option::Option<i16> >]

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -111,8 +111,9 @@
 // cdb-check:    [11]             : 33 '!' [Type: char]
 
 // cdb-command: dx os_string
-// cdb-check:os_string        [Type: [...]::OsString]
-// NOTE: OsString doesn't have a .natvis entry yet.
+// cdb-check:os_string        : "IAMA OS string 😃" [Type: std::ffi::os_str::OsString]
+// cdb-check:    [<Raw View>]     [Type: std::ffi::os_str::OsString]
+// cdb-check:    [chars]
 
 // cdb-command: dx some
 // cdb-check:some             : Some [Type: enum$<core::option::Option<i16> >]

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -140,7 +140,7 @@
 // cdb-check:vecdeque         : { len=0x2 } [Type: alloc::collections::vec_deque::VecDeque<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::collections::vec_deque::VecDeque<i32>]
 // cdb-check:    [len]            : 0x2
-// cdb-check:    [capacity]       : 0x8 [Type: unsigned __int64]
+// cdb-check:    [capacity]       : 0x8 [Type: unsigned [...]]
 // cdb-check:    [0x0]            : 90 [Type: int]
 // cdb-check:    [0x1]            : 20 [Type: int]
 

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -129,9 +129,23 @@
 // NOTE: cdb fails to interpret debug info of Option enums on i686.
 // cdb-check:some_string      [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>]
 
-#![allow(unused_variables)]
-use std::ffi::OsString;
+// cdb-command: dx linkedlist
+// cdb-check:linkedlist       : { len=0x2 } [Type: alloc::collections::linked_list::LinkedList<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::collections::linked_list::LinkedList<i32>]
+// cdb-check:    [0x0]            : 128 [Type: int]
+// cdb-check:    [0x1]            : 42 [Type: int]
 
+// cdb-command: dx vecdeque
+// cdb-check:vecdeque         : { len=0x2 } [Type: alloc::collections::vec_deque::VecDeque<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::collections::vec_deque::VecDeque<i32>]
+// cdb-check:    [len]            : 0x2
+// cdb-check:    [capacity]       : 0x8 [Type: unsigned __int64]
+// cdb-check:    [0x0]            : 90 [Type: int]
+// cdb-check:    [0x1]            : 20 [Type: int]
+
+#![allow(unused_variables)]
+use std::collections::{LinkedList, VecDeque};
+use std::ffi::OsString;
 
 fn main() {
 
@@ -155,6 +169,16 @@ fn main() {
     let none: Option<i64> = None;
 
     let some_string = Some("IAMA optional string!".to_owned());
+
+    // LinkedList
+    let mut linkedlist = LinkedList::new();
+    linkedlist.push_back(42);
+    linkedlist.push_front(128);
+
+    // VecDeque
+    let mut vecdeque = VecDeque::new();
+    vecdeque.push_back(20);
+    vecdeque.push_front(90);
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/range-types.rs
+++ b/src/test/debuginfo/range-types.rs
@@ -9,26 +9,27 @@
 // cdb-command: g
 
 // cdb-command: dx r1,d
-// cdb-check:r1,d             [Type: core::ops::range::Range<i32>]
-// cdb-check:    [...] start            : 3 [Type: int]
-// cdb-check:    [...] end              : 5 [Type: int]
+// cdb-check:r1,d             : (3..5) [Type: core::ops::range::Range<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::ops::range::Range<i32>]
 
 // cdb-command: dx r2,d
-// cdb-check:r2,d             [Type: core::ops::range::RangeFrom<i32>]
-// cdb-check:    [...] start            : 2 [Type: int]
+// cdb-check:r2,d             : (2..) [Type: core::ops::range::RangeFrom<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeFrom<i32>]
 
 // cdb-command: dx r3,d
-// cdb-check:r3,d             [Type: core::ops::range::RangeInclusive<i32>]
-// cdb-check:    [...] start            : 1 [Type: int]
-// cdb-check:    [...] end              : 4 [Type: int]
-// cdb-check:    [...] exhausted        : false [Type: bool]
+// cdb-check:r3,d             : (1..=4) [Type: core::ops::range::RangeInclusive<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeInclusive<i32>]
 
 // cdb-command: dx r4,d
-// cdb-check:r4,d             [Type: core::ops::range::RangeToInclusive<i32>]
-// cdb-check:    [...] end              : 3 [Type: int]
+// cdb-check:r4,d             : (..10) [Type: core::ops::range::RangeTo<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeTo<i32>]
 
 // cdb-command: dx r5,d
-// cdb-check:r5,d             [Type: core::ops::range::RangeFull]
+// cdb-check:r5,d             : (..=3) [Type: core::ops::range::RangeToInclusive<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeToInclusive<i32>]
+
+// cdb-command: dx r6,d
+// cdb-check:r6,d             [Type: core::ops::range::RangeFull]
 
 #[allow(unused_variables)]
 
@@ -36,11 +37,12 @@ use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
 
 fn main()
 {
-    let r1 = Range{start: 3, end: 5};
-    let r2 = RangeFrom{start: 2};
-    let r3 = RangeInclusive::new(1, 4);
-    let r4 = RangeToInclusive{end: 3};
-    let r5 = RangeFull{};
+    let r1 = (3..5);
+    let r2 = (2..);
+    let r3 = (1..=4);
+    let r4 = (..10);
+    let r5 = (..=3);
+    let r6 = (..);
     zzz(); // #break
 }
 

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -31,29 +31,37 @@
 // cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
 // cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
 // cdb-command:dx r1,d
 // cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
 // cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
 // cdb-command:dx w1,d
 // cdb-check:w1,d             : 42 [Type: alloc::rc::Weak<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
 // cdb-command:dx a,d
 // cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
 // cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
 // cdb-command:dx a1,d
 // cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
 // cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
 // cdb-command:dx w2,d
 // cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
 // cdb-check:    [<Raw View>]     [Type: alloc::sync::Weak<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -29,22 +29,31 @@
 
 // cdb-command:dx r,d
 // cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
 
 // cdb-command:dx r1,d
 // cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
 
 // cdb-command:dx w1,d
-// cdb-check:w1,d             [Type: alloc::rc::Weak<i32>]
-// cdb-check:    [...] ptr              : [...] [Type: core::ptr::non_null::NonNull<alloc::rc::RcBox<i32> >]
+// cdb-check:w1,d             : 42 [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::rc::Weak<i32>]
 
 // cdb-command:dx a,d
 // cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
 // cdb-command:dx a1,d
 // cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
 // cdb-command:dx w2,d
 // cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
+// cdb-check:    [<Raw View>]     [Type: alloc::sync::Weak<i32>]
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/test/debuginfo/rwlock-read.rs
+++ b/src/test/debuginfo/rwlock-read.rs
@@ -11,15 +11,15 @@
 // cdb-command:dx l
 // cdb-check:l                [Type: std::sync::rwlock::RwLock<i32>]
 // cdb-check:    [...] poison           [Type: std::sync::poison::Flag]
-// cdb-check:    [...] data             [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] data             : 0 [Type: core::cell::UnsafeCell<i32>]
 //
 // cdb-command:dx r
 // cdb-check:r                [Type: std::sync::rwlock::RwLockReadGuard<i32>]
 // cdb-check:    [...] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
 //
 // cdb-command:dx r.lock->data,d
-// cdb-check:r.lock->data,d   [Type: core::cell::UnsafeCell<i32>]
-// cdb-check:    [...] value            : 0 [Type: int]
+// cdb-check:r.lock->data,d   : 0 [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [<Raw View>]     [Type: core::cell::UnsafeCell<i32>]
 
 #[allow(unused_variables)]
 

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -47,3 +47,10 @@ pub mod sub_mod {
     /// ```
     pub struct Foo;
 }
+
+pub mod long_trait {
+    use std::ops::DerefMut;
+
+    pub trait ALongNameBecauseItHelpsTestingTheCurrentProblem: DerefMut<Target = u32>
+        + From<u128> + Send + Sync + AsRef<str> + 'static {}
+}

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -1,0 +1,8 @@
+// This test ensures that the type declaration content overflow is handled inside the <pre> directly.
+goto: file://|DOC_PATH|/lib2/long_trait/trait.ALongNameBecauseItHelpsTestingTheCurrentProblem.html
+// We set a fixed size so there is no chance of "random" resize.
+size: (1100, 800)
+// Logically, the <body> scroll width should be the width of the window.
+assert-property: ("body", {"scrollWidth": "1100"})
+// However, since there is overflow in the type declaration, its scroll width is bigger.
+assert-property: (".type-decl pre", {"scrollWidth": "1324"})

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.rs
@@ -195,6 +195,21 @@ fn box_mut_2() {
     //~| NOTE: Min Capture p_foo[Deref,Deref,(0, 0)] -> UniqueImmBorrow
 }
 
+// Test that move closures can take ownership of Copy type
+fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
+    let x = 10;
+
+    let c = #[rustc_capture_analysis] move || x;
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| First Pass analysis includes:
+    //~| NOTE: Capturing x[] -> ImmBorrow
+    //~| Min Capture analysis includes:
+    //~| NOTE: Min Capture x[] -> ByValue
+
+    c
+}
+
 fn main() {
     simple_move_closure();
     simple_ref();

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -88,6 +88,39 @@ LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:202:13
+   |
+LL |     let c = #[rustc_capture_analysis] move || x;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:202:39
+   |
+LL |     let c = #[rustc_capture_analysis] move || x;
+   |                                       ^^^^^^^^^
+   |
+note: Capturing x[] -> ImmBorrow
+  --> $DIR/move_closure.rs:202:47
+   |
+LL |     let c = #[rustc_capture_analysis] move || x;
+   |                                               ^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:202:39
+   |
+LL |     let c = #[rustc_capture_analysis] move || x;
+   |                                       ^^^^^^^^^
+   |
+note: Min Capture x[] -> ByValue
+  --> $DIR/move_closure.rs:202:47
+   |
+LL |     let c = #[rustc_capture_analysis] move || x;
+   |                                               ^
+
 error: First Pass analysis includes:
   --> $DIR/move_closure.rs:15:5
    |
@@ -424,6 +457,6 @@ note: Min Capture p_foo[Deref,Deref,(0, 0)] -> UniqueImmBorrow
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                               ^^^^^^^
 
-error: aborting due to 30 previous errors
+error: aborting due to 33 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
@@ -3,6 +3,8 @@
 
 // Test that move closures compile properly with `capture_disjoint_fields` enabled.
 
+#![allow(unused)]
+
 fn simple_ref() {
     let mut s = 10;
     let ref_s = &mut s;
@@ -92,6 +94,15 @@ fn data_moved_but_not_fn_once() {
     c();
 }
 
+// Test that move closures can take ownership of Copy type
+fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
+    let x = 10;
+
+    let c = move || x;
+
+    c
+}
+
 fn main() {
     simple_ref();
     struct_contains_ref_to_another_struct();
@@ -100,4 +111,6 @@ fn main() {
 
     disjoint_via_ref();
     data_moved_but_not_fn_once();
+
+    returned_closure_owns_copy_type_data();
 }

--- a/src/test/ui/lint/cli-lint-override.forbid_warn.stderr
+++ b/src/test/ui/lint/cli-lint-override.forbid_warn.stderr
@@ -1,0 +1,11 @@
+error: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `-F missing-abi`
+   = help: the default ABI is C
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/cli-lint-override.force_warn_deny.stderr
+++ b/src/test/ui/lint/cli-lint-override.force_warn_deny.stderr
@@ -1,0 +1,11 @@
+warning: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `--force-warns missing-abi`
+   = help: the default ABI is C
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/cli-lint-override.rs
+++ b/src/test/ui/lint/cli-lint-override.rs
@@ -1,0 +1,17 @@
+// Tests that subsequent lints specified via the command line override
+// each other, except for ForceWarn and Forbid, which cannot be overriden.
+//
+// revisions: warn_deny forbid_warn force_warn_deny
+//
+//[warn_deny] compile-flags: --warn missing_abi --deny missing_abi
+//[forbid_warn] compile-flags: --warn missing_abi --forbid missing_abi
+//[force_warn_deny] compile-flags: -Z unstable-options --force-warns missing_abi --allow missing_abi
+//[force_warn_deny] check-pass
+
+
+extern fn foo() {}
+//[warn_deny]~^ ERROR extern declarations without an explicit ABI are deprecated
+//[forbid_warn]~^^ ERROR extern declarations without an explicit ABI are deprecated
+//[force_warn_deny]~^^^ WARN extern declarations without an explicit ABI are deprecated
+
+fn main() {}

--- a/src/test/ui/lint/cli-lint-override.warn_deny.stderr
+++ b/src/test/ui/lint/cli-lint-override.warn_deny.stderr
@@ -1,0 +1,11 @@
+error: extern declarations without an explicit ABI are deprecated
+  --> $DIR/cli-lint-override.rs:12:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^ ABI should be specified here
+   |
+   = note: requested on the command line with `-D missing-abi`
+   = help: the default ABI is C
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/cli-unknown-force-warn.rs
+++ b/src/test/ui/lint/cli-unknown-force-warn.rs
@@ -1,0 +1,7 @@
+// Checks that rustc correctly errors when passed an invalid lint with
+// `--force-warns`. This is a regression test for issue #86958.
+//
+// compile-flags: -Z unstable-options --force-warns foo-qux
+// error-pattern: unknown lint: `foo_qux`
+
+fn main() {}

--- a/src/test/ui/lint/cli-unknown-force-warn.stderr
+++ b/src/test/ui/lint/cli-unknown-force-warn.stderr
@@ -1,0 +1,15 @@
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error[E0602]: unknown lint: `foo_qux`
+   |
+   = note: requested on the command line with `--force-warns foo_qux`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0602`.

--- a/src/tools/clippy/clippy_lints/src/escape.rs
+++ b/src/tools/clippy/clippy_lints/src/escape.rs
@@ -11,7 +11,7 @@ use rustc_span::source_map::Span;
 use rustc_span::symbol::kw;
 use rustc_target::abi::LayoutOf;
 use rustc_target::spec::abi::Abi;
-use rustc_typeck::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
+use rustc_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 
 #[derive(Copy, Clone)]
 pub struct BoxedLocal {
@@ -133,13 +133,10 @@ fn is_argument(map: rustc_middle::hir::map::Map<'_>, id: HirId) -> bool {
 }
 
 impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
-    fn consume(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, mode: ConsumeMode) {
+    fn consume(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
         if cmt.place.projections.is_empty() {
             if let PlaceBase::Local(lid) = cmt.place.base {
-                if let ConsumeMode::Move = mode {
-                    // moved out or in. clearly can't be localized
-                    self.set.remove(&lid);
-                }
+                self.set.remove(&lid);
                 let map = &self.cx.tcx.hir();
                 if let Some(Node::Binding(_)) = map.find(cmt.hir_id) {
                     if self.set.contains(&lid) {

--- a/src/tools/clippy/clippy_lints/src/loops/mut_range_bound.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/mut_range_bound.rs
@@ -7,7 +7,7 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::LateContext;
 use rustc_middle::{mir::FakeReadCause, ty};
 use rustc_span::source_map::Span;
-use rustc_typeck::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
+use rustc_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 
 pub(super) fn check(cx: &LateContext<'_>, arg: &Expr<'_>, body: &Expr<'_>) {
     if let Some(higher::Range {
@@ -82,7 +82,7 @@ struct MutatePairDelegate<'a, 'tcx> {
 }
 
 impl<'tcx> Delegate<'tcx> for MutatePairDelegate<'_, 'tcx> {
-    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId, _: ConsumeMode) {}
+    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, diag_expr_id: HirId, bk: ty::BorrowKind) {
         if let ty::BorrowKind::MutBorrow = bk {

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -326,10 +326,8 @@ impl MovedVariablesCtxt {
 }
 
 impl<'tcx> euv::Delegate<'tcx> for MovedVariablesCtxt {
-    fn consume(&mut self, cmt: &euv::PlaceWithHirId<'tcx>, _: HirId, mode: euv::ConsumeMode) {
-        if let euv::ConsumeMode::Move = mode {
-            self.move_common(cmt);
-        }
+    fn consume(&mut self, cmt: &euv::PlaceWithHirId<'tcx>, _: HirId) {
+        self.move_common(cmt);
     }
 
     fn borrow(&mut self, _: &euv::PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {}

--- a/src/tools/clippy/clippy_utils/src/usage.rs
+++ b/src/tools/clippy/clippy_utils/src/usage.rs
@@ -10,7 +10,7 @@ use rustc_lint::LateContext;
 use rustc_middle::hir::map::Map;
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty;
-use rustc_typeck::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
+use rustc_typeck::expr_use_visitor::{Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 
 /// Returns a set of mutated local variable IDs, or `None` if mutations could not be determined.
 pub fn mutated_variables<'tcx>(expr: &'tcx Expr<'_>, cx: &LateContext<'tcx>) -> Option<HirIdSet> {
@@ -67,7 +67,7 @@ impl<'tcx> MutVarsDelegate {
 }
 
 impl<'tcx> Delegate<'tcx> for MutVarsDelegate {
-    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId, _: ConsumeMode) {}
+    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, bk: ty::BorrowKind) {
         if let ty::BorrowKind::MutBorrow = bk {


### PR DESCRIPTION
Successful merges:

 - #86970 (Make `--force-warns` a normal lint level option)
 - #86983 (Add or improve natvis definitions for common standard library types)
 - #87069 (ExprUseVisitor: Treat ByValue use of Copy types as ImmBorrow)
 - #87162 (Fix type decl layout "overflow")

Failed merges:

 - #87145 (Make --cap-lints and related options leave crate hash alone)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86970,86983,87069,87162)
<!-- homu-ignore:end -->