### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,145 @@
+Version 1.55.0 (2021-09-09)
+============================
+
+Language
+--------
+- [You can now write open "from" range patterns (`X..`), which will start at `X` and
+  will end at the maximum value of the integer.][83918]
+- [You can now explicitly import the prelude of different editions
+  through `std::prelude` (e.g. `use std::prelude::rust_2021::*;`).][86294]
+
+Compiler
+--------
+- [Added tier 3\* support for `powerpc-unknown-freebsd`.][87370]
+- [Added tier 3 support for `powerpc64le-unknown-freebsd`.][83572]
+
+\* Refer to Rust's [platform support page][platform-support-doc] for more
+   information on Rust's tiered platform support.
+
+Libraries
+---------
+
+- [Updated std's float parsing to use the Eisel-Lemire algorithm.][86761]
+  These improvements should in general provide faster string parsing of floats,
+  no longer reject certain valid floating point values, and reduce
+  the produced code size for non-stripped artifacts.
+- [`string::Drain` now implements `AsRef<str>` and `AsRef<[u8]>`.][86858]
+- [`collections::{BinaryHeap, BTreeSet, HashSet, LinkedList, VecDeque}` now
+  implement `From<[T; N]>`.][84111]
+- [`collections::{BTreeMap, HashMap}` now implement `From<[(K, V); N]>`.][84111]
+  This allows you to write the following;
+  ```rust
+  let highscores = std::collections::HashMap::from([
+      ("Alice", 9000u32),
+      ("Bob", 7250),
+      ("Charlie", 5500),
+  ]);
+  ```
+
+Stabilised APIs
+---------------
+
+- [`Bound::cloned`]
+- [`Drain::as_str`]
+- [`IntoInnerError::into_error`]
+- [`IntoInnerError::into_parts`]
+- [`MaybeUninit::assume_init_mut`]
+- [`MaybeUninit::assume_init_ref`]
+- [`MaybeUninit::write`]
+- [`array::map`]
+- [`ops::ControlFlow`]
+- [`x86::_bittest`]
+- [`x86::_bittestandcomplement`]
+- [`x86::_bittestandreset`]
+- [`x86::_bittestandset`]
+- [`x86_64::_bittest64`]
+- [`x86_64::_bittestandcomplement64`]
+- [`x86_64::_bittestandreset64`]
+- [`x86_64::_bittestandset64`]
+
+The following previously stable functions are now `const`.
+
+- [`str::from_utf8_unchecked`]
+- [`mem::transmute`]
+
+
+Cargo
+-----
+- [Cargo will now deduplicate compiler diagnostics to the terminal when invoking
+  rustc in parallel such as when using `cargo test`.][cargo/9675]
+- [The package definition in `cargo metadata` now includes the `"default_run"`
+  field from the manifest.][cargo/9550]
+- [Added `cargo d` as an alias for `cargo doc`.][cargo/9680]
+
+Rustdoc
+-------
+- [Added "Go to item on exact match" search option.][85876]
+- [The "Implementors" section on traits no longer shows redundant
+  method definitions.][85970]
+- [Trait implementations are toggled open by default.][86260] This should make the
+  implementations more searchable by tools like `CTRL+F` in your browser.
+- [Intra-doc links should now correctly resolve associated items (e.g. methods)
+  through type aliases.][86334]
+- [Traits which are marked with `#[doc(hidden)]` will no longer appear in the
+  "Trait Implementations" section.][86513]
+
+
+Compatibility Notes
+-------------------
+- [std functions that return an `io::Error` will no longer use the
+  `ErrorKind::Other` variant.][85746] This is to better reflect that these
+  kinds of errors could be categorised [into newer more specific `ErrorKind`
+  variants][79965], and that they do not represent a user error.
+- [Using environment variable names with `process::Command` on Windows now
+  behaves as expected.][85270] Previously using envionment variables with
+  `Command` would cause them to be ASCII-uppercased.
+- [Rustdoc will now warn on using rustdoc lints that aren't prefixed
+  with `rustdoc::`][86849]
+
+[86849]: https://github.com/rust-lang/rust/pull/86849
+[86513]: https://github.com/rust-lang/rust/pull/86513
+[86334]: https://github.com/rust-lang/rust/pull/86334
+[86260]: https://github.com/rust-lang/rust/pull/86260
+[85970]: https://github.com/rust-lang/rust/pull/85970
+[85876]: https://github.com/rust-lang/rust/pull/85876
+[83572]: https://github.com/rust-lang/rust/pull/83572
+[86294]: https://github.com/rust-lang/rust/pull/86294
+[86858]: https://github.com/rust-lang/rust/pull/86858
+[86761]: https://github.com/rust-lang/rust/pull/86761
+[85769]: https://github.com/rust-lang/rust/pull/85769
+[85746]: https://github.com/rust-lang/rust/pull/85746
+[85305]: https://github.com/rust-lang/rust/pull/85305
+[85270]: https://github.com/rust-lang/rust/pull/85270
+[84111]: https://github.com/rust-lang/rust/pull/84111
+[83918]: https://github.com/rust-lang/rust/pull/83918
+[79965]: https://github.com/rust-lang/rust/pull/79965
+[87370]: https://github.com/rust-lang/rust/pull/87370
+[87298]: https://github.com/rust-lang/rust/pull/87298
+[cargo/9675]: https://github.com/rust-lang/cargo/pull/9675
+[cargo/9550]: https://github.com/rust-lang/cargo/pull/9550
+[cargo/9680]: https://github.com/rust-lang/cargo/pull/9680
+[`array::map`]: https://doc.rust-lang.org/stable/std/primitive.array.html#method.map
+[`Bound::cloned`]: https://doc.rust-lang.org/stable/std/ops/enum.Bound.html#method.cloned
+[`Drain::as_str`]: https://doc.rust-lang.org/stable/std/string/struct.Drain.html#method.as_str
+[`IntoInnerError::into_error`]: https://doc.rust-lang.org/stable/std/io/struct.IntoInnerError.html#method.into_error
+[`IntoInnerError::into_parts`]: https://doc.rust-lang.org/stable/std/io/struct.IntoInnerError.html#method.into_parts
+[`MaybeUninit::assume_init_mut`]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_mut
+[`MaybeUninit::assume_init_ref`]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_ref
+[`MaybeUninit::write`]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.write
+[`Seek::rewind`]: https://doc.rust-lang.org/stable/std/io/trait.Seek.html#method.rewind
+[`mem::transmute`]: https://doc.rust-lang.org/stable/std/mem/fn.transmute.html
+[`ops::ControlFlow`]: https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html
+[`str::from_utf8_unchecked`]: https://doc.rust-lang.org/stable/std/str/fn.from_utf8_unchecked.html
+[`x86::_bittest`]: https://doc.rust-lang.org/stable/core/arch/x86/fn._bittest.html
+[`x86::_bittestandcomplement`]: https://doc.rust-lang.org/stable/core/arch/x86/fn._bittestandcomplement.html
+[`x86::_bittestandreset`]: https://doc.rust-lang.org/stable/core/arch/x86/fn._bittestandreset.html
+[`x86::_bittestandset`]: https://doc.rust-lang.org/stable/core/arch/x86/fn._bittestandset.html
+[`x86_64::_bittest64`]: https://doc.rust-lang.org/stable/core/arch/x86_64/fn._bittest64.html
+[`x86_64::_bittestandcomplement64`]: https://doc.rust-lang.org/stable/core/arch/x86_64/fn._bittestandcomplement64.html
+[`x86_64::_bittestandreset64`]: https://doc.rust-lang.org/stable/core/arch/x86_64/fn._bittestandreset64.html
+[`x86_64::_bittestandset64`]: https://doc.rust-lang.org/stable/core/arch/x86_64/fn._bittestandset64.html
+
+
 Version 1.54.0 (2021-07-29)
 ============================
 

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -63,7 +63,7 @@ pub trait TraitEngine<'tcx>: 'tcx {
         infcx: &InferCtxt<'_, 'tcx>,
     ) -> Result<(), Vec<FulfillmentError<'tcx>>>;
 
-    // FIXME this should not provide a default body for chalk as chalk should be updated
+    // FIXME(fee1-dead) this should not provide a default body for chalk as chalk should be updated
     fn select_with_constness_where_possible(
         &mut self,
         infcx: &InferCtxt<'_, 'tcx>,

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -95,7 +95,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
         let mut l = lint.build("panic message is not a string literal");
         l.note("this usage of panic!() is deprecated; it will be a hard error in Rust 2021");
         l.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>");
-        if !span.contains(arg_span) {
+        if !is_arg_inside_call(arg_span, span) {
             // No clue where this argument is coming from.
             l.emit();
             return;
@@ -180,7 +180,7 @@ fn check_panic_str<'tcx>(
                 _ => "panic message contains unused formatting placeholders",
             });
             l.note("this message is not used as a format string when given without arguments, but will be in Rust 2021");
-            if span.contains(arg.span) {
+            if is_arg_inside_call(arg.span, span) {
                 l.span_suggestion(
                     arg.span.shrink_to_hi(),
                     &format!("add the missing argument{}", pluralize!(n_arguments)),
@@ -211,7 +211,7 @@ fn check_panic_str<'tcx>(
         cx.struct_span_lint(NON_FMT_PANICS, brace_spans.unwrap_or_else(|| vec![span]), |lint| {
             let mut l = lint.build(msg);
             l.note("this message is not used as a format string, but will be in Rust 2021");
-            if span.contains(arg.span) {
+            if is_arg_inside_call(arg.span, span) {
                 l.span_suggestion(
                     arg.span.shrink_to_lo(),
                     "add a \"{}\" format string to use the message literally",
@@ -258,4 +258,12 @@ fn panic_call<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>) -> (Span, 
     let macro_symbol =
         if let hygiene::ExpnKind::Macro(_, symbol) = expn.kind { symbol } else { sym::panic };
     (expn.call_site, panic_macro, macro_symbol.as_str())
+}
+
+fn is_arg_inside_call(arg: Span, call: Span) -> bool {
+    // We only add suggestions if the argument we're looking at appears inside the
+    // panic call in the source file, to avoid invalid suggestions when macros are involved.
+    // We specifically check for the spans to not be identical, as that happens sometimes when
+    // proc_macros lie about spans and apply the same span to all the tokens they produce.
+    call.contains(arg) && !call.source_equal(&arg)
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -316,7 +316,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx.tcx
     }
 
-    /// returns `true` if the predicate is considered `const` to
+    /// Returns `true` if the predicate is considered `const` to
     /// this selection context.
     pub fn is_predicate_const(&self, pred: ty::Predicate<'_>) -> bool {
         match pred.kind().skip_binder() {

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -6,9 +6,7 @@ use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::TraitEngineExt as _;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::{GenericArg, Subst, UserSelfTy, UserSubsts};
-use rustc_middle::ty::{
-    self, FnSig, Lift, PolyFnSig, PredicateKind, Ty, TyCtxt, TypeFoldable, Variance,
-};
+use rustc_middle::ty::{self, FnSig, Lift, PolyFnSig, Ty, TyCtxt, TypeFoldable, Variance};
 use rustc_middle::ty::{ParamEnv, ParamEnvAnd, Predicate, ToPredicate};
 use rustc_span::DUMMY_SP;
 use rustc_trait_selection::infer::InferCtxtBuilderExt;
@@ -87,16 +85,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         Ok(())
     }
 
-    fn prove_predicate(&mut self, mut predicate: Predicate<'tcx>) {
-        if let PredicateKind::Trait(mut tr) = predicate.kind().skip_binder() {
-            if let hir::Constness::Const = tr.constness {
-                // FIXME check if we actually want to prove const predicates inside AscribeUserType
-                tr.constness = hir::Constness::NotConst;
-                predicate =
-                    predicate.kind().rebind(PredicateKind::Trait(tr)).to_predicate(self.tcx());
-            }
-        }
-
+    fn prove_predicate(&mut self, predicate: Predicate<'tcx>) {
         self.fulfill_cx.register_predicate_obligation(
             self.infcx,
             Obligation::new(ObligationCause::dummy(), self.param_env, predicate),

--- a/library/alloc/tests/const_fns.rs
+++ b/library/alloc/tests/const_fns.rs
@@ -10,7 +10,7 @@ pub const MY_VEC: Vec<usize> = Vec::new();
 #[allow(dead_code)]
 pub const MY_STRING: String = String::new();
 
-// FIXME remove this struct once we put `K: ?const Ord` on BTreeMap::new.
+// FIXME(fee1-dead) remove this struct once we put `K: ?const Ord` on BTreeMap::new.
 #[derive(PartialEq, Eq, PartialOrd)]
 pub struct MyType;
 

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -25,8 +25,6 @@
 #![feature(string_remove_matches)]
 #![feature(const_btree_new)]
 #![feature(const_trait_impl)]
-// FIXME remove this when const_trait_impl is not incomplete anymore
-#![allow(incomplete_features)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -42,7 +42,7 @@ dlmalloc = { version = "0.2.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = { version = "0.1.17", features = ['rustc-dep-of-std'] }
+hermit-abi = { version = "0.1.19", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.9.0", features = ['rustc-dep-of-std'], default-features = false }

--- a/library/std/src/sys/hermit/condvar.rs
+++ b/library/std/src/sys/hermit/condvar.rs
@@ -14,7 +14,7 @@ pub struct Condvar {
     sem2: *const c_void,
 }
 
-pub type MovableCondvar = Box<Condvar>;
+pub type MovableCondvar = Condvar;
 
 unsafe impl Send for Condvar {}
 unsafe impl Sync for Condvar {}

--- a/library/std/src/sys/hermit/mutex.rs
+++ b/library/std/src/sys/hermit/mutex.rs
@@ -156,7 +156,7 @@ pub struct Mutex {
     inner: Spinlock<MutexInner>,
 }
 
-pub type MovableMutex = Box<Mutex>;
+pub type MovableMutex = Mutex;
 
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}

--- a/library/std/src/sys/hermit/rwlock.rs
+++ b/library/std/src/sys/hermit/rwlock.rs
@@ -8,7 +8,7 @@ pub struct RWLock {
     state: UnsafeCell<State>,
 }
 
-pub type MovableRWLock = Box<RWLock>;
+pub type MovableRWLock = RWLock;
 
 enum State {
     Unlocked,

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -73,6 +73,8 @@ Tier Policy.
 
 All tier 2 targets with host tools support the full standard library.
 
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
+
 target | notes
 -------|-------
 `aarch64-apple-darwin` | ARM64 macOS (11.0+, Big Sur+)
@@ -111,6 +113,8 @@ The `std` column in the table below has the following meanings:
 * \* indicates the target only supports [`no_std`] development.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
+
+**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
 
 target | std | notes
 -------|:---:|-------

--- a/src/test/codegen/external-no-mangle-statics.rs
+++ b/src/test/codegen/external-no-mangle-statics.rs
@@ -1,10 +1,11 @@
+// revisions: lib staticlib
 // ignore-emscripten default visibility is hidden
 // compile-flags: -O
 // `#[no_mangle]`d static variables always have external linkage, i.e., no `internal` in their
 // definitions
 
-#![crate_type = "lib"]
-#![no_std]
+#![cfg_attr(lib, crate_type = "lib")]
+#![cfg_attr(staticlib, crate_type = "staticlib")]
 
 // CHECK: @A = local_unnamed_addr constant
 #[no_mangle]

--- a/src/test/ui/asm/issue-87802.rs
+++ b/src/test/ui/asm/issue-87802.rs
@@ -1,0 +1,17 @@
+// needs-asm-support
+// Make sure rustc doesn't ICE on asm! when output type is !.
+
+#![feature(asm)]
+
+fn hmm() -> ! {
+    let x;
+    unsafe {
+        asm!("/* {0} */", out(reg) x);
+        //~^ ERROR cannot use value of type `!` for inline assembly
+    }
+    x
+}
+
+fn main() {
+    hmm();
+}

--- a/src/test/ui/asm/issue-87802.stderr
+++ b/src/test/ui/asm/issue-87802.stderr
@@ -1,0 +1,10 @@
+error: cannot use value of type `!` for inline assembly
+  --> $DIR/issue-87802.rs:9:36
+   |
+LL |         asm!("/* {0} */", out(reg) x);
+   |                                    ^
+   |
+   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/dead-code/anon-const-in-pat.rs
+++ b/src/test/ui/lint/dead-code/anon-const-in-pat.rs
@@ -1,0 +1,45 @@
+// check-pass
+#![feature(inline_const)]
+#![allow(incomplete_features)]
+#![deny(dead_code)]
+
+const fn one() -> i32 {
+    1
+}
+
+const fn two() -> i32 {
+    2
+}
+
+const fn three() -> i32 {
+    3
+}
+
+fn inline_const() {
+    // rust-lang/rust#78171: dead_code lint triggers even though function is used in const pattern
+    match 1 {
+        const { one() } => {}
+        _ => {}
+    }
+}
+
+fn inline_const_range() {
+    match 1 {
+        1 ..= const { two() } => {}
+        _ => {}
+    }
+}
+
+struct S<const C: i32>;
+
+fn const_generic_arg() {
+    match S::<3> {
+        S::<{three()}> => {}
+    }
+}
+
+fn main() {
+    inline_const();
+    inline_const_range();
+    const_generic_arg();
+}


### PR DESCRIPTION
Successful merges:

 - #87677 (Adding explicit notice of lack of documentation for Tier 2 Platforms)
 - #87967 (Detect fake spans in non_fmt_panic lint.)
 - #87985 (Forbid `!` from being used in `asm!` output)
 - #88002 (Unbox mutexes, condvars and rwlocks on hermit)
 - #88030 (Assign FIXMEs to me and remove obsolete ones)
 - #88032 (Fix `reachable_set` for non-function items in non-library crates)
 - #88036 (Fix dead code warning when inline const is used in pattern)
 - #88052 (Update redox_syscall)
 - #88055 (Update RELEASES.md for 1.55.0)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87677,87967,87985,88002,88030,88032,88036,88052,88055)
<!-- homu-ignore:end -->