### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "core-foundation",


### PR DESCRIPTION
11 commits in d21c22870e58499d6c31f1bef3bf1255eb021666..cc17afbb0067b1f57d8882640f63b2168d5b7624
2021-07-26 20:23:21 +0000 to 2021-08-02 20:28:08 +0000
- Stabilize the rust-version field (rust-lang/cargo#9732)
- Remove nbsp characters. (rust-lang/cargo#9751)
- Update unstable documentation TOC. (rust-lang/cargo#9750)
- Some minor updates for package/publish package selection. (rust-lang/cargo#9749)
- Bump to 0.57.0, update changelog (rust-lang/cargo#9748)
- Stabilize `[env]` sections (rust-lang/cargo#9411)
- doc: Clarify [doc].browser docs, document PathAndArgs better (rust-lang/cargo#9747)
- Bump cargo-util version. (rust-lang/cargo#9745)
- Make clippy happy (rust-lang/cargo#9736)
- Fix typo in features doc (rust-lang/cargo#9737)
- doc test supports silent output (rust-lang/cargo#9730)