### PR TITLE
encode `generics_of` for fields and ty params

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -918,12 +918,12 @@ fn should_encode_generics(def_kind: DefKind) -> bool {
         | DefKind::AnonConst
         | DefKind::OpaqueTy
         | DefKind::Impl
+        | DefKind::Field
+        | DefKind::TyParam
         | DefKind::Closure
         | DefKind::Generator => true,
         DefKind::Mod
-        | DefKind::Field
         | DefKind::ForeignMod
-        | DefKind::TyParam
         | DefKind::ConstParam
         | DefKind::Macro(..)
         | DefKind::Use

--- a/src/test/ui/const-generics/auxiliary/generics_of_parent.rs
+++ b/src/test/ui/const-generics/auxiliary/generics_of_parent.rs
@@ -1,0 +1,23 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+// library portion of regression test for #87674
+pub struct Foo<const N: usize>([(); N + 1])
+where
+    [(); N + 1]: ;
+
+// library portion of regression test for #87603
+pub struct S<T: Copy + Default, const N: usize>
+where
+    [T; N * 2]: Sized,
+{
+    pub s: [T; N * 2],
+}
+impl<T: Default + Copy, const N: usize> S<T, N>
+where
+    [T; N * 2]: Sized,
+{
+    pub fn test() -> Self {
+        S { s: [T::default(); N * 2] }
+    }
+}

--- a/src/test/ui/const-generics/auxiliary/generics_of_parent_impl_trait.rs
+++ b/src/test/ui/const-generics/auxiliary/generics_of_parent_impl_trait.rs
@@ -1,7 +1,8 @@
 #![feature(const_generics, const_evaluatable_checked)]
 #![allow(incomplete_features)]
 
-// library portion of testing that `impl Trait<{ expr }>` doesnt ice because of a `DefKind::TyParam` parent
+// library portion of testing that `impl Trait<{ expr }>` doesnt
+// ice because of a `DefKind::TyParam` parent
 pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
     foo.into();
 }

--- a/src/test/ui/const-generics/auxiliary/generics_of_parent_impl_trait.rs
+++ b/src/test/ui/const-generics/auxiliary/generics_of_parent_impl_trait.rs
@@ -1,0 +1,7 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+// library portion of testing that `impl Trait<{ expr }>` doesnt ice because of a `DefKind::TyParam` parent
+pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
+    foo.into();
+}

--- a/src/test/ui/const-generics/parent_generics_of_encoding.rs
+++ b/src/test/ui/const-generics/parent_generics_of_encoding.rs
@@ -1,0 +1,25 @@
+// aux-build:generics_of_parent.rs
+// check-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+extern crate generics_of_parent;
+
+use generics_of_parent::{Foo, S};
+
+fn main() {
+    // regression test for #87603
+    const N: usize = 2;
+    let x: S<u8, N> = S::test();
+}
+
+// regression test for #87674
+fn new<U>(a: U) -> U {
+    a
+}
+fn foo<const N: usize>(bar: &mut Foo<N>)
+where
+    [(); N + 1]: ,
+{
+    *bar = new(loop {});
+}

--- a/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.rs
+++ b/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.rs
@@ -1,0 +1,11 @@
+// aux-build:generics_of_parent_impl_trait.rs
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+extern crate generics_of_parent_impl_trait;
+
+fn main() {
+    // check for `impl Trait<{ const }>` which has a parent of a `DefKind::TyParam`
+    generics_of_parent_impl_trait::foo([()]);
+    //~^ error: type annotations needed:
+}

--- a/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed: cannot satisfy `the constant `foo::{opaqu
 LL |     generics_of_parent_impl_trait::foo([()]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `the constant `foo::{opaque#0}::{constant#0}` can be evaluated`
    |
-  ::: $DIR/auxiliary/generics_of_parent_impl_trait.rs:5:48
+  ::: $DIR/auxiliary/generics_of_parent_impl_trait.rs:6:48
    |
 LL | pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
    |                                                ----- required by this bound in `foo`

--- a/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/src/test/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -1,0 +1,14 @@
+error[E0284]: type annotations needed: cannot satisfy `the constant `foo::{opaque#0}::{constant#0}` can be evaluated`
+  --> $DIR/parent_generics_of_encoding_impl_trait.rs:9:5
+   |
+LL |     generics_of_parent_impl_trait::foo([()]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `the constant `foo::{opaque#0}::{constant#0}` can be evaluated`
+   |
+  ::: $DIR/auxiliary/generics_of_parent_impl_trait.rs:5:48
+   |
+LL | pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
+   |                                                ----- required by this bound in `foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0284`.


### PR DESCRIPTION
Fixes #87674
Fixes #87603

ICE was caused by calling `generics_of` on a `DefId` without any `generics_of` results. This was happening when we call `generics_of` on parent `DefId`s of an unevaluated const when we evaluate it.

r? @lcnr 