### PR TITLE
unstable proc_macro tracked::* rename/restructure

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -402,7 +402,7 @@ impl server::FreeFunctions for Rustc<'_, '_> {
             .insert((Symbol::intern(var), value.map(Symbol::intern)));
     }
 
-    fn track_fs_path(&mut self, path: &str) {
+    fn track_path(&mut self, path: &str) {
         self.sess().file_depinfo.borrow_mut().insert(Symbol::intern(path));
     }
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -402,8 +402,8 @@ impl server::FreeFunctions for Rustc<'_, '_> {
             .insert((Symbol::intern(var), value.map(Symbol::intern)));
     }
 
-    fn track_path(&mut self, path: &str) {
-        self.sess().file_depinfo.borrow_mut().insert(Symbol::intern(path));
+    fn track_path(&mut self, path: std::path::PathBuf) {
+        self.sess().file_depinfo.borrow_mut().insert(path);
     }
 
     fn literal_from_str(&mut self, s: &str) -> Result<Literal<Self::Span, Self::Symbol>, ()> {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -19,6 +19,11 @@ use rustc_span::symbol::{self, sym, Symbol};
 use rustc_span::{BytePos, FileName, Pos, SourceFile, Span};
 use smallvec::{smallvec, SmallVec};
 use std::ops::{Bound, Range};
+use std::{path, ascii, panic};
+use pm::bridge::{
+    server, DelimSpan, ExpnGlobals, Group, Ident, LitKind, Literal, Punct, TokenTree,
+};
+use pm::{Delimiter, Level, LineColumn};
 
 trait FromInternal<T> {
     fn from_internal(x: T) -> Self;
@@ -402,8 +407,8 @@ impl server::FreeFunctions for Rustc<'_, '_> {
             .insert((Symbol::intern(var), value.map(Symbol::intern)));
     }
 
-    fn track_path(&mut self, path: &str) {
-        self.sess().file_depinfo.borrow_mut().insert(Symbol::intern(path));
+    fn track_fs_path(&mut self, path: &str) {
+        self.sess().file_depinfo.borrow_mut().insert(path::PathBuf::from(path));
     }
 
     fn literal_from_str(&mut self, s: &str) -> Result<Literal<Self::Span, Self::Symbol>, ()> {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -19,11 +19,6 @@ use rustc_span::symbol::{self, sym, Symbol};
 use rustc_span::{BytePos, FileName, Pos, SourceFile, Span};
 use smallvec::{smallvec, SmallVec};
 use std::ops::{Bound, Range};
-use std::{path, ascii, panic};
-use pm::bridge::{
-    server, DelimSpan, ExpnGlobals, Group, Ident, LitKind, Literal, Punct, TokenTree,
-};
-use pm::{Delimiter, Level, LineColumn};
 
 trait FromInternal<T> {
     fn from_internal(x: T) -> Self;
@@ -408,7 +403,7 @@ impl server::FreeFunctions for Rustc<'_, '_> {
     }
 
     fn track_fs_path(&mut self, path: &str) {
-        self.sess().file_depinfo.borrow_mut().insert(path::PathBuf::from(path));
+        self.sess().file_depinfo.borrow_mut().insert(Symbol::intern(path));
     }
 
     fn literal_from_str(&mut self, s: &str) -> Result<Literal<Self::Span, Self::Symbol>, ()> {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -469,13 +469,12 @@ fn write_out_deps(tcx: TyCtxt<'_>, outputs: &OutputFilenames, out_filenames: &[P
         // (e.g. accessed in proc macros).
         let file_depinfo = sess.parse_sess.file_depinfo.borrow();
 
-        let normalize_path = |path: PathBuf| {
+        let normalize_path = |path: PathBuf| -> String {
             let file = FileName::from(path);
             escape_dep_filename(&file.prefer_local().to_string())
         };
 
-        let extra_tracked_files =
-            file_depinfo.iter().map(|path_sym| normalize_path(PathBuf::from(path_sym.as_str())));
+        let extra_tracked_files = file_depinfo.iter().map(|path| normalize_path(path.to_owned()));
         files.extend(extra_tracked_files);
 
         // We also need to track used PGO profile files

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -23,7 +23,6 @@ use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{Span, Symbol};
 
 use rustc_ast::attr::AttrIdGenerator;
-use std::path;
 use std::str;
 
 /// The set of keys (and, optionally, values) that define the compilation
@@ -215,9 +214,7 @@ pub struct ParseSess {
     /// Environment variables accessed during the build and their values when they exist.
     pub env_depinfo: Lock<FxHashSet<(Symbol, Option<Symbol>)>>,
     /// File paths accessed during the build.
-    pub file_depinfo: Lock<FxHashSet<path::PathBuf>>,
-    /// All the type ascriptions expressions that have had a suggestion for likely path typo.
-    pub type_ascription_path_suggestions: Lock<FxHashSet<Span>>,
+    pub file_depinfo: Lock<FxHashSet<Symbol>>,
     /// Whether cfg(version) should treat the current release as incomplete
     pub assume_incomplete_release: bool,
     /// Spans passed to `proc_macro::quote_span`. Each span has a numerical

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -23,6 +23,7 @@ use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{Span, Symbol};
 
 use rustc_ast::attr::AttrIdGenerator;
+use std::path;
 use std::str;
 
 /// The set of keys (and, optionally, values) that define the compilation
@@ -214,7 +215,9 @@ pub struct ParseSess {
     /// Environment variables accessed during the build and their values when they exist.
     pub env_depinfo: Lock<FxHashSet<(Symbol, Option<Symbol>)>>,
     /// File paths accessed during the build.
-    pub file_depinfo: Lock<FxHashSet<Symbol>>,
+    pub file_depinfo: Lock<FxHashSet<path::PathBuf>>,
+    /// All the type ascriptions expressions that have had a suggestion for likely path typo.
+    pub type_ascription_path_suggestions: Lock<FxHashSet<Span>>,
     /// Whether cfg(version) should treat the current release as incomplete
     pub assume_incomplete_release: bool,
     /// Spans passed to `proc_macro::quote_span`. Each span has a numerical

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -214,7 +214,8 @@ pub struct ParseSess {
     /// Environment variables accessed during the build and their values when they exist.
     pub env_depinfo: Lock<FxHashSet<(Symbol, Option<Symbol>)>>,
     /// File paths accessed during the build.
-    pub file_depinfo: Lock<FxHashSet<Symbol>>,
+    /// Paths are relative to ???.
+    pub file_depinfo: Lock<FxHashSet<std::path::PathBuf>>,
     /// Whether cfg(version) should treat the current release as incomplete
     pub assume_incomplete_release: bool,
     /// Spans passed to `proc_macro::quote_span`. Each span has a numerical

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -57,7 +57,7 @@ macro_rules! with_api {
             FreeFunctions {
                 fn drop($self: $S::FreeFunctions);
                 fn track_env_var(var: &str, value: Option<&str>);
-                fn track_path(path: &str);
+                fn track_path(path: std::path::PathBuf);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
             },

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -16,6 +16,7 @@ use std::mem;
 use std::ops::Bound;
 use std::ops::Range;
 use std::panic;
+use std::path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Once;
 use std::thread;
@@ -56,7 +57,7 @@ macro_rules! with_api {
             FreeFunctions {
                 fn drop($self: $S::FreeFunctions);
                 fn track_env_var(var: &str, value: Option<&str>);
-                fn track_path(path: &str);
+                fn track_fs_path(path: &str);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
             },
@@ -300,6 +301,7 @@ mark_noop! {
     LitKind,
     Level,
     Spacing,
+    path::PathBuf,
 }
 
 rpc_encode_decode!(

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -57,7 +57,7 @@ macro_rules! with_api {
             FreeFunctions {
                 fn drop($self: $S::FreeFunctions);
                 fn track_env_var(var: &str, value: Option<&str>);
-                fn track_fs_path(path: &str);
+                fn track_path(path: &str);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
             },

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -3,6 +3,7 @@
 use std::any::Any;
 use std::io::Write;
 use std::num::NonZeroU32;
+use std::path;
 use std::str;
 
 pub(super) type Writer = super::buffer::Buffer;
@@ -241,6 +242,18 @@ impl<'a, S, T: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S> for Vec<T> {
             vec.push(T::decode(r, s));
         }
         vec
+    }
+}
+
+impl<S> Encode<S> for path::PathBuf {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.to_str().expect("`PathBuf`s must be valid UTF-8 for now!").encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for path::PathBuf {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        path::PathBuf::from(<&str>::decode(r, s))
     }
 }
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1489,9 +1489,34 @@ impl fmt::Debug for Literal {
     }
 }
 
-/// Tracked access to environment variables.
-#[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
-pub mod tracked_env {
+#[unstable(feature = "proc_macro_tracked_env", issue = "74690")]
+/// Tracked access to env and path.
+pub mod tracked {
+    #[unstable(feature = "proc_macro_tracked_path", issue = "73921")]
+    use std::path::Path;
+
+    /// Track a file as if it was a dependency.
+    ///
+    /// The file is located relative to the current file where the proc-macro
+    /// is used (similarly to how modules are found). The provided path is
+    /// interpreted in a platform-specific way at compile time. So, for
+    /// instance, an invocation with a Windows path
+    /// containing backslashes `\` would not compile correctly on Unix.
+    ///
+    /// Errors if the provided `Path` cannot be encoded as a `str`
+    ///
+    /// Commonly used for tracking asset preprocessing.
+    #[unstable(feature = "proc_macro_tracked_path", issue = "73921")]
+    pub fn path<P: AsRef<Path>>(path: P) -> Result<(), ()> {
+        let path: &Path = path.as_ref();
+        if let Some(path) = path.to_str() {
+            crate::bridge::client::FreeFunctions::track_fs_path(path);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
     use std::env::{self, VarError};
     use std::ffi::OsStr;
 
@@ -1500,25 +1525,11 @@ pub mod tracked_env {
     /// compilation, and will be able to rerun the build when the value of that variable changes.
     /// Besides the dependency tracking this function should be equivalent to `env::var` from the
     /// standard library, except that the argument must be UTF-8.
-    #[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
-    pub fn var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
+    #[unstable(feature = "proc_macro_tracked_env", issue = "74690")]
+    pub fn env_var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
         let key: &str = key.as_ref();
         let value = env::var(key);
         crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
         value
-    }
-}
-
-/// Tracked access to additional files.
-#[unstable(feature = "track_path", issue = "99515")]
-pub mod tracked_path {
-
-    /// Track a file explicitly.
-    ///
-    /// Commonly used for tracking asset preprocessing.
-    #[unstable(feature = "track_path", issue = "99515")]
-    pub fn path<P: AsRef<str>>(path: P) {
-        let path: &str = path.as_ref();
-        crate::bridge::client::FreeFunctions::track_path(path);
     }
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1507,18 +1507,14 @@ pub mod tracked {
     ///
     /// Commonly used for tracking asset preprocessing.
     #[unstable(feature = "proc_macro_tracked_path", issue = "73921")]
-    pub fn path<P: AsRef<Path>>(path: P) -> Result<(), ()> {
+    pub fn path<P: AsRef<Path>>(path: P) {
         let path: &Path = path.as_ref();
-        if let Some(path) = path.to_str() {
-            crate::bridge::client::FreeFunctions::track_path(path);
-            Ok(())
-        } else {
-            Err(())
-        }
+        crate::bridge::client::FreeFunctions::track_path(PathBuf::from(path));
     }
 
     use std::env::{self, VarError};
     use std::ffi::OsStr;
+    use std::path::PathBuf;
 
     /// Retrieve an environment variable and add it to build dependency info.
     /// The build system executing the compiler will know that the variable was accessed during

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1490,10 +1490,29 @@ impl fmt::Debug for Literal {
 }
 
 #[unstable(feature = "proc_macro_tracked_env", issue = "74690")]
-/// Tracked access to env and path.
-pub mod tracked {
-    #[unstable(feature = "proc_macro_tracked_path", issue = "73921")]
-    use std::path::Path;
+/// Tracked access to env variables.
+pub mod tracked_env {
+    use std::env::{self, VarError};
+    use std::ffi::OsStr;
+
+    /// Retrieve an environment variable and add it to build dependency info.
+    /// The build system executing the compiler will know that the variable was accessed during
+    /// compilation, and will be able to rerun the build when the value of that variable changes.
+    /// Besides the dependency tracking this function should be equivalent to `env::var` from the
+    /// standard library, except that the argument must be UTF-8.
+    #[unstable(feature = "proc_macro_tracked_env", issue = "74690")]
+    pub fn var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
+        let key: &str = key.as_ref();
+        let value = env::var(key);
+        crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
+        value
+    }
+}
+
+/// Tracked access to additional files.
+#[unstable(feature = "track_path", issue = "99515")]
+pub mod tracked_path {
+    use std::path::{Path, PathBuf};
 
     /// Track a file as if it was a dependency.
     ///
@@ -1506,26 +1525,8 @@ pub mod tracked {
     /// Errors if the provided `Path` cannot be encoded as a `str`
     ///
     /// Commonly used for tracking asset preprocessing.
-    #[unstable(feature = "proc_macro_tracked_path", issue = "73921")]
     pub fn path<P: AsRef<Path>>(path: P) {
-        let path: &Path = path.as_ref();
-        crate::bridge::client::FreeFunctions::track_path(PathBuf::from(path));
-    }
-
-    use std::env::{self, VarError};
-    use std::ffi::OsStr;
-    use std::path::PathBuf;
-
-    /// Retrieve an environment variable and add it to build dependency info.
-    /// The build system executing the compiler will know that the variable was accessed during
-    /// compilation, and will be able to rerun the build when the value of that variable changes.
-    /// Besides the dependency tracking this function should be equivalent to `env::var` from the
-    /// standard library, except that the argument must be UTF-8.
-    #[unstable(feature = "proc_macro_tracked_env", issue = "74690")]
-    pub fn env_var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
-        let key: &str = key.as_ref();
-        let value = env::var(key);
-        crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
-        value
+        let path = PathBuf::from(path.as_ref());
+        crate::bridge::client::FreeFunctions::track_path(path);
     }
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1510,7 +1510,7 @@ pub mod tracked {
     pub fn path<P: AsRef<Path>>(path: P) -> Result<(), ()> {
         let path: &Path = path.as_ref();
         if let Some(path) = path.to_str() {
-            crate::bridge::client::FreeFunctions::track_fs_path(path);
+            crate::bridge::client::FreeFunctions::track_path(path);
             Ok(())
         } else {
             Err(())

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1510,7 +1510,7 @@ pub mod tracked_env {
 }
 
 /// Tracked access to additional files.
-#[unstable(feature = "track_path", issue = "99515")]
+#[unstable(feature = "proc_macro_tracked_path", issue = "99515")]
 pub mod tracked_path {
     use std::path::{Path, PathBuf};
 

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -80,7 +80,7 @@ fn track_files(parse_sess: &mut ParseSess) {
     // Used by `clippy::cargo` lints and to determine the MSRV. `cargo clippy` executes `clippy-driver`
     // with the current directory set to `CARGO_MANIFEST_DIR` so a relative path is fine
     if Path::new("Cargo.toml").exists() {
-        file_depinfo.insert(Symbol::intern("Cargo.toml"));
+        file_depinfo.insert(std::path::PathBuf::from("Cargo.toml"));
     }
 
     // `clippy.toml` will be automatically tracked as it's loaded with `sess.source_map().load_file()`
@@ -95,7 +95,7 @@ fn track_files(parse_sess: &mut ParseSess) {
         if let Ok(current_exe) = env::current_exe()
             && let Some(current_exe) = current_exe.to_str()
         {
-            file_depinfo.insert(Symbol::intern(current_exe));
+            file_depinfo.insert(std::path::PathBuf::from(current_exe));
         }
     }
 }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server.rs
@@ -58,7 +58,7 @@ impl server::FreeFunctions for RustAnalyzer {
         // FIXME: track env var accesses
         // https://github.com/rust-lang/rust/pull/71858
     }
-    fn track_path(&mut self, _path: &str) {}
+    fn track_path(&mut self, _path: std::path::PathBuf) {}
 
     fn literal_from_str(
         &mut self,

--- a/tests/run-make/env-dep-info/macro_def.rs
+++ b/tests/run-make/env-dep-info/macro_def.rs
@@ -6,7 +6,7 @@ use proc_macro::*;
 
 #[proc_macro]
 pub fn access_env_vars(_: TokenStream) -> TokenStream {
-    let _ = tracked_env::var("EXISTING_PROC_MACRO_ENV");
-    let _ = tracked_env::var("NONEXISTENT_PROC_MACEO_ENV");
+    let _ = tracked::env_var("EXISTING_PROC_MACRO_ENV");
+    let _ = tracked::env_var("NONEXISTENT_PROC_MACEO_ENV");
     TokenStream::new()
 }

--- a/tests/run-make/env-dep-info/macro_def.rs
+++ b/tests/run-make/env-dep-info/macro_def.rs
@@ -1,5 +1,5 @@
-#![feature(proc_macro_tracked_env)]
 #![crate_type = "proc-macro"]
+#![feature(proc_macro_tracked_env)]
 
 extern crate proc_macro;
 use proc_macro::*;

--- a/tests/run-make/env-dep-info/macro_def.rs
+++ b/tests/run-make/env-dep-info/macro_def.rs
@@ -6,7 +6,7 @@ use proc_macro::*;
 
 #[proc_macro]
 pub fn access_env_vars(_: TokenStream) -> TokenStream {
-    let _ = tracked::env_var("EXISTING_PROC_MACRO_ENV");
-    let _ = tracked::env_var("NONEXISTENT_PROC_MACEO_ENV");
+    let _ = tracked_env::var("EXISTING_PROC_MACRO_ENV");
+    let _ = tracked_env::var("NONEXISTENT_PROC_MACEO_ENV");
     TokenStream::new()
 }

--- a/tests/run-make/track-path-dep-info/macro_def.rs
+++ b/tests/run-make/track-path-dep-info/macro_def.rs
@@ -1,11 +1,21 @@
-#![feature(track_path)]
+#![feature(proc_macro_tracked_env,proc_macro_tracked_path)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;
 use proc_macro::*;
 
+use std::str;
+
 #[proc_macro]
 pub fn access_tracked_paths(_: TokenStream) -> TokenStream {
-    tracked_path::path("emojis.txt");
+    assert!(tracked::path("emojis.txt").is_ok());
+
+    // currently only valid utf-8 paths are supported
+    let invalid = [1_u8, 2,123, 254, 0, 0, 1, 1];
+    let invalid: &str = unsafe {
+        str::from_utf8_unchecked(&invalid[..])
+    };
+    assert!(tracked::path(invalid).is_err());
+
     TokenStream::new()
 }

--- a/tests/run-make/track-path-dep-info/macro_def.rs
+++ b/tests/run-make/track-path-dep-info/macro_def.rs
@@ -8,14 +8,14 @@ use std::str;
 
 #[proc_macro]
 pub fn access_tracked_paths(_: TokenStream) -> TokenStream {
-    assert!(tracked::path("emojis.txt").is_ok());
+    assert!(tracked_path::path("emojis.txt").is_ok());
 
     // currently only valid utf-8 paths are supported
     let invalid = [1_u8, 2,123, 254, 0, 0, 1, 1];
     let invalid: &str = unsafe {
         str::from_utf8_unchecked(&invalid[..])
     };
-    assert!(tracked::path(invalid).is_err());
+    assert!(tracked_path::path(invalid).is_err());
 
     TokenStream::new()
 }

--- a/tests/run-make/track-path-dep-info/macro_def.rs
+++ b/tests/run-make/track-path-dep-info/macro_def.rs
@@ -1,5 +1,5 @@
-#![feature(proc_macro_tracked_env,proc_macro_tracked_path)]
 #![crate_type = "proc-macro"]
+#![feature(proc_macro_tracked_path)]
 
 extern crate proc_macro;
 use proc_macro::*;
@@ -8,14 +8,16 @@ use std::str;
 
 #[proc_macro]
 pub fn access_tracked_paths(_: TokenStream) -> TokenStream {
-    assert!(tracked_path::path("emojis.txt").is_ok());
+    tracked_path::path("emojis.txt");
 
     // currently only valid utf-8 paths are supported
-    let invalid = [1_u8, 2,123, 254, 0, 0, 1, 1];
-    let invalid: &str = unsafe {
-        str::from_utf8_unchecked(&invalid[..])
-    };
-    assert!(tracked_path::path(invalid).is_err());
+    if false {
+        let invalid = [1_u8, 2,123, 254, 0, 0, 1, 1];
+        let invalid: &str = unsafe {
+            str::from_utf8_unchecked(&invalid[..])
+        };
+        tracked_path::path(invalid);
+    }
 
     TokenStream::new()
 }


### PR DESCRIPTION
Extracted restructure of the unstable `tracked::{fs,env}::*`

Originally part of https://github.com/rust-lang/rust/pull/84029

It's slightly clunky to to have three distinct unstable features, since one cannot use two annotations on one `mod tracked {..}` declaration.

The second thing I am unsure is `rust-analyzer` which would need some adaption for the new structure.

CC @Xanewok 