### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_middle/src/ich/impls_syntax.rs
+++ b/compiler/rustc_middle/src/ich/impls_syntax.rs
@@ -6,6 +6,7 @@ use crate::ich::StableHashingContext;
 use rustc_ast as ast;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_span::{BytePos, NormalizedPos, SourceFile};
+use std::assert::assert_matches;
 
 use smallvec::SmallVec;
 

--- a/compiler/rustc_middle/src/ich/impls_syntax.rs
+++ b/compiler/rustc_middle/src/ich/impls_syntax.rs
@@ -6,7 +6,7 @@ use crate::ich::StableHashingContext;
 use rustc_ast as ast;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_span::{BytePos, NormalizedPos, SourceFile};
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 use smallvec::SmallVec;
 

--- a/compiler/rustc_mir/src/interpret/memory.rs
+++ b/compiler/rustc_mir/src/interpret/memory.rs
@@ -6,6 +6,7 @@
 //! integer. It is crucial that these operations call `check_align` *before*
 //! short-circuiting the empty case!
 
+use std::assert::assert_matches;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};

--- a/compiler/rustc_mir/src/interpret/memory.rs
+++ b/compiler/rustc_mir/src/interpret/memory.rs
@@ -6,7 +6,7 @@
 //! integer. It is crucial that these operations call `check_align` *before*
 //! short-circuiting the empty case!
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -187,7 +187,7 @@ mod macros;
 #[cfg(not(test))]
 #[unstable(feature = "assert_matches", issue = "82775")]
 /// Unstable module containing the unstable `assert_matches` macro.
-pub mod assert {
+pub mod assert_matches {
     #[unstable(feature = "assert_matches", issue = "82775")]
     pub use crate::macros::{assert_matches, debug_assert_matches};
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -182,6 +182,16 @@ use prelude::v1::*;
 #[macro_use]
 mod macros;
 
+// We don't export this through #[macro_export] for now, to avoid breakage.
+// See https://github.com/rust-lang/rust/issues/82913
+#[cfg(not(test))]
+#[unstable(feature = "assert_matches", issue = "82775")]
+/// Unstable module containing the unstable `assert_matches` macro.
+pub mod assert {
+    #[unstable(feature = "assert_matches", issue = "82775")]
+    pub use crate::macros::{assert_matches, debug_assert_matches};
+}
+
 #[macro_use]
 mod internal_macros;
 

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -126,6 +126,8 @@ macro_rules! assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
+/// use std::assert::assert_matches;
+///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
 /// assert_matches!(a, Some(_));
@@ -134,10 +136,10 @@ macro_rules! assert_ne {
 /// let c = Ok("abc".to_string());
 /// assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
-#[macro_export]
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(core_panic)]
-macro_rules! assert_matches {
+#[rustc_macro_transparency = "semitransparent"]
+pub macro assert_matches {
     ($left:expr, $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => ({
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
@@ -149,7 +151,7 @@ macro_rules! assert_matches {
                 );
             }
         }
-    });
+    }),
     ($left:expr, $( $pattern:pat_param )|+ $( if $guard: expr )?, $($arg:tt)+) => ({
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
@@ -161,7 +163,7 @@ macro_rules! assert_matches {
                 );
             }
         }
-    });
+    }),
 }
 
 /// Asserts that a boolean expression is `true` at runtime.
@@ -283,6 +285,8 @@ macro_rules! debug_assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
+/// use std::assert::debug_assert_matches;
+///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
 /// debug_assert_matches!(a, Some(_));
