### PR TITLE
add Cell::as_array_of_cells, similar to Cell::as_slice_of_cells

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -576,6 +576,26 @@ impl<T> Cell<[T]> {
     }
 }
 
+impl<T, const N: usize> Cell<[T; N]> {
+    /// Returns a `&[Cell<T>; N]` from a `&Cell<[T; N]>`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(as_array_of_cells)]
+    /// use std::cell::Cell;
+    ///
+    /// let mut array: [i32; 3] = [1, 2, 3];
+    /// let cell_array: &Cell<[i32; 3]> = Cell::from_mut(&mut array);
+    /// let array_cell: &[Cell<i32>; 3] = cell_array.as_array_of_cells();
+    /// ```
+    #[unstable(feature = "as_array_of_cells", issue = "88248")]
+    pub fn as_array_of_cells(&self) -> &[Cell<T>; N] {
+        // SAFETY: `Cell<T>` has the same memory layout as `T`.
+        unsafe { &*(self as *const Cell<[T; N]> as *const [Cell<T>; N]) }
+    }
+}
+
 /// A mutable memory location with dynamically checked borrow rules
 ///
 /// See the [module-level documentation](self) for more.

--- a/src/test/ui/rfcs/rfc-1789-as-cell/from-mut.rs
+++ b/src/test/ui/rfcs/rfc-1789-as-cell/from-mut.rs
@@ -1,5 +1,7 @@
 // run-pass
 
+#![feature(as_array_of_cells)]
+
 use std::cell::Cell;
 
 fn main() {
@@ -8,4 +10,11 @@ fn main() {
     let slice_cell: &[Cell<i32>] = cell_slice.as_slice_of_cells();
 
     assert_eq!(slice_cell.len(), 3);
+
+    let mut array: [i32; 3] = [1, 2, 3];
+    let cell_array: &Cell<[i32; 3]> = Cell::from_mut(&mut array);
+    let array_cell: &[Cell<i32>; 3] = cell_array.as_array_of_cells();
+
+    array_cell[0].set(99);
+    assert_eq!(array, [99, 2, 3]);
 }


### PR DESCRIPTION
I'd like to propose adding `Cell::as_array_of_cells`, as a natural analog to `Cell::as_slice_of_cells`. I don't have a specific use case in mind, other than that supporting slices but not arrays feels like a gap. Do other folks agree with that intuition? Would this addition be substantial enough to need an RFC?

---

Previously, converting `&mut [T; N]` to `&[Cell<T>; N]` looks like this:

```rust
let array = &mut [1, 2, 3];
let cells: &[Cell<i32>; 3] = Cell::from_mut(&mut array[..])
    .as_slice_of_cells()
    .try_into()
    .unwrap();
```

With this new helper method, it looks like this:

```rust
let array = &mut [1, 2, 3];
let cells = Cell::from_mut(array).as_array_of_cells();
```