### PR TITLE
Remove special case for `ExprKind::Paren` in `MutVisitor`

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1347,12 +1347,6 @@ pub fn noop_visit_expr<T: MutVisitor>(
         }
         ExprKind::Paren(expr) => {
             vis.visit_expr(expr);
-
-            // Nodes that are equal modulo `Paren` sugar no-ops should have the same IDs.
-            *id = expr.id;
-            vis.visit_span(span);
-            visit_thin_attrs(attrs, vis);
-            return;
         }
         ExprKind::Yield(expr) => {
             visit_opt(expr, |expr| vis.visit_expr(expr));

--- a/src/test/ui/lint/issue-87274-paren-parent.rs
+++ b/src/test/ui/lint/issue-87274-paren-parent.rs
@@ -1,0 +1,9 @@
+// check-pass
+// Tests that we properly lint at 'paren' expressions
+
+fn foo() -> Result<(), String>  {
+    (try!(Ok::<u8, String>(1))); //~ WARN use of deprecated macro `try`
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/lint/issue-87274-paren-parent.stderr
+++ b/src/test/ui/lint/issue-87274-paren-parent.stderr
@@ -1,0 +1,10 @@
+warning: use of deprecated macro `try`: use the `?` operator instead
+  --> $DIR/issue-87274-paren-parent.rs:5:6
+   |
+LL |     (try!(Ok::<u8, String>(1)));
+   |      ^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
The special case breaks several useful invariants (`ExpnId`s are
globally unique, and never change). This special case
was added back in 2016 in https://github.com/rust-lang/rust/pull/34355


r? @petrochenkov 