### PR TITLE
Added the `Option::unzip()` method

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1408,6 +1408,8 @@ impl<T, U> Option<(T, U)> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(unzip_option)]
+    ///
     /// let x = Some((1, "hi"));
     /// let y = None::<(u8, u32)>;
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1417,7 +1417,7 @@ impl<T, U> Option<(T, U)> {
     /// assert_eq!(y.unzip(), (None, None));
     /// ```
     #[inline]
-    #[unstable(feature = "unzip_option", issue = "none", reason = "recently added")]
+    #[unstable(feature = "unzip_option", issue = "87800", reason = "recently added")]
     pub const fn unzip(self) -> (Option<T>, Option<U>) {
         match self {
             Some((a, b)) => (Some(a), Some(b)),

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1399,6 +1399,31 @@ impl<T> Option<T> {
     }
 }
 
+impl<T, U> Option<(T, U)> {
+    /// Unzips an option containing a tuple of two options
+    ///
+    /// If `self` is `Some((a, b))` this method returns `(Some(a), Some(b))`.
+    /// Otherwise, `(None, None)` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let x = Some((1, "hi"));
+    /// let y = None::<(u8, u32)>;
+    ///
+    /// assert_eq!(x.unzip(), (Some(1), Some("hi")));
+    /// assert_eq!(y.unzip(), (None, None));
+    /// ```
+    #[inline]
+    #[unstable(feature = "unzip_option", issue = "none", reason = "recently added")]
+    pub const fn unzip(self) -> (Option<T>, Option<U>) {
+        match self {
+            Some((a, b)) => (Some(a), Some(b)),
+            None => (None, None),
+        }
+    }
+}
+
 impl<T: Copy> Option<&T> {
     /// Maps an `Option<&T>` to an `Option<T>` by copying the contents of the
     /// option.

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -66,6 +66,7 @@
 #![feature(slice_group_by)]
 #![feature(trusted_random_access)]
 #![feature(unsize)]
+#![feature(unzip_option)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate test;

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -399,11 +399,43 @@ fn test_unwrap_drop() {
 }
 
 #[test]
-pub fn option_ext() {
+fn option_ext() {
     let thing = "{{ f }}";
     let f = thing.find("{{");
 
     if f.is_none() {
         println!("None!");
     }
+}
+
+#[test]
+fn zip_options() {
+    let x = Some(10);
+    let y = Some("foo");
+    let z: Option<usize> = None;
+
+    assert_eq!(x.zip(y), Some((10, "foo")));
+    assert_eq!(x.zip(z), None);
+    assert_eq!(z.zip(x), None);
+}
+
+#[test]
+fn unzip_options() {
+    let x = Some((10, "foo"));
+    let y = None::<(bool, i32)>;
+
+    assert_eq!(x.unzip(), (Some(10), Some("foo")));
+    assert_eq!(y.unzip(), (None, None));
+}
+
+#[test]
+fn zip_unzip_roundtrip() {
+    let x = Some(10);
+    let y = Some("foo");
+
+    let z = x.zip(y);
+    assert_eq!(z, Some((10, "foo")));
+
+    let a = z.unzip();
+    assert_eq!(a, (x, y));
 }


### PR DESCRIPTION
* Adds the `Option::unzip()` method to turn an `Option<(T, U)>` into `(Option<T>, Option<U>)` under the `unzip_option` feature
* Adds tests for both `Option::unzip()` and `Option::zip()`, I noticed that `.zip()` didn't have any
* Adds `#[inline]` to a few of `Option`'s methods that were missing it