### PR TITLE
rustc_symbol_mangling: support structural constants and &str in v0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -15,7 +15,7 @@ measureme = "9.1.0"
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }
-rustc-demangle = "0.1.18"
+rustc-demangle = "0.1.21"
 rustc_attr = { path = "../rustc_attr" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1229,9 +1229,9 @@ pub trait PrettyPrinter<'tcx>:
                         )?;
                     }
                     ty::Adt(def, substs) => {
-                        let variant_id =
-                            contents.variant.expect("destructed const of adt without variant id");
-                        let variant_def = &def.variants[variant_id];
+                        let variant_idx =
+                            contents.variant.expect("destructed const of adt without variant idx");
+                        let variant_def = &def.variants[variant_idx];
                         p!(print_value_path(variant_def.def_id, substs));
 
                         match variant_def.ctor_kind {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1218,8 +1218,15 @@ pub trait PrettyPrinter<'tcx>:
                         }
                         p!(")");
                     }
-                    ty::Adt(def, substs) if def.variants.is_empty() => {
-                        p!(print_value_path(def.did, substs));
+                    ty::Adt(def, _) if def.variants.is_empty() => {
+                        self = self.typed_value(
+                            |mut this| {
+                                write!(this, "unreachable()")?;
+                                Ok(this)
+                            },
+                            |this| this.print_type(ty),
+                            ": ",
+                        )?;
                     }
                     ty::Adt(def, substs) => {
                         let variant_id =

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 [dependencies]
 tracing = "0.1"
 punycode = "0.4.0"
-rustc-demangle = "0.1.18"
+rustc-demangle = "0.1.21"
 
 rustc_span = { path = "../rustc_span" }
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -91,6 +91,7 @@
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(in_band_lifetimes)]
+#![feature(iter_zip)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -534,39 +534,53 @@ impl Printer<'tcx> for &mut SymbolMangler<'tcx> {
     }
 
     fn print_const(mut self, ct: &'tcx ty::Const<'tcx>) -> Result<Self::Const, Self::Error> {
+        // We only mangle a typed value if the const can be evaluated.
+        let ct = ct.eval(self.tcx, ty::ParamEnv::reveal_all());
+        match ct.val {
+            ty::ConstKind::Value(_) => {}
+
+            // Placeholders (should be demangled as `_`).
+            // NOTE(eddyb) despite `Unevaluated` having a `DefId` (and therefore
+            // a path), even for it we still need to encode a placeholder, as
+            // the path could refer back to e.g. an `impl` using the constant.
+            ty::ConstKind::Unevaluated(_)
+            | ty::ConstKind::Param(_)
+            | ty::ConstKind::Infer(_)
+            | ty::ConstKind::Bound(..)
+            | ty::ConstKind::Placeholder(_)
+            | ty::ConstKind::Error(_) => {
+                // Never cached (single-character).
+                self.push("p");
+                return Ok(self);
+            }
+        }
+
         if let Some(&i) = self.consts.get(&ct) {
             return self.print_backref(i);
         }
         let start = self.out.len();
 
-        let mut neg = false;
-        let val = match ct.ty.kind() {
-            ty::Uint(_) | ty::Bool | ty::Char => {
-                ct.try_eval_bits(self.tcx, ty::ParamEnv::reveal_all(), ct.ty)
-            }
-            ty::Int(ity) => {
-                ct.try_eval_bits(self.tcx, ty::ParamEnv::reveal_all(), ct.ty).and_then(|b| {
-                    let val = Integer::from_int_ty(&self.tcx, *ity).size().sign_extend(b) as i128;
+        match ct.ty.kind() {
+            ty::Uint(_) | ty::Int(_) | ty::Bool | ty::Char => {
+                self = ct.ty.print(self)?;
+
+                let mut bits = ct.eval_bits(self.tcx, ty::ParamEnv::reveal_all(), ct.ty);
+
+                // Negative integer values are mangled using `n` as a "sign prefix".
+                if let ty::Int(ity) = ct.ty.kind() {
+                    let val =
+                        Integer::from_int_ty(&self.tcx, *ity).size().sign_extend(bits) as i128;
                     if val < 0 {
-                        neg = true;
+                        self.push("n");
                     }
-                    Some(val.unsigned_abs())
-                })
+                    bits = val.unsigned_abs();
+                }
+
+                let _ = write!(self.out, "{:x}_", bits);
             }
             _ => {
                 bug!("symbol_names: unsupported constant of type `{}` ({:?})", ct.ty, ct);
             }
-        };
-
-        if let Some(bits) = val {
-            // We only print the type if the const can be evaluated.
-            self = ct.ty.print(self)?;
-            let _ = write!(self.out, "{}{:x}_", if neg { "n" } else { "" }, bits);
-        } else {
-            // NOTE(eddyb) despite having the path, we need to
-            // encode a placeholder, as the path could refer
-            // back to e.g. an `impl` using the constant.
-            self.push("p");
         }
 
         // Only cache consts that do not refer to an enclosing

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -24,7 +24,7 @@ std_detect = { path = "../stdarch/crates/std_detect", default-features = false, 
 
 # Dependencies of the `backtrace` crate
 addr2line = { version = "0.16.0", optional = true, default-features = false }
-rustc-demangle = { version = "0.1.18", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.21", features = ['rustc-dep-of-std'] }
 miniz_oxide = { version = "0.4.0", optional = true, default-features = false }
 [dependencies.object]
 version = "0.26.1"

--- a/src/test/debuginfo/function-call.rs
+++ b/src/test/debuginfo/function-call.rs
@@ -1,5 +1,5 @@
 // This test does not passed with gdb < 8.0. See #53497.
-// min-gdb-version: 8.0
+// min-gdb-version: 10.1
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -1,5 +1,5 @@
 // Function names are formatted differently in old versions of GDB
-// min-gdb-version: 9.2
+// min-gdb-version: 10.1
 
 // compile-flags:-g
 

--- a/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
@@ -1,0 +1,5 @@
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:21:5
+stack backtrace:
+   0: std::panicking::begin_panic
+   1: issue_47429_short_backtraces::main
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/src/test/ui/panics/issue-47429-short-backtraces.rs
+++ b/src/test/ui/panics/issue-47429-short-backtraces.rs
@@ -12,6 +12,11 @@
 // ignore-emscripten no panic or subprocess support
 // ignore-sgx no subprocess support
 
+// NOTE(eddyb) output differs between symbol mangling schemes
+// revisions: legacy v0
+// [legacy] compile-flags: -Zsymbol-mangling-version=legacy
+//     [v0] compile-flags: -Zsymbol-mangling-version=v0
+
 fn main() {
     panic!()
 }

--- a/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
@@ -1,5 +1,5 @@
-thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:16:5
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:21:5
 stack backtrace:
-   0: std::panicking::begin_panic
+   0: std::panicking::begin_panic::<&str>
    1: issue_47429_short_backtraces::main
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/src/test/ui/symbol-names/const-generics-demangling.rs
+++ b/src/test/ui/symbol-names/const-generics-demangling.rs
@@ -6,7 +6,7 @@ pub struct Unsigned<const F: u8>;
 
 #[rustc_symbol_name]
 //~^ ERROR symbol-name(_RMCsno73SFvQKx_1cINtB0_8UnsignedKhb_E)
-//~| ERROR demangling(<c[464da6a86cb672f]::Unsigned<11: u8>>)
+//~| ERROR demangling(<c[464da6a86cb672f]::Unsigned<11u8>>)
 //~| ERROR demangling-alt(<c::Unsigned<11>>)
 impl Unsigned<11> {}
 
@@ -14,7 +14,7 @@ pub struct Signed<const F: i16>;
 
 #[rustc_symbol_name]
 //~^ ERROR symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6SignedKsn98_E)
-//~| ERROR demangling(<c[464da6a86cb672f]::Signed<-152: i16>>)
+//~| ERROR demangling(<c[464da6a86cb672f]::Signed<-152i16>>)
 //~| ERROR demangling-alt(<c::Signed<-152>>)
 impl Signed<-152> {}
 
@@ -22,7 +22,7 @@ pub struct Bool<const F: bool>;
 
 #[rustc_symbol_name]
 //~^ ERROR symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_4BoolKb1_E)
-//~| ERROR demangling(<c[464da6a86cb672f]::Bool<true: bool>>)
+//~| ERROR demangling(<c[464da6a86cb672f]::Bool<true>>)
 //~| ERROR demangling-alt(<c::Bool<true>>)
 impl Bool<true> {}
 
@@ -30,7 +30,7 @@ pub struct Char<const F: char>;
 
 #[rustc_symbol_name]
 //~^ ERROR symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_4CharKc2202_E)
-//~| ERROR demangling(<c[464da6a86cb672f]::Char<'∂': char>>)
+//~| ERROR demangling(<c[464da6a86cb672f]::Char<'∂'>>)
 //~| ERROR demangling-alt(<c::Char<'∂'>>)
 impl Char<'∂'> {}
 

--- a/src/test/ui/symbol-names/const-generics-demangling.rs
+++ b/src/test/ui/symbol-names/const-generics-demangling.rs
@@ -1,37 +1,37 @@
 // build-fail
-// compile-flags: -Z symbol-mangling-version=v0
+// compile-flags: -Z symbol-mangling-version=v0 --crate-name=c
 #![feature(rustc_attrs)]
 
 pub struct Unsigned<const F: u8>;
 
 #[rustc_symbol_name]
-//~^ ERROR symbol-name(_RMCsaP8qXevlYG3_25const_generics_demanglingINtB0_8UnsignedKhb_E)
-//~| ERROR demangling(<const_generics_demangling[7e153590edc26969]::Unsigned<11: u8>>)
-//~| ERROR demangling-alt(<const_generics_demangling::Unsigned<11>>)
+//~^ ERROR symbol-name(_RMCsno73SFvQKx_1cINtB0_8UnsignedKhb_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Unsigned<11: u8>>)
+//~| ERROR demangling-alt(<c::Unsigned<11>>)
 impl Unsigned<11> {}
 
 pub struct Signed<const F: i16>;
 
 #[rustc_symbol_name]
-//~^ ERROR symbol-name(_RMs_CsaP8qXevlYG3_25const_generics_demanglingINtB2_6SignedKsn98_E)
-//~| ERROR demangling(<const_generics_demangling[7e153590edc26969]::Signed<-152: i16>>)
-//~| ERROR demangling-alt(<const_generics_demangling::Signed<-152>>)
+//~^ ERROR symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6SignedKsn98_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Signed<-152: i16>>)
+//~| ERROR demangling-alt(<c::Signed<-152>>)
 impl Signed<-152> {}
 
 pub struct Bool<const F: bool>;
 
 #[rustc_symbol_name]
-//~^ ERROR symbol-name(_RMs0_CsaP8qXevlYG3_25const_generics_demanglingINtB3_4BoolKb1_E)
-//~| ERROR demangling(<const_generics_demangling[7e153590edc26969]::Bool<true: bool>>)
-//~| ERROR demangling-alt(<const_generics_demangling::Bool<true>>)
+//~^ ERROR symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_4BoolKb1_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Bool<true: bool>>)
+//~| ERROR demangling-alt(<c::Bool<true>>)
 impl Bool<true> {}
 
 pub struct Char<const F: char>;
 
 #[rustc_symbol_name]
-//~^ ERROR symbol-name(_RMs1_CsaP8qXevlYG3_25const_generics_demanglingINtB3_4CharKc2202_E)
-//~| ERROR demangling(<const_generics_demangling[7e153590edc26969]::Char<'∂': char>>)
-//~| ERROR demangling-alt(<const_generics_demangling::Char<'∂'>>)
+//~^ ERROR symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_4CharKc2202_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Char<'∂': char>>)
+//~| ERROR demangling-alt(<c::Char<'∂'>>)
 impl Char<'∂'> {}
 
 fn main() {}

--- a/src/test/ui/symbol-names/const-generics-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-demangling.stderr
@@ -1,70 +1,70 @@
-error: symbol-name(_RMCsaP8qXevlYG3_25const_generics_demanglingINtB0_8UnsignedKhb_E)
+error: symbol-name(_RMCsno73SFvQKx_1cINtB0_8UnsignedKhb_E)
   --> $DIR/const-generics-demangling.rs:7:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<const_generics_demangling[7e153590edc26969]::Unsigned<11: u8>>)
+error: demangling(<c[464da6a86cb672f]::Unsigned<11: u8>>)
   --> $DIR/const-generics-demangling.rs:7:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<const_generics_demangling::Unsigned<11>>)
+error: demangling-alt(<c::Unsigned<11>>)
   --> $DIR/const-generics-demangling.rs:7:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs_CsaP8qXevlYG3_25const_generics_demanglingINtB2_6SignedKsn98_E)
+error: symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6SignedKsn98_E)
   --> $DIR/const-generics-demangling.rs:15:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<const_generics_demangling[7e153590edc26969]::Signed<-152: i16>>)
