### PR TITLE
Link to edition guide instead of issues for 2021 lints.

### DIFF
--- a/compiler/rustc_lint/src/array_into_iter.rs
+++ b/compiler/rustc_lint/src/array_into_iter.rs
@@ -32,7 +32,7 @@ declare_lint! {
     Warn,
     "detects calling `into_iter` on arrays in Rust 2015 and 2018",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #66145 <https://github.com/rust-lang/rust/issues/66145>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>",
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2021),
     };
 }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1680,7 +1680,7 @@ declare_lint! {
     Warn,
     "`...` range patterns are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #80165 <https://github.com/rust-lang/rust/issues/80165>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1605,7 +1605,7 @@ declare_lint! {
     Warn,
     "suggest using `dyn Trait` for trait objects",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #80165 <https://github.com/rust-lang/rust/issues/80165>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
 }
@@ -3247,7 +3247,7 @@ declare_lint! {
     Allow,
     "detects usage of old versions of or-patterns",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #84869 <https://github.com/rust-lang/rust/issues/84869>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
 }
@@ -3296,7 +3296,7 @@ declare_lint! {
     "detects the usage of trait methods which are ambiguous with traits added to the \
         prelude in future editions",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #85684 <https://github.com/rust-lang/rust/issues/85684>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
 }
@@ -3331,7 +3331,7 @@ declare_lint! {
     Allow,
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #84978 <https://github.com/rust-lang/rust/issues/84978>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
     crate_level_only

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -139,7 +139,7 @@ LL |     foo::<BAR + BAR>();
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/const-expression-suggest-missing-braces.rs:11:11

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #[deny(bare_trait_objects)]
    |        ^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -19,7 +19,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |                                   ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:9:14
@@ -28,7 +28,7 @@ LL |     let _x: &SomeTrait = todo!();
    |              ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -18,7 +18,7 @@ LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:7:27

--- a/src/test/ui/issues/issue-86756.stderr
+++ b/src/test/ui/issues/issue-86756.stderr
@@ -22,7 +22,7 @@ LL |     eq::<dyn, Foo>
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0107]: missing generics for trait `Foo`
   --> $DIR/issue-86756.rs:5:15

--- a/src/test/ui/iterators/into-iter-on-arrays-2018.stderr
+++ b/src/test/ui/iterators/into-iter-on-arrays-2018.stderr
@@ -6,7 +6,7 @@ LL |     let _: Iter<'_, i32> = array.into_iter();
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     let _: Iter<'_, i32> = array.iter();
@@ -23,7 +23,7 @@ LL |     let _: Iter<'_, i32> = Box::new(array).into_iter();
    |                                            ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     let _: Iter<'_, i32> = Box::new(array).iter();
@@ -40,7 +40,7 @@ LL |     for _ in [1, 2, 3].into_iter() {}
    |                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     for _ in [1, 2, 3].iter() {}

--- a/src/test/ui/iterators/into-iter-on-arrays-lint.stderr
+++ b/src/test/ui/iterators/into-iter-on-arrays-lint.stderr
@@ -6,7 +6,7 @@ LL |     small.into_iter();
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     small.iter();
@@ -23,7 +23,7 @@ LL |     [1, 2].into_iter();
    |            ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     [1, 2].iter();
@@ -40,7 +40,7 @@ LL |     big.into_iter();
    |         ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     big.iter();
@@ -57,7 +57,7 @@ LL |     [0u8; 33].into_iter();
    |               ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     [0u8; 33].iter();
@@ -74,7 +74,7 @@ LL |     Box::new(small).into_iter();
    |                     ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(small).iter();
@@ -91,7 +91,7 @@ LL |     Box::new([1, 2]).into_iter();
    |                      ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new([1, 2]).iter();
@@ -108,7 +108,7 @@ LL |     Box::new(big).into_iter();
    |                   ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(big).iter();
@@ -125,7 +125,7 @@ LL |     Box::new([0u8; 33]).into_iter();
    |                         ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new([0u8; 33]).iter();
@@ -142,7 +142,7 @@ LL |     Box::new(Box::new(small)).into_iter();
    |                               ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(Box::new(small)).iter();
@@ -159,7 +159,7 @@ LL |     Box::new(Box::new([1, 2])).into_iter();
    |                                ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(Box::new([1, 2])).iter();
@@ -176,7 +176,7 @@ LL |     Box::new(Box::new(big)).into_iter();
    |                             ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(Box::new(big)).iter();
