### PR TITLE
Mark `format_args_nl` as `#[doc(hidden)]`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -845,6 +845,7 @@ pub(crate) mod builtin {
                   language use and is subject to change"
     )]
     #[allow_internal_unstable(fmt_internals)]
+    #[doc(hidden)]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! format_args_nl {


### PR DESCRIPTION
It's described as being internal-only and has no tracking issue, so hide it from public docs.