### PR TITLE
parse and handle `where T = U` predicate

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -680,6 +680,9 @@ declare_features! (
     /// Allows `#[derive(Default)]` and `#[default]` on enums.
     (active, derive_default_enum, "1.56.0", Some(86985), None),
 
+    /// Allows `where T = U` in where predicates.
+    (active, type_equality_constraints, "1.56.0", Some(87533), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -26,6 +26,7 @@ pub fn explicit_outlives_bounds<'tcx>(
             | ty::PredicateKind::TypeOutlives(..)
             | ty::PredicateKind::ConstEvaluatable(..)
             | ty::PredicateKind::ConstEquate(..)
+            | ty::PredicateKind::TypeEquate(..)
             | ty::PredicateKind::TypeWellFormedFromEnv(..) => None,
             ty::PredicateKind::RegionOutlives(ty::OutlivesPredicate(r_a, r_b)) => {
                 Some(OutlivesBound::RegionSubRegion(r_b, r_a))

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -172,6 +172,10 @@ impl Elaborator<'tcx> {
                 // Currently, we do not elaborate const-equate
                 // predicates.
             }
+            ty::PredicateKind::TypeEquate(..) => {
+                // Currently, we do not elaborate type-equate
+                // predicates.
+            }
             ty::PredicateKind::RegionOutlives(..) => {
                 // Nothing to elaborate from `'a: 'b`.
             }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1612,6 +1612,7 @@ impl<'tcx> LateLintPass<'tcx> for TrivialConstraints {
                     Subtype(..) |
                     ConstEvaluatable(..) |
                     ConstEquate(..) |
+                    TypeEquate(..) |
                     TypeWellFormedFromEnv(..) => continue,
                 };
                 if predicate.is_global() {

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -252,6 +252,10 @@ impl FlagComputation {
             ty::PredicateKind::TypeWellFormedFromEnv(ty) => {
                 self.add_ty(ty);
             }
+            ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                self.add_ty(lhs);
+                self.add_ty(rhs);
+            }
         }
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -492,6 +492,9 @@ pub enum PredicateKind<'tcx> {
     ///
     /// Only used for Chalk.
     TypeWellFormedFromEnv(Ty<'tcx>),
+
+    /// `where T = U`
+    TypeEquate(Ty<'tcx>, Ty<'tcx>),
 }
 
 /// The crate outlives map is computed during typeck and contains the
@@ -800,6 +803,7 @@ impl<'tcx> Predicate<'tcx> {
             | PredicateKind::TypeOutlives(..)
             | PredicateKind::ConstEvaluatable(..)
             | PredicateKind::ConstEquate(..)
+            | PredicateKind::TypeEquate(..)
             | PredicateKind::TypeWellFormedFromEnv(..) => None,
         }
     }
@@ -817,6 +821,7 @@ impl<'tcx> Predicate<'tcx> {
             | PredicateKind::ClosureKind(..)
             | PredicateKind::ConstEvaluatable(..)
             | PredicateKind::ConstEquate(..)
+            | PredicateKind::TypeEquate(..)
             | PredicateKind::TypeWellFormedFromEnv(..) => None,
         }
     }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2292,6 +2292,9 @@ define_print_and_forward_display! {
             ty::PredicateKind::TypeWellFormedFromEnv(ty) => {
                 p!("the type `", print(ty), "` is found in the environment")
             }
+            ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                p!("the type `", print(lhs), "` equals `", print(rhs), "`")
+            }
         }
     }
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -198,6 +198,9 @@ impl fmt::Debug for ty::PredicateKind<'tcx> {
             ty::PredicateKind::TypeWellFormedFromEnv(ty) => {
                 write!(f, "TypeWellFormedFromEnv({:?})", ty)
             }
+            ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                write!(f, "TypeEquate({:?}, {:?})", lhs, rhs)
+            }
         }
     }
 }
@@ -449,6 +452,9 @@ impl<'a, 'tcx> Lift<'tcx> for ty::PredicateKind<'a> {
             }
             ty::PredicateKind::TypeWellFormedFromEnv(ty) => {
                 tcx.lift(ty).map(ty::PredicateKind::TypeWellFormedFromEnv)
+            }
+            ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                tcx.lift((lhs, rhs)).map(|(lhs, rhs)| ty::PredicateKind::TypeEquate(lhs, rhs))
             }
         }
     }

