### PR TITLE
Fix anchors display in rustdoc

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -735,17 +735,21 @@ a {
 .anchor {
 	display: none;
 	position: absolute;
-	left: -7px;
+	left: 0;
+	background: none !important;
 }
 .anchor.field {
 	left: -5px;
 }
 .small-section-header > .anchor {
-	left: -28px;
-	padding-right: 10px; /* avoid gap that causes hover to disappear */
+	left: -15px;
+	padding-right: 8px;
 }
-.anchor:before {
-	content: '\2002\00a7\2002';
+h2.small-section-header > .anchor {
+	padding-right: 6px;
+}
+.anchor::before {
+	content: '§';
 }
 
 .docblock a:not(.srclink):not(.test-arrow):hover,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/87611 (it simplifies the positioning and fix the background).

![Screenshot from 2021-08-06 16-47-03](https://user-images.githubusercontent.com/3050060/128531105-61d1c21f-4a4d-4d68-aedf-9bfe0332f8ae.png)
![Screenshot from 2021-08-06 16-47-10](https://user-images.githubusercontent.com/3050060/128531109-b2ea8065-10b0-4400-9507-322122e42e78.png)
![Screenshot from 2021-08-06 16-47-14](https://user-images.githubusercontent.com/3050060/128531111-8a17cbdb-29e8-4baa-a0d6-81aa4f6ac6ed.png)

r? @camelid 