@@ -193,7 +193,7 @@ LL |     Box::new(Box::new([0u8; 33])).into_iter();
    |                                   ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     Box::new(Box::new([0u8; 33])).iter();

--- a/src/test/ui/lint/bare-trait-objects-path.stderr
+++ b/src/test/ui/lint/bare-trait-objects-path.stderr
@@ -12,7 +12,7 @@ LL |     Dyn::func();
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:17:5
@@ -21,7 +21,7 @@ LL |     ::Dyn::func();
    |     ^^^^^ help: use `dyn`: `<dyn (::Dyn)>`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:20:5
@@ -30,7 +30,7 @@ LL |     Dyn::CONST;
    |     ^^^ help: use `dyn`: `<dyn Dyn>`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to previous error; 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/force-lint-in-allowed-group.stderr
+++ b/src/test/ui/lint/force-warn/force-lint-in-allowed-group.stderr
@@ -6,7 +6,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = note: requested on the command line with `--force-warn bare-trait-objects`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/force-warn/force-warn-cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/force-warn-cap-lints-allow.stderr
@@ -6,7 +6,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = note: requested on the command line with `--force-warn bare-trait-objects`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/force-warn/force-warn-cap-lints-warn.stderr
+++ b/src/test/ui/lint/force-warn/force-warn-cap-lints-warn.stderr
@@ -6,7 +6,7 @@ LL |         0...100 => true,
    |
    = note: `--force-warn ellipsis-inclusive-range-patterns` implied by `--force-warn rust-2021-compatibility`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/force-warn/force-warn-group-allow-warning.stderr
