### PR TITLE
Notify the Rust 2021 edition working group in zulip of edition bugs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -112,8 +112,8 @@ message_on_add = """\
 """
 message_on_remove = "Issue #{number}'s nomination request has been removed."
 
-[notify-zulip."edition 2021"]
-required_labels = ["C-bug", "A-edition-2021"]
+[notify-zulip."A-edition-2021"]
+required_labels = ["C-bug"]
 zulip_stream = 268952 # #edition 2021
 topic = "Edition Bugs"
 message_on_add = """\

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -112,6 +112,14 @@ message_on_add = """\
 """
 message_on_remove = "Issue #{number}'s nomination request has been removed."
 
+[notify-zulip."edition 2021"]
+required_labels = ["C-bug", "A-edition-2021"]
+zulip_stream = 268952 # #edition 2021
+topic = "Edition Bugs"
+message_on_add = """\
+Issue #{number} "{title}" has been added.
+"""
+
 [github-releases]
 format = "rustc"
 project-name = "Rust"


### PR DESCRIPTION
Notifying the group of these issues will make it easier for us to track them. 

r? @jyn514 