### PR TITLE
Closure migration multispan suggestions

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -16,11 +16,11 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
-LL +
-LL +
-LL +
-LL +
-LL +         *fptr.0 = 20;
+LL |
+LL |
+LL |
+LL |
+LL |         *fptr.0 = 20;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` trait implementation for closure
@@ -36,11 +36,11 @@ LL |         *fptr.0.0 = 20;
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
-LL +
-LL +
-LL +
-LL +
-LL +         *fptr.0.0 = 20;
+LL |
+LL |
+LL |
+LL |
+LL |         *fptr.0.0 = 20;
  ...
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure and drop order
@@ -60,11 +60,7 @@ help: add a dummy let to cause `f` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &f;
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -30,11 +30,7 @@ help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = (&t, &t1, &t2);
-LL +
-LL +
-LL +
-LL + 
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:41:13
@@ -59,11 +55,7 @@ help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = (&t, &t1);
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:62:13
@@ -82,11 +74,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:83:13
@@ -105,11 +93,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:104:13
@@ -128,11 +112,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:122:13
@@ -156,11 +136,7 @@ help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL ~     let c = move || {
 LL +         let _ = (&t1, &t);
-LL +
-LL +
-LL +
-LL +         println!("{} {}", t1.1, t.1);
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop.rs:142:13
@@ -179,11 +155,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -20,11 +20,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/insignificant_drop_attr_migrations.rs:57:13
@@ -43,11 +39,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = move || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.1;
- ...
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/macro.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/macro.stderr
@@ -18,7 +18,7 @@ LL | #![deny(rust_2021_incompatible_closure_captures)]
 help: add a dummy let to cause `a` to be fully captured
    |
 LL |     let _ = || { let _ = &a; dbg!(a.0) };
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                +++++++++++++           +
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -20,11 +20,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/migrations_rustfix.rs:33:13
@@ -41,7 +37,7 @@ LL | }
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; t.0 };
-   |                ~~~~~~~~~~~~~~~~~~~
+   |                +++++++++++++     +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -17,11 +17,7 @@ help: add a dummy let to cause `f` to be fully captured
    |
 LL ~     let result = panic::catch_unwind(move || {
 LL +         let _ = &f;
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -23,11 +23,7 @@ help: add a dummy let to cause `f1`, `f2` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = (&f1, &f2);
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
   --> $DIR/multi_diagnostics.rs:42:13
@@ -43,11 +39,7 @@ help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &f1;
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure
   --> $DIR/multi_diagnostics.rs:67:13
@@ -69,11 +61,7 @@ help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &f1;
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect `Clone` trait implementation for closure and drop order
   --> $DIR/multi_diagnostics.rs:86:13
@@ -98,11 +86,7 @@ help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &f1;
-LL +
-LL +
-LL +
-LL +
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect `Sync`, `Send` trait implementation for closure
   --> $DIR/multi_diagnostics.rs:119:19
@@ -123,11 +107,11 @@ LL |         *fptr2.0 = 20;
 help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
-LL +
-LL +
-LL +
-LL +
-LL +
+LL |
+LL |
+LL |
+LL |
+LL |
  ...
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -20,11 +20,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/precise.rs:45:13
@@ -53,11 +49,7 @@ help: add a dummy let to cause `u` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &u;
-LL +
-LL +
-LL +
-LL +         let _x = u.0.0;
- ...
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -30,11 +30,7 @@ help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = (&t, &t1, &t2);
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:50:13
@@ -59,11 +55,7 @@ help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = (&t, &t1);
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:71:13
@@ -82,11 +74,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:91:13
@@ -105,11 +93,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:109:13
@@ -128,11 +112,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:125:13
@@ -151,11 +131,7 @@ help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
 LL +         let _ = &t;
-LL +
-LL +
-LL +
-LL +         let _t = t.1;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:143:13
@@ -179,11 +155,7 @@ help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL ~     let c = move || {
 LL +         let _ = (&t1, &t);
-LL +
-LL +
-LL +
-LL +         println!("{:?} {:?}", t1.1, t.1);
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:163:21
@@ -202,11 +174,7 @@ help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~             let c = || {
 LL +                 let _ = &tuple;
-LL +
-LL +
-LL +
-LL +                 tuple.0;
- ...
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order
   --> $DIR/significant_drop.rs:181:17
@@ -225,11 +193,7 @@ help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~         let c = || {
 LL +             let _ = &tuple;
-LL +
-LL +
-LL +
-LL +             tuple.0;
- ...
+   |
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This changes the `rust_2021_incompatible_closure_captures` lint to only suggest inserting the parts that need to be inserted, instead of suggesting to replace the entire closure by an almost identical closure with one statement added.

Before:
```
[...]
help: add a dummy let to cause `a` to be fully captured
   |
5  ~     let _ = || {
6  +         let _ = &a;
7  +         dbg!(a.0);
8  +         println!("1");
9  +         println!("2");
10 +         println!("3");
 ...
   |

[...]
help: add a dummy let to cause `b` to be fully captured
   |
14 |     let _ = || { let _ = &b; dbg!(b.0); };
   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~

[...]
help: add a dummy let to cause `c` to be fully captured
   |
16 |     let _ = || { let _ = &c; dbg!(c.0) };
   |                ~~~~~~~~~~~~~~~~~~~~~~~~~
```

After:
```
[...]
help: add a dummy let to cause `a` to be fully captured
   |
5  ~     let _ = || {
6  +         let _ = &a;
   |

[...]
help: add a dummy let to cause `b` to be fully captured
   |
14 |     let _ = || { let _ = &b; dbg!(b.0); };
   |                  +++++++++++

[...]
help: add a dummy let to cause `c` to be fully captured
   |
16 |     let _ = || { let _ = &c; dbg!(c.0) };
   |                +++++++++++++           +
```