### PR TITLE
Fix a parser ICE on invalid `fn` body

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1715,13 +1715,11 @@ impl<'a> Parser<'a> {
                     // the AST for typechecking.
                     err.span_label(ident.span, "while parsing this `fn`");
                     err.emit();
-                    (Vec::new(), None)
                 } else {
                     return Err(err);
                 }
-            } else {
-                unreachable!()
             }
+            (Vec::new(), None)
         };
         attrs.extend(inner_attrs);
         Ok(body)

--- a/src/test/ui/parser/issue-87635.rs
+++ b/src/test/ui/parser/issue-87635.rs
@@ -1,0 +1,9 @@
+struct Foo {}
+
+impl Foo {
+    pub fn bar()
+    //~^ ERROR: expected `;`, found `}`
+    //~| ERROR: associated function in `impl` without body
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-87635.stderr
+++ b/src/test/ui/parser/issue-87635.stderr
@@ -1,0 +1,19 @@
+error: expected `;`, found `}`
+  --> $DIR/issue-87635.rs:4:17
+   |
+LL |     pub fn bar()
+   |                 ^ help: add `;` here
+...
+LL | }
+   | - unexpected token
+
+error: associated function in `impl` without body
+  --> $DIR/issue-87635.rs:4:5
+   |
+LL |     pub fn bar()
+   |     ^^^^^^^^^^^-
+   |                |
+   |                help: provide a definition for the function: `{ <body> }`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #87635
A better fix would add a check for `fn` body on `expected_one_of_not_found` but I haven't come up with a graceful way. Any idea?
r? @oli-obk @estebank 