### PR TITLE
Trait upcasting coercion (part2)

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/vtable.rs
+++ b/compiler/rustc_codegen_cranelift/src/vtable.rs
@@ -5,7 +5,7 @@
 use crate::constant::data_id_for_alloc_id;
 use crate::prelude::*;
 
-fn vtable_memflags() -> MemFlags {
+pub(crate) fn vtable_memflags() -> MemFlags {
     let mut flags = MemFlags::trusted(); // A vtable access is always aligned and will never trap.
     flags.set_readonly(); // A vtable is always read-only.
     flags

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -977,6 +977,11 @@ rustc_queries! {
         desc { |tcx| "finding all vtable entries for trait {}", tcx.def_path_str(key.def_id()) }
     }
 
+    query vtable_trait_upcasting_coercion_new_vptr_slot(key: (ty::PolyTraitRef<'tcx>, ty::PolyTraitRef<'tcx>)) -> Option<usize> {
+        desc { |tcx| "finding the slot within vtable for trait {} vtable ptr during trait upcasting coercion from {} vtable",
+            tcx.def_path_str(key.1.def_id()), tcx.def_path_str(key.0.def_id()) }
+    }
+
     query codegen_fulfill_obligation(
         key: (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>)
     ) -> Result<ImplSource<'tcx, ()>, ErrorReported> {

--- a/compiler/rustc_mir/src/interpret/cast.rs
+++ b/compiler/rustc_mir/src/interpret/cast.rs
@@ -269,12 +269,34 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     Immediate::new_slice(ptr, length.eval_usize(*self.tcx, self.param_env), self);
                 self.write_immediate(val, dest)
             }
-            (&ty::Dynamic(..), &ty::Dynamic(..)) => {
-                // For now, upcasts are limited to changes in marker
-                // traits, and hence never actually require an actual
-                // change to the vtable.
+            (&ty::Dynamic(ref data_a, ..), &ty::Dynamic(ref data_b, ..)) => {
                 let val = self.read_immediate(src)?;
-                self.write_immediate(*val, dest)
+                if data_a.principal_def_id() == data_b.principal_def_id() {
+                    return self.write_immediate(*val, dest);
+                }
+                // trait upcasting coercion
+                let principal_a = data_a.principal().expect(
+                    "unsize_into_ptr: missing principal trait for trait upcasting coercion",
+                );
+                let principal_b = data_b.principal().expect(
+                    "unsize_into_ptr: missing principal trait for trait upcasting coercion",
+                );
+
+                let vptr_entry_idx = self.tcx.vtable_trait_upcasting_coercion_new_vptr_slot((
+                    principal_a.with_self_ty(*self.tcx, src_pointee_ty),
+                    principal_b.with_self_ty(*self.tcx, src_pointee_ty),
+                ));
+
+                if let Some(entry_idx) = vptr_entry_idx {
+                    let entry_idx = u64::try_from(entry_idx).unwrap();
+                    let (old_data, old_vptr) = val.to_scalar_pair()?;
+                    let old_vptr = self.scalar_to_ptr(old_vptr);
+                    let new_vptr = self
+                        .read_new_vtable_after_trait_upcasting_from_vtable(old_vptr, entry_idx)?;
+                    self.write_immediate(Immediate::new_dyn_trait(old_data, new_vptr, self), dest)
+                } else {
+                    self.write_immediate(*val, dest)
+                }
             }
             (_, &ty::Dynamic(ref data, _)) => {
                 // Initial cast from sized to dyn trait

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -79,6 +79,16 @@ impl<'tcx, Tag: Provenance> Immediate<Tag> {
     pub fn to_scalar(self) -> InterpResult<'tcx, Scalar<Tag>> {
         self.to_scalar_or_uninit().check_init()
     }
+
+    #[inline]
+    pub fn to_scalar_pair(self) -> InterpResult<'tcx, (Scalar<Tag>, Scalar<Tag>)> {
+        match self {
+            Immediate::ScalarPair(val1, val2) => Ok((val1.check_init()?, val2.check_init()?)),
+            Immediate::Scalar(..) => {
+                bug!("Got a scalar where a wide pointer was expected")
+            }
+        }
+    }
 }
 
 // ScalarPair needs a type to interpret, so we often have an immediate and a type together

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -63,15 +63,19 @@ impl<'tcx, Tag: Provenance> Immediate<Tag> {
         Immediate::ScalarPair(val.into(), Scalar::from_machine_usize(len, cx).into())
     }
 
-    pub fn new_dyn_trait(val: Scalar<Tag>, vtable: Pointer<Tag>, cx: &impl HasDataLayout) -> Self {
-        Immediate::ScalarPair(val.into(), ScalarMaybeUninit::from_pointer(vtable, cx))
+    pub fn new_dyn_trait(
+        val: Scalar<Tag>,
+        vtable: Pointer<Option<Tag>>,
+        cx: &impl HasDataLayout,
+    ) -> Self {
+        Immediate::ScalarPair(val.into(), ScalarMaybeUninit::from_maybe_pointer(vtable, cx))
     }
 
     #[inline]
     pub fn to_scalar_or_uninit(self) -> ScalarMaybeUninit<Tag> {
         match self {
             Immediate::Scalar(val) => val,
-            Immediate::ScalarPair(..) => bug!("Got a wide pointer where a scalar was expected"),
+            Immediate::ScalarPair(..) => bug!("Got a scalar pair where a scalar was expected"),
         }
     }
 
@@ -85,7 +89,7 @@ impl<'tcx, Tag: Provenance> Immediate<Tag> {
         match self {
             Immediate::ScalarPair(val1, val2) => Ok((val1.check_init()?, val2.check_init()?)),
             Immediate::Scalar(..) => {
-                bug!("Got a scalar where a wide pointer was expected")
+                bug!("Got a scalar where a scalar pair was expected")
             }
         }
     }

--- a/compiler/rustc_query_impl/src/keys.rs
+++ b/compiler/rustc_query_impl/src/keys.rs
@@ -282,6 +282,16 @@ impl<'tcx> Key for ty::PolyTraitRef<'tcx> {
     }
 }
 