+error: demangling(<c[464da6a86cb672f]::Signed<-152: i16>>)
   --> $DIR/const-generics-demangling.rs:15:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<const_generics_demangling::Signed<-152>>)
+error: demangling-alt(<c::Signed<-152>>)
   --> $DIR/const-generics-demangling.rs:15:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs0_CsaP8qXevlYG3_25const_generics_demanglingINtB3_4BoolKb1_E)
+error: symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_4BoolKb1_E)
   --> $DIR/const-generics-demangling.rs:23:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<const_generics_demangling[7e153590edc26969]::Bool<true: bool>>)
+error: demangling(<c[464da6a86cb672f]::Bool<true: bool>>)
   --> $DIR/const-generics-demangling.rs:23:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<const_generics_demangling::Bool<true>>)
+error: demangling-alt(<c::Bool<true>>)
   --> $DIR/const-generics-demangling.rs:23:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs1_CsaP8qXevlYG3_25const_generics_demanglingINtB3_4CharKc2202_E)
+error: symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_4CharKc2202_E)
   --> $DIR/const-generics-demangling.rs:31:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<const_generics_demangling[7e153590edc26969]::Char<'∂': char>>)
+error: demangling(<c[464da6a86cb672f]::Char<'∂': char>>)
   --> $DIR/const-generics-demangling.rs:31:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<const_generics_demangling::Char<'∂'>>)
