### PR TITLE
Disable unused_must_use for statically known bools

### DIFF
--- a/src/test/ui/lint/unused/issue-85913.rs
+++ b/src/test/ui/lint/unused/issue-85913.rs
@@ -1,8 +1,47 @@
 #![deny(unused_must_use)]
 
+fn fire_missiles() -> bool {
+    true
+}
+
+fn is_missiles_ready() -> bool {
+    true
+}
+
+fn bang() -> ! {
+    loop {}
+}
+
 pub fn fun() -> i32 {
     function() && return 1;
+    is_missiles_ready() && fire_missiles();
     //~^ ERROR: unused logical operation that must be used
+    !is_missiles_ready() || fire_missiles();
+    //~^ ERROR: unused logical operation that must be used
+    fire_missiles() || panic!("failed");
+    fire_missiles() && bang();
+    fire_missiles() || { panic!("failed"); };
+    fire_missiles() && { bang(); };
+    fire_missiles() || { panic!("failed") };
+    fire_missiles() && { bang() };
+    is_missiles_ready() && fire_missiles() || panic!("failed");
+    !is_missiles_ready() || fire_missiles() && panic!("booom");
+    //~^ ERROR: unused logical operation that must be used
+    is_missiles_ready() && fire_missiles() || return 5;
+    !is_missiles_ready() || {
+        fire_missiles();
+        panic!("booom");
+    };
+    !is_missiles_ready() || {
+    //~^ ERROR: unused logical operation that must be used
+        if fire_missiles() {
+            panic!("booom");
+        }
+        println!("failed");
+        false
+    };
+    fire_missiles() && fire_missiles() && panic!("2x booom");
+    fire_missiles() && fire_missiles() || panic!("2x booom");
     return 0;
 }
 

--- a/src/test/ui/lint/unused/issue-85913.stderr
+++ b/src/test/ui/lint/unused/issue-85913.stderr
@@ -1,8 +1,8 @@
 error: unused logical operation that must be used
-  --> $DIR/issue-85913.rs:4:5
+  --> $DIR/issue-85913.rs:17:5
    |
-LL |     function() && return 1;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ the logical operation produces a value
+LL |     is_missiles_ready() && fire_missiles();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the logical operation produces a value
    |
 note: the lint level is defined here
   --> $DIR/issue-85913.rs:1:9
@@ -11,8 +11,47 @@ LL | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the resulting value
    |
-LL |     let _ = function() && return 1;
+LL |     let _ = is_missiles_ready() && fire_missiles();
    |     +++++++
 
-error: aborting due to previous error
+error: unused logical operation that must be used
+  --> $DIR/issue-85913.rs:19:5
+   |
+LL |     !is_missiles_ready() || fire_missiles();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the logical operation produces a value
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = !is_missiles_ready() || fire_missiles();
+   |     +++++++
+
+error: unused logical operation that must be used
+  --> $DIR/issue-85913.rs:28:5
+   |
+LL |     !is_missiles_ready() || fire_missiles() && panic!("booom");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the logical operation produces a value
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = !is_missiles_ready() || fire_missiles() && panic!("booom");
+   |     +++++++
+
+error: unused logical operation that must be used
+  --> $DIR/issue-85913.rs:35:5
+   |
+LL | /     !is_missiles_ready() || {
+LL | |
+LL | |         if fire_missiles() {
+LL | |             panic!("booom");
+...  |
+LL | |         false
+LL | |     };
+   | |_____^ the logical operation produces a value
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = !is_missiles_ready() || {
+   |     +++++++
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
I'm still not sure if this PR contradicts unused_must_use spirit or not, but I don't think anyone is interested in storing what is statically known and warning in this case has no benefit.

Fix #88017
Fix #69466
CC #85913 #87607
r? @estebank
