### PR TITLE
[WIP] parameterize `-C prefer-dynamic`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -77,7 +77,7 @@ fn prepare_lto(
     // with either fat or thin LTO
     let mut upstream_modules = Vec::new();
     if cgcx.lto != Lto::ThinLocal {
-        if cgcx.opts.cg.prefer_dynamic {
+        if cgcx.opts.cg.prefer_dynamic.is_non_empty() {
             diag_handler
                 .struct_err("cannot prefer dynamic linking when performing LTO")
                 .note(

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -256,7 +256,7 @@ impl CodegenCx<'ll, 'tcx> {
             debug_assert!(
                 !(self.tcx.sess.opts.cg.linker_plugin_lto.enabled()
                     && self.tcx.sess.target.is_like_windows
-                    && self.tcx.sess.opts.cg.prefer_dynamic)
+                    && self.tcx.sess.opts.cg.prefer_dynamic.is_non_empty())
             );
 
             if needs_dll_storage_attr {

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1950,7 +1950,7 @@ fn msvc_imps_needed(tcx: TyCtxt<'_>) -> bool {
     assert!(
         !(tcx.sess.opts.cg.linker_plugin_lto.enabled()
             && tcx.sess.target.is_like_windows
-            && tcx.sess.opts.cg.prefer_dynamic)
+            && tcx.sess.opts.cg.prefer_dynamic.is_non_empty())
     );
 
     tcx.sess.target.is_like_windows &&

--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -46,10 +46,10 @@
 //! all dynamic. This isn't currently very well battle tested, so it will likely
 //! fall short in some use cases.
 //!
-//! Currently, there is no way to specify the preference of linkage with a
-//! particular library (other than a global dynamic/static switch).
-//! Additionally, the algorithm is geared towards finding *any* solution rather
-//! than finding a number of solutions (there are normally quite a few).
+//! The algorithm is geared towards finding *any* solution rather than finding a
+//! number of solutions (there are normally quite a few). One can specify the
+//! preference of linkage for a particular list of crates by specifying that
+//! list via `-C prefer-dynamic=crate1,crate2,...`.
 
 use crate::creader::CStore;
 

--- a/compiler/rustc_middle/src/middle/cstore.rs
+++ b/compiler/rustc_middle/src/middle/cstore.rs
@@ -58,7 +58,7 @@ impl CrateDepKind {
     }
 }
 
-#[derive(Copy, Debug, PartialEq, Clone, Encodable, Decodable, HashStable)]
+#[derive(Copy, Debug, PartialEq, Eq, Clone, Encodable, Decodable, Hash, HashStable)]
 pub enum LinkagePreference {
     RequireDynamic,
     RequireStatic,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1238,6 +1238,10 @@ options! {
         "use a more precise version of drop elaboration for matches on enums (default: yes). \
         This results in better codegen, but has caused miscompilations on some tier 2 platforms. \
         See #77382 and #74551."),
+    prefer_dynamic_std: bool = (false, parse_bool, [UNTRACKED],
+        "enable use of unstable `-C prefer-dynamic=std` variant"),
+    prefer_dynamic_subset: bool = (false, parse_bool, [UNTRACKED],
+        "enable use of unstable `-C prefer-dynamic=crate1,crate2,...` variant"),
     print_fuel: Option<String> = (None, parse_opt_string, [TRACKED],
         "make rustc print the total optimization fuel used by a crate"),
     print_link_args: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1379,7 +1379,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // when compiling for LLD ThinLTO. This way we can validly just not generate
     // the `dllimport` attributes and `__imp_` symbols in that case.
     if sess.opts.cg.linker_plugin_lto.enabled()
-        && sess.opts.cg.prefer_dynamic
+        && sess.opts.cg.prefer_dynamic.is_non_empty()
         && sess.target.is_like_windows
     {
         sess.err(

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -402,6 +402,13 @@ linkage. This flag takes one of the following values:
 
 * `y`, `yes`, `on`, or no value: use dynamic linking.
 * `n`, `no`, or `off`: use static linking (the default).
+* A comma-separated list of crate names `crate1,crate2,...`: prefer dynamic
+  linking, but solely for the indicated crates. For example, to statically link
+  everything except `std`, use `-C prefer-dynamic=std`.
+
+Note that the explicit list of crate names variant of this flag is gated behind
+`-Zprefer-dynamic-subset`; as a special case, one can enable the handling of
+the single crate `std` as shown in the example above via `-Zprefer-dynamic-std`.
 
 ## profile-generate
 

--- a/src/test/run-make-fulldeps/dylib-subset/Makefile
+++ b/src/test/run-make-fulldeps/dylib-subset/Makefile
@@ -1,0 +1,176 @@
+-include ../tools.mk
+
+# Here's the basic overview: the crates all form a chain of dependencies,
+#
+#   m6 -> m5 -> m4 -> m3 -> m2 -> m1
+#
+# but: some crates have both rlibs and dylibs available, and others have only
+# rlib, or only dylib.
+#
+#   m6 (app) -> m5 (rlib) -> m4 (dylib) -> m3 (rlib,dylib) -> m2 (lib) -> m1 (dylib,rlib)
+#
+# So the question we explore in this test is: What is the effect of `-C
+# prefer-dynamic` at different points in the chain.
+#
+# For example, if you try to build the above without *any* use of `-C
+# prefer-dynamic`, build of `m6` fails, because the compilation of dylib for
+# `m4` prefers the rlib for `m3` (which itself statically links the rlib for
+# `m1`). This is illustrated in v1 below.
+
+RLIB_TYPE=--crate-type rlib --cfg rlib_type
+DYLIB_TYPE=--crate-type dylib --cfg dylib_type
+LIB_TYPE=--crate-type lib --cfg lib_type
+BIN_TYPE=--crate-type bin --cfg bin_type
+PREFER_DYNAMIC_INPUT=-Zprefer-dynamic-subset -Cprefer-dynamic=std,m2,m3,$(1)
+
+# How to read this command sequence, for people unversed in shell scripting:
+#
+# I have tried to write useful comments as `echo` statements. Their text is usually
+# delimited by single quotes ('') rathern than double quotes ("") so that I can use
+# backticks (``) in the notes without it being interpreted as a shell invocation.
+#
+# `COMMAND && exit 1 && exit 0` is how we run a command and say that we're
+# expecting it to fail.
+#
+# `>&2 echo "stuff"` emits "stuff" to stderr; that's useful for humans reviewing
+# the error output on expected errors.
+#
+# (I'm not going so far as to programmatically verify the error output actually
+# matches our expectations here; that is a bridge too far. Instead, I'm just
+# trusting that if an error arises, its for the reason stated in the comment
+# emitted to stderr.)
+#
+# Note: you can add a `false` to the end of the recipe if you want to forcibly
+# see the stderr and stdout output captured in `compiletest`.
+
+all:
+	echo 'v1: no extra flags, just see what default behavior is for this strange chain of crates.'
+	>&2 echo '`m1` build as dylib and rlib, v1'
+	$(RUSTC) m1.rs $(DYLIB_TYPE)
+	$(RUSTC) m1.rs $(RLIB_TYPE)
+	>&2 echo '`m2` build as lib, v1'
+	$(RUSTC) m2.rs $(LIB_TYPE)
+	>&2 echo '`m3` build as dylib, v1; no prefer-dynamic: expected to select rlib for `m1`'
+	$(RUSTC) m3.rs $(DYLIB_TYPE)
+	>&2 echo '`m3` build as rlib, v1'
+	$(RUSTC) m3.rs $(RLIB_TYPE)
+	>&2 echo '`m4` build as dylib, v1; no prefer-dynamic: expected to select rlib for `m3`'
+	$(RUSTC) m4.rs $(DYLIB_TYPE)
+	>&2 echo '`m5` build as rlib, v1'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build binary, v1: selects dylib for `m4`, because no rlib available'
+	$(RUSTC) m6.rs $(BIN_TYPE) && exit 1 || exit 0
+	>&2 echo 'above expected to fail: `m1`, `m3` and `std` linked dynamically via `m6` and statically via `m4`.'
+
+	echo 'v2: most immediate fix for problem from previous version: prefer-dynamic on `m4`.'
+	>&2 echo '`m4` build as dylib v2: prefer-dynamic (selects dylibs for `std` and `m3`)'
+	$(RUSTC) m4.rs $(DYLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m5` build as rlib v2'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build binary, v2: selects dylib for `m4`, because no rlib available'
+	$(RUSTC) m6.rs $(BIN_TYPE)
+	echo 'run `m6` v2'
+	$(call RUN,m6) > $(TMPDIR)/v2.output
+	echo 'expectation: prefer-dynamic on `m4` selected dylib for `m3`, while latter linked rlib for `m1`.'
+	echo 'linkage: m6:bin m5:rlib m4:dylib m3:dylib m2:lib m1:rlib' > $(TMPDIR)/v2.expect
+	diff -u $(TMPDIR)/v2.output $(TMPDIR)/v2.expect
+	echo 'expectation: removing m4 dylib will cause run attempt to fail.'
+	>&2 echo 'remove m4 dylib'
+	$(call REMOVE_DYLIBS,m4)
+	$(call FAIL,m6)
+	>&2 echo 'rebuild m4 and check that recovered state.'
+	$(RUSTC) m4.rs $(DYLIB_TYPE) -C prefer-dynamic
+	$(call RUN,m6)
+	echo 'expectation: removing m3 dylib alone will cause run attempt to fail.'
+	>&2 echo 'remove m3 dylib'
+	$(call REMOVE_DYLIBS,m3)
+	$(call FAIL,m6)
+	>&2 echo 'rebuild m3 and check that recovered state.'
+	$(RUSTC) m3.rs $(DYLIB_TYPE)
+	$(call RUN,m6)
+	echo 'expectation: removing m1 dylib and rlib will not perturb run v2 attempt.'
+	>&2 echo 'remove `m1` rlib and dylib'
+	$(call REMOVE_DYLIBS,m1)
+	$(call REMOVE_RLIBS,m1)
+	$(call RUN,m6)
+	>&2 echo 'rebuild `m1` rlib and dylib'
+	$(RUSTC) m1.rs $(RLIB_TYPE)
+	$(RUSTC) m1.rs $(DYLIB_TYPE)
+
+	echo 'v3: try `-C prefer-dynamic` when compiling `m2` now.'
+	>&2 echo 'rebuild m1 dylib'
+	$(RUSTC) m1.rs $(RLIB_TYPE)
+	$(RUSTC) m1.rs $(DYLIB_TYPE)
+	>&2 echo '`m2` build as lib, v3: prefer-dynamic (overall, still selects m1.rlib)'
+	$(RUSTC) m2.rs $(LIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m3` build as dylib, v3'
+	$(RUSTC) m3.rs $(DYLIB_TYPE)
+	>&2 echo '`m3` build as rlib, v3'
+	$(RUSTC) m3.rs $(RLIB_TYPE)
+	>&2 echo '`m4` build as dylib v3: prefer-dynamic (to avoid duplicate static linkage)'
+	$(RUSTC) m4.rs $(DYLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m5` build as rlib v3'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build bin v3'
+	$(RUSTC) m6.rs $(BIN_TYPE)
+	$(call RUN,m6) > $(TMPDIR)/v3.output
+	echo 'expectation: prefer-dynamic on `m2` had no effect on which m1 got linked compared to previous.'
+	echo 'linkage: m6:bin m5:rlib m4:dylib m3:dylib m2:lib m1:rlib' > $(TMPDIR)/v3.expect
+	diff -u $(TMPDIR)/v3.output $(TMPDIR)/v3.expect
+
+	echo 'v4: try `-C prefer-dynamic` when compiling `m3` now.'
+	>&2 echo 'rebuild m1 dylib'
+	$(RUSTC) m1.rs $(RLIB_TYPE)
+	$(RUSTC) m1.rs $(DYLIB_TYPE)
+	>&2 echo '`m2` build as lib, v4'
+	$(RUSTC) m2.rs $(LIB_TYPE)
+	>&2 echo '`m3` build as dylib, v4; prefer-dynamic, and now selects m1.dylib'
+	$(RUSTC) m3.rs $(DYLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m3` build as rlib, v4: prefer-dynamic'
+	$(RUSTC) m3.rs $(RLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m4` build as dylib v4'
+	$(RUSTC) m4.rs $(DYLIB_TYPE)
+	>&2 echo '`m5` build as rlib v4'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build bin v4: selects dylib for `m4`, because no rlib available'
+	$(RUSTC) m6.rs $(BIN_TYPE) && exit 1 || exit 0
+	>&2 echo 'above expected to fail: `std` linked dynamically via `m6` and statically via `m4`.'
+
+	echo 'v5: try `-C prefer-dynamic` when compiling `m3` now.'
+	>&2 echo 'rebuild m1 dylib'
+	$(RUSTC) m1.rs $(RLIB_TYPE)
+	$(RUSTC) m1.rs $(DYLIB_TYPE)
+	>&2 echo '`m2` build as lib, v5'
+	$(RUSTC) m2.rs $(LIB_TYPE)
+	>&2 echo '`m3` build as dylib, v5; prefer-dynamic, and now selects dylib for `m1`.'
+	$(RUSTC) m3.rs $(DYLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m3` build as rlib, v5: prefer-dynamic; it nonetheless resolves to rlib for `m1`'
+	$(RUSTC) m3.rs $(RLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m4` build as dylib v5; prefer-dynamic just for std, not m3'
+	$(RUSTC) m4.rs $(DYLIB_TYPE) -C prefer-dynamic=std -Z prefer-dynamic-std
+	>&2 echo '`m5` build as rlib v5'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build bin v5; prefer-dynamic just for `m4` and `std`, not `m3`'
+	$(RUSTC) m6.rs $(BIN_TYPE) -C prefer-dynamic=std,m4 -Z prefer-dynamic-subset
+	$(call RUN,m6) > $(TMPDIR)/v5.output
+	echo 'expectation: prefer-dynamic=std,m4 on `m4`/`m6` meant m3 rlib gets linked, and m3 rlib links m1 rlib.'
+	echo 'linkage: m6:bin m5:rlib m4:dylib m3:rlib m2:lib m1:rlib' > $(TMPDIR)/v5.expect
+	diff -u $(TMPDIR)/v5.output $(TMPDIR)/v5.expect
+
+	echo 'v6: try `-C prefer-dynamic` when `m3` and `m4` now.'
+	>&2 echo '`m4` build as dylib v6; prefer-dynamic for everything; selects dylib for `m3`.'
+	$(RUSTC) m4.rs $(DYLIB_TYPE) -C prefer-dynamic
+	>&2 echo '`m5` build as rlib v6'
+	$(RUSTC) m5.rs $(RLIB_TYPE)
+	>&2 echo '`m6` build bin v6: selects dylib for `m4` and thus for `m3` and `m1`.'
+	$(RUSTC) m6.rs $(BIN_TYPE)
+	$(call RUN,m6) > $(TMPDIR)/v6.output
+	echo 'expectation: prefer-dynamic on `m3`/`m4` meant m3 dylib gets linked, and m3 dylib links m1 dylib.'
+	echo 'linkage: m6:bin m5:rlib m4:dylib m3:dylib m2:lib m1:dylib' > $(TMPDIR)/v6.expect
+	diff -u $(TMPDIR)/v6.output $(TMPDIR)/v6.expect
+
+#	>&2 echo 'reached final false'
+#	false
+
+# Note: you can add a `false` to the end of the recipe if you want to forcibly
+# see the stderr and stdout output captured in `compiletest`.

--- a/src/test/run-make-fulldeps/dylib-subset/common_body.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/common_body.rs
@@ -1,0 +1,20 @@
+#[cfg(bin_type)]
+pub fn crate_type() -> &'static str { "bin" }
+
+#[cfg(lib_type)]
+pub fn crate_type() -> &'static str { "lib" }
+
+#[cfg(dylib_type)]
+pub fn crate_type() -> &'static str { "dylib" }
+
+#[cfg(rlib_type)]
+pub fn crate_type() -> &'static str { "rlib" }
+
+// (The cases below are not used in any of these tests yet. But it might be good
+// to think about adding them.)
+
+#[cfg(staticlib_type)]
+pub extern "C" fn crate_type() -> *const u8 { "staticlib\0".as_ptr() }
+
+#[cfg(cdylib_type)]
+pub extern "C" fn crate_type() -> *const u8 { "cdylib\0".as_ptr() }

--- a/src/test/run-make-fulldeps/dylib-subset/m1.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m1.rs
@@ -1,0 +1,5 @@
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m1:{}", ::common_body::crate_type())
+}

--- a/src/test/run-make-fulldeps/dylib-subset/m2.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m2.rs
@@ -1,0 +1,7 @@
+extern crate m1 as next;
+
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m2:{} {}", crate::common_body::crate_type(), next::linkage_chain())
+}

--- a/src/test/run-make-fulldeps/dylib-subset/m3.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m3.rs
@@ -1,0 +1,7 @@
+extern crate m2 as next;
+
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m3:{} {}", crate::common_body::crate_type(), next::linkage_chain())
+}

--- a/src/test/run-make-fulldeps/dylib-subset/m4.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m4.rs
@@ -1,0 +1,7 @@
+extern crate m3 as next;
+
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m4:{} {}", ::common_body::crate_type(), next::linkage_chain())
+}

--- a/src/test/run-make-fulldeps/dylib-subset/m5.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m5.rs
@@ -1,0 +1,7 @@
+extern crate m4 as next;
+
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m5:{} {}", crate::common_body::crate_type(), next::linkage_chain())
+}

--- a/src/test/run-make-fulldeps/dylib-subset/m6.rs
+++ b/src/test/run-make-fulldeps/dylib-subset/m6.rs
@@ -1,0 +1,11 @@
+extern crate m5 as next;
+
+mod common_body;
+
+pub fn linkage_chain() -> String {
+    format!("m6:{} {}", ::common_body::crate_type(), next::linkage_chain())
+}
+
+fn main() {
+    println!("linkage: {}", linkage_chain());
+}

--- a/src/test/ui/dylibs/README.md
+++ b/src/test/ui/dylibs/README.md
@@ -1,0 +1,30 @@
+This directory is a collection of tests of how dylibs and rlibs are compiled and loaded.
+
+It is mostly an exploration checkpointing the current state of Rust.
+
+We tend to advise people to try make at least one format available all the way
+ up: e.g. all rlibs or all dylibs. But it is good to keep track of how we are
+ handling other combinations.
+
+There are seven auxiliary crates: `a`,`i`,`j`,`m`,`s`,`t`,`z`. Each top-level
+test in this directory varies which of the auxiliary crates are compiled to
+dylibs and which are compiled to rlibs.
+
+The seven auxiliary form a dependence graph that looks like this (a pair of
+diamonds):
+
+```graphviz
+   z -> s; s -> m; m -> i; i -> a
+   z -> t; t -> m; m -> j; j -> a
+// ~    ~~~~    ~~~~    ~~~~    ~
+// |     |        |      |      |
+// |     |        |      |      +- basement
+// |     |        |      |
+// |     |        |      +- ground
+// |     |        |
+// |     |        +- middle
+// |     |
+// |     +- upper
+// |
+// +- roof
+```

--- a/src/test/ui/dylibs/auxiliary/a_basement_both.rs
+++ b/src/test/ui/dylibs/auxiliary/a_basement_both.rs
@@ -1,0 +1,8 @@
+#![crate_name="a_basement"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+mod a_basement_core;
+pub use a_basement_core::*;

--- a/src/test/ui/dylibs/auxiliary/a_basement_core.rs
+++ b/src/test/ui/dylibs/auxiliary/a_basement_core.rs
@@ -1,0 +1,5 @@
+pub fn a() -> String {
+    format!("a_basement_core")
+}
+
+pub fn a_addr() -> usize { a as fn() -> String as *const u8 as usize }

--- a/src/test/ui/dylibs/auxiliary/a_basement_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/a_basement_dynamic.rs
@@ -1,0 +1,5 @@
+#![crate_name="a_basement"]
+#![crate_type="dylib"]
+
+mod a_basement_core;
+pub use a_basement_core::*;

--- a/src/test/ui/dylibs/auxiliary/a_basement_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/a_basement_rlib.rs
@@ -1,0 +1,8 @@
+#![crate_name="a_basement"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+mod a_basement_core;
+pub use a_basement_core::*;

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar.rs
@@ -1,0 +1,9 @@
+#![crate_name="bar"]
+#![crate_type="rlib"]
+#![crate_type="cdylib"]
+
+pub struct Bar;
+
+pub fn bar() -> Bar {
+    Bar
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_noprefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_noprefdyn.rs
@@ -1,0 +1,11 @@
+#![crate_name="bar"]
+#![crate_type="rlib"]
+#![crate_type="cdylib"]
+
+// no-prefer-dynamic
+
+pub struct Bar;
+
+pub fn bar() -> Bar {
+    Bar
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdyn.rs
@@ -1,0 +1,12 @@
+#![crate_name="bar"]
+#![crate_type="rlib"]
+#![crate_type="cdylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic
+
+pub struct Bar;
+
+pub fn bar() -> Bar {
+    Bar
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdynstd.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdynstd.rs
@@ -1,0 +1,12 @@
+#![crate_name="bar"]
+#![crate_type="rlib"]
+#![crate_type="cdylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std
+
+pub struct Bar;
+
+pub fn bar() -> Bar {
+    Bar
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdynsubset.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_bar_prefdynsubset.rs
@@ -1,0 +1,12 @@
+#![crate_name="bar"]
+#![crate_type="rlib"]
+#![crate_type="cdylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=shared,std -Z prefer-dynamic-subset
+
+pub struct Bar;
+
+pub fn bar() -> Bar {
+    Bar
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_noprefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_noprefdyn.rs
@@ -1,0 +1,13 @@
+#![crate_name="foo"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+extern crate bar;
+
+pub struct Foo;
+pub use bar::bar;
+
+pub fn foo() -> Foo {
+    Foo
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdyn.rs
@@ -1,0 +1,14 @@
+#![crate_name="foo"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic
+
+extern crate bar;
+
+pub struct Foo;
+pub use bar::bar;
+
+pub fn foo() -> Foo {
+    Foo
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdynstd.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdynstd.rs
@@ -1,0 +1,14 @@
+#![crate_name="foo"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std
+
+extern crate bar;
+
+pub struct Foo;
+pub use bar::bar;
+
+pub fn foo() -> Foo {
+    Foo
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdynsubset.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_foo_prefdynsubset.rs
@@ -1,0 +1,14 @@
+#![crate_name="foo"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=shared,std -Z prefer-dynamic-subset
+
+extern crate bar;
+
+pub struct Foo;
+pub use bar::bar;
+
+pub fn foo() -> Foo {
+    Foo
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_noprefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_noprefdyn.rs
@@ -1,0 +1,17 @@
+#![crate_name="shared"]
+#![crate_type="dylib"]
+
+// no-prefer-dynamic
+
+extern crate foo;
+
+pub struct Test;
+
+impl Test {
+    pub fn new() -> Self {
+        let _ = foo::foo();
+        let _ = foo::bar();
+        // let _ = bar::bar();
+        Self
+    }
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdyn.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdyn.rs
@@ -1,0 +1,18 @@
+#![crate_name="shared"]
+#![crate_type="dylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic
+
+extern crate foo;
+
+pub struct Test;
+
+impl Test {
+    pub fn new() -> Self {
+        let _ = foo::foo();
+        let _ = foo::bar();
+        // let _ = bar::bar();
+        Self
+    }
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdynstd.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdynstd.rs
@@ -1,0 +1,18 @@
+#![crate_name="shared"]
+#![crate_type="dylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std
+
+extern crate foo;
+
+pub struct Test;
+
+impl Test {
+    pub fn new() -> Self {
+        let _ = foo::foo();
+        let _ = foo::bar();
+        // let _ = bar::bar();
+        Self
+    }
+}

--- a/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdynsubset.rs
+++ b/src/test/ui/dylibs/auxiliary/aaa_issue_82151_shared_prefdynsubset.rs
@@ -1,0 +1,18 @@
+#![crate_name="shared"]
+#![crate_type="dylib"]
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=shared,std -Z prefer-dynamic-subset
+
+extern crate foo;
+
+pub struct Test;
+
+impl Test {
+    pub fn new() -> Self {
+        let _ = foo::foo();
+        let _ = foo::bar();
+        // let _ = bar::bar();
+        Self
+    }
+}

--- a/src/test/ui/dylibs/auxiliary/i_ground_both.rs
+++ b/src/test/ui/dylibs/auxiliary/i_ground_both.rs
@@ -1,0 +1,10 @@
+#![crate_name="i_ground"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate a_basement as a;
+
+mod i_ground_core;
+pub use i_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/i_ground_core.rs
+++ b/src/test/ui/dylibs/auxiliary/i_ground_core.rs
@@ -1,0 +1,7 @@
+pub fn i() -> String {
+    format!("i_ground_core -> ({})", a::a())
+}
+
+pub fn i_addr() -> usize { i as fn() -> String as *const u8 as usize }
+
+pub fn a_addr() -> usize { a::a_addr() }

--- a/src/test/ui/dylibs/auxiliary/i_ground_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/i_ground_dynamic.rs
@@ -1,0 +1,7 @@
+#![crate_name="i_ground"]
+#![crate_type="dylib"]
+
+pub extern crate a_basement as a;
+
+mod i_ground_core;
+pub use i_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/i_ground_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/i_ground_rlib.rs
@@ -1,0 +1,10 @@
+#![crate_name="i_ground"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate a_basement as a;
+
+mod i_ground_core;
+pub use i_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/j_ground_both.rs
+++ b/src/test/ui/dylibs/auxiliary/j_ground_both.rs
@@ -1,0 +1,10 @@
+#![crate_name="j_ground"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate a_basement as a;
+
+mod j_ground_core;
+pub use j_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/j_ground_core.rs
+++ b/src/test/ui/dylibs/auxiliary/j_ground_core.rs
@@ -1,0 +1,7 @@
+pub fn j() -> String {
+    format!("j_ground_core -> ({})", a::a())
+}
+
+pub fn j_addr() -> usize { j as fn() -> String as *const u8 as usize }
+
+pub fn a_addr() -> usize { a::a_addr() }

--- a/src/test/ui/dylibs/auxiliary/j_ground_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/j_ground_dynamic.rs
@@ -1,0 +1,7 @@
+#![crate_name="j_ground"]
+#![crate_type="dylib"]
+
+pub extern crate a_basement as a;
+
+mod j_ground_core;
+pub use j_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/j_ground_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/j_ground_rlib.rs
@@ -1,0 +1,10 @@
+#![crate_name="j_ground"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate a_basement as a;
+
+mod j_ground_core;
+pub use j_ground_core::*;

--- a/src/test/ui/dylibs/auxiliary/m_middle_both.rs
+++ b/src/test/ui/dylibs/auxiliary/m_middle_both.rs
@@ -1,0 +1,11 @@
+#![crate_name="m_middle"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate i_ground as i;
+pub extern crate j_ground as j;
+
+mod m_middle_core;
+pub use m_middle_core::*;

--- a/src/test/ui/dylibs/auxiliary/m_middle_core.rs
+++ b/src/test/ui/dylibs/auxiliary/m_middle_core.rs
@@ -1,0 +1,13 @@
+pub fn m() -> String {
+    format!("m_middle_core -> ({}), -> ({})", i::i(), j::j())
+}
+
+pub fn m_addr() -> usize { m as fn() -> String as *const u8 as usize }
+
+pub fn i_addr() -> usize { i::i_addr() }
+
+pub fn j_addr() -> usize { j::j_addr() }
+
+pub fn i_a_addr() -> usize { i::a_addr() }
+
+pub fn j_a_addr() -> usize { j::a_addr() }

--- a/src/test/ui/dylibs/auxiliary/m_middle_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/m_middle_dynamic.rs
@@ -1,0 +1,8 @@
+#![crate_name="m_middle"]
+#![crate_type="dylib"]
+
+pub extern crate i_ground as i;
+pub extern crate j_ground as j;
+
+mod m_middle_core;
+pub use m_middle_core::*;

--- a/src/test/ui/dylibs/auxiliary/m_middle_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/m_middle_rlib.rs
@@ -1,0 +1,11 @@
+#![crate_name="m_middle"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate i_ground as i;
+pub extern crate j_ground as j;
+
+mod m_middle_core;
+pub use m_middle_core::*;

--- a/src/test/ui/dylibs/auxiliary/s_upper_both.rs
+++ b/src/test/ui/dylibs/auxiliary/s_upper_both.rs
@@ -1,0 +1,10 @@
+#![crate_name="s_upper"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate m_middle as m;
+
+mod s_upper_core;
+pub use s_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/s_upper_core.rs
+++ b/src/test/ui/dylibs/auxiliary/s_upper_core.rs
@@ -1,0 +1,15 @@
+pub fn s() -> String {
+    format!("s_upper_core -> ({})", m::m())
+}
+
+pub fn s_addr() -> usize { s as fn() -> String as *const u8 as usize }
+
+pub fn m_addr() -> usize { m::m_addr() }
+
+pub fn m_i_addr() -> usize { m::i_addr() }
+
+pub fn m_j_addr() -> usize { m::j_addr() }
+
+pub fn m_i_a_addr() -> usize { m::i_a_addr() }
+
+pub fn m_j_a_addr() -> usize { m::j_a_addr() }

--- a/src/test/ui/dylibs/auxiliary/s_upper_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/s_upper_dynamic.rs
@@ -1,0 +1,7 @@
+#![crate_name="s_upper"]
+#![crate_type="dylib"]
+
+pub extern crate m_middle as m;
+
+mod s_upper_core;
+pub use s_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/s_upper_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/s_upper_rlib.rs
@@ -1,0 +1,10 @@
+#![crate_name="s_upper"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate m_middle as m;
+
+mod s_upper_core;
+pub use s_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/t_upper_both.rs
+++ b/src/test/ui/dylibs/auxiliary/t_upper_both.rs
@@ -1,0 +1,10 @@
+#![crate_name="t_upper"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate m_middle as m;
+
+mod t_upper_core;
+pub use t_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/t_upper_core.rs
+++ b/src/test/ui/dylibs/auxiliary/t_upper_core.rs
@@ -1,0 +1,15 @@
+pub fn t() -> String {
+    format!("t_upper_core -> {}", m::m())
+}
+
+pub fn t_addr() -> usize { t as fn() -> String as *const u8 as usize }
+
+pub fn m_addr() -> usize { m::m_addr() }
+
+pub fn m_i_addr() -> usize { m::i_addr() }
+
+pub fn m_j_addr() -> usize { m::j_addr() }
+
+pub fn m_i_a_addr() -> usize { m::i_a_addr() }
+
+pub fn m_j_a_addr() -> usize { m::j_a_addr() }

--- a/src/test/ui/dylibs/auxiliary/t_upper_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/t_upper_dynamic.rs
@@ -1,0 +1,7 @@
+#![crate_name="t_upper"]
+#![crate_type="dylib"]
+
+pub extern crate m_middle as m;
+
+mod t_upper_core;
+pub use t_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/t_upper_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/t_upper_rlib.rs
@@ -1,0 +1,10 @@
+#![crate_name="t_upper"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate m_middle as m;
+
+mod t_upper_core;
+pub use t_upper_core::*;

--- a/src/test/ui/dylibs/auxiliary/z_roof_both.rs
+++ b/src/test/ui/dylibs/auxiliary/z_roof_both.rs
@@ -1,0 +1,11 @@
+#![crate_name="z_roof"]
+#![crate_type="dylib"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic
+
+pub extern crate s_upper as s;
+pub extern crate t_upper as t;
+
+mod z_roof_core;
+pub use z_roof_core::*;

--- a/src/test/ui/dylibs/auxiliary/z_roof_core.rs
+++ b/src/test/ui/dylibs/auxiliary/z_roof_core.rs
@@ -1,0 +1,29 @@
+pub fn z() -> String {
+    format!("z_roof_core -> ({}), -> ({})", s::s(), t::t())
+}
+
+pub fn z_addr() -> usize { z as fn() -> String as *const u8 as usize }
+
+pub fn s_addr() -> usize { s::s_addr() }
+
+pub fn t_addr() -> usize { t::t_addr() }
+
+pub fn s_m_addr() -> usize { s::m_addr() }
+
+pub fn t_m_addr() -> usize { t::m_addr() }
+
+pub fn s_m_i_addr() -> usize { s::m_i_addr() }
+
+pub fn s_m_j_addr() -> usize { s::m_j_addr() }
+
+pub fn t_m_i_addr() -> usize { t::m_i_addr() }
+
+pub fn t_m_j_addr() -> usize { t::m_j_addr() }
+
+pub fn s_m_i_a_addr() -> usize { s::m_i_a_addr() }
+
+pub fn s_m_j_a_addr() -> usize { s::m_j_a_addr() }
+
+pub fn t_m_i_a_addr() -> usize { t::m_i_a_addr() }
+
+pub fn t_m_j_a_addr() -> usize { t::m_j_a_addr() }

--- a/src/test/ui/dylibs/auxiliary/z_roof_dynamic.rs
+++ b/src/test/ui/dylibs/auxiliary/z_roof_dynamic.rs
@@ -1,0 +1,8 @@
+#![crate_name="z_roof"]
+#![crate_type="dylib"]
+
+pub extern crate s_upper as s;
+pub extern crate t_upper as t;
+
+mod z_roof_core;
+pub use z_roof_core::*;

--- a/src/test/ui/dylibs/auxiliary/z_roof_rlib.rs
+++ b/src/test/ui/dylibs/auxiliary/z_roof_rlib.rs
@@ -1,0 +1,11 @@
+#![crate_name="z_roof"]
+#![crate_type="rlib"]
+
+// no-prefer-dynamic : flag controls both `-C prefer-dynamic` *and* overrides the
+// output crate type for this file.
+
+pub extern crate s_upper as s;
+pub extern crate t_upper as t;
+
+mod z_roof_core;
+pub use z_roof_core::*;

--- a/src/test/ui/dylibs/diamonds-b-prefdynstd.rs
+++ b/src/test/ui/dylibs/diamonds-b-prefdynstd.rs
@@ -1,0 +1,12 @@
+// run-pass
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std
+
+// aux-build: a_basement_both.rs
+
+pub extern crate a_basement as a;
+
+fn main() {
+    a::a();
+}

--- a/src/test/ui/dylibs/diamonds-b.rs
+++ b/src/test/ui/dylibs/diamonds-b.rs
@@ -1,0 +1,14 @@
+// build-fail
+
+// The a_basement dependency has been compiled with `-C prefer-dynamic=no`,
+// which ends up leading to a duplication of `std` (and all crates underneath
+// it) in both the `a_basement` crate and in this crate. Rust does not support
+// having duplicate libraries like that, so this compilation will fail.
+
+// aux-build: a_basement_both.rs
+
+pub extern crate a_basement as a;
+
+fn main() {
+    a::a();
+}

--- a/src/test/ui/dylibs/diamonds-b.stderr
+++ b/src/test/ui/dylibs/diamonds-b.stderr
@@ -1,0 +1,74 @@
+error: cannot satisfy dependencies so `std` only shows up once (previously required dynamic, via [`diamonds_b`], and now also requires static, via [`a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `core` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `compiler_builtins` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_std_workspace_core` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `alloc` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `libc` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `unwind` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `cfg_if` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `hashbrown` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_std_workspace_alloc` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_demangle` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `std_detect` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `addr2line` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `gimli` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `object` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `miniz_oxide` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `adler` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `panic_unwind` only shows up once (two static copies from multiple different locations, via [`std`, `a_basement`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: aborting due to 18 previous errors
+

--- a/src/test/ui/dylibs/diamonds-bbbbbbb-prefdyn-z.rs
+++ b/src/test/ui/dylibs/diamonds-bbbbbbb-prefdyn-z.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` flag so only `z` is linked dynamically.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=z_roof -Z prefer-dynamic-subset
+
+// aux-build: a_basement_both.rs
+// aux-build: i_ground_both.rs
+// aux-build: j_ground_both.rs
+// aux-build: m_middle_both.rs
+// aux-build: s_upper_both.rs
+// aux-build: t_upper_both.rs
+// aux-build: z_roof_both.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-bbbbbbb-prefdynstd.rs
+++ b/src/test/ui/dylibs/diamonds-bbbbbbb-prefdynstd.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` flag to allow *only* `std` to be linked dynamically.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std
+
+// aux-build: a_basement_both.rs
+// aux-build: i_ground_both.rs
+// aux-build: j_ground_both.rs
+// aux-build: m_middle_both.rs
+// aux-build: s_upper_both.rs
+// aux-build: t_upper_both.rs
+// aux-build: z_roof_both.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-d-prefdynstd.rs
+++ b/src/test/ui/dylibs/diamonds-d-prefdynstd.rs
@@ -1,0 +1,14 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` flag to allow *only* `std` to be linked dynamically.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std -la_basement
+
+// aux-build: a_basement_dynamic.rs
+
+extern crate a_basement as a;
+
+fn main() {
+    a::a();
+}

--- a/src/test/ui/dylibs/diamonds-ddddddd-prefdynstd.rs
+++ b/src/test/ui/dylibs/diamonds-ddddddd-prefdynstd.rs
@@ -1,0 +1,27 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` flag to allow *only* `std` to be
+// linked dynamically via rustc's injected flags
+//
+// All the dependencies are dylibs, so we can successfully link them all and run them, *if* we
+// provide the right additional flags.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std -la_basement -li_ground -lj_ground -lm_middle -ls_upper -lt_upper -lz_roof
+
+// aux-build: a_basement_dynamic.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+// aux-build: m_middle_dynamic.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_dynamic.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-ddddddd.rs
+++ b/src/test/ui/dylibs/diamonds-ddddddd.rs
@@ -1,0 +1,20 @@
+// run-pass
+
+// All the dependencies are dylibs, so we can successfully link them all and run them.
+
+// aux-build: a_basement_dynamic.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+// aux-build: m_middle_dynamic.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_dynamic.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-ddddrrr.rs
+++ b/src/test/ui/dylibs/diamonds-ddddrrr.rs
@@ -1,0 +1,21 @@
+// run-pass
+
+// There is no sharing of an rlib via two dylibs, and thus we can link and run
+// this program.
+
+// aux-build: a_basement_dynamic.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+// aux-build: m_middle_dynamic.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_rlib.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-dddrdd.rs
+++ b/src/test/ui/dylibs/diamonds-dddrdd.rs
@@ -1,0 +1,18 @@
+// build-fail
+
+// This fails to compile because the middle static library (m) is included via
+// two dylibs: `s_upper` and `t_upper`.
+
+// aux-build: a_basement_dynamic.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_dynamic.rs
+
+extern crate s_upper as s;
+extern crate t_upper as t;
+
+fn main() {
+    s::s(); t::t();
+}

--- a/src/test/ui/dylibs/diamonds-dddrdd.stderr
+++ b/src/test/ui/dylibs/diamonds-dddrdd.stderr
@@ -1,0 +1,6 @@
+error: cannot satisfy dependencies so `m_middle` only shows up once (two static copies from multiple different locations, via [`s_upper`, `t_upper`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: aborting due to previous error
+

--- a/src/test/ui/dylibs/diamonds-dddrrrr.rs
+++ b/src/test/ui/dylibs/diamonds-dddrrrr.rs
@@ -1,0 +1,21 @@
+// run-pass
+
+// There is no sharing of an rlib via two dylibs, and thus we can link and run
+// this program.
+
+// aux-build: a_basement_dynamic.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_rlib.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rdd.rs
+++ b/src/test/ui/dylibs/diamonds-rdd.rs
@@ -1,0 +1,15 @@
+// build-fail
+
+// This fails to compile because the static library foundation (a) is
+// included via two dylibs: `i_ground` and `j_ground`.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_dynamic.rs
+
+extern crate i_ground as i;
+extern crate j_ground as j;
+
+fn main() {
+    i::i(); j::j();
+}

--- a/src/test/ui/dylibs/diamonds-rdd.stderr
+++ b/src/test/ui/dylibs/diamonds-rdd.stderr
@@ -1,0 +1,6 @@
+error: cannot satisfy dependencies so `a_basement` only shows up once (two static copies from multiple different locations, via [`i_ground`, `j_ground`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: aborting due to previous error
+

--- a/src/test/ui/dylibs/diamonds-rdrddrd.rs
+++ b/src/test/ui/dylibs/diamonds-rdrddrd.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a) is linked via both a dylib `i_ground` and an rlib `j_upper`
+// that are themselves linked via a dylib `m_middle`. But, it currently passes,
+// presumably due to internal details of rustc's heuristic selection between
+// dynamic and static linking.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_dynamic.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rdrrdrd.rs
+++ b/src/test/ui/dylibs/diamonds-rdrrdrd.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a) is linked via both a dylib `i_ground` and an rlib `j_upper`
+// that are themselves linked via an rlib `m_middle`. But, it currently passes,
+// presumably due to internal details of rustc's heuristic selection between
+// dynamic and static linking.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rdrrrrd.rs
+++ b/src/test/ui/dylibs/diamonds-rdrrrrd.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a) is linked via both a dylib `i_ground` and an rlib `j_upper`
+// that are themselves linked via an rlib `m_middle`. But, it currently passes,
+// presumably due to internal details of rustc's heuristic selection between
+// dynamic and static linking.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rdrrrrr.rs
+++ b/src/test/ui/dylibs/diamonds-rdrrrrr.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a) is linked via both a dylib `i_ground` and an rlib `j_upper`
+// that are themselves linked via an rlib `m_middle`. But, it currently passes,
+// presumably due to internal details of rustc's heuristic selection between
+// dynamic and static linking.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_dynamic.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_rlib.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rrrrdd.rs
+++ b/src/test/ui/dylibs/diamonds-rrrrdd.rs
@@ -1,0 +1,18 @@
+// build-fail
+
+// This fails to compile because the static library foundations (a, i, j, m) are
+// included via two dylibs: `s_upper` and `t_upper`.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_rlib.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_dynamic.rs
+
+extern crate s_upper as s;
+extern crate t_upper as t;
+
+fn main() {
+    s::s(); t::t();
+}

--- a/src/test/ui/dylibs/diamonds-rrrrdd.stderr
+++ b/src/test/ui/dylibs/diamonds-rrrrdd.stderr
@@ -1,0 +1,18 @@
+error: cannot satisfy dependencies so `m_middle` only shows up once (two static copies from multiple different locations, via [`s_upper`, `t_upper`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `i_ground` only shows up once (two static copies from multiple different locations, via [`s_upper`, `t_upper`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `a_basement` only shows up once (two static copies from multiple different locations, via [`s_upper`, `t_upper`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `j_ground` only shows up once (two static copies from multiple different locations, via [`s_upper`, `t_upper`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/dylibs/diamonds-rrrrdrd.rs
+++ b/src/test/ui/dylibs/diamonds-rrrrdrd.rs
@@ -1,0 +1,24 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a, i, j, m) are linked via both a dylib `s_upper` and an rlib
+// `t_upper` that are themselves linked via a dylib `z_roof`. But, it currently
+// passes, presumably due to internal details of rustc's heuristic selection
+// between dynamic and static linking.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_rlib.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rrrrdrr.rs
+++ b/src/test/ui/dylibs/diamonds-rrrrdrr.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+// You might expect this to fail to compile because the static library
+// foundations (a, i, j, m) are included via both a dylib `s_upper` and an rlib
+// `t_upper` that are themselves linked via an rlib `z_roof`. But, inexplicably,
+// it currently passes.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_rlib.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_dynamic.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_rlib.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rrrrrrd.rs
+++ b/src/test/ui/dylibs/diamonds-rrrrrrd.rs
@@ -1,0 +1,20 @@
+// run-pass
+
+// All the dependencies are rlibs, so we can successfully link them all and run them.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_rlib.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_dynamic.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds-rrrrrrr.rs
+++ b/src/test/ui/dylibs/diamonds-rrrrrrr.rs
@@ -1,0 +1,20 @@
+// run-pass
+
+// All the dependencies are rlibs, so we can successfully link them all and run them.
+
+// aux-build: a_basement_rlib.rs
+// aux-build: i_ground_rlib.rs
+// aux-build: j_ground_rlib.rs
+// aux-build: m_middle_rlib.rs
+// aux-build: s_upper_rlib.rs
+// aux-build: t_upper_rlib.rs
+// aux-build: z_roof_rlib.rs
+
+extern crate z_roof as z;
+
+mod diamonds_core;
+
+fn main() {
+    diamonds_core::sanity_check();
+    diamonds_core::check_linked_function_equivalence();
+}

--- a/src/test/ui/dylibs/diamonds_core.rs
+++ b/src/test/ui/dylibs/diamonds_core.rs
@@ -1,0 +1,21 @@
+// ignore-test Not a test. Used by the other tests.
+
+pub fn sanity_check() {
+    // Sanity-check: getting back non-trival values from addr functions
+    assert_ne!(z::s_addr(), z::t_addr());
+    assert_ne!(z::s_m_addr(), z::s_m_i_addr());
+    assert_ne!(z::s_m_i_addr(), z::s_m_j_addr());
+    assert_ne!(z::s_m_i_addr(), z::s_m_i_a_addr());
+}
+
+pub fn check_linked_function_equivalence() {
+    // Check that the linked functions are the same code by comparing their
+    // underlying addresses.
+    assert_eq!(z::s_m_addr(), z::s::m_addr());
+    assert_eq!(z::s_m_addr(), z::t_m_addr());
+    assert_eq!(z::s_m_i_addr(), z::s::m::i_addr());
+    assert_eq!(z::s_m_i_addr(), z::t_m_i_addr());
+    assert_eq!(z::s_m_i_a_addr(), z::s::m::i::a_addr());
+    assert_eq!(z::s_m_i_a_addr(), z::t_m_i_a_addr());
+    assert_eq!(z::s_m_i_a_addr(), z::t_m_j_a_addr());
+}

--- a/src/test/ui/dylibs/issue-82151-serverctl-noprefdyn.rs
+++ b/src/test/ui/dylibs/issue-82151-serverctl-noprefdyn.rs
@@ -1,0 +1,13 @@
+// build-fail
+
+// no-prefer-dynamic
+
+// aux-build: aaa_issue_82151_bar_noprefdyn.rs
+// aux-build: aaa_issue_82151_foo_noprefdyn.rs
+// aux-build: aaa_issue_82151_shared_noprefdyn.rs
+
+extern crate shared;
+
+fn main() {
+    let _ = shared::Test::new();
+}

--- a/src/test/ui/dylibs/issue-82151-serverctl-noprefdyn.stderr
+++ b/src/test/ui/dylibs/issue-82151-serverctl-noprefdyn.stderr
@@ -1,0 +1,78 @@
+error: cannot satisfy dependencies so `std` only shows up once (previously required dynamic, via [`issue_82151_serverctl_noprefdyn`], and now also requires static, via [`shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `core` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `compiler_builtins` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_std_workspace_core` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `alloc` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `libc` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `unwind` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `cfg_if` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `hashbrown` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_std_workspace_alloc` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `rustc_demangle` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `std_detect` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `addr2line` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `gimli` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `object` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `miniz_oxide` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `adler` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `panic_unwind` only shows up once (two static copies from multiple different locations, via [`std`, `shared`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: cannot satisfy dependencies so `bar` only shows up once (previously required static, via [`shared`], and now also requires dynamic, via [`issue_82151_serverctl_noprefdyn`])
+   |
+   = help: having upstream crates all available in one format will likely make this go away
+
+error: aborting due to 19 previous errors
+

--- a/src/test/ui/dylibs/issue-82151-serverctl-prefdyn.rs
+++ b/src/test/ui/dylibs/issue-82151-serverctl-prefdyn.rs
@@ -1,0 +1,16 @@
+// build-fail
+// normalize-stderr-test "note: .*undefined reference to `bar::bar'" -> "note: undefined reference to `bar::bar'"
+// normalize-stderr-test "note: .cc..*" -> "note: $$CC_INVOCATION"
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic
+
+// aux-build: aaa_issue_82151_bar_prefdyn.rs
+// aux-build: aaa_issue_82151_foo_prefdyn.rs
+// aux-build: aaa_issue_82151_shared_prefdyn.rs
+
+extern crate shared;
+
+fn main() {
+    let _ = shared::Test::new();
+}

--- a/src/test/ui/dylibs/issue-82151-serverctl-prefdyn.stderr
+++ b/src/test/ui/dylibs/issue-82151-serverctl-prefdyn.stderr
@@ -1,0 +1,12 @@
+error: linking with `cc` failed: exit status: 1
+   |
+   = note: $CC_INVOCATION
+   = note: undefined reference to `bar::bar'
+           collect2: error: ld returned 1 exit status
+           
+   = help: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
+   = note: use the `-l` flag to specify native libraries to link
+   = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
+
+error: aborting due to previous error
+

--- a/src/test/ui/dylibs/issue-82151-serverctl-prefdynstd.rs
+++ b/src/test/ui/dylibs/issue-82151-serverctl-prefdynstd.rs
@@ -1,0 +1,18 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` flag to allow *only* `std` to be
+// linked dynamically via the rustc injected flags, and then also manually link
+// to `shared`.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=std -Z prefer-dynamic-std -lshared
+
+// aux-build: aaa_issue_82151_bar_prefdynstd.rs
+// aux-build: aaa_issue_82151_foo_prefdynstd.rs
+// aux-build: aaa_issue_82151_shared_prefdynstd.rs
+
+extern crate shared;
+
+fn main() {
+    let _ = shared::Test::new();
+}

--- a/src/test/ui/dylibs/issue-82151-serverctl-prefdynsubset.rs
+++ b/src/test/ui/dylibs/issue-82151-serverctl-prefdynsubset.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+// Make use of new `-C prefer-dynamic=...` to choose `shared` and `std` to be linked dynamically.
+
+// no-prefer-dynamic
+// compile-flags: -C prefer-dynamic=shared,std -Z prefer-dynamic-subset
+
+// aux-build: aaa_issue_82151_bar_prefdynsubset.rs
+// aux-build: aaa_issue_82151_foo_prefdynsubset.rs
+// aux-build: aaa_issue_82151_shared_prefdynsubset.rs
+
+extern crate shared;
+
+fn main() {
+    let _ = shared::Test::new();
+}


### PR DESCRIPTION
see also MCP https://github.com/rust-lang/compiler-team/issues/455

This PR generalizes `-C prefer-dynamic` so that one can specify a specific subset of the crates that should have the preferred-dynamic linkage.

Without this PR, one generally has to decide globally whether dynamic linkage will be preferred (via `-C prefer-dynamic=on`, or just `-C prefer-dynamic`) or if static linkage will be preferred (via `-C prefer-dynamic=off`, or just omitting the option entirely). The fact that this is a global choice means that one can get into tricky scenarios where, because of choices made by your crate dependencies for what output types they generate, *your* crate hits strange linkage errors. (For one example of this, see rust-lang/rust#82151.)

There are multiple ways to address the above problem, such as changing the crate dependencies to reduce the kinds of output crate types they generate (see e.g. https://github.com/alexkornitzer/hyper/commit/119904864b3dc91d77cf443af11f697821759336), or choosing `-C prefer-dynamic=no` to stop `rustc` from injecting linkage directives, and then adding on additional `RUSTFLAGS=-l<crate_name>` flags to explicitly link to the dynamic libraries you want.

This PR suggests a different way to address it: By allowing the user to specify a list of crates, `-C prefer-dynamic=crate1,crate2,...` they believe should be given preferred dynamic linkage.

Since `std` comes up as a common example here, `-C prefer-dynamic=std` is given special treatment. You can opt into arbitrary lists of crates via `-Z prefer-dynamic-subset`. Or you can enable the use of the singleton command line option `-C prefer-dynamic=std` via `-Z prefer-dynamic-std`.
 * My intent, in making separate `-Z` flags for these cases, is to fast track the stabilization of `-C prefer-dynamic=std`, because I think that will provide the biggest impact, and has relatively low risk (in terms of it not having potential for exposing sharp corners of rustc's internal heuristics for determining dynamic linkage). We can let the more general `-C prefer-dynamic=crate1,crate2,...` simmer; for example, we may want to make more changes to how chains of rlibs and dylibs are handled, and that may interact with the `prefer-dynamic-subset` feature.