### PR TITLE
Add background-color on clickable definitions in source code

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -216,6 +216,9 @@ nav.main .separator {
 a {
 	color: #c5c5c5;
 }
+body.source .example-wrap pre.rust a {
+	background: #c5c5c5;
+}
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -177,6 +177,9 @@ nav.main .separator {
 a {
 	color: #ddd;
 }
+body.source .example-wrap pre.rust a {
+	background: #333;
+}
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -172,6 +172,9 @@ nav.main .separator {
 a {
 	color: #000;
 }
+body.source .example-wrap pre.rust a {
+	background: #eee;
+}
 
 .docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,


### PR DESCRIPTION
Someone suggested to add a decoration on clickable elements in the source code pages:

![Screenshot from 2021-08-17 14-49-39](https://user-images.githubusercontent.com/3050060/129728911-def74f9e-50e2-40d2-b512-e23f1b3d0409.png)
![Screenshot from 2021-08-17 14-49-47](https://user-images.githubusercontent.com/3050060/129728925-14aec500-82ff-4336-955a-4173c769deeb.png)
![Screenshot from 2021-08-17 14-49-52](https://user-images.githubusercontent.com/3050060/129728927-a8a89d7a-e837-4ff5-b094-35be23629d14.png)

The idea is to not disturb the reading while telling the reader "you can click on this one", which is why it's not a text decoration.

What do you think @rust-lang/rustdoc ?

r? @Nemo157 