### PR TITLE
Update socket2 dependency from 0.4.0 to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,9 +4795,9 @@ checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",


### PR DESCRIPTION
This update contains a fix for building the tools that depend on this package on Haiku (tier 3).