### PR TITLE
Use smaller spans for some structured suggestions

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -298,6 +298,21 @@ impl Diagnostic {
         )
     }
 
+    /// Show a suggestion that has multiple parts to it, always as it's own subdiagnostic.
+    /// In other words, multiple changes need to be applied as part of this suggestion.
+    pub fn multipart_suggestion_verbose(
+        &mut self,
+        msg: &str,
+        suggestion: Vec<(Span, String)>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.multipart_suggestion_with_style(
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::ShowAlways,
+        )
+    }
     /// [`Diagnostic::multipart_suggestion()`] but you can set the [`SuggestionStyle`].
     pub fn multipart_suggestion_with_style(
         &mut self,

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -257,6 +257,20 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    /// See [`Diagnostic::multipart_suggestion()`].
+    pub fn multipart_suggestion_verbose(
+        &mut self,
+        msg: &str,
+        suggestion: Vec<(Span, String)>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        if !self.0.allow_suggestions {
+            return self;
+        }
+        self.0.diagnostic.multipart_suggestion_verbose(msg, suggestion, applicability);
+        self
+    }
+
     /// See [`Diagnostic::tool_only_multipart_suggestion()`].
     pub fn tool_only_multipart_suggestion(
         &mut self,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1618,50 +1618,57 @@ impl<'a> Parser<'a> {
         {
             let rfc_note = "anonymous parameters are removed in the 2018 edition (see RFC 1685)";
 
-            let (ident, self_sugg, param_sugg, type_sugg) = match pat.kind {
-                PatKind::Ident(_, ident, _) => (
-                    ident,
-                    format!("self: {}", ident),
-                    format!("{}: TypeName", ident),
-                    format!("_: {}", ident),
-                ),
-                // Also catches `fn foo(&a)`.
-                PatKind::Ref(ref pat, mutab)
-                    if matches!(pat.clone().into_inner().kind, PatKind::Ident(..)) =>
-                {
-                    match pat.clone().into_inner().kind {
-                        PatKind::Ident(_, ident, _) => {
-                            let mutab = mutab.prefix_str();
-                            (
-                                ident,
-                                format!("self: &{}{}", mutab, ident),
-                                format!("{}: &{}TypeName", ident, mutab),
-                                format!("_: &{}{}", mutab, ident),
-                            )
+            let (ident, self_sugg, param_sugg, type_sugg, self_span, param_span, type_span) =
+                match pat.kind {
+                    PatKind::Ident(_, ident, _) => (
+                        ident,
+                        "self: ".to_string(),
+                        ": TypeName".to_string(),
+                        "_: ".to_string(),
+                        pat.span.shrink_to_lo(),
+                        pat.span.shrink_to_hi(),
+                        pat.span.shrink_to_lo(),
+                    ),
+                    // Also catches `fn foo(&a)`.
+                    PatKind::Ref(ref inner_pat, mutab)
+                        if matches!(inner_pat.clone().into_inner().kind, PatKind::Ident(..)) =>
+                    {
+                        match inner_pat.clone().into_inner().kind {
+                            PatKind::Ident(_, ident, _) => {
+                                let mutab = mutab.prefix_str();
+                                (
+                                    ident,
+                                    "self: ".to_string(),
+                                    format!("{}: &{}TypeName", ident, mutab),
+                                    "_: ".to_string(),
+                                    pat.span.shrink_to_lo(),
+                                    pat.span,
+                                    pat.span.shrink_to_lo(),
+                                )
+                            }
+                            _ => unreachable!(),
                         }
-                        _ => unreachable!(),
                     }
-                }
-                _ => {
-                    // Otherwise, try to get a type and emit a suggestion.
-                    if let Some(ty) = pat.to_ty() {
-                        err.span_suggestion_verbose(
-                            pat.span,
-                            "explicitly ignore the parameter name",
-                            format!("_: {}", pprust::ty_to_string(&ty)),
-                            Applicability::MachineApplicable,
-                        );
-                        err.note(rfc_note);
-                    }
+                    _ => {
+                        // Otherwise, try to get a type and emit a suggestion.
+                        if let Some(ty) = pat.to_ty() {
+                            err.span_suggestion_verbose(
+                                pat.span,
+                                "explicitly ignore the parameter name",
+                                format!("_: {}", pprust::ty_to_string(&ty)),
+                                Applicability::MachineApplicable,
+                            );
+                            err.note(rfc_note);
+                        }
 
-                    return None;
-                }
-            };
+                        return None;
+                    }
+                };
 
             // `fn foo(a, b) {}`, `fn foo(a<x>, b<y>) {}` or `fn foo(usize, usize) {}`
             if first_param {
                 err.span_suggestion(
-                    pat.span,
+                    self_span,
                     "if this is a `self` type, give it a parameter name",
                     self_sugg,
                     Applicability::MaybeIncorrect,
@@ -1671,14 +1678,14 @@ impl<'a> Parser<'a> {
             // `fn foo(HashMap: TypeName<u32>)`.
             if self.token != token::Lt {
                 err.span_suggestion(
-                    pat.span,
+                    param_span,
                     "if this is a parameter name, give it a type",
                     param_sugg,
                     Applicability::HasPlaceholders,
                 );
             }
             err.span_suggestion(
-                pat.span,
+                type_span,
                 "if this is a type, explicitly ignore the parameter name",
                 type_sugg,
                 Applicability::MachineApplicable,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -12,7 +12,7 @@ use rustc_ast::{
 };
 use rustc_ast_pretty::pprust::path_segment_to_string;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder, SuggestionStyle};
+use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind};
@@ -1950,11 +1950,10 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                             introduce_suggestion.push((*span, formatter(&lt_name)));
                         }
                     }
-                    err.multipart_suggestion_with_style(
+                    err.multipart_suggestion_verbose(
                         &msg,
                         introduce_suggestion,
                         Applicability::MaybeIncorrect,
-                        SuggestionStyle::ShowAlways,
                     );
                 }
 
@@ -1966,14 +1965,13 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                     })
                     .map(|(formatter, span)| (*span, formatter(name)))
                     .collect();
-                err.multipart_suggestion_with_style(
+                err.multipart_suggestion_verbose(
                     &format!(
                         "consider using the `{}` lifetime",
                         lifetime_names.iter().next().unwrap()
                     ),
                     spans_suggs,
                     Applicability::MaybeIncorrect,
-                    SuggestionStyle::ShowAlways,
                 );
             };
         let suggest_new = |err: &mut DiagnosticBuilder<'_>, suggs: Vec<Option<String>>| {
@@ -2064,11 +2062,10 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                             };
                             spans_suggs.push((span, sugg.to_string()));
                         }
-                        err.multipart_suggestion_with_style(
+                        err.multipart_suggestion_verbose(
                             "consider using the `'static` lifetime",
                             spans_suggs,
                             Applicability::MaybeIncorrect,
-                            SuggestionStyle::ShowAlways,
                         );
                         continue;
                     }
@@ -2088,11 +2085,10 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                         introduce_suggestion.push((span, sugg.to_string()));
                     }
                 }
