### PR TITLE
RFC2229 Only compute place if upvars can be resolved

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/issue-87987.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87987.rs
@@ -1,0 +1,30 @@
+// run-pass
+// edition:2021
+
+struct Props {
+    field_1: u32, //~ WARNING: field is never read: `field_1`
+    field_2: u32, //~ WARNING: field is never read: `field_2`
+}
+
+fn main() {
+    // Test 1
+    let props_2 = Props { //~ WARNING: unused variable: `props_2`
+        field_1: 1,
+        field_2: 1,
+    };
+
+    let _ = || {
+        let _: Props = props_2;
+    };
+
+    // Test 2
+    let mut arr = [1, 3, 4, 5];
+
+    let mref = &mut arr;
+
+    let _c = || match arr {
+        [_, _, _, _] => println!("A")
+    };
+
+    println!("{:#?}", mref);
+}

--- a/src/test/ui/closures/2229_closure_analysis/issue-87987.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87987.stderr
@@ -1,0 +1,24 @@
+warning: unused variable: `props_2`
+  --> $DIR/issue-87987.rs:11:9
+   |
+LL |     let props_2 = Props {
+   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_props_2`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: field is never read: `field_1`
+  --> $DIR/issue-87987.rs:5:5
+   |
+LL |     field_1: u32,
+   |     ^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: field is never read: `field_2`
+  --> $DIR/issue-87987.rs:6:5
+   |
+LL |     field_2: u32,
+   |     ^^^^^^^^^^^^
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/87987

This PR fixes an ICE when trying to unwrap an Err. This error appears when trying to convert a PlaceBuilder into Place when upvars can't yet be resolved. We should only try to convert a PlaceBuilder into Place if upvars can be resolved.

r? @nikomatsakis 