+error: demangling-alt(<c::Char<'∂'>>)
   --> $DIR/const-generics-demangling.rs:31:1
    |
 LL | #[rustc_symbol_name]

--- a/src/test/ui/symbol-names/const-generics-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-demangling.stderr
@@ -4,7 +4,7 @@ error: symbol-name(_RMCsno73SFvQKx_1cINtB0_8UnsignedKhb_E)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<c[464da6a86cb672f]::Unsigned<11: u8>>)
+error: demangling(<c[464da6a86cb672f]::Unsigned<11u8>>)
   --> $DIR/const-generics-demangling.rs:7:1
    |
 LL | #[rustc_symbol_name]
@@ -22,7 +22,7 @@ error: symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6SignedKsn98_E)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<c[464da6a86cb672f]::Signed<-152: i16>>)
+error: demangling(<c[464da6a86cb672f]::Signed<-152i16>>)
   --> $DIR/const-generics-demangling.rs:15:1
    |
 LL | #[rustc_symbol_name]
@@ -40,7 +40,7 @@ error: symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_4BoolKb1_E)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<c[464da6a86cb672f]::Bool<true: bool>>)
+error: demangling(<c[464da6a86cb672f]::Bool<true>>)
   --> $DIR/const-generics-demangling.rs:23:1
    |
 LL | #[rustc_symbol_name]
