### PR TITLE
implement TrustedLen for Flatten/FlatMap if the U: IntoIterator == [T; N]

### DIFF
--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -297,7 +297,7 @@ where
         let (blo, bhi) = self.backiter.as_ref().map_or((0, Some(0)), U::size_hint);
         let lo = flo.saturating_add(blo);
 
-        if let Some(fixed_size) = <<I as Iterator>::Item as ConstSizeIterable>::size() {
+        if let Some(fixed_size) = <<I as Iterator>::Item as ConstSizeIntoIterator>::size() {
             let (lower, upper) = self.iter.size_hint();
 
             let lower = lower.saturating_mul(fixed_size).saturating_add(lo);
@@ -474,18 +474,18 @@ where
     }
 }
 
-trait ConstSizeIterable {
+trait ConstSizeIntoIterator: IntoIterator {
     fn size() -> Option<usize>;
 }
 
-impl<T> ConstSizeIterable for T {
+impl<T> ConstSizeIntoIterator for T where T: IntoIterator {
     #[inline]
     default fn size() -> Option<usize> {
         None
     }
 }
 
-impl<T, const N: usize> ConstSizeIterable for [T; N] {
+impl<T, const N: usize> ConstSizeIntoIterator for [T; N] {
     #[inline]
     fn size() -> Option<usize> {
         Some(N)

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -319,12 +319,8 @@ where
             let (lower, upper) = self.iter.size_hint();
 
             let lower = lower.saturating_mul(fixed_size).saturating_add(lo);
-            let upper = upper.and_then(|i| i.checked_mul(fixed_size));
-            let upper = fhi
-                .zip_with(bhi, usize::checked_add)
-                .flatten()
-                .zip_with(upper, usize::checked_add)
-                .flatten();
+            let upper =
+                try { fhi?.checked_add(bhi?)?.checked_add(fixed_size.checked_mul(upper?)?)? };
 
             return (lower, upper);
         }

--- a/library/core/tests/iter/adapters/flatten.rs
+++ b/library/core/tests/iter/adapters/flatten.rs
@@ -129,7 +129,23 @@ fn test_trusted_len_flatten() {
     let iter = array::IntoIter::new([[(); usize::MAX]; 2]).flatten();
     assert_eq!(iter.size_hint(), (usize::MAX, None));
 
+    let mut a = [(); 10];
+    let mut b = [(); 10];
+
+    let iter = array::IntoIter::new([&mut a, &mut b]).flatten();
+    assert_trusted_len(&iter);
+    assert_eq!(iter.size_hint(), (20, Some(20)));
+    core::mem::drop(iter);
+
+    let iter = array::IntoIter::new([&a, &b]).flatten();
+    assert_trusted_len(&iter);
+    assert_eq!(iter.size_hint(), (20, Some(20)));
+
     let iter = [(), (), ()].iter().flat_map(|_| [(); 1000]);
     assert_trusted_len(&iter);
     assert_eq!(iter.size_hint(), (3000, Some(3000)));
+
+    let iter = [(), ()].iter().flat_map(|_| &a);
+    assert_trusted_len(&iter);
+    assert_eq!(iter.size_hint(), (20, Some(20)));
 }

--- a/library/core/tests/iter/adapters/flatten.rs
+++ b/library/core/tests/iter/adapters/flatten.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::array;
 use core::iter::*;
 
 #[test]
@@ -108,4 +109,27 @@ fn test_double_ended_flatten() {
     assert_eq!(it.next_back(), None);
     assert_eq!(it.next(), None);
     assert_eq!(it.next_back(), None);
+}
+
+#[test]
+fn test_trusted_len_flatten() {
+    fn assert_trusted_len<T: TrustedLen>(_: &T) {}
+    let mut iter = array::IntoIter::new([[0; 3]; 4]).flatten();
+    assert_trusted_len(&iter);
+
+    assert_eq!(iter.size_hint(), (12, Some(12)));
+    iter.next();
+    assert_eq!(iter.size_hint(), (11, Some(11)));
+    iter.next_back();
+    assert_eq!(iter.size_hint(), (10, Some(10)));
+
+    let iter = array::IntoIter::new([[(); usize::MAX]; 1]).flatten();
+    assert_eq!(iter.size_hint(), (usize::MAX, Some(usize::MAX)));
+
+    let iter = array::IntoIter::new([[(); usize::MAX]; 2]).flatten();
+    assert_eq!(iter.size_hint(), (usize::MAX, None));
+
+    let iter = [(), (), ()].iter().flat_map(|_| [(); 1000]);
+    assert_trusted_len(&iter);
+    assert_eq!(iter.size_hint(), (3000, Some(3000)));
 }


### PR DESCRIPTION
This only works if arrays are passed directly instead of array iterators
because we need to be sure that they have not been advanced before
Flatten does its size calculation.

resolves #87094