### PR TITLE
Deprecate llvm_asm!

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -155,6 +155,7 @@ pub fn spin_loop() {
 #[inline]
 #[unstable(feature = "bench_black_box", issue = "64102")]
 #[cfg_attr(not(bootstrap), allow(unused_mut))]
+#[cfg_attr(bootstrap, allow(deprecated))]
 pub fn black_box<T>(mut dummy: T) -> T {
     #[cfg(bootstrap)]
     // SAFETY: the inline assembly is a no-op.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1347,6 +1347,10 @@ pub(crate) mod builtin {
         issue = "70173",
         reason = "prefer using the new asm! syntax instead"
     )]
+    #[rustc_deprecated(
+        since = "1.56",
+        reason = "will be removed from the compiler, use asm! instead"
+    )]
     #[rustc_builtin_macro]
     #[macro_export]
     macro_rules! llvm_asm {

--- a/src/test/ui/abi/abi-sysv64-register-usage.rs
+++ b/src/test/ui/abi/abi-sysv64-register-usage.rs
@@ -7,6 +7,7 @@
 // ignore-aarch64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(target_arch = "x86_64")]
 pub extern "sysv64" fn all_the_registers(rdi: i64, rsi: i64, rdx: i64,

--- a/src/test/ui/asm/naked-functions.rs
+++ b/src/test/ui/asm/naked-functions.rs
@@ -4,6 +4,7 @@
 #![feature(naked_functions)]
 #![feature(or_patterns)]
 #![crate_type = "lib"]
+#![allow(deprecated)] // llvm_asm!
 
 #[repr(C)]
 pub struct P { x: u8, y: u16 }

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -1,35 +1,35 @@
 error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:126:14
+  --> $DIR/naked-functions.rs:127:14
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:13:5
+  --> $DIR/naked-functions.rs:14:5
    |
 LL |     mut a: u32,
    |     ^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:15:5
+  --> $DIR/naked-functions.rs:16:5
    |
 LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:17:6
+  --> $DIR/naked-functions.rs:18:6
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
    |      ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:19:5
+  --> $DIR/naked-functions.rs:20:5
    |
 LL |     P { x, y }: P,
    |     ^^^^^^^^^^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:29:5
+  --> $DIR/naked-functions.rs:30:5
    |
 LL |     a + 1
    |     ^
@@ -37,7 +37,7 @@ LL |     a + 1
    = help: follow the calling convention in asm block to use parameters
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:26:1
+  --> $DIR/naked-functions.rs:27:1
    |
 LL | / pub unsafe extern "C" fn inc(a: u32) -> u32 {
 LL | |
@@ -53,7 +53,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:35:31
+  --> $DIR/naked-functions.rs:36:31
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                               ^
@@ -61,7 +61,7 @@ LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    = help: follow the calling convention in asm block to use parameters
 
 warning: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:35:23
+  --> $DIR/naked-functions.rs:36:23
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                       ^^^^^^^^^
@@ -70,7 +70,7 @@ LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:42:1
+  --> $DIR/naked-functions.rs:43:1
    |
 LL | / pub unsafe extern "C" fn inc_closure(a: u32) -> u32 {
 LL | |
@@ -84,7 +84,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:62:10
+  --> $DIR/naked-functions.rs:63:10
    |
 LL |          in(reg) a,
    |          ^^^^^^^^^
@@ -102,7 +102,7 @@ LL |          out(reg) e,
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:59:5
+  --> $DIR/naked-functions.rs:60:5
    |
 LL | /     asm!("/* {0} {1} {2} {3} {4} {5} {6} */",
 LL | |
@@ -117,7 +117,7 @@ LL | |     );
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:49:1
+  --> $DIR/naked-functions.rs:50:1
    |
 LL | / pub unsafe extern "C" fn unsupported_operands() {
 LL | |
@@ -141,7 +141,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:75:1
+  --> $DIR/naked-functions.rs:76:1
    |
 LL | / pub extern "C" fn missing_assembly() {
 LL | |
@@ -153,7 +153,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:5
+  --> $DIR/naked-functions.rs:85:5
    |
 LL |     asm!("");
    |     ^^^^^^^^^
@@ -162,7 +162,7 @@ LL |     asm!("");
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:87:5
+  --> $DIR/naked-functions.rs:88:5
    |
 LL |     asm!("");
    |     ^^^^^^^^^
@@ -171,7 +171,7 @@ LL |     asm!("");
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:90:5
+  --> $DIR/naked-functions.rs:91:5
    |
 LL |     asm!("");
    |     ^^^^^^^^^
@@ -180,7 +180,7 @@ LL |     asm!("");
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:81:1
+  --> $DIR/naked-functions.rs:82:1
    |
 LL | / pub extern "C" fn too_many_asm_blocks() {
 LL | |
@@ -202,7 +202,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:101:11
+  --> $DIR/naked-functions.rs:102:11
    |
 LL |         *&y
    |           ^
@@ -210,7 +210,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:98:5
+  --> $DIR/naked-functions.rs:99:5
    |
 LL | /     pub extern "C" fn inner(y: usize) -> usize {
 LL | |
@@ -225,7 +225,7 @@ LL | |     }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: the LLVM-style inline assembly is unsupported in naked functions
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:112:5
    |
 LL |     llvm_asm!("");
    |     ^^^^^^^^^^^^^^
@@ -236,7 +236,7 @@ LL |     llvm_asm!("");
    = note: this warning originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:108:1
+  --> $DIR/naked-functions.rs:109:1
    |
 LL | / unsafe extern "C" fn llvm() -> ! {
 LL | |
@@ -252,7 +252,7 @@ LL | | }
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:119:5
+  --> $DIR/naked-functions.rs:120:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL |     asm!("", options(nomem, preserves_flags, noreturn));
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm options unsupported in naked functions: `nostack`, `pure`, `readonly`
-  --> $DIR/naked-functions.rs:126:5
+  --> $DIR/naked-functions.rs:127:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -270,7 +270,7 @@ LL |     asm!("", options(readonly, nostack), options(pure));
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:126:5
+  --> $DIR/naked-functions.rs:127:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL |     asm!("", options(readonly, nostack), options(pure));
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:135:15
+  --> $DIR/naked-functions.rs:136:15
    |
 LL | pub unsafe fn default_abi() {
    |               ^^^^^^^^^^^
@@ -287,13 +287,13 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:141:29
+  --> $DIR/naked-functions.rs:142:29
    |
 LL | pub unsafe extern "Rust" fn rust_abi() {
    |                             ^^^^^^^^
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:175:1
+  --> $DIR/naked-functions.rs:176:1
    |
 LL | #[inline]
    | ^^^^^^^^^
@@ -302,7 +302,7 @@ LL | #[inline]
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:183:1
+  --> $DIR/naked-functions.rs:184:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL | #[inline(always)]
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:191:1
+  --> $DIR/naked-functions.rs:192:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ LL | #[inline(never)]
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:199:1
+  --> $DIR/naked-functions.rs:200:1
    |
 LL | #[inline]
    | ^^^^^^^^^
@@ -329,7 +329,7 @@ LL | #[inline]
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:202:1
+  --> $DIR/naked-functions.rs:203:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
@@ -338,7 +338,7 @@ LL | #[inline(always)]
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
 
 warning: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:205:1
+  --> $DIR/naked-functions.rs:206:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/asm/rustfix-asm.fixed
+++ b/src/test/ui/asm/rustfix-asm.fixed
@@ -2,6 +2,7 @@
 // only-x86_64
 
 #![feature(asm, llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/asm/rustfix-asm.rs
+++ b/src/test/ui/asm/rustfix-asm.rs
@@ -2,6 +2,7 @@
 // only-x86_64
 
 #![feature(asm, llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/asm/rustfix-asm.stderr
+++ b/src/test/ui/asm/rustfix-asm.stderr
@@ -1,5 +1,5 @@
 error: the legacy LLVM-style asm! syntax is no longer supported
-  --> $DIR/rustfix-asm.rs:10:9
+  --> $DIR/rustfix-asm.rs:11:9
    |
 LL |         asm!("" :: "r" (x));
    |         ----^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |         asm!("" :: "r" (x));
    = note: alternatively, switch to llvm_asm! to keep your code working as it is
 
 error: the legacy LLVM-style asm! syntax is no longer supported
-  --> $DIR/rustfix-asm.rs:12:9
+  --> $DIR/rustfix-asm.rs:13:9
    |
 LL |         asm!("" : "=r" (y));
    |         ----^^^^^^^^^^^^^^^^

--- a/src/test/ui/ast-json/ast-json-ice.rs
+++ b/src/test/ui/ast-json/ast-json-ice.rs
@@ -9,6 +9,7 @@
 // dont-check-compiler-stdout - don't check for any AST change.
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 enum V {
     A(i32),

--- a/src/test/ui/borrowck/borrowck-asm.rs
+++ b/src/test/ui/borrowck/borrowck-asm.rs
@@ -8,6 +8,7 @@
 // ignore-sparc64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(any(target_arch = "x86",
             target_arch = "x86_64",

--- a/src/test/ui/borrowck/borrowck-asm.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-asm.rs:25:17
+  --> $DIR/borrowck-asm.rs:26:17
    |
 LL |         let x = &mut 0isize;
    |             - move occurs because `x` has type `&mut isize`, which does not implement the `Copy` trait
@@ -11,7 +11,7 @@ LL |         let z = x;
    |                 ^ value used here after move
 
 error[E0503]: cannot use `x` because it was mutably borrowed
-  --> $DIR/borrowck-asm.rs:32:37
+  --> $DIR/borrowck-asm.rs:33:37
    |
 LL |         let y = &mut x;
    |                 ------ borrow of `x` occurs here
@@ -23,7 +23,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:40:36
+  --> $DIR/borrowck-asm.rs:41:36
    |
 LL |         let x = 3;
    |             -
@@ -35,7 +35,7 @@ LL |             llvm_asm!("nop" : "=r"(x));
    |                                    ^ cannot assign twice to immutable variable
 
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-asm.rs:54:36
+  --> $DIR/borrowck-asm.rs:55:36
    |
 LL |         let x = 3;
    |             -
@@ -47,13 +47,13 @@ LL |             llvm_asm!("nop" : "+r"(x));
    |                                    ^ cannot assign twice to immutable variable
 
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/borrowck-asm.rs:61:37
+  --> $DIR/borrowck-asm.rs:62:37
    |
 LL |             llvm_asm!("nop" : "=*r"(x));
    |                                     ^ use of possibly-uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
-  --> $DIR/borrowck-asm.rs:69:36
+  --> $DIR/borrowck-asm.rs:70:36
    |
 LL |         let y = &*x;
    |                 --- borrow of `x` occurs here
@@ -65,7 +65,7 @@ LL |         let z = y;
    |                 - borrow later used here
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-asm.rs:77:45
+  --> $DIR/borrowck-asm.rs:78:45
    |
 LL |         let x = &mut 2;
    |             - move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait

--- a/src/test/ui/consts/inline_asm.rs
+++ b/src/test/ui/consts/inline_asm.rs
@@ -1,6 +1,6 @@
-#![feature(llvm_asm)]
+#![feature(asm)]
 
-const _: () = unsafe { llvm_asm!("nop") };
+const _: () = unsafe { asm!("nop") };
 //~^ ERROR inline assembly
 
 fn main() {}

--- a/src/test/ui/consts/inline_asm.stderr
+++ b/src/test/ui/consts/inline_asm.stderr
@@ -1,10 +1,8 @@
 error[E0015]: inline assembly is not allowed in constants
   --> $DIR/inline_asm.rs:3:24
    |
-LL | const _: () = unsafe { llvm_asm!("nop") };
-   |                        ^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL | const _: () = unsafe { asm!("nop") };
+   |                        ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.rs
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.rs
@@ -2,6 +2,7 @@
 // only-x86_64
 #![feature(asm,llvm_asm)]
 #![allow(const_err)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {}
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -1,5 +1,5 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/inline_asm.rs:10:14
+  --> $DIR/inline_asm.rs:11:14
    |
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
@@ -7,7 +7,7 @@ LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/inline_asm.rs:19:14
+  --> $DIR/inline_asm.rs:20:14
    |
 LL |     unsafe { asm!("nop"); }
    |              ^^^^^^^^^^^^ inline assembly is not supported
@@ -15,12 +15,12 @@ LL |     unsafe { asm!("nop"); }
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/inline_asm.rs:10:14
+  --> $DIR/inline_asm.rs:11:14
    |
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/inline_asm.rs:19:14
+  --> $DIR/inline_asm.rs:20:14
    |
 LL |     unsafe { asm!("nop"); }
    |              ^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0660.rs
+++ b/src/test/ui/error-codes/E0660.rs
@@ -1,4 +1,5 @@
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     let a;

--- a/src/test/ui/error-codes/E0660.stderr
+++ b/src/test/ui/error-codes/E0660.stderr
@@ -1,11 +1,11 @@
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:5:5
+  --> $DIR/E0660.rs:6:5
    |
 LL |     llvm_asm!("nop" "nop");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0660]: malformed inline assembly
-  --> $DIR/E0660.rs:7:5
+  --> $DIR/E0660.rs:8:5
    |
 LL |     llvm_asm!("nop" "nop" : "=r"(a));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0661.rs
+++ b/src/test/ui/error-codes/E0661.rs
@@ -1,6 +1,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     let a; //~ ERROR type annotations needed

--- a/src/test/ui/error-codes/E0661.stderr
+++ b/src/test/ui/error-codes/E0661.stderr
@@ -1,11 +1,11 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/E0661.rs:7:23
+  --> $DIR/E0661.rs:8:23
    |
 LL |     llvm_asm!("nop" : "r"(a));
    |                       ^^^
 
 error[E0282]: type annotations needed
-  --> $DIR/E0661.rs:6:9
+  --> $DIR/E0661.rs:7:9
    |
 LL |     let a;
    |         ^ consider giving `a` a type

--- a/src/test/ui/error-codes/E0662.rs
+++ b/src/test/ui/error-codes/E0662.rs
@@ -1,6 +1,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     llvm_asm!("xor %eax, %eax"

--- a/src/test/ui/error-codes/E0662.stderr
+++ b/src/test/ui/error-codes/E0662.stderr
@@ -1,5 +1,5 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/E0662.rs:8:17
+  --> $DIR/E0662.rs:9:17
    |
 LL |               : "=test"("a")
    |                 ^^^^^^^

--- a/src/test/ui/error-codes/E0663.rs
+++ b/src/test/ui/error-codes/E0663.rs
@@ -1,6 +1,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     llvm_asm!("xor %eax, %eax"

--- a/src/test/ui/error-codes/E0663.stderr
+++ b/src/test/ui/error-codes/E0663.stderr
@@ -1,5 +1,5 @@
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/E0663.rs:8:17
+  --> $DIR/E0663.rs:9:17
    |
 LL |               : "+test"("a")
    |                 ^^^^^^^

--- a/src/test/ui/error-codes/E0664.rs
+++ b/src/test/ui/error-codes/E0664.rs
@@ -1,6 +1,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     llvm_asm!("mov $$0x200, %eax"

--- a/src/test/ui/error-codes/E0664.stderr
+++ b/src/test/ui/error-codes/E0664.stderr
@@ -1,5 +1,5 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/E0664.rs:9:17
+  --> $DIR/E0664.rs:10:17
    |
 LL |               : "{eax}"
    |                 ^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-asm.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm.rs
@@ -1,5 +1,7 @@
 // only-x86_64
 
+#![allow(deprecated)] // llvm_asm!
+
 fn main() {
     unsafe {
         asm!("");

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'asm': inline assembly is not stable enough for use and is subject to change
-  --> $DIR/feature-gate-asm.rs:5:9
+  --> $DIR/feature-gate-asm.rs:7:9
    |
 LL |         asm!("");
    |         ^^^
@@ -8,7 +8,7 @@ LL |         asm!("");
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'llvm_asm': prefer using the new asm! syntax instead
-  --> $DIR/feature-gate-asm.rs:7:9
+  --> $DIR/feature-gate-asm.rs:9:9
    |
 LL |         llvm_asm!("");
    |         ^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-asm2.rs
+++ b/src/test/ui/feature-gates/feature-gate-asm2.rs
@@ -1,5 +1,7 @@
 // only-x86_64
 
+#![allow(deprecated)] // llvm_asm!
+
 fn main() {
     unsafe {
         println!("{:?}", asm!(""));

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'asm': inline assembly is not stable enough for use and is subject to change
-  --> $DIR/feature-gate-asm2.rs:5:26
+  --> $DIR/feature-gate-asm2.rs:7:26
    |
 LL |         println!("{:?}", asm!(""));
    |                          ^^^
@@ -8,7 +8,7 @@ LL |         println!("{:?}", asm!(""));
    = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'llvm_asm': prefer using the new asm! syntax instead
-  --> $DIR/feature-gate-asm2.rs:7:26
+  --> $DIR/feature-gate-asm2.rs:9:26
    |
 LL |         println!("{:?}", llvm_asm!(""));
    |                          ^^^^^^^^

--- a/src/test/ui/issues/issue-23458.rs
+++ b/src/test/ui/issues/issue-23458.rs
@@ -1,4 +1,5 @@
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 // compile-flags: -Ccodegen-units=1
 // build-fail
 // only-x86_64

--- a/src/test/ui/issues/issue-23458.stderr
+++ b/src/test/ui/issues/issue-23458.stderr
@@ -1,11 +1,11 @@
 error: invalid operand in inline asm: 'int $3'
-  --> $DIR/issue-23458.rs:8:9
+  --> $DIR/issue-23458.rs:9:9
    |
 LL |         llvm_asm!("int $3");
    |         ^
 
 error: too few operands for instruction
-  --> $DIR/issue-23458.rs:8:9
+  --> $DIR/issue-23458.rs:9:9
    |
 LL |         llvm_asm!("int $3");
    |         ^

--- a/src/test/ui/issues/issue-37366.rs
+++ b/src/test/ui/issues/issue-37366.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 macro_rules! interrupt_handler {
     () => {

--- a/src/test/ui/issues/issue-37433.rs
+++ b/src/test/ui/issues/issue-37433.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no llvm_asm! support
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/issues/issue-37433.stderr
+++ b/src/test/ui/issues/issue-37433.stderr
@@ -1,5 +1,5 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/issue-37433.rs:8:29
+  --> $DIR/issue-37433.rs:9:29
    |
 LL |         llvm_asm!("" :: "r"(""));
    |                             ^^

--- a/src/test/ui/issues/issue-53787-inline-assembler-macro.rs
+++ b/src/test/ui/issues/issue-53787-inline-assembler-macro.rs
@@ -4,6 +4,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 macro_rules! fake_jump {
     ($id:expr) => {

--- a/src/test/ui/issues/issue-53787-inline-assembler-macro.stderr
+++ b/src/test/ui/issues/issue-53787-inline-assembler-macro.stderr
@@ -1,5 +1,5 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/issue-53787-inline-assembler-macro.rs:24:16
+  --> $DIR/issue-53787-inline-assembler-macro.rs:25:16
    |
 LL |     fake_jump!("FirstFunc");
    |                ^^^^^^^^^^^

--- a/src/test/ui/issues/issue-9129.rs
+++ b/src/test/ui/issues/issue-9129.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(deprecated)] // llvm_asm!
 // ignore-pretty unreported
 
 #![feature(box_syntax)]

--- a/src/test/ui/llvm-asm/asm-src-loc-codegen-units.rs
+++ b/src/test/ui/llvm-asm/asm-src-loc-codegen-units.rs
@@ -4,6 +4,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/llvm-asm/asm-src-loc.rs
+++ b/src/test/ui/llvm-asm/asm-src-loc.rs
@@ -3,6 +3,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/llvm-asm/inline-asm-bad-constraint.rs
+++ b/src/test/ui/llvm-asm/inline-asm-bad-constraint.rs
@@ -4,6 +4,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 extern "C" {
     fn foo(a: usize);

--- a/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
+++ b/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
@@ -1,5 +1,5 @@
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:22:9
+  --> $DIR/inline-asm-bad-constraint.rs:23:9
    |
 LL |         llvm_asm!("" :"={rax"(rax))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         llvm_asm!("" :"={rax"(rax))
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:30:9
+  --> $DIR/inline-asm-bad-constraint.rs:31:9
    |
 LL |         llvm_asm!("callq $0" : : "0"(foo))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |         llvm_asm!("callq $0" : : "0"(foo))
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
-  --> $DIR/inline-asm-bad-constraint.rs:37:9
+  --> $DIR/inline-asm-bad-constraint.rs:38:9
    |
 LL |         llvm_asm!("addb $1, $0" : "={rax}"((0i32, rax)));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/llvm-asm/inline-asm-bad-operand.rs
+++ b/src/test/ui/llvm-asm/inline-asm-bad-operand.rs
@@ -5,6 +5,7 @@
 // ignore-emscripten
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[repr(C)]
 struct MyPtr(usize);

--- a/src/test/ui/llvm-asm/inline-asm-bad-operand.stderr
+++ b/src/test/ui/llvm-asm/inline-asm-bad-operand.stderr
@@ -1,41 +1,41 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:22:29
+  --> $DIR/inline-asm-bad-operand.rs:23:29
    |
 LL |         llvm_asm!("" :: "r"(""));
    |                             ^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:27:37
+  --> $DIR/inline-asm-bad-operand.rs:28:37
    |
 LL |         llvm_asm!("ret" : : "{rdi}"(target));
    |                                     ^^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:34:34
+  --> $DIR/inline-asm-bad-operand.rs:35:34
    |
 LL |     unsafe { llvm_asm!("" :: "i"(hello)) };
    |                                  ^^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:42:43
+  --> $DIR/inline-asm-bad-operand.rs:43:43
    |
 LL |         llvm_asm!("movups $1, %xmm0"::"m"(arr));
    |                                           ^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:49:37
+  --> $DIR/inline-asm-bad-operand.rs:50:37
    |
 LL |         llvm_asm!("mov sp, $0"::"r"(addr));
    |                                     ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:56:37
+  --> $DIR/inline-asm-bad-operand.rs:57:37
    |
 LL |         llvm_asm!("mov sp, $0"::"r"(addr),
    |                                     ^^^^
 
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/inline-asm-bad-operand.rs:57:37
+  --> $DIR/inline-asm-bad-operand.rs:58:37
    |
 LL | ...                   "r"("hello e0669"));
    |                           ^^^^^^^^^^^^^

--- a/src/test/ui/llvm-asm/issue-14936.rs
+++ b/src/test/ui/llvm-asm/issue-14936.rs
@@ -1,6 +1,7 @@
 // build-pass
 #![allow(unused_macros)]
 #![allow(dead_code)]
+#![allow(deprecated)] // llvm_asm!
 #![feature(llvm_asm)]
 
 type History = Vec<&'static str>;

--- a/src/test/ui/llvm-asm/issue-33264.rs
+++ b/src/test/ui/llvm-asm/issue-33264.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code, non_upper_case_globals)]
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[repr(C)]
 pub struct D32x4(f32,f32,f32,f32);

--- a/src/test/ui/llvm-asm/issue-51431.rs
+++ b/src/test/ui/llvm-asm/issue-51431.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no llvm_asm! support
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/llvm-asm/issue-51431.stderr
+++ b/src/test/ui/llvm-asm/issue-51431.stderr
@@ -1,5 +1,5 @@
 error[E0669]: invalid value for constraint in inline assembly
-  --> $DIR/issue-51431.rs:8:37
+  --> $DIR/issue-51431.rs:9:37
    |
 LL |         llvm_asm! {"mov $0,$1"::"0"("bx"),"1"(0x00)}
    |                                     ^^^^

--- a/src/test/ui/llvm-asm/issue-54067.rs
+++ b/src/test/ui/llvm-asm/issue-54067.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no llvm_asm! support
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 pub fn boot(addr: Option<u32>) {
     unsafe {

--- a/src/test/ui/llvm-asm/issue-62046.rs
+++ b/src/test/ui/llvm-asm/issue-62046.rs
@@ -2,6 +2,7 @@
 // ignore-emscripten no asm! support
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/llvm-asm/issue-62046.stderr
+++ b/src/test/ui/llvm-asm/issue-62046.stderr
@@ -1,5 +1,5 @@
 error[E0668]: malformed inline assembly
-  --> $DIR/issue-62046.rs:8:9
+  --> $DIR/issue-62046.rs:9:9
    |
 LL |         llvm_asm!("nop" : "+r"("r15"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/llvm-asm/issue-69092.rs
+++ b/src/test/ui/llvm-asm/issue-69092.rs
@@ -3,6 +3,7 @@
 // Regression test for #69092
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe { llvm_asm!(".ascii \"Xen\0\""); }

--- a/src/test/ui/llvm-asm/issue-69092.stderr
+++ b/src/test/ui/llvm-asm/issue-69092.stderr
@@ -1,5 +1,5 @@
 error: expected string in '.ascii' directive
-  --> $DIR/issue-69092.rs:8:14
+  --> $DIR/issue-69092.rs:9:14
    |
 LL |     unsafe { llvm_asm!(".ascii \"Xen\0\""); }
    |              ^

--- a/src/test/ui/llvm-asm/llvm-asm-bad-clobber.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-bad-clobber.rs
@@ -13,6 +13,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]

--- a/src/test/ui/llvm-asm/llvm-asm-bad-clobber.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-bad-clobber.stderr
@@ -1,5 +1,5 @@
 error[E0664]: clobber should not be surrounded by braces
-  --> $DIR/llvm-asm-bad-clobber.rs:23:42
+  --> $DIR/llvm-asm-bad-clobber.rs:24:42
    |
 LL |         llvm_asm!("xor %eax, %eax" : : : "{eax}");
    |                                          ^^^^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-concat-src.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-concat-src.rs
@@ -3,6 +3,7 @@
 // ignore-emscripten no asm
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 pub fn main() {
     unsafe { llvm_asm!(concat!("", "")) };

--- a/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn foo(x: isize) { println!("{}", x); }
 

--- a/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-in-bad-modifier.stderr
@@ -1,11 +1,11 @@
 error[E0662]: input operand constraint contains '='
-  --> $DIR/llvm-asm-in-bad-modifier.rs:24:44
+  --> $DIR/llvm-asm-in-bad-modifier.rs:25:44
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "=r"(5));
    |                                            ^^^^
 
 error[E0663]: input operand constraint contains '+'
-  --> $DIR/llvm-asm-in-bad-modifier.rs:25:44
+  --> $DIR/llvm-asm-in-bad-modifier.rs:26:44
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(y) : "+r"(5));
    |                                            ^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-in-moved.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-in-moved.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 #![allow(dead_code)]
 
 use std::cell::Cell;

--- a/src/test/ui/llvm-asm/llvm-asm-in-out-operand.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-in-out-operand.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn next_power_of_2(n: u32) -> u32 {

--- a/src/test/ui/llvm-asm/llvm-asm-indirect-memory.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-indirect-memory.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn read(ptr: &u32) -> u32 {

--- a/src/test/ui/llvm-asm/llvm-asm-literal-escaping.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-literal-escaping.rs
@@ -2,6 +2,7 @@
 // only-x86_64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     unsafe {

--- a/src/test/ui/llvm-asm/llvm-asm-misplaced-option.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-misplaced-option.rs
@@ -14,6 +14,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]

--- a/src/test/ui/llvm-asm/llvm-asm-misplaced-option.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-misplaced-option.stderr
@@ -1,11 +1,11 @@
 warning: unrecognized option
-  --> $DIR/llvm-asm-misplaced-option.rs:25:69
+  --> $DIR/llvm-asm-misplaced-option.rs:26:69
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(5_usize), "0"(x) : : "cc");
    |                                                                     ^^^^
 
 warning: expected a clobber, found an option
-  --> $DIR/llvm-asm-misplaced-option.rs:32:85
+  --> $DIR/llvm-asm-misplaced-option.rs:33:85
    |
 LL |         llvm_asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8_usize) : "cc", "volatile");
    |                                                                                     ^^^^^^^^^^

--- a/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn foo(x: isize) { println!("{}", x); }
 

--- a/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-assign-imm.stderr
@@ -1,5 +1,5 @@
 error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/llvm-asm-out-assign-imm.rs:25:39
+  --> $DIR/llvm-asm-out-assign-imm.rs:26:39
    |
 LL |     let x: isize;
    |         - help: consider making this binding mutable: `mut x`

--- a/src/test/ui/llvm-asm/llvm-asm-out-assign.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-assign.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!s
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn main() {

--- a/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn foo(x: isize) { println!("{}", x); }
 

--- a/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-no-modifier.stderr
@@ -1,5 +1,5 @@
 error[E0661]: output operand constraint lacks '=' or '+'
-  --> $DIR/llvm-asm-out-no-modifier.rs:23:34
+  --> $DIR/llvm-asm-out-no-modifier.rs:24:34
    |
 LL |         llvm_asm!("mov $1, $0" : "r"(x) : "r"(5));
    |                                  ^^^

--- a/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.rs
@@ -10,6 +10,7 @@
 // ignore-mips64
 
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn foo(x: isize) { println!("{}", x); }
 

--- a/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-out-read-uninit.stderr
@@ -1,5 +1,5 @@
 error[E0381]: use of possibly-uninitialized variable: `x`
-  --> $DIR/llvm-asm-out-read-uninit.rs:23:48
+  --> $DIR/llvm-asm-out-read-uninit.rs:24:48
    |
 LL |         llvm_asm!("mov $1, $0" : "=r"(x) : "r"(x));
    |                                                ^ use of possibly-uninitialized `x`

--- a/src/test/ui/llvm-asm/llvm-asm-parse-errors.rs
+++ b/src/test/ui/llvm-asm/llvm-asm-parse-errors.rs
@@ -1,4 +1,5 @@
 #![feature(llvm_asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     llvm_asm!(); //~ ERROR requires a string literal as an argument

--- a/src/test/ui/llvm-asm/llvm-asm-parse-errors.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-parse-errors.stderr
@@ -1,65 +1,65 @@
 error: macro requires a string literal as an argument
-  --> $DIR/llvm-asm-parse-errors.rs:4:5
+  --> $DIR/llvm-asm-parse-errors.rs:5:5
    |
 LL |     llvm_asm!();
    |     ^^^^^^^^^^^^ string literal required
 
 error: expected string literal
-  --> $DIR/llvm-asm-parse-errors.rs:5:23
+  --> $DIR/llvm-asm-parse-errors.rs:6:23
    |
 LL |     llvm_asm!("nop" : struct);
    |                       ^^^^^^ not a string literal
 
 error: expected string literal
-  --> $DIR/llvm-asm-parse-errors.rs:6:35
+  --> $DIR/llvm-asm-parse-errors.rs:7:35
    |
 LL |     llvm_asm!("mov %eax, $$0x2" : struct);
    |                                   ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
-  --> $DIR/llvm-asm-parse-errors.rs:7:44
+  --> $DIR/llvm-asm-parse-errors.rs:8:44
    |
 LL |     llvm_asm!("mov %eax, $$0x2" : "={eax}" struct);
    |                                            ^^^^^^ expected `(`
 
 error: expected expression, found keyword `struct`
-  --> $DIR/llvm-asm-parse-errors.rs:8:44
+  --> $DIR/llvm-asm-parse-errors.rs:9:44
    |
 LL |     llvm_asm!("mov %eax, $$0x2" : "={eax}"(struct));
    |                                            ^^^^^^ expected expression
 
 error: expected string literal
-  --> $DIR/llvm-asm-parse-errors.rs:9:49
+  --> $DIR/llvm-asm-parse-errors.rs:10:49
    |
 LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : struct);
    |                                                 ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
-  --> $DIR/llvm-asm-parse-errors.rs:10:56
+  --> $DIR/llvm-asm-parse-errors.rs:11:56
    |
 LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}" struct);
    |                                                        ^^^^^^ expected `(`
 
 error: expected expression, found keyword `struct`
-  --> $DIR/llvm-asm-parse-errors.rs:11:56
+  --> $DIR/llvm-asm-parse-errors.rs:12:56
    |
 LL |     llvm_asm!("in %dx, %al" : "={al}"(result) : "{dx}"(struct));
    |                                                        ^^^^^^ expected expression
 
 error: expected string literal
-  --> $DIR/llvm-asm-parse-errors.rs:12:41
+  --> $DIR/llvm-asm-parse-errors.rs:13:41
    |
 LL |     llvm_asm!("mov $$0x200, %eax" : : : struct);
    |                                         ^^^^^^ not a string literal
 
 error: expected string literal
-  --> $DIR/llvm-asm-parse-errors.rs:13:50
+  --> $DIR/llvm-asm-parse-errors.rs:14:50
    |
 LL |     llvm_asm!("mov eax, 2" : "={eax}"(foo) : : : struct);
    |                                                  ^^^^^^ not a string literal
 
 error: inline assembly must be a string literal
-  --> $DIR/llvm-asm-parse-errors.rs:14:15
+  --> $DIR/llvm-asm-parse-errors.rs:15:15
    |
 LL |     llvm_asm!(123);
    |               ^^^

--- a/src/test/ui/macros/macros-nonfatal-errors.rs
+++ b/src/test/ui/macros/macros-nonfatal-errors.rs
@@ -7,6 +7,7 @@
 #![feature(trace_macros, concat_idents)]
 #![feature(stmt_expr_attributes, arbitrary_enum_discriminant)]
 #![feature(derive_default_enum)]
+#![allow(deprecated)] // llvm_asm!
 
 #[derive(Default)]
 struct DefaultInnerAttrStruct {

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -1,41 +1,41 @@
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:13:5
+  --> $DIR/macros-nonfatal-errors.rs:14:5
    |
 LL |     #[default]
    |     ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:18:36
+  --> $DIR/macros-nonfatal-errors.rs:19:36
    |
 LL | struct DefaultInnerAttrTupleStruct(#[default] ());
    |                                    ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:22:1
+  --> $DIR/macros-nonfatal-errors.rs:23:1
    |
 LL | #[default]
    | ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:26:1
+  --> $DIR/macros-nonfatal-errors.rs:27:1
    |
 LL | #[default]
    | ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:36:11
+  --> $DIR/macros-nonfatal-errors.rs:37:11
    |
 LL |     Foo = #[default] 0,
    |           ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:37:14
+  --> $DIR/macros-nonfatal-errors.rs:38:14
    |
 LL |     Bar([u8; #[default] 1]),
    |              ^^^^^^^^^^
 
 error: no default declared
-  --> $DIR/macros-nonfatal-errors.rs:42:10
+  --> $DIR/macros-nonfatal-errors.rs:43:10
    |
 LL | #[derive(Default)]
    |          ^^^^^^^
@@ -44,7 +44,7 @@ LL | #[derive(Default)]
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: multiple declared defaults
-  --> $DIR/macros-nonfatal-errors.rs:48:10
+  --> $DIR/macros-nonfatal-errors.rs:49:10
    |
 LL | #[derive(Default)]
    |          ^^^^^^^
@@ -62,7 +62,7 @@ LL |     Baz,
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[default]` attribute does not accept a value
-  --> $DIR/macros-nonfatal-errors.rs:60:5
+  --> $DIR/macros-nonfatal-errors.rs:61:5
    |
 LL |     #[default = 1]
    |     ^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |     #[default = 1]
    = help: try using `#[default]`
 
 error: multiple `#[default]` attributes
-  --> $DIR/macros-nonfatal-errors.rs:68:5
+  --> $DIR/macros-nonfatal-errors.rs:69:5
    |
 LL |     #[default]
    |     ---------- `#[default]` used here
@@ -81,13 +81,13 @@ LL |     Foo,
    |
    = note: only one `#[default]` attribute is needed
 help: try removing this
-  --> $DIR/macros-nonfatal-errors.rs:67:5
+  --> $DIR/macros-nonfatal-errors.rs:68:5
    |
 LL |     #[default]
    |     ^^^^^^^^^^
 
 error: multiple `#[default]` attributes
-  --> $DIR/macros-nonfatal-errors.rs:78:5
+  --> $DIR/macros-nonfatal-errors.rs:79:5
    |
 LL |     #[default]
    |     ---------- `#[default]` used here
@@ -99,7 +99,7 @@ LL |     Foo,
    |
    = note: only one `#[default]` attribute is needed
 help: try removing these
-  --> $DIR/macros-nonfatal-errors.rs:75:5
+  --> $DIR/macros-nonfatal-errors.rs:76:5
    |
 LL |     #[default]
    |     ^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     #[default]
    |     ^^^^^^^^^^
 
 error: the `#[default]` attribute may only be used on unit enum variants
-  --> $DIR/macros-nonfatal-errors.rs:85:5
+  --> $DIR/macros-nonfatal-errors.rs:86:5
    |
 LL |     Foo {},
    |     ^^^
@@ -117,7 +117,7 @@ LL |     Foo {},
    = help: consider a manual implementation of `Default`
 
 error: default variant must be exhaustive
-  --> $DIR/macros-nonfatal-errors.rs:93:5
+  --> $DIR/macros-nonfatal-errors.rs:94:5
    |
 LL |     #[non_exhaustive]
    |     ----------------- declared `#[non_exhaustive]` here
@@ -127,43 +127,43 @@ LL |     Foo,
    = help: consider a manual implementation of `Default`
 
 error: asm template must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:98:10
+  --> $DIR/macros-nonfatal-errors.rs:99:10
    |
 LL |     asm!(invalid);
    |          ^^^^^^^
 
 error: inline assembly must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:99:15
+  --> $DIR/macros-nonfatal-errors.rs:100:15
    |
 LL |     llvm_asm!(invalid);
    |               ^^^^^^^
 
 error: concat_idents! requires ident args.
-  --> $DIR/macros-nonfatal-errors.rs:101:5
+  --> $DIR/macros-nonfatal-errors.rs:102:5
    |
 LL |     concat_idents!("not", "idents");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:103:17
+  --> $DIR/macros-nonfatal-errors.rs:104:17
    |
 LL |     option_env!(invalid);
    |                 ^^^^^^^
 
 error: expected string literal
-  --> $DIR/macros-nonfatal-errors.rs:104:10
+  --> $DIR/macros-nonfatal-errors.rs:105:10
    |
 LL |     env!(invalid);
    |          ^^^^^^^
 
 error: expected string literal
-  --> $DIR/macros-nonfatal-errors.rs:105:10
+  --> $DIR/macros-nonfatal-errors.rs:106:10
    |
 LL |     env!(foo, abr, baz);
    |          ^^^
 
 error: environment variable `RUST_HOPEFULLY_THIS_DOESNT_EXIST` not defined
-  --> $DIR/macros-nonfatal-errors.rs:106:5
+  --> $DIR/macros-nonfatal-errors.rs:107:5
    |
 LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -171,7 +171,7 @@ LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:108:13
+  --> $DIR/macros-nonfatal-errors.rs:109:13
    |
 LL |     format!(invalid);
    |             ^^^^^^^
@@ -182,19 +182,19 @@ LL |     format!("{}", invalid);
    |             +++++
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:110:14
+  --> $DIR/macros-nonfatal-errors.rs:111:14
    |
 LL |     include!(invalid);
    |              ^^^^^^^
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:112:18
+  --> $DIR/macros-nonfatal-errors.rs:113:18
    |
 LL |     include_str!(invalid);
    |                  ^^^^^^^
 
 error: couldn't read $DIR/i'd be quite surprised if a file with this name existed: $FILE_NOT_FOUND_MSG (os error 2)
-  --> $DIR/macros-nonfatal-errors.rs:113:5
+  --> $DIR/macros-nonfatal-errors.rs:114:5
    |
 LL |     include_str!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,13 +202,13 @@ LL |     include_str!("i'd be quite surprised if a file with this name existed")
    = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument must be a string literal
-  --> $DIR/macros-nonfatal-errors.rs:114:20
+  --> $DIR/macros-nonfatal-errors.rs:115:20
    |
 LL |     include_bytes!(invalid);
    |                    ^^^^^^^
 
 error: couldn't read $DIR/i'd be quite surprised if a file with this name existed: $FILE_NOT_FOUND_MSG (os error 2)
-  --> $DIR/macros-nonfatal-errors.rs:115:5
+  --> $DIR/macros-nonfatal-errors.rs:116:5
    |
 LL |     include_bytes!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -216,7 +216,7 @@ LL |     include_bytes!("i'd be quite surprised if a file with this name existed
    = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trace_macros! accepts only `true` or `false`
-  --> $DIR/macros-nonfatal-errors.rs:117:5
+  --> $DIR/macros-nonfatal-errors.rs:118:5
    |
 LL |     trace_macros!(invalid);
    |     ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/out-of-stack.rs
+++ b/src/test/ui/out-of-stack.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused_must_use)]
 #![allow(unconditional_recursion)]
+#![allow(deprecated)] // llvm_asm!
 // ignore-android: FIXME (#20004)
 // ignore-emscripten no processes
 // ignore-sgx no processes

--- a/src/test/ui/unsafe/inline_asm.mir.stderr
+++ b/src/test/ui/unsafe/inline_asm.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:8:5
+  --> $DIR/inline_asm.rs:9:5
    |
 LL |     asm!("nop");
    |     ^^^^^^^^^^^^ use of inline assembly
@@ -7,7 +7,7 @@ LL |     asm!("nop");
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:9:5
+  --> $DIR/inline_asm.rs:10:5
    |
 LL |     llvm_asm!("nop");
    |     ^^^^^^^^^^^^^^^^^ use of inline assembly

--- a/src/test/ui/unsafe/inline_asm.rs
+++ b/src/test/ui/unsafe/inline_asm.rs
@@ -3,6 +3,7 @@
 
 #![feature(llvm_asm)]
 #![feature(asm)]
+#![allow(deprecated)] // llvm_asm!
 
 fn main() {
     asm!("nop"); //~ ERROR use of inline assembly is unsafe and requires unsafe function or block

--- a/src/test/ui/unsafe/inline_asm.thir.stderr
+++ b/src/test/ui/unsafe/inline_asm.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:8:5
+  --> $DIR/inline_asm.rs:9:5
    |
 LL |     asm!("nop");
    |     ^^^^^^^^^^^^ use of inline assembly
@@ -7,7 +7,7 @@ LL |     asm!("nop");
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:9:5
+  --> $DIR/inline_asm.rs:10:5
    |
 LL |     llvm_asm!("nop");
    |     ^^^^^^^^^^^^^^^^^ use of inline assembly


### PR DESCRIPTION
We would like to remove `llvm_asm!` from the compiler once `asm!` is stabilized. This PR deprecates `llvm_asm!` to encourage any remaining users to migrate to `asm!` (or if `asm!` is not supported for their target, to add this support to rustc).

The only remaining user of `llvm_asm!` in the standard library was `black_box`, which has been rewritten to use volatile operations when `asm!` is not available on the current target.

cc @rust-lang/wg-inline-asm 

cc @RalfJung for the changes to `black_box` which might affect Miri.

r? @nagisa