### PR TITLE
permit drop impls with generic constants in where clauses

### DIFF
--- a/compiler/rustc_typeck/src/check/dropck.rs
+++ b/compiler/rustc_typeck/src/check/dropck.rs
@@ -217,9 +217,9 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
         // repeated `.iter().any(..)` calls.
 
         // This closure is a more robust way to check `Predicate` equality
-        // than simple `==` checks (which were the previous implementation). It relies on
-        // `ty::relate` for `TraitPredicate`, `ProjectionPredicate`, `ConstEvaluatable`
-        // `TypeOutlives` and `TypeWellFormedFromEnv` (which implement the Relate trait),
+        // than simple `==` checks (which were the previous implementation).
+        // It relies on `ty::relate` for `TraitPredicate`, `ProjectionPredicate`,
+        // `ConstEvaluatable` and `TypeOutlives` (which implement the Relate trait),
         // while delegating on simple equality for the other `Predicate`.
         // This implementation solves (Issue #59497) and (Issue #58311).
         // It is unclear to me at the moment whether the approach based on `relate`
@@ -242,10 +242,6 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
                 (ty::PredicateKind::TypeOutlives(a), ty::PredicateKind::TypeOutlives(b)) => {
                     relator.relate(predicate.rebind(a.0), p.rebind(b.0)).is_ok()
                 }
-                (
-                    ty::PredicateKind::TypeWellFormedFromEnv(a),
-                    ty::PredicateKind::TypeWellFormedFromEnv(b),
-                ) => relator.relate(predicate.rebind(a), p.rebind(b)).is_ok(),
                 _ => predicate == p,
             }
         };

--- a/src/test/ui/const-generics/const_evaluatable_checked/drop_impl.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/drop_impl.rs
@@ -1,0 +1,16 @@
+//check-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize>
+where
+    [(); N + 1]: ;
+
+impl<const N: usize> Drop for Foo<N>
+where
+    [(); N + 1]: ,
+{
+    fn drop(&mut self) {}
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #79248

`==` is not sufficient to check for equality between unevaluated consts which causes the above issue because the const in `[(); N - 1]:` on the impl and the const in `[(); N - 1]:` on the struct def are not seen as equal. Any predicate that can contain an unevaluated const cant use `==` here as it will cause us to incorrectly emit an error.

I dont know much about chalk but it seems like we ought to be relating the `TypeWellFormedFromEnv` instead of `==` as it contains a `Ty` so I added that too...

r? @lcnr 