### PR TITLE
bootstrap.py: use `git rev-list` for robustness

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -473,7 +473,7 @@ class RustBuild(object):
             ]).decode(sys.getdefaultencoding()).strip()
             llvm_sha = subprocess.check_output([
                 "git", "log", "--author=bors", "--format=%H", "-n1",
-                "-m", "--first-parent",
+                "--no-patch", "--first-parent",
                 "--",
                 "{}/src/llvm-project".format(top_level),
                 "{}/src/bootstrap/download-ci-llvm-stamp".format(top_level),

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -464,7 +464,8 @@ class RustBuild(object):
             # LLVM more often than necessary.
             #
             # This git command finds that commit SHA, looking for bors-authored
-            # merges that modified src/llvm-project.
+            # commits that modified src/llvm-project or other relevant version
+            # stamp files.
             #
             # This works even in a repository that has not yet initialized
             # submodules.
@@ -472,8 +473,8 @@ class RustBuild(object):
                 "git", "rev-parse", "--show-toplevel",
             ]).decode(sys.getdefaultencoding()).strip()
             llvm_sha = subprocess.check_output([
-                "git", "log", "--author=bors", "--format=%H", "-n1",
-                "--no-patch", "--first-parent",
+                "git", "rev-list", "--author=bors@rust-lang.org", "-n1",
+                "--first-parent", "HEAD",
                 "--",
                 "{}/src/llvm-project".format(top_level),
                 "{}/src/bootstrap/download-ci-llvm-stamp".format(top_level),
@@ -665,7 +666,7 @@ class RustBuild(object):
 
         # Look for a version to compare to based on the current commit.
         # Only commits merged by bors will have CI artifacts.
-        merge_base = ["git", "log", "--author=bors", "--pretty=%H", "-n1"]
+        merge_base = ["git", "rev-list", "--author=bors@rust-lang.org", "-n1", "HEAD"]
         commit = subprocess.check_output(merge_base, universal_newlines=True).strip()
 
         # Warn if there were changes to the compiler or standard library since the ancestor commit.

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -464,7 +464,7 @@ class RustBuild(object):
             # LLVM more often than necessary.
             #
             # This git command finds that commit SHA, looking for bors-authored
-            # commits that modified src/llvm-project or other relevant version
+            # merges that modified src/llvm-project or other relevant version
             # stamp files.
             #
             # This works even in a repository that has not yet initialized
@@ -474,7 +474,7 @@ class RustBuild(object):
             ]).decode(sys.getdefaultencoding()).strip()
             llvm_sha = subprocess.check_output([
                 "git", "rev-list", "--author=bors@rust-lang.org", "-n1",
-                "--first-parent", "HEAD",
+                "--merges", "--first-parent", "HEAD",
                 "--",
                 "{}/src/llvm-project".format(top_level),
                 "{}/src/bootstrap/download-ci-llvm-stamp".format(top_level),
@@ -666,7 +666,10 @@ class RustBuild(object):
 
         # Look for a version to compare to based on the current commit.
         # Only commits merged by bors will have CI artifacts.
-        merge_base = ["git", "rev-list", "--author=bors@rust-lang.org", "-n1", "HEAD"]
+        merge_base = [
+            "git", "rev-list", "--author=bors@rust-lang.org", "-n1",
+            "--merges", "--first-parent", "HEAD"
+        ]
         commit = subprocess.check_output(merge_base, universal_newlines=True).strip()
 
         # Warn if there were changes to the compiler or standard library since the ancestor commit.


### PR DESCRIPTION
Use `git rev-list` instead of `git log` to be more robust against
UI changes in git. Also, use the full email address for bors,
because `--author` uses a substring match.

Based on #87513, but is separate because it's less minimal and may require additional manual testing.

~Open questions:~
* ~Should the `merge_base` search also use `--first-parent`?~
* ~Do we exclude non-merge commits from bors? There are a few, and I'm not sure what they have in common. Some of them look like squashes, and some look like they're in rollup branches.~

r? @jyn514
@rustbot label +A-rustbuild +C-cleanup