### PR TITLE
Update libz-sys to 1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This update to libz-sys allows rustc to be cross-compiled for Haiku (Tier 3 platform). 