### PR TITLE
Update RELEASES to clarify attribute macro values.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,17 +4,12 @@ Version 1.54.0 (2021-07-29)
 Language
 -----------------------
 
-- [You can now use macros for values in built-in attribute macros.][83366]
-  While a seemingly minor addition on its own, this enables a lot of
-  powerful functionality when combined correctly. Most notably you can
-  now include external documentation in your crate by writing the following.
+- [You can now use macros for values in some built-in attributes.][83366]
+  This primarily allows you to call macros within the `#[doc]` attribute. For
+  example, to include external documentation in your crate, you can now write
+  the following:
   ```rust
   #![doc = include_str!("README.md")]
-  ```
-  You can also use this to include auto-generated modules:
-  ```rust
-  #[path = concat!(env!("OUT_DIR"), "/generated.rs")]
-  mod generated;
   ```
 
 - [You can now cast between unsized slice types (and types which contain


### PR DESCRIPTION
As noted in #87681, macros do not work with the `#[path]` attribute.  Since the places where macros *can* be used is very limited, I have changed this to just focus on `#[doc]` which is the only attribute where this is really useful.
