### PR TITLE
Forbid inline const block referencing params from being used in patterns

### DIFF
--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,0 +1,16 @@
+#![allow(incomplete_features)]
+#![feature(inline_const)]
+
+// rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
+
+fn foo<const V: usize>() {
+  match 0 {
+    const { V } => {},
+    //~^ ERROR const parameters cannot be referenced in patterns [E0158]
+    _ => {},
+  }
+}
+
+fn main() {
+    foo::<1>();
+}

--- a/src/test/ui/inline-const/const-match-pat-generic.stderr
+++ b/src/test/ui/inline-const/const-match-pat-generic.stderr
@@ -1,0 +1,9 @@
+error[E0158]: const parameters cannot be referenced in patterns
+  --> $DIR/const-match-pat-generic.rs:8:11
+   |
+LL |     const { V } => {},
+   |           ^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0158`.


### PR DESCRIPTION
Fix #82518