### PR TITLE
Account for tabs when highlighting multiline code suggestions

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1679,27 +1679,19 @@ impl EmitterWriter {
                 // Colorize addition/replacements with green.
                 for &SubstitutionHighlight { start, end } in highlight_parts {
                     // Account for tabs when highlighting (#87972).
-                    let start: usize = line
-                        .chars()
-                        .take(start)
-                        .map(|ch| match ch {
-                            '\t' => 4,
-                            _ => 1,
-                        })
-                        .sum();
-
-                    let end: usize = line
-                        .chars()
-                        .take(end)
-                        .map(|ch| match ch {
-                            '\t' => 4,
-                            _ => 1,
-                        })
-                        .sum();
+                    // let tabs: usize = line
+                    //     .chars()
+                    //     .take(start)
+                    //     .map(|ch| match ch {
+                    //         '\t' => 3,
+                    //         _ => 0,
+                    //     })
+                    //     .sum();
+                    let tabs = 0;
                     buffer.set_style_range(
                         row_num,
-                        max_line_num_len + 3 + start,
-                        max_line_num_len + 3 + end,
+                        max_line_num_len + 3 + start + tabs,
+                        max_line_num_len + 3 + end + tabs,
                         Style::Addition,
                         true,
                     );

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1623,7 +1623,7 @@ impl EmitterWriter {
             let line_start = sm.lookup_char_pos(parts[0].span.lo()).line;
             draw_col_separator_no_space(&mut buffer, 1, max_line_num_len + 1);
             let mut lines = complete.lines();
-            for (line_pos, (line, parts)) in
+            for (line_pos, (line, highlight_parts)) in
                 lines.by_ref().zip(highlights).take(MAX_SUGGESTION_HIGHLIGHT_LINES).enumerate()
             {
                 // Print the span column to avoid confusion
@@ -1658,7 +1658,7 @@ impl EmitterWriter {
                     );
                     buffer.puts(row_num, max_line_num_len + 1, "+ ", Style::Addition);
                 } else if is_multiline {
-                    match &parts[..] {
+                    match &highlight_parts[..] {
                         [SubstitutionHighlight { start: 0, end }] if *end == line.len() => {
                             buffer.puts(row_num, max_line_num_len + 1, "+ ", Style::Addition);
                         }
@@ -1676,16 +1676,33 @@ impl EmitterWriter {
                 // print the suggestion
                 buffer.append(row_num, &replace_tabs(line), Style::NoStyle);
 
-                if is_multiline {
-                    for SubstitutionHighlight { start, end } in parts {
-                        buffer.set_style_range(
-                            row_num,
-                            max_line_num_len + 3 + start,
-                            max_line_num_len + 3 + end,
-                            Style::Addition,
-                            true,
-                        );
-                    }
+                // Colorize addition/replacements with green.
+                for &SubstitutionHighlight { start, end } in highlight_parts {
+                    // Account for tabs when highlighting (#87972).
+                    let start: usize = line
+                        .chars()
+                        .take(start)
+                        .map(|ch| match ch {
+                            '\t' => 4,
+                            _ => 1,
+                        })
+                        .sum();
+
+                    let end: usize = line
+                        .chars()
+                        .take(end)
+                        .map(|ch| match ch {
+                            '\t' => 4,
+                            _ => 1,
+                        })
+                        .sum();
+                    buffer.set_style_range(
+                        row_num,
+                        max_line_num_len + 3 + start,
+                        max_line_num_len + 3 + end,
+                        Style::Addition,
+                        true,
+                    );
                 }
                 row_num += 1;
             }
@@ -1723,13 +1740,6 @@ impl EmitterWriter {
                     assert!(underline_start >= 0 && underline_end >= 0);
                     let padding: usize = max_line_num_len + 3;
                     for p in underline_start..underline_end {
-                        // Colorize addition/replacements with green.
-                        buffer.set_style(
-                            row_num - 1,
-                            (padding as isize + p) as usize,
-                            Style::Addition,
-                            true,
-                        );
                         if !show_diff {
                             // If this is a replacement, underline with `^`, if this is an addition
                             // underline with `+`.

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1679,15 +1679,14 @@ impl EmitterWriter {
                 // Colorize addition/replacements with green.
                 for &SubstitutionHighlight { start, end } in highlight_parts {
                     // Account for tabs when highlighting (#87972).
-                    // let tabs: usize = line
-                    //     .chars()
-                    //     .take(start)
-                    //     .map(|ch| match ch {
-                    //         '\t' => 3,
-                    //         _ => 0,
-                    //     })
-                    //     .sum();
-                    let tabs = 0;
+                    let tabs: usize = line
+                        .chars()
+                        .take(start)
+                        .map(|ch| match ch {
+                            '\t' => 3,
+                            _ => 0,
+                        })
+                        .sum();
                     buffer.set_style_range(
                         row_num,
                         max_line_num_len + 3 + start + tabs,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -14,7 +14,7 @@ extern crate rustc_macros;
 
 pub use emitter::ColorConfig;
 
-use tracing::debug;
+use tracing::{debug, info};
 use Level::*;
 
 use emitter::{is_case_difference, Emitter, EmitterWriter};
@@ -349,6 +349,7 @@ impl CodeSuggestion {
                 while buf.ends_with('\n') {
                     buf.pop();
                 }
+                info!(?buf, ?highlights);
                 Some((buf, substitution.parts, highlights, only_capitalization))
             })
             .collect()

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -14,7 +14,7 @@ extern crate rustc_macros;
 
 pub use emitter::ColorConfig;
 
-use tracing::{debug, info};
+use tracing::debug;
 use Level::*;
 
 use emitter::{is_case_difference, Emitter, EmitterWriter};
@@ -348,7 +348,6 @@ impl CodeSuggestion {
                 while buf.ends_with('\n') {
                     buf.pop();
                 }
-                info!(?buf, ?highlights);
                 Some((buf, substitution.parts, highlights, only_capitalization))
             })
             .collect()

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -297,11 +297,11 @@ impl CodeSuggestion {
                             count -= 1;
                         }
                     } else {
+                        acc = 0;
                         highlights.push(std::mem::take(&mut line_highlight));
                         let mut count = push_trailing(&mut buf, prev_line.as_ref(), &prev_hi, None);
                         while count > 0 {
                             highlights.push(std::mem::take(&mut line_highlight));
-                            acc = 0;
                             count -= 1;
                         }
                         // push lines between the previous and current span (if any)
@@ -310,7 +310,6 @@ impl CodeSuggestion {
                                 buf.push_str(line.as_ref());
                                 buf.push('\n');
                                 highlights.push(std::mem::take(&mut line_highlight));
-                                acc = 0;
                             }
                         }
                         if let Some(cur_line) = sf.get_line(cur_lo.line - 1) {


### PR DESCRIPTION
Address `'\t'` case in #87972.

Before:

![Screen Shot 2021-08-12 at 8 52 27 AM](https://user-images.githubusercontent.com/1606434/129228214-e5cfd203-9aa8-41c7-acd9-ce255ef8a21e.png)

After:

![Screen Shot 2021-08-12 at 8 52 15 AM](https://user-images.githubusercontent.com/1606434/129228236-57c951fc-c8cf-4901-989f-b9b5aa5eebca.png)
