### PR TITLE
rfc3052 followup: Remove authors field from Cargo manifests

### DIFF
--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc-main"
 version = "0.0.0"
 edition = '2018'

--- a/compiler/rustc_apfloat/Cargo.toml
+++ b/compiler/rustc_apfloat/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_apfloat"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_arena/Cargo.toml
+++ b/compiler/rustc_arena/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_arena"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_ast"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_ast_lowering"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_ast_passes"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_ast_pretty"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_attr/Cargo.toml
+++ b/compiler/rustc_attr/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_attr"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_builtin_macros"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_codegen_cranelift/Cargo.toml
+++ b/compiler/rustc_codegen_cranelift/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc_codegen_cranelift"
 version = "0.1.0"
-authors = ["bjorn3 <bjorn3@users.noreply.github.com>"]
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_codegen_cranelift/build_sysroot/Cargo.toml
+++ b/compiler/rustc_codegen_cranelift/build_sysroot/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["bjorn3 <bjorn3@users.noreply.github.com>"]
 name = "sysroot"
 version = "0.0.0"
 

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_codegen_llvm"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_codegen_ssa"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_data_structures"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_driver"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_error_codes/Cargo.toml
+++ b/compiler/rustc_error_codes/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_error_codes"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_errors"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_expand"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_feature/Cargo.toml
+++ b/compiler/rustc_feature/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_feature"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_fs_util/Cargo.toml
+++ b/compiler/rustc_fs_util/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_fs_util"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_graphviz/Cargo.toml
+++ b/compiler/rustc_graphviz/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_graphviz"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_hir/Cargo.toml
+++ b/compiler/rustc_hir/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_hir"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_hir_pretty/Cargo.toml
+++ b/compiler/rustc_hir_pretty/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_hir_pretty"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_incremental/Cargo.toml
+++ b/compiler/rustc_incremental/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_incremental"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_index"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_infer/Cargo.toml
+++ b/compiler/rustc_infer/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_infer"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_interface"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_lexer/Cargo.toml
+++ b/compiler/rustc_lexer/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_lexer"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_lint"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_lint_defs/Cargo.toml
+++ b/compiler/rustc_lint_defs/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_lint_defs"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_llvm"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_macros/Cargo.toml
+++ b/compiler/rustc_macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc_macros"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_metadata"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_middle"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_mir/Cargo.toml
+++ b/compiler/rustc_mir/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_mir"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_mir/src/transform/coverage/test_macros/Cargo.toml
+++ b/compiler/rustc_mir/src/transform/coverage/test_macros/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "coverage_test_macros"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_mir_build/Cargo.toml
+++ b/compiler/rustc_mir_build/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_mir_build"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_parse"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_parse_format"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_passes"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_plugin_impl/Cargo.toml
+++ b/compiler/rustc_plugin_impl/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_plugin_impl"
 version = "0.0.0"
 build = false

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_privacy"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_query_impl"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_query_system"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_resolve"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_save_analysis/Cargo.toml
+++ b/compiler/rustc_save_analysis/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_save_analysis"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_serialize/Cargo.toml
+++ b/compiler/rustc_serialize/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_serialize"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_session/Cargo.toml
+++ b/compiler/rustc_session/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_session"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_span/Cargo.toml
+++ b/compiler/rustc_span/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_span"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_symbol_mangling"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_target"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_trait_selection"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_traits/Cargo.toml
+++ b/compiler/rustc_traits/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_traits"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_ty_utils"
 version = "0.0.0"
 edition = "2018"

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc_type_ir"
 version = "0.0.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [lib]

--- a/compiler/rustc_typeck/Cargo.toml
+++ b/compiler/rustc_typeck/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustc_typeck"
 version = "0.0.0"
 edition = "2018"

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "alloc"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "core"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "panic_unwind"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/library/proc_macro/Cargo.toml
+++ b/library/proc_macro/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "proc_macro"
 version = "0.0.0"
 edition = "2018"

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "profiler_builtins"
 version = "0.0.0"
 edition = "2018"

