### PR TITLE
Revert "Rollup merge of #87779 - Aaron1011:stmt-ast-id, r=petrochenkov"

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -559,7 +559,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         self.cx.force_mode = orig_force_mode;
 
         // Finally incorporate all the expanded macros into the input AST fragment.
-        let mut placeholder_expander = PlaceholderExpander::default();
+        let mut placeholder_expander = PlaceholderExpander::new(self.cx, self.monotonic);
         while let Some(expanded_fragments) = expanded_fragments.pop() {
             for (expn_id, expanded_fragment) in expanded_fragments.into_iter().rev() {
                 placeholder_expander
@@ -1341,9 +1341,14 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             }
         }
 
+        // The placeholder expander gives ids to statements, so we avoid folding the id here.
         // We don't use `assign_id!` - it will be called when we visit statement's contents
         // (e.g. an expression, item, or local)
-        let res = noop_flat_map_stmt(stmt, self);
+        let ast::Stmt { id, kind, span } = stmt;
+        let res = noop_flat_map_stmt_kind(kind, self)
+            .into_iter()
+            .map(|kind| ast::Stmt { id, kind, span })
+            .collect();
 
         self.cx.current_expansion.is_trailing_mac = false;
         res

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -7,7 +7,6 @@
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
 #![feature(try_blocks)]
-#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate rustc_macros;


### PR DESCRIPTION
Fixes #87877

This change interacts badly with `noop_flat_map_stmt`,
which synthesizes multiple statements with the same `NodeId`.

I'm working on a better fix that will still allow us to
remove this special case. For now, let's revert the change
to fix the ICE.

This reverts commit a4262cc9841d91d48ef994b36eab323e615a7083, reversing
changes made to 8ee962f88e1be7e29482b13c7776c26b98a93bf7.