### PR TITLE
Fix docblock <table> overflow

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -556,7 +556,8 @@ nav.sub {
 .docblock table {
 	margin: .5em 0;
 	width: calc(100% - 2px);
-	border: 1px dashed;
+	overflow-x: auto;
+	display: block;
 }
 
 .docblock table td {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -140,7 +140,7 @@ pre, .rustdoc.source .example-wrap {
 	border-bottom-color: #5c6773;
 }
 
-.docblock table, .docblock table td, .docblock table th {
+.docblock table td, .docblock table th {
 	border-color: #5c6773;
 }
 

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -97,7 +97,7 @@ pre, .rustdoc.source .example-wrap {
 	border-bottom-color: #DDD;
 }
 
-.docblock table, .docblock table td, .docblock table th {
+.docblock table td, .docblock table th {
 	border-color: #ddd;
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -97,7 +97,7 @@ pre, .rustdoc.source .example-wrap {
 	border-bottom-color: #ddd;
 }
 
-.docblock table, .docblock table td, .docblock table th {
+.docblock table td, .docblock table th {
 	border-color: #ddd;
 }
 

--- a/src/test/rustdoc-gui/docblock-table-overflow.goml
+++ b/src/test/rustdoc-gui/docblock-table-overflow.goml
@@ -1,0 +1,9 @@
+// This test ensures that the type declaration content overflow is handled inside the <pre> directly.
+goto: file://|DOC_PATH|/lib2/long_table/struct.Foo.html
+// We set a fixed size so there is no chance of "random" resize.
+size: (1100, 800)
+// Logically, the ".docblock" and the "<p>" should have the same scroll width.
+compare-elements-property: (".top-doc .docblock", ".top-doc .docblock > p", ["scrollWidth"])
+assert-property: (".top-doc .docblock", {"scrollWidth": "816"})
+// However, since there is overflow in the <table>, its scroll width is bigger.
+assert-property: (".top-doc .docblock table", {"scrollWidth": "1573"})

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -54,3 +54,12 @@ pub mod long_trait {
     pub trait ALongNameBecauseItHelpsTestingTheCurrentProblem: DerefMut<Target = u32>
         + From<u128> + Send + Sync + AsRef<str> + 'static {}
 }
+
+pub mod long_table {
+    /// | This::is::a::kinda::very::long::header::number::one | This::is::a::kinda::very::long::header::number::two | This::is::a::kinda::very::long::header::number::one | This::is::a::kinda::very::long::header::number::two |
+    /// | ----------- | ----------- | ----------- | ----------- |
+    /// | This::is::a::kinda::long::content::number::one | This::is::a::kinda::very::long::content::number::two | This::is::a::kinda::long::content::number::one | This::is::a::kinda::very::long::content::number::two |
+    ///
+    /// I wanna sqdkfnqds f dsqf qds f dsqf dsq f dsq f qds f qds f qds f dsqq f dsf sqdf dsq fds f dsq f dq f ds fq sd fqds f dsq f sqd fsq df sd fdsqfqsd fdsq f dsq f dsqfd s dfq
+    pub struct Foo;
+}

--- a/src/test/rustdoc-gui/src/lib2/src/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
Before:

![Screenshot from 2021-07-18 00-05-23](https://user-images.githubusercontent.com/3050060/126050272-ce08bc5f-74ff-4135-bc12-d708d87470cc.png)

After:

![Screenshot from 2021-07-18 00-03-55](https://user-images.githubusercontent.com/3050060/126050273-42f41b4d-ad57-4a87-91de-18e63f8504ec.png)

cc @SergioBenitez 

r? @notriddle