--- a/library/rustc-std-workspace-alloc/Cargo.toml
+++ b/library/rustc-std-workspace-alloc/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc-std-workspace-alloc"
 version = "1.99.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """
 Hack for the compiler's own build system

--- a/library/rustc-std-workspace-core/Cargo.toml
+++ b/library/rustc-std-workspace-core/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc-std-workspace-core"
 version = "1.99.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """
 Hack for the compiler's own build system

--- a/library/rustc-std-workspace-std/Cargo.toml
+++ b/library/rustc-std-workspace-std/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc-std-workspace-std"
 version = "1.99.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """
 Hack for the compiler's own build system

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "std"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "test"
 version = "0.0.0"
 edition = "2018"

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "unwind"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "bootstrap"
 version = "0.0.0"
 edition = "2018"

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "build_helper"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [lib]

--- a/src/doc/rustc/book.toml
+++ b/src/doc/rustc/book.toml
@@ -1,5 +1,4 @@
 [book]
-authors = ["The Rust Project Developers"]
 multilingual = false
 src = "src"
 title = "The rustc book"

--- a/src/doc/rustdoc/book.toml
+++ b/src/doc/rustdoc/book.toml
@@ -1,5 +1,4 @@
 [book]
-authors = ["The Rust Project Developers"]
 src = "src"
 title = "The rustdoc book"
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustdoc"
 version = "0.0.0"
 edition = "2018"

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustdoc-json-types"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [lib]

--- a/src/test/run-make/thumb-none-qemu/example/Cargo.toml
+++ b/src/test/run-make/thumb-none-qemu/example/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example"
 version = "0.1.0"
-authors = ["Hideki Sekine <sekineh@me.com>"]
 edition = "2018"
 
 [dependencies]

--- a/src/test/run-make/x86_64-fortanix-unknown-sgx-lvi/enclave/Cargo.toml
+++ b/src/test/run-make/x86_64-fortanix-unknown-sgx-lvi/enclave/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enclave"
 version = "0.1.0"
