### PR TITLE
Pre-fill the query cache instead of having two copies of the information

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -769,6 +769,7 @@ pub static DEFAULT_QUERY_PROVIDERS: SyncLazy<Providers> = SyncLazy::new(|| {
     providers.names_imported_by_glob_use = |_, ()| panic!();
     providers.extern_prelude = |_, ()| panic!();
     providers.main_def = |_, ()| panic!();
+    providers.output_filenames = |_, ()| panic!();
     *providers
 });
 
@@ -785,6 +786,7 @@ fn initialize_query_cache<'tcx>(
     gcx: &mut QueryContext<'tcx>,
     queries: &'tcx TcxQueries<'tcx>,
     resolutions: ResolverOutputs,
+    output_filenames: OutputFilenames,
 ) {
     gcx.enter(|tcx| {
         let filler = QueryCtxt { tcx, queries: &queries }.input();
@@ -807,6 +809,7 @@ fn initialize_query_cache<'tcx>(
         filler.names_imported_by_glob_use((), resolutions.glob_map);
         filler.extern_prelude((), resolutions.extern_prelude);
         filler.main_def((), resolutions.main_def);
+        filler.output_filenames((), std::sync::Arc::new(output_filenames));
     });
 }
 
@@ -879,13 +882,12 @@ pub fn create_global_ctxt<'tcx>(
                 queries.on_disk_cache.as_ref().map(OnDiskCache::as_dyn),
                 queries.as_dyn(),
                 &crate_name,
-                outputs,
             )
         })
     });
 
     let mut gcx = QueryContext { gcx };
