### PR TITLE
Bump bootstrap compiler to 1.55

### DIFF
--- a/compiler/rustc_macros/src/symbols.rs
+++ b/compiler/rustc_macros/src/symbols.rs
@@ -207,7 +207,6 @@ fn symbols_with_errors(input: TokenStream) -> (TokenStream, Vec<syn::Error>) {
             #keyword_stream
         }
 
-        #[cfg_attr(bootstrap, allow(rustc::default_hash_types))]
         #[allow(non_upper_case_globals)]
         #[doc(hidden)]
         pub mod sym_generated {

--- a/library/core/src/array/equality.rs
+++ b/library/core/src/array/equality.rs
@@ -125,11 +125,6 @@ impl<T: PartialEq<Other>, Other, const N: usize> SpecArrayEq<Other, N> for T {
 }
 
 impl<T: PartialEq<U> + IsRawEqComparable<U>, U, const N: usize> SpecArrayEq<U, N> for T {
-    #[cfg(bootstrap)]
-    fn spec_eq(a: &[T; N], b: &[U; N]) -> bool {
-        a[..] == b[..]
-    }
-    #[cfg(not(bootstrap))]
     fn spec_eq(a: &[T; N], b: &[U; N]) -> bool {
         // SAFETY: This is why `IsRawEqComparable` is an `unsafe trait`.
         unsafe {

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -161,8 +161,7 @@ pub fn default<T: Default>() -> T {
 }
 
 /// Derive macro generating an impl of the trait `Default`.
-#[cfg_attr(not(bootstrap), rustc_builtin_macro(Default, attributes(default)))]
-#[cfg_attr(bootstrap, rustc_builtin_macro)]
+#[rustc_builtin_macro(Default, attributes(default))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics)]
 pub macro Default($item:item) {

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1931,7 +1931,6 @@ extern "rust-intrinsic" {
     ///
     /// (The implementation is allowed to branch on the results of comparisons,
     /// which is UB if any of their inputs are `undef`.)
-    #[cfg(not(bootstrap))]
     #[rustc_const_unstable(feature = "const_intrinsic_raw_eq", issue = "none")]
     pub fn raw_eq<T>(a: &T, b: &T) -> bool;
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -170,8 +170,7 @@
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(bootstrap, deny(or_patterns_back_compat))]
-#![cfg_attr(not(bootstrap), deny(rust_2021_incompatible_or_patterns))]
+#![deny(rust_2021_incompatible_or_patterns)]
 
 // allow using `core::` in intra-doc links
 #[allow(unused_extern_crates)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1,7 +1,6 @@
 #[doc = include_str!("panic.md")]
 #[macro_export]
-#[cfg_attr(bootstrap, rustc_builtin_macro = "core_panic")]
-#[cfg_attr(not(bootstrap), rustc_builtin_macro(core_panic))]
+#[rustc_builtin_macro(core_panic)]
 #[allow_internal_unstable(edition_panic)]
 #[stable(feature = "core", since = "1.6.0")]
 #[rustc_diagnostic_item = "core_panic_macro"]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -95,7 +95,7 @@ impl<T> [T] {
     /// let a = [1, 2, 3];
     /// assert_eq!(a.len(), 3);
     /// ```
-    #[cfg_attr(not(bootstrap), lang = "slice_len_fn")]
+    #[lang = "slice_len_fn"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_slice_len", since = "1.39.0")]
     #[inline]

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -6,8 +6,7 @@
 
 #[doc = include_str!("../../core/src/macros/panic.md")]
 #[macro_export]
-#[cfg_attr(bootstrap, rustc_builtin_macro = "std_panic")]
-#[cfg_attr(not(bootstrap), rustc_builtin_macro(std_panic))]
+#[rustc_builtin_macro(std_panic)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable(edition_panic)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "std_panic_macro")]

--- a/library/std/src/sys/unix/weak.rs
+++ b/library/std/src/sys/unix/weak.rs
@@ -26,8 +26,6 @@ use crate::marker;
 use crate::mem;
 use crate::sync::atomic::{self, AtomicUsize, Ordering};
 
-// Temporary null documentation to work around #57569 until the fix is beta
-#[cfg_attr(bootstrap, doc = "")]
 pub(crate) macro weak {
     (fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(non_upper_case_globals)]
@@ -103,8 +101,6 @@ unsafe fn fetch(name: &str) -> usize {
     libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
 }
 
-// Temporary null documentation to work around #57569 until the fix is beta
-#[cfg_attr(bootstrap, doc = "")]
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub(crate) macro syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
@@ -123,7 +119,6 @@ pub(crate) macro syscall {
     )
 }
 
-#[cfg_attr(bootstrap, doc = "")]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) macro syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # stable release's version number. `date` is the date where the release we're
 # bootstrapping off was released.
 
-date: 2021-06-23
+date: 2021-07-29
 rustc: beta
 
 # We use a nightly rustfmt to format the source because it solves some

--- a/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
+++ b/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(bootstrap, allow(rustc::default_hash_types))]
-
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Changing the cfgs for stdarch is missing, but my understanding is that we don't need to do it as part of this PR?

r? @Mark-Simulacrum 