### PR TITLE
Fix debugger stepping behavior with `match` expressions

### DIFF
--- a/src/test/debuginfo/step-into-match.rs
+++ b/src/test/debuginfo/step-into-match.rs
@@ -1,0 +1,383 @@
+// compile-flags: -g
+// ignore-android: FIXME(#10381)
+
+// === GDB TESTS ==============================================================
+
+// gdb-command: r
+
+// gdb-command: s
+// gdb-check:[...]match x {
+
+// gdb-command: s
+// gdb-check:[...]    Some(42) => 1,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_enum(Some(12));
+
+// gdb-command: s
+// gdb-check:[...]match x {
+
+// gdb-command: s
+// gdb-check:[...]Some(_) => 2,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_enum(None);
+
+// gdb-command: s
+// gdb-check:[...]match x {
+
+// gdb-command: s
+// gdb-check:[...]None => 3,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_int(1);
+
+// gdb-command: s
+// gdb-check:[...]match y {
+
+// gdb-command: s
+// gdb-check:[...]1 => 3,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_int(2);
+
+// gdb-command: s
+// gdb-check:[...]match y {
+
+// gdb-command: s
+// gdb-check:[...]_ => 4,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_int(0);
+
+// gdb-command: s
+// gdb-check:[...]match y {
+
+// gdb-command: s
+// gdb-check:[...]0 => 2,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_int(-1);
+
+// gdb-command: s
+// gdb-check:[...]match y {
+
+// gdb-command: s
+// gdb-check:[...]-1 => 1,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_tuple(5, 12);
+
+// gdb-command: s
+// gdb-check:[...]match (a, b) {
+
+// gdb-command: s
+// gdb-check:[...](5, 12) => 3,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_tuple(29, 1);
+
+// gdb-command: s
+// gdb-check:[...]match (a, b) {
+
+// gdb-command: s
+// gdb-check:[...](29, _) => 2,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_tuple(12, 12);
+
+// gdb-command: s
+// gdb-check:[...]match (a, b) {
+
+// gdb-command: s
+// gdb-check:[...](_, _) => 5
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_tuple(42, 12);
+
+// gdb-command: s
+// gdb-check:[...]match (a, b) {
+
+// gdb-command: s
+// gdb-check:[...](42, 12) => 1,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]match_tuple(1, 9);
+
+// gdb-command: s
+// gdb-check:[...]match (a, b) {
+
+// gdb-command: s
+// gdb-check:[...](_, 9) => 4,
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// gdb-command: s
+// gdb-check:[...]}
+
+// === CDB TESTS ==============================================================
+
+// Enable line-based debugging and print lines after stepping.
+// cdb-command: .lines -e
+// cdb-command: l+s
+// cdb-command: l+t
+
+// cdb-command: g
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_enum(x: Option<u32>) -> u8 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match x {
+
+// cdb-command: t
+// cdb-check:   [...]:         Some(42) => 1,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_enum(Some(12));
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_enum(x: Option<u32>) -> u8 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match x {
+
+// cdb-command: t
+// cdb-check:   [...]:         Some(_) => 2,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_enum(None);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_enum(x: Option<u32>) -> u8 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match x {
+
+// cdb-command: t
+// cdb-check:   [...]:         None => 3,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_int(1);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_int(y: i32) -> u16 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match y {
+
+// cdb-command: t
+// cdb-check:   [...]:         1 => 3,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_int(2);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_int(y: i32) -> u16 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match y {
+
+// cdb-command: t
+// cdb-check:   [...]:         _ => 4,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_int(0);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_int(y: i32) -> u16 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match y {
+
+// cdb-command: t
+// cdb-check:   [...]:         0 => 2,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_int(-1);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_int(y: i32) -> u16 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match y {
+
+// cdb-command: t
+// cdb-check:   [...]:         -1 => 1,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_tuple(5, 12);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_tuple(a: u8, b: i8) -> u32 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match (a, b) {
+
+// cdb-command: t
+// cdb-check:   [...]:         (5, 12) => 3,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_tuple(29, 1);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_tuple(a: u8, b: i8) -> u32 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match (a, b) {
+
+// cdb-command: t
+// cdb-check:   [...]:         (29, _) => 2,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_tuple(12, 12);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_tuple(a: u8, b: i8) -> u32 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match (a, b) {
+
+// cdb-command: t
+// cdb-check:   [...]:         (_, _) => 5
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_tuple(42, 12);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_tuple(a: u8, b: i8) -> u32 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match (a, b) {
+
+// cdb-command: t
+// cdb-check:   [...]:         (42, 12) => 1,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]:     match_tuple(1, 9);
+
+// cdb-command: t
+// cdb-check:   [...]: fn match_tuple(a: u8, b: i8) -> u32 {
+
+// cdb-command: t
+// cdb-check:   [...]:     match (a, b) {
+
+// cdb-command: t
+// cdb-check:   [...]:         (_, 9) => 4,
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+// cdb-command: t
+// cdb-check:   [...]: }
+
+fn main() {
+    match_enum(Some(42)); // #break
+    match_enum(Some(12));
+    match_enum(None);
+
+    match_int(1);
+    match_int(2);
+    match_int(0);
+    match_int(-1);
+
+    match_tuple(5, 12);
+    match_tuple(29, 1);
+    match_tuple(12, 12);
+    match_tuple(42, 12);
+    match_tuple(1, 9);
+}
+
+fn match_enum(x: Option<u32>) -> u8 {
+    match x {
+        Some(42) => 1,
+        Some(_) => 2,
+        None => 3,
+    }
+}
+
+fn match_int(y: i32) -> u16 {
+    match y {
+        -1 => 1,
+        0 => 2,
+        1 => 3,
+        _ => 4,
+    }
+}
+
+fn match_tuple(a: u8, b: i8) -> u32 {
+    match (a, b) {
+        (42, 12) => 1,
+        (29, _) => 2,
+        (5, 12) => 3,
+        (_, 9) => 4,
+        (_, _) => 5
+    }
+}

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -7,18 +7,18 @@
       let mut _2: isize;                   // in scope 0 at $DIR/76803_regression.rs:12:9: 12:16
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:12:9: 12:16
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:12:9: 12:16
+          _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:11:11: 11:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:11:5: 11:12
       }
   
       bb1: {
           _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:11:5: 14:6
+          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
       }
   
       bb2: {
           discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
-          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:11:5: 14:6
+          goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
       }
   
       bb3: {

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -10,10 +10,10 @@
   
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:22: 12:28
--         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:12:22: 12:28
-+         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:22: 12:28
-+         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:12:22: 12:28
+-         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
+-         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
++         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {

--- a/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
@@ -10,35 +10,35 @@
           StorageLive(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
           StorageLive(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
           _2 = const A;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
-          switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:13: 9:14
+          switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 8:16
       }
   
       bb1: {
           _1 = const true;                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
-          goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 11:10
+          goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
       }
   
       bb2: {
           _1 = const B;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
--         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 11:10
-+         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:9: 13:14
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
++         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
       }
   
       bb3: {
--         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:9: 13:14
+-         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
 -     }
 - 
 -     bb4: {
           _0 = const 2_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
-+         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
       }
   
 -     bb5: {
 +     bb4: {
           _0 = const 1_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
--         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
-+         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
       }
   
 -     bb6: {

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -29,7 +29,7 @@
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:26: 11:30
+          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb3: {

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -29,7 +29,7 @@
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:26: 11:30
+          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb3: {

--- a/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
@@ -8,8 +8,8 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
           _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
--         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
-+         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
+-         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
++         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/switch_int.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.SimplifyBranches-after-const-prop.diff
@@ -8,8 +8,8 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
           _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
--         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:8:9: 8:10
-+         goto -> bb2;                     // scope 0 at $DIR/switch_int.rs:8:9: 8:10
+-         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
++         goto -> bb2;                     // scope 0 at $DIR/switch_int.rs:7:5: 7:12
       }
   
       bb1: {

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -31,20 +31,20 @@
       }
   
       bb1: {
-          switchInt((*_2)[0 of 4]) -> [47_u8: bb2, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:4:10: 4:14
+          switchInt((*_2)[0 of 4]) -> [47_u8: bb2, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb2: {
-          switchInt((*_2)[1 of 4]) -> [47_u8: bb3, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:4:16: 4:20
+          switchInt((*_2)[1 of 4]) -> [47_u8: bb3, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb3: {
-          switchInt((*_2)[2 of 4]) -> [47_u8: bb4, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:4:22: 4:26
+          switchInt((*_2)[2 of 4]) -> [47_u8: bb4, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb4: {
--         switchInt((*_2)[3 of 4]) -> [47_u8: bb10, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:4:28: 4:32
-+         switchInt((*_2)[3 of 4]) -> [47_u8: bb9, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:4:28: 4:32
+-         switchInt((*_2)[3 of 4]) -> [47_u8: bb10, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
++         switchInt((*_2)[3 of 4]) -> [47_u8: bb9, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb5: {
@@ -54,39 +54,39 @@
       }
   
       bb6: {
-          switchInt((*_2)[0 of 3]) -> [47_u8: bb7, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:5:10: 5:14
+          switchInt((*_2)[0 of 3]) -> [47_u8: bb7, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb7: {
-          switchInt((*_2)[1 of 3]) -> [47_u8: bb8, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:5:16: 5:20
+          switchInt((*_2)[1 of 3]) -> [47_u8: bb8, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb8: {
--         switchInt((*_2)[2 of 3]) -> [47_u8: bb11, 33_u8: bb12, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:5:22: 5:26
-+         switchInt((*_2)[2 of 3]) -> [47_u8: bb10, 33_u8: bb10, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:5:22: 5:26
+-         switchInt((*_2)[2 of 3]) -> [47_u8: bb11, 33_u8: bb12, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
++         switchInt((*_2)[2 of 3]) -> [47_u8: bb10, 33_u8: bb10, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
       bb9: {
 -         _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
 -     }
 - 
 -     bb10: {
           _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
-+         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
++         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
       }
   
 -     bb11: {
 -         _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
 -     }
 - 
 -     bb12: {
 +     bb10: {
           _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
--         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
-+         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 8:6
+-         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
++         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
       }
   
 -     bb13: {

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -29,26 +29,26 @@
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
--         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         _11 = Ne(_10, _7);               // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
-+         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:5:10: 5:17
+          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+-         switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         _10 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         _11 = Ne(_10, _7);               // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
++         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
       }
   
       bb1: {
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 7:6
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 7:6
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
--         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:5:19: 5:26
+-         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
+-         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
 -     }
 - 
 -     bb3: {
@@ -59,8 +59,8 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:5:31: 5:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
--         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 7:6
-+         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 7:6
+-         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
++         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
       }
   
 -     bb4: {

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -30,31 +30,31 @@
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
--         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         _12 = Ne(_11, _8);               // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
-+         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:13:10: 13:17
+          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+-         switchInt(move _8) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         _11 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         _12 = Ne(_11, _8);               // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
++         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
--         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:14:16: 14:20
+-         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+-         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
 -     bb2: {
 +         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
       }
   
 -     bb3: {
--         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:13:19: 13:26
--         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:13:19: 13:26
+-         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
+-         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
 -     bb4: {
@@ -66,15 +66,15 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch.rs:13:31: 13:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
       }
   
 -     bb5: {
 +     bb3: {
           _0 = const 0_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
--         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 16:6
+-         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
       }
   
 -     bb6: {

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -40,33 +40,33 @@
           StorageDead(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:19: 5:20
-          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
--         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         _15 = Ne(_14, _10);              // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
-+         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:10: 6:17
+          _10 = discriminant((_4.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+-         switchInt(move _10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageLive(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         _14 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageLive(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         _15 = Ne(_14, _10);              // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         StorageDead(_14);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
   
       bb1: {
 +         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
 +         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 8:6
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 8:6
+-         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
       }
   
       bb2: {
--         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
--         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:19: 6:26
+-         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+-         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 -     }
 - 
 -     bb3: {
-          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
--         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
-+         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:28: 6:35
+          _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
+-         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
++         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
   
 -     bb4: {
@@ -81,8 +81,8 @@
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
           StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
--         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 8:6
-+         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 8:6
+-         goto -> bb5;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
++         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
       }
   
 -     bb5: {

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyBranches-final.after.diff
@@ -80,19 +80,19 @@
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
 -         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
--         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
+          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
       bb1: {
--         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
--         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
+-         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb2: {
@@ -126,12 +126,12 @@
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +     }
 + 
       bb3: {
--         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
--         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
+-         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 +         _20 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
@@ -149,12 +149,12 @@
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
       }
   
       bb4: {
--         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
--         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
+-         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 +         _25 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
@@ -172,12 +172,12 @@
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
       }
   
       bb5: {
--         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
--         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
+-         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 +         _30 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
@@ -195,7 +195,7 @@
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
       }
   
       bb6: {
@@ -216,7 +216,7 @@
 -         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 -         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 -         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 +         discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
@@ -242,7 +242,7 @@
 -         StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 -         StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 -         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 -     }
 - 
 -     bb8: {
@@ -263,7 +263,7 @@
 -         StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 -         StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 -         StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 -     }
 - 
 -     bb9: {
@@ -284,7 +284,7 @@
 -         StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 -         StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 -         StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 -     }
 - 
 -     bb10: {

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -66,19 +66,19 @@
           (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
--         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
-+         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:11: 22:18
+          _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _34 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageLive(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         _35 = Ne(_34, _11);              // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         StorageDead(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
       bb1: {
--         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
--         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:21: 22:30
+-         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb2: {
@@ -93,18 +93,18 @@
       }
   
 -     bb3: {
--         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
--         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:21: 23:30
+-         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb4: {
--         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
--         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:23: 24:34
+-         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb5: {
--         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
--         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:23: 25:34
+-         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
 -     bb6: {
@@ -126,8 +126,8 @@
           StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
       }
   
 -     bb7: {
@@ -149,8 +149,8 @@
           StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
           StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
           StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
       }
   
 -     bb8: {
@@ -172,8 +172,8 @@
           StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
           StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
           StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
       }
   
 -     bb9: {
@@ -195,8 +195,8 @@
           StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
           StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
           StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
++         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
       }
   
 -     bb10: {

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -36,23 +36,23 @@
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17
-          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:10: 9:17
-          switchInt(move _8) -> [0_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:10: 9:17
+          _8 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          switchInt(move _8) -> [0_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
       bb1: {
-          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:16: 11:23
-          switchInt(move _6) -> [0_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:16: 11:23
+          _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          switchInt(move _6) -> [0_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
       bb2: {
           _0 = const 3_u32;                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
-          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 13:6
+          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
       }
   
       bb3: {
-          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:19: 9:26
-          switchInt(move _7) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:19: 9:26
+          _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
+          switchInt(move _7) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
       bb4: {
@@ -63,7 +63,7 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
           StorageDead(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
-          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 13:6
+          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
       }
   
       bb5: {
@@ -71,7 +71,7 @@
           _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
           _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
           StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
-          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 13:6
+          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
       }
   
       bb6: {
@@ -79,7 +79,7 @@
           _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
           _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
-          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 13:6
+          goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
       }
   
       bb7: {

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt2.EarlyOtherwiseBranch.diff
@@ -27,18 +27,18 @@
           (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:16: 19:17
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:16: 19:17
-          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:10: 20:17
-          switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:10: 20:17
+          _7 = discriminant((_3.0: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          switchInt(move _7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 19:17
       }
   
       bb1: {
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:21:14: 21:15
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 22:6
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:21:14: 21:15
       }
   
       bb2: {
-          _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:19: 20:26
-          switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:19: 20:26
+          _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:11: 19:17
+          switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 19:17
       }
   
       bb3: {
@@ -49,7 +49,7 @@
           _0 = const 0_u32;                // scope 1 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
           StorageDead(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
           StorageDead(_8);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
-          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:19:5: 22:6
+          goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:20:31: 20:32
       }
   
       bb4: {

--- a/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -19,21 +19,21 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
 
     bb0: {
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/exponential-or.rs:5:11: 5:12
-        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:15: 6:16
+        switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:15: 6:20
     }
 
     bb1: {
         _0 = const 0_u32;                // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
-        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:5:5: 8:6
+        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
     }
 
     bb2: {
-        _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:6:37: 6:48
-        switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:48
+        _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
+        switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
     }
 
     bb3: {
-        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:42: 6:43
+        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
     }
 
     bb4: {
@@ -74,7 +74,7 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
         StorageDead(_9);                 // scope 1 at $DIR/exponential-or.rs:6:87: 6:88
         StorageDead(_8);                 // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
         StorageDead(_7);                 // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
-        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:5:5: 8:6
+        goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
     }
 
     bb10: {

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -47,17 +47,17 @@
       bb1: {
           StorageDead(_5);                 // scope 0 at $DIR/funky_arms.rs:15:36: 15:37
           StorageLive(_6);                 // scope 1 at $DIR/funky_arms.rs:19:9: 19:13
-          switchInt(_4) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/funky_arms.rs:20:9: 20:14
+          switchInt(_4) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/funky_arms.rs:19:16: 19:32
       }
   
       bb2: {
           discriminant(_6) = 1;            // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
-          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:19:16: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
       }
   
       bb3: {
           discriminant(_6) = 0;            // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
-          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:19:16: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
       }
   
       bb4: {

--- a/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
@@ -20,14 +20,14 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
 -         _2 = Eq(move _3, const 17_i8);   // scope 0 at $DIR/if-condition-int.rs:44:13: 44:20
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:44:19: 44:20
--         switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 1 at $DIR/if-condition-int.rs:46:9: 46:14
+-         switchInt(_2) -> [false: bb2, otherwise: bb1]; // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
 +         _2 = Eq(_3, const 17_i8);        // scope 0 at $DIR/if-condition-int.rs:44:13: 44:20
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:44:19: 44:20
-+         switchInt(move _3) -> [17_i8: bb1, otherwise: bb2]; // scope 1 at $DIR/if-condition-int.rs:46:9: 46:14
++         switchInt(move _3) -> [17_i8: bb1, otherwise: bb2]; // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:46:9: 46:14
++         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
           StorageLive(_6);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:31
           StorageLive(_7);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:24
           _7 = _2;                         // scope 1 at $DIR/if-condition-int.rs:47:23: 47:24
@@ -35,11 +35,11 @@
           StorageDead(_7);                 // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
           _0 = Add(const 100_i32, move _6); // scope 1 at $DIR/if-condition-int.rs:47:17: 47:31
           StorageDead(_6);                 // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
-          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:45:5: 48:6
+          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:46:9: 46:14
++         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
           StorageLive(_4);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:31
           StorageLive(_5);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:24
           _5 = _2;                         // scope 1 at $DIR/if-condition-int.rs:46:23: 46:24
@@ -47,7 +47,7 @@
           StorageDead(_5);                 // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
           _0 = Add(const 10_i32, move _4); // scope 1 at $DIR/if-condition-int.rs:46:18: 46:31
           StorageDead(_4);                 // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
-          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:45:5: 48:6
+          goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
       }
   
       bb3: {

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -25,7 +25,7 @@ fn main() -> () {
         StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         FakeRead(ForMatchedPlace(None), _3); // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
-        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
+        switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:8:13: 8:23
     }
 
     bb3: {
@@ -39,7 +39,7 @@ fn main() -> () {
 
     bb5: {
         _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
     }
 
     bb6: {
@@ -47,7 +47,7 @@ fn main() -> () {
     }
 
     bb7: {
-        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:8:13: 11:14
+        goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:11:13: 11:14
     }
 
     bb8: {

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -37,8 +37,8 @@ fn test() -> Option<Box<u32>> {
 
     bb1: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
     bb2: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -53,8 +53,8 @@
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:3:9: 3:16
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:3:9: 3:16
+          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
       }
   
       bb1: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -53,8 +53,8 @@
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
-          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:3:9: 3:16
-          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:3:9: 3:16
+          _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
       }
   
       bb1: {

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -32,15 +32,15 @@
   
       bb1: {
           StorageDead(_3);                 // scope 2 at $DIR/issue-75439.rs:7:52: 7:53
-          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:13: 9:14
+          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb2: {
-          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:16: 9:17
+          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb3: {
-          switchInt(_2[2 of 4]) -> [0_u32: bb6, 4294901760_u32: bb7, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:19: 9:20
+          switchInt(_2[2 of 4]) -> [0_u32: bb6, 4294901760_u32: bb7, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb4: {

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -32,18 +32,18 @@
   
       bb0: {
 -         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
--         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
-+         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:15:10: 15:15
+-         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
++         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
       bb1: {
 -         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:9: 15:22
-+         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
++         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
       bb2: {
--         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:15:29: 15:34
-+         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
+-         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
++         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
       bb3: {
@@ -51,7 +51,7 @@
 -     }
 - 
 -     bb4: {
--         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:16:10: 16:14
+-         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
 -     }
 - 
 -     bb5: {
@@ -192,8 +192,8 @@
           StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
--         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
       }
   
 -     bb19: {
@@ -217,8 +217,8 @@
 +     bb18: {
           StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
           StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
--         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
-+         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
+-         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
++         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
       }
   
 -     bb22: {

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -28,13 +28,13 @@ fn full_tested_match() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
-        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
-        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
+        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:15:13: 15:27
     }
 
     bb1: {
         _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
     }
 
     bb2: {
@@ -83,7 +83,7 @@ fn full_tested_match() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
     }
 
     bb8: {
@@ -100,7 +100,7 @@ fn full_tested_match() -> () {
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:17:20: 17:26
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:17:25: 17:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:25: 17:26
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:17:25: 17:26
     }
 
     bb10: {

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -27,8 +27,8 @@ fn full_tested_match2() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
-        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
-        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
+        _3 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
+        switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:26:13: 26:27
     }
 
     bb1: {
@@ -47,7 +47,7 @@ fn full_tested_match2() -> () {
         _1 = (const 2_i32, move _10);    // scope 3 at $DIR/match_false_edges.rs:29:20: 29:26
         StorageDead(_10);                // scope 3 at $DIR/match_false_edges.rs:29:25: 29:26
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:25: 29:26
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:29:25: 29:26
     }
 
     bb4: {
@@ -81,7 +81,7 @@ fn full_tested_match2() -> () {
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
     }
 
     bb8: {
@@ -92,7 +92,7 @@ fn full_tested_match2() -> () {
 
     bb9: {
         _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
-        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
+        goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
     }
 
     bb10: {

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -38,8 +38,8 @@ fn main() -> () {
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         _2 = Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
-        _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
-        switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
+        _4 = discriminant(_2);           // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
+        switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:35:13: 35:26
     }
 
     bb1: {
@@ -55,7 +55,7 @@ fn main() -> () {
         _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
         StorageDead(_14);                // scope 0 at $DIR/match_false_edges.rs:39:15: 39:16
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:39:15: 39:16
     }
 
     bb4: {
@@ -86,7 +86,7 @@ fn main() -> () {
         _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
     }
 
     bb8: {
@@ -100,7 +100,7 @@ fn main() -> () {
         _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
         StorageDead(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
     }
 
     bb10: {
@@ -130,7 +130,7 @@ fn main() -> () {
         _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
-        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
+        goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
     }
 
     bb13: {

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -42,7 +42,7 @@ fn main() -> () {
 
     bb3: {
         _3 = const 3_i32;                // scope 2 at $DIR/match_test.rs:16:14: 16:15
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:12:5: 17:6
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:16:14: 16:15
     }
 
     bb4: {
@@ -60,7 +60,7 @@ fn main() -> () {
     }
 
     bb7: {
-        switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
+        switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:12:5: 12:12
     }
 
     bb8: {
@@ -78,7 +78,7 @@ fn main() -> () {
         StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:12:5: 17:6
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:13:23: 13:24
     }
 
     bb11: {
@@ -88,12 +88,12 @@ fn main() -> () {
 
     bb12: {
         _3 = const 1_i32;                // scope 2 at $DIR/match_test.rs:14:20: 14:21
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:12:5: 17:6
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:14:20: 14:21
     }
 
     bb13: {
         _3 = const 2_i32;                // scope 2 at $DIR/match_test.rs:15:15: 15:16
-        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:12:5: 17:6
+        goto -> bb14;                    // scope 2 at $DIR/match_test.rs:15:15: 15:16
     }
 
     bb14: {

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -10,7 +10,7 @@
       let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
       let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
       let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 19:12
       scope 1 {
           debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
@@ -33,7 +33,7 @@
           StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
           StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
           StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 -     }
 - 
 -     bb1: {
@@ -41,23 +41,23 @@
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
 -         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
 -     bb2: {
 -         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 -         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 +         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 +         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
           _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
           _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
           StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
           StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
           _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -10,7 +10,7 @@
       let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
       let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
       let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 19:12
       scope 1 {
           debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
@@ -33,7 +33,7 @@
           StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
           StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
           StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 -     }
 - 
 -     bb1: {
@@ -41,23 +41,23 @@
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
 -         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
 -     bb2: {
 -         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 -         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 +         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 +         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
           _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
           _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
           StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
           StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
           _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
@@ -5,11 +5,11 @@
       debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
       let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
       let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+     let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
++     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
--         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
+-         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {
@@ -21,9 +21,9 @@
 -     }
 - 
 -     bb3: {
-+         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
++         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
       }
   }

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
@@ -5,11 +5,11 @@
       debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
       let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
       let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+     let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
++     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
--         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
+-         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {
@@ -21,9 +21,9 @@
 -     }
 - 
 -     bb3: {
-+         StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+         _3 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
-+         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
++         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
       }
   }

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -90,13 +90,13 @@
 +         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
           StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
 -     bb11: {
 -         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
 -     bb12: {

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -90,13 +90,13 @@
 +         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
           StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
 -     bb11: {
 -         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
 -     bb12: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
@@ -7,18 +7,18 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:13:9: 13:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:13:9: 13:13
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
       }
   
       bb1: {
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:12:5: 15:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
       }
   
       bb2: {
           _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:12:5: 15:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
       }
   
       bb3: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
@@ -7,18 +7,18 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:13:9: 13:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:13:9: 13:13
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
       }
   
       bb1: {
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:12:5: 15:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
       }
   
       bb2: {
           _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:12:5: 15:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
       }
   
       bb3: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
@@ -7,18 +7,18 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:21:9: 21:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:21:9: 21:13
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
       }
   
       bb1: {
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:20:5: 23:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
       }
   
       bb2: {
           _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:20:5: 23:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
       }
   
       bb3: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
@@ -7,18 +7,18 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:21:9: 21:13
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:21:9: 21:13
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
       }
   
       bb1: {
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:20:5: 23:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
       }
   
       bb2: {
           _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
-          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:20:5: 23:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
       }
   
       bb3: {

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -14,8 +14,8 @@ fn unwrap(_1: Option<T>) -> T {
     }
 
     bb0: {
-        _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
-        switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:9: 9:16
+        _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
+        switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:5: 8:14
     }
 
     bb1: {

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -15,17 +15,17 @@
       bb0: {
 -         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
-          _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
-          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
+          _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
+          switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
       }
   
       bb1: {
           _0 = const 1_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
-          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 10:6
+          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
       }
   
       bb2: {
-          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:8:14: 8:15
+          switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
       }
   
       bb3: {
@@ -57,7 +57,7 @@
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
           _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
-          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 10:6
+          goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
       }
   
       bb6: {

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -115,8 +115,8 @@
       bb4: {
 -         StorageDead(_18);                // scope 7 at $DIR/remove_storage_markers.rs:8:14: 8:19
 -         StorageDead(_9);                 // scope 3 at $DIR/remove_storage_markers.rs:8:18: 8:19
-          _11 = discriminant(_8);          // scope 3 at $DIR/remove_storage_markers.rs:8:9: 8:10
-          switchInt(move _11) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $DIR/remove_storage_markers.rs:8:9: 8:10
+          _11 = discriminant(_8);          // scope 3 at $DIR/remove_storage_markers.rs:8:14: 8:19
+          switchInt(move _11) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $DIR/remove_storage_markers.rs:8:14: 8:19
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -110,10 +110,10 @@
           StorageDead(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
       bb4: {
@@ -131,10 +131,10 @@
           StorageDead(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -64,8 +64,8 @@
       bb1: {
 -         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 -         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 -     }
 - 
 -     bb2: {
@@ -121,8 +121,8 @@
 -         goto -> bb1;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
 -     bb5: {
@@ -143,8 +143,8 @@
 -         goto -> bb1;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -29,8 +29,8 @@
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
       }
   
       bb1: {
@@ -42,10 +42,10 @@
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
+-         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
+-         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
++         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
++         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
       bb2: {
@@ -57,10 +57,10 @@
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
+-         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
+-         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
++         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
++         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
       bb3: {
@@ -68,7 +68,7 @@
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
       }
   
       bb4: {
@@ -80,7 +80,7 @@
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
       }
   
       bb5: {

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -27,8 +27,8 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
+        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
+        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
     }
 
     bb1: {
@@ -44,7 +44,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         _10 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
         discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
     }
 
     bb2: {
@@ -64,7 +64,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
         StorageDead(_9);                 // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
         StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
     }
 
     bb3: {

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -29,8 +29,8 @@
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
       }
   
       bb1: {
@@ -42,9 +42,9 @@
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:15:9: 18:10
-+         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
++         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
       bb2: {
@@ -56,13 +56,13 @@
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:15:9: 18:10
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
 -     }
 - 
 -     bb3: {
-          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
--         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
+-         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
 -     bb4: {
@@ -71,8 +71,8 @@
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
       }
   
 -     bb5: {
@@ -85,8 +85,8 @@
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:14:5: 22:6
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
       }
   
 -     bb6: {

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
@@ -6,7 +6,7 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
     }
 
     bb1: {
@@ -15,12 +15,12 @@ fn match_bool(_1: bool) -> usize {
 
     bb2: {
         _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
     }
 
     bb3: {
         _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
     }
 
     bb4: {

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
@@ -6,7 +6,7 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
-        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
+        switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
     }
 
     bb1: {
@@ -15,12 +15,12 @@ fn match_bool(_1: bool) -> usize {
 
     bb2: {
         _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
     }
 
     bb3: {
         _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
-        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:6:5: 9:6
+        goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
     }
 
     bb4: {

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -13,13 +13,13 @@
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
       }
   
       bb1: {
           discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
       }
   
       bb2: {
@@ -36,7 +36,7 @@
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
 +         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
       }
   
       bb4: {

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -12,14 +12,14 @@
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
--         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:11:9: 11:16
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+-         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
       }
   
       bb1: {
 -         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
 -     }
 - 
 -     bb2: {
@@ -28,8 +28,8 @@
 - 
 -     bb3: {
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 13:6
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
++         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
       }
   
 -     bb4: {

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -19,8 +19,8 @@
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
       }
   
       bb1: {
@@ -33,7 +33,7 @@
 -         StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
 -         StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
 +         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
       }
   
       bb2: {
@@ -50,7 +50,7 @@
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
 +         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
-          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
       }
   
       bb4: {

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -17,14 +17,14 @@
       }
   
       bb0: {
-          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
--         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:18:9: 18:14
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+-         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
       }
   
       bb1: {
 -         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
 -     }
 - 
 -     bb2: {
@@ -33,8 +33,8 @@
 - 
 -     bb3: {
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 20:6
+-         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
++         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
       }
   
 -     bb4: {

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -45,8 +45,8 @@
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
           _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
-          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -40,9 +40,9 @@
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
           _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
--         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:37:9: 37:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
+-         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
++         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
@@ -22,14 +22,14 @@
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
-          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
       }
   
       bb1: {
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
       }
   
       bb2: {
@@ -45,7 +45,7 @@
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
       }
   
       bb4: {

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
@@ -22,14 +22,14 @@
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
-          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
-          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:9: 20:20
+          _3 = const 0_isize;              // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
+          goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
       }
   
       bb1: {
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
       }
   
       bb2: {
@@ -45,7 +45,7 @@
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35
           StorageDead(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
-          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
+          goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
       }
   
       bb4: {

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -25,13 +25,13 @@
           (_1.1: std::option::Option<T>) = move _3; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
           StorageDead(_2);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69
-          _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
-          switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:13: 4:20
+          _5 = discriminant((_1.0: std::option::Option<u8>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
+          switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
       }
   
       bb1: {
-          _4 = discriminant((_1.1: std::option::Option<T>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
-          switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:22: 4:26
+          _4 = discriminant((_1.1: std::option::Option<T>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
+          switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -15,9 +15,9 @@
       }
   
       bb0: {
--         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+-         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
           _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -15,9 +15,9 @@
       }
   
       bb0: {
--         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+-         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+-         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+-         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
           _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -16,13 +16,13 @@
 -         _1 = _2;                         // scope 1 at $DIR/simplify_match.rs:6:28: 6:29
 +         _1 = const false;                // scope 1 at $DIR/simplify_match.rs:6:28: 6:29
           StorageDead(_2);                 // scope 0 at $DIR/simplify_match.rs:6:30: 6:31
--         switchInt(_1) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:7:9: 7:13
-+         switchInt(const false) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:7:9: 7:13
+-         switchInt(_1) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:6:5: 6:31
++         switchInt(const false) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:6:5: 6:31
       }
   
       bb1: {
           nop;                             // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
-          goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:6:5: 9:6
+          goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
       }
   
       bb2: {

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -41,14 +41,14 @@
 -         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 -         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
 -         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
--         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
+-         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 +         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 +         nop;                             // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-+         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-          goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
++         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+          goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -45,8 +45,8 @@
           _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
           _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -39,8 +39,8 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
-        goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:22:9: 22:15
+        _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+        goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
     }
 
     bb1: {

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -16,7 +16,7 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-        _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
+        _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
         _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                          // ty::Const
@@ -32,8 +32,8 @@ fn main() -> () {
         StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
         StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-        _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
+        _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
+        switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
     }
 
     bb1: {
@@ -47,7 +47,7 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [69], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
         _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
         StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
+        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
     }
 
     bb2: {
@@ -58,7 +58,7 @@ fn main() -> () {
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
-        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
+        goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
     }
 
     bb3: {

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -17,9 +17,9 @@
           StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
-          _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
--         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
-+         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:21:9: 21:20
+          _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
+-         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
++         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
       }
   
       bb1: {
@@ -33,7 +33,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
           StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
       }
   
       bb2: {
@@ -44,7 +44,7 @@
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:21:24: 21:34
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
       }
   
       bb3: {
@@ -58,7 +58,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
           _1 = &(*_4);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
           StorageDead(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
-          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
+          goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
       }
   
       bb4: {
@@ -67,8 +67,8 @@
           StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
           StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
-          _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
-          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
+          _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
+          switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
       }
   
       bb5: {
@@ -82,7 +82,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [69], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
           StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
+          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
       }
   
       bb6: {
@@ -93,7 +93,7 @@
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
-          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
+          goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
       }
   
       bb7: {

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -29,8 +29,8 @@ fn main() -> () {
         StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
         StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
         _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-        _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
-        switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
+        _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
+        switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
     }
 
     bb1: {
@@ -44,7 +44,7 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
         _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
         StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
     }
 
     bb2: {
@@ -58,15 +58,15 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
         _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
         StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
-        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+        goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
     }
 
     bb3: {
         StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-        _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
-        switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
+        _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:11: 28:21
+        switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
     }
 
     bb4: {
@@ -80,7 +80,7 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
         _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
         StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
     }
 
     bb5: {
@@ -94,7 +94,7 @@ fn main() -> () {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
         _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
         StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
-        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+        goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
     }
 
     bb6: {

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -30,9 +30,9 @@
           StorageLive(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
           StorageLive(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
           _4 = &(_1.1: Test1);             // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
-          _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
--         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
-+         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:9: 22:20
+          _5 = discriminant((*_4));        // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:11: 21:22
+-         switchInt(move _5) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
++         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
       }
   
       bb1: {
@@ -46,7 +46,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
           StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
       }
   
       bb2: {
@@ -57,7 +57,7 @@
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
       }
   
       bb3: {
@@ -71,7 +71,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
           _3 = &(*_6);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
           StorageDead(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
       }
   
       bb4: {
@@ -85,16 +85,16 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
           StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
-          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 26:6
+          goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
       }
   
       bb5: {
           StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
           StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
           StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
-          _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
--         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb8, 2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
-+         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:9: 29:20
+          _10 = discriminant((_1.1: Test1)); // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:11: 28:21
+-         switchInt(move _10) -> [0_isize: bb7, 1_isize: bb8, 2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
++         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
       }
   
       bb6: {
@@ -108,7 +108,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
           StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
       }
   
       bb7: {
@@ -119,7 +119,7 @@
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
       }
   
       bb8: {
@@ -133,7 +133,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
           _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
           StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
       }
   
       bb9: {
@@ -147,7 +147,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
           _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
           StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
-          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
+          goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
       }
   
       bb10: {

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
@@ -34,7 +34,7 @@
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:20: 7:24
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
       bb3: {

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
@@ -34,7 +34,7 @@
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:20: 7:24
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
       bb3: {

--- a/src/test/ui/borrowck/borrowck-anon-fields-variant.rs
+++ b/src/test/ui/borrowck/borrowck-anon-fields-variant.rs
@@ -14,8 +14,8 @@ fn distinct_variant() {
     // also used for the discriminant of `Foo`, which it would be if `a` was a
     // reference.
     let b = match y {
-      Foo::Y(_, ref mut b) => b,
       //~^ ERROR cannot use `y`
+      Foo::Y(_, ref mut b) => b,
       Foo::X => panic!()
     };
 
@@ -32,8 +32,9 @@ fn same_variant() {
     };
 
     let b = match y {
-      Foo::Y(ref mut b, _) => b, //~ ERROR cannot use `y`
-      //~| ERROR cannot borrow `y.0` as mutable
+      //~^ ERROR cannot use `y`
+      Foo::Y(ref mut b, _) => b,
+      //~^ ERROR cannot borrow `y.0` as mutable
       Foo::X => panic!()
     };
 

--- a/src/test/ui/borrowck/borrowck-anon-fields-variant.stderr
+++ b/src/test/ui/borrowck/borrowck-anon-fields-variant.stderr
@@ -1,29 +1,29 @@
 error[E0503]: cannot use `y` because it was mutably borrowed
-  --> $DIR/borrowck-anon-fields-variant.rs:17:7
+  --> $DIR/borrowck-anon-fields-variant.rs:16:19
    |
 LL |       Foo::Y(ref mut a, _) => a,
    |              --------- borrow of `y.0` occurs here
 ...
-LL |       Foo::Y(_, ref mut b) => b,
-   |       ^^^^^^^^^^^^^^^^^^^^ use of borrowed `y.0`
+LL |     let b = match y {
+   |                   ^ use of borrowed `y.0`
 ...
 LL |     *a += 1;
    |     ------- borrow later used here
 
 error[E0503]: cannot use `y` because it was mutably borrowed
-  --> $DIR/borrowck-anon-fields-variant.rs:35:7
+  --> $DIR/borrowck-anon-fields-variant.rs:34:19
    |
 LL |       Foo::Y(ref mut a, _) => a,
    |              --------- borrow of `y.0` occurs here
 ...
-LL |       Foo::Y(ref mut b, _) => b,
-   |       ^^^^^^^^^^^^^^^^^^^^ use of borrowed `y.0`
+LL |     let b = match y {
+   |                   ^ use of borrowed `y.0`
 ...
 LL |     *a += 1;
    |     ------- borrow later used here
 
 error[E0499]: cannot borrow `y.0` as mutable more than once at a time
-  --> $DIR/borrowck-anon-fields-variant.rs:35:14
+  --> $DIR/borrowck-anon-fields-variant.rs:36:14
    |
 LL |       Foo::Y(ref mut a, _) => a,
    |              --------- first mutable borrow occurs here

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.rs
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.rs
@@ -164,9 +164,9 @@ fn main() {
         let mut e = E::A(3);
         let x = &mut e;
         match e {
+            //~^ ERROR cannot use `e` because it was mutably borrowed
             E::A(ref ax) =>
                 //~^ ERROR cannot borrow `e.0` as immutable because it is also borrowed as mutable
-                //~| ERROR cannot use `e` because it was mutably borrowed
                 println!("e.ax: {:?}", ax),
             E::B { x: ref bx } =>
                 //~^ ERROR cannot borrow `e.x` as immutable because it is also borrowed as mutable

--- a/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
+++ b/src/test/ui/borrowck/borrowck-describe-lvalue.stderr
@@ -238,23 +238,22 @@ LL |         drop(x);
    |              - borrow later used here
 
 error[E0503]: cannot use `e` because it was mutably borrowed
-  --> $DIR/borrowck-describe-lvalue.rs:167:13
+  --> $DIR/borrowck-describe-lvalue.rs:166:15
    |
 LL |         let x = &mut e;
    |                 ------ borrow of `e` occurs here
 LL |         match e {
-LL |             E::A(ref ax) =>
-   |             ^^^^^^^^^^^^ use of borrowed `e`
+   |               ^ use of borrowed `e`
 ...
 LL |         drop(x);
    |              - borrow later used here
 
 error[E0502]: cannot borrow `e.0` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-describe-lvalue.rs:167:18
+  --> $DIR/borrowck-describe-lvalue.rs:168:18
    |
 LL |         let x = &mut e;
    |                 ------ mutable borrow occurs here
-LL |         match e {
+...
 LL |             E::A(ref ax) =>
    |                  ^^^^^^ immutable borrow occurs here
 ...

--- a/src/test/ui/borrowck/borrowck-match-already-borrowed.rs
+++ b/src/test/ui/borrowck/borrowck-match-already-borrowed.rs
@@ -6,8 +6,8 @@ enum Foo {
 fn match_enum() {
     let mut foo = Foo::B;
     let p = &mut foo;
-    let _ = match foo {
-        Foo::B => 1, //~ ERROR [E0503]
+    let _ = match foo { //~ ERROR [E0503]
+        Foo::B => 1,
         _ => 2,
         Foo::A(x) => x //~ ERROR [E0503]
     };

--- a/src/test/ui/borrowck/borrowck-match-already-borrowed.stderr
+++ b/src/test/ui/borrowck/borrowck-match-already-borrowed.stderr
@@ -1,11 +1,10 @@
 error[E0503]: cannot use `foo` because it was mutably borrowed
-  --> $DIR/borrowck-match-already-borrowed.rs:10:9
+  --> $DIR/borrowck-match-already-borrowed.rs:9:19
    |
 LL |     let p = &mut foo;
    |             -------- borrow of `foo` occurs here
 LL |     let _ = match foo {
-LL |         Foo::B => 1,
-   |         ^^^^^^ use of borrowed `foo`
+   |                   ^^^ use of borrowed `foo`
 ...
 LL |     drop(p);
    |          - borrow later used here

--- a/src/test/ui/borrowck/issue-27282-move-match-input-into-guard.rs
+++ b/src/test/ui/borrowck/issue-27282-move-match-input-into-guard.rs
@@ -10,11 +10,11 @@
 fn main() {
     let b = &mut true;
     match b {
+        //~^ ERROR use of moved value: `b` [E0382]
         &mut false => {},
         _ if { (|| { let bar = b; *bar = false; })();
                      false } => { },
         &mut true => { println!("You might think we should get here"); },
-        //~^ ERROR use of moved value: `b` [E0382]
         _ => panic!("surely we could never get here, since rustc warns it is unreachable."),
     }
 }

--- a/src/test/ui/borrowck/issue-27282-move-match-input-into-guard.stderr
+++ b/src/test/ui/borrowck/issue-27282-move-match-input-into-guard.stderr
@@ -1,16 +1,15 @@
 error[E0382]: use of moved value: `b`
-  --> $DIR/issue-27282-move-match-input-into-guard.rs:16:14
+  --> $DIR/issue-27282-move-match-input-into-guard.rs:12:5
    |
 LL |     let b = &mut true;
    |         - move occurs because `b` has type `&mut bool`, which does not implement the `Copy` trait
+LL |     match b {
+   |     ^^^^^^^ value used here after move
 ...
 LL |         _ if { (|| { let bar = b; *bar = false; })();
    |                 --             - variable moved due to use in closure
    |                 |
    |                 value moved into closure here
-LL |                      false } => { },
-LL |         &mut true => { println!("You might think we should get here"); },
-   |              ^^^^ value used here after move
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
@@ -65,11 +65,11 @@ LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   | |                                                   ^^^^^^^^^^^ constant accesses static
+   | |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
 LL | |

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
@@ -65,11 +65,11 @@ LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   | |                                                   ^^^^^^^^^^^ constant accesses static
+   | |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
 LL | |

--- a/src/test/ui/issues/issue-17385.rs
+++ b/src/test/ui/issues/issue-17385.rs
@@ -15,8 +15,8 @@ impl Drop for Enum {
 fn main() {
     let foo = X(1);
     drop(foo);
-    match foo {
-        X(1) => (), //~ ERROR use of moved value
+    match foo { //~ ERROR use of moved value
+        X(1) => (),
         _ => unreachable!()
     }
 

--- a/src/test/ui/issues/issue-17385.stderr
+++ b/src/test/ui/issues/issue-17385.stderr
@@ -1,13 +1,12 @@
 error[E0382]: use of moved value: `foo`
-  --> $DIR/issue-17385.rs:19:11
+  --> $DIR/issue-17385.rs:18:5
    |
 LL |     let foo = X(1);
    |         --- move occurs because `foo` has type `X`, which does not implement the `Copy` trait
 LL |     drop(foo);
    |          --- value moved here
 LL |     match foo {
-LL |         X(1) => (),
-   |           ^ value used here after move
+   |     ^^^^^^^^^ value used here after move
 
 error[E0382]: use of moved value: `e`
   --> $DIR/issue-17385.rs:25:11

--- a/src/test/ui/nll/borrowed-match-issue-45045.rs
+++ b/src/test/ui/nll/borrowed-match-issue-45045.rs
@@ -10,8 +10,8 @@ fn main() {
     let f = &mut e;
     let g = f;
     match e {
-        Xyz::A => println!("a"),
         //~^ cannot use `e` because it was mutably borrowed [E0503]
+        Xyz::A => println!("a"),
         Xyz::B => println!("b"),
     };
     *g = Xyz::B;

--- a/src/test/ui/nll/borrowed-match-issue-45045.stderr
+++ b/src/test/ui/nll/borrowed-match-issue-45045.stderr
@@ -1,11 +1,11 @@
 error[E0503]: cannot use `e` because it was mutably borrowed
-  --> $DIR/borrowed-match-issue-45045.rs:13:9
+  --> $DIR/borrowed-match-issue-45045.rs:12:11
    |
 LL |     let f = &mut e;
    |             ------ borrow of `e` occurs here
-...
-LL |         Xyz::A => println!("a"),
-   |         ^^^^^^ use of borrowed `e`
+LL |     let g = f;
+LL |     match e {
+   |           ^ use of borrowed `e`
 ...
 LL |     *g = Xyz::B;
    |     ----------- borrow later used here

--- a/src/test/ui/nll/match-cfg-fake-edges2.rs
+++ b/src/test/ui/nll/match-cfg-fake-edges2.rs
@@ -7,8 +7,8 @@ fn all_previous_tests_may_be_done(y: &mut (bool, bool)) {
     let r = &mut y.1;
     // We don't actually test y.1 to select the second arm, but we don't want
     // borrowck results to be based on the order we match patterns.
-    match y {
-        (false, true) => 1, //~ ERROR cannot use `y.1` because it was mutably borrowed
+    match y { //~ ERROR cannot use `y.1` because it was mutably borrowed
+        (false, true) => 1,
         (true, _) => {
             r;
             2

--- a/src/test/ui/nll/match-cfg-fake-edges2.stderr
+++ b/src/test/ui/nll/match-cfg-fake-edges2.stderr
@@ -1,12 +1,12 @@
 error[E0503]: cannot use `y.1` because it was mutably borrowed
-  --> $DIR/match-cfg-fake-edges2.rs:11:17
+  --> $DIR/match-cfg-fake-edges2.rs:10:5
    |
 LL |     let r = &mut y.1;
    |             -------- borrow of `y.1` occurs here
 ...
-LL |         (false, true) => 1,
-   |                 ^^^^ use of borrowed `y.1`
-LL |         (true, _) => {
+LL |     match y {
+   |     ^^^^^^^ use of borrowed `y.1`
+...
 LL |             r;
    |             - borrow later used here
 

--- a/src/test/ui/nll/match-on-borrowed.rs
+++ b/src/test/ui/nll/match-on-borrowed.rs
@@ -45,8 +45,9 @@ fn enum_example(mut e: E) {
         E::W => panic!(),
     };
     match e { // Don't know that E uses a tag for its discriminant
+        //~^ ERROR
         _ if false => (),
-        E::V(_, r) => (), //~ ERROR
+        E::V(_, r) => (),
         E::W => (),
     }
     x;
@@ -58,8 +59,9 @@ fn indirect_enum_example(mut f: &mut E) {
         E::W => panic!(),
     };
     match f { // Don't know that E uses a tag for its discriminant
+        //~^ ERROR
         _ if false => (),
-        E::V(_, r) => (), //~ ERROR
+        E::V(_, r) => (),
         E::W => (),
     }
     x;
@@ -77,7 +79,8 @@ fn match_on_muatbly_borrowed_ref(mut p: &bool) {
 fn match_on_borrowed(mut t: bool) {
     let x = &mut t;
     match t {
-        true => (), //~ ERROR
+        //~^ ERROR
+        true => (),
         false => (),
     }
     x;

--- a/src/test/ui/nll/match-on-borrowed.stderr
+++ b/src/test/ui/nll/match-on-borrowed.stderr
@@ -1,41 +1,40 @@
 error[E0503]: cannot use `e` because it was mutably borrowed
-  --> $DIR/match-on-borrowed.rs:49:9
+  --> $DIR/match-on-borrowed.rs:47:11
    |
 LL |         E::V(ref mut x, _) => x,
    |              --------- borrow of `e.0` occurs here
 ...
-LL |         E::V(_, r) => (),
-   |         ^^^^^^^^^^ use of borrowed `e.0`
+LL |     match e { // Don't know that E uses a tag for its discriminant
+   |           ^ use of borrowed `e.0`
 ...
 LL |     x;
    |     - borrow later used here
 
 error[E0503]: cannot use `*f` because it was mutably borrowed
-  --> $DIR/match-on-borrowed.rs:62:9
+  --> $DIR/match-on-borrowed.rs:61:11
    |
 LL |         E::V(ref mut x, _) => x,
    |              --------- borrow of `f.0` occurs here
 ...
-LL |         E::V(_, r) => (),
-   |         ^^^^^^^^^^ use of borrowed `f.0`
+LL |     match f { // Don't know that E uses a tag for its discriminant
+   |           ^ use of borrowed `f.0`
 ...
 LL |     x;
    |     - borrow later used here
 
 error[E0503]: cannot use `t` because it was mutably borrowed
-  --> $DIR/match-on-borrowed.rs:80:9
+  --> $DIR/match-on-borrowed.rs:81:5
    |
 LL |     let x = &mut t;
    |             ------ borrow of `t` occurs here
 LL |     match t {
-LL |         true => (),
-   |         ^^^^ use of borrowed `t`
+   |     ^^^^^^^ use of borrowed `t`
 ...
 LL |     x;
    |     - borrow later used here
 
 error[E0381]: use of possibly-uninitialized variable: `n`
-  --> $DIR/match-on-borrowed.rs:90:11
+  --> $DIR/match-on-borrowed.rs:93:11
    |
 LL |     match n {}
    |           ^ use of possibly-uninitialized `n`

--- a/src/test/ui/rfc-2008-non-exhaustive/borrowck-non-exhaustive.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/borrowck-non-exhaustive.rs
@@ -10,8 +10,8 @@ fn main() {
     let mut x = NonExhaustiveMonovariant::Variant(1);
     let y = &mut x;
     match x {
-        NonExhaustiveMonovariant::Variant(_) => {},
         //~^ ERROR cannot use `x` because it was mutably borrowed
+        NonExhaustiveMonovariant::Variant(_) => {},
         _ => {},
     }
     drop(y);

--- a/src/test/ui/rfc-2008-non-exhaustive/borrowck-non-exhaustive.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/borrowck-non-exhaustive.stderr
@@ -1,11 +1,10 @@
 error[E0503]: cannot use `x` because it was mutably borrowed
-  --> $DIR/borrowck-non-exhaustive.rs:13:9
+  --> $DIR/borrowck-non-exhaustive.rs:12:11
    |
 LL |     let y = &mut x;
    |             ------ borrow of `x` occurs here
 LL |     match x {
-LL |         NonExhaustiveMonovariant::Variant(_) => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of borrowed `x`
+   |           ^ use of borrowed `x`
 ...
 LL |     drop(y);
    |          - borrow later used here

--- a/src/test/ui/union/union-unsafe.mir.stderr
+++ b/src/test/ui/union/union-unsafe.mir.stderr
@@ -55,10 +55,10 @@ LL |     let U1 { a } = u1;
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
 error[E0133]: access to union field is unsafe and requires unsafe function or block
-  --> $DIR/union-unsafe.rs:65:20
+  --> $DIR/union-unsafe.rs:65:12
    |
 LL |     if let U1 { a: 12 } = u1 {}
-   |                    ^^ access to union field
+   |            ^^^^^^^^^^^^ access to union field
    |
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 


### PR DESCRIPTION
Previously, we would set up the source lines for `match` expressions so
that the code generated to perform the test of the scrutinee was matched
to the line of the arm that required the test and then jump from the arm
block to the "next" block was matched to all of the lines in the `match`
expression.

While that makes sense, it has the side effect of causing strange
stepping behavior in debuggers.

I've changed the source information so that all of the generated tests
are sourced to `match {scrutinee}` and the jumps are sourced to the last
line of the block they are inside. This resolves the weird stepping
behavior in all debuggers and resolves some instances of "ambiguous
symbol" errors in WinDbg preventing the user from setting breakpoints at
`match` expressions.

Before:

https://user-images.githubusercontent.com/831192/128577421-ee0c9c03-da28-4d16-997a-d57988a7bb7f.mp4

After:

https://user-images.githubusercontent.com/831192/128577433-2ceab04d-953e-4e31-9387-93f049c71ff3.mp4

Fixes #87817 
