### PR TITLE
Reduce verbosity of tracing output of  RUSTC_LOG

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1287,9 +1287,6 @@ pub fn init_env_logger(env: &str) {
         .with_indent_lines(true)
         .with_ansi(color_logs)
         .with_targets(true)
-        .with_wraparound(10)
-        .with_verbose_exit(true)
-        .with_verbose_entry(true)
         .with_indent_amount(2);
     #[cfg(parallel_compiler)]
     let layer = layer.with_thread_ids(true).with_thread_names(true);


### PR DESCRIPTION
The current output is really hard to read, I find, for things like trait selection. I nearly always end up removing these calls locally.

r? @oli-obk since you originally authored this