@@ -58,7 +58,7 @@ error: symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_4CharKc2202_E)
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<c[464da6a86cb672f]::Char<'∂': char>>)
+error: demangling(<c[464da6a86cb672f]::Char<'∂'>>)
   --> $DIR/const-generics-demangling.rs:31:1
    |
 LL | #[rustc_symbol_name]

--- a/src/test/ui/symbol-names/const-generics-str-demangling.rs
+++ b/src/test/ui/symbol-names/const-generics-str-demangling.rs
@@ -1,0 +1,44 @@
+// build-fail
+// compile-flags: -Z symbol-mangling-version=v0 --crate-name=c
+#![feature(const_generics, rustc_attrs)]
+#![allow(incomplete_features)]
+
+pub struct Str<const S: &'static str>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMCsno73SFvQKx_1cINtB0_3StrKRe616263_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"abc">>)
+//~| ERROR demangling-alt(<c::Str<"abc">>)
+impl Str<"abc"> {}
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs_Csno73SFvQKx_1cINtB2_3StrKRe27_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"'">>)
+//~| ERROR demangling-alt(<c::Str<"'">>)
+impl Str<"'"> {}
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_3StrKRe090a_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"\t\n">>)
+//~| ERROR demangling-alt(<c::Str<"\t\n">>)
+impl Str<"\t\n"> {}
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_3StrKRee28882c3bc_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"∂ü">>)
+//~| ERROR demangling-alt(<c::Str<"∂ü">>)
+impl Str<"∂ü"> {}
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs2_Csno73SFvQKx_1cINtB3_3StrKRee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839be183a0e18398e18394e1839ae183985fe183a1e18390e18393e18398e1839ae18398_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"საჭმელად_გემრიელი_სადილი">>)
+//~| ERROR demangling-alt(<c::Str<"საჭმელად_გემრიელი_სადილი">>)
+impl Str<"საჭმელად_გემრიელი_სადილი"> {}
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs3_Csno73SFvQKx_1cINtB3_3StrKRef09f908af09fa688f09fa686f09f90ae20c2a720f09f90b6f09f9192e29895f09f94a520c2a720f09fa7a1f09f929bf09f929af09f9299f09f929c_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::Str<"🐊🦈🦆🐮 § 🐶👒☕🔥 § 🧡💛💚💙💜">>)
+//~| ERROR demangling-alt(<c::Str<"🐊🦈🦆🐮 § 🐶👒☕🔥 § 🧡💛💚💙💜">>)
+impl Str<"🐊🦈🦆🐮 § 🐶👒☕🔥 § 🧡💛💚💙💜"> {}
+
+fn main() {}

