### PR TITLE
Fix help message for modification to &T created by &{t}

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -119,9 +119,9 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     && !self.upvars.is_empty()
                 {
                     item_msg = format!("`{}`", access_place_desc.unwrap());
-                    debug_assert!(
-                        self.body.local_decls[ty::CAPTURE_STRUCT_LOCAL].ty.is_region_ptr()
-                    );
+                    debug_assert!(self.body.local_decls[ty::CAPTURE_STRUCT_LOCAL]
+                        .ty
+                        .is_region_ptr());
                     debug_assert!(is_closure_or_generator(
                         Place::ty_from(
                             the_place_err.local,
@@ -905,6 +905,8 @@ fn suggest_ampmut<'tcx>(
                         Some(c) if c.is_whitespace() => true,
                         // e.g. `&mut(x)`
                         Some('(') => true,
+                        // e.g. `&mut{x}`
+                        Some('{') => true,
                         // e.g. `&mutablevar`
                         _ => false,
                     }
@@ -912,9 +914,7 @@ fn suggest_ampmut<'tcx>(
                     false
                 }
             };
-            if let (true, Some(ws_pos)) =
-                (src.starts_with("&'"), src.find(|c: char| -> bool { c.is_whitespace() }))
-            {
+            if let (true, Some(ws_pos)) = (src.starts_with("&'"), src.find(char::is_whitespace)) {
                 let lt_name = &src[1..ws_pos];
                 let ty = src[ws_pos..].trim_start();
                 if !is_mutbl(ty) {
@@ -940,9 +940,7 @@ fn suggest_ampmut<'tcx>(
     };
 
     if let Ok(src) = tcx.sess.source_map().span_to_snippet(highlight_span) {
-        if let (true, Some(ws_pos)) =
-            (src.starts_with("&'"), src.find(|c: char| -> bool { c.is_whitespace() }))
-        {
+        if let (true, Some(ws_pos)) = (src.starts_with("&'"), src.find(char::is_whitespace)) {
             let lt_name = &src[1..ws_pos];
             let ty = &src[ws_pos..];
             return (highlight_span, format!("&{} mut{}", lt_name, ty));

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -119,9 +119,9 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     && !self.upvars.is_empty()
                 {
                     item_msg = format!("`{}`", access_place_desc.unwrap());
-                    debug_assert!(self.body.local_decls[ty::CAPTURE_STRUCT_LOCAL]
-                        .ty
-                        .is_region_ptr());
+                    debug_assert!(
+                        self.body.local_decls[ty::CAPTURE_STRUCT_LOCAL].ty.is_region_ptr()
+                    );
                     debug_assert!(is_closure_or_generator(
                         Place::ty_from(
                             the_place_err.local,

--- a/src/test/ui/borrowck/issue-85765.rs
+++ b/src/test/ui/borrowck/issue-85765.rs
@@ -12,4 +12,18 @@ fn main() {
     *r = 0;
     //~^ ERROR cannot assign to `*r`, which is behind a `&` reference
     //~| NOTE `r` is a `&` reference, so the data it refers to cannot be written
+
+    #[rustfmt::skip]
+    let x: &usize = &mut{0};
+    //~^ HELP consider changing this to be a mutable reference
+    *x = 1;
+    //~^ ERROR cannot assign to `*x`, which is behind a `&` reference
+    //~| NOTE `x` is a `&` reference, so the data it refers to cannot be written
+
+    #[rustfmt::skip]
+    let y: &usize = &mut(0);
+    //~^ HELP consider changing this to be a mutable reference
+    *y = 1;
+    //~^ ERROR cannot assign to `*y`, which is behind a `&` reference
+    //~| NOTE `y` is a `&` reference, so the data it refers to cannot be written
 }

--- a/src/test/ui/borrowck/issue-85765.stderr
+++ b/src/test/ui/borrowck/issue-85765.stderr
@@ -16,7 +16,25 @@ LL |
 LL |     *r = 0;
    |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
 
-error: aborting due to 2 previous errors
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+  --> $DIR/issue-85765.rs:19:5
+   |
+LL |     let x: &usize = &mut{0};
+   |         - help: consider changing this to be a mutable reference: `&mut usize`
+LL |
+LL |     *x = 1;
+   |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+
+error[E0594]: cannot assign to `*y`, which is behind a `&` reference
+  --> $DIR/issue-85765.rs:26:5
+   |
+LL |     let y: &usize = &mut(0);
+   |         - help: consider changing this to be a mutable reference: `&mut usize`
+LL |
+LL |     *y = 1;
+   |     ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.


### PR DESCRIPTION
Previous:
```rust
error[E0594]: cannot assign to `*x` which is behind a `&` reference
 --> src/main.rs:3:5
  |
2 |     let x: &usize = &mut{0};
  |                     ------- help: consider changing this to be a mutable reference: `&mut mut{0}`
3 |     *x = 1;
  |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
```