--- a/compiler/rustc_mir/src/transform/check_consts/check.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/check.rs
@@ -413,6 +413,7 @@ impl Checker<'mir, 'tcx> {
                     | ty::PredicateKind::Projection(_)
                     | ty::PredicateKind::ConstEvaluatable(..)
                     | ty::PredicateKind::ConstEquate(..)
+                    | ty::PredicateKind::TypeEquate(..)
                     | ty::PredicateKind::TypeWellFormedFromEnv(..) => continue,
                     ty::PredicateKind::ObjectSafe(_) => {
                         bug!("object safe predicate on function: {:#?}", predicate)

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -284,7 +284,7 @@ impl<'a> Parser<'a> {
             }))
         // FIXME: Decide what should be used here, `=` or `==`.
         // FIXME: We are just dropping the binders in lifetime_defs on the floor here.
-        } else if self.eat(&token::Eq) || self.eat(&token::EqEq) {
+        } else if self.eat(&token::Eq) {
             let rhs_ty = self.parse_ty()?;
             Ok(ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
                 span: lo.to(self.prev_token.span),
@@ -293,7 +293,15 @@ impl<'a> Parser<'a> {
                 id: ast::DUMMY_NODE_ID,
             }))
         } else {
-            self.unexpected()
+            if self.token == token::EqEq {
+                let err = self.struct_span_err(
+                    lo.to(self.prev_token.span),
+                    "type equality predicates are `=` not `==`",
+                );
+                Err(err)
+            } else {
+                self.unexpected()
+            }
         }
     }
 

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -132,6 +132,10 @@ where
             ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(ty, _region)) => {
                 ty.visit_with(self)
             }
+            ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                lhs.visit_with(self)?;
+                rhs.visit_with(self)
+            }
             ty::PredicateKind::RegionOutlives(..) => ControlFlow::CONTINUE,
             ty::PredicateKind::ConstEvaluatable(defs, substs)
                 if self.def_id_visitor.tcx().features().const_evaluatable_checked =>

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1285,6 +1285,7 @@ symbols! {
         type_alias_enum_variants,
         type_alias_impl_trait,
         type_ascription,
+        type_equality_constraints,
         type_id,
         type_length_limit,
         type_macros,

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -1189,6 +1189,7 @@ crate fn required_region_bounds(
                 | ty::PredicateKind::RegionOutlives(..)
                 | ty::PredicateKind::ConstEvaluatable(..)
                 | ty::PredicateKind::ConstEquate(..)
+                | ty::PredicateKind::TypeEquate(..)
                 | ty::PredicateKind::TypeWellFormedFromEnv(..) => None,
                 ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(ref t, ref r)) => {
                     // Search for a bound of the form `erased_self_ty

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -698,6 +698,17 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         )
                     }
 
+                    ty::PredicateKind::TypeEquate(..) => {
+                        // Errors for `TypeEquate` predicates show up as
+                        // `SelectionError::FIXME(type_equality_constraints)`,
+                        // not `Unimplemented`.
+                        span_bug!(
+                            span,
+                            "type-equate requirement gave wrong error: `{:?}`",
+                            obligation
+                        )
+                    }
+
                     ty::PredicateKind::TypeWellFormedFromEnv(..) => span_bug!(
                         span,
                         "TypeWellFormedFromEnv predicate should only exist in the environment"

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -302,6 +302,11 @@ fn predicate_references_self(
             // possible alternatives.
             if data.projection_ty.substs[1..].iter().any(has_self_ty) { Some(sp) } else { None }
         }
+        ty::PredicateKind::TypeEquate(lhs, rhs) => {
+            let has_self = lhs.walk().any(|arg| arg == self_ty.into())
+                || rhs.walk().any(|arg| arg == self_ty.into());
+            if has_self { Some(sp) } else { None }
+        }
         ty::PredicateKind::WellFormed(..)
         | ty::PredicateKind::ObjectSafe(..)
         | ty::PredicateKind::TypeOutlives(..)
@@ -343,6 +348,7 @@ fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
             | ty::PredicateKind::TypeOutlives(..)
             | ty::PredicateKind::ConstEvaluatable(..)
             | ty::PredicateKind::ConstEquate(..)
+            | ty::PredicateKind::TypeEquate(..)
             | ty::PredicateKind::TypeWellFormedFromEnv(..) => false,
         }
     })

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -562,6 +562,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
                 }
 