+impl<'tcx> Key for (ty::PolyTraitRef<'tcx>, ty::PolyTraitRef<'tcx>) {
+    #[inline(always)]
+    fn query_crate_is_local(&self) -> bool {
+        self.0.def_id().krate == LOCAL_CRATE
+    }
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        tcx.def_span(self.0.def_id())
+    }
+}
+
 impl<'tcx> Key for GenericArg<'tcx> {
     #[inline(always)]
     fn query_crate_is_local(&self) -> bool {

--- a/src/doc/unstable-book/src/language-features/trait-upcasting.md
+++ b/src/doc/unstable-book/src/language-features/trait-upcasting.md
@@ -1,17 +1,18 @@
 # `trait_upcasting`
 
-The tracking issue for this feature is: [#31436]
+The tracking issue for this feature is: [#65991]
 
 [#65991]: https://github.com/rust-lang/rust/issues/65991
 
 ------------------------
 
-The `trait_upcasting` feature adds support for trait upcasting. This allows a
-trait object of type `dyn Foo` to be cast to a trait object of type `dyn Bar`
-so long as `Foo: Bar`.
+The `trait_upcasting` feature adds support for trait upcasting coercion. This allows a
+trait object of type `dyn Bar` to be cast to a trait object of type `dyn Foo`
+so long as `Bar: Foo`.
 
 ```rust,edition2018
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo {}
 
@@ -21,6 +22,6 @@ impl Foo for i32 {}
 
 impl<T: Foo + ?Sized> Bar for T {}
 
-let foo: &dyn Foo = &123;
-let bar: &dyn Bar = foo;
+let bar: &dyn Bar = &123;
+let foo: &dyn Foo = bar;
 ```

--- a/src/doc/unstable-book/src/language-features/trait-upcasting.md
+++ b/src/doc/unstable-book/src/language-features/trait-upcasting.md
@@ -1,0 +1,26 @@
+# `trait_upcasting`
+
+The tracking issue for this feature is: [#31436]
+
+[#65991]: https://github.com/rust-lang/rust/issues/65991
+
+------------------------
+
+The `trait_upcasting` feature adds support for trait upcasting. This allows a
+trait object of type `dyn Foo` to be cast to a trait object of type `dyn Bar`
+so long as `Foo: Bar`.
+
+```rust,edition2018
+#![feature(trait_upcasting)]
+
+trait Foo {}
+
+trait Bar: Foo {}
+
+impl Foo for i32 {}
+
+impl<T: Foo + ?Sized> Bar for T {}
+
+let foo: &dyn Foo = &123;
+let bar: &dyn Bar = foo;
+```

--- a/src/test/ui/traits/trait-upcasting/basic.rs
+++ b/src/test/ui/traits/trait-upcasting/basic.rs
@@ -1,0 +1,80 @@
+// run-pass
+
+#![feature(trait_upcasting)]
+
+trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar: Foo {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Baz: Bar {
+    fn c(&self) -> i32 { 30 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Baz for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+fn main() {
+    let baz: &dyn Baz = &1;
+    let _: &dyn std::fmt::Debug = baz;
+    let _: &(dyn Send + Sync) = baz;
+    let _: &dyn Send = baz;
+    let _: &dyn Sync = baz;
+    assert_eq!(*baz, 1);
+    assert_eq!(baz.a(), 100);
+    assert_eq!(baz.b(), 200);
+    assert_eq!(baz.c(), 300);
+    assert_eq!(baz.z(), 11);
+    assert_eq!(baz.y(), 12);
+    assert_eq!(baz.w(), 21);
+
+    let bar: &dyn Bar = baz;
+    let _: &dyn std::fmt::Debug = bar;
+    let _: &(dyn Send + Sync) = bar;
+    let _: &dyn Send = bar;
+    let _: &dyn Sync = bar;
+    assert_eq!(*bar, 1);
+    assert_eq!(bar.a(), 100);
+    assert_eq!(bar.b(), 200);
+    assert_eq!(bar.z(), 11);
+    assert_eq!(bar.y(), 12);
+    assert_eq!(bar.w(), 21);
+
+    let foo: &dyn Foo = baz;
+    let _: &dyn std::fmt::Debug = foo;
+    let _: &(dyn Send + Sync) = foo;
+    let _: &dyn Send = foo;
+    let _: &dyn Sync = foo;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+
+    let foo: &dyn Foo = bar;
+    let _: &dyn std::fmt::Debug = foo;
+    let _: &(dyn Send + Sync) = foo;
+    let _: &dyn Send = foo;
+    let _: &dyn Sync = foo;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+}

--- a/src/test/ui/traits/trait-upcasting/basic.rs
+++ b/src/test/ui/traits/trait-upcasting/basic.rs
@@ -1,43 +1,59 @@
 // run-pass
 
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar: Foo {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Baz: Bar {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Baz for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 fn main() {
     let baz: &dyn Baz = &1;
     let _: &dyn std::fmt::Debug = baz;
-    let _: &(dyn Send + Sync) = baz;
-    let _: &dyn Send = baz;
-    let _: &dyn Sync = baz;
     assert_eq!(*baz, 1);
     assert_eq!(baz.a(), 100);
     assert_eq!(baz.b(), 200);
@@ -48,9 +64,6 @@ fn main() {
 
     let bar: &dyn Bar = baz;
     let _: &dyn std::fmt::Debug = bar;
-    let _: &(dyn Send + Sync) = bar;
-    let _: &dyn Send = bar;
-    let _: &dyn Sync = bar;
     assert_eq!(*bar, 1);
     assert_eq!(bar.a(), 100);
     assert_eq!(bar.b(), 200);
@@ -60,9 +73,6 @@ fn main() {
 
     let foo: &dyn Foo = baz;
     let _: &dyn std::fmt::Debug = foo;
-    let _: &(dyn Send + Sync) = foo;
-    let _: &dyn Send = foo;
-    let _: &dyn Sync = foo;
     assert_eq!(*foo, 1);
     assert_eq!(foo.a(), 100);
     assert_eq!(foo.z(), 11);
@@ -70,9 +80,6 @@ fn main() {
 
     let foo: &dyn Foo = bar;
     let _: &dyn std::fmt::Debug = foo;
-    let _: &(dyn Send + Sync) = foo;
-    let _: &dyn Send = foo;
-    let _: &dyn Sync = foo;
     assert_eq!(*foo, 1);
     assert_eq!(foo.a(), 100);
     assert_eq!(foo.z(), 11);

--- a/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
+++ b/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
@@ -1,0 +1,13 @@
+trait A: B + A {}
+//~^ ERROR cycle detected when computing the supertraits of `A` [E0391]
+
+trait B {}
+
+impl A for () {}
+
+impl B for () {}
+
+fn main() {
+    let a: Box<dyn A> = Box::new(());
+    let _b: Box<dyn B> = a;
+}

--- a/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
+++ b/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
@@ -1,5 +1,5 @@
 trait A: B + A {}
-//~^ ERROR cycle detected when computing the supertraits of `A` [E0391]
+//~^ ERROR cycle detected when computing the super predicates of `A` [E0391]
 
 trait B {}
 

--- a/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -1,0 +1,16 @@
+error[E0391]: cycle detected when computing the supertraits of `A`
+  --> $DIR/cyclic-trait-resolution.rs:1:14
+   |
+LL | trait A: B + A {}
+   |              ^
+   |
+   = note: ...which again requires computing the supertraits of `A`, completing the cycle
+note: cycle used when collecting item types in top-level module
+  --> $DIR/cyclic-trait-resolution.rs:1:1
+   |
+LL | trait A: B + A {}
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/src/test/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -1,10 +1,15 @@
-error[E0391]: cycle detected when computing the supertraits of `A`
+error[E0391]: cycle detected when computing the super predicates of `A`
+  --> $DIR/cyclic-trait-resolution.rs:1:1
+   |
+LL | trait A: B + A {}
+   | ^^^^^^^^^^^^^^
+   |
+note: ...which requires computing the super traits of `A`...
   --> $DIR/cyclic-trait-resolution.rs:1:14
    |
 LL | trait A: B + A {}
    |              ^
-   |
-   = note: ...which again requires computing the supertraits of `A`, completing the cycle
+   = note: ...which again requires computing the super predicates of `A`, completing the cycle
 note: cycle used when collecting item types in top-level module
   --> $DIR/cyclic-trait-resolution.rs:1:1
    |

--- a/src/test/ui/traits/trait-upcasting/diamond.rs
+++ b/src/test/ui/traits/trait-upcasting/diamond.rs
@@ -1,0 +1,108 @@
+// run-pass
+
+#![feature(trait_upcasting)]
+
+trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar1: Foo {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Bar2: Foo {
+    fn c(&self) -> i32 { 30 }
+
+    fn v(&self) -> i32 { 31 }
+}
+
+trait Baz: Bar1 + Bar2 {
+    fn d(&self) -> i32 { 40 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar1 for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Bar2 for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+impl Baz for i32 {
+    fn d(&self) -> i32 { 400 }
+}
+
+fn main() {
+    let baz: &dyn Baz = &1;
+    let _: &dyn std::fmt::Debug = baz;
+    let _: &(dyn Send + Sync) = baz;
+    let _: &dyn Send = baz;
+    let _: &dyn Sync = baz;
+    assert_eq!(*baz, 1);
+    assert_eq!(baz.a(), 100);
+    assert_eq!(baz.b(), 200);
+    assert_eq!(baz.c(), 300);
+    assert_eq!(baz.d(), 400);
+    assert_eq!(baz.z(), 11);
+    assert_eq!(baz.y(), 12);
+    assert_eq!(baz.w(), 21);
+    assert_eq!(baz.v(), 31);
+
+    let bar1: &dyn Bar1 = baz;
+    let _: &dyn std::fmt::Debug = bar1;
+    let _: &(dyn Send + Sync) = bar1;
+    let _: &dyn Send = bar1;
+    let _: &dyn Sync = bar1;
+    assert_eq!(*bar1, 1);
+    assert_eq!(bar1.a(), 100);
+    assert_eq!(bar1.b(), 200);
+    assert_eq!(bar1.z(), 11);
+    assert_eq!(bar1.y(), 12);
+    assert_eq!(bar1.w(), 21);
+
+    let bar2: &dyn Bar2 = baz;
+    let _: &dyn std::fmt::Debug = bar2;
+    let _: &(dyn Send + Sync) = bar2;
+    let _: &dyn Send = bar2;
+    let _: &dyn Sync = bar2;
+    assert_eq!(*bar2, 1);
+    assert_eq!(bar2.a(), 100);
+    assert_eq!(bar2.c(), 300);
+    assert_eq!(bar2.z(), 11);
+    assert_eq!(bar2.y(), 12);
+    assert_eq!(bar2.v(), 31);
+
+    let foo: &dyn Foo = baz;
+    let _: &dyn std::fmt::Debug = foo;
+    let _: &(dyn Send + Sync) = foo;
+    let _: &dyn Send = foo;
+    let _: &dyn Sync = foo;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+
+    let foo: &dyn Foo = bar1;
+    let _: &dyn std::fmt::Debug = foo;
+    let _: &(dyn Send + Sync) = foo;
+    let _: &dyn Send = foo;
+    let _: &dyn Sync = foo;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+
+    let foo: &dyn Foo = bar2;
+    let _: &dyn std::fmt::Debug = foo;
+    let _: &(dyn Send + Sync) = foo;
+    let _: &dyn Send = foo;
+    let _: &dyn Sync = foo;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+}

--- a/src/test/ui/traits/trait-upcasting/diamond.rs
+++ b/src/test/ui/traits/trait-upcasting/diamond.rs
@@ -1,53 +1,75 @@
 // run-pass
 
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar1: Foo {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Bar2: Foo {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 
-    fn v(&self) -> i32 { 31 }
+    fn v(&self) -> i32 {
+        31
+    }
 }
 
 trait Baz: Bar1 + Bar2 {
-    fn d(&self) -> i32 { 40 }
+    fn d(&self) -> i32 {
+        40
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar1 for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Bar2 for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 impl Baz for i32 {
-    fn d(&self) -> i32 { 400 }
+    fn d(&self) -> i32 {
+        400
+    }
 }
 
 fn main() {
     let baz: &dyn Baz = &1;
     let _: &dyn std::fmt::Debug = baz;
-    let _: &(dyn Send + Sync) = baz;
-    let _: &dyn Send = baz;
-    let _: &dyn Sync = baz;
     assert_eq!(*baz, 1);
     assert_eq!(baz.a(), 100);
     assert_eq!(baz.b(), 200);
@@ -60,9 +82,6 @@ fn main() {
 
     let bar1: &dyn Bar1 = baz;
     let _: &dyn std::fmt::Debug = bar1;
-    let _: &(dyn Send + Sync) = bar1;
-    let _: &dyn Send = bar1;
-    let _: &dyn Sync = bar1;
     assert_eq!(*bar1, 1);
     assert_eq!(bar1.a(), 100);
     assert_eq!(bar1.b(), 200);
@@ -72,9 +91,6 @@ fn main() {
 
     let bar2: &dyn Bar2 = baz;
     let _: &dyn std::fmt::Debug = bar2;
-    let _: &(dyn Send + Sync) = bar2;
-    let _: &dyn Send = bar2;
-    let _: &dyn Sync = bar2;
     assert_eq!(*bar2, 1);
     assert_eq!(bar2.a(), 100);
     assert_eq!(bar2.c(), 300);
@@ -84,25 +100,16 @@ fn main() {
 
     let foo: &dyn Foo = baz;
     let _: &dyn std::fmt::Debug = foo;
-    let _: &(dyn Send + Sync) = foo;
-    let _: &dyn Send = foo;
-    let _: &dyn Sync = foo;
     assert_eq!(*foo, 1);
     assert_eq!(foo.a(), 100);
 
     let foo: &dyn Foo = bar1;
     let _: &dyn std::fmt::Debug = foo;
-    let _: &(dyn Send + Sync) = foo;
-    let _: &dyn Send = foo;
-    let _: &dyn Sync = foo;
     assert_eq!(*foo, 1);
     assert_eq!(foo.a(), 100);
 
     let foo: &dyn Foo = bar2;
     let _: &dyn std::fmt::Debug = foo;
-    let _: &(dyn Send + Sync) = foo;
-    let _: &dyn Send = foo;
-    let _: &dyn Sync = foo;
     assert_eq!(*foo, 1);
     assert_eq!(foo.a(), 100);
 }

--- a/src/test/ui/traits/trait-upcasting/invalid-upcast.rs
+++ b/src/test/ui/traits/trait-upcasting/invalid-upcast.rs
@@ -1,68 +1,87 @@
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Baz {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Baz for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 fn main() {
     let baz: &dyn Baz = &1;
     let _: &dyn std::fmt::Debug = baz;
-    //~^ ERROR `dyn Baz` doesn't implement `std::fmt::Debug` [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Send = baz;
-    //~^ ERROR `dyn Baz` cannot be sent between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Sync = baz;
-    //~^ ERROR `dyn Baz` cannot be shared between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
 
     let bar: &dyn Bar = baz;
-    //~^ ERROR the trait bound `dyn Baz: Bar` is not satisfied [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn std::fmt::Debug = bar;
-    //~^ ERROR `dyn Bar` doesn't implement `std::fmt::Debug` [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Send = bar;
-    //~^ ERROR `dyn Bar` cannot be sent between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Sync = bar;
-    //~^ ERROR `dyn Bar` cannot be shared between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
 
     let foo: &dyn Foo = baz;
-    //~^ ERROR the trait bound `dyn Baz: Foo` is not satisfied [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn std::fmt::Debug = foo;
-    //~^ ERROR `dyn Foo` doesn't implement `std::fmt::Debug` [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Send = foo;
-    //~^ ERROR `dyn Foo` cannot be sent between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Sync = foo;
-    //~^ ERROR `dyn Foo` cannot be shared between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
 
     let foo: &dyn Foo = bar;
-    //~^ ERROR the trait bound `dyn Bar: Foo` is not satisfied [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn std::fmt::Debug = foo;
-    //~^ ERROR `dyn Foo` doesn't implement `std::fmt::Debug` [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Send = foo;
-    //~^ ERROR `dyn Foo` cannot be sent between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
     let _: &dyn Sync = foo;
-    //~^ ERROR `dyn Foo` cannot be shared between threads safely [E0277]
+    //~^ ERROR mismatched types [E0308]
 }

--- a/src/test/ui/traits/trait-upcasting/invalid-upcast.rs
+++ b/src/test/ui/traits/trait-upcasting/invalid-upcast.rs
@@ -1,0 +1,68 @@
+#![feature(trait_upcasting)]
+
+trait Foo {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Baz {
+    fn c(&self) -> i32 { 30 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Baz for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+fn main() {
+    let baz: &dyn Baz = &1;
+    let _: &dyn std::fmt::Debug = baz;
+    //~^ ERROR `dyn Baz` doesn't implement `std::fmt::Debug` [E0277]
+    let _: &dyn Send = baz;
+    //~^ ERROR `dyn Baz` cannot be sent between threads safely [E0277]
+    let _: &dyn Sync = baz;
+    //~^ ERROR `dyn Baz` cannot be shared between threads safely [E0277]
+
+    let bar: &dyn Bar = baz;
+    //~^ ERROR the trait bound `dyn Baz: Bar` is not satisfied [E0277]
+    let _: &dyn std::fmt::Debug = bar;
+    //~^ ERROR `dyn Bar` doesn't implement `std::fmt::Debug` [E0277]
+    let _: &dyn Send = bar;
+    //~^ ERROR `dyn Bar` cannot be sent between threads safely [E0277]
+    let _: &dyn Sync = bar;
+    //~^ ERROR `dyn Bar` cannot be shared between threads safely [E0277]
+
+    let foo: &dyn Foo = baz;
+    //~^ ERROR the trait bound `dyn Baz: Foo` is not satisfied [E0277]
+    let _: &dyn std::fmt::Debug = foo;
+    //~^ ERROR `dyn Foo` doesn't implement `std::fmt::Debug` [E0277]
+    let _: &dyn Send = foo;
+    //~^ ERROR `dyn Foo` cannot be sent between threads safely [E0277]
+    let _: &dyn Sync = foo;
+    //~^ ERROR `dyn Foo` cannot be shared between threads safely [E0277]
+
+    let foo: &dyn Foo = bar;
+    //~^ ERROR the trait bound `dyn Bar: Foo` is not satisfied [E0277]
+    let _: &dyn std::fmt::Debug = foo;
+    //~^ ERROR `dyn Foo` doesn't implement `std::fmt::Debug` [E0277]
+    let _: &dyn Send = foo;
+    //~^ ERROR `dyn Foo` cannot be sent between threads safely [E0277]
+    let _: &dyn Sync = foo;
+    //~^ ERROR `dyn Foo` cannot be shared between threads safely [E0277]
+}

--- a/src/test/ui/traits/trait-upcasting/invalid-upcast.stderr
+++ b/src/test/ui/traits/trait-upcasting/invalid-upcast.stderr
@@ -1,0 +1,135 @@
+error[E0277]: `dyn Baz` doesn't implement `std::fmt::Debug`
+  --> $DIR/invalid-upcast.rs:35:35
+   |
+LL |     let _: &dyn std::fmt::Debug = baz;
+   |                                   ^^^ `dyn Baz` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `dyn Baz`
+   = note: required for the cast to the object type `dyn std::fmt::Debug`
+
+error[E0277]: `dyn Baz` cannot be sent between threads safely
+  --> $DIR/invalid-upcast.rs:37:24
+   |
+LL |     let _: &dyn Send = baz;
+   |                        ^^^ `dyn Baz` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `dyn Baz`
+   = note: required for the cast to the object type `dyn std::marker::Send`
+
+error[E0277]: `dyn Baz` cannot be shared between threads safely
+  --> $DIR/invalid-upcast.rs:39:24
+   |
+LL |     let _: &dyn Sync = baz;
+   |                        ^^^ `dyn Baz` cannot be shared between threads safely
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `dyn Baz`
+   = note: required for the cast to the object type `dyn std::marker::Sync`
+
+error[E0277]: the trait bound `dyn Baz: Bar` is not satisfied
+  --> $DIR/invalid-upcast.rs:42:25
+   |
+LL |     let bar: &dyn Bar = baz;
+   |                         ^^^ the trait `Bar` is not implemented for `dyn Baz`
+   |
+   = note: required for the cast to the object type `dyn Bar`
+
+error[E0277]: `dyn Bar` doesn't implement `std::fmt::Debug`
+  --> $DIR/invalid-upcast.rs:44:35
+   |
+LL |     let _: &dyn std::fmt::Debug = bar;
+   |                                   ^^^ `dyn Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `dyn Bar`
+   = note: required for the cast to the object type `dyn std::fmt::Debug`
+
+error[E0277]: `dyn Bar` cannot be sent between threads safely
+  --> $DIR/invalid-upcast.rs:46:24
+   |
+LL |     let _: &dyn Send = bar;
+   |                        ^^^ `dyn Bar` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `dyn Bar`
+   = note: required for the cast to the object type `dyn std::marker::Send`
+
+error[E0277]: `dyn Bar` cannot be shared between threads safely
+  --> $DIR/invalid-upcast.rs:48:24
+   |
+LL |     let _: &dyn Sync = bar;
+   |                        ^^^ `dyn Bar` cannot be shared between threads safely
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `dyn Bar`
+   = note: required for the cast to the object type `dyn std::marker::Sync`
+
+error[E0277]: the trait bound `dyn Baz: Foo` is not satisfied
+  --> $DIR/invalid-upcast.rs:51:25
+   |
+LL |     let foo: &dyn Foo = baz;
+   |                         ^^^ the trait `Foo` is not implemented for `dyn Baz`
+   |
+   = note: required for the cast to the object type `dyn Foo`
+
+error[E0277]: `dyn Foo` doesn't implement `std::fmt::Debug`
+  --> $DIR/invalid-upcast.rs:53:35
+   |
+LL |     let _: &dyn std::fmt::Debug = foo;
+   |                                   ^^^ `dyn Foo` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::fmt::Debug`
+
+error[E0277]: `dyn Foo` cannot be sent between threads safely
+  --> $DIR/invalid-upcast.rs:55:24
+   |
+LL |     let _: &dyn Send = foo;
+   |                        ^^^ `dyn Foo` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::marker::Send`
+
+error[E0277]: `dyn Foo` cannot be shared between threads safely
+  --> $DIR/invalid-upcast.rs:57:24
+   |
+LL |     let _: &dyn Sync = foo;
+   |                        ^^^ `dyn Foo` cannot be shared between threads safely
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::marker::Sync`
+
+error[E0277]: the trait bound `dyn Bar: Foo` is not satisfied
+  --> $DIR/invalid-upcast.rs:60:25
+   |
+LL |     let foo: &dyn Foo = bar;
+   |                         ^^^ the trait `Foo` is not implemented for `dyn Bar`
+   |
+   = note: required for the cast to the object type `dyn Foo`
+
+error[E0277]: `dyn Foo` doesn't implement `std::fmt::Debug`
+  --> $DIR/invalid-upcast.rs:62:35
+   |
+LL |     let _: &dyn std::fmt::Debug = foo;
+   |                                   ^^^ `dyn Foo` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |
+   = help: the trait `std::fmt::Debug` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::fmt::Debug`
+
+error[E0277]: `dyn Foo` cannot be sent between threads safely
+  --> $DIR/invalid-upcast.rs:64:24
+   |
+LL |     let _: &dyn Send = foo;
+   |                        ^^^ `dyn Foo` cannot be sent between threads safely
+   |
+   = help: the trait `std::marker::Send` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::marker::Send`
+
+error[E0277]: `dyn Foo` cannot be shared between threads safely
+  --> $DIR/invalid-upcast.rs:66:24
+   |
+LL |     let _: &dyn Sync = foo;
+   |                        ^^^ `dyn Foo` cannot be shared between threads safely
+   |
+   = help: the trait `std::marker::Sync` is not implemented for `dyn Foo`
+   = note: required for the cast to the object type `dyn std::marker::Sync`
+
+error: aborting due to 15 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/trait-upcasting/invalid-upcast.stderr
+++ b/src/test/ui/traits/trait-upcasting/invalid-upcast.stderr
@@ -1,135 +1,168 @@
-error[E0277]: `dyn Baz` doesn't implement `std::fmt::Debug`
-  --> $DIR/invalid-upcast.rs:35:35
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:54:35
    |
 LL |     let _: &dyn std::fmt::Debug = baz;
-   |                                   ^^^ `dyn Baz` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |            --------------------   ^^^ expected trait `Debug`, found trait `Baz`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `dyn Baz`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: expected reference `&dyn Debug`
+              found reference `&dyn Baz`
 
-error[E0277]: `dyn Baz` cannot be sent between threads safely
-  --> $DIR/invalid-upcast.rs:37:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:56:24
    |
 LL |     let _: &dyn Send = baz;
-   |                        ^^^ `dyn Baz` cannot be sent between threads safely
+   |            ---------   ^^^ expected trait `Send`, found trait `Baz`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Send` is not implemented for `dyn Baz`
-   = note: required for the cast to the object type `dyn std::marker::Send`
+   = note: expected reference `&dyn Send`
+              found reference `&dyn Baz`
 
-error[E0277]: `dyn Baz` cannot be shared between threads safely
-  --> $DIR/invalid-upcast.rs:39:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:58:24
    |
 LL |     let _: &dyn Sync = baz;
-   |                        ^^^ `dyn Baz` cannot be shared between threads safely
+   |            ---------   ^^^ expected trait `Sync`, found trait `Baz`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Sync` is not implemented for `dyn Baz`
-   = note: required for the cast to the object type `dyn std::marker::Sync`
+   = note: expected reference `&dyn Sync`
+              found reference `&dyn Baz`
 
-error[E0277]: the trait bound `dyn Baz: Bar` is not satisfied
-  --> $DIR/invalid-upcast.rs:42:25
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:61:25
    |
 LL |     let bar: &dyn Bar = baz;
-   |                         ^^^ the trait `Bar` is not implemented for `dyn Baz`
+   |              --------   ^^^ expected trait `Bar`, found trait `Baz`
+   |              |
+   |              expected due to this
    |
-   = note: required for the cast to the object type `dyn Bar`
+   = note: expected reference `&dyn Bar`
+              found reference `&dyn Baz`
 
-error[E0277]: `dyn Bar` doesn't implement `std::fmt::Debug`
-  --> $DIR/invalid-upcast.rs:44:35
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:63:35
    |
 LL |     let _: &dyn std::fmt::Debug = bar;
-   |                                   ^^^ `dyn Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |            --------------------   ^^^ expected trait `Debug`, found trait `Bar`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `dyn Bar`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: expected reference `&dyn Debug`
+              found reference `&dyn Bar`
 
-error[E0277]: `dyn Bar` cannot be sent between threads safely
-  --> $DIR/invalid-upcast.rs:46:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:65:24
    |
 LL |     let _: &dyn Send = bar;
-   |                        ^^^ `dyn Bar` cannot be sent between threads safely
+   |            ---------   ^^^ expected trait `Send`, found trait `Bar`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Send` is not implemented for `dyn Bar`
-   = note: required for the cast to the object type `dyn std::marker::Send`
+   = note: expected reference `&dyn Send`
+              found reference `&dyn Bar`
 
-error[E0277]: `dyn Bar` cannot be shared between threads safely
-  --> $DIR/invalid-upcast.rs:48:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:67:24
    |
 LL |     let _: &dyn Sync = bar;
-   |                        ^^^ `dyn Bar` cannot be shared between threads safely
+   |            ---------   ^^^ expected trait `Sync`, found trait `Bar`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Sync` is not implemented for `dyn Bar`
-   = note: required for the cast to the object type `dyn std::marker::Sync`
+   = note: expected reference `&dyn Sync`
+              found reference `&dyn Bar`
 
-error[E0277]: the trait bound `dyn Baz: Foo` is not satisfied
-  --> $DIR/invalid-upcast.rs:51:25
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:70:25
    |
 LL |     let foo: &dyn Foo = baz;
-   |                         ^^^ the trait `Foo` is not implemented for `dyn Baz`
+   |              --------   ^^^ expected trait `Foo`, found trait `Baz`
+   |              |
+   |              expected due to this
    |
-   = note: required for the cast to the object type `dyn Foo`
+   = note: expected reference `&dyn Foo`
+              found reference `&dyn Baz`
 
-error[E0277]: `dyn Foo` doesn't implement `std::fmt::Debug`
-  --> $DIR/invalid-upcast.rs:53:35
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:72:35
    |
 LL |     let _: &dyn std::fmt::Debug = foo;
-   |                                   ^^^ `dyn Foo` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |            --------------------   ^^^ expected trait `Debug`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: expected reference `&dyn Debug`
+              found reference `&dyn Foo`
 
-error[E0277]: `dyn Foo` cannot be sent between threads safely
-  --> $DIR/invalid-upcast.rs:55:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:74:24
    |
 LL |     let _: &dyn Send = foo;
-   |                        ^^^ `dyn Foo` cannot be sent between threads safely
+   |            ---------   ^^^ expected trait `Send`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Send` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::marker::Send`
+   = note: expected reference `&dyn Send`
+              found reference `&dyn Foo`
 
-error[E0277]: `dyn Foo` cannot be shared between threads safely
-  --> $DIR/invalid-upcast.rs:57:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:76:24
    |
 LL |     let _: &dyn Sync = foo;
-   |                        ^^^ `dyn Foo` cannot be shared between threads safely
+   |            ---------   ^^^ expected trait `Sync`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Sync` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::marker::Sync`
+   = note: expected reference `&dyn Sync`
+              found reference `&dyn Foo`
 
-error[E0277]: the trait bound `dyn Bar: Foo` is not satisfied
-  --> $DIR/invalid-upcast.rs:60:25
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:79:25
    |
 LL |     let foo: &dyn Foo = bar;
-   |                         ^^^ the trait `Foo` is not implemented for `dyn Bar`
+   |              --------   ^^^ expected trait `Foo`, found trait `Bar`
+   |              |
+   |              expected due to this
    |
-   = note: required for the cast to the object type `dyn Foo`
+   = note: expected reference `&dyn Foo`
+              found reference `&dyn Bar`
 
-error[E0277]: `dyn Foo` doesn't implement `std::fmt::Debug`
-  --> $DIR/invalid-upcast.rs:62:35
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:81:35
    |
 LL |     let _: &dyn std::fmt::Debug = foo;
-   |                                   ^^^ `dyn Foo` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
+   |            --------------------   ^^^ expected trait `Debug`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: expected reference `&dyn Debug`
+              found reference `&dyn Foo`
 
-error[E0277]: `dyn Foo` cannot be sent between threads safely
-  --> $DIR/invalid-upcast.rs:64:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:83:24
    |
 LL |     let _: &dyn Send = foo;
-   |                        ^^^ `dyn Foo` cannot be sent between threads safely
+   |            ---------   ^^^ expected trait `Send`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Send` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::marker::Send`
+   = note: expected reference `&dyn Send`
+              found reference `&dyn Foo`
 
-error[E0277]: `dyn Foo` cannot be shared between threads safely
-  --> $DIR/invalid-upcast.rs:66:24
+error[E0308]: mismatched types
+  --> $DIR/invalid-upcast.rs:85:24
    |
 LL |     let _: &dyn Sync = foo;
-   |                        ^^^ `dyn Foo` cannot be shared between threads safely
+   |            ---------   ^^^ expected trait `Sync`, found trait `Foo`
+   |            |
+   |            expected due to this
    |
-   = help: the trait `std::marker::Sync` is not implemented for `dyn Foo`
-   = note: required for the cast to the object type `dyn std::marker::Sync`
+   = note: expected reference `&dyn Sync`
+              found reference `&dyn Foo`
 
 error: aborting due to 15 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/traits/trait-upcasting/lifetime.rs
+++ b/src/test/ui/traits/trait-upcasting/lifetime.rs
@@ -1,0 +1,70 @@
+// run-pass
+
+#![feature(trait_upcasting)]
+
+trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar: Foo {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Baz: Bar {
+    fn c(&self) -> i32 { 30 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Baz for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+// Note: upcast lifetime means a shorter lifetime.
+fn upcast_baz<'a: 'b, 'b, T>(v: Box<dyn Baz + 'a>, _l: &'b T) -> Box<dyn Baz + 'b> { v }
+fn upcast_bar<'a: 'b, 'b, T>(v: Box<dyn Bar + 'a>, _l: &'b T) -> Box<dyn Bar + 'b> { v }
+fn upcast_foo<'a: 'b, 'b, T>(v: Box<dyn Foo + 'a>, _l: &'b T) -> Box<dyn Foo + 'b> { v }
+
+fn main() {
+    let v = Box::new(1);
+    let l = &(); // dummy lifetime (shorter than `baz`)
+
+    let baz: Box<dyn Baz> = v.clone();
+    let u = upcast_baz(baz, &l);
+    assert_eq!(*u, 1);
+    assert_eq!(u.a(), 100);
+    assert_eq!(u.b(), 200);
+    assert_eq!(u.c(), 300);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let bar: Box<dyn Bar> = baz;
+    let u = upcast_bar(bar, &l);
+    assert_eq!(*u, 1);
+    assert_eq!(u.a(), 100);
+    assert_eq!(u.b(), 200);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let foo: Box<dyn Foo> = baz;
+    let u = upcast_foo(foo, &l);
+    assert_eq!(*u, 1);
+    assert_eq!(u.a(), 100);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let bar: Box<dyn Bar> = baz;
+    let foo: Box<dyn Foo> = bar;
+    let u = upcast_foo(foo, &l);
+    assert_eq!(*u, 1);
+    assert_eq!(u.a(), 100);
+}

--- a/src/test/ui/traits/trait-upcasting/lifetime.rs
+++ b/src/test/ui/traits/trait-upcasting/lifetime.rs
@@ -1,41 +1,67 @@
 // run-pass
+// ignore-compare-mode-nll
 
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar: Foo {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Baz: Bar {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Baz for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 // Note: upcast lifetime means a shorter lifetime.
-fn upcast_baz<'a: 'b, 'b, T>(v: Box<dyn Baz + 'a>, _l: &'b T) -> Box<dyn Baz + 'b> { v }
-fn upcast_bar<'a: 'b, 'b, T>(v: Box<dyn Bar + 'a>, _l: &'b T) -> Box<dyn Bar + 'b> { v }
-fn upcast_foo<'a: 'b, 'b, T>(v: Box<dyn Foo + 'a>, _l: &'b T) -> Box<dyn Foo + 'b> { v }
+fn upcast_baz<'a: 'b, 'b, T>(v: Box<dyn Baz + 'a>, _l: &'b T) -> Box<dyn Baz + 'b> {
+    v
+}
+fn upcast_bar<'a: 'b, 'b, T>(v: Box<dyn Bar + 'a>, _l: &'b T) -> Box<dyn Bar + 'b> {
+    v
+}
+fn upcast_foo<'a: 'b, 'b, T>(v: Box<dyn Foo + 'a>, _l: &'b T) -> Box<dyn Foo + 'b> {
+    v
+}
 
 fn main() {
     let v = Box::new(1);

--- a/src/test/ui/traits/trait-upcasting/replace-vptr.rs
+++ b/src/test/ui/traits/trait-upcasting/replace-vptr.rs
@@ -1,0 +1,49 @@
+// run-pass
+
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait A {
+    fn foo_a(&self);
+}
+
+trait B {
+    fn foo_b(&self);
+}
+
+trait C: A + B {
+    fn foo_c(&self);
+}
+
+struct S(i32);
+
+impl A for S {
+    fn foo_a(&self) {
+        unreachable!();
+    }
+}
+
+impl B for S {
+    fn foo_b(&self) {
+        assert_eq!(42, self.0);
+    }
+}
+
+impl C for S {
+    fn foo_c(&self) {
+        unreachable!();
+    }
+}
+
+fn invoke_inner(b: &dyn B) {
+    b.foo_b();
+}
+
+fn invoke_outer(c: &dyn C) {
+    invoke_inner(c);
+}
+
+fn main() {
+    let s = S(42);
+    invoke_outer(&s);
+}

--- a/src/test/ui/traits/trait-upcasting/struct.rs
+++ b/src/test/ui/traits/trait-upcasting/struct.rs
@@ -1,0 +1,155 @@
+// run-pass
+
+#![feature(trait_upcasting)]
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar: Foo {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Baz: Bar {
+    fn c(&self) -> i32 { 30 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Baz for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+fn test_box() {
+    let v = Box::new(1);
+
+    let baz: Box<dyn Baz> = v.clone();
+    assert_eq!(*baz, 1);
+    assert_eq!(baz.a(), 100);
+    assert_eq!(baz.b(), 200);
+    assert_eq!(baz.c(), 300);
+    assert_eq!(baz.z(), 11);
+    assert_eq!(baz.y(), 12);
+    assert_eq!(baz.w(), 21);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let bar: Box<dyn Bar> = baz;
+    assert_eq!(*bar, 1);
+    assert_eq!(bar.a(), 100);
+    assert_eq!(bar.b(), 200);
+    assert_eq!(bar.z(), 11);
+    assert_eq!(bar.y(), 12);
+    assert_eq!(bar.w(), 21);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let foo: Box<dyn Foo> = baz;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+
+    let baz: Box<dyn Baz> = v.clone();
+    let bar: Box<dyn Bar> = baz;
+    let foo: Box<dyn Foo> = bar;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+}
+
+fn test_rc() {
+    let v = Rc::new(1);
+
+    let baz: Rc<dyn Baz> = v.clone();
+    assert_eq!(*baz, 1);
+    assert_eq!(baz.a(), 100);
+    assert_eq!(baz.b(), 200);
+    assert_eq!(baz.c(), 300);
+    assert_eq!(baz.z(), 11);
+    assert_eq!(baz.y(), 12);
+    assert_eq!(baz.w(), 21);
+
+    let baz: Rc<dyn Baz> = v.clone();
+    let bar: Rc<dyn Bar> = baz;
+    assert_eq!(*bar, 1);
+    assert_eq!(bar.a(), 100);
+    assert_eq!(bar.b(), 200);
+    assert_eq!(bar.z(), 11);
+    assert_eq!(bar.y(), 12);
+    assert_eq!(bar.w(), 21);
+
+    let baz: Rc<dyn Baz> = v.clone();
+    let foo: Rc<dyn Foo> = baz;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+
+    let baz: Rc<dyn Baz> = v.clone();
+    let bar: Rc<dyn Bar> = baz;
+    let foo: Rc<dyn Foo> = bar;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+}
+
+fn test_arc() {
+    let v = Arc::new(1);
+
+    let baz: Arc<dyn Baz> = v.clone();
+    assert_eq!(*baz, 1);
+    assert_eq!(baz.a(), 100);
+    assert_eq!(baz.b(), 200);
+    assert_eq!(baz.c(), 300);
+    assert_eq!(baz.z(), 11);
+    assert_eq!(baz.y(), 12);
+    assert_eq!(baz.w(), 21);
+
+    let baz: Arc<dyn Baz> = v.clone();
+    let bar: Arc<dyn Bar> = baz;
+    assert_eq!(*bar, 1);
+    assert_eq!(bar.a(), 100);
+    assert_eq!(bar.b(), 200);
+    assert_eq!(bar.z(), 11);
+    assert_eq!(bar.y(), 12);
+    assert_eq!(bar.w(), 21);
+
+    let baz: Arc<dyn Baz> = v.clone();
+    let foo: Arc<dyn Foo> = baz;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+
+    let baz: Arc<dyn Baz> = v.clone();
+    let bar: Arc<dyn Bar> = baz;
+    let foo: Arc<dyn Foo> = bar;
+    assert_eq!(*foo, 1);
+    assert_eq!(foo.a(), 100);
+    assert_eq!(foo.z(), 11);
+    assert_eq!(foo.y(), 12);
+}
+
+fn main() {
+    test_box();
+    test_rc();
+    test_arc();
+}

--- a/src/test/ui/traits/trait-upcasting/struct.rs
+++ b/src/test/ui/traits/trait-upcasting/struct.rs
@@ -1,38 +1,57 @@
 // run-pass
 
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 use std::rc::Rc;
 use std::sync::Arc;
 
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar: Foo {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Baz: Bar {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Baz for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 fn test_box() {

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.rs
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.rs
@@ -1,0 +1,51 @@
+#![feature(trait_upcasting)]
+
+trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    fn a(&self) -> i32 { 10 }
+
+    fn z(&self) -> i32 { 11 }
+
+    fn y(&self) -> i32 { 12 }
+}
+
+trait Bar: Foo {
+    fn b(&self) -> i32 { 20 }
+
+    fn w(&self) -> i32 { 21 }
+}
+
+trait Baz: Bar {
+    fn c(&self) -> i32 { 30 }
+}
+
+impl Foo for i32 {
+    fn a(&self) -> i32 { 100 }
+}
+
+impl Bar for i32 {
+    fn b(&self) -> i32 { 200 }
+}
+
+impl Baz for i32 {
+    fn c(&self) -> i32 { 300 }
+}
+
+fn main() {
+    let baz: &dyn Baz = &1;
+
+    let bar: &dyn Bar = baz;
+    bar.c();
+    //~^ ERROR no method named `c` found for reference `&dyn Bar` in the current scope [E0599]
+
+    let foo: &dyn Foo = baz;
+    foo.b();
+    //~^ ERROR no method named `b` found for reference `&dyn Foo` in the current scope [E0599]
+    foo.c();
+    //~^ ERROR no method named `c` found for reference `&dyn Foo` in the current scope [E0599]
+
+    let foo: &dyn Foo = bar;
+    foo.b();
+    //~^ ERROR no method named `b` found for reference `&dyn Foo` in the current scope [E0599]
+    foo.c();
+    //~^ ERROR no method named `c` found for reference `&dyn Foo` in the current scope [E0599]
+}

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.rs
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.rs
@@ -1,33 +1,52 @@
 #![feature(trait_upcasting)]
+#![allow(incomplete_features)]
 
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
-    fn a(&self) -> i32 { 10 }
+    fn a(&self) -> i32 {
+        10
+    }
 
-    fn z(&self) -> i32 { 11 }
+    fn z(&self) -> i32 {
+        11
+    }
 
-    fn y(&self) -> i32 { 12 }
+    fn y(&self) -> i32 {
+        12
+    }
 }
 
 trait Bar: Foo {
-    fn b(&self) -> i32 { 20 }
+    fn b(&self) -> i32 {
+        20
+    }
 
-    fn w(&self) -> i32 { 21 }
+    fn w(&self) -> i32 {
+        21
+    }
 }
 
 trait Baz: Bar {
-    fn c(&self) -> i32 { 30 }
+    fn c(&self) -> i32 {
+        30
+    }
 }
 
 impl Foo for i32 {
-    fn a(&self) -> i32 { 100 }
+    fn a(&self) -> i32 {
+        100
+    }
 }
 
 impl Bar for i32 {
-    fn b(&self) -> i32 { 200 }
+    fn b(&self) -> i32 {
+        200
+    }
 }
 
 impl Baz for i32 {
-    fn c(&self) -> i32 { 300 }
+    fn c(&self) -> i32 {
+        300
+    }
 }
 
 fn main() {

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
@@ -1,64 +1,64 @@
 error[E0599]: no method named `c` found for reference `&dyn Bar` in the current scope
-  --> $DIR/subtrait-method.rs:37:9
+  --> $DIR/subtrait-method.rs:56:9
    |
 LL |     bar.c();
    |         ^ help: there is an associated function with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
-  --> $DIR/subtrait-method.rs:17:1
+  --> $DIR/subtrait-method.rs:28:1
    |
 LL | trait Baz: Bar {
    | ^^^^^^^^^^^^^^
 
 error[E0599]: no method named `b` found for reference `&dyn Foo` in the current scope
-  --> $DIR/subtrait-method.rs:41:9
+  --> $DIR/subtrait-method.rs:60:9
    |
 LL |     foo.b();
    |         ^ help: there is an associated function with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
-  --> $DIR/subtrait-method.rs:11:1
+  --> $DIR/subtrait-method.rs:18:1
    |
 LL | trait Bar: Foo {
    | ^^^^^^^^^^^^^^
 
 error[E0599]: no method named `c` found for reference `&dyn Foo` in the current scope
-  --> $DIR/subtrait-method.rs:43:9
+  --> $DIR/subtrait-method.rs:62:9
    |
 LL |     foo.c();
    |         ^ help: there is an associated function with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
-  --> $DIR/subtrait-method.rs:17:1
+  --> $DIR/subtrait-method.rs:28:1
    |
 LL | trait Baz: Bar {
    | ^^^^^^^^^^^^^^
 
 error[E0599]: no method named `b` found for reference `&dyn Foo` in the current scope
-  --> $DIR/subtrait-method.rs:47:9
+  --> $DIR/subtrait-method.rs:66:9
    |
 LL |     foo.b();
    |         ^ help: there is an associated function with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
-  --> $DIR/subtrait-method.rs:11:1
+  --> $DIR/subtrait-method.rs:18:1
    |
 LL | trait Bar: Foo {
    | ^^^^^^^^^^^^^^
 
 error[E0599]: no method named `c` found for reference `&dyn Foo` in the current scope
-  --> $DIR/subtrait-method.rs:49:9
+  --> $DIR/subtrait-method.rs:68:9
    |
 LL |     foo.c();
    |         ^ help: there is an associated function with a similar name: `a`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
-  --> $DIR/subtrait-method.rs:17:1
+  --> $DIR/subtrait-method.rs:28:1
    |
 LL | trait Baz: Bar {
    | ^^^^^^^^^^^^^^

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
@@ -1,0 +1,68 @@
+error[E0599]: no method named `c` found for reference `&dyn Bar` in the current scope
+  --> $DIR/subtrait-method.rs:37:9
+   |
+LL |     bar.c();
+   |         ^ help: there is an associated function with a similar name: `a`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Baz` defines an item `c`, perhaps you need to implement it
+  --> $DIR/subtrait-method.rs:17:1
+   |
+LL | trait Baz: Bar {
+   | ^^^^^^^^^^^^^^
+
+error[E0599]: no method named `b` found for reference `&dyn Foo` in the current scope
+  --> $DIR/subtrait-method.rs:41:9
+   |
+LL |     foo.b();
+   |         ^ help: there is an associated function with a similar name: `a`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Bar` defines an item `b`, perhaps you need to implement it
+  --> $DIR/subtrait-method.rs:11:1
+   |
+LL | trait Bar: Foo {
+   | ^^^^^^^^^^^^^^
+
+error[E0599]: no method named `c` found for reference `&dyn Foo` in the current scope
+  --> $DIR/subtrait-method.rs:43:9
+   |
+LL |     foo.c();
+   |         ^ help: there is an associated function with a similar name: `a`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Baz` defines an item `c`, perhaps you need to implement it
+  --> $DIR/subtrait-method.rs:17:1
+   |
+LL | trait Baz: Bar {
+   | ^^^^^^^^^^^^^^
+
+error[E0599]: no method named `b` found for reference `&dyn Foo` in the current scope
+  --> $DIR/subtrait-method.rs:47:9
+   |
+LL |     foo.b();
+   |         ^ help: there is an associated function with a similar name: `a`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Bar` defines an item `b`, perhaps you need to implement it
+  --> $DIR/subtrait-method.rs:11:1
+   |
+LL | trait Bar: Foo {
+   | ^^^^^^^^^^^^^^
+
+error[E0599]: no method named `c` found for reference `&dyn Foo` in the current scope
+  --> $DIR/subtrait-method.rs:49:9
+   |
+LL |     foo.c();
+   |         ^ help: there is an associated function with a similar name: `a`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Baz` defines an item `c`, perhaps you need to implement it
+  --> $DIR/subtrait-method.rs:17:1
+   |
+LL | trait Baz: Bar {
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
This is the second part of trait upcasting coercion implementation.

Currently this is blocked on #86264 .

The third part might be implemented using unsafety checking

r? @bjorn3 