### PR TITLE
Enable `--all-targets` for `x.py check` unconditionally

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -578,7 +578,7 @@ impl<'a> Builder<'a> {
     pub fn new(build: &Build) -> Builder<'_> {
         let (kind, paths) = match build.config.cmd {
             Subcommand::Build { ref paths } => (Kind::Build, &paths[..]),
-            Subcommand::Check { ref paths, all_targets: _ } => (Kind::Check, &paths[..]),
+            Subcommand::Check { ref paths } => (Kind::Check, &paths[..]),
             Subcommand::Clippy { ref paths, .. } => (Kind::Clippy, &paths[..]),
             Subcommand::Fix { ref paths } => (Kind::Fix, &paths[..]),
             Subcommand::Doc { ref paths, .. } => (Kind::Doc, &paths[..]),

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -78,9 +78,6 @@ pub enum Subcommand {
         paths: Vec<PathBuf>,
     },
     Check {
-        // Whether to run checking over all targets (e.g., unit / integration
-        // tests).
-        all_targets: bool,
         paths: Vec<PathBuf>,
     },
     Clippy {
@@ -553,7 +550,12 @@ Arguments:
         let cmd = match subcommand.as_str() {
             "build" | "b" => Subcommand::Build { paths },
             "check" | "c" => {
-                Subcommand::Check { paths, all_targets: matches.opt_present("all-targets") }
+                if matches.opt_present("all-targets") {
+                    eprintln!(
+                        "Warning: --all-targets is now on by default and does not need to be passed explicitly."
+                    );
+                }
+                Subcommand::Check { paths }
             }
             "clippy" => Subcommand::Clippy { paths, fix: matches.opt_present("fix") },
             "fix" => Subcommand::Fix { paths },


### PR DESCRIPTION
Now that Cargo deduplicates diagnostics from different targets, this doesn't flood the console with
duplicate errors.

Note that this doesn't add `--all-targets` in `Builder::cargo` directly because `impl Step for Std`
actually wants to omit `--all-targets` the first time while it's still building libtest.

When passed `--all-targets`, this warns that the option isn't needed, but still continues to compile.

Fixes https://github.com/rust-lang/rust/issues/87846.
r? @Mark-Simulacrum