### PR TITLE
Add missing whitespace after attribute in HTML template

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -83,7 +83,7 @@
                     </select> {#- -#}
                     {%- endif -%}
                     <input {# -#}
-                        class="search-input"{# -#}
+                        class="search-input" {# -#}
                         name="search" {# -#}
                         disabled {# -#}
                         autocomplete="off" {# -#}


### PR DESCRIPTION
Firefox (even though it worked) highlights it as red when you look at the source code because there is a missing whitespace.

r? @notriddle 