### PR TITLE
2229: Don't capture preicese paths on top of a union

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/issue-87378.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87378.rs
@@ -1,0 +1,26 @@
+#![feature(rustc_attrs)]
+
+// edition:2021
+
+// Test that any precise capture on a union is truncated because it's unsafe to do so.
+
+union Union {
+    value: u64,
+}
+
+fn main() {
+    let u = Union { value: 42 };
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+       unsafe { u.value }
+        //~^ NOTE: Capturing u[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture u[] -> ImmBorrow
+    };
+
+    c();
+}

--- a/src/test/ui/closures/2229_closure_analysis/issue-87378.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87378.stderr
@@ -1,0 +1,48 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/issue-87378.rs:14:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error: First Pass analysis includes:
+  --> $DIR/issue-87378.rs:17:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |        unsafe { u.value }
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing u[(0, 0)] -> ImmBorrow
+  --> $DIR/issue-87378.rs:20:17
+   |
+LL |        unsafe { u.value }
+   |                 ^^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/issue-87378.rs:17:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |        unsafe { u.value }
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture u[] -> ImmBorrow
+  --> $DIR/issue-87378.rs:20:17
+   |
+LL |        unsafe { u.value }
+   |                 ^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/issue-87378.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/issue-87378.rs
@@ -1,0 +1,16 @@
+// edition:2021
+// check-pass
+
+union Union {
+    value: u64,
+}
+
+fn main() {
+    let u = Union { value: 42 };
+
+    let c = || {
+       unsafe { u.value }
+    };
+
+    c();
+}


### PR DESCRIPTION
- Accessing fields of a union require unsafe block
- As part of 2229 we don't allow precision where we need an unsafe block
to capture.

Fixes: #87378

r? @nikomatsakis