### PR TITLE
Improve formatting of closure capture migration suggestion for multi-line closures.

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -55,7 +55,8 @@ impl Clone for U {
 
 fn test_clone_trait() {
     let f = U(S(String::from("Hello World")), T(0));
-    let c = || { let _ = &f; 
+    let c = || {
+        let _ = &f;
         //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f.1` does not implement `Clone`
         //~| NOTE: for more information, see

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -58,12 +58,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
-LL ~     let c = || { let _ = &f; 
+LL ~     let c = || {
+LL +         let _ = &f;
 LL +
 LL +
 LL +
 LL +
-LL +         let f_1 = f.1;
  ...
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -12,7 +12,8 @@ fn test1_all_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || { let _ = (&t, &t1, &t2); 
+    let c = || {
+        let _ = (&t, &t1, &t2);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
@@ -38,7 +39,8 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || { let _ = (&t, &t1); 
+    let c = || {
+        let _ = (&t, &t1);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
@@ -59,7 +61,8 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -80,7 +83,8 @@ fn test4_only_non_copy_types_need_migration() {
     // `t1` is Copy because all of its elements are Copy
     let t1 = (0i32, 0i32);
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -101,7 +105,8 @@ fn test5_only_drop_types_need_migration() {
     // `s` doesn't implement Drop or any elements within it, and doesn't need migration
     let s = S(0i32, 0i32);
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -119,7 +124,8 @@ fn test5_only_drop_types_need_migration() {
 fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = move || { let _ = (&t1, &t); 
+    let c = move || {
+        let _ = (&t1, &t);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
@@ -139,7 +145,8 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -28,12 +28,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
-LL ~     let c = || { let _ = (&t, &t1, &t2); 
+LL ~     let c = || {
+LL +         let _ = (&t, &t1, &t2);
 LL +
 LL +
 LL +
 LL + 
-LL +         let _t = t.0;
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -57,12 +57,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
-LL ~     let c = || { let _ = (&t, &t1); 
+LL ~     let c = || {
+LL +         let _ = (&t, &t1);
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -80,12 +80,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -103,12 +103,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -126,12 +126,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -154,12 +154,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
-LL ~     let c = move || { let _ = (&t1, &t); 
+LL ~     let c = move || {
+LL +         let _ = (&t1, &t);
 LL +
 LL +
 LL +
 LL +         println!("{} {}", t1.1, t.1);
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -177,12 +177,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -34,7 +34,8 @@ impl<T> Drop for GenericStruct<T> {
 fn significant_drop_needs_migration() {
     let t = (SigDrop {}, SigDrop {});
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -54,7 +55,8 @@ fn generic_struct_with_significant_drop_needs_migration() {
     let t = Wrapper(GenericStruct(SigDrop {}, SigDrop {}), 5);
 
     // move is used to force i32 to be copied instead of being a ref
-    let c = move || { let _ = &t; 
+    let c = move || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -18,12 +18,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -41,12 +41,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = move || { let _ = &t; 
+LL ~     let c = move || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.1;
-LL +
  ...
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -16,7 +16,8 @@ impl Drop for Foo {
 
 fn closure_contains_block() {
     let t = (Foo(0), Foo(0));
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -18,12 +18,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -17,7 +17,8 @@ where
     F: FnOnce(),
 {
     let f = panic::AssertUnwindSafe(f);
-    let result = panic::catch_unwind(move || { let _ = &f; 
+    let result = panic::catch_unwind(move || {
+        let _ = &f;
         //~^ ERROR: `UnwindSafe`, `RefUnwindSafe` trait implementation for closure
         //~| NOTE: in Rust 2018, this closure would implement `UnwindSafe`, `RefUnwindSafe` as `f` implements `UnwindSafe`, `RefUnwindSafe`, but in Rust 2021, this closure would no longer implement `UnwindSafe`, `RefUnwindSafe` as `f.0` does not implement `UnwindSafe`, `RefUnwindSafe`
         //~| NOTE: for more information, see

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -15,12 +15,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
-LL ~     let result = panic::catch_unwind(move || { let _ = &f; 
+LL ~     let result = panic::catch_unwind(move || {
+LL +         let _ = &f;
 LL +
 LL +
 LL +
 LL +
-LL +         f.0()
  ...
 
 error: aborting due to previous error

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
@@ -20,7 +20,8 @@ impl Clone for U {
 fn test_multi_issues() {
     let f1 = U(S(String::from("foo")), T(0));
     let f2 = U(S(String::from("bar")), T(0));
-    let c = || { let _ = (&f1, &f2); 
+    let c = || {
+        let _ = (&f1, &f2);
         //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
@@ -39,7 +40,8 @@ fn test_multi_issues() {
 
 fn test_capturing_all_disjoint_fields_individually() {
     let f1 = U(S(String::from("foo")), T(0));
-    let c = || { let _ = &f1; 
+    let c = || {
+        let _ = &f1;
         //~^ ERROR: `Clone` trait implementation for closure
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see
@@ -64,7 +66,8 @@ impl Clone for U1 {
 
 fn test_capturing_several_disjoint_fields_individually_1() {
     let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
-    let c = || { let _ = &f1; 
+    let c = || {
+        let _ = &f1;
         //~^ ERROR: `Clone` trait implementation for closure
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.2` does not implement `Clone`
@@ -83,7 +86,8 @@ fn test_capturing_several_disjoint_fields_individually_1() {
 
 fn test_capturing_several_disjoint_fields_individually_2() {
     let f1 = U1(S(String::from("foo")), T(0), S(String::from("bar")));
-    let c = || { let _ = &f1; 
+    let c = || {
+        let _ = &f1;
         //~^ ERROR: `Clone` trait implementation for closure and drop order
         //~| NOTE: in Rust 2018, this closure would implement `Clone` as `f1` implements `Clone`, but in Rust 2021, this closure would no longer implement `Clone` as `f1.0` does not implement `Clone`
         //~| NOTE: for more information, see

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -21,12 +21,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1`, `f2` to be fully captured
    |
-LL ~     let c = || { let _ = (&f1, &f2); 
+LL ~     let c = || {
+LL +         let _ = (&f1, &f2);
 LL +
 LL +
 LL +
 LL +
-LL +         let _f_1 = f1.0;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
@@ -41,12 +41,12 @@ LL |         let _f_1 = f1.0;
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
-LL ~     let c = || { let _ = &f1; 
+LL ~     let c = || {
+LL +         let _ = &f1;
 LL +
 LL +
 LL +
 LL +
-LL +         let _f_1 = f1.0;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
@@ -67,8 +67,8 @@ LL |         let _f_2 = f1.2;
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
-LL ~     let c = || { let _ = &f1; 
-LL +
+LL ~     let c = || {
+LL +         let _ = &f1;
 LL +
 LL +
 LL +
@@ -96,12 +96,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
-LL ~     let c = || { let _ = &f1; 
+LL ~     let c = || {
+LL +         let _ = &f1;
 LL +
 LL +
 LL +
 LL +
-LL +         let _f_0 = f1.0;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` trait implementation for closure

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -17,7 +17,8 @@ struct ConstainsDropField(Foo, Foo);
 fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -42,7 +43,8 @@ struct U(T, T);
 fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
-    let c = || { let _ = &u; 
+    let c = || {
+        let _ = &u;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `u` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -18,12 +18,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -51,12 +51,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured
    |
-LL ~     let c = || { let _ = &u; 
+LL ~     let c = || {
+LL +         let _ = &u;
 LL +
 LL +
 LL +
 LL +         let _x = u.0.0;
-LL +
  ...
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -22,7 +22,8 @@ fn test1_all_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || { let _ = (&t, &t1, &t2); 
+    let c = || {
+        let _ = (&t, &t1, &t2);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
@@ -47,7 +48,8 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || { let _ = (&t, &t1); 
+    let c = || {
+        let _ = (&t, &t1);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
@@ -68,7 +70,8 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -88,7 +91,8 @@ fn test3_only_by_value_need_migration() {
 fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -106,7 +110,8 @@ fn test4_type_contains_drop_need_migration() {
 fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -122,7 +127,8 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
-    let c = || { let _ = &t; 
+    let c = || {
+        let _ = &t;
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t` to be fully captured
@@ -140,7 +146,8 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0), Foo(0));
 
-    let c = move || { let _ = (&t1, &t); 
+    let c = move || {
+        let _ = (&t1, &t);
         //~^ ERROR: drop order
         //~| NOTE: for more information, see
         //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
@@ -160,7 +167,8 @@ fn test8_drop_order_and_blocks() {
         let tuple =
           (String::from("foo"), String::from("bar"));
         {
-            let c = || { let _ = &tuple; 
+            let c = || {
+                let _ = &tuple;
                 //~^ ERROR: drop order
                 //~| NOTE: for more information, see
                 //~| HELP: add a dummy let to cause `tuple` to be fully captured
@@ -178,7 +186,8 @@ fn test9_drop_order_and_nested_closures() {
     let tuple =
         (String::from("foo"), String::from("bar"));
     let b = || {
-        let c = || { let _ = &tuple; 
+        let c = || {
+            let _ = &tuple;
             //~^ ERROR: drop order
             //~| NOTE: for more information, see
             //~| HELP: add a dummy let to cause `tuple` to be fully captured

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -28,12 +28,12 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
-LL ~     let c = || { let _ = (&t, &t1, &t2); 
+LL ~     let c = || {
+LL +         let _ = (&t, &t1, &t2);
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -57,12 +57,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
-LL ~     let c = || { let _ = (&t, &t1); 
+LL ~     let c = || {
+LL +         let _ = (&t, &t1);
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -80,12 +80,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -103,12 +103,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -126,12 +126,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -149,12 +149,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
-LL ~     let c = || { let _ = &t; 
+LL ~     let c = || {
+LL +         let _ = &t;
 LL +
 LL +
 LL +
 LL +         let _t = t.1;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -177,12 +177,12 @@ LL | }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
-LL ~     let c = move || { let _ = (&t1, &t); 
+LL ~     let c = move || {
+LL +         let _ = (&t1, &t);
 LL +
 LL +
 LL +
 LL +         println!("{:?} {:?}", t1.1, t.1);
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -200,12 +200,12 @@ LL |         }
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
-LL ~             let c = || { let _ = &tuple; 
+LL ~             let c = || {
+LL +                 let _ = &tuple;
 LL +
 LL +
 LL +
 LL +                 tuple.0;
-LL +
  ...
 
 error: changes to closure capture in Rust 2021 will affect drop order
@@ -223,12 +223,12 @@ LL |     };
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
-LL ~         let c = || { let _ = &tuple; 
+LL ~         let c = || {
+LL +             let _ = &tuple;
 LL +
 LL +
 LL +
 LL +             tuple.0;
-LL +
  ...
 
 error: aborting due to 9 previous errors


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/87952

Before:
```
help: add a dummy let to cause `a` to be fully captured
  |
5 ~     let _ = || { let _ = &a; 
6 +         dbg!(a.0);
7 ~     };
  |
```

After:
```
help: add a dummy let to cause `a` to be fully captured
  |
5 ~     let _ = || {
6 +         let _ = &a;
7 +         dbg!(a.0);
8 ~     };
  |
```