### PR TITLE
Update redox_syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]


### PR DESCRIPTION
The currently pinned version doesn't compile with the latest rustc nightly

cc @jackpot51