### PR TITLE
min_type_alias_impl_trait is going to be removed in 1.56

### DIFF
--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -153,7 +153,7 @@ declare_features! (
      Some("the implementation was not maintainable, the feature may get reintroduced once the current refactorings are done")),
 
     /// Allows the use of type alias impl trait in function return positions
-    (removed, min_type_alias_impl_trait, "1.55.0", Some(63063), None,
+    (removed, min_type_alias_impl_trait, "1.56.0", Some(63063), None,
      Some("removed in favor of full type_alias_impl_trait")),
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
#87501 removed `min_type_alias_impl_trait` but meanwhile that PR was approved in homu queue, a new beta was cut so we need to bump the version because it won't be removed in 1.55.

r? @oli-obk 

@bors rollup=always