### PR TITLE
Fix typo in rustc_driver::version

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -764,13 +764,7 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("release: {}", unw(util::release_str()));
 
         let debug_flags = matches.opt_strs("Z");
-        let backend_name = debug_flags.iter().find_map(|x| {
-            if x.starts_with("codegen-backend=") {
-                Some(&x["codegen-backend=".len()..])
-            } else {
-                None
-            }
-        });
+        let backend_name = debug_flags.iter().find_map(|x| x.strip_prefix("codegen-backend="));
         get_codegen_backend(&None, backend_name).print_version();
     }
 }

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -766,7 +766,7 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         let debug_flags = matches.opt_strs("Z");
         let backend_name = debug_flags.iter().find_map(|x| {
             if x.starts_with("codegen-backend=") {
-                Some(&x["codegen-backends=".len()..])
+                Some(&x["codegen-backend=".len()..])
             } else {
                 None
             }


### PR DESCRIPTION
This caused rustc `-Zcodegen-backend=foo.so -vV` to look for `oo.so` instead of `foo.so`