### PR TITLE
rename assert_matches module

### DIFF
--- a/compiler/rustc_middle/src/ich/impls_syntax.rs
+++ b/compiler/rustc_middle/src/ich/impls_syntax.rs
@@ -6,7 +6,7 @@ use crate::ich::StableHashingContext;
 use rustc_ast as ast;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_span::{BytePos, NormalizedPos, SourceFile};
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 use smallvec::SmallVec;
 

--- a/compiler/rustc_mir/src/interpret/memory.rs
+++ b/compiler/rustc_mir/src/interpret/memory.rs
@@ -6,7 +6,7 @@
 //! integer. It is crucial that these operations call `check_align` *before*
 //! short-circuiting the empty case!
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -184,7 +184,7 @@ mod macros;
 #[cfg(not(test))]
 #[unstable(feature = "assert_matches", issue = "82775")]
 /// Unstable module containing the unstable `assert_matches` macro.
-pub mod assert {
+pub mod assert_matches {
     #[unstable(feature = "assert_matches", issue = "82775")]
     pub use crate::macros::{assert_matches, debug_assert_matches};
 }

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -127,7 +127,7 @@ macro_rules! assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert::assert_matches;
+/// use std::assert_matches::assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
@@ -301,7 +301,7 @@ macro_rules! debug_assert_ne {
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro debug_assert_matches($($arg:tt)*) {
-    if $crate::cfg!(debug_assertions) { $crate::assert::assert_matches!($($arg)*); }
+    if $crate::cfg!(debug_assertions) { $crate::assert_matches::assert_matches!($($arg)*); }
 }
 
 /// Returns whether the given expression matches any of the given patterns.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -286,7 +286,7 @@ macro_rules! debug_assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert::debug_assert_matches;
+/// use std::assert_matches::debug_assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -556,9 +556,9 @@ pub use core::{
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 pub use core::{
-    asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
-    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
-    module_path, option_env, stringify, trace_macros,
+    asm, assert, assert_matches, cfg, column, compile_error, concat, concat_idents, env, file,
+    format_args, format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm,
+    log_syntax, module_path, option_env, stringify, trace_macros,
 };
 
 #[stable(feature = "core_primitive", since = "1.43.0")]

--- a/src/test/ui/macros/assert-matches-macro-msg.rs
+++ b/src/test/ui/macros/assert-matches-macro-msg.rs
@@ -6,7 +6,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 fn main() {
     assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");

--- a/src/test/ui/matches2021.rs
+++ b/src/test/ui/matches2021.rs
@@ -6,7 +6,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 fn main() {
     assert!(matches!((), ()));


### PR DESCRIPTION
Fixes nightly breakage introduced in https://github.com/rust-lang/rust/pull/86947