### PR TITLE
Fix early exiting when `ExprUseVisitor` meets unresolved type var

### DIFF
--- a/src/test/ui/closures/issue-87814-1.rs
+++ b/src/test/ui/closures/issue-87814-1.rs
@@ -1,0 +1,8 @@
+// check-pass
+fn main() {
+    let mut schema_all = vec![];
+    (0..42).for_each(|_x| match Err(()) as Result<(), _> {
+        Ok(()) => schema_all.push(()),
+        Err(_) => (),
+    });
+}

--- a/src/test/ui/closures/issue-87814-2.rs
+++ b/src/test/ui/closures/issue-87814-2.rs
@@ -1,0 +1,11 @@
+// check-pass
+#![feature(try_reserve)]
+
+fn main() {
+    let mut schema_all: (Vec<String>, Vec<String>) = (vec![], vec![]);
+
+    let _c = || match schema_all.0.try_reserve(1) as Result<(), _> {
+        Ok(()) => (),
+        Err(_) => (),
+    };
+}


### PR DESCRIPTION
Closes #87814

```rust
fn main() {
    let mut schema_all = vec![];
    (0..42).for_each(|_x| match Err(()) as Result<(), _> {
        Ok(()) => schema_all.push(()),
        Err(_) => (),
    });
}
```

`ExprUseVisitor::walk_expr ======> hir::ExprKind::Match => MemCategorizationContext::cat_pattern ======> self.cat_pattern_ ======> PatKind::TupleStruct => self.pat_ty_adjusted ======> self.pat_ty_unadjusted ======> self.node_ty ======> self.resolve_type_vars_or_error` 

With `as Result<(), _>` presents, the argument `ty` of `resolve_type_vars_or_error` when checking `Err(_) => ..` arm is a type var rather than a unit. And the error bubbles through all the functions listed above. Which means the `walk_arm()` call in the `ExprUseVisitor::walk_expr` is skipped.

I think `walk_arm` is a process not mangled with the `cat_pattern`. So working around this problem by swallowing the type var resolving error.

r? @roxelo @nikomatsakis 