### PR TITLE
Forbid `!` from being used in `asm!` output

### DIFF
--- a/src/test/ui/asm/issue-87802.rs
+++ b/src/test/ui/asm/issue-87802.rs
@@ -1,0 +1,17 @@
+// only-x86_64
+// Make sure rustc doesn't ICE on asm! when output type is !.
+
+#![feature(asm)]
+
+fn hmm() -> ! {
+    let x;
+    unsafe {
+        asm!("/* {0} */", out(reg) x);
+        //~^ ERROR cannot use value of type `!` for inline assembly
+    }
+    x
+}
+
+fn main() {
+    hmm();
+}

--- a/src/test/ui/asm/issue-87802.stderr
+++ b/src/test/ui/asm/issue-87802.stderr
@@ -1,0 +1,10 @@
+error: cannot use value of type `!` for inline assembly
+  --> $DIR/issue-87802.rs:9:36
+   |
+LL |         asm!("/* {0} */", out(reg) x);
+   |                                    ^
+   |
+   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #87802

r? @Amanieu 