### PR TITLE
Allow more "unknown argument" strings from linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "libc",
  "object 0.25.2",
  "pathdiff",
+ "regex",
  "rustc_apfloat",
  "rustc_ast",
  "rustc_attr",

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -17,6 +17,7 @@ jobserver = "0.1.22"
 tempfile = "3.2"
 pathdiff = "0.2.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
+regex = "1.4"
 
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }


### PR DESCRIPTION
Some toolchains emit slightly different errors, e.g.

    ppc-vle-gcc: error: unrecognized option '-no-pie'