### PR TITLE
Trait upcasting coercion (part4)

### DIFF
--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -41,6 +41,7 @@ pub enum UnsafetyViolationDetails {
     MutationOfLayoutConstrainedField,
     BorrowOfLayoutConstrainedField,
     CallToFunctionWith,
+    TraitUpcastingCoercionOfRawPointer,
 }
 
 impl UnsafetyViolationDetails {
@@ -101,6 +102,10 @@ impl UnsafetyViolationDetails {
             CallToFunctionWith => (
                 "call to function with `#[target_feature]`",
                 "can only be called if the required target features are available",
+            ),
+            TraitUpcastingCoercionOfRawPointer => (
+                "trait upcasting coercion from raw pointer type",
+                "trait upcasting coercion depends on the validity of the pointer metadata",
             ),
         }
     }

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -1052,7 +1052,12 @@ fn find_vtable_types_for_unsizing<'tcx>(
             assert_eq!(source_adt_def, target_adt_def);
 
             let CustomCoerceUnsized::Struct(coerce_index) =
-                monomorphize::custom_coerce_unsize_info(tcx, source_ty, target_ty);
+                crate::transform::custom_coerce_unsize_info(
+                    tcx,
+                    source_ty,
+                    target_ty,
+                    ty::ParamEnv::reveal_all(),
+                );
 
             let source_fields = &source_adt_def.non_enum_variant().fields;
             let target_fields = &target_adt_def.non_enum_variant().fields;

--- a/compiler/rustc_mir/src/monomorphize/mod.rs
+++ b/compiler/rustc_mir/src/monomorphize/mod.rs
@@ -1,33 +1,4 @@
-use rustc_middle::traits;
-use rustc_middle::ty::adjustment::CustomCoerceUnsized;
-use rustc_middle::ty::{self, Ty, TyCtxt};
-
-use rustc_hir::lang_items::LangItem;
-
 pub mod collector;
 pub mod partitioning;
 pub mod polymorphize;
 pub mod util;
-
-fn custom_coerce_unsize_info<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    source_ty: Ty<'tcx>,
-    target_ty: Ty<'tcx>,
-) -> CustomCoerceUnsized {
-    let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
-
-    let trait_ref = ty::Binder::dummy(ty::TraitRef {
-        def_id,
-        substs: tcx.mk_substs_trait(source_ty, &[target_ty.into()]),
-    });
-
-    match tcx.codegen_fulfill_obligation((ty::ParamEnv::reveal_all(), trait_ref)) {
-        Ok(traits::ImplSource::UserDefined(traits::ImplSourceUserDefinedData {
-            impl_def_id,
-            ..
-        })) => tcx.coerce_unsized_info(impl_def_id).custom_kind.unwrap(),
-        impl_source => {
-            bug!("invalid `CoerceUnsized` impl_source: {:?}", impl_source);
-        }
-    }
-}

--- a/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion.rs
+++ b/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion.rs
@@ -1,0 +1,30 @@
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait A {
+    fn foo_a(&self) {}
+}
+
+trait B {
+    fn foo_b(&self) {}
+}
+
+trait C: A + B {
+    fn foo_c(&self) {}
+}
+
+struct S;
+
+impl A for S {}
+
+impl B for S {}
+
+impl C for S {}
+
+fn unsafe_coercion(v: * const dyn C) {
+    let g: * const dyn A = v;
+    //~^ ERROR trait upcasting coercion from
+}
+
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion.stderr
+++ b/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion.stderr
@@ -1,0 +1,11 @@
+error[E0133]: trait upcasting coercion from raw pointer type is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-trait-upcasting-coercion.rs:25:28
+   |
+LL |     let g: * const dyn A = v;
+   |                            ^ trait upcasting coercion from raw pointer type
+   |
+   = note: trait upcasting coercion depends on the validity of the pointer metadata
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion2.rs
+++ b/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion2.rs
@@ -1,0 +1,29 @@
+#![feature(trait_upcasting)]
+#![allow(incomplete_features)]
+
+trait A {
+    fn foo_a(&self) {}
+}
+
+trait B {
+    fn foo_b(&self) {}
+}
+
+trait C: A + B {
+    fn foo_c(&self) {}
+}
+
+struct S;
+
+impl A for S {}
+
+impl B for S {}
+
+impl C for S {}
+
+fn invalid_coercion(v: * const Box<dyn C>) {
+    let g: * const Box<dyn A> = v;
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion2.stderr
+++ b/src/test/ui/traits/trait-upcasting/unsafe-trait-upcasting-coercion2.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/unsafe-trait-upcasting-coercion2.rs:25:33
+   |
+LL |     let g: * const Box<dyn A> = v;
+   |            ------------------   ^ expected trait `A`, found trait `C`
+   |            |
+   |            expected due to this
+   |
+   = note: expected raw pointer `*const Box<dyn A>`
+              found raw pointer `*const Box<(dyn C + 'static)>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This is a incomplete version of trait upcasting unsafety checking. I think it's working in principle, however i think i meet a problem here. How can i know `Box<T>` or `Arc<T>`'s internal pointer can be seen as "always-valid"?

cc @RalfJung 