### PR TITLE
correctly handle enum variants in `opt_const_param_of`

### DIFF
--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -190,8 +190,12 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                 // Try to use the segment resolution if it is valid, otherwise we
                 // default to the path resolution.
                 let res = segment.res.filter(|&r| r != Res::Err).unwrap_or(path.res);
+                use def::CtorOf;
                 let generics = match res {
-                    Res::Def(DefKind::Ctor(..), def_id) => {
+                    Res::Def(DefKind::Ctor(CtorOf::Variant, _), def_id) => {
+                        tcx.generics_of(tcx.parent(def_id).and_then(|def_id| tcx.parent(def_id)).unwrap())
+                    }
+                    Res::Def(DefKind::Variant | DefKind::Ctor(CtorOf::Struct, _), def_id) => {
                         tcx.generics_of(tcx.parent(def_id).unwrap())
                     }
                     // Other `DefKind`s don't have generics and would ICE when calling
@@ -200,7 +204,6 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                         DefKind::Struct
                         | DefKind::Union
                         | DefKind::Enum
-                        | DefKind::Variant
                         | DefKind::Trait
                         | DefKind::OpaqueTy
                         | DefKind::TyAlias

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -192,9 +192,9 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                 let res = segment.res.filter(|&r| r != Res::Err).unwrap_or(path.res);
                 use def::CtorOf;
                 let generics = match res {
-                    Res::Def(DefKind::Ctor(CtorOf::Variant, _), def_id) => {
-                        tcx.generics_of(tcx.parent(def_id).and_then(|def_id| tcx.parent(def_id)).unwrap())
-                    }
+                    Res::Def(DefKind::Ctor(CtorOf::Variant, _), def_id) => tcx.generics_of(
+                        tcx.parent(def_id).and_then(|def_id| tcx.parent(def_id)).unwrap(),
+                    ),
                     Res::Def(DefKind::Variant | DefKind::Ctor(CtorOf::Struct, _), def_id) => {
                         tcx.generics_of(tcx.parent(def_id).unwrap())
                     }

--- a/src/test/ui/const-generics/enum-variants.rs
+++ b/src/test/ui/const-generics/enum-variants.rs
@@ -1,0 +1,24 @@
+// check-pass
+pub enum Foo<const N: usize> {
+    Variant,
+    Variant2(),
+    Variant3{},
+}
+
+struct Bar<const N: usize>;
+struct Bar2<const N: usize>();
+struct Bar3<const N: usize> {}
+
+fn main() {
+    let _ = Foo::Variant::<1>;
+    let _ = Foo::Variant2::<1>();
+    let _ = Foo::Variant3::<1>{};
+
+    let _ = Foo::<1>::Variant;
+    let _ = Foo::<1>::Variant2();
+    let _ = Foo::<1>::Variant3{};
+
+    let _ = Bar::<1>;
+    let _ = Bar2::<1>();
+    let _ = Bar3::<1>{};
+}

--- a/src/test/ui/const-generics/enum-variants.rs
+++ b/src/test/ui/const-generics/enum-variants.rs
@@ -1,5 +1,5 @@
 // check-pass
-pub enum Foo<const N: usize> {
+enum Foo<const N: usize> {
     Variant,
     Variant2(),
     Variant3{},


### PR DESCRIPTION
Fixes #87542

`opt_const_param_of` was returning `None` for args on an enum variant `Enum::Variant::<10>` because we called `generics_of` on the enum variant which has no generics.

r? @oli-obk 