### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/hir_wf_check.rs
+++ b/compiler/rustc_typeck/src/hir_wf_check.rs
@@ -25,7 +25,7 @@ fn diagnostic_hir_wf_check<'tcx>(
         WellFormedLoc::Ty(def_id) => def_id,
         WellFormedLoc::Param { function, param_idx: _ } => function,
     };
-    let hir_id = HirId::make_owner(def_id);
+    let hir_id = hir.local_def_id_to_hir_id(def_id);
 
     // HIR wfcheck should only ever happen as part of improving an existing error
     tcx.sess
@@ -140,6 +140,7 @@ fn diagnostic_hir_wf_check<'tcx>(
                 }
                 ref item => bug!("Unexpected item {:?}", item),
             },
+            hir::Node::Field(field) => Some(field.ty),
             ref node => bug!("Unexpected node {:?}", node),
         },
         WellFormedLoc::Param { function: _, param_idx } => {

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -333,21 +333,22 @@ pub trait Iterator {
     /// regardless of the step given.
     ///
     /// Note 2: The time at which ignored elements are pulled is not fixed.
-    /// `StepBy` behaves like the sequence `next(), nth(step-1), nth(step-1), …`,
-    /// but is also free to behave like the sequence
-    /// `advance_n_and_return_first(step), advance_n_and_return_first(step), …`
+    /// `StepBy` behaves like the sequence `self.next()`, `self.nth(step-1)`,
+    /// `self.nth(step-1)`, …, but is also free to behave like the sequence
+    /// `advance_n_and_return_first(&mut self, step)`,
+    /// `advance_n_and_return_first(&mut self, step)`, …
     /// Which way is used may change for some iterators for performance reasons.
     /// The second way will advance the iterator earlier and may consume more items.
     ///
     /// `advance_n_and_return_first` is the equivalent of:
     /// ```
-    /// fn advance_n_and_return_first<I>(iter: &mut I, total_step: usize) -> Option<I::Item>
+    /// fn advance_n_and_return_first<I>(iter: &mut I, n: usize) -> Option<I::Item>
     /// where
     ///     I: Iterator,
     /// {
     ///     let next = iter.next();
-    ///     if total_step > 1 {
-    ///         iter.nth(total_step-2);
+    ///     if n > 1 {
+    ///         iter.nth(n - 2);
     ///     }
     ///     next
     /// }

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -152,7 +152,7 @@ Subcommands:
     fmt         Run rustfmt
     test, t     Build and run some test suites
     bench       Build and run some benchmarks
-    doc         Build documentation
+    doc, d      Build documentation
     clean       Clean out build directories
     dist        Build distribution artifacts
     install     Install distribution artifacts
@@ -244,6 +244,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
                 || (s == "t")
                 || (s == "bench")
                 || (s == "doc")
+                || (s == "d")
                 || (s == "clean")
                 || (s == "dist")
                 || (s == "install")
@@ -312,7 +313,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
             "clippy" => {
                 opts.optflag("", "fix", "automatically apply lint suggestions");
             }
-            "doc" => {
+            "doc" | "d" => {
                 opts.optflag("", "open", "open the docs in a browser");
             }
             "clean" => {
@@ -487,7 +488,7 @@ Arguments:
         ./x.py test --stage 1",
                 );
             }
-            "doc" => {
+            "doc" | "d" => {
                 subcommand_help.push_str(
                     "\n
 Arguments:
@@ -573,7 +574,7 @@ Arguments:
                 },
             },
             "bench" => Subcommand::Bench { paths, test_args: matches.opt_strs("test-args") },
-            "doc" => Subcommand::Doc { paths, open: matches.opt_present("open") },
+            "doc" | "d" => Subcommand::Doc { paths, open: matches.opt_present("open") },
             "clean" => {
                 if !paths.is_empty() {
                     println!("\nclean does not take a path argument\n");

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -105,7 +105,7 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
         registry: rustc_driver::diagnostics_registry(),
     };
 
-    let mut test_args = options.test_args.clone();
+    let test_args = options.test_args.clone();
     let display_warnings = options.display_warnings;
     let nocapture = options.nocapture;
     let externs = options.externs.clone();
@@ -166,12 +166,7 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
         Err(ErrorReported) => return Err(ErrorReported),
     };
 
-    test_args.insert(0, "rustdoctest".to_string());
-    if nocapture {
-        test_args.push("--nocapture".to_string());
-    }
-
-    test::test_main(&test_args, tests, Some(test::Options::new().display_output(display_warnings)));
+    run_tests(test_args, nocapture, display_warnings, tests);
 
     // Collect and warn about unused externs, but only if we've gotten
     // reports for each doctest
@@ -212,6 +207,19 @@ crate fn run(options: Options) -> Result<(), ErrorReported> {
     }
 
     Ok(())
+}
+
+crate fn run_tests(
+    mut test_args: Vec<String>,
+    nocapture: bool,
+    display_warnings: bool,
+    tests: Vec<test::TestDescAndFn>,
+) {
+    test_args.insert(0, "rustdoctest".to_string());
+    if nocapture {
+        test_args.push("--nocapture".to_string());
+    }
+    test::test_main(&test_args, tests, Some(test::Options::new().display_output(display_warnings)));
 }
 
 // Look for `#![doc(test(no_crate_inject))]`, used by crates in the std facade.

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1029,14 +1029,12 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
 
             use crate::clean::Variant;
             if let clean::VariantItem(Variant::Struct(ref s)) = *variant.kind {
-                let count_fields = s.fields.len();
-                toggle_open(w, format_args!("{} field{}", count_fields, pluralize(count_fields)));
                 let variant_id = cx.derive_id(format!(
                     "{}.{}.fields",
                     ItemType::Variant,
                     variant.name.as_ref().unwrap()
                 ));
-                write!(w, "<div class=\"autohide sub-variant\" id=\"{id}\">", id = variant_id);
+                write!(w, "<div class=\"sub-variant\" id=\"{id}\">", id = variant_id);
                 write!(
                     w,
                     "<h3>Fields of <b>{name}</b></h3><div>",
@@ -1064,7 +1062,6 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                     }
                 }
                 w.write_str("</div></div>");
-                toggle_close(w);
             }
         }
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1072,7 +1072,7 @@ a.test-arrow:hover{
 	padding-top: 1px;
 }
 
