### PR TITLE
Adding explicit notice of lack of documentation for Tier 2 Platforms

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -73,6 +73,8 @@ Tier Policy.
 
 All tier 2 targets with host tools support the full standard library.
 
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
+
 target | notes
 -------|-------
 `aarch64-apple-darwin` | ARM64 macOS (11.0+, Big Sur+)
@@ -111,6 +113,8 @@ The `std` column in the table below has the following meanings:
 * \* indicates the target only supports [`no_std`] development.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
+
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
 
 target | std | notes
 -------|:---:|-------


### PR DESCRIPTION
Fixing: https://github.com/rust-lang/rustup/issues/2788