### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "crossbeam-utils 0.8.3",
  "curl",
  "curl-sys",
- "env_logger 0.8.1",
+ "env_logger 0.9.0",
  "filetime",
  "flate2",
  "fwdansi",
@@ -1086,6 +1086,19 @@ name = "env_logger"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
+dependencies = [
+ "atty",
+ "humantime 2.0.1",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime 2.0.1",


### PR DESCRIPTION
6 commits in 66a6737a0c9f3a974af2dd032a65d3e409c77aac..27277d966b3cfa454d6dea7f724cb961c036251c
2021-07-14 20:54:28 +0000 to 2021-07-16 00:50:39 +0000
- Flag another curl error as possibly spurious (rust-lang/cargo#9695)
- Add `d` as an alias for `doc` (rust-lang/cargo#9680)
- `cargo fix --edition`: extend warning when on latest edition (rust-lang/cargo#9694)
- Update env_logger requirement from 0.8.1 to 0.9.0 (rust-lang/cargo#9688)
- Document cargo limitation w/ workspaces & configs (rust-lang/cargo#9674)
- Change some warnings to errors (rust-lang/cargo#9689)