### PR TITLE
Fix "item info" width

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -921,6 +921,9 @@ body.blur > :not(#help) {
 	padding: 0 20px 20px 17px;;
 }
 
+.item-info .stab {
+	display: table;
+}
 .stab {
 	border-width: 1px;
 	border-style: solid;

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -1,0 +1,7 @@
+// This test ensures that the item information don't take 100% of the width if unnecessary.
+goto: file://|DOC_PATH|/lib2/struct.Foo.html
+// We set a fixed size so there is no chance of "random" resize.
+size: (1100, 800)
+// We check that ".item-info" is bigger than its content.
+assert-css: (".item-info", {"width": "807px"})
+assert-css: (".item-info .stab", {"width": "343px"})

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -1,5 +1,7 @@
 // ignore-tidy-linelength
 
+#![feature(doc_cfg)]
+
 pub mod module {
     pub mod sub_module {
         pub mod sub_sub_module {
@@ -14,6 +16,7 @@ pub fn foobar() {}
 
 pub type Alias = u32;
 
+#[doc(cfg(feature = "foo-method"))]
 pub struct Foo {
     pub x: Alias,
 }


### PR DESCRIPTION
Fixes #87202.

It now looks again like this:

![Screenshot from 2021-07-18 12-33-27](https://user-images.githubusercontent.com/3050060/126064005-013acabc-7f17-4436-8dfc-cb6b9bc24413.png)

cc @jyn514 

r? @notriddle 
