### PR TITLE
fix typo in compile_fail doctest

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -356,7 +356,7 @@
 //! // must have the same concrete type.
 //! fn make_iter(do_insert: bool) -> impl Iterator<Item = i32> {
 //!     // Explicit returns to illustrate return types not matching
-//!     match x {
+//!     match do_insert {
 //!         true => return (0..4).chain(once(42)).chain(4..8),
 //!         false => return (0..4).chain(empty()).chain(4..8),
 //!     }


### PR DESCRIPTION
Fixes a typo introduced by https://github.com/rust-lang/rust/pull/86211. For some reason this typo makes Miri go all crazy when running libcore doctests (https://github.com/rust-lang/miri/issues/1852). Kudos to @hyd-dev for noticing the typo.

Cc @tlyu @joshtriplett 