### PR TITLE
Improve documentation for `Vec::truncate`, `Vec::split_off`, `Vec::drain`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1001,7 +1001,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// If `len` is greater than the vector's current length, this has no
     /// effect.
     ///
-    /// The [`split_off`] is similar to `truncate`, but causes the excess
+    /// The [`split_off`] method is similar to `truncate`, but causes the excess
     /// elements to be returned instead of dropped.
     ///
     /// Note that this method has no effect on the allocated capacity

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1001,11 +1001,11 @@ impl<T, A: Allocator> Vec<T, A> {
     /// If `len` is greater than the vector's current length, this has no
     /// effect.
     ///
-    /// The [`split_off`] method is similar to `truncate`, but causes the excess
-    /// elements to be returned instead of dropped.
-    ///
     /// Note that this method has no effect on the allocated capacity
     /// of the vector.
+    ///
+    /// The [`split_off`] method is similar to `truncate`, but causes the
+    /// excess elements to be returned instead of dropped.
     ///
     /// # Examples
     ///
@@ -1017,8 +1017,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// No truncation occurs when `len` is greater than the vector's current
-    /// length:
+    /// No truncation or panic occurs when `len` is greater than the vector's
+    /// current length:
     ///
     /// ```
     /// let mut vec = vec![1, 2, 3];
@@ -1835,12 +1835,15 @@ impl<T, A: Allocator> Vec<T, A> {
         self.len() == 0
     }
 
-    /// Splits the collection into two at the given index.
+    /// Splits the collection in two at the given index.
     ///
     /// Returns a newly allocated vector containing the elements in the range
     /// `[at, len)`. After the call, the original vector will be left containing
     /// the elements `[0, at)` with its previous capacity unchanged.
     ///
+    /// If you do not need to own the tail `Vec`, use [`Vec::drain`] to avoid
+    /// an extra allocation.
+    /// 
     /// # Panics
     ///
     /// Panics if `at > len`.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1005,7 +1005,9 @@ impl<T, A: Allocator> Vec<T, A> {
     /// of the vector.
     ///
     /// The [`split_off`] method is similar to `truncate`, but causes the
-    /// excess elements to be returned instead of dropped.
+    /// tail elements to be returned as a newly-allocated `Vec` instead
+    /// of being dropped. Note that [`Vec::drain`] can emulate `split_off`
+    /// and avoids this extra allocation by returning an iterator.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1843,7 +1843,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// If you do not need to own the tail `Vec`, use [`Vec::drain`] to avoid
     /// an extra allocation.
-    /// 
+    ///
     /// # Panics
     ///
     /// Panics if `at > len`.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1001,7 +1001,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// If `len` is greater than the vector's current length, this has no
     /// effect.
     ///
-    /// The [`drain`] method can emulate `truncate`, but causes the excess
+    /// The [`split_off`] is similar to `truncate`, but causes the excess
     /// elements to be returned instead of dropped.
     ///
     /// Note that this method has no effect on the allocated capacity
@@ -1036,7 +1036,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     ///
     /// [`clear`]: Vec::clear
-    /// [`drain`]: Vec::drain
+    /// [`split_off`]: Vec::split_off
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn truncate(&mut self, len: usize) {
         // This is safe because:


### PR DESCRIPTION
I believe that referencing `Vec::split_off` (instead of `Vec::drain`) in the `Vec::truncate` documentation is more helpful here:

- `Vec::split_off` references `Vec::truncate` through a `#[must_use]`.
- `Vec::drain` requires a `collect` to function similarly because it returns a `Drain` iterator
- The docs for `Vec::drain` do not include information on how to use it exactly like `Vec::truncate`