+                ty::PredicateKind::TypeEquate(lhs, rhs) => {
+                    match self.infcx.can_eq(obligation.param_env, lhs, rhs) {
+                        Ok(()) => Ok(EvaluatedToOk),
+                        Err(_) => Ok(EvaluatedToErr),
+                    }
+                }
+
                 ty::PredicateKind::ConstEquate(c1, c2) => {
                     debug!(?c1, ?c2, "evaluate_predicate_recursively: equating consts");
 

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -140,6 +140,10 @@ pub fn predicate_obligations<'a, 'tcx>(
             wf.compute(c1.into());
             wf.compute(c2.into());
         }
+        ty::PredicateKind::TypeEquate(lhs, rhs) => {
+            wf.compute(lhs.into());
+            wf.compute(rhs.into());
+        }
         ty::PredicateKind::TypeWellFormedFromEnv(..) => {
             bug!("TypeWellFormedFromEnv is only used for Chalk")
         }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -110,6 +110,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::InEnvironment<chalk_ir::Goal<RustInterner<'
                 | ty::PredicateKind::ClosureKind(..)
                 | ty::PredicateKind::Subtype(..)
                 | ty::PredicateKind::ConstEvaluatable(..)
+                | ty::PredicateKind::TypeEquate(..)
                 | ty::PredicateKind::ConstEquate(..) => bug!("unexpected predicate {}", predicate),
             };
             let value = chalk_ir::ProgramClauseImplication {
@@ -194,6 +195,7 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::GoalData<RustInterner<'tcx>>> for ty::Predi
             ty::PredicateKind::ClosureKind(..)
             | ty::PredicateKind::Subtype(..)
             | ty::PredicateKind::ConstEvaluatable(..)
+            | ty::PredicateKind::TypeEquate(..)
             | ty::PredicateKind::ConstEquate(..) => {
                 chalk_ir::GoalData::All(chalk_ir::Goals::empty(interner))
             }
@@ -593,6 +595,7 @@ impl<'tcx> LowerInto<'tcx, Option<chalk_ir::QuantifiedWhereClause<RustInterner<'
             | ty::PredicateKind::ClosureKind(..)
             | ty::PredicateKind::Subtype(..)
             | ty::PredicateKind::ConstEvaluatable(..)
+            | ty::PredicateKind::TypeEquate(..)
             | ty::PredicateKind::ConstEquate(..)
             | ty::PredicateKind::TypeWellFormedFromEnv(..) => {
                 bug!("unexpected predicate {}", &self)
@@ -721,6 +724,7 @@ impl<'tcx> LowerInto<'tcx, Option<chalk_solve::rust_ir::QuantifiedInlineBound<Ru
             | ty::PredicateKind::Subtype(..)
             | ty::PredicateKind::ConstEvaluatable(..)
             | ty::PredicateKind::ConstEquate(..)
+            | ty::PredicateKind::TypeEquate(..)
             | ty::PredicateKind::TypeWellFormedFromEnv(..) => {
                 bug!("unexpected predicate {}", &self)
             }

--- a/compiler/rustc_traits/src/implied_outlives_bounds.rs
+++ b/compiler/rustc_traits/src/implied_outlives_bounds.rs
@@ -104,6 +104,7 @@ fn compute_implied_outlives_bounds<'tcx>(
                     | ty::PredicateKind::ObjectSafe(..)
                     | ty::PredicateKind::ConstEvaluatable(..)
                     | ty::PredicateKind::ConstEquate(..)
+                    | ty::PredicateKind::TypeEquate(..)
                     | ty::PredicateKind::TypeWellFormedFromEnv(..) => vec![],
                     ty::PredicateKind::WellFormed(arg) => {
                         wf_args.push(arg);

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -67,6 +67,7 @@ fn not_outlives_predicate(p: &ty::Predicate<'tcx>) -> bool {
         | ty::PredicateKind::Subtype(..)
         | ty::PredicateKind::ConstEvaluatable(..)
         | ty::PredicateKind::ConstEquate(..)
+        | ty::PredicateKind::TypeEquate(..)
         | ty::PredicateKind::TypeWellFormedFromEnv(..) => true,
     }
 }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -838,6 +838,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ty::PredicateKind::WellFormed(..) => None,
                     ty::PredicateKind::ObjectSafe(..) => None,
                     ty::PredicateKind::ConstEvaluatable(..) => None,
+                    ty::PredicateKind::TypeEquate(..) => None,
                     ty::PredicateKind::ConstEquate(..) => None,
                     // N.B., this predicate is created by breaking down a
                     // `ClosureType: FnFoo()` predicate, where

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -849,6 +849,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 | ty::PredicateKind::TypeOutlives(..)
                 | ty::PredicateKind::ConstEvaluatable(..)
                 | ty::PredicateKind::ConstEquate(..)
+                | ty::PredicateKind::TypeEquate(..)
                 | ty::PredicateKind::TypeWellFormedFromEnv(..) => None,
             }
         });

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2294,8 +2294,14 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
                 }))
             }
 