-                err.multipart_suggestion_with_style(
+                err.multipart_suggestion_verbose(
                     &msg,
                     introduce_suggestion,
                     Applicability::MaybeIncorrect,
-                    SuggestionStyle::ShowAlways,
                 );
                 if should_break {
                     break;
@@ -2167,11 +2163,10 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 if spans_suggs.len() > 0 {
                     // This happens when we have `Foo<T>` where we point at the space before `T`,
                     // but this can be confusing so we give a suggestion with placeholders.
-                    err.multipart_suggestion_with_style(
+                    err.multipart_suggestion_verbose(
                         "consider using one of the available lifetimes here",
                         spans_suggs,
                         Applicability::HasPlaceholders,
-                        SuggestionStyle::ShowAlways,
                     );
                 }
             }

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1648,14 +1648,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             constraint=constraint,
                         ));
                     } else {
-                        err.span_suggestion(
-                            span,
+                        err.span_suggestion_verbose(
+                            span.with_hi(assoc_name.span.lo()),
                             "use fully qualified syntax to disambiguate",
                             format!(
-                                "<{} as {}>::{}",
+                                "<{} as {}>::",
                                 ty_param_name(),
                                 bound.print_only_trait_path(),
-                                assoc_name,
                             ),
                             Applicability::MaybeIncorrect,
                         );

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -17,7 +17,6 @@ use rustc_span::{BytePos, Span};
 
 use super::method::probe;
 
-use std::fmt;
 use std::iter;
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
@@ -771,9 +770,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // For now, don't suggest casting with `as`.
         let can_cast = false;
 
-        let prefix = if let Some(hir::Node::Expr(hir::Expr {
-            kind: hir::ExprKind::Struct(_, fields, _),
-            ..
+        let mut sugg = vec![];
+
+        if let Some(hir::Node::Expr(hir::Expr {
+            kind: hir::ExprKind::Struct(_, fields, _), ..
         })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.hir_id))
         {
             // `expr` is a literal field for a struct, only suggest if appropriate
@@ -782,12 +782,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .find(|field| field.expr.hir_id == expr.hir_id && field.is_shorthand)
             {
                 // This is a field literal
-                Some(field) => format!("{}: ", field.ident),
+                Some(field) => {
+                    sugg.push((field.ident.span.shrink_to_lo(), format!("{}: ", field.ident)));
+                }
                 // Likely a field was meant, but this field wasn't found. Do not suggest anything.
                 None => return false,
             }
-        } else {
-            String::new()
         };
 
         if let hir::ExprKind::Call(path, args) = &expr.kind {
@@ -842,28 +842,38 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             checked_ty, expected_ty,
         );
 
-        let with_opt_paren: fn(&dyn fmt::Display) -> String =
-            if expr.precedence().order() < PREC_POSTFIX {
-                |s| format!("({})", s)
-            } else {
-                |s| s.to_string()
-            };
+        let close_paren = if expr.precedence().order() < PREC_POSTFIX {
+            sugg.push((expr.span.shrink_to_lo(), "(".to_string()));
+            ")"
+        } else {
+            ""
+        };
 
-        let cast_suggestion = format!("{}{} as {}", prefix, with_opt_paren(&src), expected_ty);
-        let into_suggestion = format!("{}{}.into()", prefix, with_opt_paren(&src));
-        let suffix_suggestion = with_opt_paren(&format_args!(
-            "{}{}",
+        let mut cast_suggestion = sugg.clone();
+        cast_suggestion
+            .push((expr.span.shrink_to_hi(), format!("{} as {}", close_paren, expected_ty)));
+        let mut into_suggestion = sugg.clone();
+        into_suggestion.push((expr.span.shrink_to_hi(), format!("{}.into()", close_paren)));
+        let mut suffix_suggestion = sugg.clone();
+        suffix_suggestion.push((
             if matches!(
                 (&expected_ty.kind(), &checked_ty.kind()),
                 (ty::Int(_) | ty::Uint(_), ty::Float(_))
             ) {
                 // Remove fractional part from literal, for example `42.0f32` into `42`
                 let src = src.trim_end_matches(&checked_ty.to_string());
-                src.split('.').next().unwrap()
+                let len = src.split('.').next().unwrap().len();
+                expr.span.with_lo(expr.span.lo() + BytePos(len as u32))
             } else {
-                src.trim_end_matches(&checked_ty.to_string())
+                let len = src.trim_end_matches(&checked_ty.to_string()).len();
+                expr.span.with_lo(expr.span.lo() + BytePos(len as u32))
             },
-            expected_ty,
+            if expr.precedence().order() < PREC_POSTFIX {
+                // Readd `)`
+                format!("{})", expected_ty)
+            } else {
+                expected_ty.to_string()
+            },
         ));
         let literal_is_ty_suffixed = |expr: &hir::Expr<'_>| {
             if let hir::ExprKind::Lit(lit) = &expr.kind { lit.node.is_suffixed() } else { false }
@@ -890,22 +900,32 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .ok()
                         .map(|src| (expr, src))
                 });
-                let (span, msg, suggestion) = if let (Some((lhs_expr, lhs_src)), false) =
+                let (msg, suggestion) = if let (Some((lhs_expr, lhs_src)), false) =
                     (lhs_expr_and_src, exp_to_found_is_fallible)
                 {
                     let msg = format!(
                         "you can convert `{}` from `{}` to `{}`, matching the type of `{}`",
                         lhs_src, expected_ty, checked_ty, src
                     );
-                    let suggestion = format!("{}::from({})", checked_ty, lhs_src);
-                    (lhs_expr.span, msg, suggestion)
+                    let suggestion = vec![
+                        (lhs_expr.span.shrink_to_lo(), format!("{}::from(", checked_ty)),
+                        (lhs_expr.span.shrink_to_hi(), ")".to_string()),
+                    ];
+                    (msg, suggestion)
                 } else {
                     let msg = format!("{} and panic if the converted value doesn't fit", msg);
-                    let suggestion =
-                        format!("{}{}.try_into().unwrap()", prefix, with_opt_paren(&src));
-                    (expr.span, msg, suggestion)
+                    let mut suggestion = sugg.clone();
+                    suggestion.push((
+                        expr.span.shrink_to_hi(),
+                        format!("{}.try_into().unwrap()", close_paren),
+                    ));
+                    (msg, suggestion)
                 };
-                err.span_suggestion(span, &msg, suggestion, Applicability::MachineApplicable);
+                err.multipart_suggestion_verbose(
+                    &msg,
+                    suggestion,
+                    Applicability::MachineApplicable,
+                );
             };
 
         let suggest_to_change_suffix_or_into =
@@ -943,7 +963,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     into_suggestion.clone()
                 };
-                err.span_suggestion(expr.span, msg, suggestion, Applicability::MachineApplicable);
+                err.multipart_suggestion_verbose(msg, suggestion, Applicability::MachineApplicable);
             };
 
         match (&expected_ty.kind(), &checked_ty.kind()) {
@@ -997,16 +1017,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if found.bit_width() < exp.bit_width() {
                     suggest_to_change_suffix_or_into(err, false, true);
                 } else if literal_is_ty_suffixed(expr) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else if can_cast {
                     // Missing try_into implementation for `f64` to `f32`
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!("{}, producing the closest possible value", cast_msg),
                         cast_suggestion,
                         Applicability::MaybeIncorrect, // lossy conversion
@@ -1016,16 +1034,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             (&ty::Uint(_) | &ty::Int(_), &ty::Float(_)) => {
                 if literal_is_ty_suffixed(expr) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else if can_cast {
                     // Missing try_into implementation for `{float}` to `{integer}`
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!("{}, rounding the float towards zero", msg),
                         cast_suggestion,
                         Applicability::MaybeIncorrect, // lossy conversion
@@ -1036,8 +1052,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (&ty::Float(ref exp), &ty::Uint(ref found)) => {
                 // if `found` is `None` (meaning found is `usize`), don't suggest `.into()`
                 if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!(
                             "{}, producing the floating point representation of the integer",
                             msg,
@@ -1046,16 +1061,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Applicability::MachineApplicable,
                     );
                 } else if literal_is_ty_suffixed(expr) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else {
                     // Missing try_into implementation for `{integer}` to `{float}`
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!(
                             "{}, producing the floating point representation of the integer,
                                  rounded if necessary",
@@ -1070,8 +1083,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (&ty::Float(ref exp), &ty::Int(ref found)) => {
                 // if `found` is `None` (meaning found is `isize`), don't suggest `.into()`
                 if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!(
                             "{}, producing the floating point representation of the integer",
                             &msg,
@@ -1080,16 +1092,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Applicability::MachineApplicable,
                     );
                 } else if literal_is_ty_suffixed(expr) {
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else {
                     // Missing try_into implementation for `{integer}` to `{float}`
-                    err.span_suggestion(
-                        expr.span,
+                    err.multipart_suggestion_verbose(
                         &format!(
                             "{}, producing the floating point representation of the integer, \
                                 rounded if necessary",

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -452,9 +452,9 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
                             let suggestions = vec![
                                 (lt_sp, sugg),
                                 (
-                                    span,
+                                    span.with_hi(item_segment.ident.span.lo()),
                                     format!(
-                                        "{}::{}",
+                                        "{}::",
                                         // Replace the existing lifetimes with a new named lifetime.
                                         self.tcx
                                             .replace_late_bound_regions(poly_trait_ref, |_| {
@@ -467,7 +467,6 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
                                                 ))
                                             })
                                             .0,
-                                        item_segment.ident
                                     ),
                                 ),
                             ];
@@ -489,14 +488,13 @@ impl AstConv<'tcx> for ItemCtxt<'tcx> {
                 | hir::Node::ForeignItem(_)
                 | hir::Node::TraitItem(_)
                 | hir::Node::ImplItem(_) => {
-                    err.span_suggestion(
-                        span,
+                    err.span_suggestion_verbose(
+                        span.with_hi(item_segment.ident.span.lo()),
                         "use a fully qualified path with inferred lifetimes",
                         format!(
-                            "{}::{}",
+                            "{}::",
                             // Erase named lt, we want `<A as B<'_>::C`, not `<A as B<'a>::C`.
                             self.tcx.anonymize_late_bound_regions(poly_trait_ref).skip_binder(),
-                            item_segment.ident
                         ),
                         Applicability::MaybeIncorrect,
                     );

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -101,9 +101,9 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
                     );
                 } else if empty_block {
                     diag.span_suggestion(
-                        sp.from_inner(InnerSpan::new(0, 3)),
+                        sp.from_inner(InnerSpan::new(0, 3)).shrink_to_hi(),
                         explanation,
-                        String::from("```text"),
+                        String::from("text"),
                         Applicability::MachineApplicable,
                     );
                 }

--- a/src/test/rustdoc-ui/invalid-syntax.stderr
+++ b/src/test/rustdoc-ui/invalid-syntax.stderr
@@ -14,7 +14,7 @@ LL | | /// ```
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
-   |     ~~~~~~~
+   |        ++++
 
 warning: could not parse code block as Rust code
   --> $DIR/invalid-syntax.rs:9:5
@@ -32,7 +32,7 @@ LL | | /// ```
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
-   |     ~~~~~~~
+   |        ++++
 
 warning: could not parse code block as Rust code
   --> $DIR/invalid-syntax.rs:21:5
@@ -47,7 +47,7 @@ LL | | /// ```
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
-   |     ~~~~~~~
+   |        ++++
 
 warning: could not parse code block as Rust code
   --> $DIR/invalid-syntax.rs:35:5
@@ -123,7 +123,7 @@ LL | | /// ```
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
-   |     ~~~~~~~
+   |        ++++
 
 warning: could not parse code block as Rust code
   --> $DIR/invalid-syntax.rs:92:9
@@ -148,7 +148,7 @@ LL | | /// ```
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
-   |     ~~~~~~~
+   |        ++++
 
 warning: 12 warnings emitted
 

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -8,15 +8,15 @@ LL |     fn foo(i32);
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn foo(self: i32);
-   |            ~~~~~~~~~
+   |            +++++
 help: if this is a parameter name, give it a type
    |
 LL |     fn foo(i32: TypeName);
-   |            ~~~~~~~~~~~~~
+   |               ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn foo(_: i32);
-   |            ~~~~~~
+   |            ++
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/anon-params-denied-2018.rs:9:29
@@ -28,7 +28,7 @@ LL |     fn foo_with_ref(&mut i32);
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn foo_with_ref(self: &mut i32);
-   |                     ~~~~~~~~~~~~~~
+   |                     +++++
 help: if this is a parameter name, give it a type
    |
 LL |     fn foo_with_ref(i32: &mut TypeName);
@@ -36,7 +36,7 @@ LL |     fn foo_with_ref(i32: &mut TypeName);
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn foo_with_ref(_: &mut i32);
-   |                     ~~~~~~~~~~~
+   |                     ++
 
 error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
   --> $DIR/anon-params-denied-2018.rs:12:47
@@ -96,15 +96,15 @@ LL |     fn bar_with_default_impl(String, String) {}
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn bar_with_default_impl(self: String, String) {}
-   |                              ~~~~~~~~~~~~
+   |                              +++++
 help: if this is a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String: TypeName, String) {}
-   |                              ~~~~~~~~~~~~~~~~
+   |                                    ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn bar_with_default_impl(_: String, String) {}
-   |                              ~~~~~~~~~
+   |                              ++
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/anon-params-denied-2018.rs:22:44
@@ -116,11 +116,11 @@ LL |     fn bar_with_default_impl(String, String) {}
 help: if this is a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String, String: TypeName) {}
-   |                                      ~~~~~~~~~~~~~~~~
+   |                                            ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn bar_with_default_impl(String, _: String) {}
-   |                                      ~~~~~~~~~
+   |                                      ++
 
 error: expected one of `:`, `@`, or `|`, found `,`
   --> $DIR/anon-params-denied-2018.rs:27:22
@@ -132,11 +132,11 @@ LL |     fn baz(a:usize, b, c: usize) -> usize {
 help: if this is a parameter name, give it a type
    |
 LL |     fn baz(a:usize, b: TypeName, c: usize) -> usize {
-   |                     ~~~~~~~~~~~
+   |                      ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn baz(a:usize, _: b, c: usize) -> usize {
-   |                     ~~~~
+   |                     ++
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
+++ b/src/test/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
@@ -13,11 +13,11 @@ LL | fn a<C:Vehicle+Box>(_: C::Color) {
 help: use fully qualified syntax to disambiguate
    |
 LL | fn a<C:Vehicle+Box>(_: <C as Box>::Color) {
-   |                        ~~~~~~~~~~~~~~~~~
+   |                        ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | fn a<C:Vehicle+Box>(_: <C as Vehicle>::Color) {
-   |                        ~~~~~~~~~~~~~~~~~~~~~
+   |                        ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:20:12
@@ -34,11 +34,11 @@ LL | fn b<C>(_: C::Color) where C : Vehicle+Box {
 help: use fully qualified syntax to disambiguate
    |
 LL | fn b<C>(_: <C as Box>::Color) where C : Vehicle+Box {
-   |            ~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | fn b<C>(_: <C as Vehicle>::Color) where C : Vehicle+Box {
-   |            ~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `C`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:24:12
@@ -55,11 +55,11 @@ LL | fn c<C>(_: C::Color) where C : Vehicle, C : Box {
 help: use fully qualified syntax to disambiguate
    |
 LL | fn c<C>(_: <C as Box>::Color) where C : Vehicle, C : Box {
-   |            ~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | fn c<C>(_: <C as Vehicle>::Color) where C : Vehicle, C : Box {
-   |            ~~~~~~~~~~~~~~~~~~~~~
+   |            ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:35:20
@@ -76,11 +76,11 @@ LL |     fn e(&self, _: X::Color) where X : Box;
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn e(&self, _: <X as Box>::Color) where X : Box;
-   |                    ~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn e(&self, _: <X as Vehicle>::Color) where X : Box;
-   |                    ~~~~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:38:20
@@ -97,11 +97,11 @@ LL |     fn f(&self, _: X::Color) where X : Box { }
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn f(&self, _: <X as Box>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn f(&self, _: <X as Vehicle>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
@@ -118,11 +118,11 @@ LL |     fn d(&self, _: X::Color) where X : Box { }
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~~~~~~
+   |                    ~~~~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -21,11 +21,11 @@ LL | fn dent<C:BoxCar>(c: C, color: C::Color) {
 help: use fully qualified syntax to disambiguate
    |
 LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
-   |                                ~~~~~~~~~~~~~~~~~~~~~
+   |                                ~~~~~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
-   |                                ~~~~~~~~~~~~~~~~~
+   |                                ~~~~~~~~~~~~
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
@@ -74,11 +74,11 @@ LL | fn paint<C:BoxCar>(c: C, d: C::Color) {
 help: use fully qualified syntax to disambiguate
    |
 LL | fn paint<C:BoxCar>(c: C, d: <C as Vehicle>::Color) {
-   |                             ~~~~~~~~~~~~~~~~~~~~~
+   |                             ~~~~~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
-   |                             ~~~~~~~~~~~~~~~~~
+   |                             ~~~~~~~~~~~~
 
 error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32

--- a/src/test/ui/associated-types/associated-types-path-1.stderr
+++ b/src/test/ui/associated-types/associated-types-path-1.stderr
@@ -19,11 +19,11 @@ LL | pub fn f2<T: Foo + Bar>(a: T, x: T::A) {}
 help: use fully qualified syntax to disambiguate
    |
 LL | pub fn f2<T: Foo + Bar>(a: T, x: <T as Bar>::A) {}
-   |                                  ~~~~~~~~~~~~~
+   |                                  ~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL | pub fn f2<T: Foo + Bar>(a: T, x: <T as Foo>::A) {}
-   |                                  ~~~~~~~~~~~~~
+   |                                  ~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -7,7 +7,7 @@ LL |     f1(2i32, 4i32);
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     f1(2i32, 4u32);
-   |              ~~~~
+   |               ~~~
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
@@ -50,7 +50,7 @@ LL |     let _: i32 = f2(2i32);
 help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ++++++++++++++++++++
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn.stderr
+++ b/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn.stderr
@@ -2,7 +2,12 @@ error[E0212]: cannot use the associated type of a trait with uninferred generic 
   --> $DIR/associated-types-project-from-hrtb-in-fn.rs:13:8
    |
 LL |     x: I::A)
-   |        ^^^^ help: use a fully qualified path with inferred lifetimes: `<I as Foo<&isize>>::A`
+   |        ^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     x: <I as Foo<&isize>>::A)
+   |        ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
+++ b/src/test/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
@@ -2,13 +2,23 @@ error[E0212]: cannot use the associated type of a trait with uninferred generic 
   --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:13:32
    |
 LL |     fn some_method(&self, arg: I::A);
-   |                                ^^^^ help: use a fully qualified path with inferred lifetimes: `<I as Foo<&isize>>::A`
+   |                                ^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     fn some_method(&self, arg: <I as Foo<&isize>>::A);
+   |                                ~~~~~~~~~~~~~~~~~~~~
 
 error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
   --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:32:24
    |
 LL |     fn mango(&self) -> X::Assoc {
-   |                        ^^^^^^^^ help: use a fully qualified path with inferred lifetimes: `<X as Banana<'_>>::Assoc`
+   |                        ^^^^^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     fn mango(&self) -> <X as Banana<'_>>::Assoc {
+   |                        ~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/type-dependent/type-mismatch.full.stderr
+++ b/src/test/ui/const-generics/type-dependent/type-mismatch.full.stderr
@@ -7,7 +7,7 @@ LL |     assert_eq!(R.method::<1u16>(), 1);
 help: change the type of the numeric literal from `u16` to `u8`
    |
 LL |     assert_eq!(R.method::<1u8>(), 1);
-   |                           ~~~
+   |                            ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/type-dependent/type-mismatch.min.stderr
+++ b/src/test/ui/const-generics/type-dependent/type-mismatch.min.stderr
@@ -7,7 +7,7 @@ LL |     assert_eq!(R.method::<1u16>(), 1);
 help: change the type of the numeric literal from `u16` to `u8`
    |
 LL |     assert_eq!(R.method::<1u8>(), 1);
-   |                           ~~~
+   |                            ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/discrim/discrim-ill-typed.stderr
+++ b/src/test/ui/discrim/discrim-ill-typed.stderr
@@ -7,7 +7,7 @@ LL |         OhNo = 0_u8,
 help: change the type of the numeric literal from `u8` to `i8`
    |
 LL |         OhNo = 0_i8,
-   |                ~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:28:16
@@ -18,7 +18,7 @@ LL |         OhNo = 0_i8,
 help: change the type of the numeric literal from `i8` to `u8`
    |
 LL |         OhNo = 0_u8,
-   |                ~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:41:16
@@ -29,7 +29,7 @@ LL |         OhNo = 0_u16,
 help: change the type of the numeric literal from `u16` to `i16`
    |
 LL |         OhNo = 0_i16,
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:54:16
@@ -40,7 +40,7 @@ LL |         OhNo = 0_i16,
 help: change the type of the numeric literal from `i16` to `u16`
    |
 LL |         OhNo = 0_u16,
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:67:16
@@ -51,7 +51,7 @@ LL |         OhNo = 0_u32,
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |         OhNo = 0_i32,
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:80:16
@@ -62,7 +62,7 @@ LL |         OhNo = 0_i32,
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |         OhNo = 0_u32,
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:93:16
@@ -73,7 +73,7 @@ LL |         OhNo = 0_u64,
 help: change the type of the numeric literal from `u64` to `i64`
    |
 LL |         OhNo = 0_i64,
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/discrim-ill-typed.rs:106:16
@@ -84,7 +84,7 @@ LL |         OhNo = 0_i64,
 help: change the type of the numeric literal from `i64` to `u64`
    |
 LL |         OhNo = 0_u64,
-   |                ~~~~~
+   |                  ~~~
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/error-codes/E0221.stderr
+++ b/src/test/ui/error-codes/E0221.stderr
@@ -13,11 +13,11 @@ LL |         let _: Self::A;
 help: use fully qualified syntax to disambiguate
    |
 LL |         let _: <Self as Foo>::A;
-   |                ~~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~~~
 help: use fully qualified syntax to disambiguate
    |
 LL |         let _: <Self as Bar>::A;
-   |                ~~~~~~~~~~~~~~~~
+   |                ~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Err` in bounds of `Self`
   --> $DIR/E0221.rs:21:16
@@ -26,12 +26,13 @@ LL |     type Err: T3;
    |     ------------- ambiguous `Err` from `My`
 LL |     fn test() {
 LL |         let _: Self::Err;
-   |                ^^^^^^^^^
-   |                |
-   |                ambiguous associated type `Err`
-   |                help: use fully qualified syntax to disambiguate: `<Self as My>::Err`
+   |                ^^^^^^^^^ ambiguous associated type `Err`
    |
    = note: associated type `Self` could derive from `FromStr`
+help: use fully qualified syntax to disambiguate
+   |
+LL |         let _: <Self as My>::Err;
+   |                ~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/float-literal-inference-restrictions.stderr
+++ b/src/test/ui/float-literal-inference-restrictions.stderr
@@ -19,7 +19,7 @@ LL |     let y: f32 = 1f64;
 help: change the type of the numeric literal from `f64` to `f32`
    |
 LL |     let y: f32 = 1f32;
-   |                  ~~~~
+   |                   ~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -16,7 +16,7 @@ LL |     bar::<isize>(i);  // i should not be re-coerced back to an isize
 help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     bar::<isize>(i.try_into().unwrap());  // i should not be re-coerced back to an isize
-   |                  ~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/integer-literal-suffix-inference.stderr
+++ b/src/test/ui/integer-literal-suffix-inference.stderr
@@ -7,7 +7,7 @@ LL |     id_i8(a16);
 help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a16.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:41:11
@@ -18,7 +18,7 @@ LL |     id_i8(a32);
 help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a32.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:44:11
@@ -29,7 +29,7 @@ LL |     id_i8(a64);
 help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(a64.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:47:11
@@ -40,16 +40,18 @@ LL |     id_i8(asize);
 help: you can convert an `isize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(asize.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:51:12
    |
 LL |     id_i16(a8);
-   |            ^^
-   |            |
-   |            expected `i16`, found `i8`
-   |            help: you can convert an `i8` to an `i16`: `a8.into()`
+   |            ^^ expected `i16`, found `i8`
+   |
+help: you can convert an `i8` to an `i16`
+   |
+LL |     id_i16(a8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:55:12
@@ -60,7 +62,7 @@ LL |     id_i16(a32);
 help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(a32.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:58:12
@@ -71,7 +73,7 @@ LL |     id_i16(a64);
 help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(a64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:61:12
@@ -82,25 +84,29 @@ LL |     id_i16(asize);
 help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(asize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:65:12
    |
 LL |     id_i32(a8);
-   |            ^^
-   |            |
-   |            expected `i32`, found `i8`
-   |            help: you can convert an `i8` to an `i32`: `a8.into()`
+   |            ^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |     id_i32(a8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:68:12
    |
 LL |     id_i32(a16);
-   |            ^^^
-   |            |
-   |            expected `i32`, found `i16`
-   |            help: you can convert an `i16` to an `i32`: `a16.into()`
+   |            ^^^ expected `i32`, found `i16`
+   |
+help: you can convert an `i16` to an `i32`
+   |
+LL |     id_i32(a16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:72:12
@@ -111,7 +117,7 @@ LL |     id_i32(a64);
 help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(a64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:75:12
@@ -122,34 +128,40 @@ LL |     id_i32(asize);
 help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(asize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:79:12
    |
 LL |     id_i64(a8);
-   |            ^^
-   |            |
-   |            expected `i64`, found `i8`
-   |            help: you can convert an `i8` to an `i64`: `a8.into()`
+   |            ^^ expected `i64`, found `i8`
+   |
+help: you can convert an `i8` to an `i64`
+   |
+LL |     id_i64(a8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:82:12
    |
 LL |     id_i64(a16);
-   |            ^^^
-   |            |
-   |            expected `i64`, found `i16`
-   |            help: you can convert an `i16` to an `i64`: `a16.into()`
+   |            ^^^ expected `i64`, found `i16`
+   |
+help: you can convert an `i16` to an `i64`
+   |
+LL |     id_i64(a16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:85:12
    |
 LL |     id_i64(a32);
-   |            ^^^
-   |            |
-   |            expected `i64`, found `i32`
-   |            help: you can convert an `i32` to an `i64`: `a32.into()`
+   |            ^^^ expected `i64`, found `i32`
+   |
+help: you can convert an `i32` to an `i64`
+   |
+LL |     id_i64(a32.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:89:12
@@ -160,25 +172,29 @@ LL |     id_i64(asize);
 help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     id_i64(asize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:93:14
    |
 LL |     id_isize(a8);
-   |              ^^
-   |              |
-   |              expected `isize`, found `i8`
-   |              help: you can convert an `i8` to an `isize`: `a8.into()`
+   |              ^^ expected `isize`, found `i8`
+   |
+help: you can convert an `i8` to an `isize`
+   |
+LL |     id_isize(a8.into());
+   |                +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:96:14
    |
 LL |     id_isize(a16);
-   |              ^^^
-   |              |
-   |              expected `isize`, found `i16`
-   |              help: you can convert an `i16` to an `isize`: `a16.into()`
+   |              ^^^ expected `isize`, found `i16`
+   |
+help: you can convert an `i16` to an `isize`
+   |
+LL |     id_isize(a16.into());
+   |                 +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:99:14
@@ -189,7 +205,7 @@ LL |     id_isize(a32);
 help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     id_isize(a32.try_into().unwrap());
-   |              ~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:102:14
@@ -200,7 +216,7 @@ LL |     id_isize(a64);
 help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     id_isize(a64.try_into().unwrap());
-   |              ~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:108:11
@@ -211,7 +227,7 @@ LL |     id_i8(c16);
 help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c16.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:111:11
@@ -222,7 +238,7 @@ LL |     id_i8(c32);
 help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c32.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:114:11
@@ -233,16 +249,18 @@ LL |     id_i8(c64);
 help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     id_i8(c64.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:118:12
    |
 LL |     id_i16(c8);
-   |            ^^
-   |            |
-   |            expected `i16`, found `i8`
-   |            help: you can convert an `i8` to an `i16`: `c8.into()`
+   |            ^^ expected `i16`, found `i8`
+   |
+help: you can convert an `i8` to an `i16`
+   |
+LL |     id_i16(c8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:122:12
@@ -253,7 +271,7 @@ LL |     id_i16(c32);
 help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(c32.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:125:12
@@ -264,25 +282,29 @@ LL |     id_i16(c64);
 help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     id_i16(c64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:129:12
    |
 LL |     id_i32(c8);
-   |            ^^
-   |            |
-   |            expected `i32`, found `i8`
-   |            help: you can convert an `i8` to an `i32`: `c8.into()`
+   |            ^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |     id_i32(c8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:132:12
    |
 LL |     id_i32(c16);
-   |            ^^^
-   |            |
-   |            expected `i32`, found `i16`
-   |            help: you can convert an `i16` to an `i32`: `c16.into()`
+   |            ^^^ expected `i32`, found `i16`
+   |
+help: you can convert an `i16` to an `i32`
+   |
+LL |     id_i32(c16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:136:12
@@ -293,34 +315,40 @@ LL |     id_i32(c64);
 help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     id_i32(c64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:140:12
    |
 LL |     id_i64(a8);
-   |            ^^
-   |            |
-   |            expected `i64`, found `i8`
-   |            help: you can convert an `i8` to an `i64`: `a8.into()`
+   |            ^^ expected `i64`, found `i8`
+   |
+help: you can convert an `i8` to an `i64`
+   |
+LL |     id_i64(a8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:143:12
    |
 LL |     id_i64(a16);
-   |            ^^^
-   |            |
-   |            expected `i64`, found `i16`
-   |            help: you can convert an `i16` to an `i64`: `a16.into()`
+   |            ^^^ expected `i64`, found `i16`
+   |
+help: you can convert an `i16` to an `i64`
+   |
+LL |     id_i64(a16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:146:12
    |
 LL |     id_i64(a32);
-   |            ^^^
-   |            |
-   |            expected `i64`, found `i32`
-   |            help: you can convert an `i32` to an `i64`: `a32.into()`
+   |            ^^^ expected `i64`, found `i32`
+   |
+help: you can convert an `i32` to an `i64`
+   |
+LL |     id_i64(a32.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:152:11
@@ -331,7 +359,7 @@ LL |     id_u8(b16);
 help: you can convert a `u16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b16.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:155:11
@@ -342,7 +370,7 @@ LL |     id_u8(b32);
 help: you can convert a `u32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b32.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:158:11
@@ -353,7 +381,7 @@ LL |     id_u8(b64);
 help: you can convert a `u64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(b64.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~
+   |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:161:11
@@ -364,16 +392,18 @@ LL |     id_u8(bsize);
 help: you can convert a `usize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     id_u8(bsize.try_into().unwrap());
-   |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:165:12
    |
 LL |     id_u16(b8);
-   |            ^^
-   |            |
-   |            expected `u16`, found `u8`
-   |            help: you can convert a `u8` to a `u16`: `b8.into()`
+   |            ^^ expected `u16`, found `u8`
+   |
+help: you can convert a `u8` to a `u16`
+   |
+LL |     id_u16(b8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:169:12
@@ -384,7 +414,7 @@ LL |     id_u16(b32);
 help: you can convert a `u32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(b32.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:172:12
@@ -395,7 +425,7 @@ LL |     id_u16(b64);
 help: you can convert a `u64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(b64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:175:12
@@ -406,25 +436,29 @@ LL |     id_u16(bsize);
 help: you can convert a `usize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     id_u16(bsize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:179:12
    |
 LL |     id_u32(b8);
-   |            ^^
-   |            |
-   |            expected `u32`, found `u8`
-   |            help: you can convert a `u8` to a `u32`: `b8.into()`
+   |            ^^ expected `u32`, found `u8`
+   |
+help: you can convert a `u8` to a `u32`
+   |
+LL |     id_u32(b8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:182:12
    |
 LL |     id_u32(b16);
-   |            ^^^
-   |            |
-   |            expected `u32`, found `u16`
-   |            help: you can convert a `u16` to a `u32`: `b16.into()`
+   |            ^^^ expected `u32`, found `u16`
+   |
+help: you can convert a `u16` to a `u32`
+   |
+LL |     id_u32(b16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:186:12
@@ -435,7 +469,7 @@ LL |     id_u32(b64);
 help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     id_u32(b64.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:189:12
@@ -446,34 +480,40 @@ LL |     id_u32(bsize);
 help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     id_u32(bsize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:193:12
    |
 LL |     id_u64(b8);
-   |            ^^
-   |            |
-   |            expected `u64`, found `u8`
-   |            help: you can convert a `u8` to a `u64`: `b8.into()`
+   |            ^^ expected `u64`, found `u8`
+   |
+help: you can convert a `u8` to a `u64`
+   |
+LL |     id_u64(b8.into());
+   |              +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:196:12
    |
 LL |     id_u64(b16);
-   |            ^^^
-   |            |
-   |            expected `u64`, found `u16`
-   |            help: you can convert a `u16` to a `u64`: `b16.into()`
+   |            ^^^ expected `u64`, found `u16`
+   |
+help: you can convert a `u16` to a `u64`
+   |
+LL |     id_u64(b16.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:199:12
    |
 LL |     id_u64(b32);
-   |            ^^^
-   |            |
-   |            expected `u64`, found `u32`
-   |            help: you can convert a `u32` to a `u64`: `b32.into()`
+   |            ^^^ expected `u64`, found `u32`
+   |
+help: you can convert a `u32` to a `u64`
+   |
+LL |     id_u64(b32.into());
+   |               +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:203:12
@@ -484,25 +524,29 @@ LL |     id_u64(bsize);
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     id_u64(bsize.try_into().unwrap());
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:207:14
    |
 LL |     id_usize(b8);
-   |              ^^
-   |              |
-   |              expected `usize`, found `u8`
-   |              help: you can convert a `u8` to a `usize`: `b8.into()`
+   |              ^^ expected `usize`, found `u8`
+   |
+help: you can convert a `u8` to a `usize`
+   |
+LL |     id_usize(b8.into());
+   |                +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:210:14
    |
 LL |     id_usize(b16);
-   |              ^^^
-   |              |
-   |              expected `usize`, found `u16`
-   |              help: you can convert a `u16` to a `usize`: `b16.into()`
+   |              ^^^ expected `usize`, found `u16`
+   |
+help: you can convert a `u16` to a `usize`
+   |
+LL |     id_usize(b16.into());
+   |                 +++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:213:14
@@ -513,7 +557,7 @@ LL |     id_usize(b32);
 help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     id_usize(b32.try_into().unwrap());
-   |              ~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/integer-literal-suffix-inference.rs:216:14
@@ -524,7 +568,7 @@ LL |     id_usize(b64);
 help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     id_usize(b64.try_into().unwrap());
-   |              ~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error: aborting due to 52 previous errors
 

--- a/src/test/ui/issues/issue-13359.stderr
+++ b/src/test/ui/issues/issue-13359.stderr
@@ -7,7 +7,7 @@ LL |     foo(1*(1 as isize));
 help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo((1*(1 as isize)).try_into().unwrap());
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         +              +++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-13359.rs:10:9
@@ -18,7 +18,7 @@ LL |     bar(1*(1 as usize));
 help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     bar((1*(1 as usize)).try_into().unwrap());
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         +              +++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-1362.stderr
+++ b/src/test/ui/issues/issue-1362.stderr
@@ -9,7 +9,7 @@ LL |   let x: u32 = 20i32;
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |   let x: u32 = 20u32;
-   |                ~~~~~
+   |                  ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1448-2.stderr
+++ b/src/test/ui/issues/issue-1448-2.stderr
@@ -7,7 +7,7 @@ LL |     println!("{}", foo(10i32));
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     println!("{}", foo(10u32));
-   |                        ~~~~~
+   |                          ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-8761.stderr
+++ b/src/test/ui/issues/issue-8761.stderr
@@ -7,7 +7,7 @@ LL |     A = 1i64,
 help: change the type of the numeric literal from `i64` to `isize`
    |
 LL |     A = 1isize,
-   |         ~~~~~~
+   |          ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-8761.rs:5:9
@@ -18,7 +18,7 @@ LL |     B = 2u8
 help: change the type of the numeric literal from `u8` to `isize`
    |
 LL |     B = 2isize
-   |         ~~~~~~
+   |          ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/meta/expected-error-correct-rev.a.stderr
+++ b/src/test/ui/meta/expected-error-correct-rev.a.stderr
@@ -9,7 +9,7 @@ LL |     let x: u32 = 22_usize;
 help: change the type of the numeric literal from `usize` to `u32`
    |
 LL |     let x: u32 = 22_u32;
-   |                  ~~~~~~
+   |                     ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/meta/meta-expected-error-wrong-rev.a.stderr
+++ b/src/test/ui/meta/meta-expected-error-wrong-rev.a.stderr
@@ -9,7 +9,7 @@ LL |     let x: u32 = 22_usize;
 help: change the type of the numeric literal from `usize` to `u32`
    |
 LL |     let x: u32 = 22_u32;
-   |                  ~~~~~~
+   |                     ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -17,7 +17,7 @@ LL |     let y: usize = x.foo();
 help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     let y: usize = x.foo().try_into().unwrap();
-   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                           ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -11,7 +11,7 @@ LL |     write!(hello);
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   +                             +++++++++++++++++++++
 
 error[E0605]: non-primitive cast: `{integer}` as `()`
   --> $DIR/issue-26480.rs:22:19

--- a/src/test/ui/mismatched_types/numeric-literal-cast.stderr
+++ b/src/test/ui/mismatched_types/numeric-literal-cast.stderr
@@ -7,7 +7,7 @@ LL |     foo(1u8);
 help: change the type of the numeric literal from `u8` to `u16`
    |
 LL |     foo(1u16);
-   |         ~~~~
+   |          ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-literal-cast.rs:8:10
@@ -18,7 +18,7 @@ LL |     foo1(2f32);
 help: change the type of the numeric literal from `f32` to `f64`
    |
 LL |     foo1(2f64);
-   |          ~~~~
+   |           ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-literal-cast.rs:10:10
@@ -29,7 +29,7 @@ LL |     foo2(3i16);
 help: change the type of the numeric literal from `i16` to `i32`
    |
 LL |     foo2(3i32);
-   |          ~~~~
+   |           ~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/numeric/const-scope.stderr
+++ b/src/test/ui/numeric/const-scope.stderr
@@ -7,7 +7,7 @@ LL | const C: i32 = 1i8;
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL | const C: i32 = 1i32;
-   |                ~~~~
+   |                 ~~~
 
 error[E0308]: mismatched types
   --> $DIR/const-scope.rs:2:15
@@ -26,7 +26,7 @@ LL |     let c: i32 = 1i8;
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL |     let c: i32 = 1i32;
-   |                  ~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/const-scope.rs:6:17
@@ -47,7 +47,7 @@ LL |     let c: i32 = 1i8;
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL |     let c: i32 = 1i32;
-   |                  ~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/const-scope.rs:11:17
@@ -60,7 +60,7 @@ LL |     let d: i8 = c;
 help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     let d: i8 = c.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~
+   |                  ++++++++++++++++++++
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/numeric/len.stderr
+++ b/src/test/ui/numeric/len.stderr
@@ -7,7 +7,7 @@ LL |     test(array.len());
 help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     test(array.len().try_into().unwrap());
-   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/numeric/numeric-cast-2.stderr
+++ b/src/test/ui/numeric/numeric-cast-2.stderr
@@ -9,27 +9,33 @@ LL |     let x: u16 = foo();
 help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     let x: u16 = foo().try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-2.rs:7:18
    |
 LL |     let y: i64 = x + x;
-   |            ---   ^^^^^
-   |            |     |
-   |            |     expected `i64`, found `u16`
-   |            |     help: you can convert a `u16` to an `i64`: `(x + x).into()`
+   |            ---   ^^^^^ expected `i64`, found `u16`
+   |            |
    |            expected due to this
+   |
+help: you can convert a `u16` to an `i64`
+   |
+LL |     let y: i64 = (x + x).into();
+   |                  +     ++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-2.rs:9:18
    |
 LL |     let z: i32 = x + x;
-   |            ---   ^^^^^
-   |            |     |
-   |            |     expected `i32`, found `u16`
-   |            |     help: you can convert a `u16` to an `i32`: `(x + x).into()`
+   |            ---   ^^^^^ expected `i32`, found `u16`
+   |            |
    |            expected due to this
+   |
+help: you can convert a `u16` to an `i32`
+   |
+LL |     let z: i32 = (x + x).into();
+   |                  +     ++++++++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/numeric/numeric-cast-binop.stderr
+++ b/src/test/ui/numeric/numeric-cast-binop.stderr
@@ -7,7 +7,7 @@ LL |         x_u8 > x_u16;
 help: you can convert `x_u8` from `u8` to `u16`, matching the type of `x_u16`
    |
 LL |         u16::from(x_u8) > x_u16;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:25:16
@@ -18,7 +18,7 @@ LL |         x_u8 > x_u32;
 help: you can convert `x_u8` from `u8` to `u32`, matching the type of `x_u32`
    |
 LL |         u32::from(x_u8) > x_u32;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:27:16
@@ -29,7 +29,7 @@ LL |         x_u8 > x_u64;
 help: you can convert `x_u8` from `u8` to `u64`, matching the type of `x_u64`
    |
 LL |         u64::from(x_u8) > x_u64;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:29:16
@@ -40,7 +40,7 @@ LL |         x_u8 > x_u128;
 help: you can convert `x_u8` from `u8` to `u128`, matching the type of `x_u128`
    |
 LL |         u128::from(x_u8) > x_u128;
-   |         ~~~~~~~~~~~~~~~~
+   |         +++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:31:16
@@ -51,16 +51,18 @@ LL |         x_u8 > x_usize;
 help: you can convert `x_u8` from `u8` to `usize`, matching the type of `x_usize`
    |
 LL |         usize::from(x_u8) > x_usize;
-   |         ~~~~~~~~~~~~~~~~~
+   |         ++++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:34:17
    |
 LL |         x_u16 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `u16`, found `u8`
-   |                 help: you can convert a `u8` to a `u16`: `x_u8.into()`
+   |                 ^^^^ expected `u16`, found `u8`
+   |
+help: you can convert a `u8` to a `u16`
+   |
+LL |         x_u16 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:36:17
@@ -71,7 +73,7 @@ LL |         x_u16 > x_u32;
 help: you can convert `x_u16` from `u16` to `u32`, matching the type of `x_u32`
    |
 LL |         u32::from(x_u16) > x_u32;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:38:17
@@ -82,7 +84,7 @@ LL |         x_u16 > x_u64;
 help: you can convert `x_u16` from `u16` to `u64`, matching the type of `x_u64`
    |
 LL |         u64::from(x_u16) > x_u64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:40:17
@@ -93,7 +95,7 @@ LL |         x_u16 > x_u128;
 help: you can convert `x_u16` from `u16` to `u128`, matching the type of `x_u128`
    |
 LL |         u128::from(x_u16) > x_u128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:42:17
@@ -104,25 +106,29 @@ LL |         x_u16 > x_usize;
 help: you can convert `x_u16` from `u16` to `usize`, matching the type of `x_usize`
    |
 LL |         usize::from(x_u16) > x_usize;
-   |         ~~~~~~~~~~~~~~~~~~
+   |         ++++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:45:17
    |
 LL |         x_u32 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `u32`, found `u8`
-   |                 help: you can convert a `u8` to a `u32`: `x_u8.into()`
+   |                 ^^^^ expected `u32`, found `u8`
+   |
+help: you can convert a `u8` to a `u32`
+   |
+LL |         x_u32 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:47:17
    |
 LL |         x_u32 > x_u16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `u32`, found `u16`
-   |                 help: you can convert a `u16` to a `u32`: `x_u16.into()`
+   |                 ^^^^^ expected `u32`, found `u16`
+   |
+help: you can convert a `u16` to a `u32`
+   |
+LL |         x_u32 > x_u16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:49:17
@@ -133,7 +139,7 @@ LL |         x_u32 > x_u64;
 help: you can convert `x_u32` from `u32` to `u64`, matching the type of `x_u64`
    |
 LL |         u64::from(x_u32) > x_u64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:51:17
@@ -144,7 +150,7 @@ LL |         x_u32 > x_u128;
 help: you can convert `x_u32` from `u32` to `u128`, matching the type of `x_u128`
    |
 LL |         u128::from(x_u32) > x_u128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:53:17
@@ -155,34 +161,40 @@ LL |         x_u32 > x_usize;
 help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_usize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:56:17
    |
 LL |         x_u64 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `u64`, found `u8`
-   |                 help: you can convert a `u8` to a `u64`: `x_u8.into()`
+   |                 ^^^^ expected `u64`, found `u8`
+   |
+help: you can convert a `u8` to a `u64`
+   |
+LL |         x_u64 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:58:17
    |
 LL |         x_u64 > x_u16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `u64`, found `u16`
-   |                 help: you can convert a `u16` to a `u64`: `x_u16.into()`
+   |                 ^^^^^ expected `u64`, found `u16`
+   |
+help: you can convert a `u16` to a `u64`
+   |
+LL |         x_u64 > x_u16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:60:17
    |
 LL |         x_u64 > x_u32;
-   |                 ^^^^^
-   |                 |
-   |                 expected `u64`, found `u32`
-   |                 help: you can convert a `u32` to a `u64`: `x_u32.into()`
+   |                 ^^^^^ expected `u64`, found `u32`
+   |
+help: you can convert a `u32` to a `u64`
+   |
+LL |         x_u64 > x_u32.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:62:17
@@ -193,7 +205,7 @@ LL |         x_u64 > x_u128;
 help: you can convert `x_u64` from `u64` to `u128`, matching the type of `x_u128`
    |
 LL |         u128::from(x_u64) > x_u128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:64:17
@@ -204,43 +216,51 @@ LL |         x_u64 > x_usize;
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_usize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:67:18
    |
 LL |         x_u128 > x_u8;
-   |                  ^^^^
-   |                  |
-   |                  expected `u128`, found `u8`
-   |                  help: you can convert a `u8` to a `u128`: `x_u8.into()`
+   |                  ^^^^ expected `u128`, found `u8`
+   |
+help: you can convert a `u8` to a `u128`
+   |
+LL |         x_u128 > x_u8.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:69:18
    |
 LL |         x_u128 > x_u16;
-   |                  ^^^^^
-   |                  |
-   |                  expected `u128`, found `u16`
-   |                  help: you can convert a `u16` to a `u128`: `x_u16.into()`
+   |                  ^^^^^ expected `u128`, found `u16`
+   |
+help: you can convert a `u16` to a `u128`
+   |
+LL |         x_u128 > x_u16.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:71:18
    |
 LL |         x_u128 > x_u32;
-   |                  ^^^^^
-   |                  |
-   |                  expected `u128`, found `u32`
-   |                  help: you can convert a `u32` to a `u128`: `x_u32.into()`
+   |                  ^^^^^ expected `u128`, found `u32`
+   |
+help: you can convert a `u32` to a `u128`
+   |
+LL |         x_u128 > x_u32.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:73:18
    |
 LL |         x_u128 > x_u64;
-   |                  ^^^^^
-   |                  |
-   |                  expected `u128`, found `u64`
-   |                  help: you can convert a `u64` to a `u128`: `x_u64.into()`
+   |                  ^^^^^ expected `u128`, found `u64`
+   |
+help: you can convert a `u64` to a `u128`
+   |
+LL |         x_u128 > x_u64.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:75:18
@@ -251,25 +271,29 @@ LL |         x_u128 > x_usize;
 help: you can convert a `usize` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_usize.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:78:19
    |
 LL |         x_usize > x_u8;
-   |                   ^^^^
-   |                   |
-   |                   expected `usize`, found `u8`
-   |                   help: you can convert a `u8` to a `usize`: `x_u8.into()`
+   |                   ^^^^ expected `usize`, found `u8`
+   |
+help: you can convert a `u8` to a `usize`
+   |
+LL |         x_usize > x_u8.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:80:19
    |
 LL |         x_usize > x_u16;
-   |                   ^^^^^
-   |                   |
-   |                   expected `usize`, found `u16`
-   |                   help: you can convert a `u16` to a `usize`: `x_u16.into()`
+   |                   ^^^^^ expected `usize`, found `u16`
+   |
+help: you can convert a `u16` to a `usize`
+   |
+LL |         x_usize > x_u16.into();
+   |                        +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:82:19
@@ -280,7 +304,7 @@ LL |         x_usize > x_u32;
 help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u32.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:84:19
@@ -291,7 +315,7 @@ LL |         x_usize > x_u64;
 help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u64.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:86:19
@@ -302,7 +326,7 @@ LL |         x_usize > x_u128;
 help: you can convert a `u128` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_u128.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:92:16
@@ -313,7 +337,7 @@ LL |         x_i8 > x_i16;
 help: you can convert `x_i8` from `i8` to `i16`, matching the type of `x_i16`
    |
 LL |         i16::from(x_i8) > x_i16;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:94:16
@@ -324,7 +348,7 @@ LL |         x_i8 > x_i32;
 help: you can convert `x_i8` from `i8` to `i32`, matching the type of `x_i32`
    |
 LL |         i32::from(x_i8) > x_i32;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:96:16
@@ -335,7 +359,7 @@ LL |         x_i8 > x_i64;
 help: you can convert `x_i8` from `i8` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_i8) > x_i64;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:98:16
@@ -346,7 +370,7 @@ LL |         x_i8 > x_i128;
 help: you can convert `x_i8` from `i8` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_i8) > x_i128;
-   |         ~~~~~~~~~~~~~~~~
+   |         +++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:100:16
@@ -357,16 +381,18 @@ LL |         x_i8 > x_isize;
 help: you can convert `x_i8` from `i8` to `isize`, matching the type of `x_isize`
    |
 LL |         isize::from(x_i8) > x_isize;
-   |         ~~~~~~~~~~~~~~~~~
+   |         ++++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:103:17
    |
 LL |         x_i16 > x_i8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i16`, found `i8`
-   |                 help: you can convert an `i8` to an `i16`: `x_i8.into()`
+   |                 ^^^^ expected `i16`, found `i8`
+   |
+help: you can convert an `i8` to an `i16`
+   |
+LL |         x_i16 > x_i8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:105:17
@@ -377,7 +403,7 @@ LL |         x_i16 > x_i32;
 help: you can convert `x_i16` from `i16` to `i32`, matching the type of `x_i32`
    |
 LL |         i32::from(x_i16) > x_i32;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:107:17
@@ -388,7 +414,7 @@ LL |         x_i16 > x_i64;
 help: you can convert `x_i16` from `i16` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_i16) > x_i64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:109:17
@@ -399,7 +425,7 @@ LL |         x_i16 > x_i128;
 help: you can convert `x_i16` from `i16` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_i16) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:111:17
@@ -410,25 +436,29 @@ LL |         x_i16 > x_isize;
 help: you can convert `x_i16` from `i16` to `isize`, matching the type of `x_isize`
    |
 LL |         isize::from(x_i16) > x_isize;
-   |         ~~~~~~~~~~~~~~~~~~
+   |         ++++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:114:17
    |
 LL |         x_i32 > x_i8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i32`, found `i8`
-   |                 help: you can convert an `i8` to an `i32`: `x_i8.into()`
+   |                 ^^^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |         x_i32 > x_i8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:116:17
    |
 LL |         x_i32 > x_i16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i32`, found `i16`
-   |                 help: you can convert an `i16` to an `i32`: `x_i16.into()`
+   |                 ^^^^^ expected `i32`, found `i16`
+   |
+help: you can convert an `i16` to an `i32`
+   |
+LL |         x_i32 > x_i16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:118:17
@@ -439,7 +469,7 @@ LL |         x_i32 > x_i64;
 help: you can convert `x_i32` from `i32` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_i32) > x_i64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:120:17
@@ -450,7 +480,7 @@ LL |         x_i32 > x_i128;
 help: you can convert `x_i32` from `i32` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_i32) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:122:17
@@ -461,34 +491,40 @@ LL |         x_i32 > x_isize;
 help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_isize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:125:17
    |
 LL |         x_i64 > x_i8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i64`, found `i8`
-   |                 help: you can convert an `i8` to an `i64`: `x_i8.into()`
+   |                 ^^^^ expected `i64`, found `i8`
+   |
+help: you can convert an `i8` to an `i64`
+   |
+LL |         x_i64 > x_i8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:127:17
    |
 LL |         x_i64 > x_i16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i64`, found `i16`
-   |                 help: you can convert an `i16` to an `i64`: `x_i16.into()`
+   |                 ^^^^^ expected `i64`, found `i16`
+   |
+help: you can convert an `i16` to an `i64`
+   |
+LL |         x_i64 > x_i16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:129:17
    |
 LL |         x_i64 > x_i32;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i64`, found `i32`
-   |                 help: you can convert an `i32` to an `i64`: `x_i32.into()`
+   |                 ^^^^^ expected `i64`, found `i32`
+   |
+help: you can convert an `i32` to an `i64`
+   |
+LL |         x_i64 > x_i32.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:131:17
@@ -499,7 +535,7 @@ LL |         x_i64 > x_i128;
 help: you can convert `x_i64` from `i64` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_i64) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:133:17
@@ -510,43 +546,51 @@ LL |         x_i64 > x_isize;
 help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_isize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:136:18
    |
 LL |         x_i128 > x_i8;
-   |                  ^^^^
-   |                  |
-   |                  expected `i128`, found `i8`
-   |                  help: you can convert an `i8` to an `i128`: `x_i8.into()`
+   |                  ^^^^ expected `i128`, found `i8`
+   |
+help: you can convert an `i8` to an `i128`
+   |
+LL |         x_i128 > x_i8.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:138:18
    |
 LL |         x_i128 > x_i16;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `i16`
-   |                  help: you can convert an `i16` to an `i128`: `x_i16.into()`
+   |                  ^^^^^ expected `i128`, found `i16`
+   |
+help: you can convert an `i16` to an `i128`
+   |
+LL |         x_i128 > x_i16.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:140:18
    |
 LL |         x_i128 > x_i32;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `i32`
-   |                  help: you can convert an `i32` to an `i128`: `x_i32.into()`
+   |                  ^^^^^ expected `i128`, found `i32`
+   |
+help: you can convert an `i32` to an `i128`
+   |
+LL |         x_i128 > x_i32.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:142:18
    |
 LL |         x_i128 > x_i64;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `i64`
-   |                  help: you can convert an `i64` to an `i128`: `x_i64.into()`
+   |                  ^^^^^ expected `i128`, found `i64`
+   |
+help: you can convert an `i64` to an `i128`
+   |
+LL |         x_i128 > x_i64.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:144:18
@@ -557,25 +601,29 @@ LL |         x_i128 > x_isize;
 help: you can convert an `isize` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_isize.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:147:19
    |
 LL |         x_isize > x_i8;
-   |                   ^^^^
-   |                   |
-   |                   expected `isize`, found `i8`
-   |                   help: you can convert an `i8` to an `isize`: `x_i8.into()`
+   |                   ^^^^ expected `isize`, found `i8`
+   |
+help: you can convert an `i8` to an `isize`
+   |
+LL |         x_isize > x_i8.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:149:19
    |
 LL |         x_isize > x_i16;
-   |                   ^^^^^
-   |                   |
-   |                   expected `isize`, found `i16`
-   |                   help: you can convert an `i16` to an `isize`: `x_i16.into()`
+   |                   ^^^^^ expected `isize`, found `i16`
+   |
+help: you can convert an `i16` to an `isize`
+   |
+LL |         x_isize > x_i16.into();
+   |                        +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:151:19
@@ -586,7 +634,7 @@ LL |         x_isize > x_i32;
 help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i32.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:153:19
@@ -597,7 +645,7 @@ LL |         x_isize > x_i64;
 help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i64.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:155:19
@@ -608,7 +656,7 @@ LL |         x_isize > x_i128;
 help: you can convert an `i128` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_i128.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:161:16
@@ -619,7 +667,7 @@ LL |         x_u8 > x_i8;
 help: you can convert an `i8` to a `u8` and panic if the converted value doesn't fit
    |
 LL |         x_u8 > x_i8.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:163:16
@@ -630,7 +678,7 @@ LL |         x_u8 > x_i16;
 help: you can convert `x_u8` from `u8` to `i16`, matching the type of `x_i16`
    |
 LL |         i16::from(x_u8) > x_i16;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:165:16
@@ -641,7 +689,7 @@ LL |         x_u8 > x_i32;
 help: you can convert `x_u8` from `u8` to `i32`, matching the type of `x_i32`
    |
 LL |         i32::from(x_u8) > x_i32;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:167:16
@@ -652,7 +700,7 @@ LL |         x_u8 > x_i64;
 help: you can convert `x_u8` from `u8` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_u8) > x_i64;
-   |         ~~~~~~~~~~~~~~~
+   |         ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:169:16
@@ -663,7 +711,7 @@ LL |         x_u8 > x_i128;
 help: you can convert `x_u8` from `u8` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_u8) > x_i128;
-   |         ~~~~~~~~~~~~~~~~
+   |         +++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:171:16
@@ -674,7 +722,7 @@ LL |         x_u8 > x_isize;
 help: you can convert `x_u8` from `u8` to `isize`, matching the type of `x_isize`
    |
 LL |         isize::from(x_u8) > x_isize;
-   |         ~~~~~~~~~~~~~~~~~
+   |         ++++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:174:17
@@ -685,7 +733,7 @@ LL |         x_u16 > x_i8;
 help: you can convert an `i8` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_i8.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:176:17
@@ -696,7 +744,7 @@ LL |         x_u16 > x_i16;
 help: you can convert an `i16` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_i16.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:178:17
@@ -707,7 +755,7 @@ LL |         x_u16 > x_i32;
 help: you can convert `x_u16` from `u16` to `i32`, matching the type of `x_i32`
    |
 LL |         i32::from(x_u16) > x_i32;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:180:17
@@ -718,7 +766,7 @@ LL |         x_u16 > x_i64;
 help: you can convert `x_u16` from `u16` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_u16) > x_i64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:182:17
@@ -729,7 +777,7 @@ LL |         x_u16 > x_i128;
 help: you can convert `x_u16` from `u16` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_u16) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:184:17
@@ -740,7 +788,7 @@ LL |         x_u16 > x_isize;
 help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |         x_u16 > x_isize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:187:17
@@ -751,7 +799,7 @@ LL |         x_u32 > x_i8;
 help: you can convert an `i8` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i8.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:189:17
@@ -762,7 +810,7 @@ LL |         x_u32 > x_i16;
 help: you can convert an `i16` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i16.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:191:17
@@ -773,7 +821,7 @@ LL |         x_u32 > x_i32;
 help: you can convert an `i32` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_i32.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:193:17
@@ -784,7 +832,7 @@ LL |         x_u32 > x_i64;
 help: you can convert `x_u32` from `u32` to `i64`, matching the type of `x_i64`
    |
 LL |         i64::from(x_u32) > x_i64;
-   |         ~~~~~~~~~~~~~~~~
+   |         ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:195:17
@@ -795,7 +843,7 @@ LL |         x_u32 > x_i128;
 help: you can convert `x_u32` from `u32` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_u32) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:197:17
@@ -806,7 +854,7 @@ LL |         x_u32 > x_isize;
 help: you can convert an `isize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |         x_u32 > x_isize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:200:17
@@ -817,7 +865,7 @@ LL |         x_u64 > x_i8;
 help: you can convert an `i8` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i8.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:202:17
@@ -828,7 +876,7 @@ LL |         x_u64 > x_i16;
 help: you can convert an `i16` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i16.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:204:17
@@ -839,7 +887,7 @@ LL |         x_u64 > x_i32;
 help: you can convert an `i32` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i32.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:206:17
@@ -850,7 +898,7 @@ LL |         x_u64 > x_i64;
 help: you can convert an `i64` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_i64.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:208:17
@@ -861,7 +909,7 @@ LL |         x_u64 > x_i128;
 help: you can convert `x_u64` from `u64` to `i128`, matching the type of `x_i128`
    |
 LL |         i128::from(x_u64) > x_i128;
-   |         ~~~~~~~~~~~~~~~~~
+   |         +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:210:17
@@ -872,7 +920,7 @@ LL |         x_u64 > x_isize;
 help: you can convert an `isize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |         x_u64 > x_isize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:213:18
@@ -883,7 +931,7 @@ LL |         x_u128 > x_i8;
 help: you can convert an `i8` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i8.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:215:18
@@ -894,7 +942,7 @@ LL |         x_u128 > x_i16;
 help: you can convert an `i16` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i16.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:217:18
@@ -905,7 +953,7 @@ LL |         x_u128 > x_i32;
 help: you can convert an `i32` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i32.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:219:18
@@ -916,7 +964,7 @@ LL |         x_u128 > x_i64;
 help: you can convert an `i64` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i64.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:221:18
@@ -927,7 +975,7 @@ LL |         x_u128 > x_i128;
 help: you can convert an `i128` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_i128.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:223:18
@@ -938,7 +986,7 @@ LL |         x_u128 > x_isize;
 help: you can convert an `isize` to a `u128` and panic if the converted value doesn't fit
    |
 LL |         x_u128 > x_isize.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:226:19
@@ -949,7 +997,7 @@ LL |         x_usize > x_i8;
 help: you can convert an `i8` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i8.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:228:19
@@ -960,7 +1008,7 @@ LL |         x_usize > x_i16;
 help: you can convert an `i16` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i16.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:230:19
@@ -971,7 +1019,7 @@ LL |         x_usize > x_i32;
 help: you can convert an `i32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i32.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:232:19
@@ -982,7 +1030,7 @@ LL |         x_usize > x_i64;
 help: you can convert an `i64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i64.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:234:19
@@ -993,7 +1041,7 @@ LL |         x_usize > x_i128;
 help: you can convert an `i128` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_i128.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:236:19
@@ -1004,7 +1052,7 @@ LL |         x_usize > x_isize;
 help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         x_usize > x_isize.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:242:16
@@ -1015,7 +1063,7 @@ LL |         x_i8 > x_u8;
 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u8.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:244:16
@@ -1026,7 +1074,7 @@ LL |         x_i8 > x_u16;
 help: you can convert a `u16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u16.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:246:16
@@ -1037,7 +1085,7 @@ LL |         x_i8 > x_u32;
 help: you can convert a `u32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u32.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:248:16
@@ -1048,7 +1096,7 @@ LL |         x_i8 > x_u64;
 help: you can convert a `u64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u64.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:250:16
@@ -1059,7 +1107,7 @@ LL |         x_i8 > x_u128;
 help: you can convert a `u128` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_u128.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:252:16
@@ -1070,16 +1118,18 @@ LL |         x_i8 > x_usize;
 help: you can convert a `usize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |         x_i8 > x_usize.try_into().unwrap();
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:255:17
    |
 LL |         x_i16 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i16`, found `u8`
-   |                 help: you can convert a `u8` to an `i16`: `x_u8.into()`
+   |                 ^^^^ expected `i16`, found `u8`
+   |
+help: you can convert a `u8` to an `i16`
+   |
+LL |         x_i16 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:257:17
@@ -1090,7 +1140,7 @@ LL |         x_i16 > x_u16;
 help: you can convert a `u16` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u16.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:259:17
@@ -1101,7 +1151,7 @@ LL |         x_i16 > x_u32;
 help: you can convert a `u32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u32.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:261:17
@@ -1112,7 +1162,7 @@ LL |         x_i16 > x_u64;
 help: you can convert a `u64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u64.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:263:17
@@ -1123,7 +1173,7 @@ LL |         x_i16 > x_u128;
 help: you can convert a `u128` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_u128.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:265:17
@@ -1134,25 +1184,29 @@ LL |         x_i16 > x_usize;
 help: you can convert a `usize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |         x_i16 > x_usize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:268:17
    |
 LL |         x_i32 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i32`, found `u8`
-   |                 help: you can convert a `u8` to an `i32`: `x_u8.into()`
+   |                 ^^^^ expected `i32`, found `u8`
+   |
+help: you can convert a `u8` to an `i32`
+   |
+LL |         x_i32 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:270:17
    |
 LL |         x_i32 > x_u16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i32`, found `u16`
-   |                 help: you can convert a `u16` to an `i32`: `x_u16.into()`
+   |                 ^^^^^ expected `i32`, found `u16`
+   |
+help: you can convert a `u16` to an `i32`
+   |
+LL |         x_i32 > x_u16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:272:17
@@ -1163,7 +1217,7 @@ LL |         x_i32 > x_u32;
 help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u32.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:274:17
@@ -1174,7 +1228,7 @@ LL |         x_i32 > x_u64;
 help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u64.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:276:17
@@ -1185,7 +1239,7 @@ LL |         x_i32 > x_u128;
 help: you can convert a `u128` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_u128.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:278:17
@@ -1196,34 +1250,40 @@ LL |         x_i32 > x_usize;
 help: you can convert a `usize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |         x_i32 > x_usize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:281:17
    |
 LL |         x_i64 > x_u8;
-   |                 ^^^^
-   |                 |
-   |                 expected `i64`, found `u8`
-   |                 help: you can convert a `u8` to an `i64`: `x_u8.into()`
+   |                 ^^^^ expected `i64`, found `u8`
+   |
+help: you can convert a `u8` to an `i64`
+   |
+LL |         x_i64 > x_u8.into();
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:283:17
    |
 LL |         x_i64 > x_u16;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i64`, found `u16`
-   |                 help: you can convert a `u16` to an `i64`: `x_u16.into()`
+   |                 ^^^^^ expected `i64`, found `u16`
+   |
+help: you can convert a `u16` to an `i64`
+   |
+LL |         x_i64 > x_u16.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:285:17
    |
 LL |         x_i64 > x_u32;
-   |                 ^^^^^
-   |                 |
-   |                 expected `i64`, found `u32`
-   |                 help: you can convert a `u32` to an `i64`: `x_u32.into()`
+   |                 ^^^^^ expected `i64`, found `u32`
+   |
+help: you can convert a `u32` to an `i64`
+   |
+LL |         x_i64 > x_u32.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:287:17
@@ -1234,7 +1294,7 @@ LL |         x_i64 > x_u64;
 help: you can convert a `u64` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_u64.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:289:17
@@ -1245,7 +1305,7 @@ LL |         x_i64 > x_u128;
 help: you can convert a `u128` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_u128.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:291:17
@@ -1256,43 +1316,51 @@ LL |         x_i64 > x_usize;
 help: you can convert a `usize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |         x_i64 > x_usize.try_into().unwrap();
-   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:294:18
    |
 LL |         x_i128 > x_u8;
-   |                  ^^^^
-   |                  |
-   |                  expected `i128`, found `u8`
-   |                  help: you can convert a `u8` to an `i128`: `x_u8.into()`
+   |                  ^^^^ expected `i128`, found `u8`
+   |
+help: you can convert a `u8` to an `i128`
+   |
+LL |         x_i128 > x_u8.into();
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:296:18
    |
 LL |         x_i128 > x_u16;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `u16`
-   |                  help: you can convert a `u16` to an `i128`: `x_u16.into()`
+   |                  ^^^^^ expected `i128`, found `u16`
+   |
+help: you can convert a `u16` to an `i128`
+   |
+LL |         x_i128 > x_u16.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:298:18
    |
 LL |         x_i128 > x_u32;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `u32`
-   |                  help: you can convert a `u32` to an `i128`: `x_u32.into()`
+   |                  ^^^^^ expected `i128`, found `u32`
+   |
+help: you can convert a `u32` to an `i128`
+   |
+LL |         x_i128 > x_u32.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:300:18
    |
 LL |         x_i128 > x_u64;
-   |                  ^^^^^
-   |                  |
-   |                  expected `i128`, found `u64`
-   |                  help: you can convert a `u64` to an `i128`: `x_u64.into()`
+   |                  ^^^^^ expected `i128`, found `u64`
+   |
+help: you can convert a `u64` to an `i128`
+   |
+LL |         x_i128 > x_u64.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:302:18
@@ -1303,7 +1371,7 @@ LL |         x_i128 > x_u128;
 help: you can convert a `u128` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_u128.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:304:18
@@ -1314,16 +1382,18 @@ LL |         x_i128 > x_usize;
 help: you can convert a `usize` to an `i128` and panic if the converted value doesn't fit
    |
 LL |         x_i128 > x_usize.try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:307:19
    |
 LL |         x_isize > x_u8;
-   |                   ^^^^
-   |                   |
-   |                   expected `isize`, found `u8`
-   |                   help: you can convert a `u8` to an `isize`: `x_u8.into()`
+   |                   ^^^^ expected `isize`, found `u8`
+   |
+help: you can convert a `u8` to an `isize`
+   |
+LL |         x_isize > x_u8.into();
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:309:19
@@ -1334,7 +1404,7 @@ LL |         x_isize > x_u16;
 help: you can convert a `u16` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u16.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:311:19
@@ -1345,7 +1415,7 @@ LL |         x_isize > x_u32;
 help: you can convert a `u32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u32.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:313:19
@@ -1356,7 +1426,7 @@ LL |         x_isize > x_u64;
 help: you can convert a `u64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u64.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                        ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:315:19
@@ -1367,7 +1437,7 @@ LL |         x_isize > x_u128;
 help: you can convert a `u128` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_u128.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-binop.rs:317:19
@@ -1378,7 +1448,7 @@ LL |         x_isize > x_usize;
 help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |         x_isize > x_usize.try_into().unwrap();
-   |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ++++++++++++++++++++
 
 error: aborting due to 132 previous errors
 

--- a/src/test/ui/numeric/numeric-cast-no-fix.stderr
+++ b/src/test/ui/numeric/numeric-cast-no-fix.stderr
@@ -47,7 +47,7 @@ LL |     x_u8 > -1_isize;
 help: you can convert `x_u8` from `u8` to `isize`, matching the type of `-1_isize`
    |
 LL |     isize::from(x_u8) > -1_isize;
-   |     ~~~~~~~~~~~~~~~~~
+   |     ++++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:23:15
@@ -74,7 +74,7 @@ LL |     x_u64 > -1_i128;
 help: you can convert `x_u64` from `u64` to `i128`, matching the type of `-1_i128`
    |
 LL |     i128::from(x_u64) > -1_i128;
-   |     ~~~~~~~~~~~~~~~~~
+   |     +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:29:13
@@ -85,7 +85,7 @@ LL |     x_u32 > -1_i128;
 help: you can convert `x_u32` from `u32` to `i128`, matching the type of `-1_i128`
    |
 LL |     i128::from(x_u32) > -1_i128;
-   |     ~~~~~~~~~~~~~~~~~
+   |     +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:31:13
@@ -96,7 +96,7 @@ LL |     x_u16 > -1_i128;
 help: you can convert `x_u16` from `u16` to `i128`, matching the type of `-1_i128`
    |
 LL |     i128::from(x_u16) > -1_i128;
-   |     ~~~~~~~~~~~~~~~~~
+   |     +++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:33:12
@@ -107,7 +107,7 @@ LL |     x_u8 > -1_i128;
 help: you can convert `x_u8` from `u8` to `i128`, matching the type of `-1_i128`
    |
 LL |     i128::from(x_u8) > -1_i128;
-   |     ~~~~~~~~~~~~~~~~
+   |     +++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:36:15
@@ -142,7 +142,7 @@ LL |     x_u32 > -1_i64;
 help: you can convert `x_u32` from `u32` to `i64`, matching the type of `-1_i64`
    |
 LL |     i64::from(x_u32) > -1_i64;
-   |     ~~~~~~~~~~~~~~~~
+   |     ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:44:13
@@ -153,7 +153,7 @@ LL |     x_u16 > -1_i64;
 help: you can convert `x_u16` from `u16` to `i64`, matching the type of `-1_i64`
    |
 LL |     i64::from(x_u16) > -1_i64;
-   |     ~~~~~~~~~~~~~~~~
+   |     ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:46:12
@@ -164,7 +164,7 @@ LL |     x_u8 > -1_i64;
 help: you can convert `x_u8` from `u8` to `i64`, matching the type of `-1_i64`
    |
 LL |     i64::from(x_u8) > -1_i64;
-   |     ~~~~~~~~~~~~~~~
+   |     ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:49:15
@@ -207,7 +207,7 @@ LL |     x_u16 > -1_i32;
 help: you can convert `x_u16` from `u16` to `i32`, matching the type of `-1_i32`
    |
 LL |     i32::from(x_u16) > -1_i32;
-   |     ~~~~~~~~~~~~~~~~
+   |     ++++++++++     +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:59:12
@@ -218,7 +218,7 @@ LL |     x_u8 > -1_i32;
 help: you can convert `x_u8` from `u8` to `i32`, matching the type of `-1_i32`
    |
 LL |     i32::from(x_u8) > -1_i32;
-   |     ~~~~~~~~~~~~~~~
+   |     ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:62:15
@@ -269,7 +269,7 @@ LL |     x_u8 > -1_i16;
 help: you can convert `x_u8` from `u8` to `i16`, matching the type of `-1_i16`
    |
 LL |     i16::from(x_u8) > -1_i16;
-   |     ~~~~~~~~~~~~~~~
+   |     ++++++++++    +
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast-no-fix.rs:75:15

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -7,7 +7,7 @@ LL |     foo::<usize>(x_u64);
 help: you can convert a `u64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_u64.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:25:18
@@ -18,25 +18,29 @@ LL |     foo::<usize>(x_u32);
 help: you can convert a `u32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_u32.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:27:18
    |
 LL |     foo::<usize>(x_u16);
-   |                  ^^^^^
-   |                  |
-   |                  expected `usize`, found `u16`
-   |                  help: you can convert a `u16` to a `usize`: `x_u16.into()`
+   |                  ^^^^^ expected `usize`, found `u16`
+   |
+help: you can convert a `u16` to a `usize`
+   |
+LL |     foo::<usize>(x_u16.into());
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:29:18
    |
 LL |     foo::<usize>(x_u8);
-   |                  ^^^^
-   |                  |
-   |                  expected `usize`, found `u8`
-   |                  help: you can convert a `u8` to a `usize`: `x_u8.into()`
+   |                  ^^^^ expected `usize`, found `u8`
+   |
+help: you can convert a `u8` to a `usize`
+   |
+LL |     foo::<usize>(x_u8.into());
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:31:18
@@ -47,7 +51,7 @@ LL |     foo::<usize>(x_isize);
 help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_isize.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:33:18
@@ -58,7 +62,7 @@ LL |     foo::<usize>(x_i64);
 help: you can convert an `i64` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i64.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:35:18
@@ -69,7 +73,7 @@ LL |     foo::<usize>(x_i32);
 help: you can convert an `i32` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i32.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:37:18
@@ -80,7 +84,7 @@ LL |     foo::<usize>(x_i16);
 help: you can convert an `i16` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i16.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:39:18
@@ -91,7 +95,7 @@ LL |     foo::<usize>(x_i8);
 help: you can convert an `i8` to a `usize` and panic if the converted value doesn't fit
    |
 LL |     foo::<usize>(x_i8.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:44:18
@@ -102,7 +106,7 @@ LL |     foo::<isize>(x_usize);
 help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_usize.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                         ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:46:18
@@ -113,7 +117,7 @@ LL |     foo::<isize>(x_u64);
 help: you can convert a `u64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u64.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:48:18
@@ -124,7 +128,7 @@ LL |     foo::<isize>(x_u32);
 help: you can convert a `u32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u32.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:50:18
@@ -135,16 +139,18 @@ LL |     foo::<isize>(x_u16);
 help: you can convert a `u16` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_u16.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:52:18
    |
 LL |     foo::<isize>(x_u8);
-   |                  ^^^^
-   |                  |
-   |                  expected `isize`, found `u8`
-   |                  help: you can convert a `u8` to an `isize`: `x_u8.into()`
+   |                  ^^^^ expected `isize`, found `u8`
+   |
+help: you can convert a `u8` to an `isize`
+   |
+LL |     foo::<isize>(x_u8.into());
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:55:18
@@ -155,7 +161,7 @@ LL |     foo::<isize>(x_i64);
 help: you can convert an `i64` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_i64.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:57:18
@@ -166,25 +172,29 @@ LL |     foo::<isize>(x_i32);
 help: you can convert an `i32` to an `isize` and panic if the converted value doesn't fit
    |
 LL |     foo::<isize>(x_i32.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:59:18
    |
 LL |     foo::<isize>(x_i16);
-   |                  ^^^^^
-   |                  |
-   |                  expected `isize`, found `i16`
-   |                  help: you can convert an `i16` to an `isize`: `x_i16.into()`
+   |                  ^^^^^ expected `isize`, found `i16`
+   |
+help: you can convert an `i16` to an `isize`
+   |
+LL |     foo::<isize>(x_i16.into());
+   |                       +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:61:18
    |
 LL |     foo::<isize>(x_i8);
-   |                  ^^^^
-   |                  |
-   |                  expected `isize`, found `i8`
-   |                  help: you can convert an `i8` to an `isize`: `x_i8.into()`
+   |                  ^^^^ expected `isize`, found `i8`
+   |
+help: you can convert an `i8` to an `isize`
+   |
+LL |     foo::<isize>(x_i8.into());
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:66:16
@@ -195,34 +205,40 @@ LL |     foo::<u64>(x_usize);
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:69:16
    |
 LL |     foo::<u64>(x_u32);
-   |                ^^^^^
-   |                |
-   |                expected `u64`, found `u32`
-   |                help: you can convert a `u32` to a `u64`: `x_u32.into()`
+   |                ^^^^^ expected `u64`, found `u32`
+   |
+help: you can convert a `u32` to a `u64`
+   |
+LL |     foo::<u64>(x_u32.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:71:16
    |
 LL |     foo::<u64>(x_u16);
-   |                ^^^^^
-   |                |
-   |                expected `u64`, found `u16`
-   |                help: you can convert a `u16` to a `u64`: `x_u16.into()`
+   |                ^^^^^ expected `u64`, found `u16`
+   |
+help: you can convert a `u16` to a `u64`
+   |
+LL |     foo::<u64>(x_u16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:73:16
    |
 LL |     foo::<u64>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `u64`, found `u8`
-   |                help: you can convert a `u8` to a `u64`: `x_u8.into()`
+   |                ^^^^ expected `u64`, found `u8`
+   |
+help: you can convert a `u8` to a `u64`
+   |
+LL |     foo::<u64>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:75:16
@@ -233,7 +249,7 @@ LL |     foo::<u64>(x_isize);
 help: you can convert an `isize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:77:16
@@ -244,7 +260,7 @@ LL |     foo::<u64>(x_i64);
 help: you can convert an `i64` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:79:16
@@ -255,7 +271,7 @@ LL |     foo::<u64>(x_i32);
 help: you can convert an `i32` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:81:16
@@ -266,7 +282,7 @@ LL |     foo::<u64>(x_i16);
 help: you can convert an `i16` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i16.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:83:16
@@ -277,7 +293,7 @@ LL |     foo::<u64>(x_i8);
 help: you can convert an `i8` to a `u64` and panic if the converted value doesn't fit
    |
 LL |     foo::<u64>(x_i8.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:88:16
@@ -288,7 +304,7 @@ LL |     foo::<i64>(x_usize);
 help: you can convert a `usize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:90:16
@@ -299,34 +315,40 @@ LL |     foo::<i64>(x_u64);
 help: you can convert a `u64` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_u64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:92:16
    |
 LL |     foo::<i64>(x_u32);
-   |                ^^^^^
-   |                |
-   |                expected `i64`, found `u32`
-   |                help: you can convert a `u32` to an `i64`: `x_u32.into()`
+   |                ^^^^^ expected `i64`, found `u32`
+   |
+help: you can convert a `u32` to an `i64`
+   |
+LL |     foo::<i64>(x_u32.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:94:16
    |
 LL |     foo::<i64>(x_u16);
-   |                ^^^^^
-   |                |
-   |                expected `i64`, found `u16`
-   |                help: you can convert a `u16` to an `i64`: `x_u16.into()`
+   |                ^^^^^ expected `i64`, found `u16`
+   |
+help: you can convert a `u16` to an `i64`
+   |
+LL |     foo::<i64>(x_u16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:96:16
    |
 LL |     foo::<i64>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `i64`, found `u8`
-   |                help: you can convert a `u8` to an `i64`: `x_u8.into()`
+   |                ^^^^ expected `i64`, found `u8`
+   |
+help: you can convert a `u8` to an `i64`
+   |
+LL |     foo::<i64>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:98:16
@@ -337,34 +359,40 @@ LL |     foo::<i64>(x_isize);
 help: you can convert an `isize` to an `i64` and panic if the converted value doesn't fit
    |
 LL |     foo::<i64>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:101:16
    |
 LL |     foo::<i64>(x_i32);
-   |                ^^^^^
-   |                |
-   |                expected `i64`, found `i32`
-   |                help: you can convert an `i32` to an `i64`: `x_i32.into()`
+   |                ^^^^^ expected `i64`, found `i32`
+   |
+help: you can convert an `i32` to an `i64`
+   |
+LL |     foo::<i64>(x_i32.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:103:16
    |
 LL |     foo::<i64>(x_i16);
-   |                ^^^^^
-   |                |
-   |                expected `i64`, found `i16`
-   |                help: you can convert an `i16` to an `i64`: `x_i16.into()`
+   |                ^^^^^ expected `i64`, found `i16`
+   |
+help: you can convert an `i16` to an `i64`
+   |
+LL |     foo::<i64>(x_i16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:105:16
    |
 LL |     foo::<i64>(x_i8);
-   |                ^^^^
-   |                |
-   |                expected `i64`, found `i8`
-   |                help: you can convert an `i8` to an `i64`: `x_i8.into()`
+   |                ^^^^ expected `i64`, found `i8`
+   |
+help: you can convert an `i8` to an `i64`
+   |
+LL |     foo::<i64>(x_i8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:110:16
@@ -375,7 +403,7 @@ LL |     foo::<u32>(x_usize);
 help: you can convert a `usize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:112:16
@@ -386,25 +414,29 @@ LL |     foo::<u32>(x_u64);
 help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_u64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:115:16
    |
 LL |     foo::<u32>(x_u16);
-   |                ^^^^^
-   |                |
-   |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to a `u32`: `x_u16.into()`
+   |                ^^^^^ expected `u32`, found `u16`
+   |
+help: you can convert a `u16` to a `u32`
+   |
+LL |     foo::<u32>(x_u16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:117:16
    |
 LL |     foo::<u32>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `u32`, found `u8`
-   |                help: you can convert a `u8` to a `u32`: `x_u8.into()`
+   |                ^^^^ expected `u32`, found `u8`
+   |
+help: you can convert a `u8` to a `u32`
+   |
+LL |     foo::<u32>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:119:16
@@ -415,7 +447,7 @@ LL |     foo::<u32>(x_isize);
 help: you can convert an `isize` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:121:16
@@ -426,7 +458,7 @@ LL |     foo::<u32>(x_i64);
 help: you can convert an `i64` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:123:16
@@ -437,7 +469,7 @@ LL |     foo::<u32>(x_i32);
 help: you can convert an `i32` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:125:16
@@ -448,7 +480,7 @@ LL |     foo::<u32>(x_i16);
 help: you can convert an `i16` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i16.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:127:16
@@ -459,7 +491,7 @@ LL |     foo::<u32>(x_i8);
 help: you can convert an `i8` to a `u32` and panic if the converted value doesn't fit
    |
 LL |     foo::<u32>(x_i8.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:132:16
@@ -470,7 +502,7 @@ LL |     foo::<i32>(x_usize);
 help: you can convert a `usize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:134:16
@@ -481,7 +513,7 @@ LL |     foo::<i32>(x_u64);
 help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_u64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:136:16
@@ -492,25 +524,29 @@ LL |     foo::<i32>(x_u32);
 help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_u32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:138:16
    |
 LL |     foo::<i32>(x_u16);
-   |                ^^^^^
-   |                |
-   |                expected `i32`, found `u16`
-   |                help: you can convert a `u16` to an `i32`: `x_u16.into()`
+   |                ^^^^^ expected `i32`, found `u16`
+   |
+help: you can convert a `u16` to an `i32`
+   |
+LL |     foo::<i32>(x_u16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:140:16
    |
 LL |     foo::<i32>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `i32`, found `u8`
-   |                help: you can convert a `u8` to an `i32`: `x_u8.into()`
+   |                ^^^^ expected `i32`, found `u8`
+   |
+help: you can convert a `u8` to an `i32`
+   |
+LL |     foo::<i32>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:142:16
@@ -521,7 +557,7 @@ LL |     foo::<i32>(x_isize);
 help: you can convert an `isize` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:144:16
@@ -532,25 +568,29 @@ LL |     foo::<i32>(x_i64);
 help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     foo::<i32>(x_i64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:147:16
    |
 LL |     foo::<i32>(x_i16);
-   |                ^^^^^
-   |                |
-   |                expected `i32`, found `i16`
-   |                help: you can convert an `i16` to an `i32`: `x_i16.into()`
+   |                ^^^^^ expected `i32`, found `i16`
+   |
+help: you can convert an `i16` to an `i32`
+   |
+LL |     foo::<i32>(x_i16.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:149:16
    |
 LL |     foo::<i32>(x_i8);
-   |                ^^^^
-   |                |
-   |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to an `i32`: `x_i8.into()`
+   |                ^^^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |     foo::<i32>(x_i8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:154:16
@@ -561,7 +601,7 @@ LL |     foo::<u16>(x_usize);
 help: you can convert a `usize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:156:16
@@ -572,7 +612,7 @@ LL |     foo::<u16>(x_u64);
 help: you can convert a `u64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_u64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:158:16
@@ -583,16 +623,18 @@ LL |     foo::<u16>(x_u32);
 help: you can convert a `u32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_u32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:161:16
    |
 LL |     foo::<u16>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `u16`, found `u8`
-   |                help: you can convert a `u8` to a `u16`: `x_u8.into()`
+   |                ^^^^ expected `u16`, found `u8`
+   |
+help: you can convert a `u8` to a `u16`
+   |
+LL |     foo::<u16>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:163:16
@@ -603,7 +645,7 @@ LL |     foo::<u16>(x_isize);
 help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:165:16
@@ -614,7 +656,7 @@ LL |     foo::<u16>(x_i64);
 help: you can convert an `i64` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:167:16
@@ -625,7 +667,7 @@ LL |     foo::<u16>(x_i32);
 help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:169:16
@@ -636,7 +678,7 @@ LL |     foo::<u16>(x_i16);
 help: you can convert an `i16` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i16.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:171:16
@@ -647,7 +689,7 @@ LL |     foo::<u16>(x_i8);
 help: you can convert an `i8` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     foo::<u16>(x_i8.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:176:16
@@ -658,7 +700,7 @@ LL |     foo::<i16>(x_usize);
 help: you can convert a `usize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_usize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:178:16
@@ -669,7 +711,7 @@ LL |     foo::<i16>(x_u64);
 help: you can convert a `u64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:180:16
@@ -680,7 +722,7 @@ LL |     foo::<i16>(x_u32);
 help: you can convert a `u32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:182:16
@@ -691,16 +733,18 @@ LL |     foo::<i16>(x_u16);
 help: you can convert a `u16` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_u16.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:184:16
    |
 LL |     foo::<i16>(x_u8);
-   |                ^^^^
-   |                |
-   |                expected `i16`, found `u8`
-   |                help: you can convert a `u8` to an `i16`: `x_u8.into()`
+   |                ^^^^ expected `i16`, found `u8`
+   |
+help: you can convert a `u8` to an `i16`
+   |
+LL |     foo::<i16>(x_u8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:186:16
@@ -711,7 +755,7 @@ LL |     foo::<i16>(x_isize);
 help: you can convert an `isize` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_isize.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:188:16
@@ -722,7 +766,7 @@ LL |     foo::<i16>(x_i64);
 help: you can convert an `i64` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_i64.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:190:16
@@ -733,16 +777,18 @@ LL |     foo::<i16>(x_i32);
 help: you can convert an `i32` to an `i16` and panic if the converted value doesn't fit
    |
 LL |     foo::<i16>(x_i32.try_into().unwrap());
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                     ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:193:16
    |
 LL |     foo::<i16>(x_i8);
-   |                ^^^^
-   |                |
-   |                expected `i16`, found `i8`
-   |                help: you can convert an `i8` to an `i16`: `x_i8.into()`
+   |                ^^^^ expected `i16`, found `i8`
+   |
+help: you can convert an `i8` to an `i16`
+   |
+LL |     foo::<i16>(x_i8.into());
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:198:15
@@ -753,7 +799,7 @@ LL |     foo::<u8>(x_usize);
 help: you can convert a `usize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_usize.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:200:15
@@ -764,7 +810,7 @@ LL |     foo::<u8>(x_u64);
 help: you can convert a `u64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u64.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:202:15
@@ -775,7 +821,7 @@ LL |     foo::<u8>(x_u32);
 help: you can convert a `u32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u32.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:204:15
@@ -786,7 +832,7 @@ LL |     foo::<u8>(x_u16);
 help: you can convert a `u16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_u16.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:207:15
@@ -797,7 +843,7 @@ LL |     foo::<u8>(x_isize);
 help: you can convert an `isize` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_isize.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:209:15
@@ -808,7 +854,7 @@ LL |     foo::<u8>(x_i64);
 help: you can convert an `i64` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i64.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:211:15
@@ -819,7 +865,7 @@ LL |     foo::<u8>(x_i32);
 help: you can convert an `i32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i32.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:213:15
@@ -830,7 +876,7 @@ LL |     foo::<u8>(x_i16);
 help: you can convert an `i16` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i16.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:215:15
@@ -841,7 +887,7 @@ LL |     foo::<u8>(x_i8);
 help: you can convert an `i8` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     foo::<u8>(x_i8.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:220:15
@@ -852,7 +898,7 @@ LL |     foo::<i8>(x_usize);
 help: you can convert a `usize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_usize.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:222:15
@@ -863,7 +909,7 @@ LL |     foo::<i8>(x_u64);
 help: you can convert a `u64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u64.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:224:15
@@ -874,7 +920,7 @@ LL |     foo::<i8>(x_u32);
 help: you can convert a `u32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u32.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:226:15
@@ -885,7 +931,7 @@ LL |     foo::<i8>(x_u16);
 help: you can convert a `u16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u16.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:228:15
@@ -896,7 +942,7 @@ LL |     foo::<i8>(x_u8);
 help: you can convert a `u8` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_u8.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:230:15
@@ -907,7 +953,7 @@ LL |     foo::<i8>(x_isize);
 help: you can convert an `isize` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_isize.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                      ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:232:15
@@ -918,7 +964,7 @@ LL |     foo::<i8>(x_i64);
 help: you can convert an `i64` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i64.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:234:15
@@ -929,7 +975,7 @@ LL |     foo::<i8>(x_i32);
 help: you can convert an `i32` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i32.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:236:15
@@ -940,7 +986,7 @@ LL |     foo::<i8>(x_i16);
 help: you can convert an `i16` to an `i8` and panic if the converted value doesn't fit
    |
 LL |     foo::<i8>(x_i16.try_into().unwrap());
-   |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:242:16
@@ -951,7 +997,7 @@ LL |     foo::<f64>(x_usize);
 help: you can cast a `usize` to an `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_usize as f64);
-   |                ~~~~~~~~~~~~~~
+   |                        ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:244:16
@@ -962,7 +1008,7 @@ LL |     foo::<f64>(x_u64);
 help: you can cast a `u64` to an `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_u64 as f64);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:246:16
@@ -973,7 +1019,7 @@ LL |     foo::<f64>(x_u32);
 help: you can convert a `u32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u32.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:248:16
@@ -984,7 +1030,7 @@ LL |     foo::<f64>(x_u16);
 help: you can convert a `u16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u16.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:250:16
@@ -995,7 +1041,7 @@ LL |     foo::<f64>(x_u8);
 help: you can convert a `u8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u8.into());
-   |                ~~~~~~~~~~~
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:252:16
@@ -1006,7 +1052,7 @@ LL |     foo::<f64>(x_isize);
 help: you can convert an `isize` to an `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_isize as f64);
-   |                ~~~~~~~~~~~~~~
+   |                        ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:254:16
@@ -1017,7 +1063,7 @@ LL |     foo::<f64>(x_i64);
 help: you can convert an `i64` to an `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_i64 as f64);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:256:16
@@ -1028,7 +1074,7 @@ LL |     foo::<f64>(x_i32);
 help: you can convert an `i32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i32.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:258:16
@@ -1039,7 +1085,7 @@ LL |     foo::<f64>(x_i16);
 help: you can convert an `i16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i16.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:260:16
@@ -1050,16 +1096,18 @@ LL |     foo::<f64>(x_i8);
 help: you can convert an `i8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i8.into());
-   |                ~~~~~~~~~~~
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:263:16
    |
 LL |     foo::<f64>(x_f32);
-   |                ^^^^^
-   |                |
-   |                expected `f64`, found `f32`
-   |                help: you can convert an `f32` to an `f64`: `x_f32.into()`
+   |                ^^^^^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     foo::<f64>(x_f32.into());
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:266:16
@@ -1070,7 +1118,7 @@ LL |     foo::<f32>(x_usize);
 help: you can cast a `usize` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_usize as f32);
-   |                ~~~~~~~~~~~~~~
+   |                        ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:268:16
@@ -1081,7 +1129,7 @@ LL |     foo::<f32>(x_u64);
 help: you can cast a `u64` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u64 as f32);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:270:16
@@ -1092,7 +1140,7 @@ LL |     foo::<f32>(x_u32);
 help: you can cast a `u32` to an `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u32 as f32);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:272:16
@@ -1103,7 +1151,7 @@ LL |     foo::<f32>(x_u16);
 help: you can convert a `u16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u16.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:274:16
@@ -1114,7 +1162,7 @@ LL |     foo::<f32>(x_u8);
 help: you can convert a `u8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u8.into());
-   |                ~~~~~~~~~~~
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:276:16
@@ -1125,7 +1173,7 @@ LL |     foo::<f32>(x_isize);
 help: you can convert an `isize` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_isize as f32);
-   |                ~~~~~~~~~~~~~~
+   |                        ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:278:16
@@ -1136,7 +1184,7 @@ LL |     foo::<f32>(x_i64);
 help: you can convert an `i64` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i64 as f32);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:280:16
@@ -1147,7 +1195,7 @@ LL |     foo::<f32>(x_i32);
 help: you can convert an `i32` to an `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i32 as f32);
-   |                ~~~~~~~~~~~~
+   |                      ++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:282:16
@@ -1158,7 +1206,7 @@ LL |     foo::<f32>(x_i16);
 help: you can convert an `i16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i16.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:284:16
@@ -1169,25 +1217,29 @@ LL |     foo::<f32>(x_i8);
 help: you can convert an `i8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i8.into());
-   |                ~~~~~~~~~~~
+   |                    +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:289:16
    |
 LL |     foo::<u32>(x_u8 as u16);
-   |                ^^^^^^^^^^^
-   |                |
-   |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to a `u32`: `(x_u8 as u16).into()`
+   |                ^^^^^^^^^^^ expected `u32`, found `u16`
+   |
+help: you can convert a `u16` to a `u32`
+   |
+LL |     foo::<u32>((x_u8 as u16).into());
+   |                +           ++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-cast.rs:291:16
    |
 LL |     foo::<i32>(-x_i8);
-   |                ^^^^^
-   |                |
-   |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to an `i32`: `(-x_i8).into()`
+   |                ^^^^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |     foo::<i32>((-x_i8).into());
+   |                +     ++++++++
 
 error: aborting due to 113 previous errors
 

--- a/src/test/ui/numeric/numeric-suffix.stderr
+++ b/src/test/ui/numeric/numeric-suffix.stderr
@@ -7,7 +7,7 @@ LL |     foo::<usize>(42_u64);
 help: change the type of the numeric literal from `u64` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:9:18
@@ -18,7 +18,7 @@ LL |     foo::<usize>(42_u32);
 help: change the type of the numeric literal from `u32` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:11:18
@@ -29,7 +29,7 @@ LL |     foo::<usize>(42_u16);
 help: change the type of the numeric literal from `u16` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:13:18
@@ -40,7 +40,7 @@ LL |     foo::<usize>(42_u8);
 help: change the type of the numeric literal from `u8` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:15:18
@@ -51,7 +51,7 @@ LL |     foo::<usize>(42_isize);
 help: change the type of the numeric literal from `isize` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:17:18
@@ -62,7 +62,7 @@ LL |     foo::<usize>(42_i64);
 help: change the type of the numeric literal from `i64` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:19:18
@@ -73,7 +73,7 @@ LL |     foo::<usize>(42_i32);
 help: change the type of the numeric literal from `i32` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:21:18
@@ -84,7 +84,7 @@ LL |     foo::<usize>(42_i16);
 help: change the type of the numeric literal from `i16` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:23:18
@@ -95,7 +95,7 @@ LL |     foo::<usize>(42_i8);
 help: change the type of the numeric literal from `i8` to `usize`
    |
 LL |     foo::<usize>(42_usize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:25:18
@@ -106,7 +106,7 @@ LL |     foo::<usize>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `usize`
    |
 LL |     foo::<usize>(42usize);
-   |                  ~~~~~~~
+   |                    ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:27:18
@@ -117,7 +117,7 @@ LL |     foo::<usize>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `usize`
    |
 LL |     foo::<usize>(42usize);
-   |                  ~~~~~~~
+   |                    ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:30:18
@@ -128,7 +128,7 @@ LL |     foo::<isize>(42_usize);
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:32:18
@@ -139,7 +139,7 @@ LL |     foo::<isize>(42_u64);
 help: change the type of the numeric literal from `u64` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:34:18
@@ -150,7 +150,7 @@ LL |     foo::<isize>(42_u32);
 help: change the type of the numeric literal from `u32` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:36:18
@@ -161,7 +161,7 @@ LL |     foo::<isize>(42_u16);
 help: change the type of the numeric literal from `u16` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:38:18
@@ -172,7 +172,7 @@ LL |     foo::<isize>(42_u8);
 help: change the type of the numeric literal from `u8` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:41:18
@@ -183,7 +183,7 @@ LL |     foo::<isize>(42_i64);
 help: change the type of the numeric literal from `i64` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:43:18
@@ -194,7 +194,7 @@ LL |     foo::<isize>(42_i32);
 help: change the type of the numeric literal from `i32` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:45:18
@@ -205,7 +205,7 @@ LL |     foo::<isize>(42_i16);
 help: change the type of the numeric literal from `i16` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:47:18
@@ -216,7 +216,7 @@ LL |     foo::<isize>(42_i8);
 help: change the type of the numeric literal from `i8` to `isize`
    |
 LL |     foo::<isize>(42_isize);
-   |                  ~~~~~~~~
+   |                     ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:49:18
@@ -227,7 +227,7 @@ LL |     foo::<isize>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `isize`
    |
 LL |     foo::<isize>(42isize);
-   |                  ~~~~~~~
+   |                    ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:51:18
@@ -238,7 +238,7 @@ LL |     foo::<isize>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `isize`
    |
 LL |     foo::<isize>(42isize);
-   |                  ~~~~~~~
+   |                    ~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:54:16
@@ -249,7 +249,7 @@ LL |     foo::<u64>(42_usize);
 help: change the type of the numeric literal from `usize` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:57:16
@@ -260,7 +260,7 @@ LL |     foo::<u64>(42_u32);
 help: change the type of the numeric literal from `u32` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:59:16
@@ -271,7 +271,7 @@ LL |     foo::<u64>(42_u16);
 help: change the type of the numeric literal from `u16` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:61:16
@@ -282,7 +282,7 @@ LL |     foo::<u64>(42_u8);
 help: change the type of the numeric literal from `u8` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:63:16
@@ -293,7 +293,7 @@ LL |     foo::<u64>(42_isize);
 help: change the type of the numeric literal from `isize` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:65:16
@@ -304,7 +304,7 @@ LL |     foo::<u64>(42_i64);
 help: change the type of the numeric literal from `i64` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:67:16
@@ -315,7 +315,7 @@ LL |     foo::<u64>(42_i32);
 help: change the type of the numeric literal from `i32` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:69:16
@@ -326,7 +326,7 @@ LL |     foo::<u64>(42_i16);
 help: change the type of the numeric literal from `i16` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:71:16
@@ -337,7 +337,7 @@ LL |     foo::<u64>(42_i8);
 help: change the type of the numeric literal from `i8` to `u64`
    |
 LL |     foo::<u64>(42_u64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:73:16
@@ -348,7 +348,7 @@ LL |     foo::<u64>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `u64`
    |
 LL |     foo::<u64>(42u64);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:75:16
@@ -359,7 +359,7 @@ LL |     foo::<u64>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `u64`
    |
 LL |     foo::<u64>(42u64);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:78:16
@@ -370,7 +370,7 @@ LL |     foo::<i64>(42_usize);
 help: change the type of the numeric literal from `usize` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:80:16
@@ -381,7 +381,7 @@ LL |     foo::<i64>(42_u64);
 help: change the type of the numeric literal from `u64` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:82:16
@@ -392,7 +392,7 @@ LL |     foo::<i64>(42_u32);
 help: change the type of the numeric literal from `u32` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:84:16
@@ -403,7 +403,7 @@ LL |     foo::<i64>(42_u16);
 help: change the type of the numeric literal from `u16` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:86:16
@@ -414,7 +414,7 @@ LL |     foo::<i64>(42_u8);
 help: change the type of the numeric literal from `u8` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:88:16
@@ -425,7 +425,7 @@ LL |     foo::<i64>(42_isize);
 help: change the type of the numeric literal from `isize` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:91:16
@@ -436,7 +436,7 @@ LL |     foo::<i64>(42_i32);
 help: change the type of the numeric literal from `i32` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:93:16
@@ -447,7 +447,7 @@ LL |     foo::<i64>(42_i16);
 help: change the type of the numeric literal from `i16` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:95:16
@@ -458,7 +458,7 @@ LL |     foo::<i64>(42_i8);
 help: change the type of the numeric literal from `i8` to `i64`
    |
 LL |     foo::<i64>(42_i64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:97:16
@@ -469,7 +469,7 @@ LL |     foo::<i64>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `i64`
    |
 LL |     foo::<i64>(42i64);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:99:16
@@ -480,7 +480,7 @@ LL |     foo::<i64>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `i64`
    |
 LL |     foo::<i64>(42i64);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:102:16
@@ -491,7 +491,7 @@ LL |     foo::<u32>(42_usize);
 help: change the type of the numeric literal from `usize` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:104:16
@@ -502,7 +502,7 @@ LL |     foo::<u32>(42_u64);
 help: change the type of the numeric literal from `u64` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:107:16
@@ -513,7 +513,7 @@ LL |     foo::<u32>(42_u16);
 help: change the type of the numeric literal from `u16` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:109:16
@@ -524,7 +524,7 @@ LL |     foo::<u32>(42_u8);
 help: change the type of the numeric literal from `u8` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:111:16
@@ -535,7 +535,7 @@ LL |     foo::<u32>(42_isize);
 help: change the type of the numeric literal from `isize` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:113:16
@@ -546,7 +546,7 @@ LL |     foo::<u32>(42_i64);
 help: change the type of the numeric literal from `i64` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:115:16
@@ -557,7 +557,7 @@ LL |     foo::<u32>(42_i32);
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:117:16
@@ -568,7 +568,7 @@ LL |     foo::<u32>(42_i16);
 help: change the type of the numeric literal from `i16` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:119:16
@@ -579,7 +579,7 @@ LL |     foo::<u32>(42_i8);
 help: change the type of the numeric literal from `i8` to `u32`
    |
 LL |     foo::<u32>(42_u32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:121:16
@@ -590,7 +590,7 @@ LL |     foo::<u32>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `u32`
    |
 LL |     foo::<u32>(42u32);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:123:16
@@ -601,7 +601,7 @@ LL |     foo::<u32>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `u32`
    |
 LL |     foo::<u32>(42u32);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:126:16
@@ -612,7 +612,7 @@ LL |     foo::<i32>(42_usize);
 help: change the type of the numeric literal from `usize` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:128:16
@@ -623,7 +623,7 @@ LL |     foo::<i32>(42_u64);
 help: change the type of the numeric literal from `u64` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:130:16
@@ -634,7 +634,7 @@ LL |     foo::<i32>(42_u32);
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:132:16
@@ -645,7 +645,7 @@ LL |     foo::<i32>(42_u16);
 help: change the type of the numeric literal from `u16` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:134:16
@@ -656,7 +656,7 @@ LL |     foo::<i32>(42_u8);
 help: change the type of the numeric literal from `u8` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:136:16
@@ -667,7 +667,7 @@ LL |     foo::<i32>(42_isize);
 help: change the type of the numeric literal from `isize` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:138:16
@@ -678,7 +678,7 @@ LL |     foo::<i32>(42_i64);
 help: change the type of the numeric literal from `i64` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:141:16
@@ -689,7 +689,7 @@ LL |     foo::<i32>(42_i16);
 help: change the type of the numeric literal from `i16` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:143:16
@@ -700,7 +700,7 @@ LL |     foo::<i32>(42_i8);
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL |     foo::<i32>(42_i32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:145:16
@@ -711,7 +711,7 @@ LL |     foo::<i32>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `i32`
    |
 LL |     foo::<i32>(42i32);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:147:16
@@ -722,7 +722,7 @@ LL |     foo::<i32>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `i32`
    |
 LL |     foo::<i32>(42i32);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:150:16
@@ -733,7 +733,7 @@ LL |     foo::<u16>(42_usize);
 help: change the type of the numeric literal from `usize` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:152:16
@@ -744,7 +744,7 @@ LL |     foo::<u16>(42_u64);
 help: change the type of the numeric literal from `u64` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:154:16
@@ -755,7 +755,7 @@ LL |     foo::<u16>(42_u32);
 help: change the type of the numeric literal from `u32` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:157:16
@@ -766,7 +766,7 @@ LL |     foo::<u16>(42_u8);
 help: change the type of the numeric literal from `u8` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:159:16
@@ -777,7 +777,7 @@ LL |     foo::<u16>(42_isize);
 help: change the type of the numeric literal from `isize` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:161:16
@@ -788,7 +788,7 @@ LL |     foo::<u16>(42_i64);
 help: change the type of the numeric literal from `i64` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:163:16
@@ -799,7 +799,7 @@ LL |     foo::<u16>(42_i32);
 help: change the type of the numeric literal from `i32` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:165:16
@@ -810,7 +810,7 @@ LL |     foo::<u16>(42_i16);
 help: change the type of the numeric literal from `i16` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:167:16
@@ -821,7 +821,7 @@ LL |     foo::<u16>(42_i8);
 help: change the type of the numeric literal from `i8` to `u16`
    |
 LL |     foo::<u16>(42_u16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:169:16
@@ -832,7 +832,7 @@ LL |     foo::<u16>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `u16`
    |
 LL |     foo::<u16>(42u16);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:171:16
@@ -843,7 +843,7 @@ LL |     foo::<u16>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `u16`
    |
 LL |     foo::<u16>(42u16);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:174:16
@@ -854,7 +854,7 @@ LL |     foo::<i16>(42_usize);
 help: change the type of the numeric literal from `usize` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:176:16
@@ -865,7 +865,7 @@ LL |     foo::<i16>(42_u64);
 help: change the type of the numeric literal from `u64` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:178:16
@@ -876,7 +876,7 @@ LL |     foo::<i16>(42_u32);
 help: change the type of the numeric literal from `u32` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:180:16
@@ -887,7 +887,7 @@ LL |     foo::<i16>(42_u16);
 help: change the type of the numeric literal from `u16` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:182:16
@@ -898,7 +898,7 @@ LL |     foo::<i16>(42_u8);
 help: change the type of the numeric literal from `u8` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:184:16
@@ -909,7 +909,7 @@ LL |     foo::<i16>(42_isize);
 help: change the type of the numeric literal from `isize` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:186:16
@@ -920,7 +920,7 @@ LL |     foo::<i16>(42_i64);
 help: change the type of the numeric literal from `i64` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:188:16
@@ -931,7 +931,7 @@ LL |     foo::<i16>(42_i32);
 help: change the type of the numeric literal from `i32` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:191:16
@@ -942,7 +942,7 @@ LL |     foo::<i16>(42_i8);
 help: change the type of the numeric literal from `i8` to `i16`
    |
 LL |     foo::<i16>(42_i16);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:193:16
@@ -953,7 +953,7 @@ LL |     foo::<i16>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `i16`
    |
 LL |     foo::<i16>(42i16);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:195:16
@@ -964,7 +964,7 @@ LL |     foo::<i16>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `i16`
    |
 LL |     foo::<i16>(42i16);
-   |                ~~~~~
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:198:15
@@ -975,7 +975,7 @@ LL |     foo::<u8>(42_usize);
 help: change the type of the numeric literal from `usize` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:200:15
@@ -986,7 +986,7 @@ LL |     foo::<u8>(42_u64);
 help: change the type of the numeric literal from `u64` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:202:15
@@ -997,7 +997,7 @@ LL |     foo::<u8>(42_u32);
 help: change the type of the numeric literal from `u32` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:204:15
@@ -1008,7 +1008,7 @@ LL |     foo::<u8>(42_u16);
 help: change the type of the numeric literal from `u16` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:207:15
@@ -1019,7 +1019,7 @@ LL |     foo::<u8>(42_isize);
 help: change the type of the numeric literal from `isize` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:209:15
@@ -1030,7 +1030,7 @@ LL |     foo::<u8>(42_i64);
 help: change the type of the numeric literal from `i64` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:211:15
@@ -1041,7 +1041,7 @@ LL |     foo::<u8>(42_i32);
 help: change the type of the numeric literal from `i32` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:213:15
@@ -1052,7 +1052,7 @@ LL |     foo::<u8>(42_i16);
 help: change the type of the numeric literal from `i16` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:215:15
@@ -1063,7 +1063,7 @@ LL |     foo::<u8>(42_i8);
 help: change the type of the numeric literal from `i8` to `u8`
    |
 LL |     foo::<u8>(42_u8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:217:15
@@ -1074,7 +1074,7 @@ LL |     foo::<u8>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `u8`
    |
 LL |     foo::<u8>(42u8);
-   |               ~~~~
+   |                 ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:219:15
@@ -1085,7 +1085,7 @@ LL |     foo::<u8>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `u8`
    |
 LL |     foo::<u8>(42u8);
-   |               ~~~~
+   |                 ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:222:15
@@ -1096,7 +1096,7 @@ LL |     foo::<i8>(42_usize);
 help: change the type of the numeric literal from `usize` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:224:15
@@ -1107,7 +1107,7 @@ LL |     foo::<i8>(42_u64);
 help: change the type of the numeric literal from `u64` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:226:15
@@ -1118,7 +1118,7 @@ LL |     foo::<i8>(42_u32);
 help: change the type of the numeric literal from `u32` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:228:15
@@ -1129,7 +1129,7 @@ LL |     foo::<i8>(42_u16);
 help: change the type of the numeric literal from `u16` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:230:15
@@ -1140,7 +1140,7 @@ LL |     foo::<i8>(42_u8);
 help: change the type of the numeric literal from `u8` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:232:15
@@ -1151,7 +1151,7 @@ LL |     foo::<i8>(42_isize);
 help: change the type of the numeric literal from `isize` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:234:15
@@ -1162,7 +1162,7 @@ LL |     foo::<i8>(42_i64);
 help: change the type of the numeric literal from `i64` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:236:15
@@ -1173,7 +1173,7 @@ LL |     foo::<i8>(42_i32);
 help: change the type of the numeric literal from `i32` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:238:15
@@ -1184,7 +1184,7 @@ LL |     foo::<i8>(42_i16);
 help: change the type of the numeric literal from `i16` to `i8`
    |
 LL |     foo::<i8>(42_i8);
-   |               ~~~~~
+   |                  ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:241:15
@@ -1195,7 +1195,7 @@ LL |     foo::<i8>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `i8`
    |
 LL |     foo::<i8>(42i8);
-   |               ~~~~
+   |                 ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:243:15
@@ -1206,7 +1206,7 @@ LL |     foo::<i8>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `i8`
    |
 LL |     foo::<i8>(42i8);
-   |               ~~~~
+   |                 ~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:246:16
@@ -1217,7 +1217,7 @@ LL |     foo::<f64>(42_usize);
 help: change the type of the numeric literal from `usize` to `f64`
    |
 LL |     foo::<f64>(42_f64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:248:16
@@ -1228,7 +1228,7 @@ LL |     foo::<f64>(42_u64);
 help: change the type of the numeric literal from `u64` to `f64`
    |
 LL |     foo::<f64>(42_f64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:250:16
@@ -1239,7 +1239,7 @@ LL |     foo::<f64>(42_u32);
 help: you can convert a `u32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u32.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:252:16
@@ -1250,7 +1250,7 @@ LL |     foo::<f64>(42_u16);
 help: you can convert a `u16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u16.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:254:16
@@ -1261,7 +1261,7 @@ LL |     foo::<f64>(42_u8);
 help: you can convert a `u8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u8.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:256:16
@@ -1272,7 +1272,7 @@ LL |     foo::<f64>(42_isize);
 help: change the type of the numeric literal from `isize` to `f64`
    |
 LL |     foo::<f64>(42_f64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:258:16
@@ -1283,7 +1283,7 @@ LL |     foo::<f64>(42_i64);
 help: change the type of the numeric literal from `i64` to `f64`
    |
 LL |     foo::<f64>(42_f64);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:260:16
@@ -1294,7 +1294,7 @@ LL |     foo::<f64>(42_i32);
 help: you can convert an `i32` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i32.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:262:16
@@ -1305,7 +1305,7 @@ LL |     foo::<f64>(42_i16);
 help: you can convert an `i16` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i16.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:264:16
@@ -1316,7 +1316,7 @@ LL |     foo::<f64>(42_i8);
 help: you can convert an `i8` to an `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i8.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:267:16
@@ -1327,7 +1327,7 @@ LL |     foo::<f64>(42.0_f32);
 help: change the type of the numeric literal from `f32` to `f64`
    |
 LL |     foo::<f64>(42.0_f64);
-   |                ~~~~~~~~
+   |                     ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:270:16
@@ -1338,7 +1338,7 @@ LL |     foo::<f32>(42_usize);
 help: change the type of the numeric literal from `usize` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:272:16
@@ -1349,7 +1349,7 @@ LL |     foo::<f32>(42_u64);
 help: change the type of the numeric literal from `u64` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:274:16
@@ -1360,7 +1360,7 @@ LL |     foo::<f32>(42_u32);
 help: change the type of the numeric literal from `u32` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:276:16
@@ -1371,7 +1371,7 @@ LL |     foo::<f32>(42_u16);
 help: you can convert a `u16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u16.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:278:16
@@ -1382,7 +1382,7 @@ LL |     foo::<f32>(42_u8);
 help: you can convert a `u8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u8.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:280:16
@@ -1393,7 +1393,7 @@ LL |     foo::<f32>(42_isize);
 help: change the type of the numeric literal from `isize` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:282:16
@@ -1404,7 +1404,7 @@ LL |     foo::<f32>(42_i64);
 help: change the type of the numeric literal from `i64` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:284:16
@@ -1415,7 +1415,7 @@ LL |     foo::<f32>(42_i32);
 help: change the type of the numeric literal from `i32` to `f32`
    |
 LL |     foo::<f32>(42_f32);
-   |                ~~~~~~
+   |                   ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:286:16
@@ -1426,7 +1426,7 @@ LL |     foo::<f32>(42_i16);
 help: you can convert an `i16` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i16.into());
-   |                ~~~~~~~~~~~~~
+   |                      +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:288:16
@@ -1437,7 +1437,7 @@ LL |     foo::<f32>(42_i8);
 help: you can convert an `i8` to an `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i8.into());
-   |                ~~~~~~~~~~~~
+   |                     +++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:290:16
@@ -1448,25 +1448,29 @@ LL |     foo::<f32>(42.0_f64);
 help: change the type of the numeric literal from `f64` to `f32`
    |
 LL |     foo::<f32>(42.0_f32);
-   |                ~~~~~~~~
+   |                     ~~~
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:294:16
    |
 LL |     foo::<u32>(42_u8 as u16);
-   |                ^^^^^^^^^^^^
-   |                |
-   |                expected `u32`, found `u16`
-   |                help: you can convert a `u16` to a `u32`: `(42_u8 as u16).into()`
+   |                ^^^^^^^^^^^^ expected `u32`, found `u16`
+   |
+help: you can convert a `u16` to a `u32`
+   |
+LL |     foo::<u32>((42_u8 as u16).into());
+   |                +            ++++++++
 
 error[E0308]: mismatched types
   --> $DIR/numeric-suffix.rs:296:16
    |
 LL |     foo::<i32>(-42_i8);
-   |                ^^^^^^
-   |                |
-   |                expected `i32`, found `i8`
-   |                help: you can convert an `i8` to an `i32`: `(-42_i8).into()`
+   |                ^^^^^^ expected `i32`, found `i8`
+   |
+help: you can convert an `i8` to an `i32`
+   |
+LL |     foo::<i32>((-42_i8).into());
+   |                +      ++++++++
 
 error: aborting due to 134 previous errors
 

--- a/src/test/ui/parser/inverted-parameters.stderr
+++ b/src/test/ui/parser/inverted-parameters.stderr
@@ -38,15 +38,15 @@ LL | fn fizz(i32) {}
 help: if this is a `self` type, give it a parameter name
    |
 LL | fn fizz(self: i32) {}
-   |         ~~~~~~~~~
+   |         +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn fizz(i32: TypeName) {}
-   |         ~~~~~~~~~~~~~
+   |            ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn fizz(_: i32) {}
-   |         ~~~~~~
+   |         ++
 
 error: expected one of `:`, `@`, or `|`, found `S`
   --> $DIR/inverted-parameters.rs:27:23

--- a/src/test/ui/parser/lifetime-in-pattern.stderr
+++ b/src/test/ui/parser/lifetime-in-pattern.stderr
@@ -13,16 +13,16 @@ LL | fn test(&'a str) {
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 help: if this is a `self` type, give it a parameter name
    |
-LL | fn test(self: &str) {
-   |         ~~~~~~~~~~
+LL | fn test(self: &'a str) {
+   |         +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn test(str: &TypeName) {
    |         ~~~~~~~~~~~~~~
 help: if this is a type, explicitly ignore the parameter name
    |
-LL | fn test(_: &str) {
-   |         ~~~~~~~
+LL | fn test(_: &'a str) {
+   |         ++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/omitted-arg-in-item-fn.stderr
+++ b/src/test/ui/parser/omitted-arg-in-item-fn.stderr
@@ -8,15 +8,15 @@ LL | fn foo(x) {
 help: if this is a `self` type, give it a parameter name
    |
 LL | fn foo(self: x) {
-   |        ~~~~~~~
+   |        +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn foo(x: TypeName) {
-   |        ~~~~~~~~~~~
+   |         ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn foo(_: x) {
-   |        ~~~~
+   |        ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/pat-lt-bracket-2.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-2.stderr
@@ -8,11 +8,11 @@ LL | fn a(B<) {}
 help: if this is a `self` type, give it a parameter name
    |
 LL | fn a(self: B<) {}
-   |      ~~~~~~~
+   |      +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn a(_: B<) {}
-   |      ~~~~
+   |      ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/pptypedef.stderr
+++ b/src/test/ui/pptypedef.stderr
@@ -7,7 +7,7 @@ LL |     let_in(3u32, |i| { assert!(i == 3i32); });
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     let_in(3u32, |i| { assert!(i == 3u32); });
-   |                                     ~~~~
+   |                                      ~~~
 
 error[E0308]: mismatched types
   --> $DIR/pptypedef.rs:8:37
@@ -18,7 +18,7 @@ LL |     let_in(3i32, |i| { assert!(i == 3u32); });
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     let_in(3i32, |i| { assert!(i == 3i32); });
-   |                                     ~~~~
+   |                                      ~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -18,7 +18,7 @@ LL |         Some(x) => { return x },
 help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL |         Some(x) => { return x.try_into().unwrap() },
-   |                             ~~~~~~~~~~~~~~~~~~~~~
+   |                              ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:33:22

--- a/src/test/ui/repeat_count.stderr
+++ b/src/test/ui/repeat_count.stderr
@@ -61,7 +61,7 @@ LL |     let f = [0; 4u8];
 help: change the type of the numeric literal from `u8` to `usize`
    |
 LL |     let f = [0; 4usize];
-   |                 ~~~~~~
+   |                  ~~~~~
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
@@ -8,15 +8,15 @@ LL | trait Trait2015 { fn foo(#[allow(C)] i32); }
 help: if this is a `self` type, give it a parameter name
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] self: i32); }
-   |                                      ~~~~~~~~~
+   |                                      +++++
 help: if this is a parameter name, give it a type
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] i32: TypeName); }
-   |                                      ~~~~~~~~~~~~~
+   |                                         ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] _: i32); }
-   |                                      ~~~~~~
+   |                                      ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/shift-various-bad-types.stderr
+++ b/src/test/ui/shift-various-bad-types.stderr
@@ -33,7 +33,7 @@ LL |     let _: i32 = 22_i64 >> 1_i32;
 help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
 LL |     let _: i32 = (22_i64 >> 1_i32).try_into().unwrap();
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  +               +++++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -8,11 +8,11 @@ LL | fn foo(Option<i32>, String) {}
 help: if this is a `self` type, give it a parameter name
    |
 LL | fn foo(self: Option<i32>, String) {}
-   |        ~~~~~~~~~~~~
+   |        +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn foo(_: Option<i32>, String) {}
-   |        ~~~~~~~~~
+   |        ++
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/issue-34264.rs:1:27
@@ -24,11 +24,11 @@ LL | fn foo(Option<i32>, String) {}
 help: if this is a parameter name, give it a type
    |
 LL | fn foo(Option<i32>, String: TypeName) {}
-   |                     ~~~~~~~~~~~~~~~~
+   |                           ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn foo(Option<i32>, _: String) {}
-   |                     ~~~~~~~~~
+   |                     ++
 
 error: expected one of `:`, `@`, or `|`, found `,`
   --> $DIR/issue-34264.rs:3:9
@@ -40,15 +40,15 @@ LL | fn bar(x, y: usize) {}
 help: if this is a `self` type, give it a parameter name
    |
 LL | fn bar(self: x, y: usize) {}
-   |        ~~~~~~~
+   |        +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn bar(x: TypeName, y: usize) {}
-   |        ~~~~~~~~~~~
+   |         ++++++++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn bar(_: x, y: usize) {}
-   |        ~~~~
+   |        ++
 
 error[E0061]: this function takes 2 arguments but 3 arguments were supplied
   --> $DIR/issue-34264.rs:7:5

--- a/src/test/ui/suggestions/issue-64252-self-type.stderr
+++ b/src/test/ui/suggestions/issue-64252-self-type.stderr
@@ -8,11 +8,11 @@ LL | pub fn foo(Box<Self>) { }
 help: if this is a `self` type, give it a parameter name
    |
 LL | pub fn foo(self: Box<Self>) { }
-   |            ~~~~~~~~~
+   |            +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | pub fn foo(_: Box<Self>) { }
-   |            ~~~~~~
+   |            ++
 
 error: expected one of `:`, `@`, or `|`, found `<`
   --> $DIR/issue-64252-self-type.rs:10:15
@@ -24,11 +24,11 @@ LL |     fn bar(Box<Self>) { }
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn bar(self: Box<Self>) { }
-   |            ~~~~~~~~~
+   |            +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL |     fn bar(_: Box<Self>) { }
-   |            ~~~~~~
+   |            ++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
@@ -2,19 +2,23 @@ error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:19
    |
 LL |     let _ = RGB { r, g, c };
-   |                   ^
-   |                   |
-   |                   expected `f64`, found `f32`
-   |                   help: you can convert an `f32` to an `f64`: `r: r.into()`
+   |                   ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r: r.into(), g, c };
+   |                   ++  +++++++
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:22
    |
 LL |     let _ = RGB { r, g, c };
-   |                      ^
-   |                      |
-   |                      expected `f64`, found `f32`
-   |                      help: you can convert an `f32` to an `f64`: `g: g.into()`
+   |                      ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r, g: g.into(), c };
+   |                      ++  +++++++
 
 error[E0560]: struct `RGB` has no field named `c`
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:25

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand.stderr
@@ -2,28 +2,34 @@ error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand.rs:8:19
    |
 LL |     let _ = RGB { r, g, b };
-   |                   ^
-   |                   |
-   |                   expected `f64`, found `f32`
-   |                   help: you can convert an `f32` to an `f64`: `r: r.into()`
+   |                   ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r: r.into(), g, b };
+   |                   ++  +++++++
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand.rs:8:22
    |
 LL |     let _ = RGB { r, g, b };
-   |                      ^
-   |                      |
-   |                      expected `f64`, found `f32`
-   |                      help: you can convert an `f32` to an `f64`: `g: g.into()`
+   |                      ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r, g: g.into(), b };
+   |                      ++  +++++++
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-struct-field-shorthand.rs:8:25
    |
 LL |     let _ = RGB { r, g, b };
-   |                         ^
-   |                         |
-   |                         expected `f64`, found `f32`
-   |                         help: you can convert an `f32` to an `f64`: `b: b.into()`
+   |                         ^ expected `f64`, found `f32`
+   |
+help: you can convert an `f32` to an `f64`
+   |
+LL |     let _ = RGB { r, g, b: b.into() };
+   |                         ++  +++++++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/tail-typeck.stderr
+++ b/src/test/ui/tail-typeck.stderr
@@ -9,7 +9,7 @@ LL | fn f() -> isize { return g(); }
 help: you can convert a `usize` to an `isize` and panic if the converted value doesn't fit
    |
 LL | fn f() -> isize { return g().try_into().unwrap(); }
-   |                          ~~~~~~~~~~~~~~~~~~~~~~~
+   |                             ++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/multidispatch-bad.stderr
+++ b/src/test/ui/traits/multidispatch-bad.stderr
@@ -7,7 +7,7 @@ LL |     test(22i32, 44i32);
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     test(22i32, 44u32);
-   |                 ~~~~~
+   |                   ~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
@@ -10,7 +10,7 @@ LL |     B::get_x()
 help: you can convert an `i32` to a `u8` and panic if the converted value doesn't fit
    |
 LL |     B::get_x().try_into().unwrap()
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |               ++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/tutorial-suffix-inference-test.stderr
+++ b/src/test/ui/tutorial-suffix-inference-test.stderr
@@ -2,10 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/tutorial-suffix-inference-test.rs:9:18
    |
 LL |     identity_u16(x);
-   |                  ^
-   |                  |
-   |                  expected `u16`, found `u8`
-   |                  help: you can convert a `u8` to a `u16`: `x.into()`
+   |                  ^ expected `u16`, found `u8`
+   |
+help: you can convert a `u8` to a `u16`
+   |
+LL |     identity_u16(x.into());
+   |                   +++++++
 
 error[E0308]: mismatched types
   --> $DIR/tutorial-suffix-inference-test.rs:12:18
@@ -16,7 +18,7 @@ LL |     identity_u16(y);
 help: you can convert an `i32` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     identity_u16(y.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/tutorial-suffix-inference-test.rs:21:18
@@ -27,7 +29,7 @@ LL |     identity_u16(a);
 help: you can convert an `isize` to a `u16` and panic if the converted value doesn't fit
    |
 LL |     identity_u16(a.try_into().unwrap());
-   |                  ~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/typeof/type_mismatch.stderr
+++ b/src/test/ui/typeof/type_mismatch.stderr
@@ -15,7 +15,7 @@ LL |     let b: typeof(a) = 1i8;
 help: change the type of the numeric literal from `i8` to `u8`
    |
 LL |     let b: typeof(a) = 1u8;
-   |                        ~~~
+   |                         ~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -20,7 +20,7 @@ LL |     <i32 as Add<i32>>::add(1u32, 2);
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     <i32 as Add<i32>>::add(1i32, 2);
-   |                            ~~~~
+   |                             ~~~
 
 error[E0308]: mismatched types
   --> $DIR/ufcs-qpath-self-mismatch.rs:8:31
@@ -31,7 +31,7 @@ LL |     <i32 as Add<i32>>::add(1, 2u32);
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     <i32 as Add<i32>>::add(1, 2i32);
-   |                               ~~~~
+   |                                ~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -7,7 +7,7 @@ LL |     let z = f(1_usize, 2);
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     let z = f(1_isize, 2);
-   |               ~~~~~~~
+   |                 ~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/wrong-ret-type.stderr
+++ b/src/test/ui/wrong-ret-type.stderr
@@ -9,7 +9,7 @@ LL | fn mk_int() -> usize { let i: isize = 3; return i; }
 help: you can convert an `isize` to a `usize` and panic if the converted value doesn't fit
    |
 LL | fn mk_int() -> usize { let i: isize = 3; return i.try_into().unwrap(); }
-   |                                                 ~~~~~~~~~~~~~~~~~~~~~
+   |                                                  ++++++++++++++++++++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Use more accurate suggestion spans for

* argument parse error
* fully qualified path
* missing code block type
* numeric casts