-authors = ["Raoul Strackx <raoul.strackx@fortanix.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "build-manifest"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/cargotest/Cargo.toml
+++ b/src/tools/cargotest/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cargotest2"
 version = "0.1.0"
-authors = ["Brian Anderson <banderson@mozilla.com>"]
 edition = "2018"
 
 [[bin]]

--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clippy"
 version = "0.1.56"
-authors = ["The Rust Clippy Developers"]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/src/tools/clippy/clippy_dev/Cargo.toml
+++ b/src/tools/clippy/clippy_dev/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clippy_dev"
 version = "0.0.1"
-authors = ["The Rust Clippy Developers"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/clippy/clippy_dummy/Cargo.toml
+++ b/src/tools/clippy/clippy_dummy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clippy_dummy" # rename to clippy before publishing
 version = "0.0.303"
-authors = ["The Rust Clippy Developers"]
 edition = "2018"
 readme = "crates-readme.md"
 description = "A bunch of helpful lints to avoid common pitfalls in Rust."

--- a/src/tools/clippy/clippy_lints/Cargo.toml
+++ b/src/tools/clippy/clippy_lints/Cargo.toml
@@ -3,7 +3,6 @@ name = "clippy_lints"
 # begin automatic update
 version = "0.1.56"
 # end automatic update
-authors = ["The Rust Clippy Developers"]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/src/tools/clippy/clippy_utils/Cargo.toml
+++ b/src/tools/clippy/clippy_utils/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clippy_utils"
 version = "0.1.56"
-authors = ["The Rust Clippy Developers"]
 edition = "2018"
 publish = false
 

--- a/src/tools/clippy/lintcheck/Cargo.toml
+++ b/src/tools/clippy/lintcheck/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "lintcheck"
 version = "0.0.1"
-authors = ["The Rust Clippy Developers"]
 description = "tool to monitor impact of changes in Clippys lints on a part of the ecosystem"
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/src/tools/clippy/rustc_tools_util/Cargo.toml
+++ b/src/tools/clippy/rustc_tools_util/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc_tools_util"
 version = "0.2.0"
-authors = ["The Rust Clippy Developers"]
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "compiletest"
 version = "0.0.0"
 edition = "2018"

--- a/src/tools/error_index_generator/Cargo.toml
+++ b/src/tools/error_index_generator/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "error_index_generator"
 version = "0.0.0"
 edition = "2018"

--- a/src/tools/expand-yaml-anchors/Cargo.toml
+++ b/src/tools/expand-yaml-anchors/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "expand-yaml-anchors"
 version = "0.1.0"
-authors = ["Pietro Albini <pietro@pietroalbini.org>"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/html-checker/Cargo.toml
+++ b/src/tools/html-checker/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "html-checker"
 version = "0.1.0"
-authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 edition = "2018"
 
 [[bin]]

--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "jsondocck"
 version = "0.1.0"
-authors = ["Rune Tynan <runetynan@gmail.com>"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/linkchecker/Cargo.toml
+++ b/src/tools/linkchecker/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "linkchecker"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [[bin]]

--- a/src/tools/lint-docs/Cargo.toml
+++ b/src/tools/lint-docs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "lint-docs"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 description = "A script to extract the lint documentation for the rustc book."
 

--- a/src/tools/remote-test-client/Cargo.toml
+++ b/src/tools/remote-test-client/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "remote-test-client"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/remote-test-server/Cargo.toml
+++ b/src/tools/remote-test-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "remote-test-server"
 version = "0.1.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [dependencies]

--- a/src/tools/rust-demangler/Cargo.toml
+++ b/src/tools/rust-demangler/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rust-demangler"
 version = "0.0.1"
 edition = "2018"

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["The Rust Project Developers"]
 name = "rustbook"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustc-workspace-hack"
 version = "1.0.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """
 Hack for the compiler's own build system

--- a/src/tools/rustdoc-themes/Cargo.toml
+++ b/src/tools/rustdoc-themes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustdoc-themes"
 version = "0.1.0"
-authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 edition = "2018"
 
 [[bin]]

--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustdoc-tool"
 version = "0.0.0"
-authors = ["The Rust Project Developers"]
 edition = "2018"
 
 # Cargo adds a number of paths to the dylib search path on windows, which results in

--- a/src/tools/rustfmt/Cargo.toml
+++ b/src/tools/rustfmt/Cargo.toml
@@ -2,7 +2,6 @@
 
 name = "rustfmt-nightly"
 version = "1.4.37"
-authors = ["Nicholas Cameron <ncameron@mozilla.com>", "The Rustfmt developers"]
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"
 readme = "README.md"

--- a/src/tools/rustfmt/config_proc_macro/Cargo.toml
+++ b/src/tools/rustfmt/config_proc_macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustfmt-config_proc_macro"
 version = "0.2.0"
-authors = ["topecongiro <seuchida@gmail.com>"]
 edition = "2018"
 description = "A collection of procedural macros for rustfmt"
 license = "Apache-2.0/MIT"

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tidy"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 autobins = false
 

--- a/src/tools/tier-check/Cargo.toml
+++ b/src/tools/tier-check/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tier-check"
 version = "0.1.0"
-authors = ["Eric Huss"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 

--- a/src/tools/unicode-table-generator/Cargo.toml
+++ b/src/tools/unicode-table-generator/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unicode-bdd"
 version = "0.1.0"
-authors = ["Mark Rousskov <mark.simulacrum@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/tools/unstable-book-gen/Cargo.toml
+++ b/src/tools/unstable-book-gen/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["est31 <MTest31@outlook.com>",
-           "The Rust Project Developers"]
 name = "unstable-book-gen"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/src/tools/x/Cargo.toml
+++ b/src/tools/x/Cargo.toml
@@ -2,6 +2,5 @@
 name = "x"
 version = "0.1.0"
 description = "Run x.py slightly more conveniently"
-authors = ["Casey Rodarmor <casey@rodarmor.com>"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
Since RFC 3052 soft deprecated the authors field, hiding it from
crates.io, docs.rs, and making Cargo not add it by default, and it is
not generally up to date/useful information for contributors, we may as well
remove it from crates in this repo.