### PR TITLE
Fix feature gate checking of static-nobundle and native_link_modifiers

### DIFF
--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -77,6 +77,15 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                                 modifier `-bundle` with library kind `static`",
                             )
                             .emit();
+                            if !self.tcx.features().static_nobundle {
+                                feature_err(
+                                    &self.tcx.sess.parse_sess,
+                                    sym::static_nobundle,
+                                    item.span(),
+                                    "kind=\"static-nobundle\" is unstable",
+                                )
+                                .emit();
+                            }
                             NativeLibKind::Static { bundle: Some(false), whole_archive: None }
                         }
                         "dylib" => NativeLibKind::Dylib { as_needed: None },
@@ -249,17 +258,6 @@ impl Collector<'tcx> {
                 sym::link_cfg,
                 span.unwrap(),
                 "kind=\"link_cfg\" is unstable",
-            )
-            .emit();
-        }
-        if matches!(lib.kind, NativeLibKind::Static { bundle: Some(false), .. })
-            && !self.tcx.features().static_nobundle
-        {
-            feature_err(
-                &self.tcx.sess.parse_sess,
-                sym::static_nobundle,
-                span.unwrap_or(rustc_span::DUMMY_SP),
-                "kind=\"static-nobundle\" is unstable",
             )
             .emit();
         }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1618,8 +1618,20 @@ fn select_debuginfo(
     }
 }
 
-fn parse_native_lib_kind(kind: &str, error_format: ErrorOutputType) -> NativeLibKind {
-    match kind {
+fn parse_native_lib_kind(
+    matches: &getopts::Matches,
+    kind: &str,
+    error_format: ErrorOutputType,
+) -> (NativeLibKind, Option<bool>) {
+    let is_nightly = nightly_options::match_is_nightly_build(matches);
+    let enable_unstable = nightly_options::is_unstable_enabled(matches);
+
+    let (kind, modifiers) = match kind.split_once(':') {
+        None => (kind, None),
+        Some((kind, modifiers)) => (kind, Some(modifiers)),
+    };
+
+    let kind = match kind {
         "dylib" => NativeLibKind::Dylib { as_needed: None },
         "framework" => NativeLibKind::Framework { as_needed: None },
         "static" => NativeLibKind::Static { bundle: None, whole_archive: None },
@@ -1629,17 +1641,49 @@ fn parse_native_lib_kind(kind: &str, error_format: ErrorOutputType) -> NativeLib
                 "library kind `static-nobundle` has been superseded by specifying \
                 `-bundle` on library kind `static`. Try `static:-bundle`",
             );
+            if modifiers.is_some() {
+                early_error(
+                    error_format,
+                    "linking modifier can't be used with library kind `static-nobundle`",
+                )
+            }
+            if !is_nightly {
+                early_error(
+                    error_format,
+                    "library kind `static-nobundle` are currently unstable and only accepted on \
+                the nightly compiler",
+                );
+            }
             NativeLibKind::Static { bundle: Some(false), whole_archive: None }
         }
         s => early_error(
             error_format,
             &format!("unknown library kind `{}`, expected one of dylib, framework, or static", s),
         ),
+    };
+    match modifiers {
+        None => (kind, None),
+        Some(modifiers) => {
+            if !is_nightly {
+                early_error(
+                    error_format,
+                    "linking modifiers are currently unstable and only accepted on \
+                the nightly compiler",
+                );
+            }
+            if !enable_unstable {
+                early_error(
+                    error_format,
+                    "linking modifiers are currently unstable, \
+                the `-Z unstable-options` flag must also be passed to use it",
+                )
+            }
+            parse_native_lib_modifiers(kind, modifiers, error_format)
+        }
     }
 }
 
 fn parse_native_lib_modifiers(
-    is_nightly: bool,
     mut kind: NativeLibKind,
     modifiers: &str,
     error_format: ErrorOutputType,
@@ -1654,14 +1698,6 @@ fn parse_native_lib_modifiers(
                     before one of: bundle, verbatim, whole-archive, as-needed",
             ),
         };
