### PR TITLE
Expand explanation of E0530

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0530.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0530.md
@@ -1,32 +1,57 @@
 A binding shadowed something it shouldn't.
 
-Erroneous code example:
+A match arm or a variable has a name that is already used by
+something else, e.g.
+
+* struct name
+* enum variant
+* static
+* associated constant
+
+This error may also happen when an enum variant *with fields* is used
+in a pattern, but without its fields.
+
+```compile_fail
+enum Enum {
+    WithField(i32)
+}
+
+use Enum::*;
+match WithField(1) {
+    WithField => {} // error: missing (_)
+}
+```
+
+Match bindings cannot shadow statics:
 
 ```compile_fail,E0530
 static TEST: i32 = 0;
 
-let r: (i32, i32) = (0, 0);
+let r = 123;
 match r {
-    TEST => {} // error: match bindings cannot shadow statics
+    TEST => {} // error: name of a static
 }
 ```
 
-To fix this error, just change the binding's name in order to avoid shadowing
-one of the following:
-
-* struct name
-* struct/enum variant
-* static
-* const
-* associated const
-
-Fixed example:
+Fixed examples:
 
 ```
 static TEST: i32 = 0;
 
-let r: (i32, i32) = (0, 0);
+let r = 123;
 match r {
-    something => {} // ok!
+    some_value => {} // ok!
+}
+```
+
+or
+
+```
+const TEST: i32 = 0; // const, not static
+
+let r = 123;
+match r {
+    TEST => {} // const is ok!
+    other_values => {}
 }
 ```


### PR DESCRIPTION
The explanation didn't cover a puzzling case of enum variants missing fields.