### PR TITLE
Suggest replacing braces for brackets on array-esque invalid block expr

### DIFF
--- a/src/test/ui/did_you_mean/issue-87830-try-brackets-for-arrays.rs
+++ b/src/test/ui/did_you_mean/issue-87830-try-brackets-for-arrays.rs
@@ -1,0 +1,17 @@
+fn main() {}
+
+const FOO: [u8; 3] = { //~ ERROR this code is interpreted as a block expression
+    1, 2, 3
+};
+
+const BAR: [&str; 3] = {"one", "two", "three"};
+//~^ ERROR this code is interpreted as a block expression
+
+fn foo() {
+    {1, 2, 3};
+    //~^ ERROR this code is interpreted as a block expression
+}
+
+fn bar() {
+    1, 2, 3 //~ ERROR expected one of
+}

--- a/src/test/ui/did_you_mean/issue-87830-try-brackets-for-arrays.stderr
+++ b/src/test/ui/did_you_mean/issue-87830-try-brackets-for-arrays.stderr
@@ -1,0 +1,49 @@
+error: this code is interpreted as a block expression, not an array
+  --> $DIR/issue-87830-try-brackets-for-arrays.rs:3:22
+   |
+LL |   const FOO: [u8; 3] = {
+   |  ______________________^
+LL | |     1, 2, 3
+LL | | };
+   | |_^
+   |
+   = note: to define an array, one would use square brackets instead of curly braces
+help: try using [] instead of {}
+   |
+LL ~ const FOO: [u8; 3] = [
+LL |     1, 2, 3
+LL ~ ];
+   |
+
+error: this code is interpreted as a block expression, not an array
+  --> $DIR/issue-87830-try-brackets-for-arrays.rs:7:24
+   |
+LL | const BAR: [&str; 3] = {"one", "two", "three"};
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: to define an array, one would use square brackets instead of curly braces
+help: try using [] instead of {}
+   |
+LL | const BAR: [&str; 3] = ["one", "two", "three"];
+   |                        ~                     ~
+
+error: this code is interpreted as a block expression, not an array
+  --> $DIR/issue-87830-try-brackets-for-arrays.rs:11:5
+   |
+LL |     {1, 2, 3};
+   |     ^^^^^^^^^
+   |
+   = note: to define an array, one would use square brackets instead of curly braces
+help: try using [] instead of {}
+   |
+LL |     [1, 2, 3];
+   |     ~       ~
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `,`
+  --> $DIR/issue-87830-try-brackets-for-arrays.rs:16:6
+   |
+LL |     1, 2, 3
+   |      ^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Newcomers may write `{1, 2, 3}` for making arrays, and the current error message is not informative enough to quickly convince them what is needed to fix the error.

This PR implements a diagnostic for this case, and its output looks like this:
```text
error: this code is interpreted as a block expression, not an array
 --> src/lib.rs:1:22
  |
1 |   const FOO: [u8; 3] = {
  |  ______________________^
2 | |     1, 2, 3
3 | | };
  | |_^
  |
  = note: to define an array, one would use square brackets instead of curly braces
help: try using [] instead of {}
  |
1 | const FOO: [u8; 3] = [
2 |     1, 2, 3
3 | ];
  |
```

Fix #87672