@@ -294,8 +298,9 @@ macro_rules! debug_assert_ne {
 #[macro_export]
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(assert_matches)]
-macro_rules! debug_assert_matches {
-    ($($arg:tt)*) => (if $crate::cfg!(debug_assertions) { $crate::assert_matches!($($arg)*); })
+#[rustc_macro_transparency = "semitransparent"]
+pub macro debug_assert_matches($($arg:tt)*) {
+    if $crate::cfg!(debug_assertions) { $crate::assert::assert_matches!($($arg)*); }
 }
 
 /// Returns whether the given expression matches any of the given patterns.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -126,7 +126,7 @@ macro_rules! assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert::assert_matches;
+/// use std::assert_matches::assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);
@@ -300,7 +300,7 @@ macro_rules! debug_assert_ne {
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro debug_assert_matches($($arg:tt)*) {
-    if $crate::cfg!(debug_assertions) { $crate::assert::assert_matches!($($arg)*); }
+    if $crate::cfg!(debug_assertions) { $crate::assert_matches::assert_matches!($($arg)*); }
 }
 
 /// Returns whether the given expression matches any of the given patterns.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -285,7 +285,7 @@ macro_rules! debug_assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert::debug_assert_matches;
+/// use std::assert_matches::debug_assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
 /// let b = 1u32.checked_sub(2);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -560,9 +560,9 @@ pub use core::{
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 pub use core::{
-    asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
-    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
-    module_path, option_env, stringify, trace_macros,
+    asm, assert, assert_matches, cfg, column, compile_error, concat, concat_idents, env, file,
+    format_args, format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm,
+    log_syntax, module_path, option_env, stringify, trace_macros,
 };
 
 #[stable(feature = "core_primitive", since = "1.43.0")]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -552,8 +552,8 @@ pub use std_detect::{
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated, deprecated_in_future)]
 pub use core::{
-    assert_eq, assert_matches, assert_ne, debug_assert, debug_assert_eq, debug_assert_matches,
-    debug_assert_ne, matches, r#try, todo, unimplemented, unreachable, write, writeln,
+    assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne, matches, r#try, todo,
+    unimplemented, unreachable, write, writeln,
 };
 
 // Re-export built-in macros defined through libcore.

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -139,11 +139,15 @@ macro_rules! install {
 
 install!((self, builder, _config),
     Docs, "src/doc", _config.docs, only_hosts: false, {
+        // `expect` should be safe, only None when config.docs is false,
+        // which is guarded in `should_run`
         let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
         install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
     };
     Std, "library/std", true, only_hosts: false, {
         for target in &builder.targets {
+            // `expect` should be safe, only None when host != build, but this
+            // only runs when host == build
             let tarball = builder.ensure(dist::Std {
                 compiler: self.compiler,
                 target: *target
@@ -217,6 +221,8 @@ install!((self, builder, _config),
         }
     };
     Analysis, "analysis", Self::should_build(_config), only_hosts: false, {
+        // `expect` should be safe, only None with host != build, but this
+        // only uses the `build` compiler
         let tarball = builder.ensure(dist::Analysis {
             // Find the actual compiler (handling the full bootstrap option) which
             // produced the save-analysis data because that data isn't copied

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -165,10 +165,15 @@ install!((self, builder, _config),
         }
     };
     RustAnalyzer, "rust-analyzer", Self::should_build(_config), only_hosts: true, {
-        let tarball = builder
-            .ensure(dist::RustAnalyzer { compiler: self.compiler, target: self.target })
-            .expect("missing rust-analyzer");
-        install_sh(builder, "rust-analyzer", self.compiler.stage, Some(self.target), &tarball);
+        if let Some(tarball) =
+            builder.ensure(dist::RustAnalyzer { compiler: self.compiler, target: self.target })
+        {
+            install_sh(builder, "rust-analyzer", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install rust-analyzer stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
     };
     Clippy, "clippy", Self::should_build(_config), only_hosts: true, {
         let tarball = builder.ensure(dist::Clippy { compiler: self.compiler, target: self.target });

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -139,10 +139,12 @@ macro_rules! install {
 
 install!((self, builder, _config),
     Docs, "src/doc", _config.docs, only_hosts: false, {
-        // `expect` should be safe, only None when config.docs is false,
-        // which is guarded in `should_run`
-        let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
-        install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
+        if let Some(tarball) = builder.ensure(dist::Docs { host: self.target }) {
+            install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            panic!("docs are not available to install, \
+                check that `build.docs` is true in `config.toml`");
+        }
     };
     Std, "library/std", true, only_hosts: false, {
         for target in &builder.targets {

--- a/src/test/ui/macros/assert-matches-macro-msg.rs
+++ b/src/test/ui/macros/assert-matches-macro-msg.rs
@@ -6,6 +6,8 @@
 
 #![feature(assert_matches)]
 
+use std::assert::assert_matches;
+
 fn main() {
     assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");
 }

--- a/src/test/ui/macros/assert-matches-macro-msg.rs
+++ b/src/test/ui/macros/assert-matches-macro-msg.rs
@@ -6,7 +6,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 fn main() {
     assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");

--- a/src/test/ui/matches2021.rs
+++ b/src/test/ui/matches2021.rs
@@ -6,6 +6,8 @@
 
 #![feature(assert_matches)]
 
+use std::assert::assert_matches;
+
 fn main() {
     assert!(matches!((), ()));
     assert_matches!((), ());

--- a/src/test/ui/matches2021.rs
+++ b/src/test/ui/matches2021.rs
@@ -6,7 +6,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert::assert_matches;
+use std::assert_matches::assert_matches;
 
 fn main() {
     assert!(matches!((), ()));

--- a/src/test/ui/resolve/resolve-hint-macro.rs
+++ b/src/test/ui/resolve/resolve-hint-macro.rs
@@ -1,4 +1,4 @@
 fn main() {
-    assert(true);
-    //~^ ERROR expected function, found macro `assert`
+    assert_eq(1, 1);
+    //~^ ERROR expected function, found macro `assert_eq`
 }

--- a/src/test/ui/resolve/resolve-hint-macro.stderr
+++ b/src/test/ui/resolve/resolve-hint-macro.stderr
@@ -1,13 +1,13 @@
-error[E0423]: expected function, found macro `assert`
+error[E0423]: expected function, found macro `assert_eq`
   --> $DIR/resolve-hint-macro.rs:2:5
    |
-LL |     assert(true);
-   |     ^^^^^^ not a function
+LL |     assert_eq(1, 1);
+   |     ^^^^^^^^^ not a function
    |
 help: use `!` to invoke the macro
    |
-LL |     assert!(true);
-   |           ^
+LL |     assert_eq!(1, 1);
+   |              ^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Backports:

* Move assert_matches to an inner module #86947
* rename assert_matches module #87195
* Fix rust-analyzer install when not available. #87007

Fixes #82913