### PR TITLE
BTree: toughen panicky test of clone()

### DIFF
--- a/library/alloc/src/collections/btree/testing/crash_test.rs
+++ b/library/alloc/src/collections/btree/testing/crash_test.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 /// on anything defined in the crate, apart from the `Debug` trait.
 #[derive(Debug)]
 pub struct CrashTestDummy {
-    id: usize,
+    pub id: usize,
     cloned: AtomicUsize,
     dropped: AtomicUsize,
     queried: AtomicUsize,


### PR DESCRIPTION
Test did not cover the second half of `clone_subtree` and why this clones key & value first.