### PR TITLE
Skip assert ICE with default_method_body_is_const

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/mod.rs
@@ -9,7 +9,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::mir;
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::Symbol;
+use rustc_span::{sym, Symbol};
 
 pub use self::qualifs::Qualif;
 
@@ -103,6 +103,13 @@ pub fn rustc_allow_const_fn_unstable(
 // cannot use unstable features and can only call other "const-stable" functions.
 pub fn is_const_stable_const_fn(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
     use attr::{ConstStability, Stability, StabilityLevel};
+
+    // A default body marked const is not const-stable because const
+    // trait fns currently cannot be const-stable. We shouldn't
+    // restrict default bodies to only call const-stable functions.
+    if tcx.has_attr(def_id, sym::default_method_body_is_const) {
+        return false;
+    }
 
     // Const-stability is only relevant for `const fn`.
     assert!(tcx.is_const_fn_raw(def_id));

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+// This was an ICE, because the compiler ensures the
+// function to be const when performing const checking,
+// but functions marked with the attribute are not const
+// *and* subject to const checking.
+
+#![feature(staged_api)]
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+#![stable(since = "1", feature = "foo")]
+
+trait Tr {
+    #[default_method_body_is_const]
+    fn a() {}
+}
+
+fn main() {}


### PR DESCRIPTION
functions marked with #[default_method_body_is_const] would
ICE when being const checked due to it not being a const function:
`tcx.is_const_fn_raw(did)` returns false. We should skip this assert
when it is marked with that attribute.

r? @oli-obk