### PR TITLE
Remove detection of rustup and cargo in 'missing extern crate' diagnostics

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1080,7 +1080,10 @@ impl CrateError {
                                 locator.triple
                             ));
                         }
-                        if missing_core && std::env::var("RUSTUP_HOME").is_ok() {
+                        // NOTE: this suggests using rustup, even though the user may not have it installed.
+                        // That's because they could choose to install it; or this may give them a hint which
+                        // target they need to install from their distro.
+                        if missing_core {
                             err.help(&format!(
                                 "consider downloading the target with `rustup target add {}`",
                                 locator.triple
@@ -1097,7 +1100,7 @@ impl CrateError {
                                 current_crate
                             ));
                         }
-                        if sess.is_nightly_build() && std::env::var("CARGO").is_ok() {
+                        if sess.is_nightly_build() {
                             err.help("consider building the standard library from source with `cargo build -Zbuild-std`");
                         }
                     } else if Some(crate_name)

--- a/src/test/ui/crate-loading/missing-std.rs
+++ b/src/test/ui/crate-loading/missing-std.rs
@@ -1,7 +1,6 @@
 // compile-flags: --target x86_64-unknown-uefi
 // needs-llvm-components: x86
 // rustc-env:CARGO=/usr/bin/cargo
-// rustc-env:RUSTUP_HOME=/home/bors/.rustup
 #![no_core]
 extern crate core;
 //~^ ERROR can't find crate for `core`

--- a/src/test/ui/crate-loading/missing-std.stderr
+++ b/src/test/ui/crate-loading/missing-std.stderr
@@ -1,5 +1,5 @@
 error[E0463]: can't find crate for `core`
-  --> $DIR/missing-std.rs:6:1
+  --> $DIR/missing-std.rs:5:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ can't find crate

--- a/src/test/ui/issues/issue-37131.stderr
+++ b/src/test/ui/issues/issue-37131.stderr
@@ -1,6 +1,8 @@
 error[E0463]: can't find crate for `std`
    |
    = note: the `thumbv6m-none-eabi` target may not be installed
+   = help: consider downloading the target with `rustup target add thumbv6m-none-eabi`
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-49851/compiler-builtins-error.stderr
+++ b/src/test/ui/issues/issue-49851/compiler-builtins-error.stderr
@@ -1,6 +1,8 @@
 error[E0463]: can't find crate for `core`
    |
    = note: the `thumbv7em-none-eabihf` target may not be installed
+   = help: consider downloading the target with `rustup target add thumbv7em-none-eabihf`
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Previously, this would change the test output when RUSTUP_HOME was set:

```
---- [ui] ui/issues/issue-49851/compiler-builtins-error.rs stdout ----
diff of stderr:

1       error[E0463]: can't find crate for `core`
2          |
3          = note: the `thumbv7em-none-eabihf` target may not be installed
+          = help: consider downloading the target with `rustup target add thumbv7em-none-eabihf`
4
5       error: aborting due to previous error
6
```

Originally, I fixed it by explicitly unsetting RUSTUP_HOME in
compiletest. Then I realized that almost no one has RUSTUP_HOME set,
since rustup doesn't set it itself. It does set RUST_RECURSION_COUNT
whenever it launches a proxy, though - use that instead.

r? @estebank cc @petrochenkov @kinnison