### PR TITLE
Use note for pointing at bound introducing requirement

### DIFF
--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -5,9 +5,12 @@ LL |     f1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
-...
+   |
+note: required by a bound in `f1`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:16:25
+   |
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   |                         ------------ required by this bound in `f1`
+   |                         ^^^^^^^^^^^^ required by this bound in `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
@@ -16,9 +19,12 @@ LL |     f2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
-...
+   |
+note: required by a bound in `f2`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:17:25
+   |
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   |                         ----------------------- required by this bound in `f2`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -27,9 +33,12 @@ LL |     f3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
-...
+   |
+note: required by a bound in `f3`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:18:29
+   |
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   |                             --------------- required by this bound in `f3`
+   |                             ^^^^^^^^^^^^^^^ required by this bound in `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
@@ -38,9 +47,12 @@ LL |     f4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
-...
+   |
+note: required by a bound in `f4`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:19:25
+   |
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   |                         ----------------------- required by this bound in `f4`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -49,9 +61,12 @@ LL |     f5(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
-...
+   |
+note: required by a bound in `f5`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:20:25
+   |
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   |                         -------------------------- required by this bound in `f5`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
@@ -60,9 +75,12 @@ LL |     g1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>) -> _`
-...
+   |
+note: required by a bound in `g1`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:23:25
+   |
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   |                         ------------------------- required by this bound in `g1`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -71,9 +89,12 @@ LL |     g2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
-...
+   |
+note: required by a bound in `g2`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:24:25
+   |
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   |                         ---------------- required by this bound in `g2`
+   |                         ^^^^^^^^^^^^^^^^ required by this bound in `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
@@ -82,9 +103,12 @@ LL |     g3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), Box<(dyn for<'r> Fn(&'r ()) + 'static)>) -> _`
-...
+   |
+note: required by a bound in `g3`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:25:25
+   |
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   |                         ------------------------------------ required by this bound in `g3`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -93,9 +117,12 @@ LL |     g4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
-...
+   |
+note: required by a bound in `g4`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:26:25
+   |
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   |                         --------------------------- required by this bound in `g4`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
@@ -104,9 +131,12 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), Box<(dyn for<'t0> Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
-...
+   |
+note: required by a bound in `h1`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:29:25
+   |
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   |                         -------------------------------------------- required by this bound in `h1`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -115,9 +145,12 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 't0> fn(&'r (), Box<(dyn for<'s> Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
-...
+   |
+note: required by a bound in `h2`
+  --> $DIR/anonymous-higher-ranked-lifetime.rs:30:25
+   |
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   |                         --------------------------------------------------------- required by this bound in `h2`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -4,12 +4,12 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be sent between th
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                    ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
    |
-  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+   = help: the trait `Send` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+note: required by a bound in `Send`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub unsafe auto trait Send {
-   | -------------------------- required by this bound in `Send`
-   |
-   = help: the trait `Send` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Send`
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Send {
@@ -21,12 +21,12 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` is not an iterator
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `<<Self as Case1>::C as Iterator>::Item` is not an iterator
    |
-  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = help: the trait `Iterator` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+note: required by a bound in `Iterator`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
 LL | pub trait Iterator {
-   | ------------------ required by this bound in `Iterator`
-   |
-   = help: the trait `Iterator` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+   | ^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator`
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Iterator {
@@ -38,12 +38,12 @@ error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be shared between 
 LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
    |                                                                                             ^^^^ `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
    |
-  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+   = help: the trait `Sync` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+note: required by a bound in `Sync`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub unsafe auto trait Sync {
-   | -------------------------- required by this bound in `Sync`
-   |
-   = help: the trait `Sync` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Sync`
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Sync {

--- a/src/test/ui/associated-type-bounds/bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bounds-on-assoc-in-trait.stderr
@@ -4,12 +4,12 @@ error[E0277]: `<<Self as Case1>::A as Iterator>::Item` doesn't implement `Debug`
 LL |     type A: Iterator<Item: Debug>;
    |                            ^^^^^ `<<Self as Case1>::A as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-  ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+   = help: the trait `Debug` is not implemented for `<<Self as Case1>::A as Iterator>::Item`
+note: required by a bound in `Debug`
+  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
    |
 LL | pub trait Debug {
-   | --------------- required by this bound in `Debug`
-   |
-   = help: the trait `Debug` is not implemented for `<<Self as Case1>::A as Iterator>::Item`
+   | ^^^^^^^^^^^^^^^ required by this bound in `Debug`
 help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::A as Iterator>::Item: Debug {
@@ -21,11 +21,11 @@ error[E0277]: the trait bound `<<Self as Foo>::Out as Baz>::Assoc: Default` is n
 LL | pub trait Foo { type Out: Baz<Assoc: Default>; }
    |                                      ^^^^^^^ the trait `Default` is not implemented for `<<Self as Foo>::Out as Baz>::Assoc`
    |
-  ::: $SRC_DIR/core/src/default.rs:LL:COL
+note: required by a bound in `Default`
+  --> $SRC_DIR/core/src/default.rs:LL:COL
    |
 LL | pub trait Default: Sized {
-   | ------------------------ required by this bound in `Default`
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Default`
 help: consider further restricting the associated type
    |
 LL | pub trait Foo where <<Self as Foo>::Out as Baz>::Assoc: Default { type Out: Baz<Assoc: Default>; }

--- a/src/test/ui/associated-type-bounds/issue-83017.stderr
+++ b/src/test/ui/associated-type-bounds/issue-83017.stderr
@@ -1,26 +1,32 @@
 error[E0277]: the trait bound `for<'a, 'b> <Z as TraitA<'a>>::AsA: TraitB<'a, 'b>` is not satisfied
   --> $DIR/issue-83017.rs:36:5
    |
-LL | fn foo<T>()
-   |    --- required by a bound in this
-LL | where
-LL |     for<'a> T: TraitA<'a, AsA: for<'b> TraitB<'a, 'b, AsB: for<'c> TraitC<'a, 'b, 'c>>>,
-   |                                ------------------------------------------------------- required by this bound in `foo`
-...
 LL |     foo::<Z>();
    |     ^^^^^^^^ the trait `for<'a, 'b> TraitB<'a, 'b>` is not implemented for `<Z as TraitA<'a>>::AsA`
-
-error[E0277]: the trait bound `for<'a, 'b, 'c> <<Z as TraitA<'a>>::AsA as TraitB<'a, 'b>>::AsB: TraitC<'a, 'b, 'c>` is not satisfied
-  --> $DIR/issue-83017.rs:36:5
+   |
+note: required by a bound in `foo`
+  --> $DIR/issue-83017.rs:31:32
    |
 LL | fn foo<T>()
    |    --- required by a bound in this
 LL | where
 LL |     for<'a> T: TraitA<'a, AsA: for<'b> TraitB<'a, 'b, AsB: for<'c> TraitC<'a, 'b, 'c>>>,
-   |                                                            -------------------------- required by this bound in `foo`
-...
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `for<'a, 'b, 'c> <<Z as TraitA<'a>>::AsA as TraitB<'a, 'b>>::AsB: TraitC<'a, 'b, 'c>` is not satisfied
+  --> $DIR/issue-83017.rs:36:5
+   |
 LL |     foo::<Z>();
    |     ^^^^^^^^ the trait `for<'a, 'b, 'c> TraitC<'a, 'b, 'c>` is not implemented for `<<Z as TraitA<'a>>::AsA as TraitB<'a, 'b>>::AsB`
+   |
+note: required by a bound in `foo`
+  --> $DIR/issue-83017.rs:31:60
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this
+LL | where
+LL |     for<'a> T: TraitA<'a, AsA: for<'b> TraitB<'a, 'b, AsB: for<'c> TraitC<'a, 'b, 'c>>>,
+   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -1,20 +1,26 @@
 error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
    |
-LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
-   |                   ---------- required by this bound in `blue_car`
-...
 LL | fn b() { blue_car(ModelT); }
    |          ^^^^^^^^ expected struct `Blue`, found struct `Black`
+   |
+note: required by a bound in `blue_car`
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:27:19
+   |
+LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
+   |                   ^^^^^^^^^^ required by this bound in `blue_car`
 
 error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
    |
-LL | fn black_car<C:Car<Color=Black>>(c: C) {
-   |                    ----------- required by this bound in `black_car`
-...
 LL | fn c() { black_car(ModelU); }
    |          ^^^^^^^^^ expected struct `Black`, found struct `Blue`
+   |
+note: required by a bound in `black_car`
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:24:20
+   |
+LL | fn black_car<C:Car<Color=Black>>(c: C) {
+   |                    ^^^^^^^^^^^ required by this bound in `black_car`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -16,11 +16,14 @@ LL | fn foo2<I: Foo<A = Bar>>(x: I) {
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:5
    |
-LL | fn foo1<I: Foo<A=Bar>>(x: I) {
-   |                ----- required by this bound in `foo1`
-...
 LL |     foo1(a);
    |     ^^^^ expected struct `Bar`, found `usize`
+   |
+note: required by a bound in `foo1`
+  --> $DIR/associated-types-eq-3.rs:18:16
+   |
+LL | fn foo1<I: Foo<A=Bar>>(x: I) {
+   |                ^^^^^ required by this bound in `foo1`
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:41:9

--- a/src/test/ui/associated-types/associated-types-eq-hr.nll.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.nll.stderr
@@ -1,32 +1,36 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:87:5
    |
-LL | fn foo<T>()
-   |    --- required by a bound in this
-LL | where
-LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
-   |                                    ------------- required by this bound in `foo`
-...
 LL |     foo::<UintStruct>();
    |     ^^^^^^^^^^^^^^^^^ expected `isize`, found `usize`
    |
    = note: expected reference `&isize`
               found reference `&usize`
+note: required by a bound in `foo`
+  --> $DIR/associated-types-eq-hr.rs:45:36
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this
+LL | where
+LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
+   |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
-LL | fn bar<T>()
-   |    --- required by a bound in this
-LL | where
-LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
-   |                                    ------------- required by this bound in `bar`
-...
 LL |     bar::<IntStruct>();
    |     ^^^^^^^^^^^^^^^^ expected `usize`, found `isize`
    |
    = note: expected reference `&usize`
               found reference `&isize`
+note: required by a bound in `bar`
+  --> $DIR/associated-types-eq-hr.rs:52:36
+   |
+LL | fn bar<T>()
+   |    --- required by a bound in this
+LL | where
+LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
+   |                                    ^^^^^^^^^^^^^ required by this bound in `bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -1,32 +1,36 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:87:5
    |
-LL | fn foo<T>()
-   |    --- required by a bound in this
-LL | where
-LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
-   |                                    ------------- required by this bound in `foo`
-...
 LL |     foo::<UintStruct>();
    |     ^^^^^^^^^^^^^^^^^ expected `isize`, found `usize`
    |
    = note: expected reference `&isize`
               found reference `&usize`
+note: required by a bound in `foo`
+  --> $DIR/associated-types-eq-hr.rs:45:36
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this
+LL | where
+LL |     T: for<'x> TheTrait<&'x isize, A = &'x isize>,
+   |                                    ^^^^^^^^^^^^^ required by this bound in `foo`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
-LL | fn bar<T>()
-   |    --- required by a bound in this
-LL | where
-LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
-   |                                    ------------- required by this bound in `bar`
-...
 LL |     bar::<IntStruct>();
    |     ^^^^^^^^^^^^^^^^ expected `usize`, found `isize`
    |
    = note: expected reference `&usize`
               found reference `&isize`
+note: required by a bound in `bar`
+  --> $DIR/associated-types-eq-hr.rs:52:36
+   |
+LL | fn bar<T>()
+   |    --- required by a bound in this
+LL | where
+LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
+   |                                    ^^^^^^^^^^^^^ required by this bound in `bar`
 
 error: implementation of `TheTrait` is not general enough
   --> $DIR/associated-types-eq-hr.rs:96:5

--- a/src/test/ui/associated-types/associated-types-for-unimpl-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-for-unimpl-trait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
   --> $DIR/associated-types-for-unimpl-trait.rs:10:40
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-for-unimpl-trait.rs:4:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -1,9 +1,6 @@
 error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
   --> $DIR/associated-types-issue-20346.rs:34:5
    |
-LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
-   |                                  ------ required by this bound in `is_iterator_of`
-...
 LL | fn test_adapter<T, I: Iterator<Item=Option<T>>>(it: I) {
    |                 - this type parameter
 ...
@@ -12,6 +9,11 @@ LL |     is_iterator_of::<Option<T>, _>(&adapter);
    |
    = note: expected enum `Option<T>`
               found type `T`
+note: required by a bound in `is_iterator_of`
+  --> $DIR/associated-types-issue-20346.rs:15:34
+   |
+LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
+   |                                  ^^^^^^ required by this bound in `is_iterator_of`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -3,12 +3,14 @@ error[E0271]: type mismatch resolving `<T as Foo>::Y == i32`
    |
 LL |     want_y(t);
    |     ^^^^^^ expected `i32`, found associated type
-...
-LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
-   |                 ----- required by this bound in `want_y`
    |
    = note:         expected type `i32`
            found associated type `<T as Foo>::Y`
+note: required by a bound in `want_y`
+  --> $DIR/associated-types-multiple-types-one-trait.rs:44:17
+   |
+LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
+   |                 ^^^^^ required by this bound in `want_y`
 help: consider constraining the associated type `<T as Foo>::Y` to `i32`
    |
 LL | fn have_x_want_y<T:Foo<X=u32, Y = i32>>(t: &T)
@@ -19,12 +21,14 @@ error[E0271]: type mismatch resolving `<T as Foo>::X == u32`
    |
 LL |     want_x(t);
    |     ^^^^^^ expected `u32`, found associated type
-...
-LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
-   |                 ----- required by this bound in `want_x`
    |
    = note:         expected type `u32`
            found associated type `<T as Foo>::X`
+note: required by a bound in `want_x`
+  --> $DIR/associated-types-multiple-types-one-trait.rs:42:17
+   |
+LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
+   |                 ^^^^^ required by this bound in `want_x`
 help: consider constraining the associated type `<T as Foo>::X` to `u32`
    |
 LL | fn have_y_want_x<T:Foo<Y=i32, X = u32>>(t: &T)

--- a/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/src/test/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Get` is not satisfied
   --> $DIR/associated-types-no-suitable-bound.rs:11:21
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
    |                     ^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `T`
    |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-no-suitable-bound.rs:1:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 help: consider restricting type parameter `T`
    |
 LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}

--- a/src/test/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
+++ b/src/test/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
   --> $DIR/associated-types-no-suitable-supertrait-2.rs:17:40
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-no-suitable-supertrait-2.rs:12:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}

--- a/src/test/ui/associated-types/associated-types-no-suitable-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-no-suitable-supertrait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
   --> $DIR/associated-types-no-suitable-supertrait.rs:17:40
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-no-suitable-supertrait.rs:12:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
@@ -15,11 +17,14 @@ LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Ge
 error[E0277]: the trait bound `(T, U): Get` is not satisfied
   --> $DIR/associated-types-no-suitable-supertrait.rs:22:40
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `(T, U)`
+   |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-no-suitable-supertrait.rs:12:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -1,18 +1,26 @@
 error[E0284]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
   --> $DIR/associated-types-overridden-binding.rs:4:12
    |
-LL | trait Foo: Iterator<Item = i32> {}
-   |                     ---------- required by this bound in `Foo`
 LL | trait Bar: Foo<Item = u32> {}
    |            ^^^^^^^^^^^^^^^ cannot satisfy `<Self as Iterator>::Item == i32`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/associated-types-overridden-binding.rs:3:21
+   |
+LL | trait Foo: Iterator<Item = i32> {}
+   |                     ^^^^^^^^^^ required by this bound in `Foo`
 
 error[E0284]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
   --> $DIR/associated-types-overridden-binding.rs:7:21
    |
-LL | trait I32Iterator = Iterator<Item = i32>;
-   |                              ---------- required by this bound in `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `<Self as Iterator>::Item == i32`
+   |
+note: required by a bound in `I32Iterator`
+  --> $DIR/associated-types-overridden-binding.rs:6:30
+   |
+LL | trait I32Iterator = Iterator<Item = i32>;
+   |                              ^^^^^^^^^^ required by this bound in `I32Iterator`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -12,11 +12,14 @@ LL |     f1(2i32, 4u32);
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
    |
-LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   |              --- required by this bound in `f1`
-...
 LL |     f1(2u32, 4u32);
    |     ^^ the trait `Foo` is not implemented for `u32`
+   |
+note: required by a bound in `f1`
+  --> $DIR/associated-types-path-2.rs:13:14
+   |
+LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
+   |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
@@ -27,11 +30,14 @@ LL |     f1(2u32, 4u32);
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5
    |
-LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   |              --- required by this bound in `f1`
-...
 LL |     f1(2u32, 4i32);
    |     ^^ the trait `Foo` is not implemented for `u32`
+   |
+note: required by a bound in `f1`
+  --> $DIR/associated-types-path-2.rs:13:14
+   |
+LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
+   |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5

--- a/src/test/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.stderr
+++ b/src/test/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
   --> $DIR/associated-types-projection-to-unrelated-trait-in-method-without-default.rs:10:40
    |
-LL | trait Get {
-   | --------- required by this bound in `Get`
-...
 LL |     fn okay<U:Get>(&self, foo: U, bar: <Self as Get>::Value);
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+note: required by a bound in `Get`
+  --> $DIR/associated-types-projection-to-unrelated-trait-in-method-without-default.rs:5:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^ required by this bound in `Get`
 help: consider further restricting `Self`
    |
 LL |     fn okay<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get;

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -2,33 +2,41 @@ error[E0277]: the trait bound `NotClone: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:13:5
    |
 LL |     type Ty: Clone = NotClone;
-   |     ^^^^^^^^^-----^^^^^^^^^^^^
-   |     |        |
-   |     |        required by this bound in `Tr::Ty`
-   |     the trait `Clone` is not implemented for `NotClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `Tr::Ty`
+  --> $DIR/defaults-suitability.rs:13:14
+   |
+LL |     type Ty: Clone = NotClone;
+   |              ^^^^^ required by this bound in `Tr::Ty`
 
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:22:5
    |
+LL |     type Ty = NotClone;
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |
+note: required by a bound in `Tr2::Ty`
+  --> $DIR/defaults-suitability.rs:20:15
+   |
 LL |     Self::Ty: Clone,
-   |               ----- required by this bound in `Tr2::Ty`
+   |               ^^^^^ required by this bound in `Tr2::Ty`
 LL | {
 LL |     type Ty = NotClone;
-   |     ^^^^^--^^^^^^^^^^^^
-   |     |    |
-   |     |    required by a bound in this
-   |     the trait `Clone` is not implemented for `NotClone`
+   |          -- required by a bound in this
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:28:5
    |
 LL |     type Bar: Clone = Vec<T>;
-   |     ^^^^^^^^^^-----^^^^^^^^^^
-   |     |         |
-   |     |         required by this bound in `Foo::Bar`
-   |     the trait `Clone` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<T>`
+note: required by a bound in `Foo::Bar`
+  --> $DIR/defaults-suitability.rs:28:15
+   |
+LL |     type Bar: Clone = Vec<T>;
+   |               ^^^^^ required by this bound in `Foo::Bar`
 help: consider restricting type parameter `T`
    |
 LL | trait Foo<T: std::clone::Clone> {
@@ -38,33 +46,41 @@ error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
   --> $DIR/defaults-suitability.rs:34:5
    |
 LL |     type Assoc: Foo<Self> = ();
-   |     ^^^^^^^^^^^^---------^^^^^^
-   |     |           |
-   |     |           required by this bound in `Bar::Assoc`
-   |     the trait `Foo<Self>` is not implemented for `()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo<Self>` is not implemented for `()`
+   |
+note: required by a bound in `Bar::Assoc`
+  --> $DIR/defaults-suitability.rs:34:17
+   |
+LL |     type Assoc: Foo<Self> = ();
+   |                 ^^^^^^^^^ required by this bound in `Bar::Assoc`
 
 error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
   --> $DIR/defaults-suitability.rs:56:5
    |
+LL |     type Assoc = NotClone;
+   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |
+note: required by a bound in `D::Assoc`
+  --> $DIR/defaults-suitability.rs:53:18
+   |
 LL |     Self::Assoc: IsU8<Self::Assoc>,
-   |                  ----------------- required by this bound in `D::Assoc`
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `D::Assoc`
 ...
 LL |     type Assoc = NotClone;
-   |     ^^^^^-----^^^^^^^^^^^^
-   |     |    |
-   |     |    required by a bound in this
-   |     the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |          ----- required by a bound in this
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:65:5
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |     ^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^
-   |     |         |
-   |     |         required by this bound in `Foo2::Bar`
-   |     the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<<Self as Foo2<T>>::Baz>`
+note: required by a bound in `Foo2::Bar`
+  --> $DIR/defaults-suitability.rs:65:15
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |               ^^^^^ required by this bound in `Foo2::Bar`
 help: consider further restricting the associated type
    |
 LL | trait Foo2<T> where <Self as Foo2<T>>::Baz: Clone {
@@ -74,12 +90,14 @@ error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:74:5
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |     ^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^
-   |     |         |
-   |     |         required by this bound in `Foo25::Bar`
-   |     the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<<Self as Foo25<T>>::Baz>`
+note: required by a bound in `Foo25::Bar`
+  --> $DIR/defaults-suitability.rs:74:15
+   |
+LL |     type Bar: Clone = Vec<Self::Baz>;
+   |               ^^^^^ required by this bound in `Foo25::Bar`
 help: consider further restricting the associated type
    |
 LL | trait Foo25<T: Clone> where <Self as Foo25<T>>::Baz: Clone {
@@ -88,15 +106,17 @@ LL | trait Foo25<T: Clone> where <Self as Foo25<T>>::Baz: Clone {
 error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:87:5
    |
+LL |     type Baz = T;
+   |     ^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+   |
+note: required by a bound in `Foo3::Baz`
+  --> $DIR/defaults-suitability.rs:84:16
+   |
 LL |     Self::Baz: Clone,
-   |                ----- required by this bound in `Foo3::Baz`
+   |                ^^^^^ required by this bound in `Foo3::Baz`
 ...
 LL |     type Baz = T;
-   |     ^^^^^---^^^^^
-   |     |    |
-   |     |    required by a bound in this
-   |     the trait `Clone` is not implemented for `T`
-   |
+   |          --- required by a bound in this
 help: consider further restricting type parameter `T`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -2,12 +2,14 @@ error[E0277]: `Self` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-1.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^
-   |     |                                                                                |
-   |     |                                                                                required by this bound in `UncheckedCopy::Output`
-   |     `Self` cannot be formatted with the default formatter
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:20:86
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + std::fmt::Display {
@@ -17,11 +19,13 @@ error[E0277]: cannot add-assign `&'static str` to `Self`
   --> $DIR/defaults-unsound-62211-1.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                                         |
-   |     |                                         required by this bound in `UncheckedCopy::Output`
-   |     no implementation for `Self += &'static str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Self += &'static str`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:20:47
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
@@ -31,11 +35,13 @@ error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                   |
-   |     |                   required by this bound in `UncheckedCopy::Output`
-   |     the trait `Deref` is not implemented for `Self`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `Self`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:20:25
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
@@ -45,11 +51,13 @@ error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |            |
-   |     |            required by this bound in `UncheckedCopy::Output`
-   |     the trait `Copy` is not implemented for `Self`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Self`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-1.rs:20:18
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Copy {

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -2,12 +2,14 @@ error[E0277]: `Self` doesn't implement `std::fmt::Display`
   --> $DIR/defaults-unsound-62211-2.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^
-   |     |                                                                                |
-   |     |                                                                                required by this bound in `UncheckedCopy::Output`
-   |     `Self` cannot be formatted with the default formatter
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:20:86
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + std::fmt::Display {
@@ -17,11 +19,13 @@ error[E0277]: cannot add-assign `&'static str` to `Self`
   --> $DIR/defaults-unsound-62211-2.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                                         |
-   |     |                                         required by this bound in `UncheckedCopy::Output`
-   |     no implementation for `Self += &'static str`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Self += &'static str`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:20:47
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
@@ -31,11 +35,13 @@ error[E0277]: the trait bound `Self: Deref` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                   |
-   |     |                   required by this bound in `UncheckedCopy::Output`
-   |     the trait `Deref` is not implemented for `Self`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `Self`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:20:25
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
@@ -45,11 +51,13 @@ error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:20:5
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |            |
-   |     |            required by this bound in `UncheckedCopy::Output`
-   |     the trait `Copy` is not implemented for `Self`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Self`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/defaults-unsound-62211-2.rs:20:18
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Copy {

--- a/src/test/ui/associated-types/defaults-wf.stderr
+++ b/src/test/ui/associated-types/defaults-wf.stderr
@@ -4,12 +4,12 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     type Ty = Vec<[u8]>;
    |               ^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-   |                - required by this bound in `Vec`
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
+   |                ^ required by this bound in `Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> <i32 as X<'b>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-1.rs:12:14
    |
-LL | trait X<'a>
-   |       - required by a bound in this
-LL | where
-LL |     for<'b> <Self as X<'b>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<i32 as X<'b>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-1.rs:3:33
+   |
+LL | trait X<'a>
+   |       - required by a bound in this
+LL | where
+LL |     for<'b> <Self as X<'b>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-object.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-object.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-object.rs:7:13
    |
-LL | trait X<'a>
-   |       - required by a bound in this
-LL | where
-LL |     for<'b> <Self as X<'b>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) {
    |             ^^^^^ the trait `for<'b> Clone` is not implemented for `<T as X<'b>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-object.rs:3:33
+   |
+LL | trait X<'a>
+   |       - required by a bound in this
+LL | where
+LL |     for<'b> <Self as X<'b>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> <u8 as Y<'b, u8>>::V: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-1.rs:14:14
    |
-LL | trait Y<'a, T: ?Sized>
-   |       - required by a bound in this
-...
-LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
-   |                                    ----- required by this bound in `Y`
-...
 LL |     type V = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<u8 as Y<'b, u8>>::V`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `Y`
+  --> $DIR/hr-associated-type-bound-param-1.rs:4:36
+   |
+LL | trait Y<'a, T: ?Sized>
+   |       - required by a bound in this
+...
+LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
+   |                                    ^^^^^ required by this bound in `Y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -1,47 +1,53 @@
 error[E0277]: the trait bound `for<'b> <u16 as Z<'b, u16>>::W: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-2.rs:4:8
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-LL | where
 LL |     T: Z<'a, u16>,
    |        ^^^^^^^^^^ the trait `for<'b> Clone` is not implemented for `<u16 as Z<'b, u16>>::W`
-...
-LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
-   |                                   ----- required by this bound in `Z`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `Z`
+  --> $DIR/hr-associated-type-bound-param-2.rs:7:35
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z`
 
 error[E0277]: the trait bound `for<'b> <u16 as Z<'b, u16>>::W: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-2.rs:4:8
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-LL | where
 LL |     T: Z<'a, u16>,
    |        ^^^^^^^^^^ the trait `for<'b> Clone` is not implemented for `<u16 as Z<'b, u16>>::W`
-...
-LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
-   |                                   ----- required by this bound in `Z`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `Z`
+  --> $DIR/hr-associated-type-bound-param-2.rs:7:35
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z`
 
 error[E0277]: the trait bound `for<'b> <u16 as Z<'b, u16>>::W: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-2.rs:16:14
    |
-LL | trait Z<'a, T: ?Sized>
-   |       - required by a bound in this
-...
-LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
-   |                                   ----- required by this bound in `Z`
-...
 LL |     type W = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<u16 as Z<'b, u16>>::W`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `Z`
+  --> $DIR/hr-associated-type-bound-param-2.rs:7:35
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> <(T,) as X<'b, (T,)>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-3.rs:13:14
    |
-LL | trait X<'a, T>
-   |       - required by a bound in this
-...
-LL |     for<'b> <T as X<'b, T>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<(T,) as X<'b, (T,)>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-3.rs:4:33
+   |
+LL | trait X<'a, T>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> <(T,) as X<'b, T>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-4.rs:13:14
    |
-LL | trait X<'a, T>
-   |       - required by a bound in this
-...
-LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
-   |                                    ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<(T,) as X<'b, T>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-4.rs:4:36
+   |
+LL | trait X<'a, T>
+   |       - required by a bound in this
+...
+LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
+   |                                    ^^^^^ required by this bound in `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -1,62 +1,70 @@
 error[E0277]: the trait bound `for<'b> <Box<T> as X<'b, Box<T>>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:27:14
    |
-LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
-...
-LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
-   |                                             ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<Box<T> as X<'b, Box<T>>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-5.rs:18:45
+   |
+LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
+   |                                             ^^^^^ required by this bound in `X`
 
 error[E0277]: the trait bound `for<'b> <Vec<T> as X<'b, Vec<T>>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:27:14
    |
-LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
-LL | where
-LL |     for<'b> <T as X<'b, T>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<Vec<T> as X<'b, Vec<T>>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-5.rs:16:33
+   |
+LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
+   |       - required by a bound in this
+LL | where
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error[E0277]: the trait bound `for<'b> <Vec<T> as X<'b, Vec<T>>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:33:14
+   |
+LL |     type U = str;
+   |              ^^^ the trait `for<'b> Clone` is not implemented for `<Vec<T> as X<'b, Vec<T>>>::U`
+   |
+   = help: the following implementations were found:
+             <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-5.rs:18:45
    |
 LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
    |       - required by a bound in this
 ...
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
-   |                                             ----- required by this bound in `X`
-...
-LL |     type U = str;
-   |              ^^^ the trait `for<'b> Clone` is not implemented for `<Vec<T> as X<'b, Vec<T>>>::U`
-   |
-   = help: the following implementations were found:
-             <&T as Clone>
+   |                                             ^^^^^ required by this bound in `X`
 
 error[E0277]: the trait bound `for<'b> <Box<T> as X<'b, Box<T>>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:33:14
    |
-LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
-   |       - required by a bound in this
-LL | where
-LL |     for<'b> <T as X<'b, T>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<Box<T> as X<'b, Box<T>>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-5.rs:16:33
+   |
+LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
+   |       - required by a bound in this
+LL | where
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/associated-types/hr-associated-type-bound-param-6.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-param-6.stderr
@@ -1,30 +1,34 @@
 error[E0277]: the trait bound `for<'b> <T as X<'b, T>>::U: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-6.rs:14:14
    |
-LL | trait X<'a, T>
-   |       - required by a bound in this
-...
-LL |     for<'b> <T as X<'b, T>>::U: Clone,
-   |                                 ----- required by this bound in `X`
-...
 LL |     type U = str;
    |              ^^^ the trait `for<'b> Clone` is not implemented for `<T as X<'b, T>>::U`
    |
    = help: the following implementations were found:
              <&T as Clone>
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-6.rs:4:33
+   |
+LL | trait X<'a, T>
+   |       - required by a bound in this
+...
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
 
 error[E0277]: the trait bound `for<'b> T: X<'b, T>` is not satisfied
   --> $DIR/hr-associated-type-bound-param-6.rs:12:12
+   |
+LL | impl<S, T> X<'_, T> for (S,) {
+   |            ^^^^^^^^ the trait `for<'b> X<'b, T>` is not implemented for `T`
+   |
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-param-6.rs:3:16
    |
 LL | trait X<'a, T>
    |       - required by a bound in this
 LL | where
 LL |     for<'b> T: X<'b, T>,
-   |                -------- required by this bound in `X`
-...
-LL | impl<S, T> X<'_, T> for (S,) {
-   |            ^^^^^^^^ the trait `for<'b> X<'b, T>` is not implemented for `T`
-   |
+   |                ^^^^^^^^ required by this bound in `X`
 help: consider restricting type parameter `T`
    |
 LL | impl<S, T: for<'b> X<'b, T>> X<'_, T> for (S,) {

--- a/src/test/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -1,18 +1,20 @@
 error[E0277]: the trait bound `for<'b> <T as UnsafeCopy<'b, T>>::Item: Deref` is not satisfied
   --> $DIR/hr-associated-type-projection-1.rs:15:17
    |
-LL | trait UnsafeCopy<'a, T: Copy>
-   |       ---------- required by a bound in this
-LL | where
-LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
-   |                                                --------------------------- required by this bound in `UnsafeCopy`
-...
 LL |     type Item = T;
    |                 ^ the trait `for<'b> Deref` is not implemented for `<T as UnsafeCopy<'b, T>>::Item`
    |
    = help: the following implementations were found:
              <&T as Deref>
              <&mut T as Deref>
+note: required by a bound in `UnsafeCopy`
+  --> $DIR/hr-associated-type-projection-1.rs:3:48
+   |
+LL | trait UnsafeCopy<'a, T: Copy>
+   |       ---------- required by a bound in this
+LL | where
+LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UnsafeCopy`
 
 error[E0277]: the trait bound `for<'b> <T as UnsafeCopy<'b, T>>::Item: Deref` is not satisfied
   --> $DIR/hr-associated-type-projection-1.rs:13:33

--- a/src/test/ui/associated-types/issue-20005.stderr
+++ b/src/test/ui/associated-types/issue-20005.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/issue-20005.rs:10:49
    |
-LL | trait From<Src> {
-   |            --- required by this bound in `From`
-...
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^ doesn't have a size known at compile-time
    |
+note: required by a bound in `From`
+  --> $DIR/issue-20005.rs:1:12
+   |
+LL | trait From<Src> {
+   |            ^^^ required by this bound in `From`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
+++ b/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-27675-unchecked-bounds.rs:15:31
    |
-LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
-   |            ----- required by this bound in `copy`
-...
 LL |     copy::<dyn Setup<From=T>>(t)
    |                               ^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `copy`
+  --> $DIR/issue-27675-unchecked-bounds.rs:10:12
+   |
+LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
+   |            ^^^^^ required by this bound in `copy`
 help: consider restricting type parameter `T`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {

--- a/src/test/ui/associated-types/issue-43784-associated-type.stderr
+++ b/src/test/ui/associated-types/issue-43784-associated-type.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-43784-associated-type.rs:14:5
    |
-LL |     type Assoc: Partial<Self>;
-   |                 ------------- required by this bound in `Complete::Assoc`
-...
 LL |     type Assoc = T;
    |     ^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `Complete::Assoc`
+  --> $DIR/issue-43784-associated-type.rs:5:17
+   |
+LL |     type Assoc: Partial<Self>;
+   |                 ^^^^^^^^^^^^^ required by this bound in `Complete::Assoc`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -2,10 +2,13 @@ error[E0277]: the trait bound `(dyn ToString + 'static): Default` is not satisfi
   --> $DIR/issue-43924.rs:7:5
    |
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
-   |     ^^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |         |
-   |     |         required by this bound in `Foo::Out`
-   |     the trait `Default` is not implemented for `(dyn ToString + 'static)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `(dyn ToString + 'static)`
+   |
+note: required by a bound in `Foo::Out`
+  --> $DIR/issue-43924.rs:7:15
+   |
+LL |     type Out: Default + ToString + ?Sized = dyn ToString;
+   |               ^^^^^^^ required by this bound in `Foo::Out`
 
 error[E0599]: no function or associated item named `default` found for trait object `(dyn ToString + 'static)` in the current scope
   --> $DIR/issue-43924.rs:14:39

--- a/src/test/ui/associated-types/issue-54108.stderr
+++ b/src/test/ui/associated-types/issue-54108.stderr
@@ -1,13 +1,15 @@
 error[E0277]: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
   --> $DIR/issue-54108.rs:19:5
    |
-LL |     type Size: Add<Output = Self::Size>;
-   |                ------------------------ required by this bound in `Encoder::Size`
-...
 LL |     type Size = <Self as SubEncoder>::ActualSize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `<T as SubEncoder>::ActualSize + <T as SubEncoder>::ActualSize`
    |
    = help: the trait `Add` is not implemented for `<T as SubEncoder>::ActualSize`
+note: required by a bound in `Encoder::Size`
+  --> $DIR/issue-54108.rs:4:16
+   |
+LL |     type Size: Add<Output = Self::Size>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
 help: consider further restricting the associated type
    |
 LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add

--- a/src/test/ui/associated-types/issue-63593.stderr
+++ b/src/test/ui/associated-types/issue-63593.stderr
@@ -2,11 +2,13 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
   --> $DIR/issue-63593.rs:9:5
    |
 LL |     type This = Self;
-   |     ^^^^^^^^^^^^^^^^^
-   |     |
-   |     doesn't have a size known at compile-time
-   |     required by this bound in `MyTrait::This`
+   |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
+note: required by a bound in `MyTrait::This`
+  --> $DIR/issue-63593.rs:9:5
+   |
+LL |     type This = Self;
+   |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
 help: consider further restricting `Self`
    |
 LL | trait MyTrait: Sized {

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -2,10 +2,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:10:5
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |     ^^^^^^^^^^^^^^^^---------^^^^^
-   |     |               |
-   |     |               required by this bound in `MPU::MpuConfig`
-   |     the trait `MyDisplay` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |
+note: required by a bound in `MPU::MpuConfig`
+  --> $DIR/issue-65774-1.rs:10:21
+   |
+LL |     type MpuConfig: MyDisplay = T;
+   |                     ^^^^^^^^^ required by this bound in `MPU::MpuConfig`
 
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:44:76

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -2,10 +2,13 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:10:5
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |     ^^^^^^^^^^^^^^^^---------^^^^^
-   |     |               |
-   |     |               required by this bound in `MPU::MpuConfig`
-   |     the trait `MyDisplay` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |
+note: required by a bound in `MPU::MpuConfig`
+  --> $DIR/issue-65774-2.rs:10:21
+   |
+LL |     type MpuConfig: MyDisplay = T;
+   |                     ^^^^^^^^^ required by this bound in `MPU::MpuConfig`
 
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-2.rs:39:25

--- a/src/test/ui/associated-types/issue-72806.stderr
+++ b/src/test/ui/associated-types/issue-72806.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == char`
   --> $DIR/issue-72806.rs:14:5
    |
-LL |     type Sibling: Bar2<Ok=char>;
-   |                        ------- required by this bound in `Bar::Sibling`
-...
 LL |     type Sibling = Foo2;
    |     ^^^^^^^^^^^^^^^^^^^^ expected `char`, found `u32`
+   |
+note: required by a bound in `Bar::Sibling`
+  --> $DIR/issue-72806.rs:3:24
+   |
+LL |     type Sibling: Bar2<Ok=char>;
+   |                        ^^^^^^^ required by this bound in `Bar::Sibling`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/issue-87261.stderr
+++ b/src/test/ui/associated-types/issue-87261.stderr
@@ -1,14 +1,16 @@
 error[E0271]: type mismatch resolving `<A as Trait>::Associated == ()`
   --> $DIR/issue-87261.rs:56:5
    |
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(a);
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<A as Trait>::Associated`
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 help: consider constraining the associated type `<A as Trait>::Associated` to `()`
    |
 LL |     A: Trait<Associated = ()> + 'static,
@@ -17,9 +19,6 @@ LL |     A: Trait<Associated = ()> + 'static,
 error[E0271]: type mismatch resolving `<B as Trait>::Associated == ()`
   --> $DIR/issue-87261.rs:59:5
    |
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(b);
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
@@ -27,18 +26,25 @@ LL |     accepts_trait(b);
            found associated type `<B as Trait>::Associated`
    = help: consider constraining the associated type `<B as Trait>::Associated` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<C as Trait>::Associated == ()`
   --> $DIR/issue-87261.rs:62:5
    |
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(c);
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<C as Trait>::Associated`
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 help: consider constraining the associated type `<C as Trait>::Associated` to `()`
    |
 LL |     C: Trait<Associated = ()> + Foo,
@@ -47,9 +53,6 @@ LL |     C: Trait<Associated = ()> + Foo,
 error[E0271]: type mismatch resolving `<D as Trait>::Associated == ()`
   --> $DIR/issue-87261.rs:65:5
    |
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(d);
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
@@ -57,18 +60,25 @@ LL |     accepts_trait(d);
            found associated type `<D as Trait>::Associated`
    = help: consider constraining the associated type `<D as Trait>::Associated` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<E as GenericTrait<()>>::Associated == ()`
   --> $DIR/issue-87261.rs:68:5
    |
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(e);
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<E as GenericTrait<()>>::Associated`
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 help: consider constraining the associated type `<E as GenericTrait<()>>::Associated` to `()`
    |
 LL |     E: GenericTrait<(), Associated = ()> + 'static,
@@ -77,14 +87,16 @@ LL |     E: GenericTrait<(), Associated = ()> + 'static,
 error[E0271]: type mismatch resolving `<F as GenericTrait<()>>::Associated == ()`
   --> $DIR/issue-87261.rs:71:5
    |
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(f);
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<F as GenericTrait<()>>::Associated`
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 help: consider constraining the associated type `<F as GenericTrait<()>>::Associated` to `()`
    |
 LL |     F: GenericTrait<(), Associated = ()> + Foo,
@@ -93,9 +105,6 @@ LL |     F: GenericTrait<(), Associated = ()> + Foo,
 error[E0271]: type mismatch resolving `<G as GenericTrait<()>>::Associated == ()`
   --> $DIR/issue-87261.rs:74:5
    |
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(g);
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
@@ -103,6 +112,11 @@ LL |     accepts_generic_trait(g);
            found associated type `<G as GenericTrait<()>>::Associated`
    = help: consider constraining the associated type `<G as GenericTrait<()>>::Associated` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 
 error[E0271]: type mismatch resolving `<impl Trait as Trait>::Associated == ()`
   --> $DIR/issue-87261.rs:79:5
@@ -110,14 +124,16 @@ error[E0271]: type mismatch resolving `<impl Trait as Trait>::Associated == ()`
 LL | fn returns_opaque() -> impl Trait + 'static {
    |                        -------------------- the found opaque type
 ...
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(returns_opaque());
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait as Trait>::Associated`
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 help: consider constraining the associated type `<impl Trait as Trait>::Associated` to `()`
    |
 LL | fn returns_opaque() -> impl Trait<Associated = ()> + 'static {
@@ -129,14 +145,16 @@ error[E0271]: type mismatch resolving `<impl DerivedTrait as Trait>::Associated 
 LL | fn returns_opaque_derived() -> impl DerivedTrait + 'static {
    |                                --------------------------- the found opaque type
 ...
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(returns_opaque_derived());
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<impl DerivedTrait as Trait>::Associated`
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 help: consider constraining the associated type `<impl DerivedTrait as Trait>::Associated` to `()`
    |
 LL | fn returns_opaque_derived() -> impl DerivedTrait<Associated = ()> + 'static {
@@ -148,14 +166,16 @@ error[E0271]: type mismatch resolving `<impl Trait+Foo as Trait>::Associated == 
 LL | fn returns_opaque_foo() -> impl Trait + Foo {
    |                            ---------------- the found opaque type
 ...
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(returns_opaque_foo());
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<impl Trait+Foo as Trait>::Associated`
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 help: consider constraining the associated type `<impl Trait+Foo as Trait>::Associated` to `()`
    |
 LL | fn returns_opaque_foo() -> impl Trait<Associated = ()> + Foo {
@@ -167,9 +187,6 @@ error[E0271]: type mismatch resolving `<impl DerivedTrait+Foo as Trait>::Associa
 LL | fn returns_opaque_derived_foo() -> impl DerivedTrait + Foo {
    |                                    ----------------------- the found opaque type
 ...
-LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
-   |                           --------------- required by this bound in `accepts_trait`
-...
 LL |     accepts_trait(returns_opaque_derived_foo());
    |     ^^^^^^^^^^^^^ expected `()`, found associated type
    |
@@ -177,6 +194,11 @@ LL |     accepts_trait(returns_opaque_derived_foo());
            found associated type `<impl DerivedTrait+Foo as Trait>::Associated`
    = help: consider constraining the associated type `<impl DerivedTrait+Foo as Trait>::Associated` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `accepts_trait`
+  --> $DIR/issue-87261.rs:43:27
+   |
+LL | fn accepts_trait<T: Trait<Associated = ()>>(_: T) {}
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `accepts_trait`
 
 error[E0271]: type mismatch resolving `<impl GenericTrait<()> as GenericTrait<()>>::Associated == ()`
   --> $DIR/issue-87261.rs:91:5
@@ -184,14 +206,16 @@ error[E0271]: type mismatch resolving `<impl GenericTrait<()> as GenericTrait<()
 LL | fn returns_opaque_generic() -> impl GenericTrait<()> + 'static {
    |                                ------------------------------- the found opaque type
 ...
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(returns_opaque_generic());
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()> as GenericTrait<()>>::Associated`
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 help: consider constraining the associated type `<impl GenericTrait<()> as GenericTrait<()>>::Associated` to `()`
    |
 LL | fn returns_opaque_generic() -> impl GenericTrait<(), Associated = ()> + 'static {
@@ -203,14 +227,16 @@ error[E0271]: type mismatch resolving `<impl GenericTrait<()>+Foo as GenericTrai
 LL | fn returns_opaque_generic_foo() -> impl GenericTrait<()> + Foo {
    |                                    --------------------------- the found opaque type
 ...
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(returns_opaque_generic_foo());
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
    = note:    expected unit type `()`
            found associated type `<impl GenericTrait<()>+Foo as GenericTrait<()>>::Associated`
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 help: consider constraining the associated type `<impl GenericTrait<()>+Foo as GenericTrait<()>>::Associated` to `()`
    |
 LL | fn returns_opaque_generic_foo() -> impl GenericTrait<(), Associated = ()> + Foo {
@@ -222,9 +248,6 @@ error[E0271]: type mismatch resolving `<impl GenericTrait<()>+GenericTrait<u8> a
 LL | fn returns_opaque_generic_duplicate() -> impl GenericTrait<()> + GenericTrait<u8> {
    |                                          ---------------------------------------- the found opaque type
 ...
-LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
-   |                                              --------------- required by this bound in `accepts_generic_trait`
-...
 LL |     accepts_generic_trait(returns_opaque_generic_duplicate());
    |     ^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
    |
@@ -232,6 +255,11 @@ LL |     accepts_generic_trait(returns_opaque_generic_duplicate());
            found associated type `<impl GenericTrait<()>+GenericTrait<u8> as GenericTrait<()>>::Associated`
    = help: consider constraining the associated type `<impl GenericTrait<()>+GenericTrait<u8> as GenericTrait<()>>::Associated` to `()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `accepts_generic_trait`
+  --> $DIR/issue-87261.rs:44:46
+   |
+LL | fn accepts_generic_trait<T: GenericTrait<(), Associated = ()>>(_: T) {}
+   |                                              ^^^^^^^^^^^^^^^ required by this bound in `accepts_generic_trait`
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -1,35 +1,44 @@
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:8:5
    |
-LL |     type Assoc: Bar;
-   |                 --- required by this bound in `Foo::Assoc`
-...
 LL |     type Assoc = bool;
    |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |
+note: required by a bound in `Foo::Assoc`
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:4:17
+   |
+LL |     type Assoc: Bar;
+   |                 ^^^ required by this bound in `Foo::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:19:5
    |
+LL |     type Assoc = bool;
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |
+note: required by a bound in `Baz::Assoc`
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:13:18
+   |
 LL |     Self::Assoc: Bar,
-   |                  --- required by this bound in `Baz::Assoc`
+   |                  ^^^ required by this bound in `Baz::Assoc`
 LL | {
 LL |     type Assoc;
    |          ----- required by a bound in this
-...
-LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
   --> $DIR/point-at-type-on-obligation-failure-2.rs:30:5
    |
+LL |     type Assoc = bool;
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |
+note: required by a bound in `Bat::Assoc`
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:24:27
+   |
 LL |     <Self as Bat>::Assoc: Bar,
-   |                           --- required by this bound in `Bat::Assoc`
+   |                           ^^^ required by this bound in `Bat::Assoc`
 LL | {
 LL |     type Assoc;
    |          ----- required by a bound in this
-...
-LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
   --> $DIR/point-at-type-on-obligation-failure.rs:14:5
    |
-LL |     type Sibling: Bar2<Ok=Self::Ok>;
-   |                        ----------- required by this bound in `Bar::Sibling`
-...
 LL |     type Sibling = Foo2;
    |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u32`
+   |
+note: required by a bound in `Bar::Sibling`
+  --> $DIR/point-at-type-on-obligation-failure.rs:3:24
+   |
+LL |     type Sibling: Bar2<Ok=Self::Ok>;
+   |                        ^^^^^^^^^^^ required by this bound in `Bar::Sibling`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -4,11 +4,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> {}
    |                      ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/ops/arith.rs:LL:COL
+note: required by a bound in `Add`
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
 LL | pub trait Add<Rhs = Self> {
-   |               --- required by this bound in `Add`
-   |
+   |               ^^^ required by this bound in `Add`
 help: consider further restricting `Self`
    |
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> + Sized {}

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:49:5
    |
-LL | fn assert_send(_: impl Send) {}
-   |                        ---- required by this bound in `assert_send`
-...
 LL |     assert_send(local_dropped_before_await());
    |     ^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
    |
@@ -18,13 +15,15 @@ LL |     fut().await;
    |     ^^^^^^^^^^^ await occurs here, with `x` maybe used later
 LL | }
    | - `x` is later dropped here
+note: required by a bound in `assert_send`
+  --> $DIR/async-fn-nonsend.rs:46:24
+   |
+LL | fn assert_send(_: impl Send) {}
+   |                        ^^^^ required by this bound in `assert_send`
 
 error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:51:5
    |
-LL | fn assert_send(_: impl Send) {}
-   |                        ---- required by this bound in `assert_send`
-...
 LL |     assert_send(non_send_temporary_in_match());
    |     ^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
@@ -39,13 +38,15 @@ LL |         Some(_) => fut().await,
 ...
 LL | }
    | - `non_send()` is later dropped here
+note: required by a bound in `assert_send`
+  --> $DIR/async-fn-nonsend.rs:46:24
+   |
+LL | fn assert_send(_: impl Send) {}
+   |                        ^^^^ required by this bound in `assert_send`
 
 error: future cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:53:5
    |
-LL | fn assert_send(_: impl Send) {}
-   |                        ---- required by this bound in `assert_send`
-...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
@@ -61,6 +62,11 @@ LL |         fut().await;
 LL |     }
 LL | }
    | - `f` is later dropped here
+note: required by a bound in `assert_send`
+  --> $DIR/async-fn-nonsend.rs:46:24
+   |
+LL | fn assert_send(_: impl Send) {}
+   |                        ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/async-await/issue-64130-1-sync.stderr
+++ b/src/test/ui/async-await/issue-64130-1-sync.stderr
@@ -1,9 +1,6 @@
 error: future cannot be shared between threads safely
   --> $DIR/issue-64130-1-sync.rs:21:5
    |
-LL | fn is_sync<T: Sync>(t: T) { }
-   |               ---- required by this bound in `is_sync`
-...
 LL |     is_sync(bar());
    |     ^^^^^^^ future returned by `bar` is not `Sync`
    |
@@ -17,6 +14,11 @@ LL |     baz().await;
    |     ^^^^^^^^^^^ await occurs here, with `x` maybe used later
 LL | }
    | - `x` is later dropped here
+note: required by a bound in `is_sync`
+  --> $DIR/issue-64130-1-sync.rs:11:15
+   |
+LL | fn is_sync<T: Sync>(t: T) { }
+   |               ^^^^ required by this bound in `is_sync`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-64130-2-send.stderr
+++ b/src/test/ui/async-await/issue-64130-2-send.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-64130-2-send.rs:21:5
    |
-LL | fn is_send<T: Send>(t: T) { }
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(bar());
    |     ^^^^^^^ future returned by `bar` is not `Send`
    |
@@ -17,6 +14,11 @@ LL |     baz().await;
    |     ^^^^^^^^^^^ await occurs here, with `x` maybe used later
 LL | }
    | - `x` is later dropped here
+note: required by a bound in `is_send`
+  --> $DIR/issue-64130-2-send.rs:11:15
+   |
+LL | fn is_send<T: Send>(t: T) { }
+   |               ^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-64130-3-other.stderr
+++ b/src/test/ui/async-await/issue-64130-3-other.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl Future`
   --> $DIR/issue-64130-3-other.rs:24:5
    |
-LL | fn is_qux<T: Qux>(t: T) { }
-   |              --- required by this bound in `is_qux`
-LL | 
 LL | async fn bar() {
    |                - within this `impl Future`
 ...
@@ -19,6 +16,11 @@ LL |     baz().await;
    |     ^^^^^^^^^^^ await occurs here, with `x` maybe used later
 LL | }
    | - `x` is later dropped here
+note: required by a bound in `is_qux`
+  --> $DIR/issue-64130-3-other.rs:14:14
+   |
+LL | fn is_qux<T: Qux>(t: T) { }
+   |              ^^^ required by this bound in `is_qux`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-64130-non-send-future-diags.rs:21:5
    |
-LL | fn is_send<T: Send>(t: T) { }
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(foo());
    |     ^^^^^^^ future returned by `foo` is not `Send`
    |
@@ -17,6 +14,11 @@ LL |     baz().await;
    |     ^^^^^^^^^^^ await occurs here, with `g` maybe used later
 LL | }
    | - `g` is later dropped here
+note: required by a bound in `is_send`
+  --> $DIR/issue-64130-non-send-future-diags.rs:7:15
+   |
+LL | fn is_send<T: Send>(t: T) { }
+   |               ^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-67252-unnamed-future.stderr
+++ b/src/test/ui/async-await/issue-67252-unnamed-future.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-67252-unnamed-future.rs:18:5
    |
-LL | fn spawn<T: Send>(_: T) {}
-   |             ---- required by this bound in `spawn`
-...
 LL |     spawn(async {
    |     ^^^^^ future created by async block is not `Send`
    |
@@ -17,6 +14,11 @@ LL |         AFuture.await;
    |         ^^^^^^^^^^^^^ await occurs here, with `_a` maybe used later
 LL |     });
    |     - `_a` is later dropped here
+note: required by a bound in `spawn`
+  --> $DIR/issue-67252-unnamed-future.rs:6:13
+   |
+LL | fn spawn<T: Send>(_: T) {}
+   |             ^^^^ required by this bound in `spawn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-68112.stderr
+++ b/src/test/ui/async-await/issue-68112.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-68112.rs:34:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^ future created by async block is not `Send`
    |
@@ -13,13 +10,15 @@ note: future is not `Send` as it awaits another future which is not `Send`
    |
 LL |         let _ = non_send_fut.await;
    |                 ^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:11:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error: future cannot be sent between threads safely
   --> $DIR/issue-68112.rs:43:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^ future created by async block is not `Send`
    |
@@ -29,13 +28,15 @@ note: future is not `Send` as it awaits another future which is not `Send`
    |
 LL |         let _ = make_non_send_future1().await;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:11:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/issue-68112.rs:60:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
@@ -50,6 +51,11 @@ LL |     require_send(send_fut);
    = note: required because it appears within the type `[static generator@$DIR/issue-68112.rs:55:26: 59:6]`
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@$DIR/issue-68112.rs:55:26: 59:6]>`
    = note: required because it appears within the type `impl Future`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:11:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/async-await/issue-71137.stderr
+++ b/src/test/ui/async-await/issue-71137.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-71137.rs:20:3
    |
-LL | fn fake_spawn<F: Future + Send + 'static>(f: F) { }
-   |                           ---- required by this bound in `fake_spawn`
-...
 LL |   fake_spawn(wrong_mutex());
    |   ^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
@@ -18,6 +15,11 @@ LL |     (async { "right"; }).await;
 LL |     *guard += 1;
 LL |   }
    |   - `mut guard` is later dropped here
+note: required by a bound in `fake_spawn`
+  --> $DIR/issue-71137.rs:6:27
+   |
+LL | fn fake_spawn<F: Future + Send + 'static>(f: F) { }
+   |                           ^^^^ required by this bound in `fake_spawn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-72442.stderr
+++ b/src/test/ui/async-await/issue-72442.stderr
@@ -4,10 +4,11 @@ error[E0277]: the trait bound `Option<&str>: AsRef<Path>` is not satisfied
 LL |             let mut f = File::open(path.to_str())?;
    |                                    ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`
    |
-  ::: $SRC_DIR/std/src/fs.rs:LL:COL
+note: required by a bound in `File::open`
+  --> $SRC_DIR/std/src/fs.rs:LL:COL
    |
 LL |     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
-   |                    ----------- required by this bound in `File::open`
+   |                    ^^^^^^^^^^^ required by this bound in `File::open`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.stderr
+++ b/src/test/ui/async-await/issues/issue-65436-raw-ptr-not-send.stderr
@@ -1,9 +1,6 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-65436-raw-ptr-not-send.rs:12:5
    |
-LL | fn assert_send<T: Send>(_: T) {}
-   |                   ---- required by this bound in `assert_send`
-...
 LL |     assert_send(async {
    |     ^^^^^^^^^^^ future created by async block is not `Send`
    |
@@ -25,6 +22,11 @@ help: consider moving this into a `let` binding to create a shorter lived borrow
    |
 LL |         bar(Foo(std::ptr::null())).await;
    |             ^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `assert_send`
+  --> $DIR/issue-65436-raw-ptr-not-send.rs:9:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issues/issue-67893.stderr
+++ b/src/test/ui/async-await/issues/issue-67893.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `MutexGuard<'_, ()>` cannot be sent between threads safely
   --> $DIR/issue-67893.rs:9:5
    |
-LL | fn g(_: impl Send) {}
-   |              ---- required by this bound in `g`
-...
 LL |     g(issue_67893::run())
    |     ^ `MutexGuard<'_, ()>` cannot be sent between threads safely
    |
@@ -18,6 +15,11 @@ LL | pub async fn run() {
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@run::{closure#0}]>`
    = note: required because it appears within the type `impl Future`
    = note: required because it appears within the type `impl Future`
+note: required by a bound in `g`
+  --> $DIR/issue-67893.rs:6:14
+   |
+LL | fn g(_: impl Send) {}
+   |              ^^^^ required by this bound in `g`
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/src/test/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:17:5
    |
-LL | fn is_mytrait<T: MyTrait>() {}
-   |                  ------- required by this bound in `is_mytrait`
-...
 LL |     is_mytrait::<(MyS2, MyS)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`
    |
    = note: required because it appears within the type `(MyS2, MyS)`
+note: required by a bound in `is_mytrait`
+  --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:12:18
+   |
+LL | fn is_mytrait<T: MyTrait>() {}
+   |                  ^^^^^^^ required by this bound in `is_mytrait`
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/typeck-default-trait-impl-constituent-types.stderr
+++ b/src/test/ui/auto-traits/typeck-default-trait-impl-constituent-types.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:21:18
    |
-LL | fn is_mytrait<T: MyTrait>() {}
-   |                  ------- required by this bound in `is_mytrait`
-...
 LL |     is_mytrait::<MyS2>();
    |                  ^^^^ the trait `MyTrait` is not implemented for `MyS2`
+   |
+note: required by a bound in `is_mytrait`
+  --> $DIR/typeck-default-trait-impl-constituent-types.rs:16:18
+   |
+LL | fn is_mytrait<T: MyTrait>() {}
+   |                  ^^^^^^^ required by this bound in `is_mytrait`
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/typeck-default-trait-impl-negation.stderr
+++ b/src/test/ui/auto-traits/typeck-default-trait-impl-negation.stderr
@@ -1,20 +1,26 @@
 error[E0277]: the trait bound `ThisImplsUnsafeTrait: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:22:19
    |
-LL | fn is_my_trait<T: MyTrait>() {}
-   |                   ------- required by this bound in `is_my_trait`
-...
 LL |     is_my_trait::<ThisImplsUnsafeTrait>();
    |                   ^^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
+   |
+note: required by a bound in `is_my_trait`
+  --> $DIR/typeck-default-trait-impl-negation.rs:17:19
+   |
+LL | fn is_my_trait<T: MyTrait>() {}
+   |                   ^^^^^^^ required by this bound in `is_my_trait`
 
 error[E0277]: the trait bound `ThisImplsTrait: MyUnsafeTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:25:26
    |
-LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
-   |                          ------------- required by this bound in `is_my_unsafe_trait`
-...
 LL |     is_my_unsafe_trait::<ThisImplsTrait>();
    |                          ^^^^^^^^^^^^^^ the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`
+   |
+note: required by a bound in `is_my_unsafe_trait`
+  --> $DIR/typeck-default-trait-impl-negation.rs:18:26
+   |
+LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
+   |                          ^^^^^^^^^^^^^ required by this bound in `is_my_unsafe_trait`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
+++ b/src/test/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the trait bound `u32: Signed` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:19:5
    |
-LL | fn is_defaulted<T:Defaulted>() { }
-   |                   --------- required by this bound in `is_defaulted`
-...
 LL |     is_defaulted::<&'static u32>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`
    |
    = note: required because of the requirements on the impl of `Defaulted` for `&'static u32`
+note: required by a bound in `is_defaulted`
+  --> $DIR/typeck-default-trait-impl-precedence.rs:12:19
+   |
+LL | fn is_defaulted<T:Defaulted>() { }
+   |                   ^^^^^^^^^ required by this bound in `is_defaulted`
 
 error: aborting due to previous error
 

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -76,11 +76,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider further restricting `Self`
    |
 LL | trait Foo<T>: Sized {
@@ -92,11 +92,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider further restricting `Self`
    |
 LL | trait Bar: std::fmt::Display + Sized {
@@ -108,11 +108,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider further restricting `Self`
    |
 LL | trait Baz: Sized where Self: std::fmt::Display {
@@ -124,11 +124,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider further restricting `Self`
    |
 LL | trait Qux<T>: Sized where Self: std::fmt::Display {
@@ -140,11 +140,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider further restricting `Self`
    |
 LL | trait Bat<T>: std::fmt::Display + Sized {

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:6:24
    |
-LL | trait Foo : Send+Sync { }
-   |             ---- required by this bound in `Foo`
-LL | 
 LL | impl <T: Sync+'static> Foo for (T,) { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
    = note: required because it appears within the type `(T,)`
+note: required by a bound in `Foo`
+  --> $DIR/builtin-superkinds-double-superkind.rs:4:13
+   |
+LL | trait Foo : Send+Sync { }
+   |             ^^^^ required by this bound in `Foo`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
@@ -16,13 +18,15 @@ LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
    |
-LL | trait Foo : Send+Sync { }
-   |                  ---- required by this bound in `Foo`
-...
 LL | impl <T: Send> Foo for (T,T) { }
    |                ^^^ `T` cannot be shared between threads safely
    |
    = note: required because it appears within the type `(T, T)`
+note: required by a bound in `Foo`
+  --> $DIR/builtin-superkinds-double-superkind.rs:4:18
+   |
+LL | trait Foo : Send+Sync { }
+   |                  ^^^^ required by this bound in `Foo`
 help: consider further restricting this bound
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -4,16 +4,16 @@ error[E0277]: `T` cannot be sent between threads safely
 LL | impl <T:Sync+'static> RequiresRequiresShareAndSend for X<T> { }
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be sent between threads safely
    |
-  ::: $DIR/auxiliary/trait_superkinds_in_metadata.rs:7:58
-   |
-LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
-   |                                                          ---- required by this bound in `RequiresRequiresShareAndSend`
-   |
 note: required because it appears within the type `X<T>`
   --> $DIR/builtin-superkinds-in-metadata.rs:9:8
    |
 LL | struct X<T>(T);
    |        ^
+note: required by a bound in `RequiresRequiresShareAndSend`
+  --> $DIR/auxiliary/trait_superkinds_in_metadata.rs:7:58
+   |
+LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
+   |                                                          ^^^^ required by this bound in `RequiresRequiresShareAndSend`
 help: consider further restricting this bound
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-simple.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `Rc<i8>` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-simple.rs:6:6
    |
-LL | trait Foo : Send { }
-   |             ---- required by this bound in `Foo`
-LL | 
 LL | impl Foo for std::rc::Rc<i8> { }
    |      ^^^ `Rc<i8>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<i8>`
+note: required by a bound in `Foo`
+  --> $DIR/builtin-superkinds-simple.rs:4:13
+   |
+LL | trait Foo : Send { }
+   |             ^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -1,12 +1,14 @@
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/builtin-superkinds-typaram-not-send.rs:5:24
    |
-LL | trait Foo : Send { }
-   |             ---- required by this bound in `Foo`
-LL | 
 LL | impl <T: Sync+'static> Foo for T { }
    |                        ^^^ `T` cannot be sent between threads safely
    |
+note: required by a bound in `Foo`
+  --> $DIR/builtin-superkinds-typaram-not-send.rs:3:13
+   |
+LL | trait Foo : Send { }
+   |             ^^^^ required by this bound in `Foo`
 help: consider further restricting this bound
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }

--- a/src/test/ui/chalkify/chalk_initial_program.stderr
+++ b/src/test/ui/chalkify/chalk_initial_program.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `f32: Foo` is not satisfied
   --> $DIR/chalk_initial_program.rs:15:13
    |
-LL | fn gimme<F: Foo>() { }
-   |             --- required by this bound in `gimme`
-...
 LL |     gimme::<f32>();
    |             ^^^ the trait `Foo` is not implemented for `f32`
+   |
+note: required by a bound in `gimme`
+  --> $DIR/chalk_initial_program.rs:9:13
+   |
+LL | fn gimme<F: Foo>() { }
+   |             ^^^ required by this bound in `gimme`
 
 error: aborting due to previous error
 

--- a/src/test/ui/chalkify/generic_impls.stderr
+++ b/src/test/ui/chalkify/generic_impls.stderr
@@ -1,26 +1,30 @@
 error[E0277]: the trait bound `(Option<T>, f32): Foo` is not satisfied
   --> $DIR/generic_impls.rs:12:13
    |
-LL | fn gimme<F: Foo>() { }
-   |             --- required by this bound in `gimme`
-...
 LL |     gimme::<(Option<T>, f32)>();
    |             ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(Option<T>, f32)`
    |
    = help: the following implementations were found:
              <(T, u32) as Foo>
+note: required by a bound in `gimme`
+  --> $DIR/generic_impls.rs:7:13
+   |
+LL | fn gimme<F: Foo>() { }
+   |             ^^^ required by this bound in `gimme`
 
 error[E0277]: the trait bound `(i32, f32): Foo` is not satisfied
   --> $DIR/generic_impls.rs:17:13
    |
-LL | fn gimme<F: Foo>() { }
-   |             --- required by this bound in `gimme`
-...
 LL |     gimme::<(i32, f32)>();
    |             ^^^^^^^^^^ the trait `Foo` is not implemented for `(i32, f32)`
    |
    = help: the following implementations were found:
              <(T, u32) as Foo>
+note: required by a bound in `gimme`
+  --> $DIR/generic_impls.rs:7:13
+   |
+LL | fn gimme<F: Foo>() { }
+   |             ^^^ required by this bound in `gimme`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/chalkify/impl_wf.stderr
+++ b/src/test/ui/chalkify/impl_wf.stderr
@@ -1,22 +1,27 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/impl_wf.rs:11:6
    |
-LL | trait Foo: Sized { }
-   |            ----- required by this bound in `Foo`
-...
 LL | impl Foo for str { }
    |      ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Foo`
+  --> $DIR/impl_wf.rs:3:12
+   |
+LL | trait Foo: Sized { }
+   |            ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `f32: Foo` is not satisfied
   --> $DIR/impl_wf.rs:22:6
    |
-LL | trait Baz<U: ?Sized> where U: Foo { }
-   |                               --- required by this bound in `Baz`
-...
 LL | impl Baz<f32> for f32 { }
    |      ^^^^^^^^ the trait `Foo` is not implemented for `f32`
+   |
+note: required by a bound in `Baz`
+  --> $DIR/impl_wf.rs:18:31
+   |
+LL | trait Baz<U: ?Sized> where U: Foo { }
+   |                               ^^^ required by this bound in `Baz`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/chalkify/impl_wf_2.stderr
+++ b/src/test/ui/chalkify/impl_wf_2.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `f32: Foo` is not satisfied
   --> $DIR/impl_wf_2.rs:25:5
    |
-LL |     type Item: Foo;
-   |                --- required by this bound in `Bar::Item`
-...
 LL |     type Item = f32;
    |     ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `f32`
+   |
+note: required by a bound in `Bar::Item`
+  --> $DIR/impl_wf_2.rs:8:16
+   |
+LL |     type Item: Foo;
+   |                ^^^ required by this bound in `Bar::Item`
 
 error: aborting due to previous error
 

--- a/src/test/ui/chalkify/type_inference.stderr
+++ b/src/test/ui/chalkify/type_inference.stderr
@@ -1,15 +1,17 @@
 error[E0277]: the trait bound `{float}: Bar` is not satisfied
   --> $DIR/type_inference.rs:27:14
    |
-LL | fn only_bar<T: Bar>(_x: T) { }
-   |                --- required by this bound in `only_bar`
-...
 LL |     only_bar(x);
    |              ^ the trait `Bar` is not implemented for `{float}`
    |
    = help: the following implementations were found:
              <i32 as Bar>
              <u32 as Bar>
+note: required by a bound in `only_bar`
+  --> $DIR/type_inference.rs:12:16
+   |
+LL | fn only_bar<T: Bar>(_x: T) { }
+   |                ^^^ required by this bound in `only_bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -1,15 +1,18 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
-LL | fn with_closure<F, A>(_: F)
-   |    ------------ required by a bound in this
-LL |     where F: FnOnce(A, A)
-   |              ------------ required by this bound in `with_closure`
-...
 LL |     with_closure(|x: u32, y: i32| {
    |     ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
    |     |
    |     expected signature of `fn(_, _) -> _`
+   |
+note: required by a bound in `with_closure`
+  --> $DIR/expect-infer-var-appearing-twice.rs:2:14
+   |
+LL | fn with_closure<F, A>(_: F)
+   |    ------------ required by a bound in this
+LL |     where F: FnOnce(A, A)
+   |              ^^^^^^^^^^^^ required by this bound in `with_closure`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -1,12 +1,14 @@
 error[E0277]: `F` cannot be sent between threads safely
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:22
    |
-LL | struct X<F> where F: FnOnce() + 'static + Send {
-   |                                           ---- required by this bound in `X`
-...
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |                      ^^^^ `F` cannot be sent between threads safely
    |
+note: required by a bound in `X`
+  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
+   |
+LL | struct X<F> where F: FnOnce() + 'static + Send {
+   |                                           ^^^^ required by this bound in `X`
 help: consider further restricting this bound
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -1,12 +1,14 @@
 error[E0277]: `F` cannot be shared between threads safely
   --> $DIR/closure-bounds-subtype.rs:13:22
    |
-LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
-   |                                                  ---- required by this bound in `take_const_owned`
-...
 LL |     take_const_owned(f);
    |                      ^ `F` cannot be shared between threads safely
    |
+note: required by a bound in `take_const_owned`
+  --> $DIR/closure-bounds-subtype.rs:4:50
+   |
+LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
+   |                                                  ^^^^ required by this bound in `take_const_owned`
 help: consider further restricting this bound
    |
 LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {

--- a/src/test/ui/closures/closure-move-sync.stderr
+++ b/src/test/ui/closures/closure-move-sync.stderr
@@ -4,14 +4,14 @@ error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads s
 LL |     let t = thread::spawn(|| {
    |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
-  ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
-   |
-LL |     F: Send + 'static,
-   |        ---- required by this bound in `spawn`
-   |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
    = note: required because of the requirements on the impl of `Send` for `&std::sync::mpsc::Receiver<()>`
    = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:6:27: 9:6]`
+note: required by a bound in `spawn`
+  --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
+   |
+LL |     F: Send + 'static,
+   |        ^^^^ required by this bound in `spawn`
 
 error[E0277]: `Sender<()>` cannot be shared between threads safely
   --> $DIR/closure-move-sync.rs:18:5
@@ -19,14 +19,14 @@ error[E0277]: `Sender<()>` cannot be shared between threads safely
 LL |     thread::spawn(|| tx.send(()).unwrap());
    |     ^^^^^^^^^^^^^ `Sender<()>` cannot be shared between threads safely
    |
-  ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
-   |
-LL |     F: Send + 'static,
-   |        ---- required by this bound in `spawn`
-   |
    = help: the trait `Sync` is not implemented for `Sender<()>`
    = note: required because of the requirements on the impl of `Send` for `&Sender<()>`
    = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:18:19: 18:42]`
+note: required by a bound in `spawn`
+  --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
+   |
+LL |     F: Send + 'static,
+   |        ^^^^ required by this bound in `spawn`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
+++ b/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `&dyn Trait: Trait` is not satisfied
   --> $DIR/coherence-unsafe-trait-object-impl.rs:15:13
    |
-LL | fn takes_t<S: Trait>(s: S) {
-   |               ----- required by this bound in `takes_t`
-...
 LL |     takes_t(t);
    |             ^ the trait `Trait` is not implemented for `&dyn Trait`
+   |
+note: required by a bound in `takes_t`
+  --> $DIR/coherence-unsafe-trait-object-impl.rs:10:15
+   |
+LL | fn takes_t<S: Trait>(s: S) {
+   |               ^^^^^ required by this bound in `takes_t`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/associated-type-bound-fail.full.stderr
+++ b/src/test/ui/const-generics/associated-type-bound-fail.full.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
   --> $DIR/associated-type-bound-fail.rs:13:5
    |
-LL |     type Assoc: Bar<N>;
-   |                 ------ required by this bound in `Foo::Assoc`
-...
 LL |     type Assoc = u16;
    |     ^^^^^^^^^^^^^^^^^ the trait `Bar<N>` is not implemented for `u16`
    |
    = help: the following implementations were found:
              <u16 as Bar<3_usize>>
+note: required by a bound in `Foo::Assoc`
+  --> $DIR/associated-type-bound-fail.rs:8:17
+   |
+LL |     type Assoc: Bar<N>;
+   |                 ^^^^^^ required by this bound in `Foo::Assoc`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/associated-type-bound-fail.min.stderr
+++ b/src/test/ui/const-generics/associated-type-bound-fail.min.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
   --> $DIR/associated-type-bound-fail.rs:13:5
    |
-LL |     type Assoc: Bar<N>;
-   |                 ------ required by this bound in `Foo::Assoc`
-...
 LL |     type Assoc = u16;
    |     ^^^^^^^^^^^^^^^^^ the trait `Bar<N>` is not implemented for `u16`
    |
    = help: the following implementations were found:
              <u16 as Bar<3_usize>>
+note: required by a bound in `Foo::Assoc`
+  --> $DIR/associated-type-bound-fail.rs:8:17
+   |
+LL |     type Assoc: Bar<N>;
+   |                 ^^^^^^ required by this bound in `Foo::Assoc`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-argument-if-length.full.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.full.stderr
@@ -6,11 +6,11 @@ LL | pub const fn is_zst<T: ?Sized>() -> usize {
 LL |     if std::mem::size_of::<T>() == 0 {
    |                            ^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - pub const fn is_zst<T: ?Sized>() -> usize {

--- a/src/test/ui/const-generics/const_evaluatable_checked/abstract-const-as-cast-3.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/abstract-const-as-cast-3.stderr
@@ -1,9 +1,6 @@
 error: unconstrained generic constant
   --> $DIR/abstract-const-as-cast-3.rs:17:5
    |
-LL |     fn assert_impl<T: Trait>() {}
-   |                       ----- required by this bound in `use_trait_impl::assert_impl`
-...
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -13,6 +10,11 @@ note: required because of the requirements on the impl of `Trait` for `HasCastIn
    |
 LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
    |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:14:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `use_trait_impl::assert_impl`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:17:5
@@ -26,9 +28,6 @@ LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
 error: unconstrained generic constant
   --> $DIR/abstract-const-as-cast-3.rs:20:5
    |
-LL |     fn assert_impl<T: Trait>() {}
-   |                       ----- required by this bound in `use_trait_impl::assert_impl`
-...
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -38,6 +37,11 @@ note: required because of the requirements on the impl of `Trait` for `HasCastIn
    |
 LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
    |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:14:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `use_trait_impl::assert_impl`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:20:5
@@ -69,9 +73,6 @@ LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
 error: unconstrained generic constant
   --> $DIR/abstract-const-as-cast-3.rs:35:5
    |
-LL |     fn assert_impl<T: Trait>() {}
-   |                       ----- required by this bound in `use_trait_impl_2::assert_impl`
-...
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -81,6 +82,11 @@ note: required because of the requirements on the impl of `Trait` for `HasCastIn
    |
 LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
    |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl_2::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:32:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `use_trait_impl_2::assert_impl`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:35:5
@@ -94,9 +100,6 @@ LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
 error: unconstrained generic constant
   --> $DIR/abstract-const-as-cast-3.rs:38:5
    |
-LL |     fn assert_impl<T: Trait>() {}
-   |                       ----- required by this bound in `use_trait_impl_2::assert_impl`
-...
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -106,6 +109,11 @@ note: required because of the requirements on the impl of `Trait` for `HasCastIn
    |
 LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
    |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl_2::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:32:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `use_trait_impl_2::assert_impl`
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:38:5

--- a/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/cross_crate_predicate.stderr
@@ -4,12 +4,12 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
+   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+note: required by a bound in `test1`
+  --> $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |          ---------------------------- required by this bound in `test1`
-   |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:13
@@ -17,12 +17,12 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
+   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+note: required by a bound in `test1`
+  --> $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
-   |                           ---------------------------- required by this bound in `test1`
-   |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:13
@@ -30,12 +30,12 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:6:10
+   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+note: required by a bound in `test1`
+  --> $DIR/auxiliary/const_evaluatable_lib.rs:6:10
    |
 LL |     [u8; std::mem::size_of::<T>() - 1]: Sized,
-   |          ---------------------------- required by this bound in `test1`
-   |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 
 error: unconstrained generic constant
   --> $DIR/cross_crate_predicate.rs:7:13
@@ -43,12 +43,12 @@ error: unconstrained generic constant
 LL |     let _ = const_evaluatable_lib::test1::<T>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/const_evaluatable_lib.rs:4:27
+   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+note: required by a bound in `test1`
+  --> $DIR/auxiliary/const_evaluatable_lib.rs:4:27
    |
 LL | pub fn test1<T>() -> [u8; std::mem::size_of::<T>() - 1]
-   |                           ---------------------------- required by this bound in `test1`
-   |
-   = help: try adding a `where` bound using this expression: `where [(); std::mem::size_of::<T>() - 1]:`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `test1`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
@@ -1,11 +1,14 @@
 error[E0284]: type annotations needed: cannot satisfy `the constant `use_dyn::<{_: usize}>::{constant#0}` can be evaluated`
   --> $DIR/object-safety-ok-infer-err.rs:20:5
    |
-LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
-   |                                                       ----- required by this bound in `use_dyn`
-...
 LL |     use_dyn(&());
    |     ^^^^^^^ cannot satisfy `the constant `use_dyn::<{_: usize}>::{constant#0}` can be evaluated`
+   |
+note: required by a bound in `use_dyn`
+  --> $DIR/object-safety-ok-infer-err.rs:14:55
+   |
+LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
+   |                                                       ^^^^^ required by this bound in `use_dyn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-67185-2.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-67185-2.full.stderr
@@ -37,66 +37,74 @@ LL | | }
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
   --> $DIR/issue-67185-2.rs:26:6
    |
-LL | trait Foo
-   |       --- required by a bound in this
-...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             --- required by this bound in `Foo`
-...
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:6
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:20:29
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  --- required by this bound in `Foo`
-...
+LL |         <u8 as Baz>::Quaks: Bar,
+   |                             ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:26:6
+   |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:30:14
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:19:34
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
 LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  --- required by this bound in `Foo`
-...
+   |                                  ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:30:14
+   |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:30:14
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:19:34
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             --- required by this bound in `Foo`
-...
+LL |         [<u8 as Baz>::Quaks; 2]: Bar,
+   |                                  ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:30:14
+   |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:20:29
+   |
+LL | trait Foo
+   |       --- required by a bound in this
+...
+LL |         <u8 as Baz>::Quaks: Bar,
+   |                             ^^^ required by this bound in `Foo`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-67185-2.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-67185-2.min.stderr
@@ -37,66 +37,74 @@ LL | | }
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
   --> $DIR/issue-67185-2.rs:26:6
    |
-LL | trait Foo
-   |       --- required by a bound in this
-...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             --- required by this bound in `Foo`
-...
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:6
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:20:29
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  --- required by this bound in `Foo`
-...
+LL |         <u8 as Baz>::Quaks: Bar,
+   |                             ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:26:6
+   |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:30:14
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:19:34
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
 LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  --- required by this bound in `Foo`
-...
+   |                                  ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:30:14
+   |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
-
-error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:30:14
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:19:34
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             --- required by this bound in `Foo`
-...
+LL |         [<u8 as Baz>::Quaks; 2]: Bar,
+   |                                  ^^^ required by this bound in `Foo`
+
+error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
+  --> $DIR/issue-67185-2.rs:30:14
+   |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
+note: required by a bound in `Foo`
+  --> $DIR/issue-67185-2.rs:20:29
+   |
+LL | trait Foo
+   |       --- required by a bound in this
+...
+LL |         <u8 as Baz>::Quaks: Bar,
+   |                             ^^^ required by this bound in `Foo`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-72787.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-72787.min.stderr
@@ -37,24 +37,28 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
 error[E0283]: type annotations needed
   --> $DIR/issue-72787.rs:21:26
    |
-LL | pub trait True {}
-   | -------------- required by this bound in `True`
-...
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+note: required by a bound in `True`
+  --> $DIR/issue-72787.rs:7:1
+   |
+LL | pub trait True {}
+   | ^^^^^^^^^^^^^^ required by this bound in `True`
 
 error[E0283]: type annotations needed
   --> $DIR/issue-72787.rs:21:26
    |
-LL | pub trait True {}
-   | -------------- required by this bound in `True`
-...
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
+note: required by a bound in `True`
+  --> $DIR/issue-72787.rs:7:1
+   |
+LL | pub trait True {}
+   | ^^^^^^^^^^^^^^ required by this bound in `True`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-85848.stderr
+++ b/src/test/ui/const-generics/issues/issue-85848.stderr
@@ -3,9 +3,6 @@ error[E0277]: the trait bound `(): _Contains<&C>` is not satisfied
    |
 LL |     writes_to_specific_path(&cap);
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `_Contains<&C>` is not implemented for `()`
-...
-LL | fn writes_to_specific_path<C: Delegates<()>>(cap: &C) {}
-   |                               ------------- required by this bound in `writes_to_specific_path`
    |
 note: required because of the requirements on the impl of `Contains<(), true>` for `&C`
   --> $DIR/issue-85848.rs:21:12
@@ -17,15 +14,17 @@ note: required because of the requirements on the impl of `Delegates<()>` for `&
    |
 LL | impl<T, U> Delegates<U> for T where T: Contains<U, true> {}
    |            ^^^^^^^^^^^^     ^
+note: required by a bound in `writes_to_specific_path`
+  --> $DIR/issue-85848.rs:29:31
+   |
+LL | fn writes_to_specific_path<C: Delegates<()>>(cap: &C) {}
+   |                               ^^^^^^^^^^^^^ required by this bound in `writes_to_specific_path`
 
 error: unconstrained generic constant
   --> $DIR/issue-85848.rs:24:5
    |
 LL |     writes_to_specific_path(&cap);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn writes_to_specific_path<C: Delegates<()>>(cap: &C) {}
-   |                               ------------- required by this bound in `writes_to_specific_path`
    |
    = help: try adding a `where` bound using this expression: `where [(); { contains::<T, U>() }]:`
 note: required because of the requirements on the impl of `Contains<(), true>` for `&C`
@@ -38,6 +37,11 @@ note: required because of the requirements on the impl of `Delegates<()>` for `&
    |
 LL | impl<T, U> Delegates<U> for T where T: Contains<U, true> {}
    |            ^^^^^^^^^^^^     ^
+note: required by a bound in `writes_to_specific_path`
+  --> $DIR/issue-85848.rs:29:31
+   |
+LL | fn writes_to_specific_path<C: Delegates<()>>(cap: &C) {}
+   |                               ^^^^^^^^^^^^^ required by this bound in `writes_to_specific_path`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -4,10 +4,11 @@ error[E0284]: type annotations needed: cannot satisfy `the constant `foo::{opaqu
 LL |     generics_of_parent_impl_trait::foo([()]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `the constant `foo::{opaque#0}::{constant#0}` can be evaluated`
    |
-  ::: $DIR/auxiliary/generics_of_parent_impl_trait.rs:6:48
+note: required by a bound in `foo`
+  --> $DIR/auxiliary/generics_of_parent_impl_trait.rs:6:48
    |
 LL | pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
-   |                                                ----- required by this bound in `foo`
+   |                                                ^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -7,11 +7,11 @@ LL | #[derive(Eq,PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -7,11 +7,11 @@ LL | #[derive(Eq,PartialEq)]
 LL |      Error
    |      ^^^^^ the trait `Eq` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Eq` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Eq` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -7,11 +7,11 @@ LL | #[derive(Hash)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+note: required by a bound in `std::hash::Hash::hash`
+  --> $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
-   |             - required by this bound in `std::hash::Hash::hash`
-   |
+   |             ^ required by this bound in `std::hash::Hash::hash`
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -7,11 +7,11 @@ LL | #[derive(Hash)]
 LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+note: required by a bound in `std::hash::Hash::hash`
+  --> $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
-   |             - required by this bound in `std::hash::Hash::hash`
-   |
+   |             ^ required by this bound in `std::hash::Hash::hash`
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+note: required by a bound in `std::hash::Hash::hash`
+  --> $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
-   |             - required by this bound in `std::hash::Hash::hash`
-   |
+   |             ^ required by this bound in `std::hash::Hash::hash`
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -7,11 +7,11 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Hash` is not implemented for `Error`
    |
-  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+note: required by a bound in `std::hash::Hash::hash`
+  --> $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
-   |             - required by this bound in `std::hash::Hash::hash`
-   |
+   |             ^ required by this bound in `std::hash::Hash::hash`
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `C: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
-LL | fn is_copy<T: Copy>(_: T) {}
-   |               ---- required by this bound in `is_copy`
-...
 LL |     is_copy(B { a: 1, b: C });
    |             ^^^^^^^^^^^^^^^^
    |             |
@@ -15,14 +12,16 @@ note: required because of the requirements on the impl of `Copy` for `B<C>`
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^
+note: required by a bound in `is_copy`
+  --> $DIR/deriving-copyclone.rs:18:15
+   |
+LL | fn is_copy<T: Copy>(_: T) {}
+   |               ^^^^ required by this bound in `is_copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `C: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
-LL | fn is_clone<T: Clone>(_: T) {}
-   |                ----- required by this bound in `is_clone`
-...
 LL |     is_clone(B { a: 1, b: C });
    |              ^^^^^^^^^^^^^^^^
    |              |
@@ -34,14 +33,16 @@ note: required because of the requirements on the impl of `Clone` for `B<C>`
    |
 LL | #[derive(Copy, Clone)]
    |                ^^^^^
+note: required by a bound in `is_clone`
+  --> $DIR/deriving-copyclone.rs:19:16
+   |
+LL | fn is_clone<T: Clone>(_: T) {}
+   |                ^^^^^ required by this bound in `is_clone`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `D: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
-LL | fn is_copy<T: Copy>(_: T) {}
-   |               ---- required by this bound in `is_copy`
-...
 LL |     is_copy(B { a: 1, b: D });
    |             ^^^^^^^^^^^^^^^^
    |             |
@@ -53,6 +54,11 @@ note: required because of the requirements on the impl of `Copy` for `B<D>`
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^
+note: required by a bound in `is_copy`
+  --> $DIR/deriving-copyclone.rs:18:15
+   |
+LL | fn is_copy<T: Copy>(_: T) {}
+   |               ^^^^ required by this bound in `is_copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/did_you_mean/recursion_limit.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `K: Send`
   --> $DIR/recursion_limit.rs:34:5
    |
-LL | fn is_send<T:Send>() { }
-   |              ---- required by this bound in `is_send`
-...
 LL |     is_send::<A>();
    |     ^^^^^^^^^^^^
    |
@@ -58,6 +55,11 @@ note: required because it appears within the type `A`
    |
 LL | link! { A, B }
    |         ^
+note: required by a bound in `is_send`
+  --> $DIR/recursion_limit.rs:31:14
+   |
+LL | fn is_send<T:Send>() { }
+   |              ^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/dst/dst-sized-trait-param.stderr
+++ b/src/test/ui/dst/dst-sized-trait-param.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the size for values of type `[isize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:7:6
    |
-LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |           - required by this bound in `Foo`
-LL | 
 LL | impl Foo<[isize]> for usize { }
    |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[isize]`
+note: required by a bound in `Foo`
+  --> $DIR/dst-sized-trait-param.rs:5:11
+   |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |           ^ required by this bound in `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is sized
@@ -16,13 +18,15 @@ LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is siz
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
   --> $DIR/dst-sized-trait-param.rs:10:6
    |
-LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |                ----- required by this bound in `Foo`
-...
 LL | impl Foo<isize> for [usize] { }
    |      ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[usize]`
+note: required by a bound in `Foo`
+  --> $DIR/dst-sized-trait-param.rs:5:16
+   |
+LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
+   |                ^^^^^ required by this bound in `Foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
   --> $DIR/E0271.rs:10:5
    |
-LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
-   |                                ------------------ required by this bound in `foo`
-...
 LL |     foo(3_i8);
    |     ^^^ expected `u32`, found `&str`
+   |
+note: required by a bound in `foo`
+  --> $DIR/E0271.rs:3:32
+   |
+LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
+   |                                ^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0275.stderr
+++ b/src/test/ui/error-codes/E0275.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/E0275.rs:5:33
    |
-LL | trait Foo {}
-   | --------- required by this bound in `Foo`
-...
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^
    |
@@ -15,6 +12,11 @@ LL | impl<T> Foo for T where Bar<T>: Foo {}
    |         ^^^     ^
    = note: 127 redundant requirements hidden
    = note: required because of the requirements on the impl of `Foo` for `Bar<T>`
+note: required by a bound in `Foo`
+  --> $DIR/E0275.rs:1:1
+   |
+LL | trait Foo {}
+   | ^^^^^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0277-2.stderr
+++ b/src/test/ui/error-codes/E0277-2.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `*const u8` cannot be sent between threads safely
   --> $DIR/E0277-2.rs:16:5
    |
-LL | fn is_send<T: Send>() { }
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^ `*const u8` cannot be sent between threads safely
    |
@@ -23,6 +20,11 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo {
    |        ^^^
+note: required by a bound in `is_send`
+  --> $DIR/E0277-2.rs:13:15
+   |
+LL | fn is_send<T: Send>() { }
+   |               ^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -15,11 +15,14 @@ LL | fn f(p: &Path) { }
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:15:15
    |
-LL | fn some_func<T: Foo>(foo: T) {
-   |                 --- required by this bound in `some_func`
-...
 LL |     some_func(5i32);
    |               ^^^^ the trait `Foo` is not implemented for `i32`
+   |
+note: required by a bound in `some_func`
+  --> $DIR/E0277.rs:7:17
+   |
+LL | fn some_func<T: Foo>(foo: T) {
+   |                 ^^^ required by this bound in `some_func`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/error-should-say-copy-not-pod.rs:6:17
    |
-LL | fn check_bound<T:Copy>(_: T) {}
-   |                  ---- required by this bound in `check_bound`
-...
 LL |     check_bound("nocopy".to_string());
    |                 ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `check_bound`
+  --> $DIR/error-should-say-copy-not-pod.rs:3:18
+   |
+LL | fn check_bound<T:Copy>(_: T) {}
+   |                  ^^^^ required by this bound in `check_bound`
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -1,24 +1,28 @@
 error[E0277]: `A` cannot be shared between threads safely
   --> $DIR/extern-types-not-sync-send.rs:13:19
    |
-LL | fn assert_sync<T: ?Sized + Sync>() {}
-   |                            ---- required by this bound in `assert_sync`
-...
 LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `A`
+note: required by a bound in `assert_sync`
+  --> $DIR/extern-types-not-sync-send.rs:9:28
+   |
+LL | fn assert_sync<T: ?Sized + Sync>() {}
+   |                            ^^^^ required by this bound in `assert_sync`
 
 error[E0277]: `A` cannot be sent between threads safely
   --> $DIR/extern-types-not-sync-send.rs:16:19
    |
-LL | fn assert_send<T: ?Sized + Send>() {}
-   |                            ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `A`
+note: required by a bound in `assert_send`
+  --> $DIR/extern-types-not-sync-send.rs:10:28
+   |
+LL | fn assert_send<T: ?Sized + Send>() {}
+   |                            ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:22:20
    |
-LL | fn assert_sized<T>() {}
-   |                 - required by this bound in `assert_sized`
-...
 LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `A`
+note: required by a bound in `assert_sized`
+  --> $DIR/extern-types-unsized.rs:19:17
+   |
+LL | fn assert_sized<T>() {}
+   |                 ^ required by this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -16,9 +18,6 @@ LL | fn assert_sized<T: ?Sized>() {}
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:25:5
    |
-LL | fn assert_sized<T>() {}
-   |                 - required by this bound in `assert_sized`
-...
 LL |     assert_sized::<Foo>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -28,6 +27,11 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo {
    |        ^^^
+note: required by a bound in `assert_sized`
+  --> $DIR/extern-types-unsized.rs:19:17
+   |
+LL | fn assert_sized<T>() {}
+   |                 ^ required by this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -36,9 +40,6 @@ LL | fn assert_sized<T: ?Sized>() {}
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:28:5
    |
-LL | fn assert_sized<T>() {}
-   |                 - required by this bound in `assert_sized`
-...
 LL |     assert_sized::<Bar<A>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -48,6 +49,11 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
+note: required by a bound in `assert_sized`
+  --> $DIR/extern-types-unsized.rs:19:17
+   |
+LL | fn assert_sized<T>() {}
+   |                 ^ required by this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -56,9 +62,6 @@ LL | fn assert_sized<T: ?Sized>() {}
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:31:5
    |
-LL | fn assert_sized<T>() {}
-   |                 - required by this bound in `assert_sized`
-...
 LL |     assert_sized::<Bar<Bar<A>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -73,6 +76,11 @@ note: required because it appears within the type `Bar<Bar<A>>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
+note: required by a bound in `assert_sized`
+  --> $DIR/extern-types-unsized.rs:19:17
+   |
+LL | fn assert_sized<T>() {}
+   |                 ^ required by this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -1,14 +1,16 @@
 error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
-LL | fn is_fn<F>(_: F) where F: Fn() {}
-   |                            ---- required by this bound in `is_fn`
-...
 LL |     is_fn(f);
    |           ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
    |
    = help: the trait `Fn<()>` is not implemented for `extern "C" fn() {f}`
    = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `is_fn`
+  --> $DIR/extern-wrong-value-type.rs:4:28
+   |
+LL | fn is_fn<F>(_: F) where F: Fn() {}
+   |                            ^^^^ required by this bound in `is_fn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -139,11 +139,11 @@ error[E0277]: the trait bound `<<Self as _Tr3>::A as Iterator>::Item: Copy` is n
 LL |     type A: Iterator<Item: Copy>;
    |                            ^^^^ the trait `Copy` is not implemented for `<<Self as _Tr3>::A as Iterator>::Item`
    |
-  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+note: required by a bound in `Copy`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {
-   | --------------------- required by this bound in `Copy`
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Copy`
 help: consider further restricting the associated type
    |
 LL | trait _Tr3 where <<Self as _Tr3>::A as Iterator>::Item: Copy {

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
   --> $DIR/send-sync.rs:8:5
    |
-LL | fn send<T: Send>(_: T) {}
-   |            ---- required by this bound in `send`
-...
 LL |     send(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely
    |
@@ -13,13 +10,15 @@ LL |     send(format_args!("{:?}", c));
    = note: required because it appears within the type `[ArgumentV1<'_>]`
    = note: required because of the requirements on the impl of `Send` for `&[ArgumentV1<'_>]`
    = note: required because it appears within the type `Arguments<'_>`
+note: required by a bound in `send`
+  --> $DIR/send-sync.rs:1:12
+   |
+LL | fn send<T: Send>(_: T) {}
+   |            ^^^^ required by this bound in `send`
 
 error[E0277]: `core::fmt::Opaque` cannot be shared between threads safely
   --> $DIR/send-sync.rs:9:5
    |
-LL | fn sync<T: Sync>(_: T) {}
-   |            ---- required by this bound in `sync`
-...
 LL |     sync(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely
    |
@@ -29,6 +28,11 @@ LL |     sync(format_args!("{:?}", c));
    = note: required because it appears within the type `[ArgumentV1<'_>]`
    = note: required because it appears within the type `&[ArgumentV1<'_>]`
    = note: required because it appears within the type `Arguments<'_>`
+note: required by a bound in `sync`
+  --> $DIR/send-sync.rs:2:12
+   |
+LL | fn sync<T: Sync>(_: T) {}
+   |            ^^^^ required by this bound in `sync`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -34,13 +34,15 @@ LL |     let _: () = (box || -> isize { unimplemented!() }) as Box<dyn FnMut() -
 error[E0277]: expected a `Fn<(isize,)>` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:14
    |
-LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
-   |                               ------------------ required by this bound in `needs_fn`
-...
 LL |     needs_fn(1);
    |              ^ expected an `Fn<(isize,)>` closure, found `{integer}`
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `{integer}`
+note: required by a bound in `needs_fn`
+  --> $DIR/fn-trait-formatting.rs:3:31
+   |
+LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
+   |                               ^^^^^^^^^^^^^^^^^^ required by this bound in `needs_fn`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator/generator-yielding-or-returning-itself.stderr
@@ -1,11 +1,6 @@
 error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-returning-itself.rs:15:34: 19:6] as Generator>::Return == [generator@$DIR/generator-yielding-or-returning-itself.rs:15:34: 19:6]`
   --> $DIR/generator-yielding-or-returning-itself.rs:15:5
    |
-LL | pub fn want_cyclic_generator_return<T>(_: T)
-   |        ---------------------------- required by a bound in this
-LL |     where T: Generator<Yield = (), Return = T>
-   |                                    ---------- required by this bound in `want_cyclic_generator_return`
-...
 LL |     want_cyclic_generator_return(|| {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
    |
@@ -13,15 +8,17 @@ LL |     want_cyclic_generator_return(|| {
            this error may be the result of a recent compiler bug-fix,
            see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
            for more information
+note: required by a bound in `want_cyclic_generator_return`
+  --> $DIR/generator-yielding-or-returning-itself.rs:10:36
+   |
+LL | pub fn want_cyclic_generator_return<T>(_: T)
+   |        ---------------------------- required by a bound in this
+LL |     where T: Generator<Yield = (), Return = T>
+   |                                    ^^^^^^^^^^ required by this bound in `want_cyclic_generator_return`
 
 error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6] as Generator>::Yield == [generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6]`
   --> $DIR/generator-yielding-or-returning-itself.rs:28:5
    |
-LL | pub fn want_cyclic_generator_yield<T>(_: T)
-   |        --------------------------- required by a bound in this
-LL |     where T: Generator<Yield = T, Return = ()>
-   |                        --------- required by this bound in `want_cyclic_generator_yield`
-...
 LL |     want_cyclic_generator_yield(|| {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
    |
@@ -29,6 +26,13 @@ LL |     want_cyclic_generator_yield(|| {
            this error may be the result of a recent compiler bug-fix,
            see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
            for more information
+note: required by a bound in `want_cyclic_generator_yield`
+  --> $DIR/generator-yielding-or-returning-itself.rs:23:24
+   |
+LL | pub fn want_cyclic_generator_yield<T>(_: T)
+   |        --------------------------- required by a bound in this
+LL |     where T: Generator<Yield = T, Return = ()>
+   |                        ^^^^^^^^^ required by this bound in `want_cyclic_generator_yield`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/issue-68112.stderr
+++ b/src/test/ui/generator/issue-68112.stderr
@@ -1,9 +1,6 @@
 error: generator cannot be sent between threads safely
   --> $DIR/issue-68112.rs:33:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^ generator is not `Send`
    |
@@ -17,13 +14,15 @@ LL |         yield;
    |         ^^^^^ yield occurs here, with `_non_send_gen` maybe used later
 LL |     };
    |     - `_non_send_gen` is later dropped here
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:22:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/issue-68112.rs:52:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
@@ -34,6 +33,11 @@ LL |     require_send(send_gen);
    = note: required because it appears within the type `impl Generator`
    = note: required because it appears within the type `{impl Generator, ()}`
    = note: required because it appears within the type `[generator@$DIR/issue-68112.rs:48:20: 51:6]`
+note: required by a bound in `require_send`
+  --> $DIR/issue-68112.rs:22:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -1,22 +1,21 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:16:5
    |
-LL |     fn assert_send<T: Send>(_: T) {}
-   |                       ---- required by this bound in `assert_send`
-...
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Cell<i32>`
    = note: required because of the requirements on the impl of `Send` for `&Cell<i32>`
    = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:16:17: 20:6]`
+note: required by a bound in `assert_send`
+  --> $DIR/not-send-sync.rs:7:23
+   |
+LL |     fn assert_send<T: Send>(_: T) {}
+   |                       ^^^^ required by this bound in `assert_send`
 
 error: generator cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:9:5
    |
-LL |     fn assert_sync<T: Sync>(_: T) {}
-   |                       ---- required by this bound in `assert_sync`
-...
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
@@ -30,6 +29,11 @@ LL |         yield;
    |         ^^^^^ yield occurs here, with `a` maybe used later
 LL |     });
    |     - `a` is later dropped here
+note: required by a bound in `assert_sync`
+  --> $DIR/not-send-sync.rs:6:23
+   |
+LL |     fn assert_sync<T: Sync>(_: T) {}
+   |                       ^^^^ required by this bound in `assert_sync`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/print/generator-print-verbose-1.stderr
+++ b/src/test/ui/generator/print/generator-print-verbose-1.stderr
@@ -1,9 +1,6 @@
 error: generator cannot be sent between threads safely
   --> $DIR/generator-print-verbose-1.rs:37:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^ generator is not `Send`
    |
@@ -17,13 +14,15 @@ LL |         yield;
    |         ^^^^^ yield occurs here, with `_non_send_gen` maybe used later
 LL |     };
    |     - `_non_send_gen` is later dropped here
+note: required by a bound in `require_send`
+  --> $DIR/generator-print-verbose-1.rs:26:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/generator-print-verbose-1.rs:56:5
    |
-LL | fn require_send(_: impl Send) {}
-   |                         ---- required by this bound in `require_send`
-...
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
@@ -34,6 +33,11 @@ LL |     require_send(send_gen);
    = note: required because it appears within the type `Opaque(DefId(0:42 ~ generator_print_verbose_1[70c9]::make_non_send_generator2::{opaque#0}), [])`
    = note: required because it appears within the type `{Opaque(DefId(0:42 ~ generator_print_verbose_1[70c9]::make_non_send_generator2::{opaque#0}), []), ()}`
    = note: required because it appears within the type `[test2::{closure#0} upvar_tys=() {Opaque(DefId(0:42 ~ generator_print_verbose_1[70c9]::make_non_send_generator2::{opaque#0}), []), ()}]`
+note: required by a bound in `require_send`
+  --> $DIR/generator-print-verbose-1.rs:26:25
+   |
+LL | fn require_send(_: impl Send) {}
+   |                         ^^^^ required by this bound in `require_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/print/generator-print-verbose-2.stderr
+++ b/src/test/ui/generator/print/generator-print-verbose-2.stderr
@@ -1,22 +1,21 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
   --> $DIR/generator-print-verbose-2.rs:19:5
    |
-LL |     fn assert_send<T: Send>(_: T) {}
-   |                       ---- required by this bound in `assert_send`
-...
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Cell<i32>`
    = note: required because of the requirements on the impl of `Send` for `&'_#4r Cell<i32>`
    = note: required because it appears within the type `[main::{closure#1} upvar_tys=(&'_#4r Cell<i32>) _#17t]`
+note: required by a bound in `assert_send`
+  --> $DIR/generator-print-verbose-2.rs:10:23
+   |
+LL |     fn assert_send<T: Send>(_: T) {}
+   |                       ^^^^ required by this bound in `assert_send`
 
 error: generator cannot be shared between threads safely
   --> $DIR/generator-print-verbose-2.rs:12:5
    |
-LL |     fn assert_sync<T: Sync>(_: T) {}
-   |                       ---- required by this bound in `assert_sync`
-...
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ generator is not `Sync`
    |
@@ -30,6 +29,11 @@ LL |         yield;
    |         ^^^^^ yield occurs here, with `a` maybe used later
 LL |     });
    |     - `a` is later dropped here
+note: required by a bound in `assert_sync`
+  --> $DIR/generator-print-verbose-2.rs:9:23
+   |
+LL |     fn assert_sync<T: Sync>(_: T) {}
+   |                       ^^^^ required by this bound in `assert_sync`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/sized-yield.stderr
+++ b/src/test/ui/generator/sized-yield.stderr
@@ -17,12 +17,12 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |    Pin::new(&mut gen).resume(());
    |                       ^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/ops/generator.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `GeneratorState`
+  --> $SRC_DIR/core/src/ops/generator.rs:LL:COL
    |
 LL | pub enum GeneratorState<Y, R> {
-   |                         - required by this bound in `GeneratorState`
-   |
-   = help: the trait `Sized` is not implemented for `str`
+   |                         ^ required by this bound in `GeneratorState`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6]` cannot be unpinned
   --> $DIR/static-not-unpin.rs:14:18
    |
-LL | fn assert_unpin<T: Unpin>(_: T) {
-   |                    ----- required by this bound in `assert_unpin`
-...
 LL |     assert_unpin(generator);
    |                  ^^^^^^^^^ the trait `Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6]`
    |
    = note: consider using `Box::pin`
+note: required by a bound in `assert_unpin`
+  --> $DIR/static-not-unpin.rs:7:20
+   |
+LL | fn assert_unpin<T: Unpin>(_: T) {
+   |                    ^^^^^ required by this bound in `assert_unpin`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
+++ b/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
@@ -4,10 +4,11 @@ error[E0277]: the trait bound `(): AsRef<()>` is not satisfied
 LL |     type Bar = ();
    |     ^^^^^^^^^^^^^^ the trait `AsRef<()>` is not implemented for `()`
    |
-  ::: $DIR/auxiliary/foo_defn.rs:6:15
+note: required by a bound in `foo_defn::Foo::Bar`
+  --> $DIR/auxiliary/foo_defn.rs:6:15
    |
 LL |     type Bar: AsRef<()>;
-   |               --------- required by this bound in `foo_defn::Foo::Bar`
+   |               ^^^^^^^^^ required by this bound in `foo_defn::Foo::Bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
+++ b/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-68641-check-gat-bounds.rs:14:5
    |
-LL |     type Item<'a>: Copy;
-   |                    ---- required by this bound in `UnsafeCopy::Item`
-...
 LL |     type Item<'a> = T;
    |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `UnsafeCopy::Item`
+  --> $DIR/issue-68641-check-gat-bounds.rs:6:20
+   |
+LL |     type Item<'a>: Copy;
+   |                    ^^^^ required by this bound in `UnsafeCopy::Item`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UnsafeCopy for T {

--- a/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
   --> $DIR/issue-68642-broken-llvm-ir.rs:14:5
    |
-LL |     type F<'a>: Fn() -> u32;
-   |                 ----------- required by this bound in `Fun::F`
-...
 LL |     type F<'a> = Self;
    |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fun::F`
+  --> $DIR/issue-68642-broken-llvm-ir.rs:6:17
+   |
+LL |     type F<'a>: Fn() -> u32;
+   |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Fn<()>> Fun for T {

--- a/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
   --> $DIR/issue-68643-broken-mir.rs:14:5
    |
-LL |     type F<'a>: Fn() -> u32;
-   |                 ----------- required by this bound in `Fun::F`
-...
 LL |     type F<'a> = Self;
    |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fun::F`
+  --> $DIR/issue-68643-broken-mir.rs:6:17
+   |
+LL |     type F<'a>: Fn() -> u32;
+   |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Fn<()>> Fun for T {

--- a/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
   --> $DIR/issue-68644-codegen-selection.rs:14:5
    |
-LL |     type F<'a>: Fn() -> u32;
-   |                 ----------- required by this bound in `Fun::F`
-...
 LL |     type F<'a> = Self;
    |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fun::F`
+  --> $DIR/issue-68644-codegen-selection.rs:6:17
+   |
+LL |     type F<'a>: Fn() -> u32;
+   |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Fn<()>> Fun for T {

--- a/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
   --> $DIR/issue-68645-codegen-fulfillment.rs:14:5
    |
-LL |     type F<'a>: Fn() -> u32;
-   |                 ----------- required by this bound in `Fun::F`
-...
 LL |     type F<'a> = Self;
    |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fun::F`
+  --> $DIR/issue-68645-codegen-fulfillment.rs:6:17
+   |
+LL |     type F<'a>: Fn() -> u32;
+   |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::ops::Fn<()>> Fun for T {

--- a/src/test/ui/generic-associated-types/issue-68656-unsized-values.stderr
+++ b/src/test/ui/generic-associated-types/issue-68656-unsized-values.stderr
@@ -1,9 +1,6 @@
 error[E0271]: type mismatch resolving `<T as Deref>::Target == T`
   --> $DIR/issue-68656-unsized-values.rs:15:5
    |
-LL |     type Item<'a>: std::ops::Deref<Target = T>;
-   |                                    ---------- required by this bound in `UnsafeCopy::Item`
-...
 LL | impl<T: Copy + std::ops::Deref> UnsafeCopy<T> for T {
    |      - this type parameter
 LL |     type Item<'a> = T;
@@ -11,6 +8,11 @@ LL |     type Item<'a> = T;
    |
    = note: expected type parameter `T`
              found associated type `<T as Deref>::Target`
+note: required by a bound in `UnsafeCopy::Item`
+  --> $DIR/issue-68656-unsized-values.rs:6:36
+   |
+LL |     type Item<'a>: std::ops::Deref<Target = T>;
+   |                                    ^^^^^^^^^^ required by this bound in `UnsafeCopy::Item`
 help: consider further restricting this bound
    |
 LL | impl<T: Copy + std::ops::Deref + Deref<Target = T>> UnsafeCopy<T> for T {

--- a/src/test/ui/generic-associated-types/issue-74684-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-2.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
   --> $DIR/issue-74684-2.rs:23:5
    |
-LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
-   |                            ------------ required by this bound in `bug`
-...
 LL |     bug(Box::new(x));
    |     ^^^ expected slice `[u8]`, found `i32`
+   |
+note: required by a bound in `bug`
+  --> $DIR/issue-74684-2.rs:13:28
+   |
+LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |                            ^^^^^^^^^^^^ required by this bound in `bug`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-74816.stderr
+++ b/src/test/ui/generic-associated-types/issue-74816.stderr
@@ -2,11 +2,13 @@ error[E0277]: the trait bound `Self: Trait1` is not satisfied
   --> $DIR/issue-74816.rs:9:5
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^------^^^^^^^^
-   |     |                |
-   |     |                required by this bound in `Trait2::Associated`
-   |     the trait `Trait1` is not implemented for `Self`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait1` is not implemented for `Self`
    |
+note: required by a bound in `Trait2::Associated`
+  --> $DIR/issue-74816.rs:9:22
+   |
+LL |     type Associated: Trait1 = Self;
+   |                      ^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
 LL | trait Trait2: Trait1 {
@@ -16,11 +18,13 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
   --> $DIR/issue-74816.rs:9:5
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     doesn't have a size known at compile-time
-   |     required by this bound in `Trait2::Associated`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
+note: required by a bound in `Trait2::Associated`
+  --> $DIR/issue-74816.rs:9:5
+   |
+LL |     type Associated: Trait1 = Self;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
 LL | trait Trait2: Sized {

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -2,21 +2,26 @@ error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
   --> $DIR/issue-74824.rs:7:5
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |     ^^^^^^^^^^^^^^----^^^^^^^^^^
-   |     |             |
-   |     |             required by this bound in `UnsafeCopy::Copy`
-   |     the trait `Copy` is not implemented for `Box<T>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<T>`
+   |
+note: required by a bound in `UnsafeCopy::Copy`
+  --> $DIR/issue-74824.rs:7:19
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/issue-74824.rs:7:5
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |     ^^^^^^^^^^^^^^----^^^^^^^^^^
-   |     |             |
-   |     |             required by this bound in `UnsafeCopy::Copy`
-   |     the trait `Clone` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
    |
    = note: required because of the requirements on the impl of `Clone` for `Box<T>`
+note: required by a bound in `UnsafeCopy::Copy`
+  --> $DIR/issue-74824.rs:7:19
+   |
+LL |     type Copy<T>: Copy = Box<T>;
+   |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 help: consider restricting type parameter `T`
    |
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;

--- a/src/test/ui/generic-associated-types/projection-bound-cycle-generic.stderr
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle-generic.stderr
@@ -1,11 +1,14 @@
 error[E0275]: overflow evaluating the requirement `<T as Foo>::Item: Sized`
   --> $DIR/projection-bound-cycle-generic.rs:44:18
    |
-LL |     type Item: Sized where <Self as Foo>::Item: Sized;
-   |                                                 ----- required by this bound in `Foo::Item`
-...
 LL |     type Assoc = OnlySized<<T as Foo>::Item>;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `Foo::Item`
+  --> $DIR/projection-bound-cycle-generic.rs:11:49
+   |
+LL |     type Item: Sized where <Self as Foo>::Item: Sized;
+   |                                                 ^^^^^ required by this bound in `Foo::Item`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/projection-bound-cycle.stderr
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle.stderr
@@ -1,11 +1,14 @@
 error[E0275]: overflow evaluating the requirement `<T as Foo>::Item: Sized`
   --> $DIR/projection-bound-cycle.rs:46:18
    |
-LL |     type Item: Sized where <Self as Foo>::Item: Sized;
-   |                                                 ----- required by this bound in `Foo::Item`
-...
 LL |     type Assoc = OnlySized<<T as Foo>::Item>;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `Foo::Item`
+  --> $DIR/projection-bound-cycle.rs:13:49
+   |
+LL |     type Item: Sized where <Self as Foo>::Item: Sized;
+   |                                                 ^^^^^ required by this bound in `Foo::Item`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:19:6
    |
-LL | trait Tsized<P: Sized = [Self]> {}
-   |              - required by this bound in `Tsized`
-LL | 
 LL | impl Tsized for () {}
    |      ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
+note: required by a bound in `Tsized`
+  --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:14
+   |
+LL | trait Tsized<P: Sized = [Self]> {}
+   |              ^ required by this bound in `Tsized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:26
    |
-LL | fn want_bar_for_any_ccx<B>(b: &B)
-   |    -------------------- required by a bound in this
-LL |     where B : for<'ccx> Bar<'ccx>
-   |               ------------------- required by this bound in `want_bar_for_any_ccx`
-...
 LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
    |
+note: required by a bound in `want_bar_for_any_ccx`
+  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:32:15
+   |
+LL | fn want_bar_for_any_ccx<B>(b: &B)
+   |    -------------------- required by a bound in this
+LL |     where B : for<'ccx> Bar<'ccx>
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound
    |
 LL |     where B : Qux + for<'ccx> Bar<'ccx>

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -3,12 +3,14 @@ error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
    |
 LL |     want_foo_for_any_tcx(f);
    |                          ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
-...
+   |
+note: required by a bound in `want_foo_for_any_tcx`
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:22:15
+   |
 LL | fn want_foo_for_any_tcx<F>(f: &F)
    |    -------------------- required by a bound in this
 LL |     where F : for<'tcx> Foo<'tcx>
-   |               ------------------- required by this bound in `want_foo_for_any_tcx`
-   |
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_foo_for_any_tcx`
 help: consider further restricting this bound
    |
 LL |     where F : Foo<'x> + for<'tcx> Foo<'tcx>
@@ -19,12 +21,14 @@ error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
    |
 LL |     want_bar_for_any_ccx(b);
    |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
-...
+   |
+note: required by a bound in `want_bar_for_any_ccx`
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:39:15
+   |
 LL | fn want_bar_for_any_ccx<B>(b: &B)
    |    -------------------- required by a bound in this
 LL |     where B : for<'ccx> Bar<'ccx>
-   |               ------------------- required by this bound in `want_bar_for_any_ccx`
-   |
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
 help: consider further restricting this bound
    |
 LL |     where B : Bar<'x> + for<'ccx> Bar<'ccx>

--- a/src/test/ui/impl-trait/auto-trait-leak2.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak2.stderr
@@ -4,22 +4,21 @@ error[E0277]: `Rc<Cell<i32>>` cannot be sent between threads safely
 LL | fn before() -> impl Fn(i32) {
    |                ------------ within this `impl Fn<(i32,)>`
 ...
-LL | fn send<T: Send>(_: T) {}
-   |            ---- required by this bound in `send`
-...
 LL |     send(before());
    |     ^^^^ `Rc<Cell<i32>>` cannot be sent between threads safely
    |
    = help: within `impl Fn<(i32,)>`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
    = note: required because it appears within the type `[closure@$DIR/auto-trait-leak2.rs:7:5: 7:22]`
    = note: required because it appears within the type `impl Fn<(i32,)>`
+note: required by a bound in `send`
+  --> $DIR/auto-trait-leak2.rs:10:12
+   |
+LL | fn send<T: Send>(_: T) {}
+   |            ^^^^ required by this bound in `send`
 
 error[E0277]: `Rc<Cell<i32>>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak2.rs:16:5
    |
-LL | fn send<T: Send>(_: T) {}
-   |            ---- required by this bound in `send`
-...
 LL |     send(after());
    |     ^^^^ `Rc<Cell<i32>>` cannot be sent between threads safely
 ...
@@ -29,6 +28,11 @@ LL | fn after() -> impl Fn(i32) {
    = help: within `impl Fn<(i32,)>`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
    = note: required because it appears within the type `[closure@$DIR/auto-trait-leak2.rs:24:5: 24:22]`
    = note: required because it appears within the type `impl Fn<(i32,)>`
+note: required by a bound in `send`
+  --> $DIR/auto-trait-leak2.rs:10:12
+   |
+LL | fn send<T: Send>(_: T) {}
+   |            ^^^^ required by this bound in `send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/issue-86162-1.stderr
+++ b/src/test/ui/inference/issue-86162-1.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-86162-1.rs:7:5
    |
-LL | fn foo(x: impl Clone) {}
-   |                ----- required by this bound in `foo`
-...
 LL |     foo(gen()); //<- Do not suggest `foo::<impl Clone>()`!
    |     ^^^ cannot infer type for type parameter `impl Clone` declared on the function `foo`
    |
    = note: cannot satisfy `_: Clone`
+note: required by a bound in `foo`
+  --> $DIR/issue-86162-1.rs:3:16
+   |
+LL | fn foo(x: impl Clone) {}
+   |                ^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference/issue-86162-2.stderr
+++ b/src/test/ui/inference/issue-86162-2.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-86162-2.rs:12:5
    |
-LL |     fn bar(x: impl Clone) {}
-   |                    ----- required by this bound in `Foo::bar`
-...
 LL |     Foo::bar(gen()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
    |     ^^^^^^^^ cannot infer type for type parameter `impl Clone` declared on the associated function `bar`
    |
    = note: cannot satisfy `_: Clone`
+note: required by a bound in `Foo::bar`
+  --> $DIR/issue-86162-2.rs:8:20
+   |
+LL |     fn bar(x: impl Clone) {}
+   |                    ^^^^^ required by this bound in `Foo::bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -4,15 +4,15 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     catch_unwind(|| { x.set(23); });
    |     ^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-  ::: $SRC_DIR/std/src/panic.rs:LL:COL
-   |
-LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
-   |                                        ---------- required by this bound in `catch_unwind`
-   |
    = help: within `Cell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because it appears within the type `Cell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `&Cell<i32>`
    = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:5:18: 5:35]`
+note: required by a bound in `catch_unwind`
+  --> $SRC_DIR/std/src/panic.rs:LL:COL
+   |
+LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+   |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -51,13 +51,15 @@ LL | impl<'self> Serializable<str> for &'self str {
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/issue-10412.rs:6:13
    |
-LL | trait Serializable<'self, T> {
-   |                           - required by this bound in `Serializable`
-...
 LL | impl<'self> Serializable<str> for &'self str {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `Serializable`
+  --> $DIR/issue-10412.rs:1:27
+   |
+LL | trait Serializable<'self, T> {
+   |                           ^ required by this bound in `Serializable`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Serializable<'self, T: ?Sized> {

--- a/src/test/ui/issues/issue-18611.stderr
+++ b/src/test/ui/issues/issue-18611.stderr
@@ -3,9 +3,12 @@ error[E0277]: the trait bound `isize: HasState` is not satisfied
    |
 LL | fn add_state(op: <isize as HasState>::State) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasState` is not implemented for `isize`
-...
+   |
+note: required by a bound in `HasState`
+  --> $DIR/issue-18611.rs:5:1
+   |
 LL | trait HasState {
-   | -------------- required by this bound in `HasState`
+   | ^^^^^^^^^^^^^^ required by this bound in `HasState`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18919.stderr
+++ b/src/test/ui/issues/issue-18919.stderr
@@ -3,11 +3,13 @@ error[E0277]: the size for values of type `dyn for<'r> Fn(&'r isize) -> isize` c
    |
 LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | enum Option<T> {
-   |             - required by this bound in `Option`
    |
    = help: the trait `Sized` is not implemented for `dyn for<'r> Fn(&'r isize) -> isize`
+note: required by a bound in `Option`
+  --> $DIR/issue-18919.rs:7:13
+   |
+LL | enum Option<T> {
+   |             ^ required by this bound in `Option`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-18919.rs:7:13
    |

--- a/src/test/ui/issues/issue-1920-1.stderr
+++ b/src/test/ui/issues/issue-1920-1.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-1920-1.rs:12:20
    |
-LL | fn assert_clone<T>() where T : Clone { }
-   |                                ----- required by this bound in `assert_clone`
-...
 LL |     assert_clone::<foo::issue_1920::S>();
    |                    ^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `S`
+   |
+note: required by a bound in `assert_clone`
+  --> $DIR/issue-1920-1.rs:9:32
+   |
+LL | fn assert_clone<T>() where T : Clone { }
+   |                                ^^^^^ required by this bound in `assert_clone`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-2.stderr
+++ b/src/test/ui/issues/issue-1920-2.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-1920-2.rs:10:20
    |
-LL | fn assert_clone<T>() where T : Clone { }
-   |                                ----- required by this bound in `assert_clone`
-...
 LL |     assert_clone::<bar::S>();
    |                    ^^^^^^ the trait `Clone` is not implemented for `S`
+   |
+note: required by a bound in `assert_clone`
+  --> $DIR/issue-1920-2.rs:7:32
+   |
+LL | fn assert_clone<T>() where T : Clone { }
+   |                                ^^^^^ required by this bound in `assert_clone`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-3.stderr
+++ b/src/test/ui/issues/issue-1920-3.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-1920-3.rs:14:20
    |
-LL | fn assert_clone<T>() where T : Clone { }
-   |                                ----- required by this bound in `assert_clone`
-...
 LL |     assert_clone::<foo::issue_1920::S>();
    |                    ^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `S`
+   |
+note: required by a bound in `assert_clone`
+  --> $DIR/issue-1920-3.rs:11:32
+   |
+LL | fn assert_clone<T>() where T : Clone { }
+   |                                ^^^^^ required by this bound in `assert_clone`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -10,9 +10,6 @@ LL | struct NoData<T>;
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:36
    |
-LL | trait Foo {
-   | --------- required by this bound in `Foo`
-...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^
    |
@@ -24,13 +21,15 @@ LL | impl<T> Foo for T where NoData<T>: Foo {
    |         ^^^     ^
    = note: 127 redundant requirements hidden
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
+note: required by a bound in `Foo`
+  --> $DIR/issue-20413.rs:1:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^ required by this bound in `Foo`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:36
    |
-LL | trait Foo {
-   | --------- required by this bound in `Foo`
-...
 LL | impl<T> Foo for T where NoData<T>: Foo {
    |                                    ^^^
    |
@@ -42,13 +41,15 @@ LL | impl<T> Foo for T where NoData<T>: Foo {
    |         ^^^     ^
    = note: 127 redundant requirements hidden
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
+note: required by a bound in `Foo`
+  --> $DIR/issue-20413.rs:1:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^ required by this bound in `Foo`
 
 error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Baz`
   --> $DIR/issue-20413.rs:28:42
    |
-LL | trait Baz {
-   | --------- required by this bound in `Baz`
-...
 LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    |                                          ^^^
    |
@@ -65,13 +66,15 @@ LL | impl<T> Baz for T where AlmostNoData<T>: Bar {
    |         ^^^     ^
    = note: 126 redundant requirements hidden
    = note: required because of the requirements on the impl of `Baz` for `EvenLessData<T>`
+note: required by a bound in `Baz`
+  --> $DIR/issue-20413.rs:20:1
+   |
+LL | trait Baz {
+   | ^^^^^^^^^ required by this bound in `Baz`
 
 error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Baz`
   --> $DIR/issue-20413.rs:28:42
    |
-LL | trait Baz {
-   | --------- required by this bound in `Baz`
-...
 LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    |                                          ^^^
    |
@@ -88,13 +91,15 @@ LL | impl<T> Baz for T where AlmostNoData<T>: Bar {
    |         ^^^     ^
    = note: 126 redundant requirements hidden
    = note: required because of the requirements on the impl of `Baz` for `EvenLessData<T>`
+note: required by a bound in `Baz`
+  --> $DIR/issue-20413.rs:20:1
+   |
+LL | trait Baz {
+   | ^^^^^^^^^ required by this bound in `Baz`
 
 error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Bar`
   --> $DIR/issue-20413.rs:36:42
    |
-LL | trait Bar {
-   | --------- required by this bound in `Bar`
-...
 LL | impl<T> Baz for T where AlmostNoData<T>: Bar {
    |                                          ^^^
    |
@@ -111,13 +116,15 @@ LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    |         ^^^     ^
    = note: 126 redundant requirements hidden
    = note: required because of the requirements on the impl of `Bar` for `AlmostNoData<T>`
+note: required by a bound in `Bar`
+  --> $DIR/issue-20413.rs:16:1
+   |
+LL | trait Bar {
+   | ^^^^^^^^^ required by this bound in `Bar`
 
 error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Bar`
   --> $DIR/issue-20413.rs:36:42
    |
-LL | trait Bar {
-   | --------- required by this bound in `Bar`
-...
 LL | impl<T> Baz for T where AlmostNoData<T>: Bar {
    |                                          ^^^
    |
@@ -134,6 +141,11 @@ LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    |         ^^^     ^
    = note: 126 redundant requirements hidden
    = note: required because of the requirements on the impl of `Bar` for `AlmostNoData<T>`
+note: required by a bound in `Bar`
+  --> $DIR/issue-20413.rs:16:1
+   |
+LL | trait Bar {
+   | ^^^^^^^^^ required by this bound in `Bar`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -4,12 +4,12 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
 LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[i32]`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-   |                - required by this bound in `Vec`
-   |
-   = help: the trait `Sized` is not implemented for `[i32]`
+   |                ^ required by this bound in `Vec`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -6,11 +6,11 @@ LL | #[derive(Hash)]
 LL | struct Foo(Bar);
    |            ^^^ the trait `Hash` is not implemented for `Bar`
    |
-  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+note: required by a bound in `std::hash::Hash::hash`
+  --> $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
-   |             - required by this bound in `std::hash::Hash::hash`
-   |
+   |             ^ required by this bound in `std::hash::Hash::hash`
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-21763.stderr
+++ b/src/test/ui/issues/issue-21763.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
   --> $DIR/issue-21763.rs:9:5
    |
-LL | fn foo<T: Send>() {}
-   |           ---- required by this bound in `foo`
-...
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
    |
@@ -12,6 +9,11 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    = note: required because of the requirements on the impl of `Send` for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>`
    = note: required because it appears within the type `hashbrown::map::HashMap<Rc<()>, Rc<()>, RandomState>`
    = note: required because it appears within the type `HashMap<Rc<()>, Rc<()>>`
+note: required by a bound in `foo`
+  --> $DIR/issue-21763.rs:6:11
+   |
+LL | fn foo<T: Send>() {}
+   |           ^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Bound` is not satisfied
   --> $DIR/issue-21837.rs:8:20
    |
-LL | pub struct Foo<T: Bound>(T);
-   |                   ----- required by this bound in `Foo`
-...
 LL | impl<T> Trait2 for Foo<T> {}
    |                    ^^^^^^ the trait `Bound` is not implemented for `T`
    |
+note: required by a bound in `Foo`
+  --> $DIR/issue-21837.rs:2:19
+   |
+LL | pub struct Foo<T: Bound>(T);
+   |                   ^^^^^ required by this bound in `Foo`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: Bound> Trait2 for Foo<T> {}

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-21974.rs:11:19
    |
-LL | trait Foo {
-   | --------- required by this bound in `Foo`
-...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot satisfy `&'a T: Foo`
+note: required by a bound in `Foo`
+  --> $DIR/issue-21974.rs:6:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23281.stderr
+++ b/src/test/ui/issues/issue-23281.stderr
@@ -3,11 +3,13 @@ error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known
    |
 LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Vec<T> {
-   |            - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+note: required by a bound in `Vec`
+  --> $DIR/issue-23281.rs:8:12
+   |
+LL | struct Vec<T> {
+   |            ^ required by this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-23281.rs:8:12
    |

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-24424.rs:4:57
    |
-LL | trait Trait0<'l0>  {}
-   | ----------------- required by this bound in `Trait0`
-LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
    |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`
    |
    = note: cannot satisfy `T0: Trait0<'l0>`
+note: required by a bound in `Trait0`
+  --> $DIR/issue-24424.rs:2:1
+   |
+LL | trait Trait0<'l0>  {}
+   | ^^^^^^^^^^^^^^^^^ required by this bound in `Trait0`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `(): InOut<_>` is not satisfied
   --> $DIR/issue-25076.rs:10:20
    |
-LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
-   |                  --------------- required by this bound in `do_fold`
-...
 LL |     do_fold(bot(), ());
    |                    ^^ the trait `InOut<_>` is not implemented for `()`
+   |
+note: required by a bound in `do_fold`
+  --> $DIR/issue-25076.rs:5:18
+   |
+LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
+   |                  ^^^^^^^^^^^^^^^ required by this bound in `do_fold`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32963.stderr
+++ b/src/test/ui/issues/issue-32963.stderr
@@ -23,11 +23,14 @@ LL |     size_of_copy::<dyn Misc + Copy>();
 error[E0277]: the trait bound `dyn Misc: Copy` is not satisfied
   --> $DIR/issue-32963.rs:8:5
    |
-LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
-   |                    ---- required by this bound in `size_of_copy`
-...
 LL |     size_of_copy::<dyn Misc + Copy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `dyn Misc`
+   |
+note: required by a bound in `size_of_copy`
+  --> $DIR/issue-32963.rs:5:20
+   |
+LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
+   |                    ^^^^ required by this bound in `size_of_copy`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-40827.stderr
+++ b/src/test/ui/issues/issue-40827.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `Rc<Foo>` cannot be shared between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
-LL | fn f<T: Send>(_: T) {}
-   |         ---- required by this bound in `f`
-...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `Rc<Foo>` cannot be shared between threads safely
    |
@@ -19,13 +16,15 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo(Arc<Bar>);
    |        ^^^
+note: required by a bound in `f`
+  --> $DIR/issue-40827.rs:11:9
+   |
+LL | fn f<T: Send>(_: T) {}
+   |         ^^^^ required by this bound in `f`
 
 error[E0277]: `Rc<Foo>` cannot be sent between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
-LL | fn f<T: Send>(_: T) {}
-   |         ---- required by this bound in `f`
-...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `Rc<Foo>` cannot be sent between threads safely
    |
@@ -41,6 +40,11 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo(Arc<Bar>);
    |        ^^^
+note: required by a bound in `f`
+  --> $DIR/issue-40827.rs:11:9
+   |
+LL | fn f<T: Send>(_: T) {}
+   |         ^^^^ required by this bound in `f`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -1,17 +1,20 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-43623.rs:16:5
    |
-LL | pub fn break_me<T, F>(f: F)
-   |        -------- required by a bound in this
-...
-LL |     F: for<'b> FnMut(<T as Trait<'b>>::Assoc),
-   |                ------------------------------ required by this bound in `break_me`
-LL | {
 LL |     break_me::<Type, fn(_)>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected signature of `for<'b> fn(<Type as Trait<'b>>::Assoc) -> _`
    |     found signature of `fn(()) -> _`
+   |
+note: required by a bound in `break_me`
+  --> $DIR/issue-43623.rs:14:16
+   |
+LL | pub fn break_me<T, F>(f: F)
+   |        -------- required by a bound in this
+...
+LL |     F: for<'b> FnMut(<T as Trait<'b>>::Assoc),
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `break_me`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-43784-supertrait.rs:8:9
    |
-LL | pub trait Complete: Partial {
-   |                     ------- required by this bound in `Complete`
-...
 LL | impl<T> Complete for T {}
    |         ^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `Complete`
+  --> $DIR/issue-43784-supertrait.rs:4:21
+   |
+LL | pub trait Complete: Partial {
+   |                     ^^^^^^^ required by this bound in `Complete`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Complete for T {}

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -13,14 +13,17 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
 LL |     Bar(i32),
    |     -------- takes 1 argument
 ...
+LL |     foo(Qux::Bar);
+   |         ^^^^^^^^ expected function that takes 0 arguments
+   |
+note: required by a bound in `foo`
+  --> $DIR/issue-47706.rs:22:8
+   |
 LL | fn foo<F>(f: F)
    |    --- required by a bound in this
 LL | where
 LL |     F: Fn(),
-   |        ---- required by this bound in `foo`
-...
-LL |     foo(Qux::Bar);
-   |         ^^^^^^^^ expected function that takes 0 arguments
+   |        ^^^^ required by this bound in `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -9,11 +9,13 @@ error[E0283]: type annotations needed
    |
 LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-...
-LL |     const fn const_val<T: Sized>() -> usize {
-   |                        - required by this bound in `Tt::const_val`
    |
    = note: cannot satisfy `_: Tt`
+note: required by a bound in `Tt::const_val`
+  --> $DIR/issue-54954.rs:5:24
+   |
+LL |     const fn const_val<T: Sized>() -> usize {
+   |                        ^ required by this bound in `Tt::const_val`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-59494.stderr
+++ b/src/test/ui/issues/issue-59494.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<(_,)>` closure, found `impl Fn<(((_, _), _),)>`
   --> $DIR/issue-59494.rs:21:22
    |
-LL | fn t8n<A, B, C>(f: impl Fn(A) -> B, g: impl Fn(A) -> C) -> impl Fn(A) -> (B, C)
-   |                                             ---------- required by this bound in `t8n`
-...
 LL |     let t8 = t8n(t7, t7p(f, g));
    |                      ^^^^^^^^^ expected an `Fn<(_,)>` closure, found `impl Fn<(((_, _), _),)>`
    |
    = help: the trait `Fn<(_,)>` is not implemented for `impl Fn<(((_, _), _),)>`
+note: required by a bound in `t8n`
+  --> $DIR/issue-59494.rs:5:45
+   |
+LL | fn t8n<A, B, C>(f: impl Fn(A) -> B, g: impl Fn(A) -> C) -> impl Fn(A) -> (B, C)
+   |                                             ^^^^^^^^^^ required by this bound in `t8n`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-60218.stderr
+++ b/src/test/ui/issues/issue-60218.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `for<'t> <Map<<&'t _ as IntoIterator>::IntoIter, _> as Iterator>::Item: Foo` is not satisfied
   --> $DIR/issue-60218.rs:18:5
    |
+LL |     trigger_error(vec![], |x: &u32| x)
+   |     ^^^^^^^^^^^^^ the trait `for<'t> Foo` is not implemented for `<Map<<&'t _ as IntoIterator>::IntoIter, _> as Iterator>::Item`
+   |
+note: required by a bound in `trigger_error`
+  --> $DIR/issue-60218.rs:13:72
+   |
 LL | pub fn trigger_error<I, F>(iterable: I, functor: F)
    |        ------------- required by a bound in this
 ...
 LL | for<'t> <Map<<&'t I as IntoIterator>::IntoIter, F> as Iterator>::Item: Foo,
-   |                                                                        --- required by this bound in `trigger_error`
-...
-LL |     trigger_error(vec![], |x: &u32| x)
-   |     ^^^^^^^^^^^^^ the trait `for<'t> Foo` is not implemented for `<Map<<&'t _ as IntoIterator>::IntoIter, _> as Iterator>::Item`
+   |                                                                        ^^^ required by this bound in `trigger_error`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -1,17 +1,20 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-60283.rs:17:13
    |
-LL | pub fn foo<T, F>(_: T, _: F)
-   |        --- required by a bound in this
-...
-LL |     F: for<'a> FnMut(<T as Trait<'a>>::Item),
-   |                ----------------------------- required by this bound in `foo`
-...
 LL |     foo((), drop)
    |             ^^^^
    |             |
    |             expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
    |             found signature of `fn(()) -> _`
+   |
+note: required by a bound in `foo`
+  --> $DIR/issue-60283.rs:12:16
+   |
+LL | pub fn foo<T, F>(_: T, _: F)
+   |        --- required by a bound in this
+...
+LL |     F: for<'a> FnMut(<T as Trait<'a>>::Item),
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
 
 error[E0277]: the size for values of type `<() as Trait<'_>>::Item` cannot be known at compilation time
   --> $DIR/issue-60283.rs:17:13
@@ -19,12 +22,12 @@ error[E0277]: the size for values of type `<() as Trait<'_>>::Item` cannot be kn
 LL |     foo((), drop)
    |             ^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `<() as Trait<'_>>::Item`
+note: required by a bound in `std::mem::drop`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub fn drop<T>(_x: T) {}
-   |             - required by this bound in `std::mem::drop`
-   |
-   = help: the trait `Sized` is not implemented for `<() as Trait<'_>>::Item`
+   |             ^ required by this bound in `std::mem::drop`
 help: consider further restricting the associated type
    |
 LL | fn main() where <() as Trait<'_>>::Item: Sized {

--- a/src/test/ui/issues/issue-87199.stderr
+++ b/src/test/ui/issues/issue-87199.stderr
@@ -19,13 +19,15 @@ LL | fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/issue-87199.rs:18:22
    |
-LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            - required by this bound in `ref_arg`
-...
 LL |     ref_arg::<[i32]>(&[5]);
    |                      ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
+note: required by a bound in `ref_arg`
+  --> $DIR/issue-87199.rs:10:12
+   |
+LL | fn ref_arg<T: ?Send>(_: &T) {}
+   |            ^ required by this bound in `ref_arg`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -1,13 +1,16 @@
 error[E0277]: `u8` is not an iterator
   --> $DIR/bound.rs:2:10
    |
-LL | struct S<I: Iterator>(I);
-   |             -------- required by this bound in `S`
 LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `u8`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+note: required by a bound in `S`
+  --> $DIR/bound.rs:1:13
+   |
+LL | struct S<I: Iterator>(I);
+   |             ^^^^^^^^ required by this bound in `S`
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -1,107 +1,138 @@
 error[E0277]: the trait bound `&'static mut isize: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:27:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<&'static mut isize>();
    |                   ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `&'static mut isize`
    |
    = help: the following implementations were found:
              <isize as Copy>
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `&'a mut isize: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:28:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<&'a mut isize>();
    |                   ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `&'a mut isize`
    |
    = help: the following implementations were found:
              <isize as Copy>
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Box<isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:31:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Box<isize>>();
    |                   ^^^^^^^^^^ the trait `Copy` is not implemented for `Box<isize>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:32:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<String>();
    |                   ^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Vec<isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:33:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Vec<isize> >();
    |                   ^^^^^^^^^^ the trait `Copy` is not implemented for `Vec<isize>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Box<&'a mut isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:34:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Box<&'a mut isize>>();
    |                   ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<&'a mut isize>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Box<dyn Dummy>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:42:5
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<dyn Dummy>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Box<dyn Dummy + Send>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:43:5
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Box<dyn Dummy + Send>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<dyn Dummy + Send>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `&'a mut (dyn Dummy + Send + 'a): Copy` is not satisfied
   --> $DIR/kindck-copy.rs:46:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<&'a mut (dyn Dummy + Send)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `&'a mut (dyn Dummy + Send + 'a)`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `MyNoncopyStruct: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:64:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<MyNoncopyStruct>();
    |                   ^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `MyNoncopyStruct`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error[E0277]: the trait bound `Rc<isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:67:19
    |
-LL | fn assert_copy<T:Copy>() { }
-   |                  ---- required by this bound in `assert_copy`
-...
 LL |     assert_copy::<Rc<isize>>();
    |                   ^^^^^^^^^ the trait `Copy` is not implemented for `Rc<isize>`
+   |
+note: required by a bound in `assert_copy`
+  --> $DIR/kindck-copy.rs:5:18
+   |
+LL | fn assert_copy<T:Copy>() { }
+   |                  ^^^^ required by this bound in `assert_copy`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
-LL | fn take_param<T:Foo>(foo: &T) { }
-   |                 --- required by this bound in `take_param`
-...
 LL |     take_param(&x);
    |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Foo` for `Box<{intege
    |
 LL | impl<T:Copy> Foo for T {
    |              ^^^     ^
+note: required by a bound in `take_param`
+  --> $DIR/kindck-impl-type-params-2.rs:9:17
+   |
+LL | fn take_param<T:Foo>(foo: &T) { }
+   |                 ^^^ required by this bound in `take_param`
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
-LL | fn take_param<T:Foo>(foo: &T) { }
-   |                 --- required by this bound in `take_param`
-...
 LL |     take_param(&x);
    |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Foo` for `Box<{intege
    |
 LL | impl<T:Copy> Foo for T {
    |              ^^^     ^
+note: required by a bound in `take_param`
+  --> $DIR/kindck-inherited-copy-bound.rs:17:17
+   |
+LL | fn take_param<T:Foo>(foo: &T) { }
+   |                 ^^^ required by this bound in `take_param`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:19

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
-LL | fn take_param<T:Foo>(foo: &T) { }
-   |                 --- required by this bound in `take_param`
-...
 LL |     take_param(&x);
    |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Foo` for `Box<{intege
    |
 LL | impl<T:Copy> Foo for T {
    |              ^^^     ^
+note: required by a bound in `take_param`
+  --> $DIR/kindck-inherited-copy-bound.rs:17:17
+   |
+LL | fn take_param<T:Foo>(foo: &T) { }
+   |                 ^^^ required by this bound in `take_param`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:28:13

--- a/src/test/ui/kindck/kindck-nonsendable-1.stderr
+++ b/src/test/ui/kindck/kindck-nonsendable-1.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `Rc<usize>` cannot be sent between threads safely
   --> $DIR/kindck-nonsendable-1.rs:9:5
    |
-LL | fn bar<F:FnOnce() + Send>(_: F) { }
-   |                     ---- required by this bound in `bar`
-...
 LL |     bar(move|| foo(x));
    |     ^^^ ------------- within this `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22]`
    |     |
@@ -11,6 +8,11 @@ LL |     bar(move|| foo(x));
    |
    = help: within `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22]`, the trait `Send` is not implemented for `Rc<usize>`
    = note: required because it appears within the type `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22]`
+note: required by a bound in `bar`
+  --> $DIR/kindck-nonsendable-1.rs:5:21
+   |
+LL | fn bar<F:FnOnce() + Send>(_: F) { }
+   |                     ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-send-object.stderr
+++ b/src/test/ui/kindck/kindck-send-object.stderr
@@ -1,27 +1,31 @@
 error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object.rs:12:5
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
    = note: required because of the requirements on the impl of `Send` for `&'static (dyn Dummy + 'static)`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object.rs:5:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object.rs:17:5
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
    = note: required because of the requirements on the impl of `Send` for `Unique<dyn Dummy>`
    = note: required because it appears within the type `Box<dyn Dummy>`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object.rs:5:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object1.nll.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.nll.stderr
@@ -1,27 +1,31 @@
 error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
-LL | fn assert_send<T:Send+'static>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `Send` for `&'a (dyn Dummy + 'a)`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object1.rs:5:18
+   |
+LL | fn assert_send<T:Send+'static>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
-LL | fn assert_send<T:Send+'static>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `Send` for `Unique<(dyn Dummy + 'a)>`
    = note: required because it appears within the type `Box<(dyn Dummy + 'a)>`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object1.rs:5:18
+   |
+LL | fn assert_send<T:Send+'static>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object1.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.stderr
@@ -1,14 +1,16 @@
 error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
-LL | fn assert_send<T:Send+'static>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `Send` for `&'a (dyn Dummy + 'a)`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object1.rs:5:18
+   |
+LL | fn assert_send<T:Send+'static>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error[E0477]: the type `&'a (dyn Dummy + Sync + 'a)` does not fulfill the required lifetime
   --> $DIR/kindck-send-object1.rs:14:5
@@ -25,15 +27,17 @@ LL | fn assert_send<T:Send+'static>() { }
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
-LL | fn assert_send<T:Send+'static>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `Send` for `Unique<(dyn Dummy + 'a)>`
    = note: required because it appears within the type `Box<(dyn Dummy + 'a)>`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object1.rs:5:18
+   |
+LL | fn assert_send<T:Send+'static>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object2.stderr
+++ b/src/test/ui/kindck/kindck-send-object2.stderr
@@ -1,27 +1,31 @@
 error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object2.rs:7:5
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<&'static dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
    = note: required because of the requirements on the impl of `Send` for `&'static (dyn Dummy + 'static)`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object2.rs:3:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object2.rs:12:5
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn Dummy`
    = note: required because of the requirements on the impl of `Send` for `Unique<dyn Dummy>`
    = note: required because it appears within the type `Box<dyn Dummy>`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-object2.rs:3:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-owned.stderr
+++ b/src/test/ui/kindck/kindck-send-owned.stderr
@@ -1,15 +1,17 @@
 error[E0277]: `*mut u8` cannot be sent between threads safely
   --> $DIR/kindck-send-owned.rs:12:5
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<Box<*mut u8>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut u8`
    = note: required because of the requirements on the impl of `Send` for `Unique<*mut u8>`
    = note: required because it appears within the type `Box<*mut u8>`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-owned.rs:3:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-send-unsafe.stderr
+++ b/src/test/ui/kindck/kindck-send-unsafe.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `*mut &'a isize` cannot be sent between threads safely
   --> $DIR/kindck-send-unsafe.rs:6:19
    |
-LL | fn assert_send<T:Send>() { }
-   |                  ---- required by this bound in `assert_send`
-...
 LL |     assert_send::<*mut &'a isize>();
    |                   ^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `*mut &'a isize`
+note: required by a bound in `assert_send`
+  --> $DIR/kindck-send-unsafe.rs:3:18
+   |
+LL | fn assert_send<T:Send>() { }
+   |                  ^^^^ required by this bound in `assert_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/issue-34979.stderr
+++ b/src/test/ui/lifetimes/issue-34979.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-34979.rs:6:13
    |
-LL | trait Foo {}
-   | --------- required by this bound in `Foo`
-...
 LL |     &'a (): Foo,
    |             ^^^ cannot infer type for reference `&'a ()`
    |
    = note: cannot satisfy `&'a (): Foo`
+note: required by a bound in `Foo`
+  --> $DIR/issue-34979.rs:1:1
+   |
+LL | trait Foo {}
+   | ^^^^^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -22,11 +22,11 @@ error[E0277]: the trait bound `Test1: Clone` is not satisfied
 LL | #[derive(Copy(Bad))]
    |          ^^^^ the trait `Clone` is not implemented for `Test1`
    |
-  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+note: required by a bound in `Copy`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {
-   |                 ----- required by this bound in `Copy`
-   |
+   |                 ^^^^^ required by this bound in `Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Test2: Clone` is not satisfied
@@ -35,11 +35,11 @@ error[E0277]: the trait bound `Test2: Clone` is not satisfied
 LL | #[derive(Copy="bad")]
    |          ^^^^ the trait `Clone` is not implemented for `Test2`
    |
-  ::: $SRC_DIR/core/src/marker.rs:LL:COL
+note: required by a bound in `Copy`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
    |
 LL | pub trait Copy: Clone {
-   |                 ----- required by this bound in `Copy`
-   |
+   |                 ^^^^^ required by this bound in `Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:27:17
    |
-LL | fn is_marker<T: Marker>() { }
-   |                 ------ required by this bound in `is_marker`
-...
 LL |     is_marker::<NotDebugOrDisplay>();
    |                 ^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`
+   |
+note: required by a bound in `is_marker`
+  --> $DIR/overlap-marker-trait.rs:15:17
+   |
+LL | fn is_marker<T: Marker>() { }
+   |                 ^^^^^^ required by this bound in `is_marker`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -52,13 +52,15 @@ LL |     [u8; size_of::<T>() + 1]: ,
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
   --> $DIR/issue-80742.rs:31:15
    |
-LL | struct Inline<T>
-   |               - required by this bound in `Inline`
-...
 LL |     let dst = Inline::<dyn Debug>::new(0);
    |               ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
+note: required by a bound in `Inline`
+  --> $DIR/issue-80742.rs:13:15
+   |
+LL | struct Inline<T>
+   |               ^ required by this bound in `Inline`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | struct Inline<T: ?Sized>

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -1,48 +1,60 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
-LL | fn foo<F: Fn(usize)>(_: F) {}
-   |           --------- required by this bound in `foo`
-...
 LL |     foo(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
+   |
+note: required by a bound in `foo`
+  --> $DIR/E0631.rs:3:11
+   |
+LL | fn foo<F: Fn(usize)>(_: F) {}
+   |           ^^^^^^^^^ required by this bound in `foo`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   |           --------- required by this bound in `bar`
-...
 LL |     bar(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
+   |
+note: required by a bound in `bar`
+  --> $DIR/E0631.rs:4:11
+   |
+LL | fn bar<F: Fn<usize>>(_: F) {}
+   |           ^^^^^^^^^ required by this bound in `bar`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:9
    |
-LL | fn foo<F: Fn(usize)>(_: F) {}
-   |           --------- required by this bound in `foo`
-...
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     foo(f);
    |         ^ expected signature of `fn(usize) -> _`
+   |
+note: required by a bound in `foo`
+  --> $DIR/E0631.rs:3:11
+   |
+LL | fn foo<F: Fn(usize)>(_: F) {}
+   |           ^^^^^^^^^ required by this bound in `foo`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:9
    |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   |           --------- required by this bound in `bar`
-LL | fn main() {
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     bar(f);
    |         ^ expected signature of `fn(usize) -> _`
+   |
+note: required by a bound in `bar`
+  --> $DIR/E0631.rs:4:11
+   |
+LL | fn bar<F: Fn<usize>>(_: F) {}
+   |           ^^^^^^^^^ required by this bound in `bar`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -48,14 +48,16 @@ LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
 error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   |         --------- required by this bound in `f`
-...
 LL |     f(|| panic!());
    |     ^ -- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
    |
+note: required by a bound in `f`
+  --> $DIR/closure-arg-count.rs:3:9
+   |
+LL | fn f<F: Fn<usize>>(_: F) {}
+   |         ^^^^^^^^^ required by this bound in `f`
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(|_| panic!());
@@ -64,14 +66,16 @@ LL |     f(|_| panic!());
 error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   |         --------- required by this bound in `f`
-...
 LL |     f(  move    || panic!());
    |     ^   ---------- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
    |
+note: required by a bound in `f`
+  --> $DIR/closure-arg-count.rs:3:9
+   |
+LL | fn f<F: Fn<usize>>(_: F) {}
+   |         ^^^^^^^^^ required by this bound in `f`
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(  move    |_| panic!());
@@ -149,10 +153,14 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
 LL |     call(Foo);
    |          ^^^ expected function that takes 0 arguments
 ...
-LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
-   |                              ------------- required by this bound in `call`
 LL | struct Foo(u8);
    | --------------- takes 1 argument
+   |
+note: required by a bound in `call`
+  --> $DIR/closure-arg-count.rs:42:30
+   |
+LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
+   |                              ^^^^^^^^^^^^^ required by this bound in `call`
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -3,12 +3,15 @@ error[E0631]: type mismatch in function arguments
    |
 LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
-LL | 
-LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   |                                     --------- required by this bound in `apply`
 ...
 LL |     apply(&3, takes_mut);
    |               ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
+   |
+note: required by a bound in `apply`
+  --> $DIR/fn-variance-1.rs:5:37
+   |
+LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
+   |                                     ^^^^^^^^^ required by this bound in `apply`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:15:19
@@ -16,11 +19,14 @@ error[E0631]: type mismatch in function arguments
 LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
-LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   |                                     --------- required by this bound in `apply`
-...
 LL |     apply(&mut 3, takes_imm);
    |                   ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |
+note: required by a bound in `apply`
+  --> $DIR/fn-variance-1.rs:5:37
+   |
+LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
+   |                                     ^^^^^^^^^ required by this bound in `apply`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -6,6 +6,7 @@ fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
 
 fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
 //~^ NOTE required by this bound in `call_it`
+//~| NOTE required by a bound in `call_it`
     f(2, y)
 }
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -1,14 +1,17 @@
 error[E0631]: type mismatch in closure arguments
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:15:24
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:16:24
    |
-LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   |              ------------------------- required by this bound in `call_it`
-...
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`
 LL |
 LL |     let z = call_it(3, f);
    |                        ^ expected signature of `fn(isize, isize) -> _`
+   |
+note: required by a bound in `call_it`
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:14
+   |
+LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mut/mutable-enum-indirect.stderr
+++ b/src/test/ui/mut/mutable-enum-indirect.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/mutable-enum-indirect.rs:17:5
    |
-LL | fn bar<T: Sync>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(&x);
    |     ^^^ `NoSync` cannot be shared between threads safely
    |
@@ -14,6 +11,11 @@ note: required because it appears within the type `Foo`
 LL | enum Foo { A(NoSync) }
    |      ^^^
    = note: required because it appears within the type `&Foo`
+note: required by a bound in `bar`
+  --> $DIR/mutable-enum-indirect.rs:13:11
+   |
+LL | fn bar<T: Sync>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -1,14 +1,16 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
   --> $DIR/mutexguard-sync.rs:11:15
    |
-LL | fn test_sync<T: Sync>(_t: T) {}
-   |                 ---- required by this bound in `test_sync`
-...
 LL |     test_sync(guard);
    |               ^^^^^ `Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Cell<i32>`
    = note: required because of the requirements on the impl of `Sync` for `MutexGuard<'_, Cell<i32>>`
+note: required by a bound in `test_sync`
+  --> $DIR/mutexguard-sync.rs:5:17
+   |
+LL | fn test_sync<T: Sync>(_t: T) {}
+   |                 ^^^^ required by this bound in `test_sync`
 
 error: aborting due to previous error
 

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -99,398 +99,530 @@ LL | use xm8::V;
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m1::S{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m2::S{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m2::S);
    |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:39:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm1::S{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:41:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm2::S{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:42:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm2::S);
    |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m3::TS{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:56:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m3::TS);
    |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m4::TS{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m4::TS);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:61:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm3::TS{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:62:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm3::TS);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:63:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm4::TS{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:64:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm4::TS);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m5::US{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m5::US);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m6::US{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m6::US);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:83:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm5::US{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:84:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm5::US);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:85:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm6::US{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:86:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm6::US);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m7::V{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m8::V{});
    |           ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m8::V);
    |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:105:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm7::V{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:107:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm8::V{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:108:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm8::V);
    |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m9::TV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:122:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(m9::TV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mA::TV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mA::TV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:127:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm9::TV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:128:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xm9::TV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:129:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmA::TV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:130:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmA::TV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mB::UV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mB::UV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mC::UV{});
    |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(mC::UV);
    |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:149:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmB::UV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:150:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmB::UV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:151:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmC::UV{});
    |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:152:11
    |
-LL | fn check<T: Impossible>(_: T) {}
-   |             ---------- required by this bound in `check`
-...
 LL |     check(xmC::UV);
    |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |
+note: required by a bound in `check`
+  --> $DIR/namespace-mix.rs:21:13
+   |
+LL | fn check<T: Impossible>(_: T) {}
+   |             ^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/never_type/defaulted-never-note.rs
+++ b/src/test/ui/never_type/defaulted-never-note.rs
@@ -20,7 +20,7 @@ impl ImplementedForUnitButNotNever for () {}
 
 fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 //~^ NOTE required by this bound in `foo`
-
+//~| NOTE required by a bound in `foo`
 fn smeg() {
     let _x = return;
     foo(_x);

--- a/src/test/ui/never_type/defaulted-never-note.stderr
+++ b/src/test/ui/never_type/defaulted-never-note.stderr
@@ -1,15 +1,17 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
   --> $DIR/defaulted-never-note.rs:26:5
    |
-LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-   |           ----------------------------- required by this bound in `foo`
-...
 LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
    |
    = note: this trait is implemented for `()`.
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information).
    = help: did you intend to use the type `()` here instead?
+note: required by a bound in `foo`
+  --> $DIR/defaulted-never-note.rs:21:11
+   |
+LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/never_type/issue-51506.stderr
+++ b/src/test/ui/never_type/issue-51506.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `!` is not an iterator
   --> $DIR/issue-51506.rs:13:5
    |
-LL |     type Out: Iterator<Item = u32>;
-   |               -------------------- required by this bound in `Trait::Out`
-...
 LL |     default type Out = !;
    |     ^^^^^^^^^^^^^^^^^^^^^ `!` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `!`
+note: required by a bound in `Trait::Out`
+  --> $DIR/issue-51506.rs:7:15
+   |
+LL |     type Out: Iterator<Item = u32>;
+   |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait::Out`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no-send-res-ports.stderr
+++ b/src/test/ui/no-send-res-ports.stderr
@@ -11,11 +11,6 @@ LL | |         println!("{:?}", y);
 LL | |     });
    | |_____- within this `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6]`
    |
-  ::: $SRC_DIR/std/src/thread/mod.rs:LL:COL
-   |
-LL |       F: Send + 'static,
-   |          ---- required by this bound in `spawn`
-   |
    = help: within `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6]`, the trait `Send` is not implemented for `Rc<()>`
 note: required because it appears within the type `Port<()>`
   --> $DIR/no-send-res-ports.rs:5:8
@@ -28,6 +23,11 @@ note: required because it appears within the type `Foo`
 LL |     struct Foo {
    |            ^^^
    = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6]`
+note: required by a bound in `spawn`
+  --> $SRC_DIR/std/src/thread/mod.rs:LL:COL
+   |
+LL |     F: Send + 'static,
+   |        ^^^^ required by this bound in `spawn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-enum.stderr
+++ b/src/test/ui/no_send-enum.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `NoSend` cannot be sent between threads safely
   --> $DIR/no_send-enum.rs:16:5
    |
-LL | fn bar<T: Send>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(x);
    |     ^^^ `NoSend` cannot be sent between threads safely
    |
@@ -13,6 +10,11 @@ note: required because it appears within the type `Foo`
    |
 LL | enum Foo {
    |      ^^^
+note: required by a bound in `bar`
+  --> $DIR/no_send-enum.rs:12:11
+   |
+LL | fn bar<T: Send>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/no_send-rc.rs:7:9
    |
-LL | fn bar<T: Send>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(x);
    |         ^ `Rc<{integer}>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
+note: required by a bound in `bar`
+  --> $DIR/no_send-rc.rs:3:11
+   |
+LL | fn bar<T: Send>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `Foo` cannot be sent between threads safely
   --> $DIR/no_send-struct.rs:15:9
    |
-LL | fn bar<T: Send>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(x);
    |         ^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo`
+note: required by a bound in `bar`
+  --> $DIR/no_send-struct.rs:11:11
+   |
+LL | fn bar<T: Send>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_share-enum.stderr
+++ b/src/test/ui/no_share-enum.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/no_share-enum.rs:14:5
    |
-LL | fn bar<T: Sync>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(x);
    |     ^^^ `NoSync` cannot be shared between threads safely
    |
@@ -13,6 +10,11 @@ note: required because it appears within the type `Foo`
    |
 LL | enum Foo { A(NoSync) }
    |      ^^^
+note: required by a bound in `bar`
+  --> $DIR/no_share-enum.rs:10:11
+   |
+LL | fn bar<T: Sync>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `Foo` cannot be shared between threads safely
   --> $DIR/no_share-struct.rs:12:9
    |
-LL | fn bar<T: Sync>(_: T) {}
-   |           ---- required by this bound in `bar`
-...
 LL |     bar(x);
    |         ^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
+note: required by a bound in `bar`
+  --> $DIR/no_share-struct.rs:8:11
+   |
+LL | fn bar<T: Sync>(_: T) {}
+   |           ^^^^ required by this bound in `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-panic/not-panic-safe-2.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-2.stderr
@@ -1,22 +1,21 @@
 error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `Rc<RefCell<i32>>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-2.rs:7:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -24,6 +23,11 @@ LL |     assert::<Rc<RefCell<i32>>>();
    = note: required because it appears within the type `Cell<isize>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `Rc<RefCell<i32>>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-2.rs:7:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-3.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-3.stderr
@@ -1,22 +1,21 @@
 error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `Arc<RefCell<i32>>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-3.rs:7:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -24,6 +23,11 @@ LL |     assert::<Arc<RefCell<i32>>>();
    = note: required because it appears within the type `Cell<isize>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `Arc<RefCell<i32>>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-3.rs:7:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-4.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-4.stderr
@@ -1,22 +1,21 @@
 error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `&RefCell<i32>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-4.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -24,6 +23,11 @@ LL |     assert::<&RefCell<i32>>();
    = note: required because it appears within the type `Cell<isize>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `&RefCell<i32>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-4.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-5.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-5.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-5.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<*const UnsafeCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `*const UnsafeCell<i32>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-5.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-panic/not-panic-safe-6.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-6.stderr
@@ -1,22 +1,21 @@
 error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `*mut RefCell<i32>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-6.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -24,6 +23,11 @@ LL |     assert::<*mut RefCell<i32>>();
    = note: required because it appears within the type `Cell<isize>`
    = note: required because it appears within the type `RefCell<i32>`
    = note: required because of the requirements on the impl of `UnwindSafe` for `*mut RefCell<i32>`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe-6.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the type `&mut i32` may not be safely transferred across an unwind boundary
   --> $DIR/not-panic-safe.rs:9:5
    |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   |              ---------- required by this bound in `assert`
-...
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary
    |
    = help: the trait `UnwindSafe` is not implemented for `&mut i32`
    = note: `UnwindSafe` is implemented for `&i32`, but not for `&mut i32`
+note: required by a bound in `assert`
+  --> $DIR/not-panic-safe.rs:6:14
+   |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   |              ^^^^^^^^^^ required by this bound in `assert`
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-sync.stderr
+++ b/src/test/ui/not-sync.stderr
@@ -1,68 +1,80 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:8:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<Cell<i32>>();
    |            ^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Cell<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:10:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<RefCell<i32>>();
    |            ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `Rc<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:13:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<Rc<i32>>();
    |            ^^^^^^^ `Rc<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `std::rc::Weak<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:15:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<Weak<i32>>();
    |            ^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::rc::Weak<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:18:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<Receiver<i32>>();
    |            ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `Sender<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:20:12
    |
-LL | fn test<T: Sync>() {}
-   |            ---- required by this bound in `test`
-...
 LL |     test::<Sender<i32>>();
    |            ^^^^^^^^^^^ `Sender<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Sender<i32>`
+note: required by a bound in `test`
+  --> $DIR/not-sync.rs:5:12
+   |
+LL | fn test<T: Sync>() {}
+   |            ^^^^ required by this bound in `test`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -1,10 +1,14 @@
 error[E0277]: the trait bound `Box<dyn Foo>: Foo` is not satisfied
   --> $DIR/object-does-not-impl-trait.rs:6:44
    |
-LL | fn take_foo<F:Foo>(f: F) {}
-   |               --- required by this bound in `take_foo`
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
    |                                            ^ the trait `Foo` is not implemented for `Box<dyn Foo>`
+   |
+note: required by a bound in `take_foo`
+  --> $DIR/object-does-not-impl-trait.rs:5:15
+   |
+LL | fn take_foo<F:Foo>(f: F) {}
+   |               ^^^ required by this bound in `take_foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/enclosing-scope.stderr
+++ b/src/test/ui/on-unimplemented/enclosing-scope.stderr
@@ -1,9 +1,6 @@
 error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:14:11
    |
-LL |   fn f<T: Trait>(x: T) {}
-   |           ----- required by this bound in `f`
-...
 LL |       let x = || {
    |  _____________-
 LL | |         f(Foo{});
@@ -13,26 +10,32 @@ LL | |             f(Foo{});
 LL | |         };
 LL | |     };
    | |_____- in this scope
+   |
+note: required by a bound in `f`
+  --> $DIR/enclosing-scope.rs:10:9
+   |
+LL | fn f<T: Trait>(x: T) {}
+   |         ^^^^^ required by this bound in `f`
 
 error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:16:15
    |
-LL |   fn f<T: Trait>(x: T) {}
-   |           ----- required by this bound in `f`
-...
 LL |           let y = || {
    |  _________________-
 LL | |             f(Foo{});
    | |               ^^^^^ the trait `Trait` is not implemented for `Foo`
 LL | |         };
    | |_________- in this scope
+   |
+note: required by a bound in `f`
+  --> $DIR/enclosing-scope.rs:10:9
+   |
+LL | fn f<T: Trait>(x: T) {}
+   |         ^^^^^ required by this bound in `f`
 
 error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:22:15
    |
-LL |   fn f<T: Trait>(x: T) {}
-   |           ----- required by this bound in `f`
-LL | 
 LL | / fn main() {
 LL | |     let x = || {
 LL | |         f(Foo{});
@@ -44,13 +47,16 @@ LL | |             f(Foo{});
 LL | |     f(Foo{});
 LL | | }
    | |_- in this scope
+   |
+note: required by a bound in `f`
+  --> $DIR/enclosing-scope.rs:10:9
+   |
+LL | fn f<T: Trait>(x: T) {}
+   |         ^^^^^ required by this bound in `f`
 
 error[E0277]: the trait bound `Foo: Trait` is not satisfied
   --> $DIR/enclosing-scope.rs:26:7
    |
-LL |   fn f<T: Trait>(x: T) {}
-   |           ----- required by this bound in `f`
-LL | 
 LL | / fn main() {
 LL | |     let x = || {
 LL | |         f(Foo{});
@@ -60,6 +66,12 @@ LL | |     f(Foo{});
    | |       ^^^^^ the trait `Trait` is not implemented for `Foo`
 LL | | }
    | |_- in this scope
+   |
+note: required by a bound in `f`
+  --> $DIR/enclosing-scope.rs:10:9
+   |
+LL | fn f<T: Trait>(x: T) {}
+   |         ^^^^^ required by this bound in `f`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/on-unimplemented/on-trait.stderr
+++ b/src/test/ui/on-unimplemented/on-trait.stderr
@@ -1,24 +1,28 @@
 error[E0277]: the trait bound `Option<Vec<u8>>: MyFromIterator<&u8>` is not satisfied
   --> $DIR/on-trait.rs:28:30
    |
-LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
-   |                                       ----------------- required by this bound in `collect`
-...
 LL |     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
    |                              ^^^^^^^ a collection of type `Option<Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
    |
    = help: the trait `MyFromIterator<&u8>` is not implemented for `Option<Vec<u8>>`
+note: required by a bound in `collect`
+  --> $DIR/on-trait.rs:22:39
+   |
+LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
+   |                                       ^^^^^^^^^^^^^^^^^ required by this bound in `collect`
 
 error[E0277]: the trait bound `String: Foo<u8, _, u32>` is not satisfied
   --> $DIR/on-trait.rs:31:21
    |
-LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
-   |                        --------------- required by this bound in `foobar`
-...
 LL |     let x: String = foobar();
    |                     ^^^^^^ test error `String` with `u8` `_` `u32` in `Foo`
    |
    = help: the trait `Foo<u8, _, u32>` is not implemented for `String`
+note: required by a bound in `foobar`
+  --> $DIR/on-trait.rs:12:24
+   |
+LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
+   |                        ^^^^^^^^^^^^^^^ required by this bound in `foobar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/phantom-auto-trait.stderr
+++ b/src/test/ui/phantom-auto-trait.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-auto-trait.rs:21:12
    |
-LL | fn is_zen<T: Zen>(_: T) {}
-   |              --- required by this bound in `is_zen`
-...
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
@@ -18,6 +15,11 @@ note: required because it appears within the type `Guard<'_, T>`
    |
 LL | struct Guard<'a, T: 'a> {
    |        ^^^^^
+note: required by a bound in `is_zen`
+  --> $DIR/phantom-auto-trait.rs:18:14
+   |
+LL | fn is_zen<T: Zen>(_: T) {}
+   |              ^^^ required by this bound in `is_zen`
 help: consider restricting type parameter `T`
    |
 LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
@@ -26,9 +28,6 @@ LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-auto-trait.rs:26:12
    |
-LL | fn is_zen<T: Zen>(_: T) {}
-   |              --- required by this bound in `is_zen`
-...
 LL |     is_zen(x)
    |            ^ `T` cannot be shared between threads safely
    |
@@ -48,6 +47,11 @@ note: required because it appears within the type `Nested<Guard<'_, T>>`
    |
 LL | struct Nested<T>(T);
    |        ^^^^^^
+note: required by a bound in `is_zen`
+  --> $DIR/phantom-auto-trait.rs:18:14
+   |
+LL | fn is_zen<T: Zen>(_: T) {}
+   |              ^^^ required by this bound in `is_zen`
 help: consider restricting type parameter `T`
    |
 LL | fn nested_not_sync<T: std::marker::Sync>(x: Nested<Guard<T>>) {

--- a/src/test/ui/range/range-1.stderr
+++ b/src/test/ui/range/range-1.stderr
@@ -24,12 +24,12 @@ error[E0277]: the size for values of type `[{integer}]` cannot be known at compi
 LL |     let range = *arr..;
    |                 ^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/ops/range.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[{integer}]`
+note: required by a bound in `RangeFrom`
+  --> $SRC_DIR/core/src/ops/range.rs:LL:COL
    |
 LL | pub struct RangeFrom<Idx> {
-   |                      --- required by this bound in `RangeFrom`
-   |
-   = help: the trait `Sized` is not implemented for `[{integer}]`
+   |                      ^^^ required by this bound in `RangeFrom`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/recursion/recursive-requirements.stderr
+++ b/src/test/ui/recursion/recursive-requirements.stderr
@@ -1,9 +1,6 @@
 error[E0277]: `*const Bar` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
-LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   |                      ---- required by this bound in `AssertSync`
-...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
@@ -13,13 +10,15 @@ note: required because it appears within the type `Foo`
    |
 LL | pub struct Foo {
    |            ^^^
+note: required by a bound in `AssertSync`
+  --> $DIR/recursive-requirements.rs:3:22
+   |
+LL | struct AssertSync<T: Sync>(PhantomData<T>);
+   |                      ^^^^ required by this bound in `AssertSync`
 
 error[E0277]: `*const Foo` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
-LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   |                      ---- required by this bound in `AssertSync`
-...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
@@ -35,6 +34,11 @@ note: required because it appears within the type `Foo`
    |
 LL | pub struct Foo {
    |            ^^^
+note: required by a bound in `AssertSync`
+  --> $DIR/recursive-requirements.rs:3:22
+   |
+LL | struct AssertSync<T: Sync>(PhantomData<T>);
+   |                      ^^^^ required by this bound in `AssertSync`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -8,12 +8,12 @@ LL | |     "0".parse()
 LL | | }
    | |_^ `main` can only return types that implement `Termination`
    |
-  ::: $SRC_DIR/test/src/lib.rs:LL:COL
-   |
-LL |   pub fn assert_test_result<T: Termination>(result: T) {
-   |                                ----------- required by this bound in `assert_test_result`
-   |
    = help: the trait `Termination` is not implemented for `Result<f32, ParseFloatError>`
+note: required by a bound in `assert_test_result`
+  --> $SRC_DIR/test/src/lib.rs:LL:COL
+   |
+LL | pub fn assert_test_result<T: Termination>(result: T) {
+   |                              ^^^^^^^^^^^ required by this bound in `assert_test_result`
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/rfc-2632-const-trait-impl/assoc-type.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/assoc-type.stderr
@@ -1,13 +1,15 @@
 error[E0277]: cannot add `NonConstAdd` to `NonConstAdd`
   --> $DIR/assoc-type.rs:21:5
    |
-LL |     type Bar: std::ops::Add;
-   |               ------------- required by this bound in `Foo::Bar`
-...
 LL |     type Bar = NonConstAdd;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `NonConstAdd + NonConstAdd`
    |
    = help: the trait `Add` is not implemented for `NonConstAdd`
+note: required by a bound in `Foo::Bar`
+  --> $DIR/assoc-type.rs:17:15
+   |
+LL |     type Bar: std::ops::Add;
+   |               ^^^^^^^^^^^^^ required by this bound in `Foo::Bar`
 help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
 LL | impl const Foo for NonConstAdd where NonConstAdd: Add {

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -1,13 +1,15 @@
 error[E0277]: can't compare `S` with `S`
   --> $DIR/call-generic-method-nonconst.rs:19:34
    |
-LL | const fn equals_self<T: PartialEq>(t: &T) -> bool {
-   |                         --------- required by this bound in `equals_self`
-...
 LL | pub const EQ: bool = equals_self(&S);
    |                                  ^^ no implementation for `S == S`
    |
    = help: the trait `PartialEq` is not implemented for `S`
+note: required by a bound in `equals_self`
+  --> $DIR/call-generic-method-nonconst.rs:12:25
+   |
+LL | const fn equals_self<T: PartialEq>(t: &T) -> bool {
+   |                         ^^^^^^^^^ required by this bound in `equals_self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,80 +1,92 @@
 error[E0277]: expected a `Fn<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:24:10
    |
-LL | fn call(f: impl Fn()) {
-   |                 ---- required by this bound in `call`
-...
 LL |     call(foo);
    |          ^^^ expected an `Fn<()>` closure, found `fn() {foo}`
    |
    = help: the trait `Fn<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call`
+  --> $DIR/fn-traits.rs:11:17
+   |
+LL | fn call(f: impl Fn()) {
+   |                 ^^^^ required by this bound in `call`
 
 error[E0277]: expected a `FnMut<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:25:14
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ------- required by this bound in `call_mut`
-...
 LL |     call_mut(foo);
    |              ^^^ expected an `FnMut<()>` closure, found `fn() {foo}`
    |
    = help: the trait `FnMut<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call_mut`
+  --> $DIR/fn-traits.rs:15:21
+   |
+LL | fn call_mut(f: impl FnMut()) {
+   |                     ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
    |
-LL | fn call_once(f: impl FnOnce()) {
-   |                      -------- required by this bound in `call_once`
-...
 LL |     call_once(foo);
    |               ^^^ expected an `FnOnce<()>` closure, found `fn() {foo}`
    |
    = help: the trait `FnOnce<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call_once`
+  --> $DIR/fn-traits.rs:19:22
+   |
+LL | fn call_once(f: impl FnOnce()) {
+   |                      ^^^^^^^^ required by this bound in `call_once`
 
 error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:28:10
    |
-LL | fn call(f: impl Fn()) {
-   |                 ---- required by this bound in `call`
-...
 LL |     call(foo_unsafe);
    |          ^^^^^^^^^^ expected an `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
    |
    = help: the trait `Fn<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call`
+  --> $DIR/fn-traits.rs:11:17
+   |
+LL | fn call(f: impl Fn()) {
+   |                 ^^^^ required by this bound in `call`
 
 error[E0277]: expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:30:14
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ------- required by this bound in `call_mut`
-...
 LL |     call_mut(foo_unsafe);
    |              ^^^^^^^^^^ expected an `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
    |
    = help: the trait `FnMut<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call_mut`
+  --> $DIR/fn-traits.rs:15:21
+   |
+LL | fn call_mut(f: impl FnMut()) {
+   |                     ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:32:15
    |
-LL | fn call_once(f: impl FnOnce()) {
-   |                      -------- required by this bound in `call_once`
-...
 LL |     call_once(foo_unsafe);
    |               ^^^^^^^^^^ expected an `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
    |
    = help: the trait `FnOnce<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
+note: required by a bound in `call_once`
+  --> $DIR/fn-traits.rs:19:22
+   |
+LL | fn call_once(f: impl FnOnce()) {
+   |                      ^^^^^^^^ required by this bound in `call_once`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/specialization/deafult-associated-type-bound-1.stderr
+++ b/src/test/ui/specialization/deafult-associated-type-bound-1.stderr
@@ -11,11 +11,14 @@ LL | #![feature(specialization)]
 error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/deafult-associated-type-bound-1.rs:19:5
    |
-LL |     type U: Clone;
-   |             ----- required by this bound in `X::U`
-...
 LL |     default type U = str;
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+note: required by a bound in `X::U`
+  --> $DIR/deafult-associated-type-bound-1.rs:9:13
+   |
+LL |     type U: Clone;
+   |             ^^^^^ required by this bound in `X::U`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/specialization/deafult-associated-type-bound-2.stderr
+++ b/src/test/ui/specialization/deafult-associated-type-bound-2.stderr
@@ -11,13 +11,15 @@ LL | #![feature(specialization)]
 error[E0277]: can't compare `&'static B` with `B`
   --> $DIR/deafult-associated-type-bound-2.rs:16:5
    |
-LL |     type U: PartialEq<T>;
-   |             ------------ required by this bound in `X::U`
-...
 LL |     default type U = &'static B;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `&'static B == B`
    |
    = help: the trait `PartialEq<B>` is not implemented for `&'static B`
+note: required by a bound in `X::U`
+  --> $DIR/deafult-associated-type-bound-2.rs:6:13
+   |
+LL |     type U: PartialEq<T>;
+   |             ^^^^^^^^^^^^ required by this bound in `X::U`
 help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
 LL | impl<B: 'static, T> X<B> for T where &'static B: PartialEq<B> {

--- a/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
+++ b/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
@@ -11,13 +11,15 @@ LL | #![feature(specialization)]
 error[E0277]: can't compare `T` with `T`
   --> $DIR/deafult-generic-associated-type-bound.rs:18:5
    |
-LL |     type U<'a>: PartialEq<&'a Self> where Self: 'a;
-   |                 ------------------- required by this bound in `X::U`
-...
 LL |     default type U<'a> = &'a T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `T == T`
    |
    = note: required because of the requirements on the impl of `PartialEq` for `&'a T`
+note: required by a bound in `X::U`
+  --> $DIR/deafult-generic-associated-type-bound.rs:8:17
+   |
+LL |     type U<'a>: PartialEq<&'a Self> where Self: 'a;
+   |                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `X::U`
 help: consider further restricting this bound
    |
 LL | impl<T: 'static + std::cmp::PartialEq> X for T {

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -11,12 +11,14 @@ LL | #![feature(specialization)]
 error[E0277]: the trait bound `U: Eq` is not satisfied
   --> $DIR/specialization-wfcheck.rs:7:17
    |
-LL | trait Foo<'a, T: Eq + 'a> { }
-   |                  -- required by this bound in `Foo`
-LL | 
 LL | default impl<U> Foo<'static, U> for () {}
    |                 ^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `U`
    |
+note: required by a bound in `Foo`
+  --> $DIR/specialization-wfcheck.rs:5:18
+   |
+LL | trait Foo<'a, T: Eq + 'a> { }
+   |                  ^^ required by this bound in `Foo`
 help: consider restricting type parameter `U`
    |
 LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}

--- a/src/test/ui/specialization/issue-33017.stderr
+++ b/src/test/ui/specialization/issue-33017.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-33017.rs:12:5
    |
-LL |     type Output: From<Self> + Copy + Into<Self>;
-   |                               ---- required by this bound in `UncheckedCopy::Output`
-...
 LL |     default type Output = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `UncheckedCopy::Output`
+  --> $DIR/issue-33017.rs:8:31
+   |
+LL |     type Output: From<Self> + Copy + Into<Self>;
+   |                               ^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {

--- a/src/test/ui/specialization/issue-38091.stderr
+++ b/src/test/ui/specialization/issue-38091.stderr
@@ -11,11 +11,14 @@ LL | #![feature(specialization)]
 error[E0277]: the trait bound `(): Valid` is not satisfied
   --> $DIR/issue-38091.rs:12:5
    |
-LL |     type Ty: Valid;
-   |              ----- required by this bound in `Iterate::Ty`
-...
 LL |     default type Ty = ();
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Valid` is not implemented for `()`
+   |
+note: required by a bound in `Iterate::Ty`
+  --> $DIR/issue-38091.rs:5:14
+   |
+LL |     type Ty: Valid;
+   |              ^^^^^ required by this bound in `Iterate::Ty`
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/specialization/issue-44861.stderr
+++ b/src/test/ui/specialization/issue-44861.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `(): CoerceUnsized<*const [u8]>` is not satisfied
   --> $DIR/issue-44861.rs:21:5
    |
-LL |     type Data2: CoerceUnsized<*const [u8]>;
-   |                 -------------------------- required by this bound in `Smartass::Data2`
-...
 LL |     default type Data2 = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CoerceUnsized<*const [u8]>` is not implemented for `()`
+   |
+note: required by a bound in `Smartass::Data2`
+  --> $DIR/issue-44861.rs:12:17
+   |
+LL |     type Data2: CoerceUnsized<*const [u8]>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Smartass::Data2`
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/issue-59435.stderr
+++ b/src/test/ui/specialization/issue-59435.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `MyStruct: Default` is not satisfied
   --> $DIR/issue-59435.rs:11:5
    |
-LL |     type MyType: Default;
-   |                  ------- required by this bound in `MyTrait::MyType`
-...
 LL |     default type MyType = MyStruct;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `MyStruct`
+   |
+note: required by a bound in `MyTrait::MyType`
+  --> $DIR/issue-59435.rs:7:18
+   |
+LL |     type MyType: Default;
+   |                  ^^^^^^^ required by this bound in `MyTrait::MyType`
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-mut-idx.rs:4:15
    |
-LL | fn bot<T>() -> T { loop {} }
-   |        - required by this bound in `bot`
-...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `bot`
+  --> $DIR/str-mut-idx.rs:1:8
+   |
+LL | fn bot<T>() -> T { loop {} }
+   |        ^ required by this bound in `bot`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn bot<T: ?Sized>() -> T { loop {} }

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -73,9 +73,6 @@ LL |     let x: () = foo::<'static>();
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5
    |
-LL |     fn bar<'a, T>() where T: 'a {}
-   |                              -- required by this bound in `Foo::bar`
-...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -85,6 +82,11 @@ note: required because of the requirements on the impl of `Foo<'_, '_, u8>` for 
    |
 LL | impl<'a,'b,T,S> Foo<'a, 'b, S> for T {}
    |                 ^^^^^^^^^^^^^^     ^
+note: required by a bound in `Foo::bar`
+  --> $DIR/substs-ppaux.rs:7:30
+   |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |                              ^^ required by this bound in `Foo::bar`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -73,9 +73,6 @@ LL |     let x: () = foo::<'static>();
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5
    |
-LL |     fn bar<'a, T>() where T: 'a {}
-   |                              -- required by this bound in `Foo::bar`
-...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -85,6 +82,11 @@ note: required because of the requirements on the impl of `Foo<'_#0r, '_#1r, u8>
    |
 LL | impl<'a,'b,T,S> Foo<'a, 'b, S> for T {}
    |                 ^^^^^^^^^^^^^^     ^
+note: required by a bound in `Foo::bar`
+  --> $DIR/substs-ppaux.rs:7:30
+   |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |                              ^^ required by this bound in `Foo::bar`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -3,10 +3,12 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     fn func1() -> Struct1<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Struct1<T>{
-   |                - required by this bound in `Struct1`
    |
+note: required by a bound in `Struct1`
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
+   |
+LL | struct Struct1<T>{
+   |                ^ required by this bound in `Struct1`
 help: consider further restricting `Self`
    |
 LL |     fn func1() -> Struct1<Self> where Self: Sized;
@@ -21,10 +23,12 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self>;
    |                       ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Struct2<'a, T>{
-   |                    - required by this bound in `Struct2`
    |
+note: required by a bound in `Struct2`
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
+   |
+LL | struct Struct2<'a, T>{
+   |                    ^ required by this bound in `Struct2`
 help: consider further restricting `Self`
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self> where Self: Sized;
@@ -39,10 +43,12 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     fn func3() -> Struct3<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Struct3<T>{
-   |                - required by this bound in `Struct3`
    |
+note: required by a bound in `Struct3`
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
+   |
+LL | struct Struct3<T>{
+   |                ^ required by this bound in `Struct3`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
@@ -60,10 +66,12 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
    |
 LL |     fn func4() -> Struct4<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Struct4<T>{
-   |                - required by this bound in `Struct4`
    |
+note: required by a bound in `Struct4`
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16
+   |
+LL | struct Struct4<T>{
+   |                ^ required by this bound in `Struct4`
 help: consider further restricting `Self`
    |
 LL |     fn func4() -> Struct4<Self> where Self: Sized;
@@ -76,14 +84,16 @@ LL | struct Struct4<T: ?Sized>{
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/adt-param-with-implicit-sized-bound.rs:25:9
    |
-LL | struct X<T>(T);
-   |          - required by this bound in `X`
-...
 LL | struct Struct5<T: ?Sized>{
    |                - this type parameter needs to be `std::marker::Sized`
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |
+note: required by a bound in `X`
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
+   |
+LL | struct X<T>(T);
+   |          ^ required by this bound in `X`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -3,14 +3,16 @@ error[E0277]: `fn() -> impl Future {foo}` is not a future
    |
 LL | async fn foo() {}
    |          --- consider calling this function
-LL | 
-LL | fn bar(f: impl Future<Output=()>) {}
-   |                ----------------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |         ^^^ `fn() -> impl Future {foo}` is not a future
    |
    = help: the trait `Future` is not implemented for `fn() -> impl Future {foo}`
+note: required by a bound in `bar`
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
+   |
+LL | fn bar(f: impl Future<Output=()>) {}
+   |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`
 help: use parentheses to call the function
    |
 LL |     bar(foo());
@@ -19,15 +21,17 @@ LL |     bar(foo());
 error[E0277]: `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:9
    |
-LL | fn bar(f: impl Future<Output=()>) {}
-   |                ----------------- required by this bound in `bar`
-...
 LL |     let async_closure = async || ();
    |                         -------- consider calling this closure
 LL |     bar(async_closure);
    |         ^^^^^^^^^^^^^ `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]` is not a future
    |
    = help: the trait `Future` is not implemented for `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]`
+note: required by a bound in `bar`
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
+   |
+LL | fn bar(f: impl Future<Output=()>) {}
+   |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`
 help: use parentheses to call the closure
    |
 LL |     bar(async_closure());

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -3,13 +3,15 @@ error[E0277]: the trait bound `fn() -> impl T {foo}: T` is not satisfied
    |
 LL | fn foo() -> impl T<O=()> { S }
    |    --- consider calling this function
-LL | 
-LL | fn bar(f: impl T<O=()>) {}
-   |                ------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
    |
+note: required by a bound in `bar`
+  --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16
+   |
+LL | fn bar(f: impl T<O=()>) {}
+   |                ^^^^^^^ required by this bound in `bar`
 help: use parentheses to call the function
    |
 LL |     bar(foo());
@@ -18,14 +20,16 @@ LL |     bar(foo());
 error[E0277]: the trait bound `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:19:9
    |
-LL | fn bar(f: impl T<O=()>) {}
-   |                ------- required by this bound in `bar`
-...
 LL |     let closure = || S;
    |                   -- consider calling this closure
 LL |     bar(closure);
    |         ^^^^^^^ the trait `T` is not implemented for `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]`
    |
+note: required by a bound in `bar`
+  --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16
+   |
+LL | fn bar(f: impl T<O=()>) {}
+   |                ^^^^^^^ required by this bound in `bar`
 help: use parentheses to call the closure
    |
 LL |     bar(closure());

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the trait bound `for<'b> &'b S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:17:5
    |
-LL | fn foo<X>(_: X)
-   |    --- required by a bound in this
-LL | where
-LL |     for<'b> &'b X: Trait,
-   |                    ----- required by this bound in `foo`
-...
 LL |     foo::<S>(s);
    |     ^^^^^^^^ the trait `for<'b> Trait` is not implemented for `&'b S`
    |
    = help: the following implementations were found:
              <&'a mut S as Trait>
+note: required by a bound in `foo`
+  --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:11:20
+   |
+LL | fn foo<X>(_: X)
+   |    --- required by a bound in this
+LL | where
+LL |     for<'b> &'b X: Trait,
+   |                    ^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `&S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:12:7
    |
-LL | fn foo<X: Trait>(_: X) {}
-   |           ----- required by this bound in `foo`
-...
 LL |   foo(&s);
    |       ^^ the trait `Trait` is not implemented for `&S`
    |
    = help: the following implementations were found:
              <&'a mut S as Trait>
+note: required by a bound in `foo`
+  --> $DIR/imm-ref-trait-object-literal.rs:7:11
+   |
+LL | fn foo<X: Trait>(_: X) {}
+   |           ^^^^^ required by this bound in `foo`
 help: consider changing this borrow's mutability
    |
 LL |   foo(&mut s);
@@ -17,14 +19,17 @@ LL |   foo(&mut s);
 error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7
    |
-LL | fn foo<X: Trait>(_: X) {}
-   |           ----- required by this bound in `foo`
-...
 LL |   foo(s);
    |       ^
    |       |
    |       expected an implementor of trait `Trait`
    |       help: consider mutably borrowing here: `&mut s`
+   |
+note: required by a bound in `foo`
+  --> $DIR/imm-ref-trait-object-literal.rs:7:11
+   |
+LL | fn foo<X: Trait>(_: X) {}
+   |           ^^^^^ required by this bound in `foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -3,11 +3,13 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn foo<I: Iterator>(constraints: I) where <I as Iterator>::Item: Debug {
@@ -18,11 +20,13 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn bar<T, I: Iterator>(t: T, constraints: I) where T: std::fmt::Debug, <I as Iterator>::Item: Debug {
@@ -33,11 +37,13 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn baz<I: Iterator>(t: impl std::fmt::Debug, constraints: I) where <I as Iterator>::Item: Debug {
@@ -48,11 +54,13 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn bat<I, T: std::fmt::Debug, U: Iterator>(t: T, constraints: U, _: I) where <U as Iterator>::Item: Debug {
@@ -63,11 +71,13 @@ error[E0277]: `<impl Iterator + std::fmt::Debug as Iterator>::Item` doesn't impl
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator + std::fmt::Debug as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator + std::fmt::Debug as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn bak<I: Iterator + std::fmt::Debug>(constraints: I) where <I as Iterator>::Item: Debug {
@@ -78,11 +88,13 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
    |
 LL |         qux(constraint);
    |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
-...
-LL | fn qux(_: impl std::fmt::Debug) {}
-   |                --------------- required by this bound in `qux`
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
+note: required by a bound in `qux`
+  --> $DIR/impl-trait-with-missing-bounds.rs:50:16
+   |
+LL | fn qux(_: impl std::fmt::Debug) {}
+   |                ^^^^^^^^^^^^^^^ required by this bound in `qux`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | fn baw<I: Iterator>(constraints: I) where <I as Iterator>::Item: Debug {

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the trait bound `&str: From<String>` is not satisfied
   --> $DIR/into-str.rs:4:5
    |
-LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
-   |                               ------------- required by this bound in `foo`
-...
 LL |     foo(String::new());
    |     ^^^ the trait `From<String>` is not implemented for `&str`
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
    = note: required because of the requirements on the impl of `Into<&str>` for `String`
+note: required by a bound in `foo`
+  --> $DIR/into-str.rs:1:31
+   |
+LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
+   |                               ^^^^^^^^^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
+++ b/src/test/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
@@ -3,11 +3,13 @@ error[E0277]: `<impl Foo as Foo>::Bar` cannot be sent between threads safely
    |
 LL |     assert_is_send(&bar);
    |                    ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
-...
-LL | fn assert_is_send<T: Send>(_: &T) {}
-   |                      ---- required by this bound in `assert_is_send`
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
+note: required by a bound in `assert_is_send`
+  --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
+   |
+LL | fn assert_is_send<T: Send>(_: &T) {}
+   |                      ^^^^ required by this bound in `assert_is_send`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | async fn run<F: Foo>(_: &(), foo: F) -> std::io::Result<()> where <F as Foo>::Bar: Send {
@@ -18,11 +20,13 @@ error[E0277]: `<impl Foo as Foo>::Bar` cannot be sent between threads safely
    |
 LL |     assert_is_send(&bar);
    |                    ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
-...
-LL | fn assert_is_send<T: Send>(_: &T) {}
-   |                      ---- required by this bound in `assert_is_send`
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
+note: required by a bound in `assert_is_send`
+  --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:30:22
+   |
+LL | fn assert_is_send<T: Send>(_: &T) {}
+   |                      ^^^^ required by this bound in `assert_is_send`
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL | async fn run2<F: Foo>(_: &(), foo: F) -> std::io::Result<()> where <F as Foo>::Bar: Send {

--- a/src/test/ui/suggestions/issue-84973-2.stderr
+++ b/src/test/ui/suggestions/issue-84973-2.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `i32: Tr` is not satisfied
   --> $DIR/issue-84973-2.rs:11:9
    |
-LL | fn foo<T: Tr>(i: T) {}
-   |           -- required by this bound in `foo`
-...
 LL |     foo(a);
    |         ^
    |         |
    |         expected an implementor of trait `Tr`
    |         help: consider mutably borrowing here: `&mut a`
+   |
+note: required by a bound in `foo`
+  --> $DIR/issue-84973-2.rs:7:11
+   |
+LL | fn foo<T: Tr>(i: T) {}
+   |           ^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-84973-blacklist.stderr
+++ b/src/test/ui/suggestions/issue-84973-blacklist.stderr
@@ -1,53 +1,65 @@
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/issue-84973-blacklist.rs:15:12
    |
-LL | fn f_copy<T: Copy>(t: T) {}
-   |              ---- required by this bound in `f_copy`
-...
 LL |     f_copy("".to_string());
    |            ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `f_copy`
+  --> $DIR/issue-84973-blacklist.rs:6:14
+   |
+LL | fn f_copy<T: Copy>(t: T) {}
+   |              ^^^^ required by this bound in `f_copy`
 
 error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-84973-blacklist.rs:16:13
    |
-LL | fn f_clone<T: Clone>(t: T) {}
-   |               ----- required by this bound in `f_clone`
-...
 LL |     f_clone(S);
    |             ^ the trait `Clone` is not implemented for `S`
+   |
+note: required by a bound in `f_clone`
+  --> $DIR/issue-84973-blacklist.rs:7:15
+   |
+LL | fn f_clone<T: Clone>(t: T) {}
+   |               ^^^^^ required by this bound in `f_clone`
 
 error[E0277]: `[static generator@$DIR/issue-84973-blacklist.rs:17:13: 17:33]` cannot be unpinned
   --> $DIR/issue-84973-blacklist.rs:17:5
    |
-LL | fn f_unpin<T: Unpin>(t: T) {}
-   |               ----- required by this bound in `f_unpin`
-...
 LL |     f_unpin(static || { yield; });
    |     ^^^^^^^ the trait `Unpin` is not implemented for `[static generator@$DIR/issue-84973-blacklist.rs:17:13: 17:33]`
    |
    = note: consider using `Box::pin`
+note: required by a bound in `f_unpin`
+  --> $DIR/issue-84973-blacklist.rs:8:15
+   |
+LL | fn f_unpin<T: Unpin>(t: T) {}
+   |               ^^^^^ required by this bound in `f_unpin`
 
 error[E0277]: the size for values of type `dyn Fn()` cannot be known at compilation time
   --> $DIR/issue-84973-blacklist.rs:22:13
    |
-LL | fn f_sized<T: Sized>(t: T) {}
-   |            - required by this bound in `f_sized`
-...
 LL |     f_sized(*ref_cl);
    |             ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Fn()`
+note: required by a bound in `f_sized`
+  --> $DIR/issue-84973-blacklist.rs:9:12
+   |
+LL | fn f_sized<T: Sized>(t: T) {}
+   |            ^ required by this bound in `f_sized`
 
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/issue-84973-blacklist.rs:28:12
    |
-LL | fn f_send<T: Send>(t: T) {}
-   |              ---- required by this bound in `f_send`
-...
 LL |     f_send(rc);
    |            ^^ `Rc<{integer}>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
+note: required by a bound in `f_send`
+  --> $DIR/issue-84973-blacklist.rs:10:14
+   |
+LL | fn f_send<T: Send>(t: T) {}
+   |              ^^^^ required by this bound in `f_send`
 
 error[E0277]: the size for values of type `dyn Fn()` cannot be known at compilation time
   --> $DIR/issue-84973-blacklist.rs:22:5

--- a/src/test/ui/suggestions/issue-84973-negative.stderr
+++ b/src/test/ui/suggestions/issue-84973-negative.stderr
@@ -1,23 +1,29 @@
 error[E0277]: the trait bound `i32: Tr` is not satisfied
   --> $DIR/issue-84973-negative.rs:10:9
    |
-LL | fn bar<T: Tr>(t: T) {}
-   |           -- required by this bound in `bar`
-...
 LL |     bar(a);
    |         ^ the trait `Tr` is not implemented for `i32`
+   |
+note: required by a bound in `bar`
+  --> $DIR/issue-84973-negative.rs:5:11
+   |
+LL | fn bar<T: Tr>(t: T) {}
+   |           ^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `f32: Tr` is not satisfied
   --> $DIR/issue-84973-negative.rs:11:9
    |
-LL | fn bar<T: Tr>(t: T) {}
-   |           -- required by this bound in `bar`
-...
 LL |     bar(b);
    |         ^
    |         |
    |         expected an implementor of trait `Tr`
    |         help: consider borrowing here: `&b`
+   |
+note: required by a bound in `bar`
+  --> $DIR/issue-84973-negative.rs:5:11
+   |
+LL | fn bar<T: Tr>(t: T) {}
+   |           ^^ required by this bound in `bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/src/test/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -1,12 +1,15 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:5:10
    |
-LL | struct A<T>(T) where T: Send;
-   |          - required by this bound in `A`
 LL | struct B(A<[u8]>);
    |          ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `A`
+  --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
+   |
+LL | struct A<T>(T) where T: Send;
+   |          ^ required by this bound in `A`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -17,12 +17,12 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
 LL |     let fp = BufWriter::new(fp);
    |              ^^^^^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    |
-  ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
+   = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
+note: required by a bound in `BufWriter`
+  --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |
 LL | pub struct BufWriter<W: Write> {
-   |                         ----- required by this bound in `BufWriter`
-   |
-   = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
+   |                         ^^^^^ required by this bound in `BufWriter`
 
 error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn std::io::Write>`, but its trait bounds were not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:21:5

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -1,12 +1,14 @@
 error[E0277]: `impl Sync` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:4:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `impl Sync` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider further restricting this bound
    |
 LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
@@ -15,12 +17,14 @@ LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider further restricting this bound
    |
 LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
@@ -29,12 +33,14 @@ LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider further restricting this bound
    |
 LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
@@ -43,12 +49,14 @@ LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider further restricting this bound
    |
 LL |     Sync + std::marker::Send
@@ -57,12 +65,14 @@ LL |     Sync + std::marker::Send
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider further restricting this bound
    |
 LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug + std::marker::Send {
@@ -71,12 +81,14 @@ LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug + std::mar
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
    |
-LL | fn is_send<T: Send>(val: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(val);
    |             ^^^ `S` cannot be sent between threads safely
    |
+note: required by a bound in `is_send`
+  --> $DIR/restrict-type-argument.rs:1:15
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |               ^^^^ required by this bound in `is_send`
 help: consider restricting type parameter `S`
    |
 LL | fn use_unbound<S: std::marker::Send>(val: S) {

--- a/src/test/ui/trait-bounds/unsized-bound.stderr
+++ b/src/test/ui/trait-bounds/unsized-bound.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:2:12
    |
-LL | trait Trait<A> {}
-   |             - required by this bound in `Trait`
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |         -  ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
    = note: required because it appears within the type `(A, B)`
+note: required by a bound in `Trait`
+  --> $DIR/unsized-bound.rs:1:13
+   |
+LL | trait Trait<A> {}
+   |             ^ required by this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
@@ -37,15 +40,17 @@ LL + impl<A, B> Trait<(A, B)> for (A, B) where B: ?Sized, {}
 error[E0277]: the size for values of type `C` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:5:31
    |
-LL | trait Trait<A> {}
-   |             - required by this bound in `Trait`
-...
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
    |                    -          ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |                    |
    |                    this type parameter needs to be `std::marker::Sized`
    |
    = note: required because it appears within the type `(A, B, C)`
+note: required by a bound in `Trait`
+  --> $DIR/unsized-bound.rs:1:13
+   |
+LL | trait Trait<A> {}
+   |             ^ required by this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
@@ -89,14 +94,17 @@ LL + impl<A, B, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:10:28
    |
-LL | trait Trait2<A> {}
-   |              - required by this bound in `Trait2`
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |                 -          ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |                 |
    |                 this type parameter needs to be `std::marker::Sized`
    |
    = note: required because it appears within the type `(A, B)`
+note: required by a bound in `Trait2`
+  --> $DIR/unsized-bound.rs:9:14
+   |
+LL | trait Trait2<A> {}
+   |              ^ required by this bound in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
@@ -125,13 +133,16 @@ LL + impl<A, B: ?Sized> Trait2<(A, B)> for (A, B) {}
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:14:9
    |
-LL | trait Trait3<A> {}
-   |              - required by this bound in `Trait3`
 LL | impl<A> Trait3<A> for A where A: ?Sized {}
    |      -  ^^^^^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait3`
+  --> $DIR/unsized-bound.rs:13:14
+   |
+LL | trait Trait3<A> {}
+   |              ^ required by this bound in `Trait3`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
@@ -145,13 +156,16 @@ LL | trait Trait3<A: ?Sized> {}
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:17:17
    |
-LL | trait Trait4<A> {}
-   |              - required by this bound in `Trait4`
 LL | impl<A: ?Sized> Trait4<A> for A {}
    |      -          ^^^^^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait4`
+  --> $DIR/unsized-bound.rs:16:14
+   |
+LL | trait Trait4<A> {}
+   |              ^ required by this bound in `Trait4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
@@ -165,13 +179,16 @@ LL | trait Trait4<A: ?Sized> {}
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:20:12
    |
-LL | trait Trait5<A, B> {}
-   |              - required by this bound in `Trait5`
 LL | impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
    |      -     ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait5`
+  --> $DIR/unsized-bound.rs:19:14
+   |
+LL | trait Trait5<A, B> {}
+   |              ^ required by this bound in `Trait5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
@@ -185,13 +202,16 @@ LL | trait Trait5<A: ?Sized, B> {}
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:23:20
    |
-LL | trait Trait6<A, B> {}
-   |              - required by this bound in `Trait6`
 LL | impl<X: ?Sized, Y> Trait6<X, Y> for X {}
    |      -             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait6`
+  --> $DIR/unsized-bound.rs:22:14
+   |
+LL | trait Trait6<A, B> {}
+   |              ^ required by this bound in `Trait6`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
@@ -205,13 +225,16 @@ LL | trait Trait6<A: ?Sized, B> {}
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:26:12
    |
-LL | trait Trait7<A, B> {}
-   |                 - required by this bound in `Trait7`
 LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
    |         -  ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait7`
+  --> $DIR/unsized-bound.rs:25:17
+   |
+LL | trait Trait7<A, B> {}
+   |                 ^ required by this bound in `Trait7`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
@@ -225,13 +248,16 @@ LL | trait Trait7<A, B: ?Sized> {}
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:29:20
    |
-LL | trait Trait8<A, B> {}
-   |                 - required by this bound in `Trait8`
 LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
    |         -          ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Trait8`
+  --> $DIR/unsized-bound.rs:28:17
+   |
+LL | trait Trait8<A, B> {}
+   |                 ^ required by this bound in `Trait8`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}

--- a/src/test/ui/trait-impl-bound-suggestions.stderr
+++ b/src/test/ui/trait-impl-bound-suggestions.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `X: Copy` is not satisfied
   --> $DIR/trait-impl-bound-suggestions.rs:14:52
    |
-LL | struct ConstrainedStruct<X: Copy> {
-   |                             ---- required by this bound in `ConstrainedStruct`
-...
 LL |     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
    |                                                    ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `X`
    |
+note: required by a bound in `ConstrainedStruct`
+  --> $DIR/trait-impl-bound-suggestions.rs:8:29
+   |
+LL | struct ConstrainedStruct<X: Copy> {
+   |                             ^^^^ required by this bound in `ConstrainedStruct`
 help: consider further restricting type parameter `X`
    |
 LL | trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {

--- a/src/test/ui/traits/alias/cross-crate.stderr
+++ b/src/test/ui/traits/alias/cross-crate.stderr
@@ -1,24 +1,28 @@
 error[E0277]: `Rc<u32>` cannot be sent between threads safely
   --> $DIR/cross-crate.rs:14:17
    |
-LL | fn use_alias<T: SendSync>() {}
-   |                 -------- required by this bound in `use_alias`
-...
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Rc<u32>`
+note: required by a bound in `use_alias`
+  --> $DIR/cross-crate.rs:10:17
+   |
+LL | fn use_alias<T: SendSync>() {}
+   |                 ^^^^^^^^ required by this bound in `use_alias`
 
 error[E0277]: `Rc<u32>` cannot be shared between threads safely
   --> $DIR/cross-crate.rs:14:17
    |
-LL | fn use_alias<T: SendSync>() {}
-   |                 -------- required by this bound in `use_alias`
-...
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Rc<u32>`
+note: required by a bound in `use_alias`
+  --> $DIR/cross-crate.rs:10:17
+   |
+LL | fn use_alias<T: SendSync>() {}
+   |                 ^^^^^^^^ required by this bound in `use_alias`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/alias/wf.stderr
+++ b/src/test/ui/traits/alias/wf.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/wf.rs:5:14
    |
-LL | trait A<T: Foo> {}
-   |            --- required by this bound in `A`
 LL | trait B<T> = A<T>;
    |              ^^^^ the trait `Foo` is not implemented for `T`
    |
+note: required by a bound in `A`
+  --> $DIR/wf.rs:4:12
+   |
+LL | trait A<T: Foo> {}
+   |            ^^^ required by this bound in `A`
 help: consider restricting type parameter `T`
    |
 LL | trait B<T: Foo> = A<T>;

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-1.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-1.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/check-trait-object-bounds-1.rs:12:5
    |
-LL | fn f<T: X + ?Sized>() {
-   |         - required by this bound in `f`
-...
 LL |     f::<dyn X<Y = str>>();
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+note: required by a bound in `f`
+  --> $DIR/check-trait-object-bounds-1.rs:7:9
+   |
+LL | fn f<T: X + ?Sized>() {
+   |         ^ required by this bound in `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `FnOnce<(&i32,)>` closure, found `i32`
   --> $DIR/check-trait-object-bounds-2.rs:13:5
    |
-LL | fn f<T: for<'r> X<'r> + ?Sized>() {
-   |         ------------- required by this bound in `f`
-...
 LL |     f::<dyn for<'x> X<'x, F = i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(&i32,)>` closure, found `i32`
    |
    = help: the trait `for<'r> FnOnce<(&'r i32,)>` is not implemented for `i32`
+note: required by a bound in `f`
+  --> $DIR/check-trait-object-bounds-2.rs:8:9
+   |
+LL | fn f<T: for<'r> X<'r> + ?Sized>() {
+   |         ^^^^^^^^^^^^^ required by this bound in `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-4.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-4.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/check-trait-object-bounds-4.rs:15:5
    |
-LL | fn f<T: X + ?Sized>() {
-   |         - required by this bound in `f`
-...
 LL |     f::<dyn X<Y = str>>();
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+note: required by a bound in `f`
+  --> $DIR/check-trait-object-bounds-4.rs:10:9
+   |
+LL | fn f<T: X + ?Sized>() {
+   |         ^ required by this bound in `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
   --> $DIR/check-trait-object-bounds-5.rs:23:5
    |
-LL | fn is_obj<T: ?Sized + Obj>(_: &T) {}
-   |                       --- required by this bound in `is_obj`
-...
 LL |     is_obj(x)
    |     ^^^^^^ expected `i64`, found `i32`
+   |
+note: required by a bound in `is_obj`
+  --> $DIR/check-trait-object-bounds-5.rs:20:23
+   |
+LL | fn is_obj<T: ?Sized + Obj>(_: &T) {}
+   |                       ^^^ required by this bound in `is_obj`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
@@ -1,11 +1,14 @@
 error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
   --> $DIR/check-trait-object-bounds-6.rs:20:5
    |
-LL | fn is_obj<T: ?Sized + Obj>(_: &T) {}
-   |                       --- required by this bound in `is_obj`
-...
 LL |     is_obj(x)
    |     ^^^^^^ expected `i64`, found `i32`
+   |
+note: required by a bound in `is_obj`
+  --> $DIR/check-trait-object-bounds-6.rs:17:23
+   |
+LL | fn is_obj<T: ?Sized + Obj>(_: &T) {}
+   |                       ^^^ required by this bound in `is_obj`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/bad-sized.stderr
+++ b/src/test/ui/traits/bad-sized.stderr
@@ -15,12 +15,12 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-   |                - required by this bound in `Vec`
-   |
-   = help: the trait `Sized` is not implemented for `dyn Trait`
+   |                ^ required by this bound in `Vec`
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/bad-sized.rs:4:37
@@ -41,12 +41,12 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+note: required by a bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    |
 LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
-   |                - required by this bound in `Vec`
-   |
-   = help: the trait `Sized` is not implemented for `dyn Trait`
+   |                ^ required by this bound in `Vec`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-in-fns.stderr
@@ -1,20 +1,26 @@
 error[E0277]: the trait bound `u32: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-in-fns.rs:13:15
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL | fn explode(x: Foo<u32>) {}
    |               ^^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums-in-fns.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-in-fns.rs:16:14
    |
-LL | enum Bar<T:Trait> {
-   |            ----- required by this bound in `Bar`
-...
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`
+   |
+note: required by a bound in `Bar`
+  --> $DIR/on-structs-and-enums-in-fns.rs:7:12
+   |
+LL | enum Bar<T:Trait> {
+   |            ^^^^^ required by this bound in `Bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-in-impls.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-in-impls.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `u16: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-in-impls.rs:20:6
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL | impl PolyTrait<Foo<u16>> for Struct {
    |      ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u16`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums-in-impls.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-locals.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-locals.rs:15:14
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL |     let baz: Foo<usize> = loop { };
    |              ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums-locals.rs:5:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `{integer}: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-locals.rs:10:15

--- a/src/test/ui/traits/bound/on-structs-and-enums-static.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-static.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-static.rs:9:11
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL | static X: Foo<usize> = Foo {
    |           ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums-static.rs:5:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-xc.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-xc.stderr
@@ -4,10 +4,11 @@ error[E0277]: the trait bound `usize: Trait` is not satisfied
 LL | fn explode(x: Foo<usize>) {}
    |               ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
    |
-  ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:5:18
+note: required by a bound in `Foo`
+  --> $DIR/auxiliary/on_structs_and_enums_xc.rs:5:18
    |
 LL | pub struct Foo<T:Trait> {
-   |                  ----- required by this bound in `Foo`
+   |                  ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-xc.rs:10:14
@@ -15,10 +16,11 @@ error[E0277]: the trait bound `f32: Trait` is not satisfied
 LL | fn kaboom(y: Bar<f32>) {}
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f32`
    |
-  ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
+note: required by a bound in `Bar`
+  --> $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
    |
 LL | pub enum Bar<T:Trait> {
-   |                ----- required by this bound in `Bar`
+   |                ^^^^^ required by this bound in `Bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums-xc1.stderr
@@ -4,10 +4,11 @@ error[E0277]: the trait bound `f64: Trait` is not satisfied
 LL |     let bar: Bar<f64> = return;
    |              ^^^^^^^^ the trait `Trait` is not implemented for `f64`
    |
-  ::: $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
+note: required by a bound in `Bar`
+  --> $DIR/auxiliary/on_structs_and_enums_xc.rs:9:16
    |
 LL | pub enum Bar<T:Trait> {
-   |                ----- required by this bound in `Bar`
+   |                ^^^^^ required by this bound in `Bar`
 
 error[E0277]: the trait bound `{integer}: Trait` is not satisfied
   --> $DIR/on-structs-and-enums-xc1.rs:8:15

--- a/src/test/ui/traits/bound/on-structs-and-enums.stderr
+++ b/src/test/ui/traits/bound/on-structs-and-enums.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:13:9
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
    |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: Trait> Foo<T> {
@@ -15,30 +17,38 @@ LL | impl<T: Trait> Foo<T> {
 error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:19:8
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL |     a: Foo<isize>,
    |        ^^^^^^^^^^ the trait `Trait` is not implemented for `isize`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:23:10
    |
-LL | enum Bar<T:Trait> {
-   |            ----- required by this bound in `Bar`
-...
 LL |     Quux(Bar<usize>),
    |          ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
+   |
+note: required by a bound in `Bar`
+  --> $DIR/on-structs-and-enums.rs:7:12
+   |
+LL | enum Bar<T:Trait> {
+   |            ^^^^^ required by this bound in `Bar`
 
 error[E0277]: the trait bound `U: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:27:8
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL |     b: Foo<U>,
    |        ^^^^^^ the trait `Trait` is not implemented for `U`
    |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 help: consider restricting type parameter `U`
    |
 LL | struct Badness<U: Trait> {
@@ -47,12 +57,14 @@ LL | struct Badness<U: Trait> {
 error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:31:21
    |
-LL | enum Bar<T:Trait> {
-   |            ----- required by this bound in `Bar`
-...
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
    |
+note: required by a bound in `Bar`
+  --> $DIR/on-structs-and-enums.rs:7:12
+   |
+LL | enum Bar<T:Trait> {
+   |            ^^^^^ required by this bound in `Bar`
 help: consider restricting type parameter `V`
    |
 LL | enum MoreBadness<V: Trait> {
@@ -61,20 +73,26 @@ LL | enum MoreBadness<V: Trait> {
 error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:35:5
    |
-LL | struct Foo<T:Trait> {
-   |              ----- required by this bound in `Foo`
-...
 LL |     Foo<i32>,
    |     ^^^^^^^^ the trait `Trait` is not implemented for `i32`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/on-structs-and-enums.rs:3:14
+   |
+LL | struct Foo<T:Trait> {
+   |              ^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/on-structs-and-enums.rs:39:29
    |
-LL | enum Bar<T:Trait> {
-   |            ----- required by this bound in `Bar`
-...
 LL |     DictionaryLike { field: Bar<u8> },
    |                             ^^^^^^^ the trait `Trait` is not implemented for `u8`
+   |
+note: required by a bound in `Bar`
+  --> $DIR/on-structs-and-enums.rs:7:12
+   |
+LL | enum Bar<T:Trait> {
+   |            ^^^^^ required by this bound in `Bar`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/traits/bound/same-crate-name.stderr
+++ b/src/test/ui/traits/bound/same-crate-name.stderr
@@ -4,17 +4,17 @@ error[E0277]: the trait bound `Foo: main::a::Bar` is not satisfied
 LL |         a::try_foo(foo);
    |                    ^^^ the trait `main::a::Bar` is not implemented for `Foo`
    |
-  ::: $DIR/auxiliary/crate_a1.rs:3:24
-   |
-LL | pub fn try_foo(x: impl Bar) {}
-   |                        --- required by this bound in `try_foo`
-   |
 help: trait impl with same name found
   --> $DIR/auxiliary/crate_a2.rs:5:1
    |
 LL | impl Bar for Foo {}
    | ^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a2` are being used?
+note: required by a bound in `try_foo`
+  --> $DIR/auxiliary/crate_a1.rs:3:24
+   |
+LL | pub fn try_foo(x: impl Bar) {}
+   |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `DoesNotImplementTrait: main::a::Bar` is not satisfied
   --> $DIR/same-crate-name.rs:38:20
@@ -22,10 +22,11 @@ error[E0277]: the trait bound `DoesNotImplementTrait: main::a::Bar` is not satis
 LL |         a::try_foo(implements_no_traits);
    |                    ^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `DoesNotImplementTrait`
    |
-  ::: $DIR/auxiliary/crate_a1.rs:3:24
+note: required by a bound in `try_foo`
+  --> $DIR/auxiliary/crate_a1.rs:3:24
    |
 LL | pub fn try_foo(x: impl Bar) {}
-   |                        --- required by this bound in `try_foo`
+   |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `ImplementsWrongTraitConditionally<isize>: main::a::Bar` is not satisfied
   --> $DIR/same-crate-name.rs:45:20
@@ -33,17 +34,17 @@ error[E0277]: the trait bound `ImplementsWrongTraitConditionally<isize>: main::a
 LL |         a::try_foo(other_variant_implements_mismatched_trait);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsWrongTraitConditionally<isize>`
    |
-  ::: $DIR/auxiliary/crate_a1.rs:3:24
-   |
-LL | pub fn try_foo(x: impl Bar) {}
-   |                        --- required by this bound in `try_foo`
-   |
 help: trait impl with same name found
   --> $DIR/auxiliary/crate_a2.rs:13:1
    |
 LL | impl Bar for ImplementsWrongTraitConditionally<isize> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `crate_a2` are being used?
+note: required by a bound in `try_foo`
+  --> $DIR/auxiliary/crate_a1.rs:3:24
+   |
+LL | pub fn try_foo(x: impl Bar) {}
+   |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `ImplementsTraitForUsize<isize>: main::a::Bar` is not satisfied
   --> $DIR/same-crate-name.rs:51:20
@@ -51,13 +52,13 @@ error[E0277]: the trait bound `ImplementsTraitForUsize<isize>: main::a::Bar` is 
 LL |         a::try_foo(other_variant_implements_correct_trait);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsTraitForUsize<isize>`
    |
-  ::: $DIR/auxiliary/crate_a1.rs:3:24
-   |
-LL | pub fn try_foo(x: impl Bar) {}
-   |                        --- required by this bound in `try_foo`
-   |
    = help: the following implementations were found:
              <ImplementsTraitForUsize<usize> as main::a::Bar>
+note: required by a bound in `try_foo`
+  --> $DIR/auxiliary/crate_a1.rs:3:24
+   |
+LL | pub fn try_foo(x: impl Bar) {}
+   |                        ^^^ required by this bound in `try_foo`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/traits/impl-bounds-checking.stderr
+++ b/src/test/ui/traits/impl-bounds-checking.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `isize: Clone2` is not satisfied
   --> $DIR/impl-bounds-checking.rs:10:6
    |
-LL | trait Getter<T: Clone2> {
-   |                 ------ required by this bound in `Getter`
-...
 LL | impl Getter<isize> for isize {
    |      ^^^^^^^^^^^^^ the trait `Clone2` is not implemented for `isize`
+   |
+note: required by a bound in `Getter`
+  --> $DIR/impl-bounds-checking.rs:6:17
+   |
+LL | trait Getter<T: Clone2> {
+   |                 ^^^^^^ required by this bound in `Getter`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inductive-overflow/lifetime.rs
+++ b/src/test/ui/traits/inductive-overflow/lifetime.rs
@@ -21,7 +21,7 @@ impl<'a> NotAuto for C<'a> {}
 
 fn is_send<S: NotAuto>() {}
 //~^ NOTE: required
-
+//~| NOTE: required
 fn main() {
     // Should only be a few notes.
     is_send::<X<C<'static>>>();

--- a/src/test/ui/traits/inductive-overflow/lifetime.stderr
+++ b/src/test/ui/traits/inductive-overflow/lifetime.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `Box<X<C<'_>>>: NotAuto`
   --> $DIR/lifetime.rs:27:5
    |
-LL | fn is_send<S: NotAuto>() {}
-   |               ------- required by this bound in `is_send`
-...
 LL |     is_send::<X<C<'static>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -14,6 +11,11 @@ LL | impl<T: Y> NotAuto for X<T> where T::P: NotAuto {}
    |            ^^^^^^^     ^^^^
    = note: 2 redundant requirements hidden
    = note: required because of the requirements on the impl of `NotAuto` for `X<C<'static>>`
+note: required by a bound in `is_send`
+  --> $DIR/lifetime.rs:22:15
+   |
+LL | fn is_send<S: NotAuto>() {}
+   |               ^^^^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inductive-overflow/simultaneous.stderr
+++ b/src/test/ui/traits/inductive-overflow/simultaneous.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `{integer}: Tweedledee`
   --> $DIR/simultaneous.rs:18:5
    |
-LL | fn is_ee<T: Combo>(t: T) {
-   |             ----- required by this bound in `is_ee`
-...
 LL |     is_ee(4);
    |     ^^^^^
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Combo` for `{integer}
    |
 LL | impl<T: Tweedledee + Tweedledum> Combo for T {}
    |                                  ^^^^^     ^
+note: required by a bound in `is_ee`
+  --> $DIR/simultaneous.rs:13:13
+   |
+LL | fn is_ee<T: Combo>(t: T) {
+   |             ^^^^^ required by this bound in `is_ee`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -9,13 +9,15 @@ LL | auto trait Magic: Copy {}
 error[E0277]: the trait bound `NoClone: Copy` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23
    |
-LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   |            ----- required by this bound in `copy`
-...
 LL |     let (a, b) = copy(NoClone);
    |                       ^^^^^^^ the trait `Copy` is not implemented for `NoClone`
    |
    = note: required because of the requirements on the impl of `Magic` for `NoClone`
+note: required by a bound in `copy`
+  --> $DIR/supertrait-auto-trait.rs:10:12
+   |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   |            ^^^^^ required by this bound in `copy`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/inductive-overflow/supertrait.stderr
+++ b/src/test/ui/traits/inductive-overflow/supertrait.stderr
@@ -1,9 +1,6 @@
 error[E0275]: overflow evaluating the requirement `NoClone: Magic`
   --> $DIR/supertrait.rs:13:18
    |
-LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   |            ----- required by this bound in `copy`
-...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^
    |
@@ -12,6 +9,11 @@ note: required because of the requirements on the impl of `Magic` for `NoClone`
    |
 LL | impl<T: Magic> Magic for T {}
    |                ^^^^^     ^
+note: required by a bound in `copy`
+  --> $DIR/supertrait.rs:7:12
+   |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   |            ^^^^^ required by this bound in `copy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inductive-overflow/two-traits.stderr
+++ b/src/test/ui/traits/inductive-overflow/two-traits.stderr
@@ -1,12 +1,14 @@
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/two-traits.rs:11:5
    |
-LL |     type X: Trait;
-   |             ----- required by this bound in `Magic::X`
-...
 LL |     type X = Self;
    |     ^^^^^^^^^^^^^^ `T` cannot be shared between threads safely
    |
+note: required by a bound in `Magic::X`
+  --> $DIR/two-traits.rs:8:13
+   |
+LL |     type X: Trait;
+   |             ^^^^^ required by this bound in `Magic::X`
 help: consider further restricting this bound
    |
 LL | impl<T: Magic + std::marker::Sync> Magic for T {
@@ -15,11 +17,14 @@ LL | impl<T: Magic + std::marker::Sync> Magic for T {
 error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/two-traits.rs:20:5
    |
-LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
-   |              ----- required by this bound in `wizard`
-...
 LL |     wizard::<*mut ()>();
    |     ^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `wizard`
+  --> $DIR/two-traits.rs:17:14
+   |
+LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
+   |              ^^^^^ required by this bound in `wizard`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/issue-65673.stderr
+++ b/src/test/ui/traits/issue-65673.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
   --> $DIR/issue-65673.rs:9:5
    |
-LL |     type Ctx;
-   |     --------- required by this bound in `WithType::Ctx`
-...
 LL |     type Ctx = dyn Alias<T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+note: required by a bound in `WithType::Ctx`
+  --> $DIR/issue-65673.rs:4:5
+   |
+LL |     type Ctx;
+   |     ^^^^^^^^^ required by this bound in `WithType::Ctx`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -4,12 +4,12 @@ error[E0283]: type annotations needed
 LL |     T: FnMut(&'a ()),
    |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
    |
-  ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
+   = note: cannot satisfy `T: FnMut<(&'a (),)>`
+note: required by a bound in `FnMut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    |
 LL | pub trait FnMut<Args>: FnOnce<Args> {
-   | ----------------------------------- required by this bound in `FnMut`
-   |
-   = note: cannot satisfy `T: FnMut<(&'a (),)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FnMut`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.stderr
@@ -4,12 +4,12 @@ error[E0275]: overflow evaluating the requirement `Option<_>: Sized`
 LL |     iso(left, right)
    |     ^^^
    |
-  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`mutual_recursion_issue_75860`)
+note: required by a bound in `Option`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {
-   |                 - required by this bound in `Option`
-   |
-   = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`mutual_recursion_issue_75860`)
+   |                 ^ required by this bound in `Option`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -14,43 +14,46 @@ LL | struct Outer<T: Send>(T);
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:5
    |
-LL | struct Outer<T: Send>(T);
-   |                 ---- required by this bound in `Outer`
-...
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
+note: required by a bound in `Outer`
+  --> $DIR/negated-auto-traits-error.rs:10:17
+   |
+LL | struct Outer<T: Send>(T);
+   |                 ^^^^ required by this bound in `Outer`
 
 error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:32:13
    |
-LL | fn is_send<T: Send>(_: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(TestType);
    |             ^^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dummy1b::TestType`
+note: required by a bound in `is_send`
+  --> $DIR/negated-auto-traits-error.rs:16:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
 
 error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:40:13
    |
-LL | fn is_send<T: Send>(_: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send((8, TestType));
    |             ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
+note: required by a bound in `is_send`
+  --> $DIR/negated-auto-traits-error.rs:16:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
 
 error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:48:13
    |
-LL | fn is_send<T: Send>(_: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(Box::new(TestType));
    |             ^^^^^^^^^^^^^^^^^^
    |             |
@@ -60,13 +63,15 @@ LL |     is_send(Box::new(TestType));
    = note: the trait bound `dummy2::TestType: Send` is not satisfied
    = note: required because of the requirements on the impl of `Send` for `Unique<dummy2::TestType>`
    = note: required because it appears within the type `Box<dummy2::TestType>`
+note: required by a bound in `is_send`
+  --> $DIR/negated-auto-traits-error.rs:16:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
 
 error[E0277]: `dummy3::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:56:13
    |
-LL | fn is_send<T: Send>(_: T) {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send(Box::new(Outer2(TestType)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
    |
@@ -78,13 +83,15 @@ LL | struct Outer2<T>(T);
    |        ^^^^^^
    = note: required because of the requirements on the impl of `Send` for `Unique<Outer2<dummy3::TestType>>`
    = note: required because it appears within the type `Box<Outer2<dummy3::TestType>>`
+note: required by a bound in `is_send`
+  --> $DIR/negated-auto-traits-error.rs:16:15
+   |
+LL | fn is_send<T: Send>(_: T) {}
+   |               ^^^^ required by this bound in `is_send`
 
 error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
-LL | fn is_sync<T: Sync>(_: T) {}
-   |               ---- required by this bound in `is_sync`
-...
 LL |     is_sync(Outer2(TestType));
    |             ^^^^^^^^^^^^^^^^
    |             |
@@ -97,6 +104,11 @@ note: required because of the requirements on the impl of `Sync` for `Outer2<mai
    |
 LL | unsafe impl<T: Send> Sync for Outer2<T> {}
    |                      ^^^^     ^^^^^^^^^
+note: required by a bound in `is_sync`
+  --> $DIR/negated-auto-traits-error.rs:17:15
+   |
+LL | fn is_sync<T: Sync>(_: T) {}
+   |               ^^^^ required by this bound in `is_sync`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/traits/suggest-deferences/issue-39029.stderr
+++ b/src/test/ui/traits/suggest-deferences/issue-39029.stderr
@@ -7,12 +7,12 @@ LL |     let _errors = TcpListener::bind(&bad);
    |                                     the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
    |                                     help: consider adding dereference here: `&*bad`
    |
-  ::: $SRC_DIR/std/src/net/tcp.rs:LL:COL
+   = note: required because of the requirements on the impl of `ToSocketAddrs` for `&NoToSocketAddrs`
+note: required by a bound in `TcpListener::bind`
+  --> $SRC_DIR/std/src/net/tcp.rs:LL:COL
    |
 LL |     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
-   |                    ------------- required by this bound in `TcpListener::bind`
-   |
-   = note: required because of the requirements on the impl of `ToSocketAddrs` for `&NoToSocketAddrs`
+   |                    ^^^^^^^^^^^^^ required by this bound in `TcpListener::bind`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/suggest-deferences/issue-62530.stderr
+++ b/src/test/ui/traits/suggest-deferences/issue-62530.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `&String: SomeTrait` is not satisfied
   --> $DIR/issue-62530.rs:13:26
    |
-LL | fn takes_type_parameter<T>(_x: T) where T: SomeTrait {}
-   |                                            --------- required by this bound in `takes_type_parameter`
-...
 LL |     takes_type_parameter(&string);  // Error
    |                          ^^^^^^^
    |                          |
    |                          the trait `SomeTrait` is not implemented for `&String`
    |                          help: consider adding dereference here: `&*string`
+   |
+note: required by a bound in `takes_type_parameter`
+  --> $DIR/issue-62530.rs:4:44
+   |
+LL | fn takes_type_parameter<T>(_x: T) where T: SomeTrait {}
+   |                                            ^^^^^^^^^ required by this bound in `takes_type_parameter`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/suggest-deferences/multiple-0.stderr
+++ b/src/test/ui/traits/suggest-deferences/multiple-0.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `&Baz: Happy` is not satisfied
   --> $DIR/multiple-0.rs:34:9
    |
-LL | fn foo<T>(_: T) where T: Happy {}
-   |                          ----- required by this bound in `foo`
-...
 LL |     foo(&baz);
    |         ^^^^
    |         |
    |         the trait `Happy` is not implemented for `&Baz`
    |         help: consider adding dereference here: `&***baz`
+   |
+note: required by a bound in `foo`
+  --> $DIR/multiple-0.rs:30:26
+   |
+LL | fn foo<T>(_: T) where T: Happy {}
+   |                          ^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/suggest-deferences/multiple-1.stderr
+++ b/src/test/ui/traits/suggest-deferences/multiple-1.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `&mut Baz: Happy` is not satisfied
   --> $DIR/multiple-1.rs:52:9
    |
-LL | fn foo<T>(_: T) where T: Happy {}
-   |                          ----- required by this bound in `foo`
-...
 LL |     foo(&mut baz);
    |         ^^^^^^^^ the trait `Happy` is not implemented for `&mut Baz`
+   |
+note: required by a bound in `foo`
+  --> $DIR/multiple-1.rs:45:26
+   |
+LL | fn foo<T>(_: T) where T: Happy {}
+   |                          ^^^^^ required by this bound in `foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/suggest-where-clause.stderr
+++ b/src/test/ui/traits/suggest-where-clause.stderr
@@ -7,11 +7,11 @@ LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn check<T: Iterator, U: ?Sized>() {
@@ -27,16 +27,16 @@ LL | fn check<T: Iterator, U: ?Sized>() {
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
 note: required because it appears within the type `Misc<U>`
   --> $DIR/suggest-where-clause.rs:3:8
    |
 LL | struct Misc<T:?Sized>(T);
    |        ^^^^
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      ^ required by this bound in `std::mem::size_of`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn check<T: Iterator, U: ?Sized>() {
@@ -93,12 +93,12 @@ error[E0277]: the size for values of type `[T]` cannot be known at compilation t
 LL |     mem::size_of::<[T]>();
    |                    ^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[T]`
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
-   = help: the trait `Sized` is not implemented for `[T]`
+   |                      ^ required by this bound in `std::mem::size_of`
 
 error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
   --> $DIR/suggest-where-clause.rs:31:5
@@ -106,12 +106,12 @@ error[E0277]: the size for values of type `[&U]` cannot be known at compilation 
 LL |     mem::size_of::<[&U]>();
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[&U]`
+note: required by a bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
 LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
-   |
-   = help: the trait `Sized` is not implemented for `[&U]`
+   |                      ^ required by this bound in `std::mem::size_of`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -37,9 +37,12 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
    |
 LL |     generic_function(5i32);
    |                      ^^^^ the trait `Foo` is not implemented for `i32`
-...
+   |
+note: required by a bound in `generic_function`
+  --> $DIR/trivial-bounds-leak.rs:29:24
+   |
 LL | fn generic_function<T: Foo>(t: T) {}
-   |                        --- required by this bound in `generic_function`
+   |                        ^^^ required by this bound in `generic_function`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/try-trait/try-operator-on-main.stderr
+++ b/src/test/ui/try-trait/try-operator-on-main.stderr
@@ -58,9 +58,12 @@ error[E0277]: the trait bound `(): Try` is not satisfied
    |
 LL |     try_trait_generic::<()>();
    |                         ^^ the trait `Try` is not implemented for `()`
-...
+   |
+note: required by a bound in `try_trait_generic`
+  --> $DIR/try-operator-on-main.rs:17:25
+   |
 LL | fn try_trait_generic<T: Try>() -> T {
-   |                         --- required by this bound in `try_trait_generic`
+   |                         ^^^ required by this bound in `try_trait_generic`
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> $DIR/try-operator-on-main.rs:19:5

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -7,12 +7,14 @@ LL | type Underconstrained<T: Trait> = impl 'static;
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/generic_underconstrained.rs:10:31
    |
-LL | type Underconstrained<T: Trait> = impl 'static;
-   |                          ----- required by this bound in `Underconstrained`
-...
 LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
    |                               ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
+note: required by a bound in `Underconstrained`
+  --> $DIR/generic_underconstrained.rs:6:26
+   |
+LL | type Underconstrained<T: Trait> = impl 'static;
+   |                          ^^^^^ required by this bound in `Underconstrained`
 help: consider restricting type parameter `T`
    |
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -13,12 +13,14 @@ LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
 error[E0277]: `U` doesn't implement `Debug`
   --> $DIR/generic_underconstrained2.rs:9:33
    |
-LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
-   |                          --------------- required by this bound in `Underconstrained`
-...
 LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
    |                                 ^^^^^^^^^^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
+note: required by a bound in `Underconstrained`
+  --> $DIR/generic_underconstrained2.rs:5:26
+   |
+LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
+   |                          ^^^^^^^^^^^^^^^ required by this bound in `Underconstrained`
 help: consider restricting type parameter `U`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
@@ -27,12 +29,14 @@ LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
 error[E0277]: `V` doesn't implement `Debug`
   --> $DIR/generic_underconstrained2.rs:18:43
    |
-LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
-   |                           --------------- required by this bound in `Underconstrained2`
-...
 LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
    |                                           ^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
+note: required by a bound in `Underconstrained2`
+  --> $DIR/generic_underconstrained2.rs:14:27
+   |
+LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `Underconstrained2`
 help: consider restricting type parameter `V`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {

--- a/src/test/ui/type/type-annotation-needed.rs
+++ b/src/test/ui/type/type-annotation-needed.rs
@@ -1,6 +1,6 @@
 fn foo<T: Into<String>>(x: i32) {}
 //~^ NOTE required by
-
+//~| NOTE required by
 fn main() {
     foo(42);
     //~^ ERROR type annotations needed

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/type-annotation-needed.rs:5:5
    |
-LL | fn foo<T: Into<String>>(x: i32) {}
-   |           ------------ required by this bound in `foo`
-...
 LL |     foo(42);
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`
    |
    = note: cannot satisfy `_: Into<String>`
+note: required by a bound in `foo`
+  --> $DIR/type-annotation-needed.rs:1:11
+   |
+LL | fn foo<T: Into<String>>(x: i32) {}
+   |           ^^^^^^^^^^^^ required by this bound in `foo`
 help: consider specifying the type argument in the function call
    |
 LL |     foo::<T>(42);

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -1,23 +1,28 @@
 error[E0277]: a value of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:6:19
    |
-LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   |                  --------------- required by this bound in `Foo`
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
+note: required by a bound in `Foo`
+  --> $DIR/type-check-defaults.rs:5:18
+   |
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
+   |                  ^^^^^^^^^^^^^^^ required by this bound in `Foo`
 
 error[E0277]: a value of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:8:27
    |
-LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   |                  --------------- required by this bound in `Foo`
-...
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
+note: required by a bound in `Foo`
+  --> $DIR/type-check-defaults.rs:5:18
+   |
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
+   |                  ^^^^^^^^^^^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:11:17
@@ -58,11 +63,14 @@ LL | trait TraitBound<T:Copy=String> {}
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
    |
-LL | trait Super<T: Copy> { }
-   |                ---- required by this bound in `Super`
 LL | trait Base<T = String>: Super<T> { }
    |                         ^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `Super`
+  --> $DIR/type-check-defaults.rs:20:16
+   |
+LL | trait Super<T: Copy> { }
+   |                ^^^^ required by this bound in `Super`
 help: consider further restricting type parameter `T`
    |
 LL | trait Base<T = String>: Super<T> where T: std::marker::Copy { }

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,13 +1,15 @@
 error[E0283]: type annotations needed
   --> $DIR/issue-40294.rs:6:19
    |
-LL | trait Foo: Sized {
-   | ---------------- required by this bound in `Foo`
-...
 LL |     where &'a T : Foo,
    |                   ^^^ cannot infer type for reference `&'a T`
    |
    = note: cannot satisfy `&'a T: Foo`
+note: required by a bound in `Foo`
+  --> $DIR/issue-40294.rs:1:1
+   |
+LL | trait Foo: Sized {
+   | ^^^^^^^^^^^^^^^^ required by this bound in `Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -3,11 +3,13 @@ error[E0277]: `<T as Trait>::AssocType` cannot be sent between threads safely
    |
 LL |     is_send::<T::AssocType>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
-...
-LL | fn is_send<T:Send>() {
-   |              ---- required by this bound in `is_send`
    |
    = help: the trait `Send` is not implemented for `<T as Trait>::AssocType`
+note: required by a bound in `is_send`
+  --> $DIR/typeck-default-trait-impl-assoc-type.rs:14:14
+   |
+LL | fn is_send<T:Send>() {
+   |              ^^^^ required by this bound in `is_send`
 help: consider further restricting the associated type
    |
 LL | fn bar<T:Trait+Send>() where <T as Trait>::AssocType: Send {

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -1,13 +1,15 @@
 error[E0277]: `MyNotSendable` cannot be sent between threads safely
   --> $DIR/typeck-default-trait-impl-negation-send.rs:19:15
    |
-LL | fn is_send<T: Send>() {}
-   |               ---- required by this bound in `is_send`
-...
 LL |     is_send::<MyNotSendable>();
    |               ^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `MyNotSendable`
+note: required by a bound in `is_send`
+  --> $DIR/typeck-default-trait-impl-negation-send.rs:15:15
+   |
+LL | fn is_send<T: Send>() {}
+   |               ^^^^ required by this bound in `is_send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -1,20 +1,19 @@
 error[E0277]: `MyNotSync` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:33:15
    |
-LL | fn is_sync<T: Sync>() {}
-   |               ---- required by this bound in `is_sync`
-...
 LL |     is_sync::<MyNotSync>();
    |               ^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `MyNotSync`
+note: required by a bound in `is_sync`
+  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
+   |
+LL | fn is_sync<T: Sync>() {}
+   |               ^^^^ required by this bound in `is_sync`
 
 error[E0277]: `UnsafeCell<u8>` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:36:5
    |
-LL | fn is_sync<T: Sync>() {}
-   |               ---- required by this bound in `is_sync`
-...
 LL |     is_sync::<MyTypeWUnsafe>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<u8>` cannot be shared between threads safely
    |
@@ -24,13 +23,15 @@ note: required because it appears within the type `MyTypeWUnsafe`
    |
 LL | struct MyTypeWUnsafe {
    |        ^^^^^^^^^^^^^
+note: required by a bound in `is_sync`
+  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
+   |
+LL | fn is_sync<T: Sync>() {}
+   |               ^^^^ required by this bound in `is_sync`
 
 error[E0277]: `Managed` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:39:5
    |
-LL | fn is_sync<T: Sync>() {}
-   |               ---- required by this bound in `is_sync`
-...
 LL |     is_sync::<MyTypeManaged>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
@@ -40,6 +41,11 @@ note: required because it appears within the type `MyTypeManaged`
    |
 LL | struct MyTypeManaged {
    |        ^^^^^^^^^^^^^
+note: required by a bound in `is_sync`
+  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:15
+   |
+LL | fn is_sync<T: Sync>() {}
+   |               ^^^^ required by this bound in `is_sync`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -3,10 +3,12 @@ error[E0277]: `T` cannot be sent between threads safely
    |
 LL |     is_send::<T>()
    |               ^ `T` cannot be sent between threads safely
-...
-LL | fn is_send<T:Send>() {
-   |              ---- required by this bound in `is_send`
    |
+note: required by a bound in `is_send`
+  --> $DIR/typeck-default-trait-impl-send-param.rs:8:14
+   |
+LL | fn is_send<T:Send>() {
+   |              ^^^^ required by this bound in `is_send`
 help: consider restricting type parameter `T`
    |
 LL | fn foo<T: std::marker::Send>() {

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -1,31 +1,32 @@
 error[E0277]: `UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:19:10
    |
-LL | fn test<T: Sync>(s: T) {}
-   |            ---- required by this bound in `test`
-...
 LL |     test(us);
    |          ^^ `UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<MySync<{integer}>>`
+note: required by a bound in `test`
+  --> $DIR/typeck-unsafe-always-share.rs:15:12
+   |
+LL | fn test<T: Sync>(s: T) {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `UnsafeCell<NoSync>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:23:10
    |
-LL | fn test<T: Sync>(s: T) {}
-   |            ---- required by this bound in `test`
-...
 LL |     test(uns);
    |          ^^^ `UnsafeCell<NoSync>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
+note: required by a bound in `test`
+  --> $DIR/typeck-unsafe-always-share.rs:15:12
+   |
+LL | fn test<T: Sync>(s: T) {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `UnsafeCell<NoSync>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:27:5
    |
-LL | fn test<T: Sync>(s: T) {}
-   |            ---- required by this bound in `test`
-...
 LL |     test(ms);
    |     ^^^^ `UnsafeCell<NoSync>` cannot be shared between threads safely
    |
@@ -35,17 +36,24 @@ note: required because it appears within the type `MySync<NoSync>`
    |
 LL | struct MySync<T> {
    |        ^^^^^^
+note: required by a bound in `test`
+  --> $DIR/typeck-unsafe-always-share.rs:15:12
+   |
+LL | fn test<T: Sync>(s: T) {}
+   |            ^^^^ required by this bound in `test`
 
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:30:10
    |
-LL | fn test<T: Sync>(s: T) {}
-   |            ---- required by this bound in `test`
-...
 LL |     test(NoSync);
    |          ^^^^^^ `NoSync` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `NoSync`
+note: required by a bound in `test`
+  --> $DIR/typeck-unsafe-always-share.rs:15:12
+   |
+LL | fn test<T: Sync>(s: T) {}
+   |            ^^^^ required by this bound in `test`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `dyn Foo<(isize,), isize, Output = ()>: Eq<dyn Foo<(isize,), Output = ()>>` is not satisfied
   --> $DIR/unboxed-closure-sugar-default.rs:21:5
    |
-LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
-   |                                        ----- required by this bound in `eq`
-...
 LL |     eq::<dyn Foo<(isize,), isize, Output=()>, dyn Foo(isize)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<dyn Foo<(isize,), Output = ()>>` is not implemented for `dyn Foo<(isize,), isize, Output = ()>`
+   |
+note: required by a bound in `eq`
+  --> $DIR/unboxed-closure-sugar-default.rs:14:40
+   |
+LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
+   |                                        ^^^^^ required by this bound in `eq`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
@@ -1,12 +1,15 @@
 error[E0277]: the trait bound `dyn Foo<(char,), Output = ()>: Eq<dyn Foo<(), Output = ()>>` is not satisfied
   --> $DIR/unboxed-closure-sugar-equiv.rs:43:5
    |
-LL |   fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
-   |                              ----- required by this bound in `eq`
-...
 LL | /     eq::< dyn Foo<(),Output=()>,
 LL | |           dyn Foo(char)                                               >();
    | |_______________________________________________________________________^ the trait `Eq<dyn Foo<(), Output = ()>>` is not implemented for `dyn Foo<(char,), Output = ()>`
+   |
+note: required by a bound in `eq`
+  --> $DIR/unboxed-closure-sugar-equiv.rs:16:28
+   |
+LL | fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
+   |                            ^^^^^ required by this bound in `eq`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,13 +1,15 @@
 error[E0277]: expected a `Fn<(isize,)>` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
    |
-LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
-   |              ---------------- required by this bound in `call_it`
-...
 LL |     let x = call_it(&S, 22);
    |                     ^^ expected an `Fn<(isize,)>` closure, found `S`
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `S`
+note: required by a bound in `call_it`
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:23:14
+   |
+LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
+   |              ^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,35 +1,41 @@
 error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
-LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
-   |               ------------------- required by this bound in `call_it`
-...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it`
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:9:15
+   |
+LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
-LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
-   |                   ---------------------- required by this bound in `call_it_mut`
-...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it_mut`
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:19
+   |
+LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
 error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
-LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
-   |                    ----------------------- required by this bound in `call_it_once`
-...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it_once`
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:15:20
+   |
+LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_once`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,35 +1,41 @@
 error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
-LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
-   |               ------------------- required by this bound in `call_it`
-...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it`
+  --> $DIR/unboxed-closures-wrong-abi.rs:9:15
+   |
+LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
-LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
-   |                   ---------------------- required by this bound in `call_it_mut`
-...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it_mut`
+  --> $DIR/unboxed-closures-wrong-abi.rs:12:19
+   |
+LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
 error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
-LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
-   |                    ----------------------- required by this bound in `call_it_once`
-...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+note: required by a bound in `call_it_once`
+  --> $DIR/unboxed-closures-wrong-abi.rs:15:20
+   |
+LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_once`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,35 +1,41 @@
 error[E0277]: expected a `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
-LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
-   |               ------------------- required by this bound in `call_it`
-...
 LL |     let x = call_it(&square, 22);
    |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+note: required by a bound in `call_it`
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:10:15
+   |
+LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
 error[E0277]: expected a `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
-LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
-   |                   ---------------------- required by this bound in `call_it_mut`
-...
 LL |     let y = call_it_mut(&mut square, 22);
    |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+note: required by a bound in `call_it_mut`
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:19
+   |
+LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
 error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
-LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
-   |                    ----------------------- required by this bound in `call_it_once`
-...
 LL |     let z = call_it_once(square, 22);
    |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
+note: required by a bound in `call_it_once`
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:16:20
+   |
+LL | fn call_it_once<F: FnOnce(&isize) -> isize>(_: F, _: isize) -> isize {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_once`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
@@ -4,11 +4,11 @@ error[E0277]: the trait bound `U1: Copy` is not satisfied
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `Copy` is not implemented for `U1`
    |
-  ::: $SRC_DIR/core/src/clone.rs:LL:COL
+note: required by a bound in `AssertParamIsCopy`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
-   |                                 ---- required by this bound in `AssertParamIsCopy`
-   |
+   |                                 ^^^^ required by this bound in `AssertParamIsCopy`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its trait bounds were not satisfied

--- a/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
@@ -4,11 +4,11 @@ error[E0277]: the trait bound `U1: Copy` is not satisfied
 LL | #[derive(Clone)]
    |          ^^^^^ the trait `Copy` is not implemented for `U1`
    |
-  ::: $SRC_DIR/core/src/clone.rs:LL:COL
+note: required by a bound in `AssertParamIsCopy`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
    |
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
-   |                                 ---- required by this bound in `AssertParamIsCopy`
-   |
+   |                                 ^^^^ required by this bound in `AssertParamIsCopy`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its trait bounds were not satisfied

--- a/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
@@ -7,11 +7,11 @@ LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
@@ -7,11 +7,11 @@ LL | union U2 {
 LL |     a: PartialEqNotEq,
    |     ^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `PartialEqNotEq`
    |
-  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+note: required by a bound in `AssertParamIsEq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
-   |                               -- required by this bound in `AssertParamIsEq`
-   |
+   |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/unsized/issue-75707.stderr
+++ b/src/test/ui/unsized/issue-75707.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `MyCall: Callback` is not satisfied
   --> $DIR/issue-75707.rs:15:5
    |
-LL | fn f<P: Processing + ?Sized>() {
-   |         ---------- required by this bound in `f`
-...
 LL |     f::<dyn Processing<Call = MyCall>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Callback` is not implemented for `MyCall`
+   |
+note: required by a bound in `f`
+  --> $DIR/issue-75707.rs:9:9
+   |
+LL | fn f<P: Processing + ?Sized>() {
+   |         ^^^^^^^^^^ required by this bound in `f`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -1,13 +1,16 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-bare-typaram.rs:2:29
    |
-LL | fn bar<T: Sized>() { }
-   |        - required by this bound in `bar`
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        -                    ^ doesn't have a size known at compile-time
    |        |
    |        this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `bar`
+  --> $DIR/unsized-bare-typaram.rs:1:8
+   |
+LL | fn bar<T: Sized>() { }
+   |        ^ required by this bound in `bar`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo<T: ?Sized>() { bar::<T>() }

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-enum.rs:6:36
    |
-LL | enum Foo<U> { FooSome(U), FooNone }
-   |          - required by this bound in `Foo`
-LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Foo`
+  --> $DIR/unsized-enum.rs:4:10
+   |
+LL | enum Foo<U> { FooSome(U), FooNone }
+   |          ^ required by this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10
    |

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-inherent-impl-self-type.rs:7:17
    |
-LL | struct S5<Y>(Y);
-   |           - required by this bound in `S5`
-LL | 
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `S5`
+  --> $DIR/unsized-inherent-impl-self-type.rs:5:11
+   |
+LL | struct S5<Y>(Y);
+   |           ^ required by this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-struct.rs:6:36
    |
-LL | struct Foo<T> { data: T }
-   |            - required by this bound in `Foo`
-LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `Foo`
+  --> $DIR/unsized-struct.rs:4:12
+   |
+LL | struct Foo<T> { data: T }
+   |            ^ required by this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
    |
@@ -25,9 +27,6 @@ LL + fn foo2<T>() { not_sized::<Foo<T>>() }
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-struct.rs:13:24
    |
-LL | fn is_sized<T:Sized>() { }
-   |             - required by this bound in `is_sized`
-...
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         -              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
@@ -38,6 +37,11 @@ note: required because it appears within the type `Bar<T>`
    |
 LL | struct Bar<T: ?Sized> { data: T }
    |        ^^^
+note: required by a bound in `is_sized`
+  --> $DIR/unsized-struct.rs:1:13
+   |
+LL | fn is_sized<T:Sized>() { }
+   |             ^ required by this bound in `is_sized`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-self-type.rs:10:27
    |
-LL | struct S5<Y>(Y);
-   |           - required by this bound in `S5`
-LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -                    ^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `S5`
+  --> $DIR/unsized-trait-impl-self-type.rs:8:11
+   |
+LL | struct S5<Y>(Y);
+   |           ^ required by this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
    |
-LL | trait T2<Z> {
-   |          - required by this bound in `T2`
-...
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `T2`
+  --> $DIR/unsized-trait-impl-trait-arg.rs:4:10
+   |
+LL | trait T2<Z> {
+   |          ^ required by this bound in `T2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {

--- a/src/test/ui/unsized/unsized3.stderr
+++ b/src/test/ui/unsized/unsized3.stderr
@@ -5,10 +5,12 @@ LL | fn f1<X: ?Sized>(x: &X) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
-...
-LL | fn f2<X>(x: &X) {
-   |       - required by this bound in `f2`
    |
+note: required by a bound in `f2`
+  --> $DIR/unsized3.rs:10:7
+   |
+LL | fn f2<X>(x: &X) {
+   |       ^ required by this bound in `f2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
@@ -26,10 +28,12 @@ LL | fn f3<X: ?Sized + T>(x: &X) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
-...
-LL | fn f4<X: T>(x: &X) {
-   |       - required by this bound in `f4`
    |
+note: required by a bound in `f4`
+  --> $DIR/unsized3.rs:21:7
+   |
+LL | fn f4<X: T>(x: &X) {
+   |       ^ required by this bound in `f4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
@@ -43,9 +47,6 @@ LL | fn f4<X: T + ?Sized>(x: &X) {
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:33:8
    |
-LL | fn f5<Y>(x: &Y) {}
-   |       - required by this bound in `f5`
-...
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(x1);
@@ -56,6 +57,11 @@ note: required because it appears within the type `S<X>`
    |
 LL | struct S<X: ?Sized> {
    |        ^
+note: required by a bound in `f5`
+  --> $DIR/unsized3.rs:24:7
+   |
+LL | fn f5<Y>(x: &Y) {}
+   |       ^ required by this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
@@ -110,9 +116,6 @@ LL + fn f10<X>(x1: Box<S<X>>) {
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:45:8
    |
-LL | fn f5<Y>(x: &Y) {}
-   |       - required by this bound in `f5`
-...
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
@@ -124,6 +127,11 @@ note: required because it appears within the type `S<X>`
 LL | struct S<X: ?Sized> {
    |        ^
    = note: required because it appears within the type `({integer}, S<X>)`
+note: required by a bound in `f5`
+  --> $DIR/unsized3.rs:24:7
+   |
+LL | fn f5<Y>(x: &Y) {}
+   |       ^ required by this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/src/test/ui/unsized/unsized7.stderr
+++ b/src/test/ui/unsized/unsized7.stderr
@@ -1,14 +1,16 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized7.rs:12:21
    |
-LL | trait T1<Z: T> {
-   |          - required by this bound in `T1`
-...
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `std::marker::Sized`
    |
+note: required by a bound in `T1`
+  --> $DIR/unsized7.rs:7:10
+   |
+LL | trait T1<Z: T> {
+   |          ^ required by this bound in `T1`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {

--- a/src/test/ui/wf/hir-wf-check-erase-regions.stderr
+++ b/src/test/ui/wf/hir-wf-check-erase-regions.stderr
@@ -4,13 +4,13 @@ error[E0277]: `&T` is not an iterator
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&T` is not an iterator
    |
-  ::: $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
-   |
-LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
-   |                                      ------------ required by this bound in `Flatten`
-   |
    = help: the trait `Iterator` is not implemented for `&T`
    = note: required because of the requirements on the impl of `IntoIterator` for `&T`
+note: required by a bound in `Flatten`
+  --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
+   |
+LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
+   |                                      ^^^^^^^^^^^^ required by this bound in `Flatten`
 
 error[E0277]: `&T` is not an iterator
   --> $DIR/hir-wf-check-erase-regions.rs:10:27
@@ -18,13 +18,13 @@ error[E0277]: `&T` is not an iterator
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&T` is not an iterator
    |
-  ::: $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
-   |
-LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
-   |                                      ------------ required by this bound in `Flatten`
-   |
    = help: the trait `Iterator` is not implemented for `&T`
    = note: required because of the requirements on the impl of `IntoIterator` for `&T`
+note: required by a bound in `Flatten`
+  --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
+   |
+LL | pub struct Flatten<I: Iterator<Item: IntoIterator>> {
+   |                                      ^^^^^^^^^^^^ required by this bound in `Flatten`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/wf/wf-complex-assoc-type.stderr
+++ b/src/test/ui/wf/wf-complex-assoc-type.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `bool: MyTrait` is not satisfied
   --> $DIR/wf-complex-assoc-type.rs:9:28
    |
-LL | struct AssertMyTrait<T: MyTrait>(T);
-   |                         ------- required by this bound in `AssertMyTrait`
-...
 LL |     type MyItem = Option<((AssertMyTrait<bool>, u8))>;
    |                            ^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `bool`
+   |
+note: required by a bound in `AssertMyTrait`
+  --> $DIR/wf-complex-assoc-type.rs:2:25
+   |
+LL | struct AssertMyTrait<T: MyTrait>(T);
+   |                         ^^^^^^^ required by this bound in `AssertMyTrait`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
-LL | struct IsCopy<T:Copy> { t: T }
-   |                 ---- required by this bound in `IsCopy`
-...
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`
    |
    = note: required because of the requirements on the impl of `Copy` for `Option<NotCopy>`
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-const-type.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> { t: T }
+   |                 ^^^^ required by this bound in `IsCopy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-enum-bound.rs:10:14
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-enum-bound.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider further restricting type parameter `U`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `A: Copy` is not satisfied
   --> $DIR/wf-enum-fields-struct-variant.rs:13:12
    |
-LL | struct IsCopy<T:Copy> {
-   |                 ---- required by this bound in `IsCopy`
-...
 LL |         f: IsCopy<A>
    |            ^^^^^^^^^ the trait `Copy` is not implemented for `A`
    |
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-enum-fields-struct-variant.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> {
+   |                 ^^^^ required by this bound in `IsCopy`
 help: consider restricting type parameter `A`
    |
 LL | enum AnotherEnum<A: std::marker::Copy> {

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `A: Copy` is not satisfied
   --> $DIR/wf-enum-fields.rs:12:17
    |
-LL | struct IsCopy<T:Copy> {
-   |                 ---- required by this bound in `IsCopy`
-...
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `Copy` is not implemented for `A`
    |
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-enum-fields.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> {
+   |                 ^^^^ required by this bound in `IsCopy`
 help: consider restricting type parameter `A`
    |
 LL | enum SomeEnum<A: std::marker::Copy> {

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-fn-where-clause.rs:8:24
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-LL | 
 LL | fn foo<T,U>() where T: ExtraCopy<U>
    |                        ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-fn-where-clause.rs:6:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider further restricting type parameter `U`
    |
 LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
@@ -17,11 +19,13 @@ error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-...
-LL | struct Vec<T> {
-   |            - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
+note: required by a bound in `Vec`
+  --> $DIR/wf-fn-where-clause.rs:16:12
+   |
+LL | struct Vec<T> {
+   |            ^ required by this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |

--- a/src/test/ui/wf/wf-foreign-fn-decl-ret.stderr
+++ b/src/test/ui/wf/wf-foreign-fn-decl-ret.stderr
@@ -1,20 +1,26 @@
 error[E0277]: the trait bound `(): Foo` is not satisfied
   --> $DIR/wf-foreign-fn-decl-ret.rs:11:25
    |
-LL | pub trait Foo {
-   | ------------- required by this bound in `Foo`
-...
 LL |     pub fn lint_me() -> <() as Foo>::Assoc;
    |                         ^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `()`
+   |
+note: required by a bound in `Foo`
+  --> $DIR/wf-foreign-fn-decl-ret.rs:6:1
+   |
+LL | pub trait Foo {
+   | ^^^^^^^^^^^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `u32: Unsatisfied` is not satisfied
   --> $DIR/wf-foreign-fn-decl-ret.rs:14:32
    |
-LL | pub struct Bar<T: Unsatisfied>(T);
-   |                   ----------- required by this bound in `Bar`
-...
 LL |     pub fn lint_me_aswell() -> Bar<u32>;
    |                                ^^^^^^^^ the trait `Unsatisfied` is not implemented for `u32`
+   |
+note: required by a bound in `Bar`
+  --> $DIR/wf-foreign-fn-decl-ret.rs:4:19
+   |
+LL | pub struct Bar<T: Unsatisfied>(T);
+   |                   ^^^^^^^^^^^ required by this bound in `Bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: MyHash` is not satisfied
   --> $DIR/wf-impl-associated-type-trait.rs:17:16
    |
-LL | pub struct MySet<T:MyHash> {
-   |                    ------ required by this bound in `MySet`
-...
 LL |     type Bar = MySet<T>;
    |                ^^^^^^^^ the trait `MyHash` is not implemented for `T`
    |
+note: required by a bound in `MySet`
+  --> $DIR/wf-impl-associated-type-trait.rs:8:20
+   |
+LL | pub struct MySet<T:MyHash> {
+   |                    ^^^^^^ required by this bound in `MySet`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: MyHash> Foo for T {

--- a/src/test/ui/wf/wf-impl-self-type.stderr
+++ b/src/test/ui/wf/wf-impl-self-type.stderr
@@ -4,12 +4,12 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL | impl Foo for Option<[u8]> {}
    |              ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `Option`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
    |
 LL | pub enum Option<T> {
-   |                 - required by this bound in `Option`
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
+   |                 ^ required by this bound in `Option`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-in-fn-arg.rs:10:15
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ---- required by this bound in `MustBeCopy`
-...
 LL | fn bar<T>(_: &MustBeCopy<T>)
    |               ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-fn-arg.rs:6:21
+   |
+LL | struct MustBeCopy<T:Copy> {
+   |                     ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | fn bar<T: std::marker::Copy>(_: &MustBeCopy<T>)

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-in-fn-ret.rs:10:16
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ---- required by this bound in `MustBeCopy`
-...
 LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-fn-ret.rs:6:21
+   |
+LL | struct MustBeCopy<T:Copy> {
+   |                     ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-in-fn-type-arg.rs:9:11
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ---- required by this bound in `MustBeCopy`
-...
 LL |     x: fn(MustBeCopy<T>)
    |           ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-fn-type-arg.rs:3:21
+   |
+LL | struct MustBeCopy<T:Copy> {
+   |                     ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | struct Bar<T: std::marker::Copy> {

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-in-fn-type-ret.rs:9:16
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ---- required by this bound in `MustBeCopy`
-...
 LL |     x: fn() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-fn-type-ret.rs:3:21
+   |
+LL | struct MustBeCopy<T:Copy> {
+   |                     ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | struct Foo<T: std::marker::Copy> {

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-in-fn-where-clause.rs:10:14
    |
-LL | trait MustBeCopy<T:Copy> {
-   |                    ---- required by this bound in `MustBeCopy`
-...
 LL |     where T: MustBeCopy<U>
    |              ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-fn-where-clause.rs:6:20
+   |
+LL | trait MustBeCopy<T:Copy> {
+   |                    ^^^^ required by this bound in `MustBeCopy`
 help: consider further restricting type parameter `U`
    |
 LL |     where T: MustBeCopy<U>, U: std::marker::Copy

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-in-obj-type-trait.rs:11:19
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ---- required by this bound in `MustBeCopy`
-...
 LL |     x: dyn Object<MustBeCopy<T>>
    |                   ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `MustBeCopy`
+  --> $DIR/wf-in-obj-type-trait.rs:5:21
+   |
+LL | struct MustBeCopy<T:Copy> {
+   |                     ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | struct Bar<T: std::marker::Copy> {

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-inherent-impl-method-where-clause.rs:12:27
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL |     fn foo(self) where T: ExtraCopy<U>
    |                           ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-inherent-impl-method-where-clause.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider restricting type parameter `U`
    |
 LL | impl<T,U: std::marker::Copy> Foo<T,U> {

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-inherent-impl-where-clause.rs:11:29
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |                             ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-inherent-impl-where-clause.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider further restricting type parameter `U`
    |
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: std::marker::Copy

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -1,13 +1,15 @@
 error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
-LL | struct IsCopy<T:Copy> { t: T }
-   |                 ---- required by this bound in `IsCopy`
-...
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`
    |
    = note: required because of the requirements on the impl of `Copy` for `Option<NotCopy>`
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-static-type.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> { t: T }
+   |                 ^^^^ required by this bound in `IsCopy`
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-struct-bound.rs:10:14
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-struct-bound.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider further restricting type parameter `U`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `A: Copy` is not satisfied
   --> $DIR/wf-struct-field.rs:12:11
    |
-LL | struct IsCopy<T:Copy> {
-   |                 ---- required by this bound in `IsCopy`
-...
 LL |     data: IsCopy<A>
    |           ^^^^^^^^^ the trait `Copy` is not implemented for `A`
    |
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-struct-field.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> {
+   |                 ^^^^ required by this bound in `IsCopy`
 help: consider restricting type parameter `A`
    |
 LL | struct SomeStruct<A: std::marker::Copy> {

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-bound.rs:10:17
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL |     type Type1: ExtraCopy<T>;
    |                 ^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-trait-associated-type-bound.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider restricting type parameter `T`
    |
 LL | trait SomeTrait<T: std::marker::Copy> {

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `<Self as SomeTrait>::Type1: Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-trait.rs:11:19
    |
-LL | struct IsCopy<T:Copy> { x: T }
-   |                 ---- required by this bound in `IsCopy`
-...
 LL |     type Type2 = (IsCopy<Self::Type1>, bool);
    |                   ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `<Self as SomeTrait>::Type1`
    |
+note: required by a bound in `IsCopy`
+  --> $DIR/wf-trait-associated-type-trait.rs:7:17
+   |
+LL | struct IsCopy<T:Copy> { x: T }
+   |                 ^^^^ required by this bound in `IsCopy`
 help: consider further restricting the associated type
    |
 LL | trait SomeTrait where <Self as SomeTrait>::Type1: Copy {

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `U: Copy` is not satisfied
   --> $DIR/wf-trait-bound.rs:10:14
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-...
 LL |     where T: ExtraCopy<U>
    |              ^^^^^^^^^^^^ the trait `Copy` is not implemented for `U`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-trait-bound.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider further restricting type parameter `U`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-arg.rs:11:23
    |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |              -- required by this bound in `Bar`
-...
 LL |     fn bar(&self, x: &Bar<Self>) {
    |                       ^^^^^^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-default-fn-arg.rs:8:14
+   |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |              ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar(&self, x: &Bar<Self>) where Self: Eq {

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-ret.rs:11:22
    |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |              -- required by this bound in `Bar`
-...
 LL |     fn bar(&self) -> Bar<Self> {
    |                      ^^^^^^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-default-fn-ret.rs:8:14
+   |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |              ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar(&self) -> Bar<Self> where Self: Eq {

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-where-clause.rs:11:31
    |
-LL | trait Bar<T:Eq+?Sized> { }
-   |             -- required by this bound in `Bar`
-...
 LL |     fn bar<A>(&self) where A: Bar<Self> {
    |                               ^^^^^^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-default-fn-where-clause.rs:8:13
+   |
+LL | trait Bar<T:Eq+?Sized> { }
+   |             ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar<A>(&self) where A: Bar<Self>, Self: Eq {

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-fn-arg.rs:10:23
    |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |              -- required by this bound in `Bar`
-...
 LL |     fn bar(&self, x: &Bar<Self>);
    |                       ^^^^^^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-fn-arg.rs:7:14
+   |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |              ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar(&self, x: &Bar<Self>) where Self: Eq;

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-fn-ret.rs:10:22
    |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |              -- required by this bound in `Bar`
-...
 LL |     fn bar(&self) -> &Bar<Self>;
    |                      ^^^^^^^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-fn-ret.rs:7:14
+   |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |              ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar(&self) -> &Bar<Self> where Self: Eq;

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `Self: Eq` is not satisfied
   --> $DIR/wf-trait-fn-where-clause.rs:10:49
    |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   |              -- required by this bound in `Bar`
-...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
    |                                                 ^^^^ the trait `Eq` is not implemented for `Self`
    |
+note: required by a bound in `Bar`
+  --> $DIR/wf-trait-fn-where-clause.rs:7:14
+   |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |              ^^ required by this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy, Self: Eq;

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/wf-trait-superbound.rs:9:21
    |
-LL | trait ExtraCopy<T:Copy> { }
-   |                   ---- required by this bound in `ExtraCopy`
-LL | 
 LL | trait SomeTrait<T>: ExtraCopy<T> {
    |                     ^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `ExtraCopy`
+  --> $DIR/wf-trait-superbound.rs:7:19
+   |
+LL | trait ExtraCopy<T:Copy> { }
+   |                   ^^^^ required by this bound in `ExtraCopy`
 help: consider restricting type parameter `T`
    |
 LL | trait SomeTrait<T: std::marker::Copy>: ExtraCopy<T> {

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:22
    |
-LL | fn require_copy<T: Copy>(x: T) {}
-   |                    ---- required by this bound in `require_copy`
-...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `require_copy`
+  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:1:20
+   |
+LL | fn require_copy<T: Copy>(x: T) {}
+   |                    ^^^^ required by this bound in `require_copy`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Foo<T> {

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:22
    |
-LL | fn require_copy<T: Copy>(x: T) {}
-   |                    ---- required by this bound in `require_copy`
-...
 LL |         require_copy(self.x);
    |                      ^^^^^^ the trait `Copy` is not implemented for `T`
    |
+note: required by a bound in `require_copy`
+  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:1:20
+   |
+LL | fn require_copy<T: Copy>(x: T) {}
+   |                    ^^^^ required by this bound in `require_copy`
 help: consider restricting type parameter `T`
    |
 LL | impl<T: std::marker::Copy> Foo<T> for Bar<T> {

--- a/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
@@ -1,11 +1,14 @@
 error[E0277]: the trait bound `Struct: Eq` is not satisfied
   --> $DIR/where-clauses-unsatisfied.rs:6:10
    |
-LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
-   |                                             -- required by this bound in `equal`
-...
 LL |     drop(equal(&Struct, &Struct))
    |          ^^^^^ the trait `Eq` is not implemented for `Struct`
+   |
+note: required by a bound in `equal`
+  --> $DIR/where-clauses-unsatisfied.rs:1:45
+   |
+LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
+   |                                             ^^ required by this bound in `equal`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Modify output for pointing where a trait bound obligation is introduced in an E0277 from using a span label to using a note in order to always preserve order of the output:

Before:
```
error[E0277]: `<<Self as Case1>::A as Iterator>::Item` doesn't implement `Debug`
  --> $DIR/bounds-on-assoc-in-trait.rs:18:28
   |
LL |     type A: Iterator<Item: Debug>;
   |                            ^^^^^ `<<Self as Case1>::A as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
   |
  ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
   |
LL | pub trait Debug {
   | --------------- required by this bound in `Debug`
   |
   = help: the trait `Debug` is not implemented for `<<Self as Case1>::A as Iterator>::Item`
```
After:
```
error[E0277]: `<<Self as Case1>::A as Iterator>::Item` doesn't implement `Debug`
  --> $DIR/bounds-on-assoc-in-trait.rs:18:28
   |
LL |     type A: Iterator<Item: Debug>;
   |                            ^^^^^ `<<Self as Case1>::A as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
   |
   = help: the trait `Debug` is not implemented for `<<Self as Case1>::A as Iterator>::Item`
note: required by a bound in `Debug`
  --> $SRC_DIR/core/src/fmt/mod.rs:LL:COL
   |
LL | pub trait Debug {
   | ^^^^^^^^^^^^^^^ required by this bound in `Debug`
```