### PR TITLE
Stabilize built-in attribute macro `#[cfg_eval]`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1461,11 +1461,7 @@ pub(crate) mod builtin {
     }
 
     /// Expands all `#[cfg]` and `#[cfg_attr]` attributes in the code fragment it's applied to.
-    #[unstable(
-        feature = "cfg_eval",
-        issue = "82679",
-        reason = "`cfg_eval` is a recently implemented feature"
-    )]
+    #[stable(feature = "cfg_eval", since = "1.55.0")]
     #[rustc_builtin_macro]
     pub macro cfg_eval($($tt:tt)*) {
         /* compiler built-in */

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -79,10 +79,6 @@ pub use crate::macros::builtin::derive;
 #[doc(no_inline)]
 pub use crate::macros::builtin::cfg_accessible;
 
-#[unstable(
-    feature = "cfg_eval",
-    issue = "82679",
-    reason = "`cfg_eval` is a recently implemented feature"
-)]
+#[stable(feature = "cfg_eval", since = "1.55.0")]
 #[doc(no_inline)]
 pub use crate::macros::builtin::cfg_eval;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -237,7 +237,6 @@
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]
-#![feature(cfg_eval)]
 #![feature(cfg_target_has_atomic)]
 #![feature(cfg_target_thread_local)]
 #![feature(char_error_internals)]

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -66,11 +66,7 @@ pub use core::prelude::v1::derive;
 #[doc(hidden)]
 pub use core::prelude::v1::cfg_accessible;
 
-#[unstable(
-    feature = "cfg_eval",
-    issue = "82679",
-    reason = "`cfg_eval` is a recently implemented feature"
-)]
+#[stable(feature = "cfg_eval", since = "1.55.0")]
 #[doc(hidden)]
 pub use core::prelude::v1::cfg_eval;
 

