### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/vec_map.rs
+++ b/compiler/rustc_data_structures/src/vec_map.rs
@@ -127,13 +127,15 @@ impl<K, V> IntoIterator for VecMap<K, V> {
     }
 }
 
-impl<K, V> Extend<(K, V)> for VecMap<K, V> {
+impl<K: PartialEq, V> Extend<(K, V)> for VecMap<K, V> {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
-        self.0.extend(iter);
+        for (k, v) in iter {
+            self.insert(k, v);
+        }
     }
 
-    fn extend_one(&mut self, item: (K, V)) {
-        self.0.extend_one(item);
+    fn extend_one(&mut self, (k, v): (K, V)) {
+        self.insert(k, v);
     }
 
     fn extend_reserve(&mut self, additional: usize) {

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -534,7 +534,7 @@ declare_features! (
     (active, bindings_after_at, "1.41.0", Some(65490), None),
 
     /// Allows `impl const Trait for T` syntax.
-    (incomplete, const_trait_impl, "1.42.0", Some(67792), None),
+    (active, const_trait_impl, "1.42.0", Some(67792), None),
 
     /// Allows `T: ?const Trait` syntax in bounds.
     (incomplete, const_trait_bound_opt_out, "1.42.0", Some(67794), None),

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -856,7 +856,7 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable, TypeFoldable)]
 pub struct OpaqueTypeKey<'tcx> {
     pub def_id: DefId,
     pub substs: SubstsRef<'tcx>,

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -10,6 +10,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{is_range_literal, Node};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::adjustment::AllowTwoPhase;
+use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, AssocItem, Ty, TypeAndMut};
 use rustc_span::symbol::sym;
 use rustc_span::Span;
@@ -201,7 +202,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let sole_field = &variant.fields[0];
                     let sole_field_ty = sole_field.ty(self.tcx, substs);
                     if self.can_coerce(expr_ty, sole_field_ty) {
-                        let variant_path = self.tcx.def_path_str(variant.def_id);
+                        let variant_path =
+                            with_no_trimmed_paths(|| self.tcx.def_path_str(variant.def_id));
                         // FIXME #56861: DRYer prelude filtering
                         if let Some(path) = variant_path.strip_prefix("std::prelude::") {
                             if let Some((_, path)) = path.split_once("::") {

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -112,11 +112,9 @@ use rustc_hir::{HirIdMap, ImplicitSelfKind, Node};
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::Idx;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
-use rustc_middle::ty::fold::{TypeFoldable, TypeFolder};
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::subst::{InternalSubsts, Subst, SubstsRef};
-use rustc_middle::ty::{self, RegionKind, Ty, TyCtxt, UserType};
+use rustc_middle::ty::{self, Ty, TyCtxt, UserType};
 use rustc_session::config;
 use rustc_session::parse::feature_err;
 use rustc_session::Session;
@@ -321,117 +319,6 @@ fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &FxHashSet<LocalDe
     &*tcx.typeck(def_id).used_trait_imports
 }
 
-/// Inspects the substs of opaque types, replacing any inference variables
-/// with proper generic parameter from the identity substs.
-///
-/// This is run after we normalize the function signature, to fix any inference
-/// variables introduced by the projection of associated types. This ensures that
-/// any opaque types used in the signature continue to refer to generic parameters,
-/// allowing them to be considered for defining uses in the function body
-///
-/// For example, consider this code.
-///
-/// ```rust
-/// trait MyTrait {
-///     type MyItem;
-///     fn use_it(self) -> Self::MyItem
-/// }
-/// impl<T, I> MyTrait for T where T: Iterator<Item = I> {
-///     type MyItem = impl Iterator<Item = I>;
-///     fn use_it(self) -> Self::MyItem {
-///         self
-///     }
-/// }
-/// ```
-///
-/// When we normalize the signature of `use_it` from the impl block,
-/// we will normalize `Self::MyItem` to the opaque type `impl Iterator<Item = I>`
-/// However, this projection result may contain inference variables, due
-/// to the way that projection works. We didn't have any inference variables
-/// in the signature to begin with - leaving them in will cause us to incorrectly
-/// conclude that we don't have a defining use of `MyItem`. By mapping inference
-/// variables back to the actual generic parameters, we will correctly see that
-/// we have a defining use of `MyItem`
-fn fixup_opaque_types<'tcx, T>(tcx: TyCtxt<'tcx>, val: T) -> T
-where
-    T: TypeFoldable<'tcx>,
-{
-    struct FixupFolder<'tcx> {
-        tcx: TyCtxt<'tcx>,
-    }
-
-    impl<'tcx> TypeFolder<'tcx> for FixupFolder<'tcx> {
-        fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
-            self.tcx
-        }
-
-        fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-            match *ty.kind() {
-                ty::Opaque(def_id, substs) => {
-                    debug!("fixup_opaque_types: found type {:?}", ty);
-                    // Here, we replace any inference variables that occur within
-                    // the substs of an opaque type. By definition, any type occurring
-                    // in the substs has a corresponding generic parameter, which is what
-                    // we replace it with.
-                    // This replacement is only run on the function signature, so any
-                    // inference variables that we come across must be the rust of projection
-                    // (there's no other way for a user to get inference variables into
-                    // a function signature).
-                    if ty.needs_infer() {
-                        let new_substs = InternalSubsts::for_item(self.tcx, def_id, |param, _| {
-                            let old_param = substs[param.index as usize];
-                            match old_param.unpack() {
-                                GenericArgKind::Type(old_ty) => {
-                                    if let ty::Infer(_) = old_ty.kind() {
-                                        // Replace inference type with a generic parameter
-                                        self.tcx.mk_param_from_def(param)
-                                    } else {
-                                        old_param.fold_with(self)
-                                    }
-                                }
-                                GenericArgKind::Const(old_const) => {
-                                    if let ty::ConstKind::Infer(_) = old_const.val {
-                                        // This should never happen - we currently do not support
-                                        // 'const projections', e.g.:
-                                        // `impl<T: SomeTrait> MyTrait for T where <T as SomeTrait>::MyConst == 25`
-                                        // which should be the only way for us to end up with a const inference
-                                        // variable after projection. If Rust ever gains support for this kind
-                                        // of projection, this should *probably* be changed to
-                                        // `self.tcx.mk_param_from_def(param)`
-                                        bug!(
-                                            "Found infer const: `{:?}` in opaque type: {:?}",
-                                            old_const,
-                                            ty
-                                        );
-                                    } else {
-                                        old_param.fold_with(self)
-                                    }
-                                }
-                                GenericArgKind::Lifetime(old_region) => {
-                                    if let RegionKind::ReVar(_) = old_region {
-                                        self.tcx.mk_param_from_def(param)
-                                    } else {
-                                        old_param.fold_with(self)
-                                    }
-                                }
-                            }
-                        });
-                        let new_ty = self.tcx.mk_opaque(def_id, new_substs);
-                        debug!("fixup_opaque_types: new type: {:?}", new_ty);
-                        new_ty
-                    } else {
-                        ty
-                    }
-                }
-                _ => ty.super_fold_with(self),
-            }
-        }
-    }
-
-    debug!("fixup_opaque_types({:?})", val);
-    val.fold_with(&mut FixupFolder { tcx })
-}
-
 fn typeck_const_arg<'tcx>(
     tcx: TyCtxt<'tcx>,
     (did, param_did): (LocalDefId, DefId),
