### PR TITLE
Fix suggestion of additional `pub` when using `pub pub fn ...`

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2026,7 +2026,7 @@ impl<'a> Parser<'a> {
                             else {
                                 err.span_suggestion(
                                     current_vis.span,
-                                    "there is already a visibility, remove this one",
+                                    "there is already a visibility modifier, remove one",
                                     "".to_string(),
                                     Applicability::MachineApplicable,
                                 )

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1987,7 +1987,7 @@ impl<'a> Parser<'a> {
                             // There was no explicit visibility
                             if matches!(orig_vis.kind, VisibilityKind::Inherited) {
                                 err.span_suggestion(
-                                    sp,
+                                    sp_start.to(self.prev_token.span),
                                     &format!("visibility `{}` must come before `{}`", vs, snippet),
                                     format!("{} {}", vs, snippet),
                                     Applicability::MachineApplicable,

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -474,7 +474,8 @@ impl<'a> Parser<'a> {
         params: Vec<GenericParam>,
         recover_return_sign: RecoverReturnSign,
     ) -> PResult<'a, TyKind> {
-        let ast::FnHeader { ext, unsafety, constness, asyncness } = self.parse_fn_front_matter()?;
+        let ast::FnHeader { ext, unsafety, constness, asyncness } =
+            self.parse_fn_front_matter(None)?;
         let decl = self.parse_fn_decl(|_| false, AllowPlus::No, recover_return_sign)?;
         let whole_span = lo.to(self.prev_token.span);
         if let ast::Const::Yes(span) = constness {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -474,8 +474,13 @@ impl<'a> Parser<'a> {
         params: Vec<GenericParam>,
         recover_return_sign: RecoverReturnSign,
     ) -> PResult<'a, TyKind> {
+        let inherited_vis = rustc_ast::Visibility {
+            span: rustc_span::DUMMY_SP,
+            kind: rustc_ast::VisibilityKind::Inherited,
+            tokens: None,
+        };
         let ast::FnHeader { ext, unsafety, constness, asyncness } =
-            self.parse_fn_front_matter(None)?;
+            self.parse_fn_front_matter(&inherited_vis)?;
         let decl = self.parse_fn_decl(|_| false, AllowPlus::No, recover_return_sign)?;
         let whole_span = lo.to(self.prev_token.span);
         if let ast::Const::Yes(span) = constness {

--- a/src/test/ui/parser/duplicate-visibility.rs
+++ b/src/test/ui/parser/duplicate-visibility.rs
@@ -4,6 +4,6 @@ extern "C" { //~ NOTE while parsing this item list starting here
     pub pub fn foo();
     //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `unsafe`, or `use`, found keyword `pub`
     //~| NOTE expected one of 9 possible tokens
-    //~| HELP there is already a visibility, remove this one
+    //~| HELP there is already a visibility modifier, remove one
     //~| NOTE explicit visibility first seen here
 } //~ NOTE the item list ends here

--- a/src/test/ui/parser/duplicate-visibility.rs
+++ b/src/test/ui/parser/duplicate-visibility.rs
@@ -1,6 +1,9 @@
 fn main() {}
 
-extern "C" {
+extern "C" { //~ NOTE while parsing this item list starting here
     pub pub fn foo();
     //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `unsafe`, or `use`, found keyword `pub`
-}
+    //~| NOTE expected one of 9 possible tokens
+    //~| HELP there is already a visibility, remove this one
+    //~| NOTE explicit visibility first seen here
+} //~ NOTE the item list ends here

--- a/src/test/ui/parser/duplicate-visibility.stderr
+++ b/src/test/ui/parser/duplicate-visibility.stderr
@@ -7,10 +7,16 @@ LL |     pub pub fn foo();
    |         ^^^
    |         |
    |         expected one of 9 possible tokens
-   |         help: visibility `pub` must come before `pub pub`: `pub pub pub`
-LL |
+   |         help: there is already a visibility, remove this one
+...
 LL | }
    | - the item list ends here
+   |
+note: explicit visibility first seen here
+  --> $DIR/duplicate-visibility.rs:4:5
+   |
+LL |     pub pub fn foo();
+   |     ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/duplicate-visibility.stderr
+++ b/src/test/ui/parser/duplicate-visibility.stderr
@@ -7,7 +7,7 @@ LL |     pub pub fn foo();
    |         ^^^
    |         |
    |         expected one of 9 possible tokens
-   |         help: there is already a visibility, remove this one
+   |         help: there is already a visibility modifier, remove one
 ...
 LL | }
    | - the item list ends here

--- a/src/test/ui/parser/issue-87694-duplicated-pub.rs
+++ b/src/test/ui/parser/issue-87694-duplicated-pub.rs
@@ -1,5 +1,5 @@
 pub const pub fn test() {}
 //~^ ERROR expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
 //~| NOTE expected one of `async`, `extern`, `fn`, or `unsafe`
-//~| HELP there is already a visibility, remove this one
+//~| HELP there is already a visibility modifier, remove one
 //~| NOTE explicit visibility first seen here

--- a/src/test/ui/parser/issue-87694-duplicated-pub.rs
+++ b/src/test/ui/parser/issue-87694-duplicated-pub.rs
@@ -1,0 +1,5 @@
+pub const pub fn test() {}
+//~^ ERROR expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
+//~| NOTE expected one of `async`, `extern`, `fn`, or `unsafe`
+//~| HELP there is already a visibility, remove this one
+//~| NOTE explicit visibility first seen here

--- a/src/test/ui/parser/issue-87694-duplicated-pub.stderr
+++ b/src/test/ui/parser/issue-87694-duplicated-pub.stderr
@@ -1,0 +1,17 @@
+error: expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
+  --> $DIR/issue-87694-duplicated-pub.rs:1:11
+   |
+LL | pub const pub fn test() {}
+   |           ^^^
+   |           |
+   |           expected one of `async`, `extern`, `fn`, or `unsafe`
+   |           help: there is already a visibility, remove this one
+   |
+note: explicit visibility first seen here
+  --> $DIR/issue-87694-duplicated-pub.rs:1:1
+   |
+LL | pub const pub fn test() {}
+   | ^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/issue-87694-duplicated-pub.stderr
+++ b/src/test/ui/parser/issue-87694-duplicated-pub.stderr
@@ -5,7 +5,7 @@ LL | pub const pub fn test() {}
    |           ^^^
    |           |
    |           expected one of `async`, `extern`, `fn`, or `unsafe`
-   |           help: there is already a visibility, remove this one
+   |           help: there is already a visibility modifier, remove one
    |
 note: explicit visibility first seen here
   --> $DIR/issue-87694-duplicated-pub.rs:1:1

--- a/src/test/ui/parser/issue-87694-misplaced-pub.rs
+++ b/src/test/ui/parser/issue-87694-misplaced-pub.rs
@@ -1,0 +1,5 @@
+const pub fn test() {}
+//~^ ERROR expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
+//~| NOTE expected one of `async`, `extern`, `fn`, or `unsafe`
+//~| HELP visibility `pub` must come before `const`
+//~| SUGGESTION pub const

--- a/src/test/ui/parser/issue-87694-misplaced-pub.stderr
+++ b/src/test/ui/parser/issue-87694-misplaced-pub.stderr
@@ -2,8 +2,9 @@ error: expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
   --> $DIR/issue-87694-misplaced-pub.rs:1:7
    |
 LL | const pub fn test() {}
-   | ----- ^^^ expected one of `async`, `extern`, `fn`, or `unsafe`
-   | |
+   | ------^^^
+   | |     |
+   | |     expected one of `async`, `extern`, `fn`, or `unsafe`
    | help: visibility `pub` must come before `const`: `pub const`
 
 error: aborting due to previous error

--- a/src/test/ui/parser/issue-87694-misplaced-pub.stderr
+++ b/src/test/ui/parser/issue-87694-misplaced-pub.stderr
@@ -1,0 +1,10 @@
+error: expected one of `async`, `extern`, `fn`, or `unsafe`, found keyword `pub`
+  --> $DIR/issue-87694-misplaced-pub.rs:1:7
+   |
+LL | const pub fn test() {}
+   | ----- ^^^ expected one of `async`, `extern`, `fn`, or `unsafe`
+   | |
+   | help: visibility `pub` must come before `const`: `pub const`
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/const-async-const.rs
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/const-async-const.rs
@@ -1,11 +1,9 @@
 // edition:2018
 
-// Test that even when `const` is already present, the proposed fix is `const const async`,
-// like for `pub pub`.
+// Test that even when `const` is already present, the proposed fix is to remove the second `const`
 
 const async const fn test() {}
 //~^ ERROR expected one of `extern`, `fn`, or `unsafe`, found keyword `const`
 //~| NOTE expected one of `extern`, `fn`, or `unsafe`
-//~| HELP `const` must come before `async`
-//~| SUGGESTION const async
-//~| NOTE keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+//~| HELP `const` already used earlier, remove this one
+//~| NOTE `const` first seen here

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/const-async-const.stderr
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/const-async-const.stderr
@@ -1,13 +1,17 @@
 error: expected one of `extern`, `fn`, or `unsafe`, found keyword `const`
-  --> $DIR/const-async-const.rs:6:13
+  --> $DIR/const-async-const.rs:5:13
    |
 LL | const async const fn test() {}
-   |       ------^^^^^
-   |       |     |
-   |       |     expected one of `extern`, `fn`, or `unsafe`
-   |       help: `const` must come before `async`: `const async`
+   |             ^^^^^
+   |             |
+   |             expected one of `extern`, `fn`, or `unsafe`
+   |             help: `const` already used earlier, remove this one
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+note: `const` first seen here
+  --> $DIR/const-async-const.rs:5:1
+   |
+LL | const async const fn test() {}
+   | ^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #87694.

Marked as draft to start with because I want to explore doing the same fix for `const const fn` and other repeated-but-valid keywords.

@rustbot label A-diagnostics D-invalid-suggestion T-compiler