--- a/src/test/ui/symbol-names/const-generics-str-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-str-demangling.stderr
@@ -1,0 +1,110 @@
+error: symbol-name(_RMCsno73SFvQKx_1cINtB0_3StrKRe616263_E)
+  --> $DIR/const-generics-str-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"abc">>)
+  --> $DIR/const-generics-str-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"abc">>)
+  --> $DIR/const-generics-str-demangling.rs:8:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs_Csno73SFvQKx_1cINtB2_3StrKRe27_E)
+  --> $DIR/const-generics-str-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"'">>)
+  --> $DIR/const-generics-str-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"'">>)
+  --> $DIR/const-generics-str-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_3StrKRe090a_E)
+  --> $DIR/const-generics-str-demangling.rs:20:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"\t\n">>)
+  --> $DIR/const-generics-str-demangling.rs:20:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"\t\n">>)
+  --> $DIR/const-generics-str-demangling.rs:20:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_3StrKRee28882c3bc_E)
+  --> $DIR/const-generics-str-demangling.rs:26:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"∂ü">>)
+  --> $DIR/const-generics-str-demangling.rs:26:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"∂ü">>)
+  --> $DIR/const-generics-str-demangling.rs:26:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs2_Csno73SFvQKx_1cINtB3_3StrKRee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839be183a0e18398e18394e1839ae183985fe183a1e18390e18393e18398e1839ae18398_E)
+  --> $DIR/const-generics-str-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"საჭმელად_გემრიელი_სადილი">>)
+  --> $DIR/const-generics-str-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"საჭმელად_გემრიელი_სადილი">>)
+  --> $DIR/const-generics-str-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs3_Csno73SFvQKx_1cINtB3_3StrKRef09f908af09fa688f09fa686f09f90ae20c2a720f09f90b6f09f9192e29895f09f94a520c2a720f09fa7a1f09f929bf09f929af09f9299f09f929c_E)
+  --> $DIR/const-generics-str-demangling.rs:38:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Str<"🐊🦈🦆🐮 § 🐶👒☕🔥 § 🧡💛💚💙💜">>)
+  --> $DIR/const-generics-str-demangling.rs:38:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Str<"🐊🦈🦆🐮 § 🐶👒☕🔥 § 🧡💛💚💙💜">>)
+  --> $DIR/const-generics-str-demangling.rs:38:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 18 previous errors
+

