### PR TITLE
Update my name/email in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -175,6 +175,7 @@ Lennart Kudling <github@kudling.de>
 Léo Lanteri Thauvin <leseulartichaut@gmail.com>
 Léo Lanteri Thauvin <leseulartichaut@gmail.com> <38361244+LeSeulArtichaut@users.noreply.github.com>
 Léo Testard <leo.testard@gmail.com>
+Lily Ballard <lily@ballards.net> <kevin@sb.org>
 Lindsey Kuper <lindsey@composition.al> <lindsey@rockstargirl.org>
 Lindsey Kuper <lindsey@composition.al> <lkuper@mozilla.com>
 Luke Metz <luke.metz@students.olin.edu>


### PR DESCRIPTION
I should have done this years ago.

My name is also scattered across many other rust-lang repos, but none of the other repos I've looked at have a `.mailmap`. Is there any particular reason for this, or any process for updating my name/email everywhere?