### PR TITLE
Bail on any found recursion when expanding opaque types

### DIFF
--- a/src/test/ui/impl-trait/issue-87450.rs
+++ b/src/test/ui/impl-trait/issue-87450.rs
@@ -1,0 +1,16 @@
+fn bar() -> impl Fn() {
+    wrap(wrap(wrap(wrap(foo()))))
+}
+
+fn foo() -> impl Fn() {
+    //~^ WARNING 5:1: 5:22: function cannot return without recursing [unconditional_recursion]
+    //~| ERROR 5:13: 5:22: cannot resolve opaque type [E0720]
+    wrap(wrap(wrap(wrap(wrap(wrap(wrap(foo())))))))
+}
+
+fn wrap(f: impl Fn()) -> impl Fn() {
+    move || f()
+}
+
+fn main() {
+}

--- a/src/test/ui/impl-trait/issue-87450.stderr
+++ b/src/test/ui/impl-trait/issue-87450.stderr
@@ -1,0 +1,27 @@
+warning: function cannot return without recursing
+  --> $DIR/issue-87450.rs:5:1
+   |
+LL | fn foo() -> impl Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
+...
+LL |     wrap(wrap(wrap(wrap(wrap(wrap(wrap(foo())))))))
+   |                                        ----- recursive call site
+   |
+   = note: `#[warn(unconditional_recursion)]` on by default
+   = help: a `loop` may express intention better if this is on purpose
+
+error[E0720]: cannot resolve opaque type
+  --> $DIR/issue-87450.rs:5:13
+   |
+LL | fn foo() -> impl Fn() {
+   |             ^^^^^^^^^ recursive opaque type
+...
+LL |     wrap(wrap(wrap(wrap(wrap(wrap(wrap(foo())))))))
+   |     ----------------------------------------------- returning here with type `impl Fn<()>`
+...
+LL | fn wrap(f: impl Fn()) -> impl Fn() {
+   |                          --------- returning this opaque type `impl Fn<()>`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0720`.


### PR DESCRIPTION
Fixes #87450. More of a bandaid because it does not fix the exponential complexity of the type folding used for opaque type expansion.