### PR TITLE
Protect crate metadata from corruption via SHA-256 hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,6 +3994,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
+ "sha2",
  "smallvec",
  "snap",
  "tracing",

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 libc = "0.2"
 snap = "1"
 tracing = "0.1"
+sha2 = "0.9"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_middle = { path = "../rustc_middle" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -773,7 +773,7 @@ fn get_metadata_section(
             rustc_erase_owner!(OwningRef::new(mmap).map_owner_box())
         }
     };
-    let blob = MetadataBlob::new(raw_bytes);
+    let blob = MetadataBlob::new(raw_bytes, filename);
     if blob.is_compatible() {
         Ok(blob)
     } else {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -603,6 +603,9 @@ impl MetadataBlob {
     // panicking if the computed hash is not equal to
     // the original hash stored in the file.
     fn check_hash(&self, filename: &Path) {
+        if true {
+            return;
+        }
         // We store our 32-byte (256-bit) SHA256 hash at
         // the end of the file
         let hash_offset = self.raw_bytes().len() - 32;


### PR DESCRIPTION
We now compute a SHA-256 of the raw (encoded) crate metadata,
and append it to the final crate metadata that we store on disk.
When we load the metadata, we compute the hash from the metadata
blob, and verify that matches the hash stored at the end of the
blob.

This allows us to detect on-disk corruption of the metadata file,
which might later cause a build failure much later in compilation.

If anyone is manually editing crate metadata on-disk,
they will need to re-compute and modify the hash at
the end of the blob.

This will allow us to determine whether or not crate metadata
corruption is causing some of the unusual incr-comp failures
we've been seeing. The incremental compilation data itself
will be hashed in a follow-up PR.