### PR TITLE
Implement `RefUnwindSafe` for `Rc<T>`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -318,6 +318,8 @@ impl<T: ?Sized> !marker::Sync for Rc<T> {}
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for Rc<T> {}
+#[stable(feature = "rc_ref_unwind_safe", since = "1.58.0")]
+impl<T: RefUnwindSafe + ?Sized> RefUnwindSafe for Rc<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}


### PR DESCRIPTION
This PR implements `RefUnwindSafe` for `Rc<T>`, where `T: RefUnwindSafe`. 

This impl was omitted by an apparent oversight. `Rc<T>` already implements `UnwindSafe`. `Arc<T>` implements both `UnwindSafe` and `RefUnwindSafe`. There is no reason why an `&Rc<T>` is any less unwind safe than a `Rc<T>` or an `&Arc<T>`, so this should be safe to add.

Resolves #45924.

