### PR TITLE
Various diagnostics clean ups/tweaks

### DIFF
--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -84,8 +84,10 @@ fn report_bad_target(sess: &Session, item: &Annotatable, span: Span) -> bool {
             sess,
             span,
             E0774,
-            "`derive` may only be applied to structs, enums and unions",
+            "`derive` may only be applied to `struct`s, `enum`s and `union`s",
         )
+        .span_label(span, "not applicable here")
+        .span_label(item.span(), "not a `struct`, `enum` or `union`")
         .emit();
     }
     bad_target
@@ -99,6 +101,7 @@ fn report_unexpected_literal(sess: &Session, lit: &ast::Lit) {
         _ => "for example, write `#[derive(Debug)]` for `Debug`".to_string(),
     };
     struct_span_err!(sess, lit.span, E0777, "expected path to a trait, found literal",)
+        .span_label(lit.span, "not a trait")
         .help(&help_msg)
         .emit();
 }

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -148,11 +148,7 @@ fn cs_clone_shallow(
             }
             _ => cx.span_bug(
                 trait_span,
-                &format!(
-                    "unexpected substructure in \
-                                                    shallow `derive({})`",
-                    name
-                ),
+                &format!("unexpected substructure in shallow `derive({})`", name),
             ),
         }
     }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -952,7 +952,7 @@ pub enum AstPass {
 }
 
 impl AstPass {
-    fn descr(self) -> &'static str {
+    pub fn descr(self) -> &'static str {
         match self {
             AstPass::StdImports => "standard library imports",
             AstPass::TestHarness => "test harness",
@@ -989,7 +989,7 @@ pub enum ForLoopLoc {
 
 impl DesugaringKind {
     /// The description wording should combine well with "desugaring of {}".
-    fn descr(self) -> &'static str {
+    pub fn descr(self) -> &'static str {
         match self {
             DesugaringKind::CondTemporary => "`if` or `while` condition",
             DesugaringKind::Async => "`async` block or function",

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -933,6 +933,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     item_name
                 );
                 err.span_label(item_name.span, &format!("private {}", kind));
+                let sp = self
+                    .tcx
+                    .hir()
+                    .span_if_local(def_id)
+                    .unwrap_or_else(|| self.tcx.def_span(def_id));
+                err.span_label(sp, &format!("private {} defined here", kind));
                 self.suggest_valid_traits(&mut err, out_of_scope_traits);
                 err.emit();
             }

--- a/src/test/ui-fulldeps/session-derive-errors.stderr
+++ b/src/test/ui-fulldeps/session-derive-errors.stderr
@@ -56,6 +56,8 @@ LL | #[message = "This error has a field, and references {name}"]
 error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/session-derive-errors.rs:116:1
    |
+LL | #[derive(SessionDiagnostic)]
+   |          ----------------- in this derive macro expansion
 LL | #[error = "E0123"]
    |               - because of this opening brace
 LL | #[message = "This is missing a closing brace: {name"]
@@ -67,6 +69,9 @@ LL | #[message = "This is missing a closing brace: {name"]
 error: invalid format string: unmatched `}` found
   --> $DIR/session-derive-errors.rs:125:1
    |
+LL | #[derive(SessionDiagnostic)]
+   |          ----------------- in this derive macro expansion
+LL | #[error = "E0123"]
 LL | #[message = "This is missing an opening brace: name}"]
    | ^ unmatched `}` in format string
    |

--- a/src/test/ui/allocator/not-an-allocator.stderr
+++ b/src/test/ui/allocator/not-an-allocator.stderr
@@ -1,37 +1,61 @@
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
    |
+LL | #[global_allocator]
+   | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = note: required by `std::alloc::GlobalAlloc::alloc`
+note: required by `std::alloc::GlobalAlloc::alloc`
+  --> $SRC_DIR/core/src/alloc/global.rs:LL:COL
+   |
+LL |     unsafe fn alloc(&self, layout: Layout) -> *mut u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
    |
+LL | #[global_allocator]
+   | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = note: required by `std::alloc::GlobalAlloc::dealloc`
+note: required by `std::alloc::GlobalAlloc::dealloc`
+  --> $SRC_DIR/core/src/alloc/global.rs:LL:COL
+   |
+LL |     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
    |
+LL | #[global_allocator]
+   | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = note: required by `std::alloc::GlobalAlloc::realloc`
+note: required by `std::alloc::GlobalAlloc::realloc`
+  --> $SRC_DIR/core/src/alloc/global.rs:LL:COL
+   |
+LL |     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
    |
+LL | #[global_allocator]
+   | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
-   = note: required by `std::alloc::GlobalAlloc::alloc_zeroed`
+note: required by `std::alloc::GlobalAlloc::alloc_zeroed`
+  --> $SRC_DIR/core/src/alloc/global.rs:LL:COL
+   |
+LL |     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -4,6 +4,7 @@ error: cannot define multiple global allocators
 LL | static A: System = System;
    | -------------------------- previous global allocator defined here
 LL | #[global_allocator]
+   | ------------------- in this procedural macro expansion
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
    |

--- a/src/test/ui/associated-consts/associated-const-array-len.stderr
+++ b/src/test/ui/associated-consts/associated-const-array-len.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/associated-const-array-len.rs:5:16
    |
-LL |     const ID: usize;
-   |     ---------------- required by `Foo::ID`
-...
 LL | const X: [i32; <i32 as Foo>::ID] = [0, 1, 2];
    |                ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |
+note: required by `Foo::ID`
+  --> $DIR/associated-const-array-len.rs:2:5
+   |
+LL |     const ID: usize;
+   |     ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-consts/associated-const-private-impl.stderr
+++ b/src/test/ui/associated-consts/associated-const-private-impl.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated constant `ID` is private
   --> $DIR/associated-const-private-impl.rs:13:30
    |
+LL |             const ID: i32 = 1;
+   |             ------------------ private associated constant defined here
+...
 LL |     assert_eq!(1, bar1::Foo::ID);
    |                              ^^ private associated constant
 

--- a/src/test/ui/associated-consts/issue-63496.stderr
+++ b/src/test/ui/associated-consts/issue-63496.stderr
@@ -1,9 +1,6 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-63496.rs:4:21
    |
-LL |     const C: usize;
-   |     --------------- required by `A::C`
-LL | 
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |                     ^^^^
    |                     |
@@ -12,13 +9,15 @@ LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |
    = note: cannot satisfy `_: A`
    = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+note: required by `A::C`
+  --> $DIR/issue-63496.rs:2:5
+   |
+LL |     const C: usize;
+   |     ^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-63496.rs:4:33
    |
-LL |     const C: usize;
-   |     --------------- required by `A::C`
-LL | 
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |                                 ^^^^
    |                                 |
@@ -27,6 +26,11 @@ LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |
    = note: cannot satisfy `_: A`
    = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+note: required by `A::C`
+  --> $DIR/issue-63496.rs:2:5
+   |
+LL |     const C: usize;
+   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-item/issue-48027.stderr
+++ b/src/test/ui/associated-item/issue-48027.stderr
@@ -16,8 +16,6 @@ LL |     const X: usize;
 error[E0283]: type annotations needed
   --> $DIR/issue-48027.rs:3:32
    |
-LL |     const X: usize;
-   |     --------------- required by `Bar::X`
 LL |     fn return_n(&self) -> [u8; Bar::X];
    |                                ^^^^^^
    |                                |
@@ -26,6 +24,11 @@ LL |     fn return_n(&self) -> [u8; Bar::X];
    |
    = note: cannot satisfy `_: Bar`
    = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+note: required by `Bar::X`
+  --> $DIR/issue-48027.rs:2:5
+   |
+LL |     const X: usize;
+   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-bound-failure.stderr
+++ b/src/test/ui/associated-types/associated-types-bound-failure.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `<G as GetToInt>::R: ToInt` is not satisfied
   --> $DIR/associated-types-bound-failure.rs:19:19
    |
-LL |     fn to_int(&self) -> isize;
-   |     -------------------------- required by `ToInt::to_int`
-...
 LL |     ToInt::to_int(&g.get())
    |                   ^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
    |
+note: required by `ToInt::to_int`
+  --> $DIR/associated-types-bound-failure.rs:6:5
+   |
+LL |     fn to_int(&self) -> isize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider further restricting the associated type
    |
 LL |     where G : GetToInt, <G as GetToInt>::R: ToInt

--- a/src/test/ui/associated-types/associated-types-unconstrained.stderr
+++ b/src/test/ui/associated-types/associated-types-unconstrained.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/associated-types-unconstrained.rs:14:20
    |
-LL |     fn bar() -> isize;
-   |     ------------------ required by `Foo::bar`
-...
 LL |     let x: isize = Foo::bar();
    |                    ^^^^^^^^ cannot infer type
    |
    = note: cannot satisfy `_: Foo`
+note: required by `Foo::bar`
+  --> $DIR/associated-types-unconstrained.rs:5:5
+   |
+LL |     fn bar() -> isize;
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/issue-44153.stderr
+++ b/src/test/ui/associated-types/issue-44153.stderr
@@ -1,9 +1,6 @@
 error[E0271]: type mismatch resolving `<() as Array>::Element == &()`
   --> $DIR/issue-44153.rs:18:5
    |
-LL |     fn visit() {}
-   |     ---------- required by `Visit::visit`
-...
 LL |     <() as Visit>::visit();
    |     ^^^^^^^^^^^^^^^^^^^^ expected `&()`, found `()`
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Visit` for `()`
    |
 LL | impl<'a> Visit for () where
    |          ^^^^^     ^^
+note: required by `Visit::visit`
+  --> $DIR/issue-44153.rs:6:5
+   |
+LL |     fn visit() {}
+   |     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -5,7 +5,11 @@ LL |     foo()?;
    |     ^^^^^^ the `?` operator cannot be applied to type `impl Future`
    |
    = help: the trait `Try` is not implemented for `impl Future`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider `await`ing on the `Future`
    |
 LL |     foo().await?;
@@ -18,7 +22,11 @@ LL |     t?;
    |     ^^ the `?` operator cannot be applied to type `T`
    |
    = help: the trait `Try` is not implemented for `T`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider `await`ing on the `Future`
    |
 LL |     t.await?;

--- a/src/test/ui/async-await/issue-70594.stderr
+++ b/src/test/ui/async-await/issue-70594.stderr
@@ -25,7 +25,11 @@ LL |     [1; ().await];
    |         ^^^^^^^^ `()` is not a future
    |
    = help: the trait `Future` is not implemented for `()`
-   = note: required by `poll`
+note: required by `poll`
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   |
+LL |     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/issue-84841.stderr
+++ b/src/test/ui/async-await/issue-84841.stderr
@@ -5,7 +5,11 @@ LL |     test()?;
    |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future`
    |
    = help: the trait `Try` is not implemented for `impl Future`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in an async function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/issue-84841.rs:9:11
@@ -21,7 +25,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<_>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -34,7 +34,11 @@ LL |     (|_| 2333).await;
    |     ^^^^^^^^^^^^^^^^ `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]` is not a future
    |
    = help: the trait `Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]`
-   = note: required by `poll`
+note: required by `poll`
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   |
+LL |     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/pin-needed-to-poll-2.stderr
+++ b/src/test/ui/async-await/pin-needed-to-poll-2.stderr
@@ -10,7 +10,11 @@ note: required because it appears within the type `Sleep`
    |
 LL | struct Sleep(std::marker::PhantomPinned);
    |        ^^^^^
-   = note: required by `Pin::<P>::new`
+note: required by `Pin::<P>::new`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+   |
+LL |     pub const fn new(pointer: P) -> Pin<P> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/try-on-option-in-async.stderr
+++ b/src/test/ui/async-await/try-on-option-in-async.stderr
@@ -11,7 +11,11 @@ LL | |     }
    | |_____- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `{integer}`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in an async closure that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-in-async.rs:17:10
@@ -26,7 +30,11 @@ LL | |     };
    | |_____- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `u32`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in an async function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-in-async.rs:26:6
@@ -41,7 +49,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `u32`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/box/into-boxed-slice-fail.stderr
+++ b/src/test/ui/box/into-boxed-slice-fail.stderr
@@ -5,7 +5,11 @@ LL |     let _ = Box::into_boxed_slice(boxed_slice);
    |                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: required by `Box::<T, A>::into_boxed_slice`
+note: required by `Box::<T, A>::into_boxed_slice`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL |     pub fn into_boxed_slice(boxed: Self) -> Box<[T], A> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/into-boxed-slice-fail.rs:7:13
@@ -23,7 +27,11 @@ LL |     let _ = Box::into_boxed_slice(boxed_trait);
    |                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
-   = note: required by `Box::<T, A>::into_boxed_slice`
+note: required by `Box::<T, A>::into_boxed_slice`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL |     pub fn into_boxed_slice(boxed: Self) -> Box<[T], A> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
   --> $DIR/into-boxed-slice-fail.rs:11:13

--- a/src/test/ui/chalkify/type_wf.stderr
+++ b/src/test/ui/chalkify/type_wf.stderr
@@ -1,15 +1,17 @@
 error[E0277]: the trait bound `{float}: Foo` is not satisfied
   --> $DIR/type_wf.rs:18:13
    |
-LL | struct S<T: Foo> {
-   | ---------------- required by `S`
-...
 LL |     let s = S {
    |             ^ the trait `Foo` is not implemented for `{float}`
    |
    = help: the following implementations were found:
              <Option<T> as Foo>
              <i32 as Foo>
+note: required by `S`
+  --> $DIR/type_wf.rs:6:1
+   |
+LL | struct S<T: Foo> {
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/dont-evaluate-array-len-on-err-1.stderr
+++ b/src/test/ui/const-generics/dont-evaluate-array-len-on-err-1.stderr
@@ -3,9 +3,12 @@ error[E0277]: the trait bound `[Adt; _]: Foo` is not satisfied
    |
 LL |         <[Adt; std::mem::size_of::<Self::Assoc>()] as Foo>::bar()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `[Adt; _]`
-...
+   |
+note: required by `Foo::bar`
+  --> $DIR/dont-evaluate-array-len-on-err-1.rs:19:5
+   |
 LL |     fn bar() {}
-   |     -------- required by `Foo::bar`
+   |     ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/exhaustive-value.full.stderr
+++ b/src/test/ui/const-generics/exhaustive-value.full.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `(): Foo<N>` is not satisfied
   --> $DIR/exhaustive-value.rs:266:5
    |
-LL |     fn test() {}
-   |     --------- required by `Foo::test`
-...
 LL |     <() as Foo<N>>::test()
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `Foo<N>` is not implemented for `()`
    |
@@ -13,6 +10,11 @@ LL |     <() as Foo<N>>::test()
              <() as Foo<101_u8>>
              <() as Foo<102_u8>>
            and 252 others
+note: required by `Foo::test`
+  --> $DIR/exhaustive-value.rs:6:5
+   |
+LL |     fn test() {}
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/exhaustive-value.min.stderr
+++ b/src/test/ui/const-generics/exhaustive-value.min.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `(): Foo<N>` is not satisfied
   --> $DIR/exhaustive-value.rs:266:5
    |
-LL |     fn test() {}
-   |     --------- required by `Foo::test`
-...
 LL |     <() as Foo<N>>::test()
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `Foo<N>` is not implemented for `()`
    |
@@ -13,6 +10,11 @@ LL |     <() as Foo<N>>::test()
              <() as Foo<101_u8>>
              <() as Foo<102_u8>>
            and 252 others
+note: required by `Foo::test`
+  --> $DIR/exhaustive-value.rs:6:5
+   |
+LL |     fn test() {}
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -1,16 +1,18 @@
 error[E0277]: the trait bound `A<{_: usize}>: Bar<{_: usize}>` is not satisfied
   --> $DIR/unused-substs-1.rs:12:13
    |
-LL | / struct A<const N: usize>
-LL | | where
-LL | |     A<N>: Bar<N>;
-   | |_________________- required by `A`
-...
-LL |       let _ = A;
-   |               ^ the trait `Bar<{_: usize}>` is not implemented for `A<{_: usize}>`
+LL |     let _ = A;
+   |             ^ the trait `Bar<{_: usize}>` is not implemented for `A<{_: usize}>`
    |
    = help: the following implementations were found:
              <A<7_usize> as Bar<N>>
+note: required by `A`
+  --> $DIR/unused-substs-1.rs:7:1
+   |
+LL | / struct A<const N: usize>
+LL | | where
+LL | |     A<N>: Bar<N>;
+   | |_________________^
 
 error: aborting due to previous error
 

--- a/src/test/ui/custom_test_frameworks/mismatch.stderr
+++ b/src/test/ui/custom_test_frameworks/mismatch.stderr
@@ -1,6 +1,8 @@
 error[E0277]: the trait bound `TestDescAndFn: Testable` is not satisfied
   --> $DIR/mismatch.rs:9:1
    |
+LL | #[test]
+   | ------- in this procedural macro expansion
 LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |

--- a/src/test/ui/derives/derive-on-trait-item-or-impl-item.rs
+++ b/src/test/ui/derives/derive-on-trait-item-or-impl-item.rs
@@ -1,6 +1,6 @@
 trait Foo {
     #[derive(Clone)]
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     type Bar;
 }
 
@@ -8,7 +8,7 @@ struct Bar;
 
 impl Bar {
     #[derive(Clone)]
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     fn bar(&self) {}
 }
 

--- a/src/test/ui/derives/derive-on-trait-item-or-impl-item.stderr
+++ b/src/test/ui/derives/derive-on-trait-item-or-impl-item.stderr
@@ -1,14 +1,20 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/derive-on-trait-item-or-impl-item.rs:2:5
    |
 LL |     #[derive(Clone)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL |     type Bar;
+   |     --------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/derive-on-trait-item-or-impl-item.rs:10:5
    |
 LL |     #[derive(Clone)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL |     fn bar(&self) {}
+   |     ---------------- not a `struct`, `enum` or `union`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Clone` is not satisfied
   --> $DIR/derives-span-Clone-enum-struct-variant.rs:9:6
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Clone-enum.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Clone` is not satisfied
   --> $DIR/derives-span-Clone-enum.rs:9:6
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Clone-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Clone` is not satisfied
   --> $DIR/derives-span-Clone-struct.rs:8:5
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Clone` is not satisfied
   --> $DIR/derives-span-Clone-tuple-struct.rs:8:5
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `Error` doesn't implement `Debug`
   --> $DIR/derives-span-Debug-enum-struct-variant.rs:9:6
    |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |

--- a/src/test/ui/derives/derives-span-Debug-enum.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `Error` doesn't implement `Debug`
   --> $DIR/derives-span-Debug-enum.rs:9:6
    |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ `Error` cannot be formatted using `{:?}`
    |

--- a/src/test/ui/derives/derives-span-Debug-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `Error` doesn't implement `Debug`
   --> $DIR/derives-span-Debug-struct.rs:8:5
    |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |

--- a/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `Error` doesn't implement `Debug`
   --> $DIR/derives-span-Debug-tuple-struct.rs:8:5
    |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ `Error` cannot be formatted using `{:?}`
    |

--- a/src/test/ui/derives/derives-span-Default-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Default` is not satisfied
   --> $DIR/derives-span-Default-struct.rs:8:5
    |
+LL | #[derive(Default)]
+   |          ------- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Default` is not implemented for `Error`
    |
-   = note: required by `std::default::Default::default`
+note: required by `std::default::Default::default`
+  --> $SRC_DIR/core/src/default.rs:LL:COL
+   |
+LL |     fn default() -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Default` is not satisfied
   --> $DIR/derives-span-Default-tuple-struct.rs:8:5
    |
+LL | #[derive(Default)]
+   |          ------- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Default` is not implemented for `Error`
    |
-   = note: required by `std::default::Default::default`
+note: required by `std::default::Default::default`
+  --> $SRC_DIR/core/src/default.rs:LL:COL
+   |
+LL |     fn default() -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Eq` is not satisfied
   --> $DIR/derives-span-Eq-enum-struct-variant.rs:9:6
    |
+LL | #[derive(Eq,PartialEq)]
+   |          -- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Eq` is not satisfied
   --> $DIR/derives-span-Eq-enum.rs:9:6
    |
+LL | #[derive(Eq,PartialEq)]
+   |          -- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ the trait `Eq` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Eq` is not satisfied
   --> $DIR/derives-span-Eq-struct.rs:8:5
    |
+LL | #[derive(Eq,PartialEq)]
+   |          -- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Eq` is not satisfied
   --> $DIR/derives-span-Eq-tuple-struct.rs:8:5
    |
+LL | #[derive(Eq,PartialEq)]
+   |          -- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Eq` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Hash` is not satisfied
   --> $DIR/derives-span-Hash-enum-struct-variant.rs:9:6
    |
+LL | #[derive(Hash)]
+   |          ---- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Hash` is not satisfied
   --> $DIR/derives-span-Hash-enum.rs:8:6
    |
+LL | #[derive(Hash)]
+   |          ---- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Hash` is not satisfied
   --> $DIR/derives-span-Hash-struct.rs:8:5
    |
+LL | #[derive(Hash)]
+   |          ---- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Error: Hash` is not satisfied
   --> $DIR/derives-span-Hash-tuple-struct.rs:8:5
    |
+LL | #[derive(Hash)]
+   |          ---- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Hash` is not implemented for `Error`
    | 

--- a/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Ord` is not satisfied
   --> $DIR/derives-span-Ord-enum-struct-variant.rs:9:6
    |
+LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
+   |          --- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Ord-enum.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Ord` is not satisfied
   --> $DIR/derives-span-Ord-enum.rs:9:6
    |
+LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
+   |          --- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Ord-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Ord` is not satisfied
   --> $DIR/derives-span-Ord-struct.rs:8:5
    |
+LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
+   |          --- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
@@ -1,10 +1,17 @@
 error[E0277]: the trait bound `Error: Ord` is not satisfied
   --> $DIR/derives-span-Ord-tuple-struct.rs:8:5
    |
+LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
+   |          --- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -1,6 +1,9 @@
 error[E0369]: binary operation `==` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:9:6
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^
    |
@@ -10,6 +13,9 @@ LL |      x: Error
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:9:6
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^
    |

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -1,6 +1,9 @@
 error[E0369]: binary operation `==` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum.rs:9:6
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^
    |
@@ -10,6 +13,9 @@ LL |      Error
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum.rs:9:6
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^
    |

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -1,6 +1,9 @@
 error[E0369]: binary operation `==` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-struct.rs:8:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^
    |
@@ -10,6 +13,9 @@ LL |     x: Error
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-struct.rs:8:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^
    |

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -1,6 +1,9 @@
 error[E0369]: binary operation `==` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-tuple-struct.rs:8:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^
    |
@@ -10,6 +13,9 @@ LL |     Error
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-tuple-struct.rs:8:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^
    |

--- a/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
@@ -1,11 +1,18 @@
 error[E0277]: can't compare `Error` with `Error`
   --> $DIR/derives-span-PartialOrd-enum-struct-variant.rs:9:6
    |
+LL | #[derive(PartialOrd,PartialEq)]
+   |          ---------- in this derive macro expansion
+...
 LL |      x: Error
    |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
@@ -1,11 +1,18 @@
 error[E0277]: can't compare `Error` with `Error`
   --> $DIR/derives-span-PartialOrd-enum.rs:9:6
    |
+LL | #[derive(PartialOrd,PartialEq)]
+   |          ---------- in this derive macro expansion
+...
 LL |      Error
    |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
@@ -1,11 +1,18 @@
 error[E0277]: can't compare `Error` with `Error`
   --> $DIR/derives-span-PartialOrd-struct.rs:8:5
    |
+LL | #[derive(PartialOrd,PartialEq)]
+   |          ---------- in this derive macro expansion
+LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
@@ -1,11 +1,18 @@
 error[E0277]: can't compare `Error` with `Error`
   --> $DIR/derives-span-PartialOrd-tuple-struct.rs:8:5
    |
+LL | #[derive(PartialOrd,PartialEq)]
+   |          ---------- in this derive macro expansion
+LL | struct Struct(
 LL |     Error
    |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -10,7 +10,12 @@ LL |     is_copy(B { a: 1, b: C });
    |             expected an implementor of trait `Copy`
    |             help: consider borrowing here: `&B { a: 1, b: C }`
    |
-   = note: required because of the requirements on the impl of `Copy` for `B<C>`
+note: required because of the requirements on the impl of `Copy` for `B<C>`
+  --> $DIR/deriving-copyclone.rs:9:10
+   |
+LL | #[derive(Copy, Clone)]
+   |          ^^^^
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `C: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
@@ -24,7 +29,12 @@ LL |     is_clone(B { a: 1, b: C });
    |              expected an implementor of trait `Clone`
    |              help: consider borrowing here: `&B { a: 1, b: C }`
    |
-   = note: required because of the requirements on the impl of `Clone` for `B<C>`
+note: required because of the requirements on the impl of `Clone` for `B<C>`
+  --> $DIR/deriving-copyclone.rs:9:16
+   |
+LL | #[derive(Copy, Clone)]
+   |                ^^^^^
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `D: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
@@ -38,7 +48,12 @@ LL |     is_copy(B { a: 1, b: D });
    |             expected an implementor of trait `Copy`
    |             help: consider borrowing here: `&B { a: 1, b: D }`
    |
-   = note: required because of the requirements on the impl of `Copy` for `B<D>`
+note: required because of the requirements on the impl of `Copy` for `B<D>`
+  --> $DIR/deriving-copyclone.rs:9:10
+   |
+LL | #[derive(Copy, Clone)]
+   |          ^^^^
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -1,6 +1,9 @@
 error[E0369]: binary operation `==` cannot be applied to type `NoCloneOrEq`
   --> $DIR/deriving-no-inner-impl-error-message.rs:5:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct E {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
@@ -10,6 +13,9 @@ LL |     x: NoCloneOrEq
 error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
   --> $DIR/deriving-no-inner-impl-error-message.rs:5:5
    |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | struct E {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
@@ -19,10 +25,17 @@ LL |     x: NoCloneOrEq
 error[E0277]: the trait bound `NoCloneOrEq: Clone` is not satisfied
   --> $DIR/deriving-no-inner-impl-error-message.rs:10:5
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct C {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
    |
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/derives/deriving-non-type.rs
+++ b/src/test/ui/derives/deriving-non-type.rs
@@ -2,29 +2,29 @@
 
 struct S;
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 trait T { }
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 impl S { }
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 impl T for S { }
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 static s: usize = 0;
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 const c: usize = 0;
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 mod m { }
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 extern "C" { }
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 type A = usize;
 
-#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to structs, enums and unions
+#[derive(PartialEq)] //~ ERROR: `derive` may only be applied to `struct`s, `enum`s and `union`s
 fn main() { }

--- a/src/test/ui/derives/deriving-non-type.stderr
+++ b/src/test/ui/derives/deriving-non-type.stderr
@@ -1,56 +1,74 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:5:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | trait T { }
+   | ----------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:8:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | impl S { }
+   | ---------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:11:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | impl T for S { }
+   | ---------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:14:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | static s: usize = 0;
+   | -------------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:17:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | const c: usize = 0;
+   | ------------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:20:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | mod m { }
+   | --------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:23:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | extern "C" { }
+   | -------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:26:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | type A = usize;
+   | --------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/deriving-non-type.rs:29:1
    |
 LL | #[derive(PartialEq)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^ not applicable here
+LL | fn main() { }
+   | ------------- not a `struct`, `enum` or `union`
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `i8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:24:21
    |
-LL |     fn bar(&self){}
-   |     ------------- required by `Foo::bar`
-...
 LL |     Foo::<i32>::bar(&1i8);
    |                     ^^^^ the trait `Foo<i32>` is not implemented for `i8`
    |
@@ -13,13 +10,15 @@ LL |     Foo::<i32>::bar(&1i8);
              <i8 as Foo<u32>>
              <i8 as Foo<u64>>
              <i8 as Foo<u8>>
+note: required by `Foo::bar`
+  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
+   |
+LL |     fn bar(&self){}
+   |     ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
    |
-LL |     fn bar(&self){}
-   |     ------------- required by `Foo::bar`
-...
 LL |     Foo::<i32>::bar(&1u8);
    |                     ^^^^ the trait `Foo<i32>` is not implemented for `u8`
    |
@@ -28,13 +27,15 @@ LL |     Foo::<i32>::bar(&1u8);
              <u8 as Foo<u16>>
              <u8 as Foo<u32>>
              <u8 as Foo<u64>>
+note: required by `Foo::bar`
+  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
+   |
+LL |     fn bar(&self){}
+   |     ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
    |
-LL |     fn bar(&self){}
-   |     ------------- required by `Foo::bar`
-...
 LL |     Foo::<i32>::bar(&true);
    |                     ^^^^^ the trait `Foo<i32>` is not implemented for `bool`
    |
@@ -44,6 +45,11 @@ LL |     Foo::<i32>::bar(&true);
              <bool as Foo<u16>>
              <bool as Foo<u32>>
            and 2 others
+note: required by `Foo::bar`
+  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
+   |
+LL |     fn bar(&self){}
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0283.stderr
+++ b/src/test/ui/error-codes/E0283.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/E0283.rs:30:21
    |
-LL |     fn create() -> u32;
-   |     ------------------- required by `Generator::create`
-...
 LL |     let cont: u32 = Generator::create();
    |                     ^^^^^^^^^^^^^^^^^ cannot infer type
    |
    = note: cannot satisfy `_: Generator`
+note: required by `Generator::create`
+  --> $DIR/E0283.rs:2:5
+   |
+LL |     fn create() -> u32;
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/E0283.rs:35:24

--- a/src/test/ui/error-codes/E0624.stderr
+++ b/src/test/ui/error-codes/E0624.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `method` is private
   --> $DIR/E0624.rs:11:9
    |
+LL |         fn method(&self) {}
+   |         ---------------- private associated function defined here
+...
 LL |     foo.method();
    |         ^^^^^^ private associated function
 

--- a/src/test/ui/error-codes/E0777.stderr
+++ b/src/test/ui/error-codes/E0777.stderr
@@ -2,7 +2,7 @@ error[E0777]: expected path to a trait, found literal
   --> $DIR/E0777.rs:1:10
    |
 LL | #[derive("Clone")]
-   |          ^^^^^^^
+   |          ^^^^^^^ not a trait
    |
    = help: try using `#[derive(Clone)]`
 
@@ -12,7 +12,7 @@ error[E0777]: expected path to a trait, found literal
 LL |   #[derive("Clone
    |  __________^
 LL | | ")]
-   | |_^
+   | |_^ not a trait
    |
    = help: for example, write `#[derive(Debug)]` for `Debug`
 

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -84,18 +84,33 @@ error[E0624]: associated function `pub_crate` is private
    |
 LL |     r.pub_crate();
    |       ^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:114:9
+   |
+LL |         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
+   |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:51:7
    |
 LL |     r.pub_mod();
    |       ^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:116:9
+   |
+LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
+   |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:52:7
    |
 LL |     r.private();
    |       ^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:118:9
+   |
+LL |         fn private(&self) -> i32 { self.d_priv }
+   |         ------------------------ private associated function defined here
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:57:7
@@ -120,18 +135,33 @@ error[E0624]: associated function `pub_crate` is private
    |
 LL |     t.pub_crate();
    |       ^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:129:9
+   |
+LL |         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
+   |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
   --> $DIR/explore-issue-38412.rs:64:7
    |
 LL |     t.pub_mod();
    |       ^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:130:9
+   |
+LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
+   |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
   --> $DIR/explore-issue-38412.rs:65:7
    |
 LL |     t.private();
    |       ^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub-and-stability.rs:131:9
+   |
+LL |         fn private(&self) -> i32 { self.0 }
+   |         ------------------------ private associated function defined here
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/feature-gates/issue-43106-gating-of-derive.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-derive.rs
@@ -2,14 +2,14 @@
 // definitions.
 
 #[derive(Debug)]
-//~^ ERROR `derive` may only be applied to structs, enums and unions
+//~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
 mod derive {
     mod inner { #![derive(Debug)] }
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     //~| ERROR inner macro attributes are unstable
 
     #[derive(Debug)]
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     fn derive() { }
 
     #[derive(Copy, Clone)] // (can't derive Debug for unions)
@@ -22,11 +22,11 @@ mod derive {
     enum E { }
 
     #[derive(Debug)]
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     type T = S;
 
     #[derive(Debug)]
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     impl S { }
 }
 

--- a/src/test/ui/feature-gates/issue-43106-gating-of-derive.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-derive.stderr
@@ -1,8 +1,17 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:4:1
    |
-LL | #[derive(Debug)]
-   | ^^^^^^^^^^^^^^^^
+LL |   #[derive(Debug)]
+   |   ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL | / mod derive {
+LL | |     mod inner { #![derive(Debug)] }
+LL | |
+LL | |
+...  |
+LL | |     impl S { }
+LL | | }
+   | |_- not a `struct`, `enum` or `union`
 
 error[E0658]: inner macro attributes are unstable
   --> $DIR/issue-43106-gating-of-derive.rs:7:20
@@ -13,29 +22,41 @@ LL |     mod inner { #![derive(Debug)] }
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:7:17
    |
 LL |     mod inner { #![derive(Debug)] }
-   |                 ^^^^^^^^^^^^^^^^^
+   |     ------------^^^^^^^^^^^^^^^^^--
+   |     |           |
+   |     |           not applicable here
+   |     not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:11:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL |     fn derive() { }
+   |     --------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:24:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL |     type T = S;
+   |     ----------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:28:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |
+LL |     impl S { }
+   |     ---------- not a `struct`, `enum` or `union`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/fmt/ifmt-unimpl.stderr
+++ b/src/test/ui/fmt/ifmt-unimpl.stderr
@@ -5,7 +5,11 @@ LL |     format!("{:X}", "3");
    |                     ^^^ the trait `UpperHex` is not implemented for `str`
    |
    = note: required because of the requirements on the impl of `UpperHex` for `&str`
-   = note: required by `std::fmt::UpperHex::fmt`
+note: required by `std::fmt::UpperHex::fmt`
+  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+   |
+LL |     fn fmt(&self, f: &mut Formatter<'_>) -> Result;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/for/for-c-in-str.stderr
+++ b/src/test/ui/for/for-c-in-str.stderr
@@ -6,7 +6,11 @@ LL |     for c in "asdf" {
    |
    = help: the trait `Iterator` is not implemented for `&str`
    = note: required because of the requirements on the impl of `IntoIterator` for `&str`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/for/for-loop-bogosity.stderr
+++ b/src/test/ui/for/for-loop-bogosity.stderr
@@ -6,7 +6,11 @@ LL |     for x in bogus {
    |
    = help: the trait `Iterator` is not implemented for `MyStruct`
    = note: required because of the requirements on the impl of `IntoIterator` for `MyStruct`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/generator/yield-outside-generator-issue-78653.stderr
+++ b/src/test/ui/generator/yield-outside-generator-issue-78653.stderr
@@ -13,7 +13,11 @@ LL |     yield || for i in 0 { }
    = help: the trait `Iterator` is not implemented for `{integer}`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `{integer}`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -47,7 +47,11 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
 LL |     type C where Self: Copy = String;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `Copy` for `Fooy<T>`
+note: required because of the requirements on the impl of `Copy` for `Fooy<T>`
+  --> $DIR/impl_bounds.rs:11:10
+   |
+LL | #[derive(Copy, Clone)]
+   |          ^^^^
 note: the requirement `Fooy<T>: Copy` appears on the associated impl type `C` but not on the corresponding associated trait type
   --> $DIR/impl_bounds.rs:7:5
    |
@@ -56,6 +60,7 @@ LL | trait Foo {
 ...
 LL |     type C where Self: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ this trait associated type doesn't have the requirement `Fooy<T>: Copy`
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
@@ -67,7 +72,11 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
 LL |     fn d() where Self: Copy {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
-   = note: required because of the requirements on the impl of `Copy` for `Fooy<T>`
+note: required because of the requirements on the impl of `Copy` for `Fooy<T>`
+  --> $DIR/impl_bounds.rs:11:10
+   |
+LL | #[derive(Copy, Clone)]
+   |          ^^^^
 note: the requirement `Fooy<T>: Copy` appears on the impl method `d` but not on the corresponding trait method
   --> $DIR/impl_bounds.rs:8:8
    |
@@ -76,6 +85,7 @@ LL | trait Foo {
 ...
 LL |     fn d() where Self: Clone;
    |        ^ this trait method doesn't have the requirement `Fooy<T>: Copy`
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {

--- a/src/test/ui/issues/issue-12997-2.stderr
+++ b/src/test/ui/issues/issue-12997-2.stderr
@@ -1,6 +1,8 @@
 error[E0308]: mismatched types
   --> $DIR/issue-12997-2.rs:8:1
    |
+LL | #[bench]
+   | -------- in this procedural macro expansion
 LL | fn bar(x: isize) { }
    | ^^^^^^^^^^^^^^^^^^^^ expected `isize`, found `&mut Bencher`
    |

--- a/src/test/ui/issues/issue-17651.stderr
+++ b/src/test/ui/issues/issue-17651.stderr
@@ -5,7 +5,11 @@ LL |     (|| Box::new(*(&[0][..])))();
    |                  ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[{integer}]`
-   = note: required by `Box::<T>::new`
+note: required by `Box::<T>::new`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL |     pub fn new(x: T) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[{integer}]` cannot be known at compilation time
   --> $DIR/issue-17651.rs:5:9

--- a/src/test/ui/issues/issue-20605.stderr
+++ b/src/test/ui/issues/issue-20605.stderr
@@ -6,7 +6,11 @@ LL |     for item in *things { *item = 0 }
    |
    = help: the trait `Sized` is not implemented for `dyn Iterator<Item = &'a mut u8>`
    = note: required because of the requirements on the impl of `IntoIterator` for `dyn Iterator<Item = &'a mut u8>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -1,6 +1,8 @@
 error[E0277]: the trait bound `Bar: Hash` is not satisfied
   --> $DIR/issue-21160.rs:8:12
    |
+LL | #[derive(Hash)]
+   |          ---- in this derive macro expansion
 LL | struct Foo(Bar);
    |            ^^^ the trait `Hash` is not implemented for `Bar`
    | 

--- a/src/test/ui/issues/issue-21202.stderr
+++ b/src/test/ui/issues/issue-21202.stderr
@@ -3,6 +3,11 @@ error[E0624]: associated function `foo` is private
    |
 LL |         Foo::foo(&f);
    |              ^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/issue-21202.rs:4:9
+   |
+LL |         fn foo(&self) { }
+   |         ------------- private associated function defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28098.stderr
+++ b/src/test/ui/issues/issue-28098.stderr
@@ -5,7 +5,11 @@ LL |     let _ = Iterator::next(&mut ());
    |                            ^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
+note: required by `std::iter::Iterator::next`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `bool` is not an iterator
   --> $DIR/issue-28098.rs:6:14
@@ -15,7 +19,11 @@ LL |     for _ in false {}
    |
    = help: the trait `Iterator` is not implemented for `bool`
    = note: required because of the requirements on the impl of `IntoIterator` for `bool`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:9:28
@@ -24,7 +32,11 @@ LL |     let _ = Iterator::next(&mut ());
    |                            ^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
+note: required by `std::iter::Iterator::next`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:2:13
@@ -41,7 +53,11 @@ LL |     let _ = Iterator::next(&mut ());
    |                            ^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
+note: required by `std::iter::Iterator::next`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:22:28
@@ -50,7 +66,11 @@ LL |     let _ = Iterator::next(&mut ());
    |                            ^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
+note: required by `std::iter::Iterator::next`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `bool` is not an iterator
   --> $DIR/issue-28098.rs:25:14
@@ -60,7 +80,11 @@ LL |     for _ in false {}
    |
    = help: the trait `Iterator` is not implemented for `bool`
    = note: required because of the requirements on the impl of `IntoIterator` for `bool`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:18:13

--- a/src/test/ui/issues/issue-29147.stderr
+++ b/src/test/ui/issues/issue-29147.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-29147.rs:21:13
    |
-LL | trait Foo { fn xxx(&self); }
-   |             -------------- required by `Foo::xxx`
-...
 LL |     let _ = <S5<_>>::xxx;
    |             ^^^^^^^^^^^^ cannot infer type for struct `S5<_>`
    |
    = note: cannot satisfy `S5<_>: Foo`
+note: required by `Foo::xxx`
+  --> $DIR/issue-29147.rs:10:13
+   |
+LL | trait Foo { fn xxx(&self); }
+   |             ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -8,7 +8,11 @@ LL |     Err(5)?;
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, {integer}>>` for `Result<i32, ()>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-33941.stderr
+++ b/src/test/ui/issues/issue-33941.stderr
@@ -17,7 +17,11 @@ LL |     for _ in HashMap::new().iter().cloned() {}
                   found tuple `(&_, &_)`
    = note: required because of the requirements on the impl of `Iterator` for `Cloned<std::collections::hash_map::Iter<'_, _, _>>`
    = note: required because of the requirements on the impl of `IntoIterator` for `Cloned<std::collections::hash_map::Iter<'_, _, _>>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<std::collections::hash_map::Iter<'_, _, _> as Iterator>::Item == &_`
   --> $DIR/issue-33941.rs:4:14
@@ -28,7 +32,11 @@ LL |     for _ in HashMap::new().iter().cloned() {}
    = note: expected reference `&_`
                   found tuple `(&_, &_)`
    = note: required because of the requirements on the impl of `Iterator` for `Cloned<std::collections::hash_map::Iter<'_, _, _>>`
-   = note: required by `std::iter::Iterator::next`
+note: required by `std::iter::Iterator::next`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-34229.stderr
+++ b/src/test/ui/issues/issue-34229.stderr
@@ -2,10 +2,16 @@ error[E0277]: can't compare `Comparable` with `Comparable`
   --> $DIR/issue-34229.rs:2:46
    |
 LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
+   |                     ----------               ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
+   |                     |
+   |                     in this derive macro expansion
    |
    = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-3763.stderr
+++ b/src/test/ui/issues/issue-3763.stderr
@@ -13,12 +13,18 @@ LL |     let _woohoo = (Box::new(my_struct)).priv_field;
 error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:24:18
    |
+LL |         fn happyfun(&self) {}
+   |         ------------------ private associated function defined here
+...
 LL |     (&my_struct).happyfun();
    |                  ^^^^^^^^ private associated function
 
 error[E0624]: associated function `happyfun` is private
   --> $DIR/issue-3763.rs:26:27
    |
+LL |         fn happyfun(&self) {}
+   |         ------------------ private associated function defined here
+...
 LL |     (Box::new(my_struct)).happyfun();
    |                           ^^^^^^^^ private associated function
 

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -1,9 +1,6 @@
 error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
   --> $DIR/issue-39970.rs:19:5
    |
-LL |     fn visit() {}
-   |     ---------- required by `Visit::visit`
-...
 LL |     <() as Visit>::visit();
    |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&()`
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Visit` for `()`
    |
 LL | impl Visit for () where
    |      ^^^^^     ^^
+note: required by `Visit::visit`
+  --> $DIR/issue-39970.rs:6:5
+   |
+LL |     fn visit() {}
+   |     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43023.rs
+++ b/src/test/ui/issues/issue-43023.rs
@@ -1,19 +1,19 @@
 struct S;
 
 impl S {
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     fn f() {
         file!();
     }
 }
 
 trait Tr1 {
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     fn f();
 }
 
 trait Tr2 {
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     type F;
 }
 

--- a/src/test/ui/issues/issue-43023.stderr
+++ b/src/test/ui/issues/issue-43023.stderr
@@ -1,20 +1,28 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43023.rs:4:5
    |
-LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+LL |       #[derive(Debug)]
+   |       ^^^^^^^^^^^^^^^^ not applicable here
+LL | /     fn f() {
+LL | |         file!();
+LL | |     }
+   | |_____- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43023.rs:11:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |     fn f();
+   |     ------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43023.rs:16:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |     type F;
+   |     ------- not a `struct`, `enum` or `union`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-49934.rs
+++ b/src/test/ui/issues/issue-49934.rs
@@ -7,24 +7,24 @@ fn main() {
     struct Foo;
 
     // fold_stmt (Mac)
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     println!("Hello, world!");
 
     // fold_stmt (Semi)
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     "Hello, world!";
 
     // fold_stmt (Local)
-    #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     let _ = "Hello, world!";
 
     // visit_expr
     let _ = #[derive(Debug)] "Hello, world!";
-    //~^ ERROR `derive` may only be applied to structs, enums and unions
+    //~^ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
 
     let _ = [
         // filter_map_expr
-        #[derive(Debug)] //~ ERROR `derive` may only be applied to structs, enums and unions
+        #[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
         "Hello, world!",
     ];
 }

--- a/src/test/ui/issues/issue-49934.stderr
+++ b/src/test/ui/issues/issue-49934.stderr
@@ -1,32 +1,42 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-49934.rs:10:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |     println!("Hello, world!");
+   |     -------------------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-49934.rs:14:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |     "Hello, world!";
+   |     ---------------- not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-49934.rs:18:5
    |
 LL |     #[derive(Debug)]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ not applicable here
+LL |     let _ = "Hello, world!";
+   |     ------------------------ not a `struct`, `enum` or `union`
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-49934.rs:22:13
    |
 LL |     let _ = #[derive(Debug)] "Hello, world!";
-   |             ^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^ --------------- not a `struct`, `enum` or `union`
+   |             |
+   |             not applicable here
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-49934.rs:27:9
    |
 LL |         #[derive(Debug)]
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ not applicable here
+LL |         "Hello, world!",
+   |         --------------- not a `struct`, `enum` or `union`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-53498.stderr
+++ b/src/test/ui/issues/issue-53498.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `foo` is private
   --> $DIR/issue-53498.rs:16:27
    |
+LL |         fn foo() {}
+   |         -------- private associated function defined here
+...
 LL |     test::Foo::<test::B>::foo();
    |                           ^^^ private associated function
 

--- a/src/test/ui/issues/issue-58022.stderr
+++ b/src/test/ui/issues/issue-58022.stderr
@@ -7,9 +7,6 @@ LL |         Foo(Box::new(*slice))
 error[E0283]: type annotations needed
   --> $DIR/issue-58022.rs:4:25
    |
-LL |     const SIZE: usize;
-   |     ------------------ required by `Foo::SIZE`
-LL | 
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |                         ^^^^^^^^^
    |                         |
@@ -18,6 +15,11 @@ LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |
    = note: cannot satisfy `_: Foo`
    = note: associated constants cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+note: required by `Foo::SIZE`
+  --> $DIR/issue-58022.rs:2:5
+   |
+LL |     const SIZE: usize;
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-66353.stderr
+++ b/src/test/ui/issues/issue-66353.stderr
@@ -7,11 +7,14 @@ LL |     _Func::< <() as _A>::AssocT >::func(());
 error[E0277]: the trait bound `(): _Func<_>` is not satisfied
   --> $DIR/issue-66353.rs:12:41
    |
-LL |     fn func(_: Self);
-   |     ----------------- required by `_Func::func`
-...
 LL |     _Func::< <() as _A>::AssocT >::func(());
    |                                         ^^ the trait `_Func<_>` is not implemented for `()`
+   |
+note: required by `_Func::func`
+  --> $DIR/issue-66353.rs:4:5
+   |
+LL |     fn func(_: Self);
+   |     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-72690.stderr
+++ b/src/test/ui/issues/issue-72690.stderr
@@ -5,7 +5,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0282]: type annotations needed
   --> $DIR/issue-72690.rs:11:6
@@ -30,7 +34,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:25:5
@@ -39,7 +47,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:33:5
@@ -48,7 +60,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:41:5
@@ -57,7 +73,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:47:5
@@ -66,7 +86,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:55:5
@@ -75,7 +99,11 @@ LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/iterators/integral.stderr
+++ b/src/test/ui/iterators/integral.stderr
@@ -7,7 +7,11 @@ LL |     for _ in 42 {}
    = help: the trait `Iterator` is not implemented for `{integer}`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `{integer}`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `u8` is not an iterator
   --> $DIR/integral.rs:4:14
@@ -18,7 +22,11 @@ LL |     for _ in 42 as u8 {}
    = help: the trait `Iterator` is not implemented for `u8`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `u8`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `i8` is not an iterator
   --> $DIR/integral.rs:6:14
@@ -29,7 +37,11 @@ LL |     for _ in 42 as i8 {}
    = help: the trait `Iterator` is not implemented for `i8`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `i8`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `u16` is not an iterator
   --> $DIR/integral.rs:8:14
@@ -40,7 +52,11 @@ LL |     for _ in 42 as u16 {}
    = help: the trait `Iterator` is not implemented for `u16`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `u16`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `i16` is not an iterator
   --> $DIR/integral.rs:10:14
@@ -51,7 +67,11 @@ LL |     for _ in 42 as i16 {}
    = help: the trait `Iterator` is not implemented for `i16`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `i16`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `u32` is not an iterator
   --> $DIR/integral.rs:12:14
@@ -62,7 +82,11 @@ LL |     for _ in 42 as u32 {}
    = help: the trait `Iterator` is not implemented for `u32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `u32`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/integral.rs:14:14
@@ -73,7 +97,11 @@ LL |     for _ in 42 as i32 {}
    = help: the trait `Iterator` is not implemented for `i32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `i32`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `u64` is not an iterator
   --> $DIR/integral.rs:16:14
@@ -84,7 +112,11 @@ LL |     for _ in 42 as u64 {}
    = help: the trait `Iterator` is not implemented for `u64`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `u64`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `i64` is not an iterator
   --> $DIR/integral.rs:18:14
@@ -95,7 +127,11 @@ LL |     for _ in 42 as i64 {}
    = help: the trait `Iterator` is not implemented for `i64`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `i64`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `usize` is not an iterator
   --> $DIR/integral.rs:20:14
@@ -106,7 +142,11 @@ LL |     for _ in 42 as usize {}
    = help: the trait `Iterator` is not implemented for `usize`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `usize`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `isize` is not an iterator
   --> $DIR/integral.rs:22:14
@@ -117,7 +157,11 @@ LL |     for _ in 42 as isize {}
    = help: the trait `Iterator` is not implemented for `isize`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `isize`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `{float}` is not an iterator
   --> $DIR/integral.rs:24:14
@@ -127,7 +171,11 @@ LL |     for _ in 42.0 {}
    |
    = help: the trait `Iterator` is not implemented for `{float}`
    = note: required because of the requirements on the impl of `IntoIterator` for `{float}`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/iterators/ranges.stderr
+++ b/src/test/ui/iterators/ranges.stderr
@@ -7,7 +7,11 @@ LL |     for _ in ..10 {}
    = help: the trait `Iterator` is not implemented for `RangeTo<{integer}>`
    = note: `..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a bounded `Range`: `0..end`
    = note: required because of the requirements on the impl of `IntoIterator` for `RangeTo<{integer}>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `RangeToInclusive<{integer}>` is not an iterator
   --> $DIR/ranges.rs:4:14
@@ -18,7 +22,11 @@ LL |     for _ in ..=10 {}
    = help: the trait `Iterator` is not implemented for `RangeToInclusive<{integer}>`
    = note: `..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant to have a bounded `RangeInclusive`: `0..=end`
    = note: required because of the requirements on the impl of `IntoIterator` for `RangeToInclusive<{integer}>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/iterators/string.stderr
+++ b/src/test/ui/iterators/string.stderr
@@ -6,7 +6,11 @@ LL |     for _ in "".to_owned() {}
    |
    = help: the trait `Iterator` is not implemented for `String`
    = note: required because of the requirements on the impl of `IntoIterator` for `String`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `&str` is not an iterator
   --> $DIR/string.rs:4:14
@@ -16,7 +20,11 @@ LL |     for _ in "" {}
    |
    = help: the trait `Iterator` is not implemented for `&str`
    = note: required because of the requirements on the impl of `IntoIterator` for `&str`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/trace_faulty_macros.rs
+++ b/src/test/ui/macros/trace_faulty_macros.rs
@@ -39,5 +39,5 @@ fn main() {
 #[my_macro]
 fn use_bang_macro_as_attr() {}
 
-#[derive(Debug)] //~ ERROR `derive` may only be applied to structs
+#[derive(Debug)] //~ ERROR `derive` may only be applied to `struct`s
 fn use_derive_macro_as_attr() {}

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -60,11 +60,13 @@ LL |     let a = pat_macro!();
    |
    = note: this error originates in the macro `pat_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/trace_faulty_macros.rs:42:1
    |
 LL | #[derive(Debug)]
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^ not applicable here
+LL | fn use_derive_macro_as_attr() {}
+   | -------------------------------- not a `struct`, `enum` or `union`
 
 note: trace_macro
   --> $DIR/trace_faulty_macros.rs:36:13

--- a/src/test/ui/on-unimplemented/multiple-impls.stderr
+++ b/src/test/ui/on-unimplemented/multiple-impls.stderr
@@ -1,35 +1,41 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:18
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::index(&[] as &[i32], 2u32);
    |                  ^^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
+note: required by `Index::index`
+  --> $DIR/multiple-impls.rs:12:5
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:18
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |                  ^^^^^^^^^^^^^ on impl for Foo
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
+note: required by `Index::index`
+  --> $DIR/multiple-impls.rs:12:5
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:18
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |                  ^^^^^^^^^^^^^ on impl for Bar
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
+note: required by `Index::index`
+  --> $DIR/multiple-impls.rs:12:5
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5

--- a/src/test/ui/on-unimplemented/on-impl.stderr
+++ b/src/test/ui/on-unimplemented/on-impl.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:25
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |                         ^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
+note: required by `Index::index`
+  --> $DIR/on-impl.rs:9:5
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5

--- a/src/test/ui/parser/struct-literal-in-for.stderr
+++ b/src/test/ui/parser/struct-literal-in-for.stderr
@@ -25,7 +25,11 @@ LL | |     }.hi() {
    |
    = help: the trait `Iterator` is not implemented for `bool`
    = note: required because of the requirements on the impl of `IntoIterator` for `bool`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/privacy/privacy1.stderr
+++ b/src/test/ui/privacy/privacy1.stderr
@@ -157,30 +157,45 @@ LL |     trait B {
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:77:23
    |
+LL |             fn bar() {}
+   |             -------- private associated function defined here
+...
 LL |         self::baz::A::bar();
    |                       ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:95:13
    |
+LL |         fn bar() {}
+   |         -------- private associated function defined here
+...
 LL |     bar::A::bar();
    |             ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:102:19
    |
+LL |         fn bar() {}
+   |         -------- private associated function defined here
+...
 LL |         ::bar::A::bar();
    |                   ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
   --> $DIR/privacy1.rs:105:24
    |
+LL |             fn bar() {}
+   |             -------- private associated function defined here
+...
 LL |         ::bar::baz::A::bar();
    |                        ^^^ private associated function
 
 error[E0624]: associated function `bar2` is private
   --> $DIR/privacy1.rs:108:23
    |
+LL |             fn bar2(&self) {}
+   |             -------------- private associated function defined here
+...
 LL |         ::bar::baz::A.bar2();
    |                       ^^^^ private associated function
 

--- a/src/test/ui/privacy/private-impl-method.stderr
+++ b/src/test/ui/privacy/private-impl-method.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `foo` is private
   --> $DIR/private-impl-method.rs:20:7
    |
+LL |         fn foo(&self) {}
+   |         ------------- private associated function defined here
+...
 LL |     s.foo();
    |       ^^^ private associated function
 

--- a/src/test/ui/privacy/private-method-cross-crate.stderr
+++ b/src/test/ui/privacy/private-method-cross-crate.stderr
@@ -3,6 +3,11 @@ error[E0624]: associated function `nap` is private
    |
 LL |   nyan.nap();
    |        ^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/cci_class_5.rs:8:9
+   |
+LL |         fn nap(&self) {}
+   |         ------------- private associated function defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/private-method-inherited.stderr
+++ b/src/test/ui/privacy/private-method-inherited.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `f` is private
   --> $DIR/private-method-inherited.rs:13:7
    |
+LL |         fn f(self) {}
+   |         ---------- private associated function defined here
+...
 LL |     x.f();
    |       ^ private associated function
 

--- a/src/test/ui/privacy/private-method.stderr
+++ b/src/test/ui/privacy/private-method.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `nap` is private
   --> $DIR/private-method.rs:22:8
    |
+LL |         fn nap(&self) {}
+   |         ------------- private associated function defined here
+...
 LL |   nyan.nap();
    |        ^^^ private associated function
 

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -55,12 +55,18 @@ LL |     S::default().x;
 error[E0624]: associated function `f` is private
   --> $DIR/test.rs:32:18
    |
+LL |             pub(super) fn f(&self) {}
+   |             ---------------------- private associated function defined here
+...
 LL |     S::default().f();
    |                  ^ private associated function
 
 error[E0624]: associated function `g` is private
   --> $DIR/test.rs:33:8
    |
+LL |             pub(super) fn g() {}
+   |             ----------------- private associated function defined here
+...
 LL |     S::g();
    |        ^ private associated function
 
@@ -81,12 +87,22 @@ error[E0624]: associated function `g` is private
    |
 LL |     u.g();
    |       ^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub_restricted.rs:14:5
+   |
+LL |     pub(crate) fn g(&self) {}
+   |     ---------------------- private associated function defined here
 
 error[E0624]: associated function `h` is private
   --> $DIR/test.rs:46:7
    |
 LL |     u.h();
    |       ^ private associated function
+   | 
+  ::: $DIR/auxiliary/pub_restricted.rs:15:5
+   |
+LL |     crate fn h(&self) {}
+   |     ----------------- private associated function defined here
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/proc-macro/attributes-on-modules-fail.rs
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.rs
@@ -13,7 +13,7 @@ mod m {
 struct Y;
 type A = X; //~ ERROR cannot find type `X` in this scope
 
-#[derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions
+#[derive(Copy)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
 mod n {}
 
 #[empty_attr]

--- a/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -1,8 +1,10 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/attributes-on-modules-fail.rs:16:1
    |
 LL | #[derive(Copy)]
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ not applicable here
+LL | mod n {}
+   | -------- not a `struct`, `enum` or `union`
 
 error[E0658]: non-inline modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:20:1

--- a/src/test/ui/proc-macro/macros-in-extern-derive.rs
+++ b/src/test/ui/proc-macro/macros-in-extern-derive.rs
@@ -1,5 +1,5 @@
 extern "C" {
-    #[derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions
+    #[derive(Copy)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
     fn f();
 }
 

--- a/src/test/ui/proc-macro/macros-in-extern-derive.stderr
+++ b/src/test/ui/proc-macro/macros-in-extern-derive.stderr
@@ -1,8 +1,10 @@
-error[E0774]: `derive` may only be applied to structs, enums and unions
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/macros-in-extern-derive.rs:2:5
    |
 LL |     #[derive(Copy)]
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ not applicable here
+LL |     fn f();
+   |     ------- not a `struct`, `enum` or `union`
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/span-from-proc-macro.stderr
+++ b/src/test/ui/proc-macro/span-from-proc-macro.stderr
@@ -10,7 +10,7 @@ LL |             field: MissingType
   ::: $DIR/span-from-proc-macro.rs:8:1
    |
 LL | #[error_from_attribute]
-   | ----------------------- in this macro invocation
+   | ----------------------- in this procedural macro expansion
 
 error[E0412]: cannot find type `OtherMissingType` in this scope
   --> $DIR/auxiliary/span-from-proc-macro.rs:46:21
@@ -24,7 +24,7 @@ LL |             Variant(OtherMissingType)
   ::: $DIR/span-from-proc-macro.rs:11:10
    |
 LL | #[derive(ErrorFromDerive)]
-   |          --------------- in this macro invocation
+   |          --------------- in this derive macro expansion
 
 error[E0425]: cannot find value `my_ident` in this scope
   --> $DIR/auxiliary/span-from-proc-macro.rs:29:9

--- a/src/test/ui/range/range-1.stderr
+++ b/src/test/ui/range/range-1.stderr
@@ -12,7 +12,11 @@ LL |     for i in false..true {}
    |
    = note: required because of the requirements on the impl of `Iterator` for `std::ops::Range<bool>`
    = note: required because of the requirements on the impl of `IntoIterator` for `std::ops::Range<bool>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[{integer}]` cannot be known at compilation time
   --> $DIR/range-1.rs:14:17

--- a/src/test/ui/range/range_traits-1.stderr
+++ b/src/test/ui/range/range_traits-1.stderr
@@ -1,115 +1,199 @@
 error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize>`
   --> $DIR/range_traits-1.rs:5:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+LL | struct AllTheRanges {
 LL |     a: Range<usize>,
    |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
   --> $DIR/range_traits-1.rs:8:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+...
 LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
   --> $DIR/range_traits-1.rs:11:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+...
 LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:14:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+...
 LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
   --> $DIR/range_traits-1.rs:17:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+...
 LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
   --> $DIR/range_traits-1.rs:20:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                ---------- in this derive macro expansion
+...
 LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
+note: required by `std::cmp::PartialOrd::partial_cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::Range<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:5:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+LL | struct AllTheRanges {
 LL |     a: Range<usize>,
    |     ^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::Range<usize>`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeTo<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:8:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+...
 LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFrom<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:11:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+...
 LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFull: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:14:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+...
 LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:17:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+...
 LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeToInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:20:5
    |
+LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+   |                                            --- in this derive macro expansion
+...
 LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
    |
-   = note: required by `std::cmp::Ord::cmp`
+note: required by `std::cmp::Ord::cmp`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL |     fn cmp(&self, other: &Self) -> Ordering;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -1,6 +1,8 @@
 error[E0277]: `main` has invalid return type `Result<f32, ParseFloatError>`
   --> $DIR/termination-trait-test-wrong-type.rs:6:1
    |
+LL |   #[test]
+   |   ------- in this procedural macro expansion
 LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()
 LL | | }

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -502,7 +502,11 @@ LL |     if (let 0 = 0)? {}
    |        ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
    = help: the trait `Try` is not implemented for `bool`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/disallowed-positions.rs:46:19
@@ -520,7 +524,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<_>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:56:8
@@ -660,7 +668,11 @@ LL |         if let 0 = 0? {}
    |                    ^^ the `?` operator cannot be applied to type `{integer}`
    |
    = help: the trait `Try` is not implemented for `{integer}`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:96:11
@@ -690,7 +702,11 @@ LL |     while (let 0 = 0)? {}
    |           ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
    = help: the trait `Try` is not implemented for `bool`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/disallowed-positions.rs:110:22
@@ -708,7 +724,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<_>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:120:11
@@ -848,7 +868,11 @@ LL |         while let 0 = 0? {}
    |                       ^^ the `?` operator cannot be applied to type `{integer}`
    |
    = help: the trait `Try` is not implemented for `{integer}`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0614]: type `bool` cannot be dereferenced
   --> $DIR/disallowed-positions.rs:173:5
@@ -869,7 +893,11 @@ LL |     (let 0 = 0)?;
    |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
    = help: the trait `Try` is not implemented for `bool`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/disallowed-positions.rs:183:16
@@ -887,7 +915,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<_>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:198:10
@@ -916,7 +948,11 @@ LL |         let 0 = 0?;
    |                 ^^ the `?` operator cannot be applied to type `{integer}`
    |
    = help: the trait `Try` is not implemented for `{integer}`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 104 previous errors; 2 warnings emitted
 

--- a/src/test/ui/span/issue-29595.stderr
+++ b/src/test/ui/span/issue-29595.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `u8: Tr` is not satisfied
   --> $DIR/issue-29595.rs:6:17
    |
-LL |     const C: Self;
-   |     -------------- required by `Tr::C`
-...
 LL |     let a: u8 = Tr::C;
    |                 ^^^^^ the trait `Tr` is not implemented for `u8`
+   |
+note: required by `Tr::C`
+  --> $DIR/issue-29595.rs:2:5
+   |
+LL |     const C: Self;
+   |     ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-method-privacy.stderr
+++ b/src/test/ui/static/static-method-privacy.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `new` is private
   --> $DIR/static-method-privacy.rs:9:19
    |
+LL |         fn new() -> S { S }
+   |         ------------- private associated function defined here
+...
 LL |     let _ = a::S::new();
    |                   ^^^ private associated function
 

--- a/src/test/ui/structs/struct-path-alias-bounds.stderr
+++ b/src/test/ui/structs/struct-path-alias-bounds.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `NoClone: Clone` is not satisfied
   --> $DIR/struct-path-alias-bounds.rs:9:13
    |
-LL | struct S<T: Clone> { a: T }
-   | ------------------ required by `S`
-...
 LL |     let s = A { a: NoClone };
    |             ^ the trait `Clone` is not implemented for `NoClone`
+   |
+note: required by `S`
+  --> $DIR/struct-path-alias-bounds.rs:3:1
+   |
+LL | struct S<T: Clone> { a: T }
+   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -47,7 +47,11 @@ LL |     Pin::new(x)
    |     ^^^^^^^^ the trait `Unpin` is not implemented for `dyn Future<Output = i32> + Send`
    |
    = note: consider using `Box::pin`
-   = note: required by `Pin::<P>::new`
+note: required by `Pin::<P>::new`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+   |
+LL |     pub const fn new(pointer: P) -> Pin<P> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dyn Future<Output = i32> + Send` cannot be unpinned
   --> $DIR/expected-boxed-future-isnt-pinned.rs:27:5
@@ -56,7 +60,11 @@ LL |     Pin::new(Box::new(x))
    |     ^^^^^^^^ the trait `Unpin` is not implemented for `dyn Future<Output = i32> + Send`
    |
    = note: consider using `Box::pin`
-   = note: required by `Pin::<P>::new`
+note: required by `Pin::<P>::new`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+   |
+LL |     pub const fn new(pointer: P) -> Pin<P> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:31:5

--- a/src/test/ui/suggestions/issue-72766.stderr
+++ b/src/test/ui/suggestions/issue-72766.stderr
@@ -5,7 +5,11 @@ LL |     SadGirl {}.call()?;
    |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future`
    |
    = help: the trait `Try` is not implemented for `impl Future`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider `await`ing on the `Future`
    |
 LL |     SadGirl {}.call().await?;

--- a/src/test/ui/suggestions/issue-84973.stderr
+++ b/src/test/ui/suggestions/issue-84973.stderr
@@ -6,9 +6,12 @@ LL |     let o = Other::new(f);
    |                        |
    |                        expected an implementor of trait `SomeTrait`
    |                        help: consider borrowing here: `&f`
-...
+   |
+note: required by `Other::<'a, G>::new`
+  --> $DIR/issue-84973.rs:27:5
+   |
 LL |     pub fn new(g: G) -> Self {
-   |     ------------------------ required by `Other::<'a, G>::new`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -5,7 +5,11 @@ LL |     let fp = BufWriter::new(fp);
    |                             ^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
-   = note: required by `BufWriter::<W>::new`
+note: required by `BufWriter::<W>::new`
+  --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
+   |
+LL |     pub fn new(inner: W) -> BufWriter<W> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14

--- a/src/test/ui/suggestions/suggest-change-mut.stderr
+++ b/src/test/ui/suggestions/suggest-change-mut.stderr
@@ -4,7 +4,11 @@ error[E0277]: the trait bound `&T: std::io::Read` is not satisfied
 LL |         let mut stream_reader = BufReader::new(&stream);
    |                                                ^^^^^^^ the trait `std::io::Read` is not implemented for `&T`
    |
-   = note: required by `BufReader::<R>::new`
+note: required by `BufReader::<R>::new`
+  --> $SRC_DIR/std/src/io/buffered/bufreader.rs:LL:COL
+   |
+LL |     pub fn new(inner: R) -> BufReader<R> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider removing the leading `&`-reference
    |
 LL |         let mut stream_reader = BufReader::new(stream);

--- a/src/test/ui/suggestions/suggest-remove-refs-1.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-1.stderr
@@ -9,7 +9,11 @@ LL |     for (i, _) in &v.iter().enumerate() {
    |
    = help: the trait `Iterator` is not implemented for `&Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required because of the requirements on the impl of `IntoIterator` for `&Enumerate<std::slice::Iter<'_, {integer}>>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-remove-refs-2.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-2.stderr
@@ -9,7 +9,11 @@ LL |     for (i, _) in & & & & &v.iter().enumerate() {
    |
    = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required because of the requirements on the impl of `IntoIterator` for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/src/test/ui/suggestions/suggest-remove-refs-3.stderr
@@ -13,7 +13,11 @@ LL | |          .enumerate() {
    |
    = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
    = note: required because of the requirements on the impl of `IntoIterator` for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
-   = note: required by `into_iter`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/bad-sized.stderr
+++ b/src/test/ui/traits/bad-sized.stderr
@@ -29,7 +29,11 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: required by `Vec::<T>::new`
+note: required by `Vec::<T>::new`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL |     pub const fn new() -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/bad-sized.rs:4:37

--- a/src/test/ui/traits/bound/on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-locals.stderr
@@ -10,11 +10,14 @@ LL |     let baz: Foo<usize> = loop { };
 error[E0277]: the trait bound `{integer}: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-locals.rs:10:15
    |
-LL | struct Foo<T:Trait> {
-   | ------------------- required by `Foo`
-...
 LL |     let foo = Foo {
    |               ^^^ the trait `Trait` is not implemented for `{integer}`
+   |
+note: required by `Foo`
+  --> $DIR/on-structs-and-enums-locals.rs:5:1
+   |
+LL | struct Foo<T:Trait> {
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
@@ -15,7 +15,11 @@ error[E0277]: the trait bound `{integer}: Trait` is not satisfied
 LL |     let foo = Foo {
    |               ^^^ the trait `Trait` is not implemented for `{integer}`
    |
-   = note: required by `Foo`
+note: required by `Foo`
+  --> $DIR/auxiliary/on_structs_and_enums_xc.rs:5:1
+   |
+LL | pub struct Foo<T:Trait> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/cycle-cache-err-60010.stderr
+++ b/src/test/ui/traits/cycle-cache-err-60010.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `SalsaStorage: RefUnwindSafe`
   --> $DIR/cycle-cache-err-60010.rs:69:5
    |
-LL |     fn parse(&self) {
-   |     --------------- required by `SourceDatabase::parse`
-...
 LL |     SourceDatabase::parse(db);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
@@ -25,6 +22,11 @@ note: required because of the requirements on the impl of `SourceDatabase` for `
    |
 LL | impl<T> SourceDatabase for T
    |         ^^^^^^^^^^^^^^     ^
+note: required by `SourceDatabase::parse`
+  --> $DIR/cycle-cache-err-60010.rs:14:5
+   |
+LL |     fn parse(&self) {
+   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/src/test/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -18,21 +18,26 @@ LL | fn with_trait<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
 error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:34:5
    |
-LL |     fn same_as(&self, t: T) -> bool;
-   |     -------------------------------- required by `CompareTo::same_as`
-...
 LL |     <dyn CompareToInts>::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
+   |
+note: required by `CompareTo::same_as`
+  --> $DIR/repeated-supertrait-ambig.rs:9:5
+   |
+LL |     fn same_as(&self, t: T) -> bool;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:5
    |
-LL |     fn same_as(&self, t: T) -> bool;
-   |     -------------------------------- required by `CompareTo::same_as`
-...
 LL |     CompareTo::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
    |
+note: required by `CompareTo::same_as`
+  --> $DIR/repeated-supertrait-ambig.rs:9:5
+   |
+LL |     fn same_as(&self, t: T) -> bool;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider further restricting this bound
    |
 LL | fn with_ufcs2<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {

--- a/src/test/ui/traits/issue-71136.stderr
+++ b/src/test/ui/traits/issue-71136.stderr
@@ -1,11 +1,18 @@
 error[E0277]: the trait bound `Foo: Clone` is not satisfied
   --> $DIR/issue-71136.rs:5:5
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct FooHolster {
 LL |     the_foos: Vec<Foo>,
    |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/traits/issue-77982.stderr
+++ b/src/test/ui/traits/issue-77982.stderr
@@ -17,7 +17,11 @@ LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect(
    |                                            cannot infer type for type parameter `T` declared on the trait `From`
    |
    = note: cannot satisfy `u32: From<_>`
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed for `Box<T>`
   --> $DIR/issue-77982.rs:35:16

--- a/src/test/ui/traits/issue-79458.stderr
+++ b/src/test/ui/traits/issue-79458.stderr
@@ -1,13 +1,20 @@
 error[E0277]: the trait bound `&mut T: Clone` is not satisfied
   --> $DIR/issue-79458.rs:6:5
    |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct Foo<'a, T> {
 LL |     bar: &'a mut T
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `&mut T`
    |
    = help: the following implementations were found:
              <&T as Clone>
    = note: `Clone` is implemented for `&T`, but not for `&mut T`
-   = note: required by `clone`
+note: required by `clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+LL |     fn clone(&self) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -35,6 +35,9 @@ LL | use method::B;
 error[E0624]: associated function `a` is private
   --> $DIR/item-privacy.rs:72:7
    |
+LL |         fn a(&self) { }
+   |         ----------- private associated function defined here
+...
 LL |     c.a();
    |       ^ private associated function
 
@@ -72,6 +75,9 @@ LL | use method::B;
 error[E0624]: associated function `a` is private
   --> $DIR/item-privacy.rs:84:14
    |
+LL |         fn a(&self) { }
+   |         ----------- private associated function defined here
+...
 LL |     <dyn C>::a(&S);
    |              ^ private associated function
 
@@ -109,6 +115,9 @@ LL | use assoc_const::B;
 error[E0624]: associated constant `A` is private
   --> $DIR/item-privacy.rs:101:14
    |
+LL |         const A: u8 = 0;
+   |         ---------------- private associated constant defined here
+...
 LL |     <dyn C>::A;
    |              ^ private associated constant
 

--- a/src/test/ui/traits/method-private.stderr
+++ b/src/test/ui/traits/method-private.stderr
@@ -1,6 +1,9 @@
 error[E0624]: associated function `method` is private
   --> $DIR/method-private.rs:19:9
    |
+LL |         fn method(&self) {}
+   |         ---------------- private associated function defined here
+...
 LL |     foo.method();
    |         ^^^^^^ private associated function
    |

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:11
    |
-LL | struct Outer<T: Send>(T);
-   | ------------------------- required by `Outer`
-...
 LL |     Outer(TestType);
    |           ^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
+note: required by `Outer`
+  --> $DIR/negated-auto-traits-error.rs:10:1
+   |
+LL | struct Outer<T: Send>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:5

--- a/src/test/ui/traits/reservation-impl/no-use.stderr
+++ b/src/test/ui/traits/reservation-impl/no-use.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `(): MyTrait` is not satisfied
   --> $DIR/no-use.rs:10:26
    |
-LL | trait MyTrait { fn foo(&self); }
-   |                 -------------- required by `MyTrait::foo`
-...
 LL |     <() as MyTrait>::foo(&());
    |                          ^^^ the trait `MyTrait` is not implemented for `()`
    |
    = help: the following implementations were found:
              <() as MyTrait>
+note: required by `MyTrait::foo`
+  --> $DIR/no-use.rs:5:17
+   |
+LL | trait MyTrait { fn foo(&self); }
+   |                 ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/static-method-generic-inference.stderr
+++ b/src/test/ui/traits/static-method-generic-inference.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/static-method-generic-inference.rs:24:25
    |
-LL |         fn new() -> T;
-   |         -------------- required by `HasNew::new`
-...
 LL |     let _f: base::Foo = base::HasNew::new();
    |                         ^^^^^^^^^^^^^^^^^ cannot infer type
    |
    = note: cannot satisfy `_: HasNew<Foo>`
+note: required by `HasNew::new`
+  --> $DIR/static-method-generic-inference.rs:8:9
+   |
+LL |         fn new() -> T;
+   |         ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/suggest-where-clause.stderr
+++ b/src/test/ui/traits/suggest-where-clause.stderr
@@ -38,7 +38,11 @@ error[E0277]: the trait bound `u64: From<T>` is not satisfied
 LL |     <u64 as From<T>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `From<T>` is not implemented for `u64`
    |
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
 LL | fn check<T: Iterator, U: ?Sized>() where u64: From<T> {
@@ -50,7 +54,11 @@ error[E0277]: the trait bound `u64: From<<T as Iterator>::Item>` is not satisfie
 LL |     <u64 as From<<T as Iterator>::Item>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<<T as Iterator>::Item>` is not implemented for `u64`
    |
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
 LL | fn check<T: Iterator, U: ?Sized>() where u64: From<<T as Iterator>::Item> {
@@ -62,7 +70,11 @@ error[E0277]: the trait bound `Misc<_>: From<T>` is not satisfied
 LL |     <Misc<_> as From<T>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<T>` is not implemented for `Misc<_>`
    |
-   = note: required by `from`
+note: required by `from`
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+LL |     fn from(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `[T]` cannot be known at compilation time
   --> $DIR/suggest-where-clause.rs:28:20

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -23,11 +23,14 @@ LL | pub trait Foo {
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:25:15
    |
-LL |     fn test(&self);
-   |     --------------- required by `Foo::test`
-...
 LL |     Foo::test(&4i32);
    |               ^^^^^ the trait `Foo` is not implemented for `i32`
+   |
+note: required by `Foo::test`
+  --> $DIR/trivial-bounds-leak.rs:5:5
+   |
+LL |     fn test(&self);
+   |     ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:26:22

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -8,7 +8,11 @@ LL |         Err("")?;
    = help: the following implementations were found:
              <TryFromSliceError as From<Infallible>>
    = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, &str>>` for `Result<u32, TryFromSliceError>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<Result<i32, i32> as Try>::Output == &str`
   --> $DIR/try-block-bad-type.rs:12:9
@@ -29,7 +33,11 @@ LL |     let res: () = try { };
    |                         ^ could not wrap the final value of the block as `()` doesn't implement `Try`
    |
    = help: the trait `Try` is not implemented for `()`
-   = note: required by `from_output`
+note: required by `from_output`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_output(output: Self::Output) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: a `try` block must return `Result` or `Option` (or another type that implements `Try`)
   --> $DIR/try-block-bad-type.rs:20:26
@@ -38,7 +46,11 @@ LL |     let res: i32 = try { 5 };
    |                          ^ could not wrap the final value of the block as `i32` doesn't implement `Try`
    |
    = help: the trait `Try` is not implemented for `i32`
-   = note: required by `from_output`
+note: required by `from_output`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_output(output: Self::Output) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/try-block/try-block-in-while.stderr
+++ b/src/test/ui/try-block/try-block-in-while.stderr
@@ -5,7 +5,11 @@ LL |     while try { false } {}
    |                 ^^^^^ could not wrap the final value of the block as `bool` doesn't implement `Try`
    |
    = help: the trait `Try` is not implemented for `bool`
-   = note: required by `from_output`
+note: required by `from_output`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_output(output: Self::Output) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/try-trait/bad-interconversion.stderr
+++ b/src/test/ui/try-trait/bad-interconversion.stderr
@@ -11,7 +11,11 @@ LL |     Ok(Err(123_i32)?)
              <u8 as From<NonZeroU8>>
              <u8 as From<bool>>
    = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, i32>>` for `Result<u64, u8>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:11:12
@@ -25,7 +29,11 @@ LL | | }
    | |_- this function returns a `Result`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u64, String>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `Result`s in a function that returns `Result`
   --> $DIR/bad-interconversion.rs:17:31
@@ -38,7 +46,11 @@ LL | | }
    | |_- this function returns a `Result`
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Result<u64, String>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:22:22
@@ -51,7 +63,11 @@ LL | | }
    | |_- this function returns an `Option`
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `Option<u16>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `Option`s in a function that returns `Option`
   --> $DIR/bad-interconversion.rs:27:33
@@ -64,7 +80,11 @@ LL | | }
    | |_- this function returns an `Option`
    |
    = help: the trait `FromResidual<ControlFlow<{integer}, Infallible>>` is not implemented for `Option<u64>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
   --> $DIR/bad-interconversion.rs:32:39
@@ -77,7 +97,11 @@ LL | | }
    | |_- this function returns a `ControlFlow`
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
   --> $DIR/bad-interconversion.rs:37:12
@@ -91,7 +115,11 @@ LL | | }
    | |_- this function returns a `ControlFlow`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator in a function that returns `ControlFlow<B, _>` can only be used on other `ControlFlow<B, _>`s (with the same Break type)
   --> $DIR/bad-interconversion.rs:43:29
@@ -106,7 +134,11 @@ LL | | }
    |
    = help: the trait `FromResidual<ControlFlow<u8, Infallible>>` is not implemented for `ControlFlow<i64>`
    = note: unlike `Result`, there's no `From`-conversion performed for `ControlFlow`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/try-trait/option-to-result.stderr
+++ b/src/test/ui/try-trait/option-to-result.stderr
@@ -10,7 +10,11 @@ LL | | }
    | |_- this function returns a `Result`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<(), ()>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used on `Option`s, not `Result`s, in a function that returns `Option`
   --> $DIR/option-to-result.rs:11:6
@@ -24,7 +28,11 @@ LL | | }
    | |_- this function returns an `Option`
    |
    = help: the trait `FromResidual<Result<Infallible, i32>>` is not implemented for `Option<i32>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/try-trait/try-on-option-diagnostics.stderr
+++ b/src/test/ui/try-trait/try-on-option-diagnostics.stderr
@@ -10,7 +10,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `u32`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a closure that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-diagnostics.rs:14:10
@@ -25,7 +29,11 @@ LL | |     };
    | |_____- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `{integer}`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a method that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-diagnostics.rs:26:14
@@ -38,7 +46,11 @@ LL | |         }
    | |_________- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a trait method that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option-diagnostics.rs:39:14
@@ -51,7 +63,11 @@ LL | |         }
    | |_________- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/try-trait/try-on-option.stderr
+++ b/src/test/ui/try-trait/try-on-option.stderr
@@ -10,7 +10,11 @@ LL | | }
    | |_- this function returns a `Result`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-on-option.rs:13:6
@@ -24,7 +28,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `u32`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/try-trait/try-operator-on-main.stderr
+++ b/src/test/ui/try-trait/try-operator-on-main.stderr
@@ -12,7 +12,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> $DIR/try-operator-on-main.rs:10:5
@@ -21,7 +25,11 @@ LL |     ()?;
    |     ^^^ the `?` operator cannot be applied to type `()`
    |
    = help: the trait `Try` is not implemented for `()`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-operator-on-main.rs:10:7
@@ -39,7 +47,11 @@ LL | | }
    | |_- this function should return `Result` or `Option` to accept `?`
    |
    = help: the trait `FromResidual<_>` is not implemented for `()`
-   = note: required by `from_residual`
+note: required by `from_residual`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn from_residual(residual: R) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): Try` is not satisfied
   --> $DIR/try-operator-on-main.rs:14:25
@@ -57,7 +69,11 @@ LL |     ()?;
    |     ^^^ the `?` operator cannot be applied to type `()`
    |
    = help: the trait `Try` is not implemented for `()`
-   = note: required by `branch`
+note: required by `branch`
+  --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
+   |
+LL |     fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -23,28 +23,37 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:11:17
    |
 LL | struct Bounds<T:Copy=String>(T);
-   | ----------------^^^^------------
-   | |               |
-   | |               the trait `Copy` is not implemented for `String`
-   | required by `Bounds`
+   |                 ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by `Bounds`
+  --> $DIR/type-check-defaults.rs:11:1
+   |
+LL | struct Bounds<T:Copy=String>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:14:42
    |
 LL | struct WhereClause<T=String>(T) where T: Copy;
-   | -----------------------------------------^^^^-
-   | |                                        |
-   | |                                        the trait `Copy` is not implemented for `String`
-   | required by `WhereClause`
+   |                                          ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by `WhereClause`
+  --> $DIR/type-check-defaults.rs:14:1
+   |
+LL | struct WhereClause<T=String>(T) where T: Copy;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:17:20
    |
 LL | trait TraitBound<T:Copy=String> {}
-   | -------------------^^^^--------
-   | |                  |
-   | |                  the trait `Copy` is not implemented for `String`
-   | required by `TraitBound`
+   |                    ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by `TraitBound`
+  --> $DIR/type-check-defaults.rs:17:1
+   |
+LL | trait TraitBound<T:Copy=String> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
@@ -63,12 +72,14 @@ error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:66
    |
 LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-   | -----------------------------------------------------------------^^^^^^^
-   | |                                                                |
-   | |                                                                no implementation for `i32 + u8`
-   | required by `ProjectionPred`
+   |                                                                  ^^^^^^^ no implementation for `i32 + u8`
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
+note: required by `ProjectionPred`
+  --> $DIR/type-check-defaults.rs:24:1
+   |
+LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/type/type-params-in-different-spaces-2.stderr
+++ b/src/test/ui/type/type-params-in-different-spaces-2.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Tr<U>` is not satisfied
   --> $DIR/type-params-in-different-spaces-2.rs:10:9
    |
-LL |     fn op(_: T) -> Self;
-   |     -------------------- required by `Tr::op`
-...
 LL |         Tr::op(u)
    |         ^^^^^^ the trait `Tr<U>` is not implemented for `Self`
    |
+note: required by `Tr::op`
+  --> $DIR/type-params-in-different-spaces-2.rs:5:5
+   |
+LL |     fn op(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^
 help: consider further restricting `Self`
    |
 LL |     fn test<U>(u: U) -> Self where Self: Tr<U> {
@@ -15,12 +17,14 @@ LL |     fn test<U>(u: U) -> Self where Self: Tr<U> {
 error[E0277]: the trait bound `Self: Tr<U>` is not satisfied
   --> $DIR/type-params-in-different-spaces-2.rs:16:9
    |
-LL |     fn op(_: T) -> Self;
-   |     -------------------- required by `Tr::op`
-...
 LL |         Tr::op(u)
    |         ^^^^^^ the trait `Tr<U>` is not implemented for `Self`
    |
+note: required by `Tr::op`
+  --> $DIR/type-params-in-different-spaces-2.rs:5:5
+   |
+LL |     fn op(_: T) -> Self;
+   |     ^^^^^^^^^^^^^^^^^^^^
 help: consider further restricting `Self`
    |
 LL |     fn test<U>(u: U) -> Self where Self: Tr<U> {

--- a/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -5,7 +5,11 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
-   = note: required by `add`
+note: required by `add`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL |     fn add(self, rhs: Rhs) -> Self::Output;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:6:28

--- a/src/test/ui/unevaluated_fixed_size_array_len.stderr
+++ b/src/test/ui/unevaluated_fixed_size_array_len.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `[(); 0]: Foo` is not satisfied
   --> $DIR/unevaluated_fixed_size_array_len.rs:12:5
    |
-LL |     fn foo();
-   |     --------- required by `Foo::foo`
-...
 LL |     <[(); 0] as Foo>::foo()
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `[(); 0]`
    |
    = help: the following implementations were found:
              <[(); 1] as Foo>
+note: required by `Foo::foo`
+  --> $DIR/unevaluated_fixed_size_array_len.rs:4:5
+   |
+LL |     fn foo();
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `PartialEqNotEq: Eq` is not satisfied
   --> $DIR/union-derive-eq.rs:16:5
    |
+LL | #[derive(Eq)]
+   |          -- in this derive macro expansion
+LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    | 

--- a/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `PartialEqNotEq: Eq` is not satisfied
   --> $DIR/union-derive-eq.rs:16:5
    |
+LL | #[derive(Eq)]
+   |          -- in this derive macro expansion
+LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    | 

--- a/src/test/ui/union/union-generic.mirunsafeck.stderr
+++ b/src/test/ui/union/union-generic.mirunsafeck.stderr
@@ -1,20 +1,26 @@
 error[E0277]: the trait bound `Rc<u32>: Copy` is not satisfied
   --> $DIR/union-generic.rs:11:13
    |
-LL | union U<T: Copy> {
-   | ---------------- required by `U`
-...
 LL |     let u = U { a: Rc::new(0u32) };
    |             ^ the trait `Copy` is not implemented for `Rc<u32>`
+   |
+note: required by `U`
+  --> $DIR/union-generic.rs:6:1
+   |
+LL | union U<T: Copy> {
+   | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Rc<u32>: Copy` is not satisfied
   --> $DIR/union-generic.rs:13:13
    |
-LL | union U<T: Copy> {
-   | ---------------- required by `U`
-...
 LL |     let u = U::<Rc<u32>> { a: Default::default() };
    |             ^^^^^^^^^^^^ the trait `Copy` is not implemented for `Rc<u32>`
+   |
+note: required by `U`
+  --> $DIR/union-generic.rs:6:1
+   |
+LL | union U<T: Copy> {
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/union/union-generic.thirunsafeck.stderr
+++ b/src/test/ui/union/union-generic.thirunsafeck.stderr
@@ -1,20 +1,26 @@
 error[E0277]: the trait bound `Rc<u32>: Copy` is not satisfied
   --> $DIR/union-generic.rs:11:13
    |
-LL | union U<T: Copy> {
-   | ---------------- required by `U`
-...
 LL |     let u = U { a: Rc::new(0u32) };
    |             ^ the trait `Copy` is not implemented for `Rc<u32>`
+   |
+note: required by `U`
+  --> $DIR/union-generic.rs:6:1
+   |
+LL | union U<T: Copy> {
+   | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Rc<u32>: Copy` is not satisfied
   --> $DIR/union-generic.rs:13:13
    |
-LL | union U<T: Copy> {
-   | ---------------- required by `U`
-...
 LL |     let u = U::<Rc<u32>> { a: Default::default() };
    |             ^^^^^^^^^^^^ the trait `Copy` is not implemented for `Rc<u32>`
+   |
+note: required by `U`
+  --> $DIR/union-generic.rs:6:1
+   |
+LL | union U<T: Copy> {
+   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xc-private-method.stderr
+++ b/src/test/ui/xc-private-method.stderr
@@ -3,12 +3,22 @@ error[E0624]: associated function `static_meth_struct` is private
    |
 LL |     let _ = xc_private_method_lib::Struct::static_meth_struct();
    |                                            ^^^^^^^^^^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/xc-private-method-lib.rs:8:5
+   |
+LL |     fn static_meth_struct() -> Struct {
+   |     --------------------------------- private associated function defined here
 
 error[E0624]: associated function `static_meth_enum` is private
   --> $DIR/xc-private-method.rs:9:42
    |
 LL |     let _ = xc_private_method_lib::Enum::static_meth_enum();
    |                                          ^^^^^^^^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/xc-private-method-lib.rs:23:5
+   |
+LL |     fn static_meth_enum() -> Enum {
+   |     ----------------------------- private associated function defined here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/xc-private-method2.stderr
+++ b/src/test/ui/xc-private-method2.stderr
@@ -3,12 +3,22 @@ error[E0624]: associated function `meth_struct` is private
    |
 LL |     let _ = xc_private_method_lib::Struct{ x: 10 }.meth_struct();
    |                                                    ^^^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/xc-private-method-lib.rs:12:5
+   |
+LL |     fn meth_struct(&self) -> isize {
+   |     ------------------------------ private associated function defined here
 
 error[E0624]: associated function `meth_enum` is private
   --> $DIR/xc-private-method2.rs:9:55
    |
 LL |     let _ = xc_private_method_lib::Enum::Variant1(20).meth_enum();
    |                                                       ^^^^^^^^^ private associated function
+   | 
+  ::: $DIR/auxiliary/xc-private-method-lib.rs:27:5
+   |
+LL |     fn meth_enum(&self) -> isize {
+   |     ---------------------------- private associated function defined here
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
* Always point at macros, including derive macros
* Point at non-local items that introduce a trait requirement
* On private associated item, point at definition