### PR TITLE
#[inline] slice::Iter::advance_by

### DIFF
--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -185,8 +185,9 @@ macro_rules! iterator {
                 }
             }
 
+            #[inline]
             fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-                let advance = cmp::min(n, len!(self));
+                let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.post_inc_start(advance as isize) };
                 if advance == n { Ok(()) } else { Err(advance) }
@@ -381,7 +382,7 @@ macro_rules! iterator {
 
             #[inline]
             fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
-                let advance = cmp::min(n, len!(self));
+                let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.pre_dec_end(advance as isize) };
                 if advance == n { Ok(()) } else { Err(advance) }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/87387#issuecomment-891942661 was marked as a regression. One of the methods in the PR was missing an inline annotation unlike all the other methods on slice iterators.

Let's see if that makes a difference.