### PR TITLE
typeck: don't suggest inaccessible fields in struct literals and suggest ignoring inaccessible fields in struct patterns

### DIFF
--- a/src/test/ui/typeck/issue-87872-missing-inaccessible-field-literal.rs
+++ b/src/test/ui/typeck/issue-87872-missing-inaccessible-field-literal.rs
@@ -1,0 +1,11 @@
+pub mod foo {
+    pub struct Foo {
+        pub you_can_use_this_field: bool,
+        you_cant_use_this_field: bool,
+    }
+}
+
+fn main() {
+    foo::Foo {};
+    //~^ ERROR cannot construct `Foo` with struct literal syntax due to inaccessible fields
+}

--- a/src/test/ui/typeck/issue-87872-missing-inaccessible-field-literal.stderr
+++ b/src/test/ui/typeck/issue-87872-missing-inaccessible-field-literal.stderr
@@ -1,0 +1,8 @@
+error: cannot construct `Foo` with struct literal syntax due to inaccessible fields
+  --> $DIR/issue-87872-missing-inaccessible-field-literal.rs:9:5
+   |
+LL |     foo::Foo {};
+   |     ^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/typeck/issue-87872-missing-inaccessible-field-pattern.rs
+++ b/src/test/ui/typeck/issue-87872-missing-inaccessible-field-pattern.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code, unused_variables)]
+
+pub mod foo {
+    #[derive(Default)]
+    pub struct Foo { pub visible: bool, invisible: bool, }
+}
+
+fn main() {
+    let foo::Foo {} = foo::Foo::default();
+    //~^ ERROR pattern does not mention field `visible` and inaccessible fields
+}

--- a/src/test/ui/typeck/issue-87872-missing-inaccessible-field-pattern.stderr
+++ b/src/test/ui/typeck/issue-87872-missing-inaccessible-field-pattern.stderr
@@ -1,0 +1,18 @@
+error[E0027]: pattern does not mention field `visible` and inaccessible fields
+  --> $DIR/issue-87872-missing-inaccessible-field-pattern.rs:9:9
+   |
+LL |     let foo::Foo {} = foo::Foo::default();
+   |         ^^^^^^^^^^^ missing field `visible` and inaccessible fields
+   |
+help: include the missing field in the pattern and ignore the inaccessible fields
+   |
+LL |     let foo::Foo { visible, .. } = foo::Foo::default();
+   |                  ^^^^^^^^^^^^^^^
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |     let foo::Foo { .. } = foo::Foo::default();
+   |                  ^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0027`.


### PR DESCRIPTION
Fixes #87872.

This PR adjusts the missing field diagnostic logic in typeck so that when any of the missing fields in a struct literal or pattern is inaccessible then the error is less confusing, even if some of the missing fields are accessible.

See also #76524.