### PR TITLE
Fix implicit Sized relaxation when attempting to relax other, unsupported trait

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -838,6 +838,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                              this does nothing because the given bound is not \
                              a default; only `?Sized` is supported",
                         );
+                        return false;
                     }
                 }
             }

--- a/src/test/ui/issues/issue-87199.rs
+++ b/src/test/ui/issues/issue-87199.rs
@@ -7,15 +7,14 @@
 // Check that these function definitions only emit warnings, not errors
 fn arg<T: ?Send>(_: T) {}
 //~^ warning: default bound relaxed for a type parameter, but this does nothing
-//~^^ the size for values of type `T`
 fn ref_arg<T: ?Send>(_: &T) {}
 //~^ warning: default bound relaxed for a type parameter, but this does nothing
 fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
 //~^ warning: default bound relaxed for a type parameter, but this does nothing
-//~^^ the size for values of type `impl Iterator+?Sized` cannot be known
 
 // Check that there's no `?Sized` relaxation!
 fn main() {
     ref_arg::<i32>(&5);
     ref_arg::<[i32]>(&[5]);
+    //~^ the size for values of type `[i32]` cannot be known
 }

--- a/src/test/ui/issues/issue-87199.rs
+++ b/src/test/ui/issues/issue-87199.rs
@@ -1,0 +1,21 @@
+// Regression test for issue #87199, where attempting to relax a bound
+// other than the only supported `?Sized` would still cause the compiler
+// to assume that the `Sized` bound was relaxed.
+
+// check-fail
+
+// Check that these function definitions only emit warnings, not errors
+fn arg<T: ?Send>(_: T) {}
+//~^ warning: default bound relaxed for a type parameter, but this does nothing
+//~^^ the size for values of type `T`
+fn ref_arg<T: ?Send>(_: &T) {}
+//~^ warning: default bound relaxed for a type parameter, but this does nothing
+fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
+//~^ warning: default bound relaxed for a type parameter, but this does nothing
+//~^^ the size for values of type `impl Iterator+?Sized` cannot be known
+
+// Check that there's no `?Sized` relaxation!
+fn main() {
+    ref_arg::<i32>(&5);
+    ref_arg::<[i32]>(&[5]);
+}

--- a/src/test/ui/issues/issue-87199.stderr
+++ b/src/test/ui/issues/issue-87199.stderr
@@ -5,40 +5,32 @@ LL | fn arg<T: ?Send>(_: T) {}
    |        ^
 
 warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-87199.rs:11:12
+  --> $DIR/issue-87199.rs:10:12
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
    |            ^
 
 warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
-  --> $DIR/issue-87199.rs:13:13
+  --> $DIR/issue-87199.rs:12:13
    |
 LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `impl Iterator+?Sized` cannot be known at compilation time
-  --> $DIR/issue-87199.rs:13:13
+error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+  --> $DIR/issue-87199.rs:18:22
    |
-LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+LL | fn ref_arg<T: ?Send>(_: &T) {}
+   |            - required by this bound in `ref_arg`
+...
+LL |     ref_arg::<[i32]>(&[5]);
+   |                      ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `impl Iterator+?Sized`
-   = note: the return type of a function must have a statically known size
+   = help: the trait `Sized` is not implemented for `[i32]`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}
+   |                     ^^^^^^^^
 
-error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/issue-87199.rs:8:18
-   |
-LL | fn arg<T: ?Send>(_: T) {}
-   |        -         ^ doesn't have a size known at compile-time
-   |        |
-   |        this type parameter needs to be `std::marker::Sized`
-   |
-   = help: unsized fn params are gated as an unstable feature
-help: function arguments must have a statically known size, borrowed types always have a known size
-   |
-LL | fn arg<T: ?Send>(_: &T) {}
-   |                     ^
-
-error: aborting due to 2 previous errors; 3 warnings emitted
+error: aborting due to previous error; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-87199.stderr
+++ b/src/test/ui/issues/issue-87199.stderr
@@ -1,0 +1,44 @@
+warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
+  --> $DIR/issue-87199.rs:8:8
+   |
+LL | fn arg<T: ?Send>(_: T) {}
+   |        ^
+
+warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
+  --> $DIR/issue-87199.rs:11:12
+   |
+LL | fn ref_arg<T: ?Send>(_: &T) {}
+   |            ^
+
+warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
+  --> $DIR/issue-87199.rs:13:13
+   |
+LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the size for values of type `impl Iterator+?Sized` cannot be known at compilation time
+  --> $DIR/issue-87199.rs:13:13
+   |
+LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `impl Iterator+?Sized`
+   = note: the return type of a function must have a statically known size
+
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/issue-87199.rs:8:18
+   |
+LL | fn arg<T: ?Send>(_: T) {}
+   |        -         ^ doesn't have a size known at compile-time
+   |        |
+   |        this type parameter needs to be `std::marker::Sized`
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn arg<T: ?Send>(_: &T) {}
+   |                     ^
+
+error: aborting due to 2 previous errors; 3 warnings emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #87199.

Do note that this bug fix causes code like the `ref_arg::<[i32]>(&[5]);` line in the test case in combination with an affected function to no longer compile.