### PR TITLE
Fix assert in diy_float

### DIFF
--- a/library/core/src/num/diy_float.rs
+++ b/library/core/src/num/diy_float.rs
@@ -65,7 +65,7 @@ impl Fp {
             f <<= 1;
             e -= 1;
         }
-        debug_assert!(f >= (1 >> 63));
+        debug_assert!(f >= (1 << 63));
         Fp { f, e }
     }
 


### PR DESCRIPTION
The shifting should have gone the other way, the current incarnation is always true.