@@ -509,8 +396,6 @@ fn typeck_with_fallback<'tcx>(
                 param_env,
                 fn_sig,
             );
-
-            let fn_sig = fixup_opaque_types(tcx, fn_sig);
 
             let fcx = check_fn(&inh, param_env, fn_sig, decl, id, body, None).0;
             fcx

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -509,10 +509,9 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
     }
 }
 
+#[instrument(skip(tcx), level = "debug")]
 fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
     use rustc_hir::{Expr, ImplItem, Item, TraitItem};
-
-    debug!("find_opaque_ty_constraints({:?})", def_id);
 
     struct ConstraintLocator<'tcx> {
         tcx: TyCtxt<'tcx>,
@@ -522,13 +521,11 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
     }
 
     impl ConstraintLocator<'_> {
+        #[instrument(skip(self), level = "debug")]
         fn check(&mut self, def_id: LocalDefId) {
             // Don't try to check items that cannot possibly constrain the type.
             if !self.tcx.has_typeck_results(def_id) {
-                debug!(
-                    "find_opaque_ty_constraints: no constraint for `{:?}` at `{:?}`: no typeck results",
-                    self.def_id, def_id,
-                );
+                debug!("no constraint: no typeck results");
                 return;
             }
             // Calling `mir_borrowck` can lead to cycle errors through
@@ -540,10 +537,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
                 .get_by(|(key, _)| key.def_id == self.def_id)
                 .is_none()
             {
-                debug!(
-                    "find_opaque_ty_constraints: no constraint for `{:?}` at `{:?}`",
-                    self.def_id, def_id,
-                );
+                debug!("no constraints in typeck results");
                 return;
             }
             // Use borrowck to get the type with unerased regions.
@@ -603,7 +597,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
 
                 if let Some((prev_span, prev_ty)) = self.found {
                     if *concrete_type != prev_ty {
-                        debug!("find_opaque_ty_constraints: span={:?}", span);
+                        debug!(?span);
                         // Found different concrete types for the opaque type.
                         let mut err = self.tcx.sess.struct_span_err(
                             span,

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -296,7 +296,6 @@ impl<T, const N: usize> [T; N] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(array_map)]
     /// let x = [1, 2, 3];
     /// let y = x.map(|v| v + 1);
     /// assert_eq!(y, [2, 3, 4]);
@@ -310,7 +309,7 @@ impl<T, const N: usize> [T; N] {
     /// let y = x.map(|v| v.len());
     /// assert_eq!(y, [6, 9, 3, 3]);
     /// ```
-    #[unstable(feature = "array_map", issue = "75243")]
+    #[stable(feature = "array_map", since = "1.55.0")]
     pub fn map<F, U>(self, f: F) -> [U; N]
     where
         F: FnMut(T) -> U,
@@ -377,7 +376,7 @@ impl<T, const N: usize> [T; N] {
     /// array if its elements are not `Copy`.
     ///
     /// ```
-    /// #![feature(array_methods, array_map)]
+    /// #![feature(array_methods)]
     ///
     /// let strings = ["Ferris".to_string(), "♥".to_string(), "Rust".to_string()];
     /// let is_ascii = strings.each_ref().map(|s| s.is_ascii());

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,7 +1,6 @@
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
 #![feature(array_methods)]
-#![feature(array_map)]
 #![feature(array_windows)]
 #![feature(bool_to_option)]
 #![feature(box_syntax)]

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1729,7 +1729,8 @@ details.undocumented[open] > summary::before {
 		width: calc(100% + 30px);
 	}
 
-	.show-it {
+	.show-it, .sidebar-elems:focus-within {
+		z-index:  2;
 		left: 0;
 	}
 

--- a/src/test/rustdoc-gui/auto-hide-trait-implementations.goml
+++ b/src/test/rustdoc-gui/auto-hide-trait-implementations.goml
@@ -1,0 +1,13 @@
+// Checks that the setting "auto hide trait implementations" is working as expected.
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+
+// By default, the trait implementations are not collapsed.
+assert-attribute: ("#trait-implementations-list > details", {"open": ""}, ALL)
+
+// We now set the setting to auto hide all trait implementations.
+local-storage: {"rustdoc-auto-hide-trait-implementations": "true" }
+// We reload to ensure the trait implementations are collapsed as expected.
+reload:
+
+// We now check that all matching elements don't have the open attributes.
+assert-attribute-false: ("#trait-implementations-list > details", {"open": ""}, ALL)

--- a/src/test/rustdoc-gui/sidebar-mobile.goml
+++ b/src/test/rustdoc-gui/sidebar-mobile.goml
@@ -8,3 +8,13 @@ assert-css: (".sidebar-elems", {"display": "block", "left": "-246px"})
 // Opening the sidebar menu.
 click: ".sidebar-menu"
 assert-css: (".sidebar-elems", {"display": "block", "left": "0px"})
+// Closing the sidebar menu.
+click: ".sidebar-menu"
+assert-css: (".sidebar-elems", {"display": "block", "left": "-246px"})
+// Force the sidebar open by focusing a link inside it.
+// This makes it easier for keyboard users to get to it.
+focus: ".sidebar-title"
+assert-css: (".sidebar-elems", {"display": "block", "left": "0px"})
+// When we tab out of the sidebar, close it.
+focus: ".search-input"
+assert-css: (".sidebar-elems", {"display": "block", "left": "-246px"})

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -5,6 +5,7 @@
 #![feature(doc_keyword)]
 #![feature(doc_cfg)]
 
+use std::convert::AsRef;
 use std::fmt;
 
 /// Basic function with some code examples:
@@ -33,6 +34,12 @@ impl Foo {
     #[must_use]
     pub fn must_use(&self) -> bool {
         true
+    }
+}
+
+impl AsRef<str> for Foo {
+    fn as_ref(&self) -> &str {
+        "hello"
     }
 }
 

--- a/src/test/ui/consts/const-float-classify.rs
+++ b/src/test/ui/consts/const-float-classify.rs
@@ -5,7 +5,6 @@
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 // Don't promote
 const fn nop<T>(x: T) -> T { x }

--- a/src/test/ui/consts/rustc-impl-const-stability.rs
+++ b/src/test/ui/consts/rustc-impl-const-stability.rs
@@ -1,7 +1,6 @@
 // build-pass
 
 #![crate_type = "lib"]
-#![allow(incomplete_features)]
 #![feature(staged_api)]
 #![feature(const_trait_impl)]
 #![stable(feature = "foo", since = "1.0.0")]

--- a/src/test/ui/rfc-2632-const-trait-impl/assoc-type.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/assoc-type.rs
@@ -3,7 +3,6 @@
 // FIXME: This test should fail since, within a const impl of `Foo`, the bound on `Foo::Bar` should
 // require a const impl of `Add` for the associated type.
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct NonConstAdd(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 #[default_method_body_is_const] //~ ERROR attribute should be applied
 trait A {

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
@@ -1,5 +1,5 @@
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:4:1
+  --> $DIR/attr-misuse.rs:3:1
    |
 LL |   #[default_method_body_is_const]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | | }
    | |_- not a trait method or missing a body
 
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:13:1
+  --> $DIR/attr-misuse.rs:12:1
    |
 LL | #[default_method_body_is_const]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | fn main() {}
    | ------------ not a trait method or missing a body
 
 error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:6:5
+  --> $DIR/attr-misuse.rs:5:5
    |
 LL |     #[default_method_body_is_const]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 pub trait MyTrait {
     fn func(self);

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/staged-api.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 #![feature(staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 pub trait Plus {

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/call-const-trait-method-fail.rs:25:5
+  --> $DIR/call-const-trait-method-fail.rs:24:5
    |
 LL |     a.plus(b)
    |     ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-pass.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct Int(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
@@ -4,7 +4,6 @@
 
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
@@ -2,7 +2,6 @@
 // ignore-test
 
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
@@ -4,7 +4,6 @@
 
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 pub struct Int(i32);

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `std::ops::Add` for type `i32`
-  --> $DIR/const-and-non-const-impl.rs:6:1
+  --> $DIR/const-and-non-const-impl.rs:5:1
    |
 LL | impl const std::ops::Add for i32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | impl const std::ops::Add for i32 {
            - impl Add for i32;
 
 error[E0119]: conflicting implementations of trait `std::ops::Add` for type `Int`
-  --> $DIR/const-and-non-const-impl.rs:24:1
+  --> $DIR/const-and-non-const-impl.rs:23:1
    |
 LL | impl std::ops::Add for Int {
    | -------------------------- first implementation here
@@ -17,7 +17,7 @@ LL | impl const std::ops::Add for Int {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Int`
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-  --> $DIR/const-and-non-const-impl.rs:6:1
+  --> $DIR/const-and-non-const-impl.rs:5:1
    |
 LL | impl const std::ops::Add for i32 {
    | ^^^^^^^^^^^-------------^^^^^---

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-check-fns-in-const-impl.rs:12:16
+  --> $DIR/const-check-fns-in-const-impl.rs:11:16
    |
 LL |     fn foo() { non_const() }
    |                ^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -1,6 +1,5 @@
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)] // FIXME is this needed?
-#![allow(incomplete_features)]
 
 trait ConstDefaultFn: Sized {
     fn b(self);

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-default-method-bodies.rs:26:5
+  --> $DIR/const-default-method-bodies.rs:25:5
    |
 LL |     NonConstImpl.a();
    |     ^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 struct Foo;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-norecover.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-norecover.rs:6:7
+  --> $DIR/const-impl-norecover.rs:5:7
    |
 LL | const impl Foo {
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 trait Foo {}
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:6:7
+  --> $DIR/const-impl-recovery.rs:5:7
    |
 LL | const impl Foo for i32 {}
    |       ^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL | impl const Foo for i32 {}
    |--    ^^^^^
 
 error: expected identifier, found keyword `impl`
-  --> $DIR/const-impl-recovery.rs:10:7
+  --> $DIR/const-impl-recovery.rs:9:7
    |
 LL | const impl<T: Foo> Bar for T {}
    |       ^^^^ expected identifier, found keyword

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
@@ -1,5 +1,5 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:16:5
+  --> $DIR/cross-crate.rs:15:5
    |
 LL |     NonConst.func();
    |     ^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
@@ -1,6 +1,5 @@
 // revisions: stock gated
 #![cfg_attr(gated, feature(const_trait_impl))]
-#![allow(incomplete_features)]
 
 // aux-build: cross-crate.rs
 extern crate cross_crate;

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
@@ -1,11 +1,11 @@
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:16:5
+  --> $DIR/cross-crate.rs:15:5
    |
 LL |     NonConst.func();
    |     ^^^^^^^^^^^^^^^
 
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:18:5
+  --> $DIR/cross-crate.rs:17:5
    |
 LL |     Const.func();
    |     ^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.gated.stderr
@@ -1,5 +1,5 @@
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/feature-gate.rs:14:1
+  --> $DIR/feature-gate.rs:13:1
    |
 LL | fn main() {}
    | ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.rs
@@ -2,7 +2,6 @@
 // gate-test-const_trait_impl
 
 #![cfg_attr(gated, feature(const_trait_impl))]
-#![allow(incomplete_features)]
 #![feature(rustc_attrs)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/feature-gate.stock.stderr
@@ -1,5 +1,5 @@
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:10:6
+  --> $DIR/feature-gate.rs:9:6
    |
 LL | impl const T for S {}
    |      ^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_trait_impl)]
 #![feature(const_fn_trait_bound)]
 

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.rs
@@ -1,7 +1,6 @@
 // Regression test for #69615.
 
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 pub trait MyTrait {
     fn method(&self) -> Option<()>;

--- a/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/hir-const-check.stderr
@@ -1,5 +1,5 @@
 error[E0744]: `?` is not allowed in a `const fn`
-  --> $DIR/hir-const-check.rs:12:9
+  --> $DIR/hir-const-check.rs:11:9
    |
 LL |         Some(())?;
    |         ^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.rs
@@ -1,5 +1,4 @@
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 trait Tr {
     fn req(&self);

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn.stderr
@@ -1,5 +1,5 @@
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:18:1
+  --> $DIR/impl-with-default-fn.rs:17:1
    |
 LL | / impl const Tr for S {
 LL | |     fn req(&self) {}
@@ -9,7 +9,7 @@ LL | | }
    = note: `prov` not implemented
 
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:33:1
+  --> $DIR/impl-with-default-fn.rs:32:1
    |
 LL | / impl const Tr for u32 {
 LL | |     fn req(&self) {}
@@ -20,7 +20,7 @@ LL | | }
    = note: `prov` not implemented
 
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn.rs:27:1
+  --> $DIR/impl-with-default-fn.rs:26:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(allow_internal_unstable)]
 #![feature(const_add)]
 #![feature(const_trait_impl)]

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
@@ -1,5 +1,5 @@
 error: trait methods cannot be stable const fn
-  --> $DIR/stability.rs:14:5
+  --> $DIR/stability.rs:13:5
    |
 LL | /     fn sub(self, rhs: Self) -> Self {
 LL | |
@@ -8,7 +8,7 @@ LL | |     }
    | |_____^
 
 error: `<Int as Add>::add` is not yet stable as a const fn
-  --> $DIR/stability.rs:32:5
+  --> $DIR/stability.rs:31:5
    |
 LL |     Int(1i32) + Int(2i32)
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/syntax.rs
@@ -3,7 +3,6 @@
 
 #![feature(const_trait_bound_opt_out)]
 #![feature(const_trait_impl)]
-#![allow(incomplete_features)]
 
 // For now, this parses since an error does not occur until AST lowering.
 impl ?const T {}

--- a/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.rs
+++ b/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.rs
@@ -1,0 +1,10 @@
+mod option {
+    pub enum O<T> {
+        Some(T),
+        None,
+    }
+}
+
+fn main() {
+    let _: option::O<()> = (); //~ ERROR 9:28: 9:30: mismatched types [E0308]
+}

--- a/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.stderr
+++ b/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-full-enum-variant-for-local-module.rs:9:28
+   |
+LL |     let _: option::O<()> = ();
+   |            -------------   ^^
+   |            |               |
+   |            |               expected enum `O`, found `()`
+   |            |               help: try using a variant of the expected enum: `option::O::Some(())`
+   |            expected due to this
+   |
+   = note:   expected enum `O<()>`
+           found unit type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-impl-trait/issue-60371.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-60371.rs
@@ -9,7 +9,7 @@ trait Bug {
 impl Bug for &() {
     type Item = impl Bug; //~ ERROR `impl Trait` in type aliases is unstable
     //~^ ERROR the trait bound `(): Bug` is not satisfied
-    //~^^ ERROR could not find defining uses
+    //~^^ ERROR the trait bound `(): Bug` is not satisfied
 
     const FUN: fn() -> Self::Item = || ();
     //~^ ERROR type alias impl trait is not permitted here

--- a/src/test/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60371.stderr
@@ -25,11 +25,14 @@ LL |     type Item = impl Bug;
    = help: the following implementations were found:
              <&() as Bug>
 
-error: could not find defining uses
+error[E0277]: the trait bound `(): Bug` is not satisfied
   --> $DIR/issue-60371.rs:10:17
    |
 LL |     type Item = impl Bug;
-   |                 ^^^^^^^^
+   |                 ^^^^^^^^ the trait `Bug` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <&() as Bug>
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/issue-85113.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-85113.rs
@@ -12,6 +12,7 @@ trait Output<'a> {}
 impl<'a> Output<'a> for &'a str {}
 
 fn cool_fn<'a>(arg: &'a str) -> OpaqueOutputImpl<'a> {
+    //~^ ERROR: concrete type differs from previous defining opaque type use
     let out: OpaqueOutputImpl<'a> = arg;
     arg
 }

--- a/src/test/ui/type-alias-impl-trait/issue-85113.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-85113.stderr
@@ -10,6 +10,18 @@ note: hidden type `&'<empty> str` captures lifetime smaller than the function bo
 LL | type OpaqueOutputImpl<'a> = impl Output<'a> + 'a;
    |                             ^^^^^^^^^^^^^^^^^^^^
 
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/issue-85113.rs:14:1
+   |
+LL | fn cool_fn<'a>(arg: &'a str) -> OpaqueOutputImpl<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'<empty> str`, got `&'a str`
+   |
+note: previous use here
+  --> $DIR/issue-85113.rs:14:1
+   |
+LL | fn cool_fn<'a>(arg: &'a str) -> OpaqueOutputImpl<'a> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0477]: the type `&'<empty> str` does not fulfill the required lifetime
   --> $DIR/issue-85113.rs:5:29
    |
@@ -42,7 +54,7 @@ LL | type OpaqueOutputImpl<'a> = impl Output<'a> + 'a;
    = note: expected `Output<'a>`
               found `Output<'_>`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0477, E0495, E0700.
 For more information about an error, try `rustc --explain E0477`.


### PR DESCRIPTION
Successful merges:

 - #87107 (Loop over all opaque types instead of looking at just the first one with the same DefId)
 - #87158 (Suggest full enum variant for local modules)
 - #87174 (Stabilize `[T; N]::map()`)
 - #87179 (Mark `const_trait_impl` as active)
 - #87180 (feat(rustdoc): open sidebar menu when links inside it are focused)
 - #87188 (Add GUI test for auto-hide-trait-implementations setting)
 - #87200 (TAIT: Infer all inference variables in opaque type substitutions via InferCx)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87107,87158,87174,87179,87180,87188,87200)
<!-- homu-ignore:end -->