### PR TITLE
Add support for artifact size profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,8 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "measureme"
-version = "9.1.2"
-source = "git+https://github.com/rylev/measureme#b9cccd7ad4c859a5e0e3dd6bff3daac7a190bdd7"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd460fad6e55ca82fa0cd9dab0d315294188fd9ec6efbf4105e5635d4872ef9c"
 dependencies = [
  "log",
  "memmap2",
@@ -2255,8 +2256,8 @@ dependencies = [
  "hex 0.4.2",
  "libc",
  "log",
- "measureme 9.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.3",
+ "measureme 9.1.2",
+ "rand 0.8.4",
  "rustc-workspace-hack",
  "rustc_version 0.4.0",
  "shell-escape",
@@ -3232,7 +3233,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme 9.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "measureme 9.1.2",
  "memmap2",
  "parking_lot",
  "rustc-ap-rustc_graphviz",
@@ -3670,7 +3671,7 @@ dependencies = [
  "bitflags",
  "cstr",
  "libc",
- "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
+ "measureme 10.0.0",
  "rustc-demangle",
  "rustc_arena",
  "rustc_ast",
@@ -3765,7 +3766,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
+ "measureme 10.0.0",
  "memmap2",
  "parking_lot",
  "rustc-hash",
@@ -4289,7 +4290,7 @@ dependencies = [
 name = "rustc_query_impl"
 version = "0.0.0"
 dependencies = [
- "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
+ "measureme 10.0.0",
  "rustc-rayon-core",
  "rustc_ast",
  "rustc_data_structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "measureme"
+version = "9.1.2"
+source = "git+https://github.com/rylev/measureme#b9cccd7ad4c859a5e0e3dd6bff3daac7a190bdd7"
+dependencies = [
+ "log",
+ "memmap2",
+ "parking_lot",
+ "perf-event-open-sys",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,8 +2255,8 @@ dependencies = [
  "hex 0.4.2",
  "libc",
  "log",
- "measureme",
- "rand 0.8.4",
+ "measureme 9.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.3",
  "rustc-workspace-hack",
  "rustc_version 0.4.0",
  "shell-escape",
@@ -3219,7 +3232,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme",
+ "measureme 9.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap2",
  "parking_lot",
  "rustc-ap-rustc_graphviz",
@@ -3657,7 +3670,7 @@ dependencies = [
  "bitflags",
  "cstr",
  "libc",
- "measureme",
+ "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
  "rustc-demangle",
  "rustc_arena",
  "rustc_ast",
@@ -3752,7 +3765,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme",
+ "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
  "memmap2",
  "parking_lot",
  "rustc-hash",
@@ -4276,7 +4289,7 @@ dependencies = [
 name = "rustc_query_impl"
 version = "0.0.0"
 dependencies = [
- "measureme",
+ "measureme 9.1.2 (git+https://github.com/rylev/measureme)",
  "rustc-rayon-core",
  "rustc_ast",
  "rustc_data_structures",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 bitflags = "1.0"
 cstr = "0.2"
 libc = "0.2"
-measureme = "9.1.0"
+measureme = { git = "https://github.com/rylev/measureme" }
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 bitflags = "1.0"
 cstr = "0.2"
 libc = "0.2"
-measureme = { git = "https://github.com/rylev/measureme" }
+measureme = "10.0.0"
 snap = "1"
 tracing = "0.1"
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = "1.1.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 bitflags = "1.2.1"
-measureme = { git = "https://github.com/rylev/measureme" }
+measureme = "10.0.0"
 libc = "0.2"
 stacker = "0.1.14"
 tempfile = "3.2"

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = "1.1.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 bitflags = "1.2.1"
-measureme = "9.1.0"
+measureme = { git = "https://github.com/rylev/measureme" }
 libc = "0.2"
 stacker = "0.1.14"
 tempfile = "3.2"

--- a/compiler/rustc_incremental/src/persist/file_format.rs
+++ b/compiler/rustc_incremental/src/persist/file_format.rs
@@ -95,6 +95,12 @@ where
         return;
     }
 
+    sess.prof.artifact_size(
+        &name.replace(' ', "_"),
+        path_buf.file_name().unwrap().to_string_lossy(),
+        encoder.position() as u64,
+    );
+
     debug!("save: data written to disk successfully");
 }
 

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-measureme = "9.0.0"
+measureme = { git = "https://github.com/rylev/measureme" }
 rustc-rayon-core = "0.3.1"
 tracing = "0.1"
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-measureme = { git = "https://github.com/rylev/measureme" }
+measureme = "10.0.0"
 rustc-rayon-core = "0.3.1"
 tracing = "0.1"
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1279,7 +1279,7 @@ options! {
         "specify the events recorded by the self profiler;
         for example: `-Z self-profile-events=default,query-keys`
         all options: none, all, default, generic-activity, query-provider, query-cache-hit
-                     query-blocked, incr-cache-load, incr-result-hashing, query-keys, function-args, args, llvm"),
+                     query-blocked, incr-cache-load, incr-result-hashing, query-keys, function-args, args, llvm, artifact-sizes"),
     share_generics: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make the current crate share its generic instantiations"),
     show_span: Option<String> = (None, parse_opt_string, [TRACKED],


### PR DESCRIPTION
This adds support for profiling artifact file sizes (incremental compilation artifacts and query cache to begin with). 

Eventually we want to track this in perf.rlo so we can ensure that file sizes do not change dramatically on each pull request. 

This relies on support in measureme: https://github.com/rust-lang/measureme/pull/169. Once that lands we can update this PR to not point to a git dependency. 

This was worked on together with @michaelwoerister.

r? @wesleywiser 