### PR TITLE
Properly find owner of closure in THIR unsafeck

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -599,13 +599,10 @@ pub fn check_unsafety<'tcx>(tcx: TyCtxt<'tcx>, def: ty::WithOptConstParam<LocalD
 
     // Closures are handled by their owner, if it has a body
     if tcx.is_closure(def.did.to_def_id()) {
-        let owner = tcx.hir().local_def_id_to_hir_id(def.did).owner;
-        let owner_hir_id = tcx.hir().local_def_id_to_hir_id(owner);
-
-        if tcx.hir().maybe_body_owned_by(owner_hir_id).is_some() {
-            tcx.ensure().thir_check_unsafety(owner);
-            return;
-        }
+        let hir = tcx.hir();
+        let owner = hir.enclosing_body_owner(hir.local_def_id_to_hir_id(def.did));
+        tcx.ensure().thir_check_unsafety(hir.local_def_id(owner));
+        return;
     }
 
     let (thir, expr) = tcx.thir_body(def);

--- a/src/test/ui/unsafe/issue-87414-query-cycle.rs
+++ b/src/test/ui/unsafe/issue-87414-query-cycle.rs
@@ -1,0 +1,15 @@
+// Regression test for #87414.
+
+// check-pass
+// compile-flags: -Zthir-unsafeck
+
+fn bad<T>() -> Box<dyn Iterator<Item = [(); { |x: u32| { x }; 4 }]>> { todo!() }
+
+fn foo() -> [(); { |x: u32| { x }; 4 }] { todo!() }
+fn bar() { let _: [(); { |x: u32| { x }; 4 }]; }
+
+// This one should not cause any errors either:
+unsafe fn unsf() {}
+fn bad2<T>() -> Box<dyn Iterator<Item = [(); { unsafe { || { unsf() } }; 4 }]>> { todo!() }
+
+fn main() {}


### PR DESCRIPTION
Previously, when encountering a closure in a constant, the THIR unsafeck gets invoked on the owner of the constant instead of the constant itself, producing cycles.
Supersedes #87492. @FabianWolff thanks for your work on that PR, I copied your test file and added you as a co-author.

Fixes #87414.
r? @oli-obk