### PR TITLE
RFC2229 Add missing edge case

### DIFF
--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -266,7 +266,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                                         needs_to_be_read = true;
                                     }
                                 } else {
-                                    // If it is not ty::Adt, then it is a MultiVariant
+                                    // If it is not ty::Adt, then it should be read
                                     needs_to_be_read = true;
                                 }
                             }

--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -265,6 +265,9 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                                     if def.variants.len() > 1 {
                                         needs_to_be_read = true;
                                     }
+                                } else {
+                                    // If it is not ty::Adt, then it is a MultiVariant
+                                    needs_to_be_read = true;
                                 }
                             }
                             PatKind::Lit(_) | PatKind::Range(..) => {

--- a/src/test/ui/closures/2229_closure_analysis/issue-87988.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87988.rs
@@ -1,0 +1,19 @@
+// run-pass
+// edition:2021
+
+const LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED: i32 = 0x01;
+const LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT: i32 = 0x02;
+
+pub fn hotplug_callback(event: i32) {
+    let _ = || {
+        match event {
+            LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED => (),
+            LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT => (),
+            _ => (),
+        };
+    };
+}
+
+fn main() {
+    hotplug_callback(1);
+}

--- a/src/test/ui/closures/2229_closure_analysis/match-edge-cases.rs
+++ b/src/test/ui/closures/2229_closure_analysis/match-edge-cases.rs
@@ -5,7 +5,7 @@ const PATTERN_REF: &str = "Hello World";
 const NUMBER: i32 = 30;
 const NUMBER_POINTER: *const i32 = &NUMBER;
 
-pub fn multi_variant_ref(event: &str) {
+pub fn edge_case_ref(event: &str) {
     let _ = || {
         match event {
             PATTERN_REF => (),
@@ -14,7 +14,7 @@ pub fn multi_variant_ref(event: &str) {
     };
 }
 
-pub fn multi_variant_str(event: String) {
+pub fn edge_case_str(event: String) {
     let _ = || {
         match event.as_str() {
             "hello" => (),
@@ -23,7 +23,7 @@ pub fn multi_variant_str(event: String) {
     };
 }
 
-pub fn multi_variant_raw_ptr(event: *const i32) {
+pub fn edge_case_raw_ptr(event: *const i32) {
     let _ = || {
         match event {
             NUMBER_POINTER => (),
@@ -32,7 +32,7 @@ pub fn multi_variant_raw_ptr(event: *const i32) {
     };
 }
 
-pub fn multi_variant_char(event: char) {
+pub fn edge_case_char(event: char) {
     let _ = || {
         match event {
             'a' => (),

--- a/src/test/ui/closures/2229_closure_analysis/match-multi-variant.rs
+++ b/src/test/ui/closures/2229_closure_analysis/match-multi-variant.rs
@@ -1,0 +1,44 @@
+// run-pass
+// edition:2021
+
+const PATTERN_REF: &str = "Hello World";
+const NUMBER: i32 = 30;
+const NUMBER_POINTER: *const i32 = &NUMBER;
+
+pub fn multi_variant_ref(event: &str) {
+    let _ = || {
+        match event {
+            PATTERN_REF => (),
+            _ => (),
+        };
+    };
+}
+
+pub fn multi_variant_str(event: String) {
+    let _ = || {
+        match event.as_str() {
+            "hello" => (),
+            _ => (),
+        };
+    };
+}
+
+pub fn multi_variant_raw_ptr(event: *const i32) {
+    let _ = || {
+        match event {
+            NUMBER_POINTER => (),
+            _ => (),
+        };
+    };
+}
+
+pub fn multi_variant_char(event: char) {
+    let _ = || {
+        match event {
+            'a' => (),
+            _ => (),
+        };
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/87988

This PR fixes an ICE where a match discriminant is not being read when expected. This ICE was the result of a missing edge case which assumed that if a pattern is of type `PatKind::TupleStruct(..) | PatKind::Path(..) | PatKind::Struct(..) | PatKind::Tuple(..)` then a place could only be a multi variant if the place is of type kind Adt.