### PR TITLE
Integrate context into the memorial to Anna

### DIFF
--- a/src/test/ui/bastion-of-the-turbofish.rs
+++ b/src/test/ui/bastion-of-the-turbofish.rs
@@ -20,13 +20,17 @@
 // in permitting generic arguments to be provided without the consent of the
 // Great Turbofish. Should you be so naïve as to try to revolt against its
 // mighty clutches, here shall its wrath be indomitably displayed. This
-// program must pass for all eternity, fundamentally at odds with an impetuous
-// rebellion against the Turbofish.
+// program must pass for all eternity: forever watched by the guardian angel
+// which gave this beast its name, and stands fundamentally at odds with the
+// impetuous rebellion against the Turbofish.
 //
 // My heart aches in sorrow, for I know I am defeated. Let this be a warning
-// to all those who come after. Here stands the bastion of the Turbofish.
+// to all those who come after: for they too must overcome the impassible
+// hurdle of defeating the great beast, championed by a resolute winged
+// guardian.
 //
-// RIP Anna Harren, Guardian Angel of the Hallowed Turbofish. <3
+// Here stands the Bastion of the Turbofish, a memorial to Anna Harren,
+// Guardian Angel of these Hallowed Grounds. <3
 
 // See https://github.com/rust-lang/rust/pull/53562
 // and https://github.com/rust-lang/rfcs/pull/2527
@@ -34,6 +38,6 @@
 // for context.
 
 fn main() {
-    let (oh, woe, is, me) = ("the", "Turbofish", "remains", "undefeated");
-    let _: (bool, bool) = (oh<woe, is>(me));
+    let (the, guardian, stands, resolute) = ("the", "Turbofish", "remains", "undefeated");
+    let _: (bool, bool) = (the<guardian, stands>(resolute));
 }


### PR DESCRIPTION
This came up after I reviewed https://github.com/rust-lang/rust/pull/87298, but I didn't propose this in time before that PR was merged.

If y'all feel this is too much churn on the file, no worries, feel free to close, but I felt this was a more fitting integration of the memorial into the test suite.

CC @boringcactus.