--- a/src/test/ui/symbol-names/const-generics-structural-demangling.rs
+++ b/src/test/ui/symbol-names/const-generics-structural-demangling.rs
@@ -1,0 +1,96 @@
+// build-fail
+// compile-flags: -Z symbol-mangling-version=v0 --crate-name=c
+
+// NOTE(eddyb) we need `core` for `core::option::Option`, normalize away its
+// disambiguator hash, which can/should change (including between stage{1,2}).
+// normalize-stderr-test: "Cs[0-9a-zA-Z]+_4core" -> "Cs$$HASH_4core"
+// normalize-stderr-test: "core\[[0-9a-f]+\]" -> "core[$$HASH_HEX]"
+
+#![feature(const_generics, decl_macro, rustc_attrs)]
+#![allow(incomplete_features)]
+
+pub struct RefByte<const RB: &'static u8>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMCsno73SFvQKx_1cINtB0_7RefByteKRh7b_E)
+//~| ERROR demangling(<c[464da6a86cb672f]::RefByte<{&123u8}>>)
+//~| ERROR demangling-alt(<c::RefByte<{&123}>>)
+impl RefByte<{&123}> {}
+
+// FIXME(eddyb) this was supposed to be `RefMutZst` with `&mut []`,
+// but that is currently not allowed in const generics.
+pub struct RefZst<const RMZ: &'static [u8; 0]>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6RefZstKRAEE)
+//~| ERROR demangling(<c[464da6a86cb672f]::RefZst<{&[]}>>)
+//~| ERROR demangling-alt(<c::RefZst<{&[]}>>)
+impl RefZst<{&[]}> {}
+
+pub struct Array3Bytes<const A3B: [u8; 3]>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_11Array3BytesKAh1_h2_h3_EE)
+//~| ERROR demangling(<c[464da6a86cb672f]::Array3Bytes<{[1u8, 2u8, 3u8]}>>)
+//~| ERROR demangling-alt(<c::Array3Bytes<{[1, 2, 3]}>>)
+impl Array3Bytes<{[1, 2, 3]}> {}
+
+pub struct TupleByteBool<const TBB: (u8, bool)>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_13TupleByteBoolKTh1_b0_EE)
+//~| ERROR demangling(<c[464da6a86cb672f]::TupleByteBool<{(1u8, false)}>>)
+//~| ERROR demangling-alt(<c::TupleByteBool<{(1, false)}>>)
+impl TupleByteBool<{(1, false)}> {}
+
+pub struct OptionUsize<const OU: Option<usize>>;
+
+// HACK(eddyb) the full mangling is only in `.stderr` because we can normalize
+// the `core` disambiguator hash away there, but not here.
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs2_Csno73SFvQKx_1cINtB3_11OptionUsizeKVNtINtNtCs
+//~| ERROR demangling(<c[464da6a86cb672f]::OptionUsize<{core[
+//~| ERROR demangling-alt(<c::OptionUsize<{core::option::Option::<usize>::None}>>)
+impl OptionUsize<{None}> {}
+
+// HACK(eddyb) the full mangling is only in `.stderr` because we can normalize
+// the `core` disambiguator hash away there, but not here.
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs3_Csno73SFvQKx_1cINtB3_11OptionUsizeKVNtINtNtCs
+//~| ERROR demangling(<c[464da6a86cb672f]::OptionUsize<{core[
+//~| ERROR demangling-alt(<c::OptionUsize<{core::option::Option::<usize>::Some(0)}>>)
+impl OptionUsize<{Some(0)}> {}
+
+#[derive(PartialEq, Eq)]
+pub struct Foo {
+    s: &'static str,
+    ch: char,
+    slice: &'static [u8],
+}
+pub struct Foo_<const F: Foo>;
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMs4_Csno73SFvQKx_1cINtB3_4Foo_KVNtB3_3FooS1sRe616263_2chc78_5sliceRAh1_h2_h3_EEE)
+//~| ERROR demangling(<c[464da6a86cb672f]::Foo_<{c[464da6a86cb672f]::Foo { s: "abc", ch: 'x', slice: &[1u8, 2u8, 3u8] }}>>)
+//~| ERROR demangling-alt(<c::Foo_<{c::Foo { s: "abc", ch: 'x', slice: &[1, 2, 3] }}>>)
+impl Foo_<{Foo { s: "abc", ch: 'x', slice: &[1, 2, 3] }}> {}
+
+// NOTE(eddyb) this tests specifically the use of disambiguators in field names,
+// using macros 2.0 hygiene to create a `struct` with conflicting field names.
+macro duplicate_field_name_test($x:ident) {
+    #[derive(PartialEq, Eq)]
+    pub struct Bar {
+        $x: u8,
+        x: u16,
+    }
+    pub struct Bar_<const B: Bar>;
+
+    #[rustc_symbol_name]
+    //~^ ERROR symbol-name(_RMs9_Csno73SFvQKx_1cINtB3_4Bar_KVNtB3_3BarS1xh7b_s_1xt1000_EE)
+    //~| ERROR demangling(<c[464da6a86cb672f]::Bar_<{c[464da6a86cb672f]::Bar { x: 123u8, x: 4096u16 }}>>)
+    //~| ERROR demangling-alt(<c::Bar_<{c::Bar { x: 123, x: 4096 }}>>)
+    impl Bar_<{Bar { $x: 123, x: 4096 }}> {}
+}
+duplicate_field_name_test!(x);
+
+fn main() {}

