### PR TITLE
Switch Instant to use CLOCK_BOOTTIME

### DIFF
--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -293,7 +293,7 @@ mod inner {
 
     impl Instant {
         pub fn now() -> Instant {
-            Instant { t: now(libc::CLOCK_MONOTONIC) }
+            Instant { t: now(libc::CLOCK_BOOTTIME) }
         }
 
         pub const fn zero() -> Instant {


### PR DESCRIPTION
For Linux-like platforms, use CLOCK_BOOTTIME which continues ticking
during suspend. Without this change, `Duration` between two `Instant`s
can bear little relation to reality if a suspend took place in between.

Fixes rust-lang#87906