### PR TITLE
Make `lexical_region_resolve` public for Clippy

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -58,7 +58,7 @@ mod fudge;
 mod glb;
 mod higher_ranked;
 pub mod lattice;
-mod lexical_region_resolve;
+pub mod lexical_region_resolve;
 mod lub;
 pub mod nll_relate;
 pub mod opaque_types;


### PR DESCRIPTION
I have a locally working fix for https://github.com/rust-lang/rust-clippy/issues/4002 that involves `lexical_region_resolve::resolve`. I'm doing my best to understand region checking and how it should integrate with Clippy, so please tell me if I'm totally on the wrong path. Basically I need to construct and evaluate a `TypeOutlives` obligation.