### PR TITLE
Prefer suggestion paths which are not doc-hidden 

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -580,3 +580,12 @@ impl NestedMetaItem {
         MetaItem::from_tokens(tokens).map(NestedMetaItem::MetaItem)
     }
 }
+
+/// Return true if the attributes contain `#[doc(hidden)]`
+pub fn is_doc_hidden(attrs: &[ast::Attribute]) -> bool {
+    attrs
+        .iter()
+        .filter(|attr| attr.has_name(sym::doc))
+        .filter_map(ast::Attribute::meta_item_list)
+        .any(|l| list_contains_name(&l, sym::hidden))
+}

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -346,9 +346,11 @@ where
     }
 }
 
-impl<A, CTX> HashStable<CTX> for SmallVec<[A; 1]>
+impl<T, CTX, const N: usize> HashStable<CTX> for SmallVec<[T; N]>
 where
-    A: HashStable<CTX>,
+    T: HashStable<CTX>,
+    [T; N]: smallvec::Array,
+    <[T; N] as smallvec::Array>::Item: HashStable<CTX>,
 {
     #[inline]
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -977,8 +977,8 @@ rustc_queries! {
     }
 
     /// Gets the span for the identifier of the definition.
-    query def_ident_span(def_id: DefId) -> Option<Span> {
-        desc { |tcx| "looking up span for `{}`'s identifier", tcx.def_path_str(def_id) }
+    query def_ident(def_id: DefId) -> Option<Ident> {
+        desc { |tcx| "looking up ident for `{}`'s identifier", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
@@ -1552,9 +1552,13 @@ rustc_queries! {
         desc { "calculating the missing lang items in a crate" }
         separate_provide_extern
     }
-    query visible_parent_map(_: ()) -> DefIdMap<DefId> {
+
+    query visible_parents_map(_: ()) -> DefIdMap<smallvec::SmallVec<[DefId; 4]>> {
         storage(ArenaCacheSelector<'tcx>)
         desc { "calculating the visible parent map" }
+    }
+    query best_visible_parent(child: DefId) -> Option<DefId> {
+        desc { "calculating best visible parent" }
     }
     query trimmed_def_paths(_: ()) -> FxHashMap<DefId, Symbol> {
         storage(ArenaCacheSelector<'tcx>)

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -30,7 +30,7 @@ use crate::traits::specialization_graph;
 use crate::traits::{self, ImplSource};
 use crate::ty::subst::{GenericArg, SubstsRef};
 use crate::ty::util::AlwaysRequiresDrop;
-use crate::ty::{self, AdtSizedConstraint, CrateInherentImpls, ParamEnvAnd, Ty, TyCtxt};
+use crate::ty::{self, AdtSizedConstraint, CrateInherentImpls, Ident, ParamEnvAnd, Ty, TyCtxt};
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_data_structures::steal::Steal;

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -197,8 +197,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
 
             if let Some(def_id) = def_id {
-                if let Some(def_span) = tcx.def_ident_span(def_id) {
-                    let mut spans: MultiSpan = def_span.into();
+                if let Some(def_ident) = tcx.def_ident(def_id) {
+                    let mut spans: MultiSpan = def_ident.span.into();
 
                     let params = tcx
                         .hir()

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -12,7 +12,7 @@ use rustc_hir::{ExprKind, Node, QPath};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_middle::ty::fast_reject::{simplify_type, SimplifyParams, StripReferences};
 use rustc_middle::ty::print::with_crate_prefix;
-use rustc_middle::ty::{self, DefIdTree, ToPredicate, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable};
 use rustc_span::lev_distance;
 use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::{source_map, FileName, MultiSpan, Span, Symbol};
@@ -1310,17 +1310,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         mut msg: String,
         candidates: Vec<DefId>,
     ) {
-        let parent_map = self.tcx.visible_parent_map(());
-
         // Separate out candidates that must be imported with a glob, because they are named `_`
         // and cannot be referred with their identifier.
         let (candidates, globs): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|trait_did| {
-            if let Some(parent_did) = parent_map.get(trait_did) {
+            if let Some(parent_did) = self.tcx.best_visible_parent(*trait_did) {
                 // If the item is re-exported as `_`, we should suggest a glob-import instead.
-                if Some(*parent_did) != self.tcx.parent(*trait_did)
+                if Some(parent_did) != self.tcx.best_visible_parent(*trait_did)
                     && self
                         .tcx
-                        .item_children(*parent_did)
+                        .item_children(parent_did)
                         .iter()
                         .filter(|child| child.res.opt_def_id() == Some(*trait_did))
                         .all(|child| child.ident.name == kw::Underscore)
@@ -1347,14 +1345,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
 
             let glob_path_strings = globs.iter().map(|trait_did| {
-                let parent_did = parent_map.get(trait_did).unwrap();
-
                 // Produce an additional newline to separate the new use statement
                 // from the directly following item.
                 let additional_newline = if found_use { "" } else { "\n" };
                 format!(
                     "use {}::*; // trait {}\n{}",
-                    with_crate_prefix(|| self.tcx.def_path_str(*parent_did)),
+                    with_crate_prefix(|| self
+                        .tcx
+                        .def_path_str(self.tcx.best_visible_parent(*trait_did).unwrap())),
                     self.tcx.item_name(*trait_did),
                     additional_newline
                 )
@@ -1385,19 +1383,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             for (i, trait_did) in
                 globs.iter().take(limit.saturating_sub(candidates.len())).enumerate()
             {
-                let parent_did = parent_map.get(trait_did).unwrap();
+                let parent_did = self.tcx.best_visible_parent(*trait_did).unwrap();
 
                 if candidates.len() + globs.len() > 1 {
                     msg.push_str(&format!(
                         "\ncandidate #{}: `use {}::*; // trait {}`",
                         candidates.len() + i + 1,
-                        with_crate_prefix(|| self.tcx.def_path_str(*parent_did)),
+                        with_crate_prefix(|| self.tcx.def_path_str(parent_did)),
                         self.tcx.item_name(*trait_did),
                     ));
                 } else {
                     msg.push_str(&format!(
                         "\n`use {}::*; // trait {}`",
-                        with_crate_prefix(|| self.tcx.def_path_str(*parent_did)),
+                        with_crate_prefix(|| self.tcx.def_path_str(parent_did)),
                         self.tcx.item_name(*trait_did),
                     ));
                 }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1025,7 +1025,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         let last_subpat_span = *subpat_spans.last().unwrap();
         let res_span = self.tcx.def_span(res.def_id());
-        let def_ident_span = self.tcx.def_ident_span(res.def_id()).unwrap_or(res_span);
+        let def_ident_span =
+            self.tcx.def_ident(res.def_id()).map(|ident| ident.span).unwrap_or(res_span);
         let field_def_spans = if fields.is_empty() {
             vec![res_span]
         } else {

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -730,9 +730,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
     /// Builds the `type defined here` message.
     fn show_definition(&self, err: &mut DiagnosticBuilder<'_>) {
-        let mut spans: MultiSpan = if let Some(def_span) = self.tcx.def_ident_span(self.def_id) {
-            if self.tcx.sess.source_map().span_to_snippet(def_span).is_ok() {
-                def_span.into()
+        let mut spans: MultiSpan = if let Some(def_ident) = self.tcx.def_ident(self.def_id) {
+            if self.tcx.sess.source_map().span_to_snippet(def_ident.span).is_ok() {
+                def_ident.span.into()
             } else {
                 return;
             }

--- a/src/test/ui/proc-macro/issue-37788.rs
+++ b/src/test/ui/proc-macro/issue-37788.rs
@@ -4,6 +4,6 @@
 extern crate test_macros;
 
 fn main() {
-    // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
+    // Test that constructing the `visible_parents_map` (in `cstore_impl.rs`) does not ICE.
     std::cell::Cell::new(0) //~ ERROR mismatched types
 }

--- a/src/test/ui/proc-macro/issue-37788.stderr
+++ b/src/test/ui/proc-macro/issue-37788.stderr
@@ -3,7 +3,7 @@ error[E0308]: mismatched types
    |
 LL | fn main() {
    |           - expected `()` because of default return type
-LL |     // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
+LL |     // Test that constructing the `visible_parents_map` (in `cstore_impl.rs`) does not ICE.
 LL |     std::cell::Cell::new(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
    |     |

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+
+extern crate core;
+
+#[doc(hidden)]
+pub mod __private {
+	pub use core::option::Option::{self, None, Some};
+}

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/auxiliary/other_crate.rs
@@ -4,5 +4,5 @@ extern crate core;
 
 #[doc(hidden)]
 pub mod __private {
-	pub use core::option::Option::{self, None, Some};
+    pub use core::option::Option::{self, None, Some};
 }

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.rs
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.rs
@@ -1,0 +1,7 @@
+// aux-build:other_crate.rs
+
+extern crate other_crate;
+
+fn main() {
+    let x: Option<i32> = 1i32; //~ ERROR 6:26: 6:30: mismatched types [E0308]
+}

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
@@ -2,14 +2,16 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-doc-hidden-variant-for-enum.rs:6:26
    |
 LL |     let x: Option<i32> = 1i32;
-   |            -----------   ^^^^
-   |            |             |
-   |            |             expected enum `Option`, found `i32`
-   |            |             help: try using a variant of the expected enum: `Some(1i32)`
+   |            -----------   ^^^^ expected enum `Option`, found `i32`
+   |            |
    |            expected due to this
    |
    = note: expected enum `Option<i32>`
               found type `i32`
+help: try wrapping the expression in `Some`
+   |
+LL |     let x: Option<i32> = Some(1i32);
+   |                          +++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
+++ b/src/test/ui/suggestions/dont-suggest-doc-hidden-variant-for-enum/dont-suggest-doc-hidden-variant-for-enum.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-doc-hidden-variant-for-enum.rs:6:26
+   |
+LL |     let x: Option<i32> = 1i32;
+   |            -----------   ^^^^
+   |            |             |
+   |            |             expected enum `Option`, found `i32`
+   |            |             help: try using a variant of the expected enum: `Some(1i32)`
+   |            expected due to this
+   |
+   = note: expected enum `Option<i32>`
+              found type `i32`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -1,4 +1,3 @@
-use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_note, span_lint_and_then};
 use clippy_utils::source::{first_line_of_span, snippet_with_applicability};
 use clippy_utils::ty::{implements_trait, is_type_diagnostic_item};
@@ -7,6 +6,7 @@ use if_chain::if_chain;
 use itertools::Itertools;
 use rustc_ast::ast::{Async, AttrKind, Attribute, Fn, FnRetTy, ItemKind};
 use rustc_ast::token::CommentKind;
+use rustc_ast::attr::is_doc_hidden;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::emitter::EmitterWriter;

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -1,9 +1,9 @@
-use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::{meets_msrv, msrvs};
 use if_chain::if_chain;
 use rustc_ast::ast::{FieldDef, Item, ItemKind, Variant, VariantData, VisibilityKind};
+use rustc_ast::attr::is_doc_hidden;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_semver::RustcVersion;

--- a/src/tools/clippy/clippy_lints/src/matches.rs
+++ b/src/tools/clippy/clippy_lints/src/matches.rs
@@ -15,7 +15,7 @@ use clippy_utils::{
 use clippy_utils::{paths, search_same, SpanlessEq, SpanlessHash};
 use core::iter::{once, ExactSizeIterator};
 use if_chain::if_chain;
-use rustc_ast::ast::{Attribute, LitKind};
+use rustc_ast::{ast::{LitKind, Attribute}, attr::is_doc_hidden};
 use rustc_errors::Applicability;
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::LangItem::{OptionNone, OptionSome};
@@ -1021,7 +1021,8 @@ impl CommonPrefixSearcher<'a> {
 
 fn is_hidden(cx: &LateContext<'_>, variant_def: &VariantDef) -> bool {
     let attrs = cx.tcx.get_attrs(variant_def.def_id);
-    clippy_utils::attrs::is_doc_hidden(attrs) || clippy_utils::attrs::is_unstable(attrs)
+
+    is_doc_hidden(attrs) || clippy_utils::attrs::is_unstable(attrs)
 }
 
 #[allow(clippy::too_many_lines)]

--- a/src/tools/clippy/clippy_lints/src/missing_doc.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_doc.rs
@@ -5,9 +5,8 @@
 // [`missing_doc`]: https://github.com/rust-lang/rust/blob/cf9cf7c923eb01146971429044f216a3ca905e06/compiler/rustc_lint/src/builtin.rs#L415
 //
 
-use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::span_lint;
-use rustc_ast::ast;
+use rustc_ast::{ast, attr::is_doc_hidden};
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty;

--- a/src/tools/clippy/clippy_utils/src/attrs.rs
+++ b/src/tools/clippy/clippy_utils/src/attrs.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{ast, attr};
+use rustc_ast::ast;
 use rustc_errors::Applicability;
 use rustc_session::Session;
 use rustc_span::sym;
@@ -146,15 +146,6 @@ pub fn get_unique_inner_attr(sess: &Session, attrs: &[ast::Attribute], name: &'s
 /// `proc_macro_derive` or `proc_macro_attribute`, false otherwise
 pub fn is_proc_macro(sess: &Session, attrs: &[ast::Attribute]) -> bool {
     attrs.iter().any(|attr| sess.is_proc_macro_attr(attr))
-}
-
-/// Return true if the attributes contain `#[doc(hidden)]`
-pub fn is_doc_hidden(attrs: &[ast::Attribute]) -> bool {
-    attrs
-        .iter()
-        .filter(|attr| attr.has_name(sym::doc))
-        .filter_map(ast::Attribute::meta_item_list)
-        .any(|l| attr::list_contains_name(&l, sym::hidden))
 }
 
 /// Return true if the attributes contain `#[unstable]`


### PR DESCRIPTION
There are cases (as clearly shown in test) when compiler will prefer doc-hidden public reexport of item which is available at alternative path.

```rust
extern crate serde;

fn main() {
    let x: Option<i32> = 1i32; // This suggests `serde::__private::Some(1i32)`, but should suggest `Some(1i32)`
}
```