### PR TITLE
perf-check: Revert "Rollup merge of #87596"

### DIFF
--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -63,11 +63,7 @@ impl LitKind {
                         unescape_literal(&s, Mode::Str, &mut |_, unescaped_char| {
                             match unescaped_char {
                                 Ok(c) => buf.push(c),
-                                Err(err) => {
-                                    if err.is_fatal() {
-                                        error = Err(LitError::LexerError);
-                                    }
-                                }
+                                Err(_) => error = Err(LitError::LexerError),
                             }
                         });
                         error?;
@@ -87,11 +83,7 @@ impl LitKind {
                         unescape_literal(&s, Mode::RawStr, &mut |_, unescaped_char| {
                             match unescaped_char {
                                 Ok(c) => buf.push(c),
-                                Err(err) => {
-                                    if err.is_fatal() {
-                                        error = Err(LitError::LexerError);
-                                    }
-                                }
+                                Err(_) => error = Err(LitError::LexerError),
                             }
                         });
                         error?;
@@ -108,11 +100,7 @@ impl LitKind {
                 unescape_byte_literal(&s, Mode::ByteStr, &mut |_, unescaped_byte| {
                     match unescaped_byte {
                         Ok(c) => buf.push(c),
-                        Err(err) => {
-                            if err.is_fatal() {
-                                error = Err(LitError::LexerError);
-                            }
-                        }
+                        Err(_) => error = Err(LitError::LexerError),
                     }
                 });
                 error?;
@@ -126,11 +114,7 @@ impl LitKind {
                     unescape_byte_literal(&s, Mode::RawByteStr, &mut |_, unescaped_byte| {
                         match unescaped_byte {
                             Ok(c) => buf.push(c),
-                            Err(err) => {
-                                if err.is_fatal() {
-                                    error = Err(LitError::LexerError);
-                                }
-                            }
+                            Err(_) => error = Err(LitError::LexerError),
                         }
                     });
                     error?;

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -7,7 +7,7 @@ use std::str::Chars;
 #[cfg(test)]
 mod tests;
 
-/// Errors and warnings that can occur during string unescaping.
+/// Errors that can occur during string unescaping.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EscapeError {
     /// Expected 1 char, but 0 were found.
@@ -56,20 +56,6 @@ pub enum EscapeError {
     NonAsciiCharInByte,
     /// Non-ascii character in byte string literal.
     NonAsciiCharInByteString,
-
-    /// After a line ending with '\', the next line contains whitespace
-    /// characters that are not skipped.
-    UnskippedWhitespaceWarning,
-}
-
-impl EscapeError {
-    /// Returns true for actual errors, as opposed to warnings.
-    pub fn is_fatal(&self) -> bool {
-        match self {
-            EscapeError::UnskippedWhitespaceWarning => false,
-            _ => true,
-        }
-    }
 }
 
 /// Takes a contents of a literal (without quotes) and produces a
@@ -297,7 +283,7 @@ where
                         // if unescaped '\' character is followed by '\n'.
                         // For details see [Rust language reference]
                         // (https://doc.rust-lang.org/reference/tokens.html#string-literals).
-                        skip_ascii_whitespace(&mut chars, start, callback);
+                        skip_ascii_whitespace(&mut chars);
                         continue;
                     }
                     _ => scan_escape(first_char, &mut chars, mode),
@@ -311,25 +297,13 @@ where
         callback(start..end, unescaped_char);
     }
 
-    fn skip_ascii_whitespace<F>(chars: &mut Chars<'_>, start: usize, callback: &mut F)
-    where
-        F: FnMut(Range<usize>, Result<char, EscapeError>),
-    {
+    fn skip_ascii_whitespace(chars: &mut Chars<'_>) {
         let str = chars.as_str();
         let first_non_space = str
             .bytes()
             .position(|b| b != b' ' && b != b'\t' && b != b'\n' && b != b'\r')
             .unwrap_or(str.len());
-        let tail = &str[first_non_space..];
-        if let Some(c) = tail.chars().nth(0) {
-            // For error reporting, we would like the span to contain the character that was not
-            // skipped.  The +1 is necessary to account for the leading \ that started the escape.
-            let end = start + first_non_space + c.len_utf8() + 1;
-            if c.is_whitespace() {
-                callback(start..end, Err(EscapeError::UnskippedWhitespaceWarning));
-            }
-        }
-        *chars = tail.chars();
+        *chars = str[first_non_space..].chars()
     }
 }
 

--- a/compiler/rustc_lexer/src/unescape/tests.rs
+++ b/compiler/rustc_lexer/src/unescape/tests.rs
@@ -99,25 +99,6 @@ fn test_unescape_char_good() {
 }
 
 #[test]
-fn test_unescape_str_warn() {
-    fn check(literal: &str, expected: &[(Range<usize>, Result<char, EscapeError>)]) {
-        let mut unescaped = Vec::with_capacity(literal.len());
-        unescape_literal(literal, Mode::Str, &mut |range, res| unescaped.push((range, res)));
-        assert_eq!(unescaped, expected);
-    }
-
-    check(
-        "\\\n \u{a0} x",
-        &[
-            (0..5, Err(EscapeError::UnskippedWhitespaceWarning)),
-            (3..5, Ok('\u{a0}')),
-            (5..6, Ok(' ')),
-            (6..7, Ok('x')),
-        ],
-    );
-}
-
-#[test]
 fn test_unescape_str_good() {
     fn check(literal_text: &str, expected: &str) {
         let mut buf = Ok(String::with_capacity(literal_text.len()));

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -274,12 +274,6 @@ pub(crate) fn emit_unescape_error(
             let msg = "invalid trailing slash in literal";
             handler.struct_span_err(span, msg).span_label(span, msg).emit();
         }
-        EscapeError::UnskippedWhitespaceWarning => {
-            let (c, char_span) = last_char();
-            let msg =
-                format!("non-ASCII whitespace symbol '{}' is not skipped", c.escape_unicode());
-            handler.struct_span_warn(span, &msg).span_label(char_span, &msg).emit();
-        }
     }
 }
 


### PR DESCRIPTION
Checking the perf regression in https://github.com/rust-lang/rust/pull/87640#issuecomment-891911569.
Only this PR touches `rustc_ast` in the rollup and it should affect the bootstrap time at least, let's see if this also causes the regression.
r? @ghost cc @Mark-Simulacrum 