### PR TITLE
Allow casting unsized pointer types

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -44,7 +44,7 @@ impl<T: ?Sized> *const T {
     #[stable(feature = "ptr_cast", since = "1.38.0")]
     #[rustc_const_stable(feature = "const_ptr_cast", since = "1.38.0")]
     #[inline]
-    pub const fn cast<U>(self) -> *const U {
+    pub const fn cast<U: ?Sized>(self) -> *const U {
         self as _
     }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -43,7 +43,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "ptr_cast", since = "1.38.0")]
     #[rustc_const_stable(feature = "const_ptr_cast", since = "1.38.0")]
     #[inline(always)]
-    pub const fn cast<U>(self) -> *mut U {
+    pub const fn cast<U: ?Sized>(self) -> *mut U {
         self as _
     }
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -382,7 +382,7 @@ impl<T: ?Sized> NonNull<T> {
     #[stable(feature = "nonnull_cast", since = "1.27.0")]
     #[rustc_const_stable(feature = "const_nonnull_cast", since = "1.36.0")]
     #[inline]
-    pub const fn cast<U>(self) -> NonNull<U> {
+    pub const fn cast<U: ?Sized>(self) -> NonNull<U> {
         // SAFETY: `self` is a `NonNull` pointer which is necessarily non-null
         unsafe { NonNull::new_unchecked(self.as_ptr() as *mut U) }
     }

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -132,7 +132,7 @@ impl<T: ?Sized> Unique<T> {
 
     /// Casts to a pointer of another type.
     #[inline]
-    pub const fn cast<U>(self) -> Unique<U> {
+    pub const fn cast<U: ?Sized>(self) -> Unique<U> {
         // SAFETY: Unique::new_unchecked() creates a new unique and needs
         // the given pointer to not be null.
         // Since we are passing self as a pointer, it cannot be null.


### PR DESCRIPTION
I don't think it was intentional to give these types `Sized` bounds.