### PR TITLE
Silence non_fmt_panic from external macros.

### DIFF
--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -2,6 +2,7 @@ use crate::{LateContext, LateLintPass, LintContext};
 use rustc_ast as ast;
 use rustc_errors::{pluralize, Applicability};
 use rustc_hir as hir;
+use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty;
 use rustc_parse_format::{ParseMode, Parser, Piece};
 use rustc_session::lint::FutureIncompatibilityReason;
@@ -74,6 +75,11 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
     // The argument is *not* a string literal.
 
     let (span, panic, symbol_str) = panic_call(cx, f);
+
+    if in_external_macro(cx.sess(), span) {
+        // Nothing that can be done about it in the current crate.
+        return;
+    }
 
     // Find the span of the argument to `panic!()`, before expansion in the
     // case of `panic!(some_macro!())`.
@@ -152,6 +158,13 @@ fn check_panic_str<'tcx>(
         return;
     }
 
+    let (span, _, _) = panic_call(cx, f);
+
+    if in_external_macro(cx.sess(), span) && in_external_macro(cx.sess(), arg.span) {
+        // Nothing that can be done about it in the current crate.
+        return;
+    }
+
     let fmt_span = arg.span.source_callsite();
 
     let (snippet, style) = match cx.sess().parse_sess.source_map().span_to_snippet(fmt_span) {
@@ -166,8 +179,6 @@ fn check_panic_str<'tcx>(
     let mut fmt_parser =
         Parser::new(fmt.as_ref(), style, snippet.clone(), false, ParseMode::Format);
     let n_arguments = (&mut fmt_parser).filter(|a| matches!(a, Piece::NextArgument(_))).count();
-
-    let (span, _, _) = panic_call(cx, f);
 
     if n_arguments > 0 && fmt_parser.errors.is_empty() {
         let arg_spans: Vec<_> = match &fmt_parser.arg_places[..] {

--- a/src/test/ui/auxiliary/fancy-panic.rs
+++ b/src/test/ui/auxiliary/fancy-panic.rs
@@ -1,5 +1,8 @@
 #[macro_export]
 macro_rules! fancy_panic {
+    () => {
+        panic!("{}");
+    };
     ($msg:expr) => {
         panic!($msg)
     };

--- a/src/test/ui/non-fmt-panic.rs
+++ b/src/test/ui/non-fmt-panic.rs
@@ -26,8 +26,8 @@ fn main() {
     fancy_panic::fancy_panic!("test {} 123");
     //~^ WARN panic message contains an unused formatting placeholder
 
-    fancy_panic::fancy_panic!(S);
-    //~^ WARN panic message is not a string literal
+    fancy_panic::fancy_panic!(); // OK
+    fancy_panic::fancy_panic!(S); // OK
 
     macro_rules! a {
         () => { 123 };

--- a/src/test/ui/non-fmt-panic.stderr
+++ b/src/test/ui/non-fmt-panic.stderr
@@ -181,15 +181,6 @@ LL |     fancy_panic::fancy_panic!("test {} 123");
    = note: this message is not used as a format string when given without arguments, but will be in Rust 2021
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:29:31
-   |
-LL |     fancy_panic::fancy_panic!(S);
-   |                               ^
-   |
-   = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
-
-warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:36:12
    |
 LL |     panic!(a!());
@@ -285,5 +276,5 @@ help: or use std::panic::panic_any instead
 LL |     std::panic::panic_any(123);
    |     ~~~~~~~~~~~~~~~~~~~~~~   ~
 
-warning: 20 warnings emitted
+warning: 19 warnings emitted
 


### PR DESCRIPTION
This stops the non_fmt_panic lint from triggering if a macro from another crate is entirely responsible. In those cases there's nothing that the current crate can/should do.

See also https://github.com/rust-lang/rust/issues/87621#issuecomment-890311054