### PR TITLE
Mark `const_trait_impl` as active

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -534,7 +534,7 @@ declare_features! (
     (active, bindings_after_at, "1.41.0", Some(65490), None),
 
     /// Allows `impl const Trait for T` syntax.
-    (incomplete, const_trait_impl, "1.42.0", Some(67792), None),
+    (active, const_trait_impl, "1.42.0", Some(67792), None),
 
     /// Allows `T: ?const Trait` syntax in bounds.
     (incomplete, const_trait_bound_opt_out, "1.42.0", Some(67794), None),

--- a/src/test/ui/consts/const-float-classify.rs
+++ b/src/test/ui/consts/const-float-classify.rs
@@ -5,7 +5,6 @@
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 // Don't promote
 const fn nop<T>(x: T) -> T { x }

--- a/src/test/ui/consts/rustc-impl-const-stability.rs
+++ b/src/test/ui/consts/rustc-impl-const-stability.rs
@@ -1,7 +1,6 @@
 // build-pass
 
 #![crate_type = "lib"]
-#![allow(incomplete_features)]
 #![feature(staged_api)]
 #![feature(const_trait_impl)]
 #![stable(feature = "foo", since = "1.0.0")]

--- a/src/test/ui/rfc-2632-const-trait-impl/assoc-type.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/assoc-type.rs
@@ -3,7 +3,6 @@
 // FIXME: This test should fail since, within a const impl of `Foo`, the bound on `Foo::Bar` should
 // require a const impl of `Add` for the associated type.
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct NonConstAdd(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 #[default_method_body_is_const] //~ ERROR attribute should be applied
 trait A {

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
@@ -1,5 +1,5 @@
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:4:1
+  --> $DIR/attr-misuse.rs:3:1
    |
 LL |   #[default_method_body_is_const]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | | }
    | |_- not a trait method or missing a body
 
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:13:1
+  --> $DIR/attr-misuse.rs:12:1
    |
 LL | #[default_method_body_is_const]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | fn main() {}
    | ------------ not a trait method or missing a body
 
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:6:5
+  --> $DIR/attr-misuse.rs:5:5
    |
 LL |     #[default_method_body_is_const]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 pub trait MyTrait {
     fn func(self);

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 #![feature(staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 pub trait Plus {

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/call-const-trait-method-fail.rs:25:5
+  --> $DIR/call-const-trait-method-fail.rs:24:5
    |
 LL |     a.plus(b)
    |     ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-pass.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct Int(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
@@ -4,7 +4,6 @@
 
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
@@ -2,7 +2,6 @@
 // ignore-test
 
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
@@ -4,7 +4,6 @@
 
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 pub struct Int(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `std::ops::Add` for type `i32`
-  --> $DIR/const-and-non-const-impl.rs:6:1
+  --> $DIR/const-and-non-const-impl.rs:5:1
    |
 LL | impl const std::ops::Add for i32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | impl const std::ops::Add for i32 {
            - impl Add for i32;
 
 error[E0119]: conflicting implementations of trait `std::ops::Add` for type `Int`
-  --> $DIR/const-and-non-const-impl.rs:24:1
+  --> $DIR/const-and-non-const-impl.rs:23:1
    |
 LL | impl std::ops::Add for Int {
    | -------------------------- first implementation here
@@ -17,7 +17,7 @@ LL | impl const std::ops::Add for Int {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Int`
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-  --> $DIR/const-and-non-const-impl.rs:6:1
+  --> $DIR/const-and-non-const-impl.rs:5:1
    |
 LL | impl const std::ops::Add for i32 {
    | ^^^^^^^^^^^-------------^^^^^---

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-check-fns-in-const-impl.rs:12:16
+  --> $DIR/const-check-fns-in-const-impl.rs:11:16
    |
 LL |     fn foo() { non_const() }
    |                ^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -1,6 +1,5 @@
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)] // FIXME is this needed?
-#![allow(incomplete_features)]
 
 trait ConstDefaultFn: Sized {
     fn b(self);

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-default-method-bodies.rs:26:5
+  --> $DIR/const-default-method-bodies.rs:25:5
    |
 LL |     NonConstImpl.a();
    |     ^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 struct Foo;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-norecover.rs:6:7
+  --> $DIR/const-impl-norecover.rs:5:7
    |
 LL | const impl Foo {
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 trait Foo {}
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:6:7
+  --> $DIR/const-impl-recovery.rs:5:7
    |
 LL | const impl Foo for i32 {}
    |       ^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL | impl const Foo for i32 {}
    |--    ^^^^^
 
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:10:7
+  --> $DIR/const-impl-recovery.rs:9:7
    |
 LL | const impl<T: Foo> Bar for T {}
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:16:5
+  --> $DIR/cross-crate.rs:15:5
    |
 LL |     NonConst.func();
    |     ^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
@@ -1,6 +1,5 @@
 // revisions: stock gated
 #![cfg_attr(gated, feature(const_trait_impl))]
-#![allow(incomplete_features)]
 
 // aux-build: cross-crate.rs
 extern crate cross_crate;

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
@@ -1,11 +1,11 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:16:5
+  --> $DIR/cross-crate.rs:15:5
    |
 LL |     NonConst.func();
    |     ^^^^^^^^^^^^^^^
 
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:18:5
+  --> $DIR/cross-crate.rs:17:5
    |
 LL |     Const.func();
    |     ^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
@@ -1,5 +1,5 @@
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/feature-gate.rs:14:1
+  --> $DIR/feature-gate.rs:13:1
    |
 LL | fn main() {}
    | ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.rs
@@ -2,7 +2,6 @@
 // gate-test-const_trait_impl
 
 #![cfg_attr(gated, feature(const_trait_impl))]
-#![allow(incomplete_features)]
 #![feature(rustc_attrs)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
@@ -1,5 +1,5 @@
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:10:6
+  --> $DIR/feature-gate.rs:9:6
    |
 LL | impl const T for S {}
    |      ^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
 

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
@@ -1,7 +1,6 @@
 // Regression test for #69615.
 
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 pub trait MyTrait {
     fn method(&self) -> Option<()>;

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
@@ -1,5 +1,5 @@
 error[E0744]: `?` is not allowed in a `const fn`
-  --> $DIR/hir-const-check.rs:12:9
+  --> $DIR/hir-const-check.rs:11:9
    |
 LL |         Some(())?;
    |         ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 trait Tr {
     fn req(&self);

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.stderr
@@ -1,5 +1,5 @@
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:18:1
+  --> $DIR/impl-with-default-fn.rs:17:1
    |
 LL | / impl const Tr for S {
 LL | |     fn req(&self) {}
@@ -9,7 +9,7 @@ LL | | }
    = note: `prov` not implemented
 
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:33:1
+  --> $DIR/impl-with-default-fn.rs:32:1
    |
 LL | / impl const Tr for u32 {
 LL | |     fn req(&self) {}
@@ -20,7 +20,7 @@ LL | | }
    = note: `prov` not implemented
 
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn.rs:27:1
+  --> $DIR/impl-with-default-fn.rs:26:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(allow_internal_unstable)]
 #![feature(const_add)]
 #![feature(const_trait_impl)]

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
@@ -1,5 +1,5 @@
 error: trait methods cannot be stable const fn
-  --> $DIR/stability.rs:14:5
+  --> $DIR/stability.rs:13:5
    |
 LL | /     fn sub(self, rhs: Self) -> Self {
 LL | |
@@ -8,7 +8,7 @@ LL | |     }
    | |_____^
 
 error: `<Int as Add>::add` is not yet stable as a const fn
-  --> $DIR/stability.rs:32:5
+  --> $DIR/stability.rs:31:5
    |
 LL |     Int(1i32) + Int(2i32)
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
@@ -3,7 +3,6 @@
 
 #![feature(const_trait_bound_opt_out)]
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 // For now, this parses since an error does not occur until AST lowering.
 impl ?const T {}


### PR DESCRIPTION
See [this zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/implementation.20path.20for.20const.20trait.20impls).

r? @oli-obk 