### PR TITLE
Remove size_of == 1 case from `fill` specialization.

### DIFF
--- a/library/core/src/slice/specialize.rs
+++ b/library/core/src/slice/specialize.rs
@@ -1,6 +1,3 @@
-use crate::mem::{size_of, transmute_copy};
-use crate::ptr::write_bytes;
-
 pub(super) trait SpecFill<T> {
     fn spec_fill(&mut self, value: T);
 }
@@ -19,17 +16,8 @@ impl<T: Clone> SpecFill<T> for [T] {
 
 impl<T: Copy> SpecFill<T> for [T] {
     fn spec_fill(&mut self, value: T) {
-        if size_of::<T>() == 1 {
-            // SAFETY: The size_of check above ensures that values are 1 byte wide, as required
-            // for the transmute and write_bytes
-            unsafe {
-                let value: u8 = transmute_copy(&value);
-                write_bytes(self.as_mut_ptr(), value, self.len());
-            }
-        } else {
-            for item in self.iter_mut() {
-                *item = value;
-            }
+        for item in self.iter_mut() {
+            *item = value;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/87891

See [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/potential.20UB.20in.20slice.3A.3Afill/near/248875743).