### PR TITLE
Remove duplicate trait bounds in `rustc_data_structures::graph`

### DIFF
--- a/compiler/rustc_data_structures/src/graph/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/mod.rs
@@ -60,18 +60,13 @@ pub trait WithStartNode: DirectedGraph {
 }
 
 pub trait ControlFlowGraph:
-    DirectedGraph + WithStartNode + WithPredecessors + WithStartNode + WithSuccessors + WithNumNodes
+    DirectedGraph + WithStartNode + WithPredecessors + WithSuccessors + WithNumNodes
 {
     // convenient trait
 }
 
 impl<T> ControlFlowGraph for T where
-    T: DirectedGraph
-        + WithStartNode
-        + WithPredecessors
-        + WithStartNode
-        + WithSuccessors
-        + WithNumNodes
+    T: DirectedGraph + WithStartNode + WithPredecessors + WithSuccessors + WithNumNodes
 {
 }
 


### PR DESCRIPTION
Remove duplicate trait bounds in `rustc_data_structures::graph`.