### PR TITLE
Support negative numbers in Literal::from_str

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1588,6 +1588,10 @@ impl Symbol {
         self.0.as_u32()
     }
 
+    pub fn len(self) -> usize {
+        with_interner(|interner| interner.get(self).len())
+    }
+
     pub fn is_empty(self) -> bool {
         self == kw::Empty
     }

--- a/src/test/ui/proc-macro/auxiliary/api/parse.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/parse.rs
@@ -1,7 +1,13 @@
 use proc_macro::Literal;
 
 pub fn test() {
+    test_display_literal();
     test_parse_literal();
+}
+
+fn test_display_literal() {
+    assert_eq!(Literal::isize_unsuffixed(-10).to_string(), "- 10");
+    assert_eq!(Literal::isize_suffixed(-10).to_string(), "- 10isize");
 }
 
 fn test_parse_literal() {
@@ -12,7 +18,10 @@ fn test_parse_literal() {
     assert_eq!("b\"\"".parse::<Literal>().unwrap().to_string(), "b\"\"");
     assert_eq!("r##\"\"##".parse::<Literal>().unwrap().to_string(), "r##\"\"##");
     assert_eq!("10ulong".parse::<Literal>().unwrap().to_string(), "10ulong");
+    assert_eq!("-10ulong".parse::<Literal>().unwrap().to_string(), "- 10ulong");
 
+    assert!("true".parse::<Literal>().is_err());
+    assert!(".8".parse::<Literal>().is_err());
     assert!("0 1".parse::<Literal>().is_err());
     assert!("'a".parse::<Literal>().is_err());
     assert!(" 0".parse::<Literal>().is_err());
@@ -20,4 +29,6 @@ fn test_parse_literal() {
     assert!("/* comment */0".parse::<Literal>().is_err());
     assert!("0/* comment */".parse::<Literal>().is_err());
     assert!("0// comment".parse::<Literal>().is_err());
+    assert!("- 10".parse::<Literal>().is_err());
+    assert!("-'x'".parse::<Literal>().is_err());
 }


### PR DESCRIPTION
proc_macro::Literal has allowed negative numbers in a single literal token ever since Rust 1.29, using https://doc.rust-lang.org/stable/proc_macro/struct.Literal.html#method.isize_unsuffixed and similar constructors.

```rust
let lit = proc_macro::Literal::isize_unsuffixed(-10);
```

However, the suite of constructors on Literal is not sufficient for all use cases, for example arbitrary precision floats, or custom suffixes in FFI macros.

```rust
let lit = proc_macro::Literal::f64_unsuffixed(0.101001000100001000001000000100000001); // :(
let lit = proc_macro::Literal::i???_suffixed(10ulong); // :(
```

For those, macros construct the literal using from_str instead, which preserves arbitrary precision, custom suffixes, base, and digit grouping.

```rust
let lit = "0.101001000100001000001000000100000001".parse::<Literal>().unwrap();
let lit = "10ulong".parse::<Literal>().unwrap();
let lit = "0b1000_0100_0010_0001".parse::<Literal>().unwrap();
```

However, until this PR it was not possible to construct a literal token that is **both** negative **and** preserving of arbitrary precision etc.

This PR fixes `Literal::from_str` to recognize negative integer and float literals.