### PR TITLE
Don't run MIR unsafeck at all when using `-Zthir-unsafeck`

### DIFF
--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -259,10 +259,12 @@ fn mir_const<'tcx>(
     }
 
     // Unsafety check uses the raw mir, so make sure it is run.
-    if let Some(param_did) = def.const_param_did {
-        tcx.ensure().unsafety_check_result_for_const_arg((def.did, param_did));
-    } else {
-        tcx.ensure().unsafety_check_result(def.did);
+    if !tcx.sess.opts.debugging_opts.thir_unsafeck {
+        if let Some(param_did) = def.const_param_did {
+            tcx.ensure().unsafety_check_result_for_const_arg((def.did, param_did));
+        } else {
+            tcx.ensure().unsafety_check_result(def.did);
+        }
     }
 
     let mut body = tcx.mir_built(def).steal();


### PR DESCRIPTION
I don't know how I missed this :D
r? @oli-obk