### PR TITLE
Don't mark `if_let_guard` as an incomplete feature

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -555,7 +555,7 @@ declare_features! (
     (incomplete, lazy_normalization_consts, "1.46.0", Some(72219), None),
 
     /// Allows `if let` guard in match arms.
-    (incomplete, if_let_guard, "1.47.0", Some(51114), None),
+    (active, if_let_guard, "1.47.0", Some(51114), None),
 
     /// Allows non-trivial generic constants which have to be manually propagated upwards.
     (incomplete, const_evaluatable_checked, "1.48.0", Some(76560), None),

--- a/src/test/ui/generator/yielding-in-match-guards.rs
+++ b/src/test/ui/generator/yielding-in-match-guards.rs
@@ -11,7 +11,6 @@
 // of the underlying generator.
 
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 async fn f() -> u8 { 1 }
 async fn foo() -> [bool; 10] { [false; 10] }

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.rs
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.rs
@@ -1,5 +1,4 @@
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 #![deny(irrefutable_let_patterns)]
 

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
@@ -1,11 +1,11 @@
 error: irrefutable `if let` pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:7:8
+  --> $DIR/deny-irrefutable-let-patterns.rs:6:8
    |
 LL |     if let _ = 5 {}
    |        ^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/deny-irrefutable-let-patterns.rs:4:9
+  --> $DIR/deny-irrefutable-let-patterns.rs:3:9
    |
 LL | #![deny(irrefutable_let_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #![deny(irrefutable_let_patterns)]
    = help: consider replacing the `if let` with a `let`
 
 error: irrefutable `while let` pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:9:11
+  --> $DIR/deny-irrefutable-let-patterns.rs:8:11
    |
 LL |     while let _ = 5 {
    |           ^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     while let _ = 5 {
    = help: consider instead using a `loop { ... }` with a `let` inside it
 
 error: irrefutable `if let` guard pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:14:18
+  --> $DIR/deny-irrefutable-let-patterns.rs:13:18
    |
 LL |         _ if let _ = 2 => {}
    |                  ^

--- a/src/test/ui/rfc-2294-if-let-guard/bindings.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/bindings.rs
@@ -1,5 +1,4 @@
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 fn main() {
     match Some(None) {

--- a/src/test/ui/rfc-2294-if-let-guard/bindings.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/bindings.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find value `y` in this scope
-  --> $DIR/bindings.rs:7:14
+  --> $DIR/bindings.rs:6:14
    |
 LL |         _ => y,
    |              ^ not found in this scope
 
 error[E0425]: cannot find value `y` in this scope
-  --> $DIR/bindings.rs:9:5
+  --> $DIR/bindings.rs:8:5
    |
 LL |     y
    |     ^ not found in this scope

--- a/src/test/ui/rfc-2294-if-let-guard/run-pass.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/run-pass.rs
@@ -1,7 +1,6 @@
 // run-pass
 
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 enum Foo {
     Bar,

--- a/src/test/ui/rfc-2294-if-let-guard/typeck.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/typeck.rs
@@ -1,5 +1,4 @@
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 fn ok() -> Result<Option<bool>, ()> {
     Ok(Some(true))

--- a/src/test/ui/rfc-2294-if-let-guard/typeck.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/typeck.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/typeck.rs:10:22
+  --> $DIR/typeck.rs:9:22
    |
 LL |         Ok(x) if let Err(_) = x => {},
    |                      ^^^^^^ expected enum `Option`, found enum `Result`
@@ -8,7 +8,7 @@ LL |         Ok(x) if let Err(_) = x => {},
               found enum `Result<_, _>`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck.rs:12:22
+  --> $DIR/typeck.rs:11:22
    |
 LL |         Ok(x) if let 0 = x => {},
    |                      ^ expected enum `Option`, found integer

--- a/src/test/ui/rfc-2294-if-let-guard/warns.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.rs
@@ -1,5 +1,4 @@
 #![feature(if_let_guard)]
-#![allow(incomplete_features)]
 
 #[deny(irrefutable_let_patterns)]
 fn irrefutable_let_guard() {

--- a/src/test/ui/rfc-2294-if-let-guard/warns.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.stderr
@@ -1,11 +1,11 @@
 error: irrefutable `if let` guard pattern
-  --> $DIR/warns.rs:7:24
+  --> $DIR/warns.rs:6:24
    |
 LL |         Some(x) if let () = x => {}
    |                        ^^
    |
 note: the lint level is defined here
-  --> $DIR/warns.rs:4:8
+  --> $DIR/warns.rs:3:8
    |
 LL | #[deny(irrefutable_let_patterns)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,13 +13,13 @@ LL | #[deny(irrefutable_let_patterns)]
    = help: consider removing the guard and adding a `let` inside the match arm
 
 error: unreachable pattern
-  --> $DIR/warns.rs:16:25
+  --> $DIR/warns.rs:15:25
    |
 LL |         x if let None | None = x => {}
    |                         ^^^^
    |
 note: the lint level is defined here
-  --> $DIR/warns.rs:13:8
+  --> $DIR/warns.rs:12:8
    |
 LL | #[deny(unreachable_patterns)]
    |        ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I don't think there is any reason for `if_let_guard` to be an incomplete feature, and I think the reason they were marked in the first place was simply because they weren't implemented at all.

r? @pnkfelix
cc tracking issue #51114