### PR TITLE
Improve error messages for recursive GATs implicitly deriving `Sized`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -327,8 +327,7 @@ impl<'a, 'b, 'tcx> AssocTypeNormalizer<'a, 'b, 'tcx> {
 
     fn fold<T: TypeFoldable<'tcx>>(&mut self, value: T) -> T {
         let value = self.selcx.infcx().resolve_vars_if_possible(value);
-        debug!(?value);
-
+        debug!(?value, "fold");
         assert!(
             !value.has_escaping_bound_vars(),
             "Normalizing {:?} without wrapping in a `Binder`",

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -868,7 +868,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     where
         I: Iterator<Item = ty::Predicate<'tcx>>,
     {
-        cycle.all(|predicate| self.coinductive_predicate(predicate))
+        cycle.all(|predicate| {
+            debug!(?predicate, "coinductive_match");
+            self.coinductive_predicate(predicate)
+        })
     }
 
     fn coinductive_predicate(&self, predicate: ty::Predicate<'tcx>) -> bool {
@@ -1572,8 +1575,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         // NOTE: binder moved to (*)
         let self_ty = self.infcx.shallow_resolve(obligation.predicate.skip_binder().self_ty());
+        debug!(?self_ty, "sized_conditions");
 
-        match self_ty.kind() {
+        match *self_ty.kind() {
             ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
             | ty::Uint(_)
             | ty::Int(_)

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -193,7 +193,7 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AdtSizedConstrain
     let result = tcx.mk_type_list(
         def.variants
             .iter()
-            .flat_map(|v| v.fields.last())
+            .flat_map(|v| &v.fields)
             .flat_map(|f| sized_constraint_for_ty(tcx, def, tcx.type_of(f.did))),
     );
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -1978,6 +1978,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
 
     let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
     let node = tcx.hir().get(hir_id);
+    debug!("explicit_predicates_of: node = {:?}", node);
 
     let mut is_trait = None;
     let mut is_default_impl_trait = None;
@@ -2070,6 +2071,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
     if let Some(_trait_ref) = is_trait {
         predicates.extend(tcx.super_predicates_of(def_id).predicates.iter().cloned());
     }
+    debug!("explicit_predicates_of: super predicates = {:?}", predicates);
 
     // In default impls, we can assume that the self type implements
     // the trait. So in:
@@ -2085,6 +2087,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
             tcx.def_span(def_id),
         ));
     }
+    debug!("explicit_predicates_of: default impls = {:?}", predicates);
 
     // Collect the region predicates that were declared inline as
     // well. In the case of parameters declared on a fn or method, we
@@ -2113,6 +2116,8 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
         }
     }
 
+    debug!("explicit_predicates_of: region predicates = {:?}", predicates);
+
     // Collect the predicates that were written inline by the user on each
     // type parameter (e.g., `<T: Foo>`).
     for param in ast_generics.params {
@@ -2132,6 +2137,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
                     sized,
                     param.span,
                 );
+                debug!("explicit_predicates_of: bounds = {:?}", bounds);
                 predicates.extend(bounds.predicates(tcx, param_ty));
             }
             GenericParamKind::Const { .. } => {
@@ -2141,6 +2147,8 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
             }
         }
     }
+
+    debug!("explicit_predicates_of: inline predicates = {:?}", predicates);
 
     // Add in the bounds that appear in the where-clause.
     let where_clause = &ast_generics.where_clause;
@@ -2251,8 +2259,11 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
         }
     }
 
+    debug!("explicit_predicates_of: where predicates = {:?}", predicates);
+
     if tcx.features().const_evaluatable_checked {
         predicates.extend(const_evaluatable_predicates_of(tcx, def_id.expect_local()));
+        debug!("explicit_predicates_of: const predicates = {:?}", predicates);
     }
 
     let mut predicates: Vec<_> = predicates.into_iter().collect();

