### PR TITLE
Suggest `br` if the unknown string prefix `rb` is found

### DIFF
--- a/src/test/ui/suggestions/raw-byte-string-prefix.rs
+++ b/src/test/ui/suggestions/raw-byte-string-prefix.rs
@@ -1,0 +1,10 @@
+// `br` and `rb` are easy to confuse; check that we issue a suggestion to help.
+
+// edition:2021
+
+fn main() {
+    rb"abc";
+    //~^ ERROR: prefix `rb` is unknown
+    //~| HELP: use `br` for a raw byte string
+    //~| ERROR: expected one of
+}

--- a/src/test/ui/suggestions/raw-byte-string-prefix.stderr
+++ b/src/test/ui/suggestions/raw-byte-string-prefix.stderr
@@ -1,0 +1,20 @@
+error: prefix `rb` is unknown
+  --> $DIR/raw-byte-string-prefix.rs:6:5
+   |
+LL |     rb"abc";
+   |     ^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: use `br` for a raw byte string
+   |
+LL |     br"abc";
+   |     ^^
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"abc"`
+  --> $DIR/raw-byte-string-prefix.rs:6:7
+   |
+LL |     rb"abc";
+   |       ^^^^^ expected one of 8 possible tokens
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Currently, for the following code:
```rust
fn main() {
    rb"abc";
}
```
we issue the following suggestion:
```
help: consider inserting whitespace here
  |
2 |     rb "abc";
  |       --
```
With my changes (only in edition 2021, where unknown prefixes became an error), I get:
```
help: use `br` for a raw byte string
  |
2 |     br"abc";
  |     ^^
```