### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -63,7 +63,7 @@ pub trait TraitEngine<'tcx>: 'tcx {
         infcx: &InferCtxt<'_, 'tcx>,
     ) -> Result<(), Vec<FulfillmentError<'tcx>>>;
 
-    // FIXME this should not provide a default body for chalk as chalk should be updated
+    // FIXME(fee1-dead) this should not provide a default body for chalk as chalk should be updated
     fn select_with_constness_where_possible(
         &mut self,
         infcx: &InferCtxt<'_, 'tcx>,

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -95,7 +95,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
         let mut l = lint.build("panic message is not a string literal");
         l.note("this usage of panic!() is deprecated; it will be a hard error in Rust 2021");
         l.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>");
-        if !span.contains(arg_span) {
+        if !is_arg_inside_call(arg_span, span) {
             // No clue where this argument is coming from.
             l.emit();
             return;
@@ -180,7 +180,7 @@ fn check_panic_str<'tcx>(
                 _ => "panic message contains unused formatting placeholders",
             });
             l.note("this message is not used as a format string when given without arguments, but will be in Rust 2021");
-            if span.contains(arg.span) {
+            if is_arg_inside_call(arg.span, span) {
                 l.span_suggestion(
                     arg.span.shrink_to_hi(),
                     &format!("add the missing argument{}", pluralize!(n_arguments)),
@@ -211,7 +211,7 @@ fn check_panic_str<'tcx>(
         cx.struct_span_lint(NON_FMT_PANICS, brace_spans.unwrap_or_else(|| vec![span]), |lint| {
             let mut l = lint.build(msg);
             l.note("this message is not used as a format string, but will be in Rust 2021");
-            if span.contains(arg.span) {
+            if is_arg_inside_call(arg.span, span) {
                 l.span_suggestion(
                     arg.span.shrink_to_lo(),
                     "add a \"{}\" format string to use the message literally",
@@ -258,4 +258,12 @@ fn panic_call<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>) -> (Span, 
     let macro_symbol =
         if let hygiene::ExpnKind::Macro(_, symbol) = expn.kind { symbol } else { sym::panic };
     (expn.call_site, panic_macro, macro_symbol.as_str())
+}
+
+fn is_arg_inside_call(arg: Span, call: Span) -> bool {
+    // We only add suggestions if the argument we're looking at appears inside the
+    // panic call in the source file, to avoid invalid suggestions when macros are involved.
+    // We specifically check for the spans to not be identical, as that happens sometimes when
+    // proc_macros lie about spans and apply the same span to all the tokens they produce.
+    call.contains(arg) && !call.source_equal(&arg)
 }

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -120,13 +120,26 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
                 );
             }
         } else {
+            let ty = cx.typeck_results().expr_ty(arg);
+            // If this is a &str or String, we can confidently give the `"{}", ` suggestion.
+            let is_str = matches!(
+                ty.kind(),
+                ty::Ref(_, r, _) if *r.kind() == ty::Str
+            ) || matches!(
+                (ty.ty_adt_def(), cx.tcx.get_diagnostic_item(sym::string_type)),
+                (Some(ty_def), Some(string_type)) if ty_def.did == string_type
+            );
             l.span_suggestion_verbose(
                 arg_span.shrink_to_lo(),
                 "add a \"{}\" format string to Display the message",
                 "\"{}\", ".into(),
-                Applicability::MaybeIncorrect,
+                if is_str {
+                    Applicability::MachineApplicable
+                } else {
+                    Applicability::MaybeIncorrect
+                },
             );
-            if panic == sym::std_panic_macro {
+            if !is_str && panic == sym::std_panic_macro {
                 if let Some((open, close, del)) = find_delimiters(cx, span) {
                     l.multipart_suggestion(
                         "or use std::panic::panic_any instead",

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -124,10 +124,10 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
             // If this is a &str or String, we can confidently give the `"{}", ` suggestion.
             let is_str = matches!(
                 ty.kind(),
-                ty::Ref(_, r, _) if *r.kind() == ty::Str
+                ty::Ref(_, r, _) if *r.kind() == ty::Str,
             ) || matches!(
-                (ty.ty_adt_def(), cx.tcx.get_diagnostic_item(sym::string_type)),
-                (Some(ty_def), Some(string_type)) if ty_def.did == string_type
+                ty.ty_adt_def(),
+                Some(ty_def) if cx.tcx.is_diagnostic_item(sym::string_type, ty_def.did),
             );
             l.span_suggestion_verbose(
                 arg_span.shrink_to_lo(),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -316,7 +316,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx.tcx
     }
 
-    /// returns `true` if the predicate is considered `const` to
+    /// Returns `true` if the predicate is considered `const` to
     /// this selection context.
     pub fn is_predicate_const(&self, pred: ty::Predicate<'_>) -> bool {
         match pred.kind().skip_binder() {

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -6,9 +6,7 @@ use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::TraitEngineExt as _;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::{GenericArg, Subst, UserSelfTy, UserSubsts};
-use rustc_middle::ty::{
-    self, FnSig, Lift, PolyFnSig, PredicateKind, Ty, TyCtxt, TypeFoldable, Variance,
-};
+use rustc_middle::ty::{self, FnSig, Lift, PolyFnSig, Ty, TyCtxt, TypeFoldable, Variance};
 use rustc_middle::ty::{ParamEnv, ParamEnvAnd, Predicate, ToPredicate};
 use rustc_span::DUMMY_SP;
 use rustc_trait_selection::infer::InferCtxtBuilderExt;
@@ -87,16 +85,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         Ok(())
     }
 
-    fn prove_predicate(&mut self, mut predicate: Predicate<'tcx>) {
-        if let PredicateKind::Trait(mut tr) = predicate.kind().skip_binder() {
-            if let hir::Constness::Const = tr.constness {
-                // FIXME check if we actually want to prove const predicates inside AscribeUserType
-                tr.constness = hir::Constness::NotConst;
-                predicate =
-                    predicate.kind().rebind(PredicateKind::Trait(tr)).to_predicate(self.tcx());
-            }
-        }
-
+    fn prove_predicate(&mut self, predicate: Predicate<'tcx>) {
         self.fulfill_cx.register_predicate_obligation(
             self.infcx,
             Obligation::new(ObligationCause::dummy(), self.param_env, predicate),

--- a/library/alloc/tests/const_fns.rs
+++ b/library/alloc/tests/const_fns.rs
@@ -10,7 +10,7 @@ pub const MY_VEC: Vec<usize> = Vec::new();
 #[allow(dead_code)]
 pub const MY_STRING: String = String::new();
 
-// FIXME remove this struct once we put `K: ?const Ord` on BTreeMap::new.
+// FIXME(fee1-dead) remove this struct once we put `K: ?const Ord` on BTreeMap::new.
 #[derive(PartialEq, Eq, PartialOrd)]
 pub struct MyType;
 

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -25,8 +25,6 @@
 #![feature(string_remove_matches)]
 #![feature(const_btree_new)]
 #![feature(const_trait_impl)]
-// FIXME remove this when const_trait_impl is not incomplete anymore
-#![allow(incomplete_features)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -42,7 +42,7 @@ dlmalloc = { version = "0.2.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = { version = "0.1.17", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.1.19", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/library/std/src/sys/hermit/condvar.rs
+++ b/library/std/src/sys/hermit/condvar.rs
@@ -14,7 +14,7 @@ pub struct Condvar {
     sem2: *const c_void,
 }
 
-pub type MovableCondvar = Box<Condvar>;
+pub type MovableCondvar = Condvar;
 
 unsafe impl Send for Condvar {}
 unsafe impl Sync for Condvar {}

--- a/library/std/src/sys/hermit/mutex.rs
+++ b/library/std/src/sys/hermit/mutex.rs
@@ -156,7 +156,7 @@ pub struct Mutex {
     inner: Spinlock<MutexInner>,
 }
 
-pub type MovableMutex = Box<Mutex>;
+pub type MovableMutex = Mutex;
 
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}

--- a/library/std/src/sys/hermit/rwlock.rs
+++ b/library/std/src/sys/hermit/rwlock.rs
@@ -8,7 +8,7 @@ pub struct RWLock {
     state: UnsafeCell<State>,
 }
 
-pub type MovableRWLock = Box<RWLock>;
+pub type MovableRWLock = RWLock;
 
 enum State {
     Unlocked,

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -220,11 +220,13 @@ else
 fi
 
 if [ "$CI" != "" ]; then
-    # Get some needed information for $BASE_COMMIT
-    git fetch "https://github.com/$GITHUB_REPOSITORY" "$GITHUB_BASE_REF"
-    BASE_COMMIT="$(git merge-base FETCH_HEAD HEAD)"
+  # Get some needed information for $BASE_COMMIT
+  #
+  # This command gets the last merge commit which we'll use as base to list
+  # deleted files since then.
+  BASE_COMMIT="$(git log --author=bors@rust-lang.org -n 2 --pretty=format:%H | tail -n 1)"
 else
-    BASE_COMMIT=""
+  BASE_COMMIT=""
 fi
 
 docker \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -73,6 +73,8 @@ Tier Policy.
 
 All tier 2 targets with host tools support the full standard library.
 
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
+
 target | notes
 -------|-------
 `aarch64-apple-darwin` | ARM64 macOS (11.0+, Big Sur+)
@@ -111,6 +113,8 @@ The `std` column in the table below has the following meanings:
 * \* indicates the target only supports [`no_std`] development.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
+
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
 
 target | std | notes
 -------|:---:|-------

--- a/src/test/ui/asm/issue-87802.rs
+++ b/src/test/ui/asm/issue-87802.rs
@@ -1,0 +1,17 @@
+// needs-asm-support
+// Make sure rustc doesn't ICE on asm! when output type is !.
+
+#![feature(asm)]
+
+fn hmm() -> ! {
+    let x;
+    unsafe {
+        asm!("/* {0} */", out(reg) x);
+        //~^ ERROR cannot use value of type `!` for inline assembly
+    }
+    x
+}
+
+fn main() {
+    hmm();
+}

--- a/src/test/ui/asm/issue-87802.stderr
+++ b/src/test/ui/asm/issue-87802.stderr
@@ -1,0 +1,10 @@
+error: cannot use value of type `!` for inline assembly
+  --> $DIR/issue-87802.rs:9:36
+   |
+LL |         asm!("/* {0} */", out(reg) x);
+   |                                    ^
+   |
+   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: aborting due to previous error
+

--- a/src/test/ui/non-fmt-panic.fixed
+++ b/src/test/ui/non-fmt-panic.fixed
@@ -1,0 +1,54 @@
+// run-rustfix
+// rustfix-only-machine-applicable
+// build-pass (FIXME(62277): should be check-pass)
+// aux-build:fancy-panic.rs
+
+extern crate fancy_panic;
+
+const C: &str = "abc {}";
+static S: &str = "{bla}";
+
+#[allow(unreachable_code)]
+fn main() {
+    panic!("{}", "here's a brace: {"); //~ WARN panic message contains a brace
+    std::panic!("{}", "another one: }"); //~ WARN panic message contains a brace
+    core::panic!("{}", "Hello {}"); //~ WARN panic message contains an unused formatting placeholder
+    assert!(false, "{}", "{:03x} {test} bla");
+    //~^ WARN panic message contains unused formatting placeholders
+    assert!(false, "{}", S);
+    //~^ WARN panic message is not a string literal
+    debug_assert!(false, "{}", "{{}} bla"); //~ WARN panic message contains braces
+    panic!("{}", C); //~ WARN panic message is not a string literal
+    panic!("{}", S); //~ WARN panic message is not a string literal
+    std::panic::panic_any(123); //~ WARN panic message is not a string literal
+    core::panic!("{}", &*"abc"); //~ WARN panic message is not a string literal
+    panic!("{}", concat!("{", "}")); //~ WARN panic message contains an unused formatting placeholder
+    panic!("{}", concat!("{", "{")); //~ WARN panic message contains braces
+
+    fancy_panic::fancy_panic!("test {} 123");
+    //~^ WARN panic message contains an unused formatting placeholder
+
+    fancy_panic::fancy_panic!(); // OK
+    fancy_panic::fancy_panic!(S); // OK
+
+    macro_rules! a {
+        () => { 123 };
+    }
+
+    std::panic::panic_any(a!()); //~ WARN panic message is not a string literal
+
+    panic!("{}", 1); //~ WARN panic message is not a string literal
+    assert!(false, "{}", 1); //~ WARN panic message is not a string literal
+    debug_assert!(false, "{}", 1); //~ WARN panic message is not a string literal
+
+    std::panic::panic_any(123); //~ WARN panic message is not a string literal
+    std::panic::panic_any(123); //~ WARN panic message is not a string literal
+
+    // Check that the lint only triggers for std::panic and core::panic,
+    // not any panic macro:
+    macro_rules! panic {
+        ($e:expr) => ();
+    }
+    panic!("{}"); // OK
+    panic!(S); // OK
+}

--- a/src/test/ui/non-fmt-panic.rs
+++ b/src/test/ui/non-fmt-panic.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+// rustfix-only-machine-applicable
 // build-pass (FIXME(62277): should be check-pass)
 // aux-build:fancy-panic.rs
 

--- a/src/test/ui/non-fmt-panic.stderr
+++ b/src/test/ui/non-fmt-panic.stderr
@@ -1,5 +1,5 @@
 warning: panic message contains a brace
-  --> $DIR/non-fmt-panic.rs:11:29
+  --> $DIR/non-fmt-panic.rs:13:29
    |
 LL |     panic!("here's a brace: {");
    |                             ^
@@ -12,7 +12,7 @@ LL |     panic!("{}", "here's a brace: {");
    |            +++++
 
 warning: panic message contains a brace
-  --> $DIR/non-fmt-panic.rs:12:31
+  --> $DIR/non-fmt-panic.rs:14:31
    |
 LL |     std::panic!("another one: }");
    |                               ^
@@ -24,7 +24,7 @@ LL |     std::panic!("{}", "another one: }");
    |                 +++++
 
 warning: panic message contains an unused formatting placeholder
-  --> $DIR/non-fmt-panic.rs:13:25
+  --> $DIR/non-fmt-panic.rs:15:25
    |
 LL |     core::panic!("Hello {}");
    |                         ^^
@@ -40,7 +40,7 @@ LL |     core::panic!("{}", "Hello {}");
    |                  +++++
 
 warning: panic message contains unused formatting placeholders
-  --> $DIR/non-fmt-panic.rs:14:21
+  --> $DIR/non-fmt-panic.rs:16:21
    |
 LL |     assert!(false, "{:03x} {test} bla");
    |                     ^^^^^^ ^^^^^^
@@ -56,7 +56,7 @@ LL |     assert!(false, "{}", "{:03x} {test} bla");
    |                    +++++
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:16:20
+  --> $DIR/non-fmt-panic.rs:18:20
    |
 LL |     assert!(false, S);
    |                    ^
@@ -69,7 +69,7 @@ LL |     assert!(false, "{}", S);
    |                    +++++
 
 warning: panic message contains braces
-  --> $DIR/non-fmt-panic.rs:18:27
+  --> $DIR/non-fmt-panic.rs:20:27
    |
 LL |     debug_assert!(false, "{{}} bla");
    |                           ^^^^
@@ -81,7 +81,7 @@ LL |     debug_assert!(false, "{}", "{{}} bla");
    |                          +++++
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:19:12
+  --> $DIR/non-fmt-panic.rs:21:12
    |
 LL |     panic!(C);
    |            ^
@@ -92,13 +92,9 @@ help: add a "{}" format string to Display the message
    |
 LL |     panic!("{}", C);
    |            +++++
-help: or use std::panic::panic_any instead
-   |
-LL |     std::panic::panic_any(C);
-   |     ~~~~~~~~~~~~~~~~~~~~~
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:20:12
+  --> $DIR/non-fmt-panic.rs:22:12
    |
 LL |     panic!(S);
    |            ^
@@ -109,13 +105,9 @@ help: add a "{}" format string to Display the message
    |
 LL |     panic!("{}", S);
    |            +++++
-help: or use std::panic::panic_any instead
-   |
-LL |     std::panic::panic_any(S);
-   |     ~~~~~~~~~~~~~~~~~~~~~
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:21:17
+  --> $DIR/non-fmt-panic.rs:23:17
    |
 LL |     std::panic!(123);
    |                 ^^^
@@ -132,7 +124,7 @@ LL |     std::panic::panic_any(123);
    |     ~~~~~~~~~~~~~~~~~~~~~
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:22:18
+  --> $DIR/non-fmt-panic.rs:24:18
    |
 LL |     core::panic!(&*"abc");
    |                  ^^^^^^^
@@ -145,7 +137,7 @@ LL |     core::panic!("{}", &*"abc");
    |                  +++++
 
 warning: panic message contains an unused formatting placeholder
-  --> $DIR/non-fmt-panic.rs:23:12
+  --> $DIR/non-fmt-panic.rs:25:12
    |
 LL |     panic!(concat!("{", "}"));
    |            ^^^^^^^^^^^^^^^^^
@@ -161,7 +153,7 @@ LL |     panic!("{}", concat!("{", "}"));
    |            +++++
 
 warning: panic message contains braces
-  --> $DIR/non-fmt-panic.rs:24:5
+  --> $DIR/non-fmt-panic.rs:26:5
    |
 LL |     panic!(concat!("{", "{"));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +165,7 @@ LL |     panic!("{}", concat!("{", "{"));
    |            +++++
 
 warning: panic message contains an unused formatting placeholder
-  --> $DIR/non-fmt-panic.rs:26:37
+  --> $DIR/non-fmt-panic.rs:28:37
    |
 LL |     fancy_panic::fancy_panic!("test {} 123");
    |                                     ^^
@@ -181,7 +173,7 @@ LL |     fancy_panic::fancy_panic!("test {} 123");
    = note: this message is not used as a format string when given without arguments, but will be in Rust 2021
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:36:12
+  --> $DIR/non-fmt-panic.rs:38:12
    |
 LL |     panic!(a!());
    |            ^^^^
@@ -198,7 +190,7 @@ LL |     std::panic::panic_any(a!());
    |     ~~~~~~~~~~~~~~~~~~~~~
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:38:12
+  --> $DIR/non-fmt-panic.rs:40:12
    |
 LL |     panic!(format!("{}", 1));
    |            ^^^^^^^^^^^^^^^^
@@ -213,7 +205,7 @@ LL +     panic!("{}", 1);
    | 
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:39:20
+  --> $DIR/non-fmt-panic.rs:41:20
    |
 LL |     assert!(false, format!("{}", 1));
    |                    ^^^^^^^^^^^^^^^^
@@ -228,7 +220,7 @@ LL +     assert!(false, "{}", 1);
    | 
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:40:26
+  --> $DIR/non-fmt-panic.rs:42:26
    |
 LL |     debug_assert!(false, format!("{}", 1));
    |                          ^^^^^^^^^^^^^^^^
@@ -243,7 +235,7 @@ LL +     debug_assert!(false, "{}", 1);
    | 
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:42:12
+  --> $DIR/non-fmt-panic.rs:44:12
    |
 LL |     panic![123];
    |            ^^^
@@ -260,7 +252,7 @@ LL |     std::panic::panic_any(123);
    |     ~~~~~~~~~~~~~~~~~~~~~~   ~
 
 warning: panic message is not a string literal
-  --> $DIR/non-fmt-panic.rs:43:12
+  --> $DIR/non-fmt-panic.rs:45:12
    |
 LL |     panic!{123};
    |            ^^^

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -121,12 +121,12 @@ async function main(argv) {
     }
     files = files.filter(file => path.extname(file) == ".goml");
     if (files.length === 0) {
-        console.log("rustdoc-gui: No test selected");
+        console.error("rustdoc-gui: No test selected");
         process.exit(2);
     }
     files.sort();
 
-    console.log(`running ${files.length} rustdoc-gui tests`);
+    console.log(`Running ${files.length} rustdoc-gui tests...`);
     process.setMaxListeners(files.length + 1);
     let tests = [];
     let results = new Array(files.length);
@@ -137,7 +137,6 @@ async function main(argv) {
         tests.push(
             runTest(testPath, options)
             .then(out => {
-                //console.log(i);
                 const [output, nb_failures] = out;
                 results[i] = {
                     status: nb_failures === 0 ? RUN_SUCCESS : RUN_FAILED,
@@ -186,14 +185,8 @@ async function main(argv) {
     });
     // print run errors on the bottom so developers see them better
     results.forEach(r => {
-        switch (r.status) {
-            case RUN_SUCCESS:
-            case RUN_FAILED:
-                // skip
-                break;
-            case RUN_ERRORED:
-                console.error(r.output);
-                break;
+        if (r.status === RUN_ERRORED) {
+            console.error(r.output);
         }
     });
 

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -84,7 +84,10 @@ async function main(argv) {
         process.exit(1);
     }
 
+    // Print successful tests too
     let debug = false;
+    // Run tests in sequentially
+    let no_headless = false;
     const options = new Options();
     try {
         // This is more convenient that setting fields one by one.
@@ -101,6 +104,7 @@ async function main(argv) {
         }
         if (opts["no_headless"]) {
             args.push("--no-headless");
+            no_headless = true;
         }
         options.parseArguments(args);
     } catch (error) {
@@ -155,6 +159,9 @@ async function main(argv) {
                 failed = true;
             })
         );
+        if (no_headless) {
+            await tests[i];
+        }
     }
     await Promise.all(tests);
     // final \n after the tests
@@ -187,9 +194,6 @@ async function main(argv) {
             case RUN_ERRORED:
                 console.error(r.output);
                 break;
-            default:
-                console.error(`unexpected status = ${r.status}`);
-                process.exit(4);
         }
     });
 

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -75,7 +75,7 @@ function print_test_successful() {
 }
 
 function print_test_erroneous() {
-    process.stdout.write("F");
+    process.stderr.write("F");
 }
 
 async function main(argv) {

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -5,6 +5,7 @@
 // ```
 const fs = require("fs");
 const path = require("path");
+const os = require('os');
 const {Options, runTest} = require('browser-ui-test');
 
 function showHelp() {
@@ -78,7 +79,7 @@ function char_printer(n_tests) {
         successful: function() {
             current += 1;
             if (current % max_per_line === 0) {
-                process.stdout.write(`. (${current}/${n_tests})\n`);
+                process.stdout.write(`. (${current}/${n_tests})${os.EOL}`);
             } else {
                 process.stdout.write(".");
             }
@@ -86,10 +87,14 @@ function char_printer(n_tests) {
         erroneous: function() {
             current += 1;
             if (current % max_per_line === 0) {
-                process.stderr.write(`F (${current}/${n_tests})\n`);
+                process.stderr.write(`F (${current}/${n_tests})${os.EOL}`);
             } else {
                 process.stderr.write("F");
             }
+        },
+        finish: function() {
+            const spaces = " ".repeat(max_per_line - (current % max_per_line));
+            process.stdout.write(`${spaces} (${current}/${n_tests})${os.EOL}${os.EOL}`);
         },
     };
 }
@@ -187,9 +192,10 @@ async function main(argv) {
             await tests[i];
         }
     }
-    await Promise.all(tests);
-    // final \n after the tests
-    console.log("\n");
+    if (!no_headless) {
+        await Promise.all(tests);
+    }
+    status_bar.finish();
 
     if (debug === false) {
         results.successful.sort(by_filename);

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -197,21 +197,28 @@ async function main(argv) {
     }
     status_bar.finish();
 
-    if (debug === false) {
+    if (debug) {
         results.successful.sort(by_filename);
         results.successful.forEach(r => {
             console.log(r.output);
         });
     }
-    results.failed.sort(by_filename);
-    results.failed.forEach(r => {
-        console.log(r.output);
-    });
-    // print run errors on the bottom so developers see them better
-    results.errored.sort(by_filename);
-    results.errored.forEach(r => {
-        console.error(r.output);
-    });
+
+    if (results.failed.length > 0) {
+        console.log("");
+        results.failed.sort(by_filename);
+        results.failed.forEach(r => {
+            console.log(r.output);
+        });
+    }
+    if (results.errored.length > 0) {
+        console.log(os.EOL);
+        // print run errors on the bottom so developers see them better
+        results.errored.sort(by_filename);
+        results.errored.forEach(r => {
+            console.error(r.output);
+        });
+    }
 
     if (failed) {
         process.exit(1);


### PR DESCRIPTION
Successful merges:

 - #86692 (Run rustdoc-gui tests in parallel)
 - #87677 (Adding explicit notice of lack of documentation for Tier 2 Platforms)
 - #87792 (Remove git fetch from CI)
 - #87967 (Detect fake spans in non_fmt_panic lint.)
 - #87982 (Add automatic migration for assert!(.., string).)
 - #87985 (Forbid `!` from being used in `asm!` output)
 - #88002 (Unbox mutexes, condvars and rwlocks on hermit)
 - #88030 (Assign FIXMEs to me and remove obsolete ones)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86692,87677,87792,87967,87982,87985,88002,88030)
<!-- homu-ignore:end -->