### PR TITLE
Allow specifying an deployment target version for all iOS llvm targets

### DIFF
--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -92,6 +92,12 @@ fn ios_deployment_target() -> (u32, u32) {
 }
 
 pub fn ios_llvm_target(arch: &str) -> String {
+    // Modern iOS tooling extracts information about deployment target
+    // from LC_BUILD_VERSION. This load command will only be emitted when
+    // we build with a version specific `llvm_target`, with the version
+    // set high enough. Luckily one LC_BUILD_VERSION is enough, for Xcode
+    // to pick it up (since std and core are still built with the fallback
+    // of version 7.0 and hence emit the old LC_IPHONE_MIN_VERSION).
     let (major, minor) = ios_deployment_target();
     format!("{}-apple-ios{}.{}.0", arch, major, minor)
 }

--- a/compiler/rustc_target/src/spec/armv7_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/armv7_apple_ios.rs
@@ -3,7 +3,7 @@ use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
-        llvm_target: "armv7-apple-ios".to_string(),
+        llvm_target: super::apple_base::ios_llvm_target("armv7"),
         pointer_width: 32,
         data_layout: "e-m:o-p:32:32-Fi8-f64:32:64-v64:32:64-v128:32:128-a:0:32-n32-S32".to_string(),
         arch: "arm".to_string(),

--- a/compiler/rustc_target/src/spec/i386_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/i386_apple_ios.rs
@@ -4,7 +4,7 @@ use crate::spec::{StackProbeType, Target, TargetOptions};
 pub fn target() -> Target {
     let base = opts("ios", Arch::I386);
     Target {
-        llvm_target: "i386-apple-ios".to_string(),
+        llvm_target: super::apple_base::ios_sim_llvm_target("i386"),
         pointer_width: 32,
         data_layout: "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
             f64:32:64-f80:128-n8:16:32-S128"

--- a/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios.rs
@@ -4,7 +4,7 @@ use crate::spec::{StackProbeType, Target, TargetOptions};
 pub fn target() -> Target {
     let base = opts("ios", Arch::X86_64);
     Target {
-        llvm_target: "x86_64-apple-ios".to_string(),
+        llvm_target: super::apple_base::ios_sim_llvm_target("x86_64"),
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/79408

This pull requests adds the same procedure to define the iOS-version for the LLVM-target as was used for the simulator target and the desktop target.

This then closes the original problem mentioned in the above issue. The problem with incompatible bitcode remains, but is probably not easy fixable.

I realised that something is still not right. Try to fix that.

r? @petrochenkov