### PR TITLE
Fix typo

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2184,7 +2184,7 @@ impl<'a> Parser<'a> {
                                     && expr_lines.lines.len() == 2
                                     && this.token == token::FatArrow =>
                             {
-                                // We check whether there's any trailing code in the parse span,
+                                // We check whether there's any trailing comma in the parse span,
                                 // if there isn't, we very likely have the following:
                                 //
                                 // X |     &Y => "y"


### PR DESCRIPTION
I'm not 100% confident that using `code` here is wrong, but `comma` looks more natural.