-#main > details > .sub-variant > h3 {
+#main .sub-variant > h3 {
 	font-size: 15px;
 	margin-left: 25px;
 	margin-bottom: 5px;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -329,6 +329,7 @@ nav.sub {
 .logo-container > img {
 	max-width: 100px;
 	max-height: 100px;
+	height: 100%;
 	position: absolute;
 	left: 50%;
 	top: 50%;

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -115,7 +115,7 @@ crate fn render<P: AsRef<Path>>(
 }
 
 /// Runs any tests/code examples in the markdown file `input`.
-crate fn test(mut options: Options) -> Result<(), String> {
+crate fn test(options: Options) -> Result<(), String> {
     let input_str = read_to_string(&options.input)
         .map_err(|err| format!("{}: {}", options.input.display(), err))?;
     let mut opts = TestOptions::default();
@@ -135,14 +135,11 @@ crate fn test(mut options: Options) -> Result<(), String> {
 
     find_testable_code(&input_str, &mut collector, codes, options.enable_per_target_ignores, None);
 
-    options.test_args.insert(0, "rustdoctest".to_string());
-    if options.nocapture {
-        options.test_args.push("--nocapture".to_string());
-    }
-    test::test_main(
-        &options.test_args,
+    crate::doctest::run_tests(
+        options.test_args,
+        options.nocapture,
+        options.display_warnings,
         collector.tests,
-        Some(test::Options::new().display_output(options.display_warnings)),
     );
     Ok(())
 }

--- a/src/test/rustdoc/toggle-item-contents.rs
+++ b/src/test/rustdoc/toggle-item-contents.rs
@@ -62,8 +62,7 @@ pub struct PrivStruct {
 }
 
 // @has 'toggle_item_contents/enum.Enum.html'
-// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
-// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show 2 fields'
+// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]'
 pub enum Enum {
     A, B, C,
     D {
@@ -73,8 +72,7 @@ pub enum Enum {
 }
 
 // @has 'toggle_item_contents/enum.EnumStructVariant.html'
-// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
-// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show 1 field'
+// @!has - '//details[@class="rustdoc-toggle type-contents-toggle"]'
 pub enum EnumStructVariant {
     A, B, C,
     D {

--- a/src/test/ui/bastion-of-the-turbofish.rs
+++ b/src/test/ui/bastion-of-the-turbofish.rs
@@ -25,9 +25,12 @@
 //
 // My heart aches in sorrow, for I know I am defeated. Let this be a warning
 // to all those who come after. Here stands the bastion of the Turbofish.
+//
+// RIP Anna Harren, Guardian Angel of the Hallowed Turbofish. <3
 
 // See https://github.com/rust-lang/rust/pull/53562
 // and https://github.com/rust-lang/rfcs/pull/2527
+// and https://twitter.com/garblefart/status/1393236602856611843
 // for context.
 
 fn main() {

--- a/src/test/ui/impl-trait/issues/issue-54600.rs
+++ b/src/test/ui/impl-trait/issues/issue-54600.rs
@@ -1,0 +1,7 @@
+use std::fmt::Debug;
+
+fn main() {
+    let x: Option<impl Debug> = Some(44_u32);
+    //~^ `impl Trait` not allowed outside of function and method return types
+    println!("{:?}", x);
+}

--- a/src/test/ui/impl-trait/issues/issue-54600.stderr
+++ b/src/test/ui/impl-trait/issues/issue-54600.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-54600.rs:4:19
+   |
+LL |     let x: Option<impl Debug> = Some(44_u32);
+   |                   ^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-54840.rs
+++ b/src/test/ui/impl-trait/issues/issue-54840.rs
@@ -1,0 +1,7 @@
+use std::ops::Add;
+
+fn main() {
+    let i: i32 = 0;
+    let j: &impl Add = &i;
+    //~^ `impl Trait` not allowed outside of function and method return types
+}

--- a/src/test/ui/impl-trait/issues/issue-54840.stderr
+++ b/src/test/ui/impl-trait/issues/issue-54840.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-54840.rs:5:13
+   |
+LL |     let j: &impl Add = &i;
+   |             ^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-58504.rs
+++ b/src/test/ui/impl-trait/issues/issue-58504.rs
@@ -1,0 +1,12 @@
+#![feature(generators, generator_trait, never_type)]
+
+use std::ops::Generator;
+
+fn mk_gen() -> impl Generator<Return=!, Yield=()> {
+    || { loop { yield; } }
+}
+
+fn main() {
+    let gens: [impl Generator<Return=!, Yield=()>;2] = [ mk_gen(), mk_gen() ];
+    //~^ `impl Trait` not allowed outside of function and method return types
+}

--- a/src/test/ui/impl-trait/issues/issue-58504.stderr
+++ b/src/test/ui/impl-trait/issues/issue-58504.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-58504.rs:10:16
+   |
+LL |     let gens: [impl Generator<Return=!, Yield=()>;2] = [ mk_gen(), mk_gen() ];
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-58956.rs
+++ b/src/test/ui/impl-trait/issues/issue-58956.rs
@@ -1,0 +1,14 @@
+trait Lam {}
+
+pub struct B;
+impl Lam for B {}
+pub struct Wrap<T>(T);
+
+const _A: impl Lam = {
+    //~^ `impl Trait` not allowed outside of function and method return types
+    let x: Wrap<impl Lam> = Wrap(B);
+    //~^ `impl Trait` not allowed outside of function and method return types
+    x.0
+};
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-58956.stderr
+++ b/src/test/ui/impl-trait/issues/issue-58956.stderr
@@ -1,0 +1,15 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-58956.rs:7:11
+   |
+LL | const _A: impl Lam = {
+   |           ^^^^^^^^
+
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-58956.rs:9:17
+   |
+LL |     let x: Wrap<impl Lam> = Wrap(B);
+   |                 ^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-70971.rs
+++ b/src/test/ui/impl-trait/issues/issue-70971.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let x : (impl Copy,) = (true,);
+    //~^ `impl Trait` not allowed outside of function and method return types
+}

--- a/src/test/ui/impl-trait/issues/issue-70971.stderr
+++ b/src/test/ui/impl-trait/issues/issue-70971.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-70971.rs:2:14
+   |
+LL |     let x : (impl Copy,) = (true,);
+   |              ^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-79099.rs
+++ b/src/test/ui/impl-trait/issues/issue-79099.rs
@@ -1,0 +1,10 @@
+struct Bug {
+    V1: [(); {
+        let f: impl core::future::Future<Output = u8> = async { 1 };
+        //~^ `impl Trait` not allowed outside of function and method return types
+        //~| expected identifier
+        1
+    }],
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-79099.stderr
+++ b/src/test/ui/impl-trait/issues/issue-79099.stderr
@@ -1,0 +1,20 @@
+error: expected identifier, found `1`
+  --> $DIR/issue-79099.rs:3:65
+   |
+LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
+   |                                                         -----   ^ expected identifier
+   |                                                         |
+   |                                                         `async` blocks are only allowed in Rust 2018 or later
+   |
+   = help: set `edition = "2018"` in `Cargo.toml`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-79099.rs:3:16
+   |
+LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-84919.rs
+++ b/src/test/ui/impl-trait/issues/issue-84919.rs
@@ -1,0 +1,9 @@
+trait Trait {}
+impl Trait for () {}
+
+fn foo<'a: 'a>() {
+    let _x: impl Trait = ();
+    //~^ `impl Trait` not allowed outside of function and method return types
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-84919.stderr
+++ b/src/test/ui/impl-trait/issues/issue-84919.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-84919.rs:5:13
+   |
+LL |     let _x: impl Trait = ();
+   |             ^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-86201.rs
+++ b/src/test/ui/impl-trait/issues/issue-86201.rs
@@ -1,0 +1,13 @@
+#![feature(unboxed_closures)]
+#![feature(min_type_alias_impl_trait)]
+
+type FunType = impl Fn<()>;
+//~^ could not find defining uses
+static STATIC_FN: FunType = some_fn;
+//~^ mismatched types
+
+fn some_fn() {}
+
+fn main() {
+    let _: <FunType as FnOnce<()>>::Output = STATIC_FN();
+}

--- a/src/test/ui/impl-trait/issues/issue-86201.stderr
+++ b/src/test/ui/impl-trait/issues/issue-86201.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-86201.rs:6:29
+   |
+LL | type FunType = impl Fn<()>;
+   |                ----------- the expected opaque type
+LL |
+LL | static STATIC_FN: FunType = some_fn;
+   |                             ^^^^^^^ expected opaque type, found fn item
+   |
+   = note: expected opaque type `impl Fn<()>`
+                  found fn item `fn() {some_fn}`
+
+error: could not find defining uses
+  --> $DIR/issue-86201.rs:4:16
+   |
+LL | type FunType = impl Fn<()>;
+   |                ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/impl-trait/issues/issue-86642.rs
+++ b/src/test/ui/impl-trait/issues/issue-86642.rs
@@ -1,0 +1,8 @@
+static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+    //~^ `impl Trait` not allowed outside of function and method return types
+    let res = (move |source| Ok(source))(source);
+    let res = res.or((move |source| Ok(source))(source));
+    res
+};
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-86642.stderr
+++ b/src/test/ui/impl-trait/issues/issue-86642.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-86642.rs:1:11
+   |
+LL | static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/impl-trait/issues/issue-87295.rs
+++ b/src/test/ui/impl-trait/issues/issue-87295.rs
@@ -1,0 +1,18 @@
+trait Trait {
+    type Output;
+}
+impl Trait for () {
+    type Output = i32;
+}
+
+struct Struct<F>(F);
+impl<F> Struct<F> {
+    pub fn new(_: F) -> Self {
+        todo!()
+    }
+}
+
+fn main() {
+    let _do_not_waste: Struct<impl Trait<Output = i32>> = Struct::new(());
+    //~^ `impl Trait` not allowed outside of function and method return types
+}

--- a/src/test/ui/impl-trait/issues/issue-87295.stderr
+++ b/src/test/ui/impl-trait/issues/issue-87295.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/issue-87295.rs:16:31
+   |
+LL |     let _do_not_waste: Struct<impl Trait<Output = i32>> = Struct::new(());
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/issues/issue-19380.stderr
+++ b/src/test/ui/issues/issue-19380.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Qiz` cannot be made into an object
-  --> $DIR/issue-19380.rs:11:9
+  --> $DIR/issue-19380.rs:11:29
    |
 LL |   foos: &'static [&'static (dyn Qiz + 'static)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Qiz` cannot be made into an object
+   |                             ^^^^^^^^^^^^^^^^^ `Qiz` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/wf-in-fn-type-arg.rs:9:8
+  --> $DIR/wf-in-fn-type-arg.rs:9:11
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn(MustBeCopy<T>)
-   |        ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |           ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/wf-in-fn-type-ret.rs:9:8
+  --> $DIR/wf-in-fn-type-ret.rs:9:16
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: fn() -> MustBeCopy<T>
-   |        ^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/wf-in-obj-type-trait.rs:11:8
+  --> $DIR/wf-in-obj-type-trait.rs:11:19
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ---- required by this bound in `MustBeCopy`
 ...
 LL |     x: dyn Object<MustBeCopy<T>>
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                   ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |


### PR DESCRIPTION
Successful merges:

 - #87034 (DOC: fix hypothetical Rust code in `step_by()` docstring)
 - #87298 (memorialize Anna Harren in the bastion of the turbofish)
 - #87332 (Don't hide fields of enum struct variants)
 - #87362 (Make `x.py d` an alias for `x.py doc`)
 - #87372 (Move calls to test_main into one function)
 - #87373 (Extend HIR WF checking to fields)
 - #87376 (Change rustdoc logo to use the full container size)
 - #87383 (Add regression tests for the impl_trait_in_bindings ICEs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87034,87298,87332,87362,87372,87373,87376,87383)
<!-- homu-ignore:end -->