### PR TITLE
Add `extend_front` method to `VecDeque`

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2041,6 +2041,30 @@ impl<T> VecDeque<T> {
         self.extend(other.drain(..));
     }
 
+    /// Extends `self` with the contents of `iter`, placing all the elements of `iter` at the
+    /// front of `self`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new number of elements in self overflows a `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(vec_deque_extend_front)]
+    /// use std::collections::VecDeque;
+    ///
+    /// let mut buf: VecDeque<_> = vec![2, 4].into_iter().collect();
+    /// buf.extend_front([3, 5, 7]);
+    /// assert_eq!(buf, [3, 5, 7, 2, 4]);
+    /// ```
+    #[unstable(feature = "vec_deque_extend_front", reason = "new API", issue = "87463")]
+    pub fn extend_front<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let prev_len = self.len();
+        self.extend(iter);
+        self.rotate_right(self.len() - prev_len);
+    }
+
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all elements `e` such that `f(&e)` returns false.


### PR DESCRIPTION
Working on something earlier today, I realized `VecDeque` lacks a method for adding several elements at once to its beginning. The changes included in this PR enable this via a new method `extend_front` on `VecDeque` As a concrete example, this PR enables the following:

```rust
#![feature(vec_deque_extend_front)]
use std::collections::VecDeque;

let mut buf: VecDeque<_> = vec![2, 4].into_iter().collect();
buf.extend_front([3, 5, 7]);
assert_eq!(buf, [3, 5, 7, 2, 4]);
```

 If this is something that is found desirable, it might make more sense to implement this by adding a new trait `ExtendFront` so that other collections that can perform this operation efficiently  (e.g. `LinkedList`) could also take advantage of this (though I assume an RFC would be required at that point). 

Please note that the implementation of this method included presently is not as efficient as it could be. Should this feature become a candidate for inclusion in stable Rust, the implementation should be improved (by pushing each element to the front, then reversing the sub-slice containing the new elements once the iterator has been exhausted).


