### PR TITLE
[rustdoc] Copy only item path to clipboard rather than full `use` statement.

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -84,11 +84,10 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer,
     write!(buf, "<a class=\"{}\" href=\"#\">{}</a>", item.type_(), item.name.as_ref().unwrap());
     write!(
         buf,
-        "<button id=\"copy-path\" onclick=\"copy_path(this)\" title=\"copy path\">\
+        "<button id=\"copy-path\" onclick=\"copy_path(this)\" title=\"Copy item path to clipboard\">\
             <img src=\"{static_root_path}clipboard{suffix}.svg\" \
                 width=\"19\" height=\"18\" \
-                alt=\"Copy item import\" \
-                title=\"Copy item import to clipboard\">\
+                alt=\"Copy item path\">\
          </button>",
         static_root_path = page.get_static_root_path(),
         suffix = page.resource_suffix,

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -985,7 +985,7 @@ function hideThemeButtonState() {
         });
 
         var el = document.createElement('textarea');
-        el.value = 'use ' + path.join('::') + ';';
+        el.value = path.join('::');
         el.setAttribute('readonly', '');
         // To not make it appear on the screen.
         el.style.position = 'absolute';


### PR DESCRIPTION
The (somewhat) recent addition of the "copy item import to clipboard" button is extremely nice.

However, i tend to write my code with fully qualified paths wherever feasible and only resort to `use` statements as a refactoring pass. This makes the "copy to clipboard" workflow awkward to use, as i would be copy-pasting that as, say

```rust
impl use std::ops::Add; for MyType {
```

and then go back  and remove the `use ` and `;`.

This PR removes the `use ;` decorations, making it much nicer to use for fully-qualified items. I argue, however, that this does not noticeably degrade experience for those who prefer to import items, since the hard part about those is getting the path right, and writing the `use ;` decoration can be done by hand with little effort.