### PR TITLE
Add `aarch64-apple-ios-sim` as a possible target to the manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -54,6 +54,7 @@ static HOSTS: &[&str] = &[
 static TARGETS: &[&str] = &[
     "aarch64-apple-darwin",
     "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
     "aarch64-fuchsia",
     "aarch64-linux-android",
     "aarch64-pc-windows-msvc",


### PR DESCRIPTION
This should allow rustup and similar to actually make use of this new
target now.

r? @Mark-Simulacrum

Followup to #85782