--- a/src/test/ui/symbol-names/const-generics-structural-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-structural-demangling.stderr
@@ -1,0 +1,161 @@
+error: symbol-name(_RMCsno73SFvQKx_1cINtB0_7RefByteKRh7b_E)
+  --> $DIR/const-generics-structural-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::RefByte<{&123u8}>>)
+  --> $DIR/const-generics-structural-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::RefByte<{&123}>>)
+  --> $DIR/const-generics-structural-demangling.rs:14:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs_Csno73SFvQKx_1cINtB2_6RefZstKRAEE)
+  --> $DIR/const-generics-structural-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::RefZst<{&[]}>>)
+  --> $DIR/const-generics-structural-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::RefZst<{&[]}>>)
+  --> $DIR/const-generics-structural-demangling.rs:24:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs0_Csno73SFvQKx_1cINtB3_11Array3BytesKAh1_h2_h3_EE)
+  --> $DIR/const-generics-structural-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Array3Bytes<{[1u8, 2u8, 3u8]}>>)
+  --> $DIR/const-generics-structural-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Array3Bytes<{[1, 2, 3]}>>)
+  --> $DIR/const-generics-structural-demangling.rs:32:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs1_Csno73SFvQKx_1cINtB3_13TupleByteBoolKTh1_b0_EE)
+  --> $DIR/const-generics-structural-demangling.rs:40:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::TupleByteBool<{(1u8, false)}>>)
+  --> $DIR/const-generics-structural-demangling.rs:40:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::TupleByteBool<{(1, false)}>>)
+  --> $DIR/const-generics-structural-demangling.rs:40:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs2_Csno73SFvQKx_1cINtB3_11OptionUsizeKVNtINtNtCs$HASH_4core6option6OptionjE4NoneUE)
+  --> $DIR/const-generics-structural-demangling.rs:50:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::OptionUsize<{core[$HASH_HEX]::option::Option::<usize>::None}>>)
+  --> $DIR/const-generics-structural-demangling.rs:50:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::OptionUsize<{core::option::Option::<usize>::None}>>)
+  --> $DIR/const-generics-structural-demangling.rs:50:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs3_Csno73SFvQKx_1cINtB3_11OptionUsizeKVNtINtNtCs$HASH_4core6option6OptionjE4SomeTj0_EE)
+  --> $DIR/const-generics-structural-demangling.rs:58:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::OptionUsize<{core[$HASH_HEX]::option::Option::<usize>::Some(0usize)}>>)
+  --> $DIR/const-generics-structural-demangling.rs:58:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::OptionUsize<{core::option::Option::<usize>::Some(0)}>>)
+  --> $DIR/const-generics-structural-demangling.rs:58:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs4_Csno73SFvQKx_1cINtB3_4Foo_KVNtB3_3FooS1sRe616263_2chc78_5sliceRAh1_h2_h3_EEE)
+  --> $DIR/const-generics-structural-demangling.rs:72:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<c[464da6a86cb672f]::Foo_<{c[464da6a86cb672f]::Foo { s: "abc", ch: 'x', slice: &[1u8, 2u8, 3u8] }}>>)
+  --> $DIR/const-generics-structural-demangling.rs:72:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<c::Foo_<{c::Foo { s: "abc", ch: 'x', slice: &[1, 2, 3] }}>>)
+  --> $DIR/const-generics-structural-demangling.rs:72:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs9_Csno73SFvQKx_1cINtB3_4Bar_KVNtB3_3BarS1xh7b_s_1xt1000_EE)
+  --> $DIR/const-generics-structural-demangling.rs:88:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+...
+LL | duplicate_field_name_test!(x);
+   | ------------------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: demangling(<c[464da6a86cb672f]::Bar_<{c[464da6a86cb672f]::Bar { x: 123u8, x: 4096u16 }}>>)
+  --> $DIR/const-generics-structural-demangling.rs:88:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+...
+LL | duplicate_field_name_test!(x);
+   | ------------------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: demangling-alt(<c::Bar_<{c::Bar { x: 123, x: 4096 }}>>)
+  --> $DIR/const-generics-structural-demangling.rs:88:5
+   |
+LL |     #[rustc_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^
+...
+LL | duplicate_field_name_test!(x);
+   | ------------------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 24 previous errors
+

