### PR TITLE
Test and fix `size_hint` for slice’s [r]split* iterators

### DIFF
--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1001,11 +1001,7 @@ fn test_split_iterators_size_hint() {
         Lower,
         Upper,
     }
-    fn assert_precise_size_hints<I: Iterator>(
-        mut it: I,
-        which: Bounds,
-        context: impl fmt::Display,
-    ) {
+    fn assert_precise_size_hints(mut it: impl Iterator, which: Bounds, context: impl fmt::Display) {
         match which {
             Bounds::Lower => {
                 let mut lower_bounds = vec![it.size_hint().0];

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1001,7 +1001,7 @@ fn test_split_iterators_size_hint() {
         Lower,
         Upper,
     }
-    fn assert_precise_size_hints(mut it: impl Iterator, which: Bounds, context: impl fmt::Display) {
+    fn assert_tight_size_hints(mut it: impl Iterator, which: Bounds, ctx: impl fmt::Display) {
         match which {
             Bounds::Lower => {
                 let mut lower_bounds = vec![it.size_hint().0];
@@ -1009,7 +1009,7 @@ fn test_split_iterators_size_hint() {
                     lower_bounds.push(it.size_hint().0);
                 }
                 let target: Vec<_> = (0..lower_bounds.len()).rev().collect();
-                assert_eq!(lower_bounds, target, "incorrect lower bounds: {}", context);
+                assert_eq!(lower_bounds, target, "lower bounds incorrect or not tight: {}", ctx);
             }
             Bounds::Upper => {
                 let mut upper_bounds = vec![it.size_hint().1];
@@ -1017,7 +1017,7 @@ fn test_split_iterators_size_hint() {
                     upper_bounds.push(it.size_hint().1);
                 }
                 let target: Vec<_> = (0..upper_bounds.len()).map(Some).rev().collect();
-                assert_eq!(upper_bounds, target, "incorrect upper bounds: {}", context);
+                assert_eq!(upper_bounds, target, "upper bounds incorrect or not tight: {}", ctx);
             }
         }
     }
@@ -1028,13 +1028,13 @@ fn test_split_iterators_size_hint() {
         // p: predicate, b: bound selection
         for (p, b) in [
             // with a predicate always returning false, the split*-iterators
-            // become maximally short, so the size_hint lower bounds are correct
+            // become maximally short, so the size_hint lower bounds are tight
             ((|_| false) as fn(&_) -> _, Bounds::Lower),
             // with a predicate always returning true, the split*-iterators
-            // become maximally long, so the size_hint upper bounds are correct
+            // become maximally long, so the size_hint upper bounds are tight
             ((|_| true) as fn(&_) -> _, Bounds::Upper),
         ] {
-            use assert_precise_size_hints as a;
+            use assert_tight_size_hints as a;
             use format_args as f;
 
             a(v.split(p), b, "split");

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -400,7 +400,13 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.finished { (0, Some(0)) } else { (1, Some(self.v.len() + 1)) }
+        if self.finished {
+            (0, Some(0))
+        } else {
+            // If the predicate doesn't match anything, we yield one slice.
+            // If it matches every element, we yield `len() + 1` empty slices.
+            (1, Some(self.v.len() + 1))
+        }
     }
 }
 
@@ -525,7 +531,14 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.finished { (0, Some(0)) } else { (1, Some(self.v.len() + 1)) }
+        if self.finished {
+            (0, Some(0))
+        } else {
+            // If the predicate doesn't match anything, we yield one slice.
+            // If it matches every element, we yield `len()` one-element slices,
+            // or a single empty slice.
+            (1, Some(cmp::max(1, self.v.len())))
+        }
     }
 }
 
@@ -647,8 +660,8 @@ where
         if self.finished {
             (0, Some(0))
         } else {
-            // if the predicate doesn't match anything, we yield one slice
-            // if it matches every element, we yield len+1 empty slices.
+            // If the predicate doesn't match anything, we yield one slice.
+            // If it matches every element, we yield `len() + 1` empty slices.
             (1, Some(self.v.len() + 1))
         }
     }
@@ -763,9 +776,10 @@ where
         if self.finished {
             (0, Some(0))
         } else {
-            // if the predicate doesn't match anything, we yield one slice
-            // if it matches every element, we yield len+1 empty slices.
-            (1, Some(self.v.len() + 1))
+            // If the predicate doesn't match anything, we yield one slice.
+            // If it matches every element, we yield `len()` one-element slices,
+            // or a single empty slice.
+            (1, Some(cmp::max(1, self.v.len())))
         }
     }
 }
@@ -1008,7 +1022,10 @@ impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper_opt) = self.iter.size_hint();
-        (lower, upper_opt.map(|upper| cmp::min(self.count, upper)))
+        (
+            cmp::min(self.count, lower),
+            Some(upper_opt.map_or(self.count, |upper| cmp::min(self.count, upper))),
+        )
     }
 }
 


### PR DESCRIPTION
Adds extensive test (of `size_hint`) for all the _[r]split*_ iterators.
Fixes `size_hint` upper bound for _split_inclusive*_ iterators which was one higher than necessary for non-empty slices.
Fixes `size_hint` lower bound for _[r]splitn*_ iterators when _n == 0_, which was one too high.

**Lower bound being one too high was a logic error, violating the correctness condition of `size_hint`.**

_Edit:_ I’ve opened an issue for that bug, so this PR fixes #87978