### PR TITLE
Make two Paths unequal if they differ in trailing slash

### DIFF
--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1551,6 +1551,11 @@ fn test_trailing_separator() {
         assert_eq!(dir, Path::new(r"tmp\f\\"));
     }
 
+    let dir_dot = Path::new("tmp/f/.");
+    assert_ne!(file, dir_dot);
+    assert!(file < dir_dot);
+    assert_eq!(dir, dir_dot);
+
     let file = file.to_owned();
     let dir = dir.to_owned();
     assert_ne!(file, dir);
@@ -1658,9 +1663,15 @@ fn test_ord() {
     ord!(Less, "foo/./bar", "foo/bar/");
     ord!(Equal, "foo/./bar/", "foo/bar/");
     ord!(Less, "foo/bar", "foo/bar/");
-    ord!(Equal, "foo/bar", "foo/bar/.");
+    ord!(Less, "foo/bar", "foo/bar/.");
     ord!(Less, "foo/bar", "foo/bar//");
     ord!(Equal, "foo/bar/", "foo/bar//");
+    ord!(Equal, "foo/bar/", "foo/bar/.");
+    ord!(Equal, "foo/bar/", "foo/bar/./");
+    ord!(Equal, "foo/bar/", "foo/bar/./.");
+    ord!(Less, "/", "./");
+    ord!(Equal, ".", "./");
+    ord!(Equal, ".", "./.");
 }
 
 #[bench]


### PR DESCRIPTION
It seems problematic to consider two paths equal if one of them can exist when the other does not exist.

In the previous behavior, the following asserts pass:

```rust
use std::path::Path;

fn main() {
    let path1 = Path::new("/etc/passwd");
    let path2 = Path::new("/etc/passwd/");

    assert_eq!(path1, path2);

    assert!(path1.metadata().is_ok());

    // Err: Os { code: 20, kind: Other, message: "Not a directory" }
    assert!(path2.metadata().is_err());
}
```

In this PR `path1 == path2` becomes false.