### PR TITLE
Fix ICE in `improper_ctypes_definitions` lint with all-ZST transparent types

### DIFF
--- a/src/test/ui/repr/repr-transparent-issue-87496.rs
+++ b/src/test/ui/repr/repr-transparent-issue-87496.rs
@@ -1,0 +1,12 @@
+// Regression test for the ICE described in #87496.
+
+// check-pass
+
+#[repr(transparent)]
+struct TransparentCustomZst(());
+extern "C" {
+    fn good17(p: TransparentCustomZst);
+    //~^ WARNING: `extern` block uses type `TransparentCustomZst`, which is not FFI-safe
+}
+
+fn main() {}

--- a/src/test/ui/repr/repr-transparent-issue-87496.stderr
+++ b/src/test/ui/repr/repr-transparent-issue-87496.stderr
@@ -1,0 +1,16 @@
+warning: `extern` block uses type `TransparentCustomZst`, which is not FFI-safe
+  --> $DIR/repr-transparent-issue-87496.rs:8:18
+   |
+LL |     fn good17(p: TransparentCustomZst);
+   |                  ^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = note: `#[warn(improper_ctypes)]` on by default
+   = note: this struct contains only zero-sized fields
+note: the type is defined here
+  --> $DIR/repr-transparent-issue-87496.rs:6:1
+   |
+LL | struct TransparentCustomZst(());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #87496. There is also another function in the same file that looks fishy, but I haven't been able to produce an ICE there, and in any case, it's not related to #87496:
https://github.com/rust-lang/rust/blob/fd853c00e255559255885aadff9e93a1760c8728/compiler/rustc_lint/src/types.rs#L720-L734

r? @JohnTitor