--- a/src/test/ui/symbol-names/impl1.rs
+++ b/src/test/ui/symbol-names/impl1.rs
@@ -64,7 +64,7 @@ fn main() {
             //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method
             //[legacy]~| ERROR demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method)
              //[v0]~^^^^ ERROR symbol-name(_RNvXNCNvCs2qSCrjELJET_5impl14mains_0ARDNtB6_3Foop5AssocFG_KCRL0_hvEuNtB6_9AutoTraitEL_j3_NtB2_3Bar6method)
-                //[v0]~| ERROR demangling(<[&dyn impl1[1c5860ab79c9e305]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[1c5860ab79c9e305]::AutoTrait; 3: usize] as impl1[1c5860ab79c9e305]::main::{closure#1}::Bar>::method)
+                //[v0]~| ERROR demangling(<[&dyn impl1[1c5860ab79c9e305]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[1c5860ab79c9e305]::AutoTrait; 3usize] as impl1[1c5860ab79c9e305]::main::{closure#1}::Bar>::method)
                 //[v0]~| ERROR demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
             #[rustc_def_path]
             //[legacy]~^ ERROR def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8, ...)> + AutoTrait; 3] as main::{closure#1}::Bar>::method)

--- a/src/test/ui/symbol-names/impl1.v0.stderr
+++ b/src/test/ui/symbol-names/impl1.v0.stderr
@@ -52,7 +52,7 @@ error: symbol-name(_RNvXNCNvCs2qSCrjELJET_5impl14mains_0ARDNtB6_3Foop5AssocFG_KC
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<[&dyn impl1[1c5860ab79c9e305]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[1c5860ab79c9e305]::AutoTrait; 3: usize] as impl1[1c5860ab79c9e305]::main::{closure#1}::Bar>::method)
+error: demangling(<[&dyn impl1[1c5860ab79c9e305]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[1c5860ab79c9e305]::AutoTrait; 3usize] as impl1[1c5860ab79c9e305]::main::{closure#1}::Bar>::method)
   --> $DIR/impl1.rs:62:13
    |
 LL |             #[rustc_symbol_name]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3227,7 +3227,7 @@ impl<'test> TestCx<'test> {
                 // so it needs to be removed when comparing the run-pass test execution output
                 lazy_static! {
                     static ref REMOTE_TEST_RE: Regex = Regex::new(
-                        "^uploaded \"\\$TEST_BUILD_DIR(/[[:alnum:]_\\-]+)+\", waiting for result\n"
+                        "^uploaded \"\\$TEST_BUILD_DIR(/[[:alnum:]_\\-.]+)+\", waiting for result\n"
                     )
                     .unwrap();
                 }


### PR DESCRIPTION
This PR should unblock #85530 (except for float `const` generics, which AFAIK should've never worked).
(cc @tmiasko could the https://github.com/rust-lang/rust/pull/85530#issuecomment-857855379 failures be retried with a quick crater "subset" run of this PR + changing the default to `v0`? Just to make sure I didn't miss anything other than the floats)

The encoding is the one suggested before in e.g. https://github.com/rust-lang/rust/issues/61486#issuecomment-878932102, tho this PR won't by itself finish #61486, before closing that we'd likely want to move to @oli-obk's "valtrees" (i.e. #83234 and other associated work).

<hr>

**EDITs**:
1. switched unit/tuple/braced-with-named-fields `<const-fields>` prefixes from `"u"`/`"T"`/`""` to `"U"`/`"T"`/`"S"` to avoid the ambiguity reported by @tmiasko in https://github.com/rust-lang/rust/pull/87194#issuecomment-884279921.

2. `rustc-demangle` PR: https://github.com/alexcrichton/rustc-demangle/pull/55

3. RFC amendment PR: https://github.com/rust-lang/rfcs/pull/3161
    * also removed the grammar changes included in that PR, from this description

4. added tests (temporarily using my fork of `rustc-demangle`)

<hr>

r? @michaelwoerister