### PR TITLE
Add hint for unresolved associated trait items if the trait has a single item

### DIFF
--- a/src/test/ui/associated-item/issue-87638.fixed
+++ b/src/test/ui/associated-item/issue-87638.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+trait Trait {
+    const FOO: usize;
+
+    type Target;
+}
+
+struct S;
+
+impl Trait for S {
+    const FOO: usize = 0;
+    type Target = ();
+}
+
+fn main() {
+    let _: <S as Trait>::Target; //~ ERROR cannot find associated type `Output` in trait `Trait`
+                                 //~^ HELP maybe you meant this associated type
+
+    let _ = <S as Trait>::FOO; //~ ERROR cannot find method or associated constant `BAR` in trait `Trait`
+                               //~^ HELP maybe you meant this associated constant
+}

--- a/src/test/ui/associated-item/issue-87638.rs
+++ b/src/test/ui/associated-item/issue-87638.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+trait Trait {
+    const FOO: usize;
+
+    type Target;
+}
+
+struct S;
+
+impl Trait for S {
+    const FOO: usize = 0;
+    type Target = ();
+}
+
+fn main() {
+    let _: <S as Trait>::Output; //~ ERROR cannot find associated type `Output` in trait `Trait`
+                                 //~^ HELP maybe you meant this associated type
+
+    let _ = <S as Trait>::BAR; //~ ERROR cannot find method or associated constant `BAR` in trait `Trait`
+                               //~^ HELP maybe you meant this associated constant
+}

--- a/src/test/ui/associated-item/issue-87638.stderr
+++ b/src/test/ui/associated-item/issue-87638.stderr
@@ -1,0 +1,27 @@
+error[E0576]: cannot find associated type `Output` in trait `Trait`
+  --> $DIR/issue-87638.rs:17:26
+   |
+LL |     type Target;
+   |     ------------ associated type `Target` defined here
+...
+LL |     let _: <S as Trait>::Output;
+   |                          ^^^^^^
+   |                          |
+   |                          not found in `Trait`
+   |                          help: maybe you meant this associated type: `Target`
+
+error[E0576]: cannot find method or associated constant `BAR` in trait `Trait`
+  --> $DIR/issue-87638.rs:20:27
+   |
+LL |     const FOO: usize;
+   |     ----------------- associated constant `FOO` defined here
+...
+LL |     let _ = <S as Trait>::BAR;
+   |                           ^^^
+   |                           |
+   |                           not found in `Trait`
+   |                           help: maybe you meant this associated constant: `FOO`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0576`.

--- a/src/test/ui/associated-types/issue-22037.stderr
+++ b/src/test/ui/associated-types/issue-22037.stderr
@@ -1,8 +1,13 @@
 error[E0576]: cannot find associated type `X` in trait `A`
   --> $DIR/issue-22037.rs:3:33
    |
+LL |     type Output;
+   |     ------------ associated type `Output` defined here
 LL |     fn a(&self) -> <Self as A>::X;
-   |                                 ^ not found in `A`
+   |                                 ^
+   |                                 |
+   |                                 not found in `A`
+   |                                 help: maybe you meant this associated type: `Output`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19883.stderr
+++ b/src/test/ui/issues/issue-19883.stderr
@@ -1,8 +1,14 @@
 error[E0576]: cannot find associated type `Dst` in trait `From`
   --> $DIR/issue-19883.rs:9:30
    |
+LL |     type Output;
+   |     ------------ associated type `Output` defined here
+...
 LL |         <Dst as From<Self>>::Dst
-   |                              ^^^ not found in `From`
+   |                              ^^^
+   |                              |
+   |                              not found in `From`
+   |                              help: maybe you meant this associated type: `Output`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR introduces a special-cased hint for unresolved trait items paths. It is shown if:
- the path was not resolved to any existing trait item
- and no existing trait item's name was reasonably close with regard to edit distance
- and the trait only has a single item in the corresponding namespace

I didn't know where I should put tests, therefore so far I just managed to bless two existing tests. I would be glad for hints where should tests for a hint like this be created, how should they be named (with reference to the original issue?) and what tests should I create (is it enough to test it just for types? or create separate tests also for functions and constants?).

It could also be turned into a machine applicable suggestion I suppose.

This is my first `rustc` PR, so please go easy on me :)

Fixes: https://github.com/rust-lang/rust/issues/87638