-            hir::WherePredicate::EqPredicate(..) => {
-                // FIXME(#20041)
+            hir::WherePredicate::EqPredicate(where_eq_pred) => {
+                let hir::WhereEqPredicate { hir_id: _, span, lhs_ty, rhs_ty } = where_eq_pred;
+                let lhs = icx.to_ty(&lhs_ty);
+                let rhs = icx.to_ty(&rhs_ty);
+                // FIXME(type_equality_constraints): prevent 2 ty::Params here which currently
+                // doesn't constrain types at all? It's still useful when programming though.
+                predicates
+                    .insert((ty::PredicateKind::TypeEquate(lhs, rhs).to_predicate(icx.tcx), *span));
             }
         }
     }

--- a/compiler/rustc_typeck/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_typeck/src/impl_wf_check/min_specialization.rs
@@ -407,6 +407,7 @@ fn trait_predicate_kind<'tcx>(
         | ty::PredicateKind::ClosureKind(..)
         | ty::PredicateKind::ConstEvaluatable(..)
         | ty::PredicateKind::ConstEquate(..)
+        | ty::PredicateKind::TypeEquate(..)
         | ty::PredicateKind::TypeWellFormedFromEnv(..) => None,
     }
 }

--- a/compiler/rustc_typeck/src/outlives/explicit.rs
+++ b/compiler/rustc_typeck/src/outlives/explicit.rs
@@ -58,6 +58,7 @@ impl<'tcx> ExplicitPredicatesMap<'tcx> {
                     | ty::PredicateKind::Subtype(..)
                     | ty::PredicateKind::ConstEvaluatable(..)
                     | ty::PredicateKind::ConstEquate(..)
+                    | ty::PredicateKind::TypeEquate(..)
                     | ty::PredicateKind::TypeWellFormedFromEnv(..) => (),
                 }
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -327,6 +327,7 @@ impl<'a> Clean<Option<WherePredicate>> for ty::Predicate<'a> {
             ty::PredicateKind::RegionOutlives(pred) => pred.clean(cx),
             ty::PredicateKind::TypeOutlives(pred) => pred.clean(cx),
             ty::PredicateKind::Projection(pred) => Some(pred.clean(cx)),
+            ty::PredicateKind::TypeEquate(..) => todo!(),
             ty::PredicateKind::ConstEvaluatable(..) => None,
 
             ty::PredicateKind::Subtype(..)

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -295,9 +295,9 @@ crate fn print_where_clause<'a, 'tcx: 'a>(
                 }
                 clean::WherePredicate::EqPredicate { lhs, rhs } => {
                     if f.alternate() {
-                        clause.push_str(&format!("{:#} == {:#}", lhs.print(cx), rhs.print(cx),));
+                        clause.push_str(&format!("{:#} = {:#}", lhs.print(cx), rhs.print(cx),));
                     } else {
-                        clause.push_str(&format!("{} == {}", lhs.print(cx), rhs.print(cx),));
+                        clause.push_str(&format!("{} = {}", lhs.print(cx), rhs.print(cx),));
                     }
                 }
             }

