### PR TITLE
Re-use std::sealed::Sealed in os/linux/process.

### DIFF
--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -5,6 +5,7 @@
 use crate::io::Result;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::process;
+use crate::sealed::Sealed;
 #[cfg(not(doc))]
 use crate::sys::fd::FileDesc;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
@@ -84,15 +85,10 @@ impl IntoRawFd for PidFd {
     }
 }
 
-mod private_child_ext {
-    pub trait Sealed {}
-    impl Sealed for crate::process::Child {}
-}
-
 /// Os-specific extensions for [`Child`]
 ///
 /// [`Child`]: process::Child
-pub trait ChildExt: private_child_ext::Sealed {
+pub trait ChildExt: Sealed {
     /// Obtains a reference to the [`PidFd`] created for this [`Child`], if available.
     ///
     /// A pidfd will only be available if its creation was requested with
@@ -120,15 +116,10 @@ pub trait ChildExt: private_child_ext::Sealed {
     fn take_pidfd(&mut self) -> Result<PidFd>;
 }
 
-mod private_command_ext {
-    pub trait Sealed {}
-    impl Sealed for crate::process::Command {}
-}
-
 /// Os-specific extensions for [`Command`]
 ///
 /// [`Command`]: process::Command
-pub trait CommandExt: private_command_ext::Sealed {
+pub trait CommandExt: Sealed {
     /// Sets whether a [`PidFd`](struct@PidFd) should be created for the [`Child`]
     /// spawned by this [`Command`].
     /// By default, no pidfd will be created.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -205,6 +205,10 @@ pub struct Child {
     pub stderr: Option<ChildStderr>,
 }
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Child {}
+
 impl AsInner<imp::Process> for Child {
     fn as_inner(&self) -> &imp::Process {
         &self.handle


### PR DESCRIPTION
This uses `std::sealed::Sealed` in `std::os::linux::process` instead of defining new `Sealed` traits there.