### PR TITLE
Recover invalid assoc type bounds using `==`

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1959,11 +1959,11 @@ impl<'a> Parser<'a> {
                 if token::EqEq == snapshot.token.kind {
                     err.span_suggestion(
                         snapshot.token.span,
-                        "replace `==` with `=`",
+                        "if you meant to use an associated type binding, replace `==` with `=`",
                         "=".to_string(),
                         Applicability::MaybeIncorrect,
                     );
-                    let value = self.mk_expr_err(expr.span);
+                    let value = self.mk_expr_err(start.to(expr.span));
                     err.emit();
                     return Ok(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }));
                 } else if token::Comma == self.token.kind || self.token.kind.should_end_const_arg()

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1955,7 +1955,19 @@ impl<'a> Parser<'a> {
         }
         match self.parse_expr_res(Restrictions::CONST_EXPR, None) {
             Ok(expr) => {
-                if token::Comma == self.token.kind || self.token.kind.should_end_const_arg() {
+                // Find a mistake like `MyTrait<Assoc == S::Assoc>`.
+                if token::EqEq == snapshot.token.kind {
+                    err.span_suggestion(
+                        snapshot.token.span,
+                        "replace `==` with `=`",
+                        "=".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
+                    let value = self.mk_expr_err(expr.span);
+                    err.emit();
+                    return Ok(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }));
+                } else if token::Comma == self.token.kind || self.token.kind.should_end_const_arg()
+                {
                     // Avoid the following output by checking that we consumed a full const arg:
                     // help: expressions must be enclosed in braces to be used as const generic
                     //       arguments

--- a/src/test/ui/const-generics/issues/issue-87493.rs
+++ b/src/test/ui/const-generics/issues/issue-87493.rs
@@ -1,0 +1,14 @@
+pub trait MyTrait {
+    type Assoc;
+}
+
+pub fn foo<S, T>(_s: S, _t: T)
+where
+    S: MyTrait,
+    T: MyTrait<Assoc == S::Assoc>,
+    //~^ ERROR: expected one of `,` or `>`, found `==`
+    //~| ERROR: this trait takes 0 generic arguments but 1 generic argument was supplied
+{
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-87493.stderr
+++ b/src/test/ui/const-generics/issues/issue-87493.stderr
@@ -2,10 +2,12 @@ error: expected one of `,` or `>`, found `==`
   --> $DIR/issue-87493.rs:8:22
    |
 LL |     T: MyTrait<Assoc == S::Assoc>,
-   |                      ^^
-   |                      |
-   |                      expected one of `,` or `>`
-   |                      help: replace `==` with `=`: `=`
+   |                      ^^ expected one of `,` or `>`
+   |
+help: if you meant to use an associated type binding, replace `==` with `=`
+   |
+LL |     T: MyTrait<Assoc = S::Assoc>,
+   |                      ~
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-87493.rs:8:8

--- a/src/test/ui/const-generics/issues/issue-87493.stderr
+++ b/src/test/ui/const-generics/issues/issue-87493.stderr
@@ -1,0 +1,26 @@
+error: expected one of `,` or `>`, found `==`
+  --> $DIR/issue-87493.rs:8:22
+   |
+LL |     T: MyTrait<Assoc == S::Assoc>,
+   |                      ^^
+   |                      |
+   |                      expected one of `,` or `>`
+   |                      help: replace `==` with `=`: `=`
+
+error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-87493.rs:8:8
+   |
+LL |     T: MyTrait<Assoc == S::Assoc>,
+   |        ^^^^^^^------------------- help: remove these generics
+   |        |
+   |        expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/issue-87493.rs:1:11
+   |
+LL | pub trait MyTrait {
+   |           ^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fix #87493
r? @estebank