### PR TITLE
Validate FFI-safety warnings on naked functions

### DIFF
--- a/src/test/ui/asm/naked-functions-ffi.rs
+++ b/src/test/ui/asm/naked-functions-ffi.rs
@@ -1,0 +1,12 @@
+// check-pass
+// only-x86_64
+#![feature(asm)]
+#![feature(naked_functions)]
+#![crate_type = "lib"]
+
+#[naked]
+pub extern "C" fn naked(p: char) -> u128 {
+    //~^ WARN uses type `char`
+    //~| WARN uses type `u128`
+    unsafe { asm!("", options(noreturn)); }
+}

--- a/src/test/ui/asm/naked-functions-ffi.stderr
+++ b/src/test/ui/asm/naked-functions-ffi.stderr
@@ -1,0 +1,20 @@
+warning: `extern` fn uses type `char`, which is not FFI-safe
+  --> $DIR/naked-functions-ffi.rs:8:28
+   |
+LL | pub extern "C" fn naked(p: char) -> u128 {
+   |                            ^^^^ not FFI-safe
+   |
+   = note: `#[warn(improper_ctypes_definitions)]` on by default
+   = help: consider using `u32` or `libc::wchar_t` instead
+   = note: the `char` type has no C equivalent
+
+warning: `extern` fn uses type `u128`, which is not FFI-safe
+  --> $DIR/naked-functions-ffi.rs:8:37
+   |
+LL | pub extern "C" fn naked(p: char) -> u128 {
+   |                                     ^^^^ not FFI-safe
+   |
+   = note: 128-bit integers don't currently have a known stable ABI
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Test that FFI-safety warnings don't get accidentally dropped on naked
functions. The big picture is that if you implement a naked function
with the Rust ABI you'll get a warning. Further, if you implement a
naked function with a standardized ABI, but use non-FFI-safe types you
will still get a warning.

rust-lang/rfcs#2774
rust-lang/rfcs#2972

cc @joshtriplett @Amanieu @haraldh 