### PR TITLE
Promote `aarch64-apple-ios-sim` to Tier 2

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -165,6 +165,7 @@ target | std | notes
 `wasm32-unknown-unknown` | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI
 `x86_64-apple-ios` | ✓ | 64-bit x86 iOS
+[`aarch64-apple-ios-sim`](platform-support/aarch64-apple-ios-sim.md) | ✓ |  | Apple iOS Simulator on ARM64
 `x86_64-fortanix-unknown-sgx` | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 `x86_64-fuchsia` | ✓ | 64-bit Fuchsia
 `x86_64-linux-android` | ✓ | 64-bit x86 Android
@@ -196,7 +197,6 @@ host tools.
 target | std | host | notes
 -------|:---:|:----:|-------
 `aarch64-apple-ios-macabi` | ? |  | Apple Catalyst on ARM64
-[`aarch64-apple-ios-sim`](platform-support/aarch64-apple-ios-sim.md) | ✓ |  | Apple iOS Simulator on ARM64
 `aarch64-apple-tvos` | * |  | ARM64 tvOS
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 `aarch64-unknown-hermit` | ? |  |

--- a/src/doc/rustc/src/platform-support/aarch64-apple-ios-sim.md
+++ b/src/doc/rustc/src/platform-support/aarch64-apple-ios-sim.md
@@ -1,6 +1,6 @@
 # aarch64-apple-ios-sim
 
-**Tier: 3**
+**Tier: 2**
 
 Apple iOS Simulator on ARM64.
 
@@ -39,17 +39,16 @@ Currently there is no support to run the rustc test suite for this target.
 
 *Note: Building for this target requires the corresponding iOS SDK, as provided by Xcode 12+.*
 
-If `rustc` has support for that target and the library artifacts are available,
-then Rust programs can be built for that target:
+From Rust Nightly 1.56.0 (2021-08-03) on the artifacts are shipped pre-compiled:
+
+```text
+rustup target add aarch64-apple-ios-sim --toolchain nightly
+```
+
+Rust programs can be built for that target:
 
 ```text
 rustc --target aarch64-apple-ios-sim your-code.rs
-```
-
-On Rust Nightly it is possible to build without the target artifacts available:
-
-```text
-cargo build -Z build-std --target aarch64-apple-ios-sim
 ```
 
 There is no easy way to run simple programs in the iOS simulator.


### PR DESCRIPTION
As per https://github.com/rust-lang/compiler-team/issues/428 this target becomes Tier 2.

---

I tested that the latest nightly has the target and I'm already building my project with that on CI and locally.