### PR TITLE
SGX mutex is *not* moveable

### DIFF
--- a/library/std/src/sys/sgx/mutex.rs
+++ b/library/std/src/sys/sgx/mutex.rs
@@ -8,7 +8,7 @@ pub struct Mutex {
     inner: SpinMutex<WaitVariable<bool>>,
 }
 
-pub type MovableMutex = Mutex;
+pub type MovableMutex = Box<Mutex>;
 
 // Implementation according to “Operating Systems: Three Easy Pieces”, chapter 28
 impl Mutex {

--- a/library/std/src/sys/sgx/mutex.rs
+++ b/library/std/src/sys/sgx/mutex.rs
@@ -8,6 +8,7 @@ pub struct Mutex {
     inner: SpinMutex<WaitVariable<bool>>,
 }
 
+// not movable: see UnsafeList implementation
 pub type MovableMutex = Box<Mutex>;
 
 // Implementation according to “Operating Systems: Three Easy Pieces”, chapter 28

--- a/library/std/src/sys/sgx/waitqueue/unsafe_list.rs
+++ b/library/std/src/sys/sgx/waitqueue/unsafe_list.rs
@@ -23,6 +23,7 @@ impl<T> UnsafeListEntry<T> {
     }
 }
 
+// WARNING: self-referential struct!
 pub struct UnsafeList<T> {
     head_tail: NonNull<UnsafeListEntry<T>>,
     head_tail_entry: Option<UnsafeListEntry<T>>,


### PR DESCRIPTION
Reverts the erroneous change in #85029.