### PR TITLE
Description for `HashSet::insert` redundant and difficult to understand

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -809,11 +809,11 @@ where
         other.is_subset(self)
     }
 
-    /// Adds a value to the set.
+    /// Inserts a value to the set.
     ///
-    /// If the set did not have this value present, `true` is returned.
+    /// If the insertion changed the set, `true` is returned.
     ///
-    /// If the set did have this value present, `false` is returned.
+    /// If the value already has been present, `false` is returned.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I had to read it carefully to really understand, what's going on.

There has been the same sentence twice, but once negated.
So reading the second one does not give any useful information.

And the sentence, which contains the "not" is associated with `true`.
This way, it's not clear, why `true` or `false` are returned in these cases.

Instead of having descriptions of the specific cases, there should rather be a general description like "Returns if the set has been changed by adding the value" or "Returns if the value has been added".

But for clarity, I didn't remove the explicit description of the `false` case, so if you don't understand the description of the `true` case, the description of the `false` case might still help you.