### PR TITLE
Package LLVM libs for the target rather than the build host

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -38,7 +38,7 @@ changelog-seen = 2
 # This is false by default so that distributions don't unexpectedly download
 # LLVM from the internet.
 #
-# All tier 1 targets are currently supported; set this to `"if-supported"` if
+# All tier 1 targets are currently supported; set this to `"if-available"` if
 # you are not sure whether you're on a tier 1 target.
 #
 # We also currently only support this when building LLVM for the build triple.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85250

`dist.rs` uses, in the `rust-dev` stage, `llvm-config --libfiles` to get a list of the LLVM library files built but of course only for the build host. If the target differs we want to package lib files from the target's build tree instead. This is done by splitting/rejoining the paths on their build directories.

At the moment `tree` on the LLVM build directories seems to give almost identical output, but of course this might not be the case in the future. If a file is missing in the target's build tree then this stage will error in the `builder.install()` call. If the target build tree has an extra file then it silently won't be copied and we'll get a linker error when building using this artifact (via `download-ci-llvm = "if-available"`), though we would have received a linker error anyway without this change.

There was also a typo in the example config around this option.