### PR TITLE
Make `<[T]>::split_at_unchecked` and `<[T]>::split_at_mut_unchecked` public

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1559,7 +1559,7 @@ impl<T> [T] {
     ///
     /// # Examples
     ///
-    /// ```compile_fail
+    /// ```
     /// #![feature(slice_split_at_unchecked)]
     ///
     /// let v = [1, 2, 3, 4, 5, 6];
@@ -1584,7 +1584,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_split_at_unchecked", reason = "new API", issue = "76014")]
     #[inline]
-    unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {
+    pub unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {
         // SAFETY: Caller has to check that `0 <= mid <= self.len()`
         unsafe { (self.get_unchecked(..mid), self.get_unchecked(mid..)) }
     }
@@ -1608,7 +1608,7 @@ impl<T> [T] {
     ///
     /// # Examples
     ///
-    /// ```compile_fail
+    /// ```
     /// #![feature(slice_split_at_unchecked)]
     ///
     /// let mut v = [1, 0, 3, 0, 5, 6];
@@ -1624,7 +1624,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_split_at_unchecked", reason = "new API", issue = "76014")]
     #[inline]
-    unsafe fn split_at_mut_unchecked(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+    pub unsafe fn split_at_mut_unchecked(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
         let len = self.len();
         let ptr = self.as_mut_ptr();
 


### PR DESCRIPTION
The methods were originally added in https://github.com/rust-lang/rust/pull/75936 (https://github.com/sdroege/rust/commit/30dc32b10eb53e4a92c61a42062983db58838217), but for some reason as private. Nevertheless, the methods have documentation and even a [tracking issue](https://github.com/rust-lang/rust/issues/76014).

It's very weird to have a tracking issue for private methods and these methods may be useful outside of the standard library. As such, this PR makes the methods public. 