### PR TITLE
Avoid ICE caused by suggestion

### DIFF
--- a/src/test/ui/suggestions/for-i-in-vec.fixed
+++ b/src/test/ui/suggestions/for-i-in-vec.fixed
@@ -15,4 +15,13 @@ impl Foo {
     }
 }
 
+const LOADERS: &Vec<&'static u8> = &Vec::new();
+
+pub fn break_code() -> Option<&'static u8> {
+    for loader in &*LOADERS { //~ ERROR cannot move out of a shared reference
+        return Some(loader);
+    }
+    None
+}
+
 fn main() {}

--- a/src/test/ui/suggestions/for-i-in-vec.rs
+++ b/src/test/ui/suggestions/for-i-in-vec.rs
@@ -15,4 +15,13 @@ impl Foo {
     }
 }
 
+const LOADERS: &Vec<&'static u8> = &Vec::new();
+
+pub fn break_code() -> Option<&'static u8> {
+    for loader in *LOADERS { //~ ERROR cannot move out of a shared reference
+        return Some(loader);
+    }
+    None
+}
+
 fn main() {}

--- a/src/test/ui/suggestions/for-i-in-vec.stderr
+++ b/src/test/ui/suggestions/for-i-in-vec.stderr
@@ -20,6 +20,17 @@ help: consider iterating over a slice of the `HashMap<i32, i32>`'s content
 LL |         for _ in &self.h {
    |                  +
 
-error: aborting due to 2 previous errors
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/for-i-in-vec.rs:21:19
+   |
+LL |     for loader in *LOADERS {
+   |                   ^^^^^^^^ move occurs because value has type `Vec<&u8>`, which does not implement the `Copy` trait
+   |
+help: consider iterating over a slice of the `Vec<&u8>`'s content
+   |
+LL |     for loader in &*LOADERS {
+   |                   +
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
When suggesting dereferencing something that can be iterable in a `for`
loop, erase lifetimes and use a fresh `ty::ParamEnv` to avoid 'region
constraints already solved' panic.

Fix #87657, fix #87709, fix #87651.