### PR TITLE
add build support for --enable-clang

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -145,6 +145,9 @@ changelog-seen = 2
 # Whether to include the Polly optimizer.
 #polly = false
 
+# Whether to build the Clang compiler.
+#clang = false
+
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -103,6 +103,7 @@ pub struct Config {
     pub llvm_use_linker: Option<String>,
     pub llvm_allow_old_toolchain: bool,
     pub llvm_polly: bool,
+    pub llvm_clang: bool,
     pub llvm_from_ci: bool,
 
     pub use_lld: bool,
@@ -431,6 +432,7 @@ struct Llvm {
     use_linker: Option<String>,
     allow_old_toolchain: Option<bool>,
     polly: Option<bool>,
+    clang: Option<bool>,
     download_ci_llvm: Option<StringOrBool>,
 }
 
@@ -743,6 +745,7 @@ impl Config {
             config.llvm_use_linker = llvm.use_linker.clone();
             config.llvm_allow_old_toolchain = llvm.allow_old_toolchain.unwrap_or(false);
             config.llvm_polly = llvm.polly.unwrap_or(false);
+            config.llvm_clang = llvm.clang.unwrap_or(false);
             config.llvm_from_ci = match llvm.download_ci_llvm {
                 Some(StringOrBool::String(s)) => {
                     assert!(s == "if-available", "unknown option `{}` for download-ci-llvm", s);
@@ -789,6 +792,7 @@ impl Config {
                 check_ci_llvm!(llvm.use_linker);
                 check_ci_llvm!(llvm.allow_old_toolchain);
                 check_ci_llvm!(llvm.polly);
+                check_ci_llvm!(llvm.clang);
 
                 // CI-built LLVM can be either dynamic or static.
                 let ci_llvm = config.out.join(&*config.build.triple).join("ci-llvm");

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -57,6 +57,7 @@ o("cargo-native-static", "build.cargo-native-static", "static native libraries i
 o("profiler", "build.profiler", "build the profiler runtime")
 o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
+o("clang", "rust.clang", "build clang")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -57,7 +57,7 @@ o("cargo-native-static", "build.cargo-native-static", "static native libraries i
 o("profiler", "build.profiler", "build the profiler runtime")
 o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
-o("clang", "rust.clang", "build clang")
+o("clang", "llvm.clang", "build clang")
 o("missing-tools", "dist.missing-tools", "allow failures when building tools")
 o("use-libcxx", "llvm.use-libcxx", "build LLVM with libc++")
 o("control-flow-guard", "rust.control-flow-guard", "Enable Control Flow Guard")

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -343,6 +343,10 @@ impl Step for Llvm {
             enabled_llvm_projects.push("polly");
         }
 
+        if builder.config.llvm_clang {
+            enabled_llvm_projects.push("clang");
+        }
+
         // We want libxml to be disabled.
         // See https://github.com/rust-lang/rust/pull/50104
         cfg.define("LLVM_ENABLE_LIBXML2", "OFF");


### PR DESCRIPTION
As discussed here: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Add.20configure.20flag.20to.20build.20clang

This basically allows using 
```--enable-clang```
for our build configuration.

This should be (?) the minimal set of changes required to get it working. 
There is no further integration. The main goal is having a simple way of getting compatible rustc and clang versions, based on the same llvm.