### PR TITLE
Extend HIR-based WF checking to associated type defaults

### DIFF
--- a/compiler/rustc_typeck/src/hir_wf_check.rs
+++ b/compiler/rustc_typeck/src/hir_wf_check.rs
@@ -121,7 +121,11 @@ fn diagnostic_hir_wf_check<'tcx>(
 
     let ty = match tcx.hir().get(hir_id) {
         hir::Node::ImplItem(item) => match item.kind {
-            hir::ImplItemKind::TyAlias(ref ty) => Some(ty),
+            hir::ImplItemKind::TyAlias(ty) => Some(ty),
+            _ => None,
+        },
+        hir::Node::TraitItem(item) => match item.kind {
+            hir::TraitItemKind::Type(_, ty) => ty,
             _ => None,
         },
         _ => None,

--- a/src/test/ui/associated-types/defaults-wf.stderr
+++ b/src/test/ui/associated-types/defaults-wf.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/defaults-wf.rs:7:5
+  --> $DIR/defaults-wf.rs:7:15
    |
 LL |     type Ty = Vec<[u8]>;
-   |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^ doesn't have a size known at compile-time
    | 
   ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |

--- a/src/test/ui/wf/wf-trait-associated-type-trait.rs
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.rs
@@ -8,7 +8,7 @@ struct IsCopy<T:Copy> { x: T }
 
 trait SomeTrait {
     type Type1;
-    type Type2 = IsCopy<Self::Type1>;
+    type Type2 = (IsCopy<Self::Type1>, bool);
     //~^ ERROR E0277
 }
 

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `<Self as SomeTrait>::Type1: Copy` is not satisfied
-  --> $DIR/wf-trait-associated-type-trait.rs:11:5
+  --> $DIR/wf-trait-associated-type-trait.rs:11:19
    |
 LL | struct IsCopy<T:Copy> { x: T }
    |                 ---- required by this bound in `IsCopy`
 ...
-LL |     type Type2 = IsCopy<Self::Type1>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `<Self as SomeTrait>::Type1`
+LL |     type Type2 = (IsCopy<Self::Type1>, bool);
+   |                   ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `<Self as SomeTrait>::Type1`
    |
 help: consider further restricting the associated type
    |


### PR DESCRIPTION
Previously, we would only look at associated types in `impl` blocks.