### PR TITLE
Updates favicon order of precedence as it matters to Chrome

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -31,12 +31,12 @@
     {%- if layout.favicon -%}
         <link rel="shortcut icon" href="{{layout.favicon}}"> {#- -#}
     {%- else -%}
-        <link rel="icon" type="image/svg+xml" {# -#}
-            href="{{static_root_path | safe}}favicon{{page.resource_suffix}}.svg"> {#- -#}
         <link rel="alternate icon" type="image/png" {# -#}
             href="{{static_root_path | safe}}favicon-16x16{{page.resource_suffix}}.png"> {#- -#}
         <link rel="alternate icon" type="image/png" {# -#}
             href="{{static_root_path | safe}}favicon-32x32{{page.resource_suffix}}.png"> {#- -#}
+        <link rel="icon" type="image/svg+xml" {# -#}
+            href="{{static_root_path | safe}}favicon{{page.resource_suffix}}.svg"> {#- -#}
     {%- endif -%}
     {{- layout.external_html.in_header | safe -}}
     <style type="text/css"> {#- -#}


### PR DESCRIPTION
Hi, this updates #75438 to fix an order of precedence issue for Chrome. Unfortunately, the last favicon defined wins when it comes to Chrome, hence the primary icon being placed last. I [brought it up](https://bugs.chromium.org/p/chromium/issues/detail?id=1104663) with the Chromium team last year, but so far it's a non-issue.

I've created an example website that mimics the behaviour in Chrome. https://sl4m.github.io/chrome-favicon/

This is what I'm seeing at the moment when viewing https://doc.rust-lang.org/core/index.html in Chrome. It's falling back to the PNG.

<img width="80" alt="Screenshot 2021-08-12 at 21 11 58" src="https://user-images.githubusercontent.com/47347/129304041-b598213e-fcd3-4df1-addb-e6feac6c35b1.png">
