### PR TITLE
Fix typo -- "The" -> "They"

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -129,7 +129,7 @@ enum FileEntry {
     /// An HTML file.
     ///
     /// This includes the contents of the HTML file, and an optional set of
-    /// HTML IDs. The IDs are used for checking fragments. The are computed
+    /// HTML IDs. The IDs are used for checking fragments. They are computed
     /// as-needed. The source is discarded (replaced with an empty string)
     /// after the file has been checked, to conserve on memory.
     HtmlFile { source: Rc<String>, ids: RefCell<HashSet<String>> },


### PR DESCRIPTION
I was reading through source code to try to learn more about the language and how to make the most of it when I ran into a small typo, so I figured I'd offer up a fix! I'm pretty new now, but hopefully I can offer up more substantial changes later. :D