### PR TITLE
Update mdbook.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee73932975c44c485e541416d7c30abb31a053af7e49682f6e856f1e4d6ab2a"
+checksum = "0651782b4cc514c3f98c0acf9b5af1101a735bbe1ac6852bb1a90cb91bdf0ed4"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -9,6 +9,6 @@ clap = "2.25.0"
 env_logger = "0.7.1"
 
 [dependencies.mdbook]
-version = "0.4.11"
+version = "0.4.12"
 default-features = false
 features = ["search"]


### PR DESCRIPTION
This fixes a significant rendering regression in 0.4.11 for code blocks, see https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0412.