--- a/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
+++ b/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
@@ -31,6 +31,7 @@ fn paint<C:BoxCar>(c: C, d: C::Color) {
 
 fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
     //~^ ERROR the value of the associated types
+    //~| ERROR the value of the associated types
     //~| ERROR equality constraints are not yet supported in `where` clauses
 }
 

--- a/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -4,6 +4,7 @@ error: equality constraints are not yet supported in `where` clauses
 LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
+   = help: add `#![feature(type_equality_constraints)]` to the crate attributes to enable
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
@@ -81,6 +82,20 @@ LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ^^^^^^^^^^^^^^^^^
 
 error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:51
+   |
+LL |     type Color;
+   |     ----------- `Vehicle::Color` defined here
+...
+LL |     type Color;
+   |     ----------- `Box::Color` defined here
+...
+LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                                   ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+   |
+   = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
+
+error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
    |
 LL |     type Color;
@@ -94,7 +109,7 @@ LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0191, E0221, E0222.
 For more information about an error, try `rustc --explain E0191`.

--- a/src/test/ui/feature-gates/feature-gate-type_equality_constraints.normal.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_equality_constraints.normal.stderr
@@ -1,0 +1,11 @@
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/feature-gate-type_equality_constraints.rs:9:22
+   |
+LL | impl<T> Baz<T> where T = i32 {
+   |                      ^^^^^^^ not supported
+   |
+   = help: add `#![feature(type_equality_constraints)]` to the crate attributes to enable
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+
+error: aborting due to previous error
+

--- a/src/test/ui/feature-gates/feature-gate-type_equality_constraints.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_equality_constraints.rs
@@ -1,0 +1,17 @@
+// [feature] run-pass
+// revisions: normal feature
+#![cfg_attr(feature, feature(type_equality_constraints))]
+
+struct Baz<T> {
+  _t: T,
+}
+
+impl<T> Baz<T> where T = i32 {
+//[normal]~^ ERROR equality constraints
+  fn resolved(self) {}
+}
+
+fn main() {
+  let b = Baz{_t: 1i32};
+  b.resolved();
+}

--- a/src/test/ui/parser/bounds-type-where.rs
+++ b/src/test/ui/parser/bounds-type-where.rs
@@ -6,6 +6,6 @@ type A where T: Trait + Trait = u8; // OK
 type A where = u8; // OK
 type A where T: Trait + = u8; // OK
 type A where T, = u8;
-//~^ ERROR expected one of `!`, `(`, `+`, `::`, `:`, `<`, `==`, or `=`, found `,`
+//~^ ERROR expected one of `!`, `(`, `+`, `::`, `:`, `<`, or `=`, found `,`
 
 fn main() {}

--- a/src/test/ui/parser/bounds-type-where.stderr
+++ b/src/test/ui/parser/bounds-type-where.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!`, `(`, `+`, `::`, `:`, `<`, `==`, or `=`, found `,`
+error: expected one of `!`, `(`, `+`, `::`, `:`, `<`, or `=`, found `,`
   --> $DIR/bounds-type-where.rs:8:15
    |
 LL | type A where T, = u8;
-   |               ^ expected one of 8 possible tokens
+   |               ^ expected one of 7 possible tokens
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-17904.rs
+++ b/src/test/ui/parser/issue-17904.rs
@@ -1,6 +1,6 @@
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.
 struct Baz<U>(U) where U: Eq; // This rightfully signals no error as well.
-struct Foo<T> where T: Copy, (T); //~ ERROR expected one of `:`, `==`, or `=`, found `;`
+struct Foo<T> where T: Copy, (T); //~ ERROR expected one of `:` or `=`, found `;`
 
 fn main() {}

--- a/src/test/ui/parser/issue-17904.stderr
+++ b/src/test/ui/parser/issue-17904.stderr
@@ -1,8 +1,8 @@
-error: expected one of `:`, `==`, or `=`, found `;`
+error: expected one of `:` or `=`, found `;`
   --> $DIR/issue-17904.rs:4:33
    |
 LL | struct Foo<T> where T: Copy, (T);
-   |                                 ^ expected one of `:`, `==`, or `=`
+   |                                 ^ expected one of `:` or `=`
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-eq-assoc.rs
+++ b/src/test/ui/where-clauses/where-eq-assoc.rs
@@ -1,0 +1,29 @@
+#![feature(type_equality_constraints)]
+
+pub fn foo<T:Iterator>(mut t: T) -> T::Item
+    where T::Item = u32
+{
+    t.next().unwrap()
+}
+
+pub fn foo2<T:Iterator>(mut t: T) -> T::Item
+    where u32 = T::Item
+{
+    t.next().unwrap()
+}
+
+pub fn foo3<T:Iterator>(mut t: T) -> u32
+    where T::Item = u32
+{
+    t.next().unwrap()
+    //~^ ERROR mismatched types
+}
+
+pub fn foo4<T:Iterator>(mut t: T) -> u32
+    where u32 = T::Item
+{
+    t.next().unwrap()
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/where-clauses/where-eq-assoc.stderr
+++ b/src/test/ui/where-clauses/where-eq-assoc.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> $DIR/where-eq-assoc.rs:18:5
+   |
+LL | pub fn foo3<T:Iterator>(mut t: T) -> u32
+   |                                      --- expected `u32` because of return type
+...
+LL |     t.next().unwrap()
+   |     ^^^^^^^^^^^^^^^^^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Iterator>::Item`
+help: consider constraining the associated type `<T as Iterator>::Item` to `u32`
+   |
+LL | pub fn foo3<T:Iterator<Item = u32>>(mut t: T) -> u32
+   |                       ^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-assoc.rs:25:5
+   |
+LL | pub fn foo4<T:Iterator>(mut t: T) -> u32
+   |                                      --- expected `u32` because of return type
+...
+LL |     t.next().unwrap()
+   |     ^^^^^^^^^^^^^^^^^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Iterator>::Item`
+help: consider constraining the associated type `<T as Iterator>::Item` to `u32`
+   |
+LL | pub fn foo4<T:Iterator<Item = u32>>(mut t: T) -> u32
+   |                       ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/where-clauses/where-eq-double-eq.rs
+++ b/src/test/ui/where-clauses/where-eq-double-eq.rs
@@ -1,0 +1,4 @@
+pub fn foo<T>() where T == u32 {}
+//~^ ERROR type equality
+
+fn main() {}

--- a/src/test/ui/where-clauses/where-eq-double-eq.stderr
+++ b/src/test/ui/where-clauses/where-eq-double-eq.stderr
@@ -1,0 +1,8 @@
+error: type equality predicates are `=` not `==`
+  --> $DIR/where-eq-double-eq.rs:1:23
+   |
+LL | pub fn foo<T>() where T == u32 {}
+   |                       ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/where-clauses/where-eq-into-iter.rs
+++ b/src/test/ui/where-clauses/where-eq-into-iter.rs
@@ -1,0 +1,13 @@
+// run-pass
+#![feature(type_equality_constraints)]
+
+pub fn foo1<T: IntoIterator>() where T = Vec<T::Item> {}
+pub fn foo2<T: IntoIterator>() where T::Item = u32 {}
+pub fn foo3<T: IntoIterator>() where T::Item = u32, T = Vec<u32> {}
+pub fn foo4<T: IntoIterator>() where T::Item = u32, T = Vec<T::Item> {}
+
+pub trait Bar {}
+pub fn foo5<T: IntoIterator>() where T::Item = u32, T::Item: Bar {}
+pub fn foo6<T: IntoIterator>() where T::Item: Bar, T::Item = u32 {}
+
+fn main() {}

--- a/src/test/ui/where-clauses/where-eq-multiple.rs
+++ b/src/test/ui/where-clauses/where-eq-multiple.rs
@@ -1,0 +1,18 @@
+#![feature(type_equality_constraints)]
+
+// multiple types can compile, but can't actually be called
+pub fn foo7<T: IntoIterator>() where T::Item = u64, T::Item = u32 {}
+
+pub fn foo8<T>() where T = i32, T = i64, T = usize {}
+
+fn main() {
+  foo8::<i32>();
+  //~^ ERROR mismatched types
+  //~| ERROR mismatched types
+  foo8::<i64>();
+  //~^ ERROR mismatched types
+  //~| ERROR mismatched types
+  foo8::<usize>();
+  //~^ ERROR mismatched types
+  //~| ERROR mismatched types
+}

--- a/src/test/ui/where-clauses/where-eq-multiple.stderr
+++ b/src/test/ui/where-clauses/where-eq-multiple.stderr
@@ -1,0 +1,57 @@
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:9:3
+   |
+LL |   foo8::<i32>();
+   |   ^^^^^^^^^^^ expected `i32`, found `i64`
+   |
+   = note: expected type `i64`
+              found type `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:9:3
+   |
+LL |   foo8::<i32>();
+   |   ^^^^^^^^^^^ expected `i32`, found `usize`
+   |
+   = note: expected type `usize`
+              found type `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:12:3
+   |
+LL |   foo8::<i64>();
+   |   ^^^^^^^^^^^ expected `i64`, found `i32`
+   |
+   = note: expected type `i32`
+              found type `i64`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:12:3
+   |
+LL |   foo8::<i64>();
+   |   ^^^^^^^^^^^ expected `i64`, found `usize`
+   |
+   = note: expected type `usize`
+              found type `i64`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:15:3
+   |
+LL |   foo8::<usize>();
+   |   ^^^^^^^^^^^^^ expected `usize`, found `i32`
+   |
+   = note: expected type `i32`
+              found type `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq-multiple.rs:15:3
+   |
+LL |   foo8::<usize>();
+   |   ^^^^^^^^^^^^^ expected `usize`, found `i64`
+   |
+   = note: expected type `i64`
+              found type `usize`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/where-clauses/where-eq-rnd-params.rs
+++ b/src/test/ui/where-clauses/where-eq-rnd-params.rs
@@ -1,0 +1,10 @@
+#![feature(type_equality_constraints)]
+
+pub fn foo<A,B>(a: A) -> B
+    where A = B
+{
+    a
+    //~^ ERROR mismatched types
+}
+
+ fn main() {}

--- a/src/test/ui/where-clauses/where-eq-rnd-params.stderr
+++ b/src/test/ui/where-clauses/where-eq-rnd-params.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/where-eq-rnd-params.rs:6:5
+   |
+LL | pub fn foo<A,B>(a: A) -> B
+   |            - -           - expected `B` because of return type
+   |            | |
+   |            | expected type parameter
+   |            found type parameter
+...
+LL |     a
+   |     ^ expected type parameter `B`, found type parameter `A`
+   |
+   = note: expected type parameter `B`
+              found type parameter `A`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/where-clauses/where-eq-self.rs
+++ b/src/test/ui/where-clauses/where-eq-self.rs
@@ -1,0 +1,20 @@
+#![feature(type_equality_constraints)]
+
+pub struct Foo;
+
+impl Foo {
+    pub fn foo<T>(&self) where T = Self {}
+}
+
+pub trait Bar {
+    fn test<T>() -> Self where T = Self;
+}
+
+impl Bar for Foo {
+    fn test<T>() -> Self where T = Self {
+    //~^ ERROR method not compatible with trait
+      Foo
+    }
+}
+
+fn main() {}

--- a/src/test/ui/where-clauses/where-eq-self.stderr
+++ b/src/test/ui/where-clauses/where-eq-self.stderr
@@ -1,0 +1,12 @@
+error[E0308]: method not compatible with trait
+  --> $DIR/where-eq-self.rs:14:5
+   |
+LL |     fn test<T>() -> Self where T = Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found struct `Foo`
+   |
+   = note:      expected struct `Foo`
+           found type parameter `T`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/where-clauses/where-eq.rs
+++ b/src/test/ui/where-clauses/where-eq.rs
@@ -1,0 +1,19 @@
+#![feature(type_equality_constraints)]
+
+trait Foo {}
+struct Bar;
+struct NotBar;
+impl Foo for Bar {}
+impl Foo for NotBar {}
+
+fn baz<T: Foo>() where T = Bar {}
+fn baz2<T>() where T = i32 {}
+
+fn main() {
+  baz::<Bar>();
+  baz::<NotBar>();
+  //~^ ERROR mismatched types
+  baz2::<i32>();
+  baz2::<Bar>();
+  //~^ ERROR mismatched types
+}

--- a/src/test/ui/where-clauses/where-eq.stderr
+++ b/src/test/ui/where-clauses/where-eq.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/where-eq.rs:14:3
+   |
+LL |   baz::<NotBar>();
+   |   ^^^^^^^^^^^^^ expected struct `NotBar`, found struct `Bar`
+   |
+   = note: expected struct `Bar`
+              found struct `NotBar`
+
+error[E0308]: mismatched types
+  --> $DIR/where-eq.rs:17:3
+   |
+LL |   baz2::<Bar>();
+   |   ^^^^^^^^^^^ expected struct `Bar`, found `i32`
+   |
+   = note: expected type `i32`
+            found struct `Bar`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/where-clauses/where-equality-constraints.rs
+++ b/src/test/ui/where-clauses/where-equality-constraints.rs
@@ -1,6 +1,8 @@
 fn f() where u8 = u16 {}
 //~^ ERROR equality constraints are not yet supported in `where` clauses
-fn g() where for<'a> &'static (u8,) == u16, {}
+//~| ERROR mismatched types
+fn g() where for<'a> &'static (u8,) = u16, {}
 //~^ ERROR equality constraints are not yet supported in `where` clauses
+//~| ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/where-clauses/where-equality-constraints.stderr
+++ b/src/test/ui/where-clauses/where-equality-constraints.stderr
@@ -4,15 +4,36 @@ error: equality constraints are not yet supported in `where` clauses
 LL | fn f() where u8 = u16 {}
    |              ^^^^^^^^ not supported
    |
+   = help: add `#![feature(type_equality_constraints)]` to the crate attributes to enable
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/where-equality-constraints.rs:3:14
+  --> $DIR/where-equality-constraints.rs:4:14
    |
-LL | fn g() where for<'a> &'static (u8,) == u16, {}
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL | fn g() where for<'a> &'static (u8,) = u16, {}
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
+   = help: add `#![feature(type_equality_constraints)]` to the crate attributes to enable
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/where-equality-constraints.rs:1:1
+   |
+LL | fn f() where u8 = u16 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u16`
+   |
+   = note: expected type `u16`
+              found type `u8`
 
+error[E0308]: mismatched types
+  --> $DIR/where-equality-constraints.rs:4:1
+   |
+LL | fn g() where for<'a> &'static (u8,) = u16, {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&(u8,)`, found `u16`
+   |
+   = note:   expected type `u16`
+           found reference `&'static (u8,)`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -32,6 +32,7 @@ pub fn is_min_const_fn(tcx: TyCtxt<'tcx>, body: &'a Body<'tcx>, msrv: Option<&Ru
                 | ty::PredicateKind::Projection(_)
                 | ty::PredicateKind::ConstEvaluatable(..)
                 | ty::PredicateKind::ConstEquate(..)
+                | ty::PredicateKind::TypeEquate(..)
                 | ty::PredicateKind::TypeWellFormedFromEnv(..) => continue,
                 ty::PredicateKind::ObjectSafe(_) => panic!("object safe predicate on function: {:#?}", predicate),
                 ty::PredicateKind::ClosureKind(..) => panic!("closure kind predicate on function: {:#?}", predicate),


### PR DESCRIPTION
Updates #20041.

I took the most low-budget approach to adding equality checks (2 subtype checks in each direction), if it makes more sense to add in one check that does just equality, please let me know.

r? @varkor 