### PR TITLE
Change rustdoc logo to use the full container size

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -329,6 +329,7 @@ nav.sub {
 .logo-container > img {
 	max-width: 100px;
 	max-height: 100px;
+	height: 100%;
 	position: absolute;
 	left: 50%;
 	top: 50%;


### PR DESCRIPTION
We have a logo in svg that scales nicely to large sizes, but by default
is only 5px large, i.e. very small. With the change the logo expands to
the full size. By only setting the height to 100% we ensure that the
width-height ratio isn't changed.