### PR TITLE
Made `Vec::len()` and `Vec::is_empty()` const

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1816,7 +1816,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    #[rustc_const_stable(feature = "const_vec_len", since = "")]
+    pub const fn len(&self) -> usize {
         self.len
     }
 
@@ -1832,7 +1833,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_stable(feature = "const_vec_len", since = "")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
`Vec::len()` and `Vec::is_empty()` have no non-const behavior (they both just fetch the `len` field of `Vec`) so there's no reason for them not to be const