### PR TITLE
Fix heading colours in Ayu theme

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -37,7 +37,7 @@ h4 {
 .docblock code {
 	color: #ffb454;
 }
-h3 > code, h4 > code, h5 > code {
+.code-header {
 	color: #e6e1cf;
 }
 pre > code {


### PR DESCRIPTION
Closes #87828 
The issue seems to stem from #87210 where code headings were changed from a heading containing a `code` element to a heading with the `code-header` class. `rustdoc.css` was updated, but `ayu.css` was missed.