--- a/src/test/ui/generic-associated-types/issue-80626-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-80626-pass.rs
@@ -1,0 +1,60 @@
+#![feature(generic_associated_types)]
+
+// check-pass
+
+trait Allocator {
+    type Allocated<T: ?Sized>;
+}
+
+enum LinkedList<A: Allocator> {
+    Head,
+    Next(u8, A::Allocated<Self>),
+}
+
+enum LinkedList2<A: Allocator> {
+    Head,
+    Next(A::Allocated<Self>, u8),
+}
+
+impl Allocator for () {
+    type Allocated<T: ?Sized> = Box<T>;
+}
+
+fn main() {
+    {
+        use LinkedList::{Head, Next};
+        let mut ll: LinkedList<()> = Next(
+            8,
+            Box::new(Next(
+                0,
+                Box::new(Next(
+                    6,
+                    Box::new(Next(2, Box::new(Next(6, Box::new(Head))))),
+                )),
+            )),
+        );
+
+        while let Next(num, next) = ll {
+            println!("{}", num);
+            ll = *next;
+        }
+    }
+    {
+        use LinkedList2::{Head, Next};
+        let mut ll: LinkedList2<()> = Next(
+            Box::new(Next(
+                Box::new(Next(
+                    Box::new(Next(Box::new(Next(Box::new(Head), 6)), 2)),
+                    6,
+                )),
+                0,
+            )),
+            8,
+        );
+
+        while let Next(next, num) = ll {
+            println!("{}", num);
+            ll = *next;
+        }
+    }
+}

--- a/src/test/ui/generic-associated-types/issue-80626.rs
+++ b/src/test/ui/generic-associated-types/issue-80626.rs
@@ -1,0 +1,60 @@
+#![feature(generic_associated_types)]
+
+trait Allocator {
+    type Allocated<T>;
+    //~^ HELP consider relaxing
+    //~| HELP consider relaxing
+}
+
+enum LinkedList<A: Allocator> {
+    Head,
+    Next(u8, A::Allocated<Self>), //~ ERROR overflow evaluating the requirement
+}
+
+enum LinkedList2<A: Allocator> {
+    Head,
+    Next(A::Allocated<Self>, u8), //~ ERROR overflow evaluating the requirement
+}
+
+impl Allocator for () {
+    type Allocated<T> = Box<T>;
+}
+
+fn main() {
+    {
+        use LinkedList::{Head, Next};
+        let mut ll: LinkedList<()> = Next(
+            8,
+            Box::new(Next(
+                0,
+                Box::new(Next(
+                    6,
+                    Box::new(Next(2, Box::new(Next(6, Box::new(Head))))),
+                )),
+            )),
+        );
+
+        while let Next(num, next) = ll {
+            println!("{}", num);
+            ll = *next;
+        }
+    }
+    {
+        use LinkedList2::{Head, Next};
+        let mut ll: LinkedList2<()> = Next(
+            Box::new(Next(
+                Box::new(Next(
+                    Box::new(Next(Box::new(Next(Box::new(Head), 6)), 2)),
+                    6,
+                )),
+                0,
+            )),
+            8,
+        );
+
+        while let Next(next, num) = ll {
+            println!("{}", num);
+            ll = *next;
+        }
+    }
+}

--- a/src/test/ui/generic-associated-types/issue-80626.stderr
+++ b/src/test/ui/generic-associated-types/issue-80626.stderr
@@ -1,0 +1,27 @@
+error[E0275]: overflow evaluating the requirement `<A as Allocator>::Allocated<LinkedList<A>>: Sized`
+  --> $DIR/issue-80626.rs:11:14
+   |
+LL |     Next(u8, A::Allocated<Self>),
+   |              ^^^^^^^^^^^^^^^^^^
+   |
+   = note: detected recursive derive for `Sized` in a generic associated type
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Allocated<T: ?Sized>;
+   |                     ^^^^^^^^
+
+error[E0275]: overflow evaluating the requirement `<A as Allocator>::Allocated<LinkedList2<A>>: Sized`
+  --> $DIR/issue-80626.rs:16:10
+   |
+LL |     Next(A::Allocated<Self>, u8),
+   |          ^^^^^^^^^^^^^^^^^^
+   |
+   = note: detected recursive derive for `Sized` in a generic associated type
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Allocated<T: ?Sized>;
+   |                     ^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Fixes #80626

- Implemented a new error message recommending the user to add a `?Sized` constraint in case a recursive GAT is found.
- Fixed a bug where a type would not be constrained to be `Sized` if it wasn't on the last position of an ADT.
- Added tests for both fixes.