### PR TITLE
Simplify command-line argument initialization on unix

### DIFF
--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -14,11 +14,6 @@ pub unsafe fn init(argc: isize, argv: *const *const u8) {
     imp::init(argc, argv)
 }
 
-/// One-time global cleanup.
-pub unsafe fn cleanup() {
-    imp::cleanup()
-}
-
 /// Returns the command line arguments
 pub fn args() -> Args {
     imp::args()
@@ -127,12 +122,6 @@ mod imp {
         init_wrapper
     };
 
-    pub unsafe fn cleanup() {
-        let _guard = LOCK.lock();
-        ARGC.store(0, Ordering::Relaxed);
-        ARGV.store(ptr::null_mut(), Ordering::Relaxed);
-    }
-
     pub fn args() -> Args {
         Args { iter: clone().into_iter() }
     }
@@ -158,8 +147,6 @@ mod imp {
     use crate::ffi::CStr;
 
     pub unsafe fn init(_argc: isize, _argv: *const *const u8) {}
-
-    pub fn cleanup() {}
 
     #[cfg(target_os = "macos")]
     pub fn args() -> Args {

--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -125,11 +125,7 @@ mod imp {
             // Load ARGC and ARGV without a lock. If the store to either ARGV or
             // ARGC isn't visible yet, we'll return an empty argument list.
             let argv = ARGV.load(Ordering::Relaxed);
-            let argc = if argv.is_null() {
-                0
-            } else {
-                ARGC.load(Ordering::Relaxed)
-            };
+            let argc = if argv.is_null() { 0 } else { ARGC.load(Ordering::Relaxed) };
             (0..argc)
                 .map(|i| {
                     let cstr = CStr::from_ptr(*argv.offset(i) as *const libc::c_char);

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -123,7 +123,6 @@ pub unsafe fn init(argc: isize, argv: *const *const u8) {
 // SAFETY: must be called only once during runtime cleanup.
 // NOTE: this is not guaranteed to run, for example when the program aborts.
 pub unsafe fn cleanup() {
-    args::cleanup();
     stack_overflow::cleanup();
 }
 


### PR DESCRIPTION
Simplify Rust's command-line argument initialization code on unix:
 - The cleanup code isn't needed, because it was just zeroing out non-owning variables at runtime cleanup time. After 91c3eee1735ad72b579f99cbb6919c3471747d94, Rust's command-line initialization code on unix no longer allocates `CString`s and a `Vec` at startup time.
 - The `Mutex` isn't needed; if there's somehow a call to `args()` before argument initialization has happened, the code returns return an empty list, which we can do with a null check.

With these changes, a simple cdylib that doesn't use threads avoids getting `pthread_mutex_lock`/`pthread_mutex_unlock` in its symbol table.