-    initialize_query_cache(&mut gcx, queries, resolver_outputs);
+    initialize_query_cache(&mut gcx, queries, resolver_outputs, outputs);
     gcx
 }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -454,7 +454,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 
     fn encode_def_path_table(&mut self) {
-        let table = self.tcx.resolutions(()).definitions.def_path_table();
+        let table = self.tcx.definitions.def_path_table();
         if self.is_proc_macro {
             for def_index in std::iter::once(CRATE_DEF_INDEX)
                 .chain(self.tcx.hir().krate().proc_macros.iter().map(|p| p.owner.local_def_index))

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -173,6 +173,6 @@ pub fn provide(providers: &mut Providers) {
     providers.all_local_trait_impls = |tcx, ()| &tcx.hir_crate(()).trait_impls;
     providers.expn_that_defined = |tcx, id| {
         let id = id.expect_local();
-        tcx.resolutions(()).definitions.expansion_that_defined(id)
+        tcx.definitions.expansion_that_defined(id)
     };
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -14,12 +14,6 @@ rustc_queries! {
         desc { "trigger a delay span bug" }
     }
 
-    query resolutions(_: ()) -> &'tcx ty::ResolverOutputs {
-        eval_always
-        no_hash
-        desc { "get the resolver outputs" }
-    }
-
     /// Represents crate as a whole (as distinct from the top-level crate module).
     /// If you call `hir_crate` (e.g., indirectly by calling `tcx.hir().krate()`),
     /// we will have to assume that any change means that you need to be recompiled.
@@ -1160,6 +1154,7 @@ rustc_queries! {
     }
 
     query module_exports(def_id: LocalDefId) -> Option<&'tcx [Export<LocalDefId>]> {
+        eval_always
         desc { |tcx| "looking up items exported by `{}`", tcx.def_path_str(def_id.to_def_id()) }
     }
 
@@ -1262,6 +1257,10 @@ rustc_queries! {
     query entry_fn(_: ()) -> Option<(DefId, EntryFnType)> {
         desc { "looking up the entry function of a crate" }
     }
+    query main_def(_: ()) -> Option<ty::MainDefinition> {
+        eval_always
+        desc { |tcx| "looking up the entry function in the AST" }
+    }
     query proc_macro_decls_static(_: ()) -> Option<LocalDefId> {
         desc { "looking up the derive registrar for a crate" }
     }
@@ -1282,6 +1281,13 @@ rustc_queries! {
     query crate_extern_paths(_: CrateNum) -> Vec<PathBuf> {
         eval_always
         desc { "looking up the paths for extern crates" }
+    }
+
+    /// Extern prelude entries. The value is `true` if the entry was introduced
+    /// via `extern crate` item and not `--extern` option or compiler built-in.
+    query extern_prelude(_: ()) -> FxHashMap<Symbol, bool> {
+        eval_always
+        desc { "looking up prelude entries" }
     }
 
     /// Given a crate and a trait, look up all impls of that trait in the crate.
@@ -1351,6 +1357,7 @@ rustc_queries! {
     }
 
     query visibility(def_id: DefId) -> ty::Visibility {
+        eval_always
         desc { |tcx| "computing visibility of `{}`", tcx.def_path_str(def_id) }
     }
 
@@ -1375,6 +1382,7 @@ rustc_queries! {
         desc { |tcx| "collecting child items of `{}`", tcx.def_path_str(def_id) }
     }
     query extern_mod_stmt_cnum(def_id: LocalDefId) -> Option<CrateNum> {
+        eval_always
         desc { |tcx| "computing crate imported by `{}`", tcx.def_path_str(def_id.to_def_id()) }
     }
 
@@ -1451,13 +1459,17 @@ rustc_queries! {
         eval_always
     }
     query maybe_unused_trait_import(def_id: LocalDefId) -> bool {
+        eval_always
         desc { |tcx| "maybe_unused_trait_import for `{}`", tcx.def_path_str(def_id.to_def_id()) }
     }
     query maybe_unused_extern_crates(_: ()) -> &'tcx [(LocalDefId, Span)] {
+        eval_always
         desc { "looking up all possibly unused extern crates" }
     }
-    query names_imported_by_glob_use(def_id: LocalDefId) -> &'tcx FxHashSet<Symbol> {
-        desc { |tcx| "names_imported_by_glob_use for `{}`", tcx.def_path_str(def_id.to_def_id()) }
+    query names_imported_by_glob_use(_: ()) -> FxHashMap<LocalDefId, FxHashSet<Symbol>> {
+        eval_always
+        storage(ArenaCacheSelector<'tcx>)
+        desc { |tcx| "names imported by glob use" }
     }
 
     query stability_index(_: ()) -> stability::Index<'tcx> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1529,7 +1529,7 @@ rustc_queries! {
 
     query output_filenames(_: ()) -> Arc<OutputFilenames> {
         eval_always
-        desc { "output_filenames" }
+        desc { "output filenames" }
     }
 
     /// Do not call this query directly: invoke `normalize` instead.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -19,9 +19,7 @@ pub use assoc::*;
 pub use generics::*;
 pub use vtable::*;
 
-use crate::hir::exports::ExportMap;
 use crate::ich::StableHashingContext;
-use crate::middle::cstore::CrateStoreDyn;
 use crate::mir::{Body, GeneratorLayout};
 use crate::traits::{self, Reveal};
 use crate::ty;
@@ -30,7 +28,7 @@ use crate::ty::util::Discr;
 use rustc_ast as ast;
 use rustc_attr as attr;
 use rustc_data_structures::captures::Captures;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::{self, par_iter, ParallelIterator};
 use rustc_data_structures::tagged_ptr::CopyTaggedPtr;
@@ -118,23 +116,7 @@ mod sty;
 
 // Data types
 
-#[derive(Debug)]
-pub struct ResolverOutputs {
-    pub definitions: rustc_hir::definitions::Definitions,
-    pub cstore: Box<CrateStoreDyn>,
-    pub visibilities: FxHashMap<LocalDefId, Visibility>,
-    pub extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
-    pub maybe_unused_trait_imports: FxHashSet<LocalDefId>,
-    pub maybe_unused_extern_crates: Vec<(LocalDefId, Span)>,
-    pub export_map: ExportMap<LocalDefId>,
-    pub glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
-    /// Extern prelude entries. The value is `true` if the entry was introduced
-    /// via `extern crate` item and not `--extern` option or compiler built-in.
-    pub extern_prelude: FxHashMap<Symbol, bool>,
-    pub main_def: Option<MainDefinition>,
-}
-
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, HashStable)]
 pub struct MainDefinition {
     pub res: Res<ast::NodeId>,
     pub is_import: bool,

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -148,7 +148,7 @@ fn configure_main(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) -> Option<(De
     } else if let Some((hir_id, _)) = visitor.attr_main_fn {
         Some((tcx.hir().local_def_id(hir_id).to_def_id(), EntryFnType::Main))
     } else {
-        if let Some(main_def) = tcx.resolutions(()).main_def {
+        if let Some(main_def) = tcx.main_def(()) {
             if let Some(def_id) = main_def.opt_fn_def_id() {
                 // non-local main imports are handled below
                 if def_id.is_local() {
@@ -226,7 +226,7 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
         err.note(&note);
     }
 
-    if let Some(main_def) = tcx.resolutions(()).main_def {
+    if let Some(main_def) = tcx.main_def(()) {
         if main_def.opt_fn_def_id().is_none() {
             // There is something at `crate::main`, but it is not a function definition.
             err.span_label(main_def.span, "non-function item at `crate::main` is found");

--- a/compiler/rustc_query_impl/src/stats.rs
+++ b/compiler/rustc_query_impl/src/stats.rs
@@ -108,7 +108,7 @@ pub fn print_stats(tcx: TyCtxt<'_>) {
         queries.iter().filter(|q| q.local_def_id_keys.is_some()).collect();
     def_id_density.sort_by_key(|q| q.local_def_id_keys.unwrap());
     eprintln!("\nLocal DefId density:");
-    let total = tcx.resolutions(()).definitions.def_index_count() as f64;
+    let total = tcx.definitions.def_index_count() as f64;
     for q in def_id_density.iter().rev() {
         let local = q.local_def_id_keys.unwrap();
         eprintln!("   {} - {} = ({}%)", q.name, local, (local as f64 * 100.0) / total);

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -74,6 +74,13 @@ impl<C: QueryCache> QueryCacheStore<C> {
         (QueryLookup { key_hash, shard }, lock)
     }
 
+    pub fn insert(&self, key: C::Key, result: C::Value, dep_node_index: DepNodeIndex) {
+        let key_hash = hash_for_shard(&key);
+        let shard = get_shard_index_by_hash(key_hash);
+        let mut lock = self.shards.get_shard_by_index(shard).lock();
+        self.cache.complete(&mut lock, key, result, dep_node_index);
+    }
+
     pub fn iter_results(&self, f: &mut dyn FnMut(&C::Key, &C::Value, DepNodeIndex)) {
         self.cache.iter(&self.shards, f)
     }

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -1172,8 +1172,14 @@ impl<'tcx> Visitor<'tcx> for DumpVisitor<'tcx> {
             }
             hir::ItemKind::Use(path, hir::UseKind::Glob) => {
                 // Make a comma-separated list of names of imported modules.
-                let names = self.tcx.names_imported_by_glob_use(item.def_id);
-                let names: Vec<_> = names.iter().map(|n| n.to_string()).collect();
+                let names: Vec<_> = self
+                    .tcx
+                    .names_imported_by_glob_use(())
+                    .get(&item.def_id)
+                    .into_iter()
+                    .flatten()
+                    .map(|n| n.to_string())
+                    .collect();
 
                 // Otherwise it's a span with wrong macro expansion info, which
                 // we don't want to track anyway, since it's probably macro-internal `use`

--- a/compiler/rustc_typeck/src/check_unused.rs
+++ b/compiler/rustc_typeck/src/check_unused.rs
@@ -116,7 +116,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
         crates_to_lint: &mut crates_to_lint,
     });
 
-    let extern_prelude = &tcx.resolutions(()).extern_prelude;
+    let extern_prelude = &tcx.extern_prelude(());
 
     for extern_crate in &crates_to_lint {
         let def_id = extern_crate.def_id.expect_local();

--- a/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
@@ -119,7 +119,7 @@ impl LateLintPass<'_> for WildcardImports {
         if_chain! {
             if let ItemKind::Use(use_path, UseKind::Glob) = &item.kind;
             if self.warn_on_all || !self.check_exceptions(item, use_path.segments);
-            let used_imports = cx.tcx.names_imported_by_glob_use(item.def_id);
+            if let Some(used_imports) = cx.tcx.names_imported_by_glob_use(()).get(&item.def_id);
             if !used_imports.is_empty(); // Already handled by `unused_imports`
             then {
                 let mut applicability = Applicability::MachineApplicable;


### PR DESCRIPTION
Resolver outputs are stored inside the TyCtxt for the sole purpose of being returned by a query later.

This PR proposes copy this data directly into the query cache, so as to avoid the double storage.

The DepNodeIndex are constructed from the correct dep-node and the result is hashed as it would normally be.
The function inside the Providers struct returns a fallback value and is only called when the cache is empty.

The query needs to be eval_always for this to be sound: if a compiler session initializes less cache slots than its predecessor, we need to detect that and evaluate the query on the newly empty slots.
In consequence, the method is only provided for eval_always queries.
(An alternative design would be to insert a dependency to an always-red node when inserting manually into the cache, and remove the eval_always requirement. I am not convinced this is simpler.)

This facility is restricted to crates which depend on rustc_query_impl, so as to avoid accidental misuse by normal queries.