### PR TITLE
Escape item search summaries

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -34,14 +34,13 @@ use std::str;
 use crate::clean::RenderedLink;
 use crate::doctest;
 use crate::html::escape::Escape;
+use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::toc::TocBuilder;
 
 use pulldown_cmark::{
     html, BrokenLink, CodeBlockKind, CowStr, Event, LinkType, Options, Parser, Tag,
 };
-
-use super::format::Buffer;
 
 #[cfg(test)]
 mod tests;
@@ -1086,7 +1085,7 @@ fn markdown_summary_with_limit(
     let mut stopped_early = false;
 
     fn push(s: &mut String, text_length: &mut usize, text: &str) {
-        s.push_str(text);
+        write!(s, "{}", Escape(text)).unwrap();
         *text_length += text.len();
     }
 

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -234,7 +234,17 @@ fn test_short_markdown_summary() {
     t("hello [Rust](https://www.rust-lang.org \"Rust\") :)", "hello Rust :)");
     t("dud [link]", "dud [link]");
     t("code `let x = i32;` ...", "code <code>let x = i32;</code> …");
-    t("type `Type<'static>` ...", "type <code>Type<'static></code> …");
+    t("type `Type<'static>` ...", "type <code>Type&lt;&#39;static&gt;</code> …");
+    // Test to ensure escaping and length-limiting work well together.
+    // The output should be limited based on the input length,
+    // rather than the output, because escaped versions of characters
+    // are usually longer than how the character is actually displayed.
+    t(
+        "& & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & & &",
+        "&amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; \
+         &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; \
+         &amp; &amp; &amp; &amp; &amp; …",
+    );
     t("# top header", "top header");
     t("# top header\n\nfollowed by a paragraph", "top header");
     t("## header", "header");


### PR DESCRIPTION
I noticed that `Pin::new()`'s search summary looked off, and I realized
that the reason is that it has inline code containing `Pin<P>`, which is
not escaped and thus renders as a paragraph tag!
