### PR TITLE
Include (potentially remapped) working dir in crate hash

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -66,7 +66,7 @@ impl<'tcx> DebugContext<'tcx> {
             rustc_interface::util::version_str().unwrap_or("unknown version"),
             cranelift_codegen::VERSION,
         );
-        let comp_dir = tcx.sess.working_dir.to_string_lossy(false).into_owned();
+        let comp_dir = tcx.sess.opts.working_dir.to_string_lossy(false).into_owned();
         let (name, file_info) = match tcx.sess.local_crate_source_file.clone() {
             Some(path) => {
                 let name = path.to_string_lossy().into_owned();

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -771,7 +771,7 @@ pub fn file_metadata(cx: &CodegenCx<'ll, '_>, source_file: &SourceFile) -> &'ll 
     let hash = Some(&source_file.src_hash);
     let file_name = Some(source_file.name.prefer_remapped().to_string());
     let directory = if source_file.is_real_file() && !source_file.is_imported() {
-        Some(cx.sess().working_dir.to_string_lossy(false).to_string())
+        Some(cx.sess().opts.working_dir.to_string_lossy(false).to_string())
     } else {
         // If the path comes from an upstream crate we assume it has been made
         // independent of the compiler's working directory one way or another.
@@ -999,7 +999,7 @@ pub fn compile_unit_metadata(
     let producer = format!("clang LLVM ({})", rustc_producer);
 
     let name_in_debuginfo = name_in_debuginfo.to_string_lossy();
-    let work_dir = tcx.sess.working_dir.to_string_lossy(false);
+    let work_dir = tcx.sess.opts.working_dir.to_string_lossy(false);
     let flags = "\0";
     let output_filenames = tcx.output_filenames(());
     let out_dir = &output_filenames.out_directory;

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -503,7 +503,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                                 // Prepend path of working directory onto potentially
                                 // relative paths, because they could become relative
                                 // to a wrong directory.
-                                let working_dir = &self.tcx.sess.working_dir;
+                                // We include `working_dir` as part of the crate hash,
+                                // so it's okay for us to use it as part of the encoded
+                                // metadata.
+                                let working_dir = &self.tcx.sess.opts.working_dir;
                                 match working_dir {
                                     RealFileName::LocalPath(absolute) => {
                                         // If working_dir has not been remapped, then we emit a

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -185,7 +185,7 @@ impl<'tcx> DumpVisitor<'tcx> {
         };
 
         let data = CompilationOptions {
-            directory: self.tcx.sess.working_dir.remapped_path_if_available().into(),
+            directory: self.tcx.sess.opts.working_dir.remapped_path_if_available().into(),
             program,
             arguments,
             output: self.save_ctxt.compilation_output(crate_name),

--- a/compiler/rustc_save_analysis/src/span_utils.rs
+++ b/compiler/rustc_save_analysis/src/span_utils.rs
@@ -27,6 +27,7 @@ impl<'a> SpanUtils<'a> {
                         .to_string()
                 } else {
                     self.sess
+                        .opts
                         .working_dir
                         .remapped_path_if_available()
                         .join(&path)

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -10,6 +10,7 @@ use rustc_target::spec::{RelocModel, RelroLevel, SplitDebuginfo, TargetTriple, T
 
 use rustc_feature::UnstableFeatures;
 use rustc_span::edition::Edition;
+use rustc_span::RealFileName;
 use rustc_span::SourceFileHashAlgorithm;
 
 use std::collections::BTreeMap;
@@ -203,6 +204,9 @@ top_level_options!(
         json_unused_externs: bool [UNTRACKED],
 
         pretty: Option<PpMode> [UNTRACKED],
+
+        /// The (potentially remapped) working directory
+        working_dir: RealFileName [TRACKED],
     }
 );
 

--- a/src/test/run-make/issue-85019-moved-src-dir/Makefile
+++ b/src/test/run-make/issue-85019-moved-src-dir/Makefile
@@ -1,0 +1,25 @@
+include ../../run-make-fulldeps/tools.mk
+
+INCR=$(TMPDIR)/incr
+FIRST_SRC=$(TMPDIR)/first_src
+SECOND_SRC=$(TMPDIR)/second_src
+
+# Tests that we don't get an ICE when the working directory
+# (but not the build directory!) changes between compilation
+# sessions
+
+all:
+	mkdir $(INCR)
+	# Build from 'FIRST_SRC'
+	mkdir $(FIRST_SRC)
+	cp my_lib.rs $(FIRST_SRC)/my_lib.rs
+	cp main.rs $(FIRST_SRC)/main.rs
+	cd $(FIRST_SRC) && \
+		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs && \
+		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs
+	# Build from 'SECOND_SRC', keeping the output directory and incremental directory
+	# the same
+	mv $(FIRST_SRC) $(SECOND_SRC)
+	cd $(SECOND_SRC) && \
+		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs && \
+		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs

--- a/src/test/run-make/issue-85019-moved-src-dir/Makefile
+++ b/src/test/run-make/issue-85019-moved-src-dir/Makefile
@@ -18,11 +18,11 @@ all:
 	cp my_lib.rs $(FIRST_SRC)/my_lib.rs
 	cp main.rs $(FIRST_SRC)/main.rs
 	cd $(FIRST_SRC) && \
-		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs && \
-		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs
+		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs --target $(TARGET) && \
+		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs --target $(TARGET)
 	# Build from 'SECOND_SRC', keeping the output directory and incremental directory
 	# the same
 	mv $(FIRST_SRC) $(SECOND_SRC)
 	cd $(SECOND_SRC) && \
-		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs && \
-		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs
+		$(RUSTC) -C incremental=$(INCR) --crate-type lib my_lib.rs --target $(TARGET) && \
+		$(RUSTC) -C incremental=$(INCR) --extern my_lib=$(TMPDIR)/libmy_lib.rlib main.rs --target $(TARGET)

--- a/src/test/run-make/issue-85019-moved-src-dir/Makefile
+++ b/src/test/run-make/issue-85019-moved-src-dir/Makefile
@@ -4,6 +4,9 @@ INCR=$(TMPDIR)/incr
 FIRST_SRC=$(TMPDIR)/first_src
 SECOND_SRC=$(TMPDIR)/second_src
 
+# ignore-none no-std is not supported
+# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for 'std'
+
 # Tests that we don't get an ICE when the working directory
 # (but not the build directory!) changes between compilation
 # sessions

--- a/src/test/run-make/issue-85019-moved-src-dir/main.rs
+++ b/src/test/run-make/issue-85019-moved-src-dir/main.rs
@@ -1,0 +1,5 @@
+extern crate my_lib;
+
+fn main() {
+    my_lib::my_fn("hi");
+}

--- a/src/test/run-make/issue-85019-moved-src-dir/my_lib.rs
+++ b/src/test/run-make/issue-85019-moved-src-dir/my_lib.rs
@@ -1,0 +1,1 @@
+pub fn my_fn<T: Copy>(_val: T) {}


### PR DESCRIPTION
Fixes #85019

A `SourceFile` created during compilation may have a relative
path (e.g. if rustc itself is invoked with a relative path).
When we write out crate metadata, we convert all relative paths
to absolute paths using the current working directory.

However, the working directory is not included in the crate hash.
This means that the crate metadata can change while the crate
hash remains the same. Among other problems, this can cause a
fingerprint mismatch ICE, since incremental compilation uses
the crate metadata hash to determine if a foreign query is green.

This commit moves the field holding the working directory from
`Session` to `Options`, including it as part of the crate hash.

cc @ohsayan 