--- a/src/test/ui/proc-macro/cfg-eval-fail.rs
+++ b/src/test/ui/proc-macro/cfg-eval-fail.rs
@@ -1,4 +1,3 @@
-#![feature(cfg_eval)]
 #![feature(stmt_expr_attributes)]
 
 fn main() {

--- a/src/test/ui/proc-macro/cfg-eval-fail.stderr
+++ b/src/test/ui/proc-macro/cfg-eval-fail.stderr
@@ -1,17 +1,17 @@
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-eval-fail.rs:5:25
+  --> $DIR/cfg-eval-fail.rs:4:25
    |
 LL |     let _ = #[cfg_eval] #[cfg(FALSE)] 0;
    |                         ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-eval-fail.rs:5:25
+  --> $DIR/cfg-eval-fail.rs:4:25
    |
 LL |     let _ = #[cfg_eval] #[cfg(FALSE)] 0;
    |                         ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-eval-fail.rs:5:25
+  --> $DIR/cfg-eval-fail.rs:4:25
    |
 LL |     let _ = #[cfg_eval] #[cfg(FALSE)] 0;
    |                         ^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/cfg-eval-inner.rs
+++ b/src/test/ui/proc-macro/cfg-eval-inner.rs
@@ -2,7 +2,6 @@
 // aux-build:test-macros.rs
 // check-pass
 
-#![feature(cfg_eval)]
 #![feature(custom_inner_attributes)]
 #![feature(stmt_expr_attributes)]
 #![feature(rustc_attrs)]

--- a/src/test/ui/proc-macro/cfg-eval-inner.stdout
+++ b/src/test/ui/proc-macro/cfg-eval-inner.stdout
@@ -7,28 +7,28 @@ PRINT-ATTR INPUT (DISPLAY): impl Foo <
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",
-        span: $DIR/cfg-eval-inner.rs:18:1: 18:5 (#0),
+        span: $DIR/cfg-eval-inner.rs:17:1: 17:5 (#0),
     },
     Ident {
         ident: "Foo",
-        span: $DIR/cfg-eval-inner.rs:18:6: 18:9 (#0),
+        span: $DIR/cfg-eval-inner.rs:17:6: 17:9 (#0),
     },
     Punct {
         ch: '<',
         spacing: Alone,
-        span: $DIR/cfg-eval-inner.rs:18:9: 18:10 (#0),
+        span: $DIR/cfg-eval-inner.rs:17:9: 17:10 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "u8",
-                span: $DIR/cfg-eval-inner.rs:18:11: 18:13 (#0),
+                span: $DIR/cfg-eval-inner.rs:17:11: 17:13 (#0),
             },
             Punct {
                 ch: ';',
                 spacing: Alone,
-                span: $DIR/cfg-eval-inner.rs:18:13: 18:14 (#0),
+                span: $DIR/cfg-eval-inner.rs:17:13: 17:14 (#0),
             },
             Group {
                 delimiter: Brace,
@@ -36,6 +36,36 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                     Punct {
                         ch: '#',
                         spacing: Alone,
+                        span: $DIR/cfg-eval-inner.rs:18:5: 18:6 (#0),
+                    },
+                    Punct {
+                        ch: '!',
+                        spacing: Alone,
+                        span: $DIR/cfg-eval-inner.rs:18:6: 18:7 (#0),
+                    },
+                    Group {
+                        delimiter: Bracket,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "rustc_dummy",
+                                span: $DIR/cfg-eval-inner.rs:18:29: 18:40 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cursed_inner",
+                                        span: $DIR/cfg-eval-inner.rs:18:41: 18:53 (#0),
+                                    },
+                                ],
+                                span: $DIR/cfg-eval-inner.rs:18:40: 18:54 (#0),
+                            },
+                        ],
+                        span: $DIR/cfg-eval-inner.rs:18:5: 18:6 (#0),
+                    },
+                    Punct {
+                        ch: '#',
+                        spacing: Joint,
                         span: $DIR/cfg-eval-inner.rs:19:5: 19:6 (#0),
                     },
                     Punct {
@@ -47,83 +77,53 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
-                                ident: "rustc_dummy",
-                                span: $DIR/cfg-eval-inner.rs:19:29: 19:40 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "cursed_inner",
-                                        span: $DIR/cfg-eval-inner.rs:19:41: 19:53 (#0),
-                                    },
-                                ],
-                                span: $DIR/cfg-eval-inner.rs:19:40: 19:54 (#0),
-                            },
-                        ],
-                        span: $DIR/cfg-eval-inner.rs:19:5: 19:6 (#0),
-                    },
-                    Punct {
-                        ch: '#',
-                        spacing: Joint,
-                        span: $DIR/cfg-eval-inner.rs:20:5: 20:6 (#0),
-                    },
-                    Punct {
-                        ch: '!',
-                        spacing: Alone,
-                        span: $DIR/cfg-eval-inner.rs:20:6: 20:7 (#0),
-                    },
-                    Group {
-                        delimiter: Bracket,
-                        stream: TokenStream [
-                            Ident {
                                 ident: "allow",
-                                span: $DIR/cfg-eval-inner.rs:20:8: 20:13 (#0),
+                                span: $DIR/cfg-eval-inner.rs:19:8: 19:13 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "unused",
-                                        span: $DIR/cfg-eval-inner.rs:20:14: 20:20 (#0),
+                                        span: $DIR/cfg-eval-inner.rs:19:14: 19:20 (#0),
                                     },
                                 ],
-                                span: $DIR/cfg-eval-inner.rs:20:13: 20:21 (#0),
+                                span: $DIR/cfg-eval-inner.rs:19:13: 19:21 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval-inner.rs:20:7: 20:22 (#0),
+                        span: $DIR/cfg-eval-inner.rs:19:7: 19:22 (#0),
                     },
                     Ident {
                         ident: "struct",
-                        span: $DIR/cfg-eval-inner.rs:21:5: 21:11 (#0),
+                        span: $DIR/cfg-eval-inner.rs:20:5: 20:11 (#0),
                     },
                     Ident {
                         ident: "Inner",
-                        span: $DIR/cfg-eval-inner.rs:21:12: 21:17 (#0),
+                        span: $DIR/cfg-eval-inner.rs:20:12: 20:17 (#0),
                     },
                     Group {
                         delimiter: Brace,
                         stream: TokenStream [
                             Ident {
                                 ident: "field",
-                                span: $DIR/cfg-eval-inner.rs:22:9: 22:14 (#0),
+                                span: $DIR/cfg-eval-inner.rs:21:9: 21:14 (#0),
                             },
                             Punct {
                                 ch: ':',
                                 spacing: Alone,
-                                span: $DIR/cfg-eval-inner.rs:22:14: 22:15 (#0),
+                                span: $DIR/cfg-eval-inner.rs:21:14: 21:15 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "u8",
-                                        span: $DIR/cfg-eval-inner.rs:22:17: 22:19 (#0),
+                                        span: $DIR/cfg-eval-inner.rs:21:17: 21:19 (#0),
                                     },
                                     Punct {
                                         ch: ';',
                                         spacing: Alone,
-                                        span: $DIR/cfg-eval-inner.rs:22:19: 22:20 (#0),
+                                        span: $DIR/cfg-eval-inner.rs:21:19: 21:20 (#0),
                                     },
                                     Group {
                                         delimiter: Brace,
@@ -131,64 +131,64 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                             Punct {
                                                 ch: '#',
                                                 spacing: Alone,
-                                                span: $DIR/cfg-eval-inner.rs:23:13: 23:14 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:22:13: 22:14 (#0),
                                             },
                                             Punct {
                                                 ch: '!',
                                                 spacing: Alone,
-                                                span: $DIR/cfg-eval-inner.rs:23:14: 23:15 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:22:14: 22:15 (#0),
                                             },
                                             Group {
                                                 delimiter: Bracket,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "rustc_dummy",
-                                                        span: $DIR/cfg-eval-inner.rs:23:37: 23:48 (#0),
+                                                        span: $DIR/cfg-eval-inner.rs:22:37: 22:48 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "another_cursed_inner",
-                                                                span: $DIR/cfg-eval-inner.rs:23:49: 23:69 (#0),
+                                                                span: $DIR/cfg-eval-inner.rs:22:49: 22:69 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/cfg-eval-inner.rs:23:48: 23:70 (#0),
+                                                        span: $DIR/cfg-eval-inner.rs:22:48: 22:70 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/cfg-eval-inner.rs:23:13: 23:14 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:22:13: 22:14 (#0),
                                             },
                                             Literal {
                                                 kind: Integer,
                                                 symbol: "1",
                                                 suffix: None,
-                                                span: $DIR/cfg-eval-inner.rs:24:13: 24:14 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:23:13: 23:14 (#0),
                                             },
                                         ],
-                                        span: $DIR/cfg-eval-inner.rs:22:21: 25:10 (#0),
+                                        span: $DIR/cfg-eval-inner.rs:21:21: 24:10 (#0),
                                     },
                                 ],
-                                span: $DIR/cfg-eval-inner.rs:22:16: 25:11 (#0),
+                                span: $DIR/cfg-eval-inner.rs:21:16: 24:11 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval-inner.rs:21:18: 26:6 (#0),
+                        span: $DIR/cfg-eval-inner.rs:20:18: 25:6 (#0),
                     },
                     Literal {
                         kind: Integer,
                         symbol: "0",
                         suffix: None,
-                        span: $DIR/cfg-eval-inner.rs:28:5: 28:6 (#0),
+                        span: $DIR/cfg-eval-inner.rs:27:5: 27:6 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval-inner.rs:18:15: 29:2 (#0),
+                span: $DIR/cfg-eval-inner.rs:17:15: 28:2 (#0),
             },
         ],
-        span: $DIR/cfg-eval-inner.rs:18:10: 29:3 (#0),
+        span: $DIR/cfg-eval-inner.rs:17:10: 28:3 (#0),
     },
     Punct {
         ch: '>',
         spacing: Alone,
-        span: $DIR/cfg-eval-inner.rs:29:3: 29:4 (#0),
+        span: $DIR/cfg-eval-inner.rs:28:3: 28:4 (#0),
     },
     Group {
         delimiter: Brace,
@@ -196,52 +196,52 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/cfg-eval-inner.rs:32:5: 32:6 (#0),
+                span: $DIR/cfg-eval-inner.rs:31:5: 31:6 (#0),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/cfg-eval-inner.rs:32:6: 32:7 (#0),
+                span: $DIR/cfg-eval-inner.rs:31:6: 31:7 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "rustc_dummy",
-                        span: $DIR/cfg-eval-inner.rs:32:29: 32:40 (#0),
+                        span: $DIR/cfg-eval-inner.rs:31:29: 31:40 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "evaluated_attr",
-                                span: $DIR/cfg-eval-inner.rs:32:41: 32:55 (#0),
+                                span: $DIR/cfg-eval-inner.rs:31:41: 31:55 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval-inner.rs:32:40: 32:56 (#0),
+                        span: $DIR/cfg-eval-inner.rs:31:40: 31:56 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval-inner.rs:32:5: 32:6 (#0),
+                span: $DIR/cfg-eval-inner.rs:31:5: 31:6 (#0),
             },
             Ident {
                 ident: "fn",
-                span: $DIR/cfg-eval-inner.rs:34:5: 34:7 (#0),
+                span: $DIR/cfg-eval-inner.rs:33:5: 33:7 (#0),
             },
             Ident {
                 ident: "bar",
-                span: $DIR/cfg-eval-inner.rs:34:8: 34:11 (#0),
+                span: $DIR/cfg-eval-inner.rs:33:8: 33:11 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [],
-                span: $DIR/cfg-eval-inner.rs:34:11: 34:13 (#0),
+                span: $DIR/cfg-eval-inner.rs:33:11: 33:13 (#0),
             },
             Group {
                 delimiter: Brace,
                 stream: TokenStream [],
-                span: $DIR/cfg-eval-inner.rs:34:14: 36:6 (#0),
+                span: $DIR/cfg-eval-inner.rs:33:14: 35:6 (#0),
             },
         ],
-        span: $DIR/cfg-eval-inner.rs:29:5: 37:2 (#0),
+        span: $DIR/cfg-eval-inner.rs:28:5: 36:2 (#0),
     },
 ]

--- a/src/test/ui/proc-macro/cfg-eval.rs
+++ b/src/test/ui/proc-macro/cfg-eval.rs
@@ -2,7 +2,6 @@
 // compile-flags: -Z span-debug
 // aux-build:test-macros.rs
 
-#![feature(cfg_eval)]
 #![feature(proc_macro_hygiene)]
 #![feature(stmt_expr_attributes)]
 #![feature(rustc_attrs)]

--- a/src/test/ui/proc-macro/cfg-eval.stdout
+++ b/src/test/ui/proc-macro/cfg-eval.stdout
@@ -2,11 +2,11 @@ PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true : u8
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/cfg-eval.rs:17:1: 17:7 (#0),
+        span: $DIR/cfg-eval.rs:16:1: 16:7 (#0),
     },
     Ident {
         ident: "S1",
-        span: $DIR/cfg-eval.rs:17:8: 17:10 (#0),
+        span: $DIR/cfg-eval.rs:16:8: 16:10 (#0),
     },
     Group {
         delimiter: Brace,
@@ -14,73 +14,73 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:20:5: 20:6 (#0),
+                span: $DIR/cfg-eval.rs:19:5: 19:6 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "cfg",
-                        span: $DIR/cfg-eval.rs:20:7: 20:10 (#0),
+                        span: $DIR/cfg-eval.rs:19:7: 19:10 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "all",
-                                span: $DIR/cfg-eval.rs:20:11: 20:14 (#0),
+                                span: $DIR/cfg-eval.rs:19:11: 19:14 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:20:14: 20:24 (#0),
+                                span: $DIR/cfg-eval.rs:19:14: 19:24 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval.rs:20:10: 20:25 (#0),
+                        span: $DIR/cfg-eval.rs:19:10: 19:25 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:20:6: 20:26 (#0),
+                span: $DIR/cfg-eval.rs:19:6: 19:26 (#0),
             },
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:22:5: 22:6 (#0),
+                span: $DIR/cfg-eval.rs:21:5: 21:6 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "allow",
-                        span: $DIR/cfg-eval.rs:22:31: 22:36 (#0),
+                        span: $DIR/cfg-eval.rs:21:31: 21:36 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [],
-                        span: $DIR/cfg-eval.rs:22:36: 22:38 (#0),
+                        span: $DIR/cfg-eval.rs:21:36: 21:38 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:22:5: 22:6 (#0),
+                span: $DIR/cfg-eval.rs:21:5: 21:6 (#0),
             },
             Ident {
                 ident: "field_true",
-                span: $DIR/cfg-eval.rs:23:5: 23:15 (#0),
+                span: $DIR/cfg-eval.rs:22:5: 22:15 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:23:15: 23:16 (#0),
+                span: $DIR/cfg-eval.rs:22:15: 22:16 (#0),
             },
             Ident {
                 ident: "u8",
-                span: $DIR/cfg-eval.rs:23:17: 23:19 (#0),
+                span: $DIR/cfg-eval.rs:22:17: 22:19 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:23:19: 23:20 (#0),
+                span: $DIR/cfg-eval.rs:22:19: 22:20 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:17:11: 24:2 (#0),
+        span: $DIR/cfg-eval.rs:16:11: 23:2 (#0),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] (#[cfg(all())] 1,)
@@ -88,17 +88,17 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/cfg-eval.rs:35:39: 35:40 (#0),
+        span: $DIR/cfg-eval.rs:34:39: 34:40 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "rustc_dummy",
-                span: $DIR/cfg-eval.rs:35:62: 35:73 (#0),
+                span: $DIR/cfg-eval.rs:34:62: 34:73 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:35:39: 35:40 (#0),
+        span: $DIR/cfg-eval.rs:34:39: 34:40 (#0),
     },
     Group {
         delimiter: Parenthesis,
@@ -106,45 +106,45 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:36:23: 36:24 (#0),
+                span: $DIR/cfg-eval.rs:35:23: 35:24 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "cfg",
-                        span: $DIR/cfg-eval.rs:36:25: 36:28 (#0),
+                        span: $DIR/cfg-eval.rs:35:25: 35:28 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "all",
-                                span: $DIR/cfg-eval.rs:36:29: 36:32 (#0),
+                                span: $DIR/cfg-eval.rs:35:29: 35:32 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:36:32: 36:42 (#0),
+                                span: $DIR/cfg-eval.rs:35:32: 35:42 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval.rs:36:28: 36:43 (#0),
+                        span: $DIR/cfg-eval.rs:35:28: 35:43 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:36:24: 36:44 (#0),
+                span: $DIR/cfg-eval.rs:35:24: 35:44 (#0),
             },
             Literal {
                 kind: Integer,
                 symbol: "1",
                 suffix: None,
-                span: $DIR/cfg-eval.rs:36:45: 36:46 (#0),
+                span: $DIR/cfg-eval.rs:35:45: 35:46 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/cfg-eval.rs:36:46: 36:47 (#0),
+                span: $DIR/cfg-eval.rs:35:46: 35:47 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:36:5: 36:48 (#0),
+        span: $DIR/cfg-eval.rs:35:5: 35:48 (#0),
     },
 ]


### PR DESCRIPTION
Built-in attribute macro `#[cfg_eval]` is used for eagerly expanding all `#[cfg]` and `#[cfg_attr]` attributes in its input ("fully configuring" the input).
The effect is identical to effect of `#[derive(Foo, Bar)]` which also fully configures its input before passing it to macros `Foo` and `Bar`, except that `cfg_eval` is supported on any code fragments supporting macro attributes, unlike `derive`.

Example:
```rust
#[cfg_eval]
#[my_attr] // Receives `struct S {}` as input, the field is configured away by `#[cfg_eval]`
struct S {
    #[cfg(FALSE)]
    field: u8,
}
```

The main alternative to this attribute is to automatically fully configure items before expanding any attributes.
That alternative was implemented as an experiment in https://github.com/rust-lang/rust/pull/85073.
Crater showed that there are indeed attributes that want to do some custom `cfg` processing (https://github.com/rust-lang/rust/pull/85073#issuecomment-851064125) which are broken by this change, so we need some kind opt-out from eager configuration, but it's not clear how that opt-out should look like.
I suggest considering switching to this alternative for the next edition (~Rust 2024), but leave it alone for now.

This PR is somewhat related to https://github.com/rust-lang/rust/pull/87220, but I don't think they are blocking each other.

Closes #82679
r? @Aaron1011