### PR TITLE
Prevent opaque types in impl headers

### DIFF
--- a/src/test/ui/impl-trait/auto-trait.full_tait.stderr
+++ b/src/test/ui/impl-trait/auto-trait.full_tait.stderr
@@ -16,6 +16,18 @@ LL | impl<T: Send> AnotherTrait for T {}
 LL | impl AnotherTrait for D<OpaqueType> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `D<impl OpaqueTrait>`
 
-error: aborting due to previous error; 1 warning emitted
+error: cannot implement trait on type alias impl trait
+  --> $DIR/auto-trait.rs:24:1
+   |
+LL | impl AnotherTrait for D<OpaqueType> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/auto-trait.rs:10:19
+   |
+LL | type OpaqueType = impl OpaqueTrait;
+   |                   ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/impl-trait/auto-trait.min_tait.stderr
+++ b/src/test/ui/impl-trait/auto-trait.min_tait.stderr
@@ -7,6 +7,18 @@ LL | impl<T: Send> AnotherTrait for T {}
 LL | impl AnotherTrait for D<OpaqueType> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `D<impl OpaqueTrait>`
 
-error: aborting due to previous error
+error: cannot implement trait on type alias impl trait
+  --> $DIR/auto-trait.rs:24:1
+   |
+LL | impl AnotherTrait for D<OpaqueType> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/auto-trait.rs:10:19
+   |
+LL | type OpaqueType = impl OpaqueTrait;
+   |                   ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/impl-trait/auto-trait.rs
+++ b/src/test/ui/impl-trait/auto-trait.rs
@@ -21,7 +21,7 @@ impl<T: Send> AnotherTrait for T {}
 // This is in error, because we cannot assume that `OpaqueType: !Send`.
 // (We treat opaque types as "foreign types" that could grow more impls
 // in the future.)
