### PR TITLE
[beta] Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "core-foundation",


### PR DESCRIPTION
2 commits in d21c22870e58499d6c31f1bef3bf1255eb021666..1f76a218bc7f326606dda811b58c42b7e1e21168
2021-07-26 20:23:21 +0000 to 2021-07-29 22:22:25 +0000
- [beta] Backport cargo-util version fix (rust-lang/cargo#9746)
- [Beta] backport version string fix (rust-lang/cargo#9734)