+++ b/src/test/ui/lint/force-warn/force-warn-group-allow-warning.stderr
@@ -6,7 +6,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/force-warn/force-warn-group.stderr
+++ b/src/test/ui/lint/force-warn/force-warn-group.stderr
@@ -6,7 +6,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
+++ b/src/test/ui/lint/inclusive-range-pattern-syntax.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(ellipsis_inclusive_range_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: `...` range patterns are deprecated
   --> $DIR/inclusive-range-pattern-syntax.rs:16:9
@@ -19,7 +19,7 @@ LL |         &1...2 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(1..=2)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/macros/macro-or-patterns-back-compat.stderr
+++ b/src/test/ui/macros/macro-or-patterns-back-compat.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(rust_2021_incompatible_or_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84869 <https://github.com/rust-lang/rust/issues/84869>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:13:23
@@ -19,7 +19,7 @@ LL | macro_rules! bar { ($($x:pat)+ | $($y:pat)+) => {} }
    |                       ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84869 <https://github.com/rust-lang/rust/issues/84869>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:19:21
@@ -28,7 +28,7 @@ LL | macro_rules! ogg { ($x:pat | $y:pat_param) => {} }
    |                     ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84869 <https://github.com/rust-lang/rust/issues/84869>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:23:26
@@ -37,7 +37,7 @@ LL |     ( $expr:expr , $( $( $pat:pat )|+ => $expr_arm:expr ),+ ) => {
    |                          ^^^^^^^^ help: use pat_param to preserve semantics: `$pat:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84869 <https://github.com/rust-lang/rust/issues/84869>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issue-68890-2.stderr
+++ b/src/test/ui/parser/issue-68890-2.stderr
@@ -12,7 +12,7 @@ LL | type X<'a> = (?'a) +;
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/issue-68890-2.rs:3:14

--- a/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
+++ b/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
@@ -35,7 +35,7 @@ LL | fn y<'a>(y: &mut 'a + Send) {
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-73568-lifetime-after-mut.rs:19:23
@@ -44,7 +44,7 @@ LL |     let z = y as &mut 'a + Send;
    |                       ^^ help: use `dyn`: `dyn 'a`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/issue-73568-lifetime-after-mut.rs:14:18

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
@@ -12,7 +12,7 @@ LL |     m!('static);
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/trait-object-macro-matcher.rs:11:8

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -205,7 +205,7 @@ note: the lint level is defined here
 LL | #![deny(ellipsis_inclusive_range_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:45:13
@@ -214,7 +214,7 @@ LL |     if let 0...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:48:13
@@ -223,7 +223,7 @@ LL |     if let X...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:51:13
@@ -232,7 +232,7 @@ LL |     if let X...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:54:16
@@ -241,7 +241,7 @@ LL |     if let true...Y = 0 {}
    |                ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:57:13
@@ -250,7 +250,7 @@ LL |     if let X...true = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:60:14
@@ -259,7 +259,7 @@ LL |     if let .0...Y = 0 {}
    |              ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:64:13
@@ -268,7 +268,7 @@ LL |     if let X... .0 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:138:20
@@ -280,7 +280,7 @@ LL |     mac2!(0, 1);
    |     ------------ in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0029]: only `char` and numeric types are allowed in range patterns

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -24,7 +24,7 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/trait-object-trait-parens.rs:13:16
@@ -33,7 +33,7 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn ?Sized + (for<'a> Trait<'a>) + (Obj)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/trait-object-trait-parens.rs:18:16
@@ -42,7 +42,7 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn for<'a> Trait<'a> + (Obj) + (?Sized)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35

--- a/src/test/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
 LL | #![warn(ellipsis_inclusive_range_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
 LL | #![warn(ellipsis_inclusive_range_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/rust-2021/future-prelude-collision-generic.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-generic.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-generic.rs:31:5
@@ -19,7 +19,7 @@ LL |     Generic::<i32, i32>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<i32, i32> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-generic.rs:34:5
@@ -28,7 +28,7 @@ LL |     Generic::<_, _>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<_, _> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:40:22
@@ -19,7 +19,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `crate::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:53:22
@@ -28,7 +28,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `super::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/rust-2021/future-prelude-collision.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:61:13
@@ -19,7 +19,7 @@ LL |     let _ = u32::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^ help: disambiguate the associated function: `<u32 as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:66:13
@@ -28,7 +28,7 @@ LL |     let _ = <Vec<u8>>::from_iter(vec![1u8, 2, 3, 4, 5, 6].into_iter());
    |             ^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<u8> as FromByteIterator>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:74:18
@@ -37,7 +37,7 @@ LL |     let _: u32 = <_>::try_from(3u8).unwrap();
    |                  ^^^^^^^^^^^^^ help: disambiguate the associated function: `<_ as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:79:18
@@ -46,7 +46,7 @@ LL |     let _: u32 = (&3u8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(*(&3u8))`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:84:18
@@ -55,7 +55,7 @@ LL |     let _: u32 = 3.0.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(&3.0)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:90:18
@@ -64,7 +64,7 @@ LL |     let _: u32 = mut_ptr.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(mut_ptr as *const _)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:95:13
@@ -73,7 +73,7 @@ LL |     let _ = U32Alias::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<U32Alias as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: 8 warnings emitted
 

--- a/src/test/ui/rust-2021/generic-type-collision.stderr
+++ b/src/test/ui/rust-2021/generic-type-collision.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/rust-2021/inherent-dyn-collision.stderr
+++ b/src/test/ui/rust-2021/inherent-dyn-collision.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #85684 <https://github.com/rust-lang/rust/issues/85684>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![warn(rust_2021_prefixes_incompatible_syntax)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(z "hey");
@@ -23,7 +23,7 @@ LL |     m2!(prefix"hey");
    |         ^^^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(prefix "hey");
@@ -36,7 +36,7 @@ LL |     m3!(hey#123);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #123);
@@ -49,7 +49,7 @@ LL |     m3!(hey#hey);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #hey);
@@ -62,7 +62,7 @@ LL |     #name = #kind#value
    |              ^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     #name = #kind #value

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -19,7 +19,7 @@ LL | pub struct Foo {
    | ^^^ help: use `dyn`: `dyn pub`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/bound/not-on-bare-trait.stderr
+++ b/src/test/ui/traits/bound/not-on-bare-trait.stderr
@@ -6,7 +6,7 @@ LL | fn foo(_x: Foo + Send) {
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
@@ -6,7 +6,7 @@ LL |     for<'a> Dst<A + 'a>: Sized,
    |
    = note: `-D bare-trait-objects` implied by `-D warnings`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/ice-3969.rs:27:16
@@ -15,7 +15,7 @@ LL |     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);
    |                ^ help: use `dyn`: `dyn A`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/ice-3969.rs:27:57
@@ -24,7 +24,7 @@ LL |     let x: Dst<A> = *(Box::new(Dst { x: 1 }) as Box<Dst<A>>);
    |                                                         ^ help: use `dyn`: `dyn A`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This changes the 2021 lints to not link to github issues, but to the edition guide instead.

Fixes  #86996