-impl AnotherTrait for D<OpaqueType> {
+impl AnotherTrait for D<OpaqueType> { //~ ERROR cannot implement trait
     //~^ ERROR conflicting implementations of trait `AnotherTrait` for type `D<impl OpaqueTrait>`
 }
 

--- a/src/test/ui/impl-trait/negative-reasoning.full_tait.stderr
+++ b/src/test/ui/impl-trait/negative-reasoning.full_tait.stderr
@@ -18,6 +18,18 @@ LL | impl AnotherTrait for D<OpaqueType> {
    |
    = note: upstream crates may add a new impl of trait `std::fmt::Debug` for type `impl OpaqueTrait` in future versions
 
-error: aborting due to previous error; 1 warning emitted
+error: cannot implement trait on type alias impl trait
+  --> $DIR/negative-reasoning.rs:22:1
+   |
+LL | impl AnotherTrait for D<OpaqueType> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/negative-reasoning.rs:10:19
+   |
+LL | type OpaqueType = impl OpaqueTrait;
+   |                   ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/impl-trait/negative-reasoning.min_tait.stderr
+++ b/src/test/ui/impl-trait/negative-reasoning.min_tait.stderr
@@ -9,6 +9,18 @@ LL | impl AnotherTrait for D<OpaqueType> {
    |
    = note: upstream crates may add a new impl of trait `std::fmt::Debug` for type `impl OpaqueTrait` in future versions
 
-error: aborting due to previous error
+error: cannot implement trait on type alias impl trait
+  --> $DIR/negative-reasoning.rs:22:1
+   |
+LL | impl AnotherTrait for D<OpaqueType> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/negative-reasoning.rs:10:19
+   |
+LL | type OpaqueType = impl OpaqueTrait;
+   |                   ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/impl-trait/negative-reasoning.rs
+++ b/src/test/ui/impl-trait/negative-reasoning.rs
@@ -19,7 +19,7 @@ trait AnotherTrait {}
 impl<T: std::fmt::Debug> AnotherTrait for T {}
 
 // This is in error, because we cannot assume that `OpaqueType: !Debug`
-impl AnotherTrait for D<OpaqueType> {
+impl AnotherTrait for D<OpaqueType> { //~ ERROR cannot implement trait
     //~^ ERROR conflicting implementations of trait `AnotherTrait` for type `D<impl OpaqueTrait>`
 }
 

--- a/src/test/ui/type-alias-impl-trait/issue-84660-trait-impl-for-tait.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-84660-trait-impl-for-tait.rs
@@ -1,0 +1,23 @@
+// Regression test for issues #84660 and #86411: both are variations on #76202.
+// Tests that we don't ICE when we have an opaque type appearing anywhere in an impl header.
+
+#![feature(min_type_alias_impl_trait)]
+
+trait Foo {}
+impl Foo for () {}
+type Bar = impl Foo;
+fn _defining_use() -> Bar {}
+
+trait TraitArg<T> {
+    fn f();
+}
+
+impl TraitArg<Bar> for () { //~ ERROR cannot implement trait
+    fn f() {
+        println!("ho");
+    }
+}
+
+fn main() {
+    <() as TraitArg<Bar>>::f();
+}

--- a/src/test/ui/type-alias-impl-trait/issue-84660-trait-impl-for-tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-84660-trait-impl-for-tait.stderr
@@ -1,0 +1,14 @@
+error: cannot implement trait on type alias impl trait
+  --> $DIR/issue-84660-trait-impl-for-tait.rs:15:1
+   |
+LL | impl TraitArg<Bar> for () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/issue-84660-trait-impl-for-tait.rs:8:12
+   |
+LL | type Bar = impl Foo;
+   |            ^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/issue-84660-unsoundness.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-84660-unsoundness.rs
@@ -1,0 +1,41 @@
+// Another example from issue #84660, this time weaponized as a safe transmut: an opaque type in an
+// impl header being accepted was used to create unsoundness.
+
+#![feature(min_type_alias_impl_trait)]
+
+trait Foo {}
+impl Foo for () {}
+type Bar = impl Foo;
+fn _defining_use() -> Bar {}
+
+trait Trait<T, In> {
+    type Out;
+    fn convert(i: In) -> Self::Out;
+}
+
+impl<In, Out> Trait<Bar, In> for Out { //~ ERROR cannot implement trait
+    type Out = Out;
+    fn convert(_i: In) -> Self::Out {
+        unreachable!();
+    }
+}
+
+impl<In, Out> Trait<(), In> for Out {
+    type Out = In;
+    fn convert(i: In) -> Self::Out {
+        i
+    }
+}
+
+fn transmute<In, Out>(i: In) -> Out {
+    <Out as Trait<Bar, In>>::convert(i)
+}
+
+fn main() {
+    let d;
+    {
+        let x = "Hello World".to_string();
+        d = transmute::<&String, &String>(&x);
+    }
+    println!("{}", d);
+}

--- a/src/test/ui/type-alias-impl-trait/issue-84660-unsoundness.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-84660-unsoundness.stderr
@@ -1,0 +1,14 @@
+error: cannot implement trait on type alias impl trait
+  --> $DIR/issue-84660-unsoundness.rs:16:1
+   |
+LL | impl<In, Out> Trait<Bar, In> for Out {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type alias impl trait defined here
+  --> $DIR/issue-84660-unsoundness.rs:8:12
+   |
+LL | type Bar = impl Foo;
+   |            ^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Previously, https://github.com/rust-lang/rust/pull/76940 forbade simple trait impls only from using opaque types, to prevent ICES.

However, this still allowed the same ICEs in codegen on more complex cases like #86411, and could also allow weaponization via a safe transmute, as shown in #84660.

This PR prevents opaque types from appearing in impl headers altogether as requested [in Niko's comment](https://github.com/rust-lang/rust/issues/86411#issuecomment-869957145).

Fixes #86411.
Fixes #84660.

r? @oli-obk 