### PR TITLE
Use smaller spans when suggesting method call disambiguation

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1695,8 +1695,8 @@ fn print_disambiguation_help(
     source_map: &source_map::SourceMap,
 ) {
     let mut applicability = Applicability::MachineApplicable;
-    let sugg_args = if let (ty::AssocKind::Fn, Some(args)) = (kind, args) {
-        format!(
+    let (span, sugg) = if let (ty::AssocKind::Fn, Some(args)) = (kind, args) {
+        let args = format!(
             "({}{})",
             if rcvr_ty.is_region_ptr() {
                 if rcvr_ty.is_mutable_ptr() { "&mut " } else { "&" }
@@ -1710,12 +1710,12 @@ fn print_disambiguation_help(
                 }))
                 .collect::<Vec<_>>()
                 .join(", "),
-        )
+        );
+        (span, format!("{}::{}{}", trait_name, item_name, args))
     } else {
-        String::new()
+        (span.with_hi(item_name.span.lo()), format!("{}::", trait_name))
     };
-    let sugg = format!("{}::{}{}", trait_name, item_name, sugg_args);
-    err.span_suggestion(
+    err.span_suggestion_verbose(
         span,
         &format!(
             "disambiguate the {} for {}",

--- a/src/test/ui/associated-consts/associated-const-ambiguity-report.stderr
+++ b/src/test/ui/associated-consts/associated-const-ambiguity-report.stderr
@@ -17,11 +17,11 @@ LL |     const ID: i32 = 3;
 help: disambiguate the associated constant for candidate #1
    |
 LL | const X: i32 = Foo::ID;
-   |                ^^^^^^^
+   |                ^^^^^
 help: disambiguate the associated constant for candidate #2
    |
 LL | const X: i32 = Bar::ID;
-   |                ^^^^^^^
+   |                ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0034.stderr
+++ b/src/test/ui/error-codes/E0034.stderr
@@ -17,11 +17,11 @@ LL |     fn foo() {}
 help: disambiguate the associated function for candidate #1
    |
 LL |     Trait1::foo()
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 help: disambiguate the associated function for candidate #2
    |
 LL |     Trait2::foo()
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18446.stderr
+++ b/src/test/ui/issues/issue-18446.stderr
@@ -2,10 +2,7 @@ error[E0034]: multiple applicable items in scope
   --> $DIR/issue-18446.rs:18:7
    |
 LL |     x.foo();
-   |     --^^^--
-   |     | |
-   |     | multiple `foo` found
-   |     help: disambiguate the associated function for candidate #2: `T::foo(&x)`
+   |       ^^^ multiple `foo` found
    |
 note: candidate #1 is defined in an impl for the type `(dyn T + 'a)`
   --> $DIR/issue-18446.rs:9:5
@@ -17,6 +14,10 @@ note: candidate #2 is defined in the trait `T`
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
+help: disambiguate the associated function for candidate #2
+   |
+LL |     T::foo(&x);
+   |     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
+++ b/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
@@ -17,11 +17,11 @@ LL |     fn foo() {}
 help: disambiguate the associated function for candidate #1
    |
 LL |     A::foo();
-   |     ^^^^^^
+   |     ^^^
 help: disambiguate the associated function for candidate #2
    |
 LL |     B::foo();
-   |     ^^^^^^
+   |     ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -61,10 +61,7 @@ error[E0599]: no method named `is_str` found for type parameter `T` in the curre
   --> $DIR/issue-7575.rs:70:7
    |
 LL |     t.is_str()
-   |     --^^^^^^--
-   |     | |
-   |     | this is an associated function, not a method
-   |     help: disambiguate the associated function for the candidate: `ManyImplTrait::is_str(t)`
+   |       ^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `ManyImplTrait`
@@ -73,6 +70,10 @@ note: the candidate is defined in the trait `ManyImplTrait`
 LL |     fn is_str() -> bool {
    |     ^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the type parameter is bounded by the trait
+help: disambiguate the associated function for the candidate
+   |
+LL |     ManyImplTrait::is_str(t)
+   |
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Use smaller spans when suggesting method call disambiguation.