### PR TITLE
Allow the iOS toolchain to be built on Linux

### DIFF
--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -166,11 +166,6 @@ pub fn check(build: &mut Build) {
     }
 
     for target in &build.targets {
-        // Can't compile for iOS unless we're on macOS
-        if target.contains("apple-ios") && !build.build.contains("apple-darwin") {
-            panic!("the iOS target is only supported on macOS");
-        }
-
         build
             .config
             .target_config


### PR DESCRIPTION
The iOS toolchain can be built on Linux with minor changes. The compilation will invoke `xcrun` to find the path to the iPhone SDK but a fake `xcrun` executable can be used.

```
#!/bin/sh
echo "/path/to/sdk"
```

The iOS toolchain can then be built and linked with rustup.

```
$ ./x.py build --stage 2 --host x86_64-unknown-linux-gnu \
  	 --target aarch64-apple-ios
$ rustup toolchain link stage1 build/x86_64-unknown-linux-gnu/stage1
```

It's possible to take this toolchain and compile an iOS executable with it. This requires the ld64 linker and an iOS SDK. The ld64 linker can be taken from [cctools](https://github.com/tpoechtrager/cctools-port). A project's .cargo/config can then be edited to use the linker for this target.

```
[target.aarch64-apple-ios]
linker = "/path/to/cctools/bin/arm-apple-darwin-ld"
rustflags = [
    "-C",
    """
link-args=
    -F/path/to/sdk/System/Library/Frameworks
    -L/path/to/sdk/usr/lib
    -L/path/to/sdk/usr/lib/system/
    -adhoc_codesign
    """,
]
```