### PR TITLE
triagebot shortcut config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -117,3 +117,5 @@ format = "rustc"
 project-name = "Rust"
 changelog-path = "RELEASES.md"
 changelog-branch = "master"
+
+[shortcut]


### PR DESCRIPTION
Enable the new triagebot shortcuts as per [#1381/triagebot](https://github.com/rust-lang/triagebot/pull/1381)