### PR TITLE
explicit_generic_args_with_impl_trait: fix min expected number of generics

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -613,7 +613,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 param_counts.consts + named_type_param_count
                     - default_counts.types
                     - default_counts.consts
-                    - synth_type_param_count
             };
             debug!("expected_min: {:?}", expected_min);
             debug!("arg_counts.lifetimes: {:?}", gen_args.num_lifetime_params());

--- a/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -1,12 +1,12 @@
-error[E0107]: this function takes at most 1 generic argument but 2 generic arguments were supplied
+error[E0107]: this function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/explicit-generic-args-for-impl.rs:6:5
    |
 LL |     foo::<str, String>("".to_string());
    |     ^^^        ------ help: remove this generic argument
    |     |
-   |     expected at most 1 generic argument
+   |     expected 1 generic argument
    |
-note: function defined here, with at most 1 generic parameter: `T`
+note: function defined here, with 1 generic parameter: `T`
   --> $DIR/explicit-generic-args-for-impl.rs:3:4
    |
 LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}

--- a/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/issue-87718.rs
+++ b/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/issue-87718.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(explicit_generic_args_with_impl_trait)]
+
+fn f<T: ?Sized>(_: impl AsRef<T>, _: impl AsRef<T>) {}
+
+fn main() {
+    f::<[u8]>("a", b"a");
+}

--- a/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.rs
+++ b/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.rs
@@ -1,0 +1,8 @@
+#![feature(explicit_generic_args_with_impl_trait)]
+
+fn f<T: ?Sized, U: ?Sized>(_: impl AsRef<T>, _: impl AsRef<U>) {}
+
+fn main() {
+    f::<[u8]>("a", b"a");
+    //~^ ERROR: this function takes 2 generic arguments but 1 generic argument was supplied
+}

--- a/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.stderr
+++ b/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/not-enough-args.stderr
@@ -1,0 +1,21 @@
+error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+  --> $DIR/not-enough-args.rs:6:5
+   |
+LL |     f::<[u8]>("a", b"a");
+   |     ^   ---- supplied 1 generic argument
+   |     |
+   |     expected 2 generic arguments
+   |
+note: function defined here, with 2 generic parameters: `T`, `U`
+  --> $DIR/not-enough-args.rs:3:4
+   |
+LL | fn f<T: ?Sized, U: ?Sized>(_: impl AsRef<T>, _: impl AsRef<U>) {}
+   |    ^ -          -
+help: add missing generic argument
+   |
+LL |     f::<[u8], U>("a", b"a");
+   |             ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes #87718

The problem was that `synth_type_param_count` was already subtracted from `named_type_param_count`, so this ended up being subtracted again. This caused `expected_min` to overflow, and ultimately resulting in weird and wrong behaviour.

I've also added another test not present in the original issue but caused by the same bug. 