### PR TITLE
Ensure `./x.py dist` adheres to `build.tools`

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -679,6 +679,7 @@ pub struct Analysis {
 
 impl Step for Analysis {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = should_build_extended_tool(&run.builder, "analysis");
@@ -958,6 +959,7 @@ pub struct Cargo {
 
 impl Step for Cargo {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1014,6 +1016,7 @@ pub struct Rls {
 impl Step for Rls {
     type Output = Option<GeneratedTarball>;
     const ONLY_HOSTS: bool = true;
+    const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = should_build_extended_tool(&run.builder, "rls");
@@ -1059,6 +1062,7 @@ pub struct RustAnalyzer {
 
 impl Step for RustAnalyzer {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1114,6 +1118,7 @@ pub struct Clippy {
 
 impl Step for Clippy {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1164,6 +1169,7 @@ pub struct Miri {
 
 impl Step for Miri {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1223,6 +1229,7 @@ pub struct Rustfmt {
 
 impl Step for Rustfmt {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1276,6 +1283,7 @@ pub struct RustDemangler {
 
 impl Step for RustDemangler {
     type Output = Option<GeneratedTarball>;
+    const DEFAULT: bool = true;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1975,6 +1983,7 @@ pub struct LlvmTools {
 impl Step for LlvmTools {
     type Output = Option<GeneratedTarball>;
     const ONLY_HOSTS: bool = true;
+    const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let default = should_build_extended_tool(&run.builder, "llvm-tools");

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -50,12 +50,7 @@ fn should_build_extended_tool(builder: &Builder<'_>, tool: &str) -> bool {
     if !builder.config.extended {
         return false;
     }
-
-    if let Some(tools) = &builder.config.tools {
-        tools.is_empty() || tools.contains(tool)
-    } else {
-        true
-    }
+    builder.config.tools.as_ref().map_or(true, |tools| tools.contains(tool))
 }
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -951,7 +951,7 @@ pub struct Cargo {
 }
 
 impl Step for Cargo {
-    type Output = GeneratedTarball;
+    type Output = Option<GeneratedTarball>;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -969,7 +969,7 @@ impl Step for Cargo {
         });
     }
 
-    fn run(self, builder: &Builder<'_>) -> GeneratedTarball {
+    fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
         let compiler = self.compiler;
         let target = self.target;
 
@@ -994,7 +994,7 @@ impl Step for Cargo {
             }
         }
 
-        tarball.generate()
+        Some(tarball.generate())
     }
 }
 
@@ -1106,7 +1106,7 @@ pub struct Clippy {
 }
 
 impl Step for Clippy {
-    type Output = GeneratedTarball;
+    type Output = Option<GeneratedTarball>;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1124,7 +1124,7 @@ impl Step for Clippy {
         });
     }
 
-    fn run(self, builder: &Builder<'_>) -> GeneratedTarball {
+    fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
@@ -1145,7 +1145,7 @@ impl Step for Clippy {
         tarball.add_file(clippy, "bin", 0o755);
         tarball.add_file(cargoclippy, "bin", 0o755);
         tarball.add_legal_and_readme_to("share/doc/clippy");
-        tarball.generate()
+        Some(tarball.generate())
     }
 }
 
@@ -1374,8 +1374,8 @@ impl Step for Extended {
             return;
         }
 
-        tarballs.push(cargo_installer);
-        tarballs.push(clippy_installer);
+        tarballs.extend(cargo_installer);
+        tarballs.extend(clippy_installer);
         tarballs.extend(rust_demangler_installer.clone());
         tarballs.extend(rls_installer.clone());
         tarballs.extend(rust_analyzer_installer.clone());

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1386,6 +1386,10 @@ impl Step for Extended {
             tarballs.push(builder.ensure(Docs { host: target }));
         }
 
+        if target.contains("windows-gnu") {
+            tarballs.push(builder.ensure(Mingw { host: target }).expect("missing mingw"));
+        }
+
         if builder.config.profiler_enabled(target)
             || should_build_extended_tool(builder, "rust-demangler")
         {
@@ -1404,17 +1408,11 @@ impl Step for Extended {
         add_tool!("miri" => Miri { compiler, target });
         add_tool!("analysis" => Analysis { compiler, target });
 
-        let mingw_installer = builder.ensure(Mingw { host: target });
-
         let etc = builder.src.join("src/etc/installer");
 
         // Avoid producing tarballs during a dry run.
         if builder.config.dry_run {
             return;
-        }
-
-        if target.contains("pc-windows-gnu") {
-            tarballs.push(mingw_installer.unwrap());
         }
 
         let tarball = Tarball::new(builder, "rust", &target.triple);

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -139,7 +139,7 @@ macro_rules! install {
 
 install!((self, builder, _config),
     Docs, "src/doc", _config.docs, only_hosts: false, {
-        let tarball = builder.ensure(dist::Docs { host: self.target });
+        let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
         install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
     };
     Std, "library/std", true, only_hosts: false, {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -154,7 +154,9 @@ install!((self, builder, _config),
         }
     };
     Cargo, "cargo", Self::should_build(_config), only_hosts: true, {
-        let tarball = builder.ensure(dist::Cargo { compiler: self.compiler, target: self.target });
+        let tarball = builder
+            .ensure(dist::Cargo { compiler: self.compiler, target: self.target })
+            .expect("missing cargo");
         install_sh(builder, "cargo", self.compiler.stage, Some(self.target), &tarball);
     };
     Rls, "rls", Self::should_build(_config), only_hosts: true, {
@@ -178,7 +180,9 @@ install!((self, builder, _config),
         }
     };
     Clippy, "clippy", Self::should_build(_config), only_hosts: true, {
-        let tarball = builder.ensure(dist::Clippy { compiler: self.compiler, target: self.target });
+        let tarball = builder
+            .ensure(dist::Clippy { compiler: self.compiler, target: self.target })
+            .expect("missing clippy");
         install_sh(builder, "clippy", self.compiler.stage, Some(self.target), &tarball);
     };
     Miri, "miri", Self::should_build(_config), only_hosts: true, {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -139,12 +139,8 @@ macro_rules! install {
 
 install!((self, builder, _config),
     Docs, "src/doc", _config.docs, only_hosts: false, {
-        if let Some(tarball) = builder.ensure(dist::Docs { host: self.target }) {
-            install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
-        } else {
-            panic!("docs are not available to install, \
-                check that `build.docs` is true in `config.toml`");
-        }
+        let tarball = builder.ensure(dist::Docs { host: self.target });
+        install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
     };
     Std, "library/std", true, only_hosts: false, {
         for target in &builder.targets {


### PR DESCRIPTION
According to `config.toml.example`, the way to produce dist artifacts for both the compiler and a *subset* of tools would be to enable the extended build and manually specify the list of tools to build:

```toml
[build]
extended = true
tools = ["cargo", "rustfmt"]
```

This works as expected for `./x.py build` and `./x.py install`, but *not* for `./x.py dist`. Before this PR `./x.py dist` simply ignored the contents of `build.tools`, building just rustc/rustdoc if `build.extended = false` and all of the tools otherwise. This PR does two things:

* Changes `./x.py dist extended` to only build the tools defined in `build.tools`, if `build.tools` is not empty. The rest of the extended step was refactored to simplify the code.
* Changes how dist jobs for tools are gated: instead of `assert!(builder.config.extended)` to prevent tools from being built with `build.extended = false`, tools are simply built by default depending on `build.extended` and `build.tools`. This also enables to **explicitly** dist tools even with `build.extended = false`.

This PR is best reviewed commit-by-commit.


Fixes #86436