-
-        if !is_nightly {
-            early_error(
-                error_format,
-                "linking modifiers are currently unstable and only accepted on \
-                the nightly compiler",
-            );
-        }
 
         match (modifier, &mut kind) {
             ("bundle", NativeLibKind::Static { bundle, .. }) => {
@@ -1709,7 +1745,6 @@ fn parse_native_lib_modifiers(
 }
 
 fn parse_libs(matches: &getopts::Matches, error_format: ErrorOutputType) -> Vec<NativeLib> {
-    let is_nightly = nightly_options::match_is_nightly_build(matches);
     matches
         .opt_strs("l")
         .into_iter()
@@ -1723,13 +1758,7 @@ fn parse_libs(matches: &getopts::Matches, error_format: ErrorOutputType) -> Vec<
             let (name, kind, verbatim) = match s.split_once('=') {
                 None => (s, NativeLibKind::Unspecified, None),
                 Some((kind, name)) => {
-                    let (kind, verbatim) = match kind.split_once(':') {
-                        None => (parse_native_lib_kind(kind, error_format), None),
-                        Some((kind, modifiers)) => {
-                            let kind = parse_native_lib_kind(kind, error_format);
-                            parse_native_lib_modifiers(is_nightly, kind, modifiers, error_format)
-                        }
-                    };
+                    let (kind, verbatim) = parse_native_lib_kind(matches, kind, error_format);
                     (name.to_string(), kind, verbatim)
                 }
             };

--- a/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-2.rs
+++ b/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-2.rs
@@ -1,0 +1,10 @@
+// Test native_link_modifiers_bundle don't need static-nobundle
+// check-pass
+
+#![feature(native_link_modifiers)]
+#![feature(native_link_modifiers_bundle)]
+
+#[link(name = "foo", kind = "static", modifiers = "-bundle")]
+extern "C" {}
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-3.rs
+++ b/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-3.rs
@@ -1,0 +1,3 @@
+// compile-flags: -l static:-bundle=nonexistent
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-3.stderr
+++ b/src/test/ui/feature-gates/feature-gate-native_link_modifiers_bundle-3.stderr
@@ -1,0 +1,2 @@
+error: linking modifiers are currently unstable, the `-Z unstable-options` flag must also be passed to use it
+

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle-2.rs
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle-2.rs
@@ -1,6 +1,4 @@
-//~ ERROR kind="static-nobundle" is unstable
-// Test the behavior of rustc when non-existent library is statically linked
-
+// check-pass
 // compile-flags: -l static-nobundle=nonexistent
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle-2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle-2.stderr
@@ -1,10 +1,2 @@
 warning: library kind `static-nobundle` has been superseded by specifying `-bundle` on library kind `static`. Try `static:-bundle`
 
-error[E0658]: kind="static-nobundle" is unstable
-   |
-   = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
-   = help: add `#![feature(static_nobundle)]` to the crate attributes to enable
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
@@ -5,10 +5,10 @@ LL | #[link(name = "foo", kind = "static-nobundle")]
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: kind="static-nobundle" is unstable
-  --> $DIR/feature-gate-static-nobundle.rs:1:1
+  --> $DIR/feature-gate-static-nobundle.rs:1:22
    |
 LL | #[link(name = "foo", kind = "static-nobundle")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
    = help: add `#![feature(static_nobundle)]` to the crate attributes to enable


### PR DESCRIPTION
Feature native_link_modifiers_bundle don't need feature static-nobundle
to work.

Also check the feature gates when using native_link_modifiers from command line options. Current nighly compiler don't check those feature gate.

```
> touch lib.rs
> rustc +nightly lib.rs -L /usr/lib -l static:+bundle=dl --crate-type=rlib
> rustc +nightly lib.rs -L /usr/lib -l dylib:+as-needed=dl --crate-type=dylib -Ctarget-feature=-crt-static
> rustc +nightly lib.rs -L /usr/lib -l static:-bundle=dl --crate-type=rlib
error[E0658]: kind="static-nobundle" is unstable
  |
  = note: see issue #37403 <https://github.com/rust-lang/rust/issues/37403> for more information
  = help: add `#![feature(static_nobundle)]` to the crate attributes to enable

error: aborting due to previous error

For more information about this error, try `rustc --explain E0658`.

```

First found this in https://github.com/rust-lang/rust/pull/85600#discussion_r676612655