### PR TITLE
Arc locking

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -794,7 +794,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// use std::sync::Arc;
     ///
-    /// let x = Arc::new("hello".to_owned());
+    /// let mut x = Arc::new("hello".to_owned());
     /// if Arc::lock_strong_count(&mut x) {
     ///     // SAFETY: String is 'static and this is the only strong reference
     ///     unsafe { *Arc::get_mut_unchecked(&mut x) = "goodbye".to_owned(); }
@@ -820,7 +820,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// use std::sync::Arc;
     ///
-    /// let x = Arc::new("hello".to_owned());
+    /// let mut x = Arc::new("hello".to_owned());
     /// if Arc::lock_strong_count(&mut x) {
     ///     // SAFETY: String is 'static and this is the only strong reference
     ///     unsafe { *Arc::get_mut_unchecked(&mut x) = "goodbye".to_owned(); }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -789,6 +789,9 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(get_mut_unchecked)]
+    /// #![feature(lock_arc)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let x = Arc::new("hello".to_owned());
@@ -812,6 +815,9 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(get_mut_unchecked)]
+    /// #![feature(lock_arc)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let x = Arc::new("hello".to_owned());

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -786,6 +786,11 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// Returns `true` if the operation succeeded, `false` otherwise.
     ///
+    /// # Failing to unlock
+    ///
+    /// Note that dropping a locked `Arc` will leak its contents and may lead to
+    /// an abort if an attempt to `upgrade` a related `Weak` is made.
+    ///
     /// # Examples
     ///
     /// ```
@@ -811,6 +816,11 @@ impl<T: ?Sized> Arc<T> {
     /// Unlocks this `Arc`'s strong count, if it is locked.
     ///
     /// Returns `true` if the operation succeeded, `false` otherwise.
+    ///
+    /// # Failing to unlock
+    ///
+    /// Note that dropping a locked `Arc` will leak its contents and may lead to
+    /// an abort if an attempt to `upgrade` a related `Weak` is made.
     ///
     /// # Examples
     ///
@@ -1353,7 +1363,8 @@ impl<T: ?Sized> Clone for Arc<T> {
     #[inline]
     fn clone(&self) -> Arc<T> {
         // Check if we're locked. Relaxed is fine here because if this branch
-        // is taken, we're the only possible strong reference.
+        // is taken, we're the only possible strong reference and we diverge,
+        // so there's nothing to race with.
         if self.inner().strong.load(Relaxed) == 0 {
             panic!("Not allowed to clone a locked Arc");
         }


### PR DESCRIPTION
These are low-level primitives, which means this doesn't do anything on its own, but may enable third-party crates to provide safe wrappers around `get_mut_unchecked`. For example:

```rust
struct Invariant<T: ?Sized>(UnsafeCell<T>);
impl<T: ?Sized> Invariant<T> {
  fn with_mut(self: &mut Arc<Self>, f: impl FnOnce(&mut T)) {
    if !Arc::lock_strong_count(self) {
      panic!("Arc in use");
    }
    f(unsafe { Arc::get_mut_unchecked(self) }.0.get_mut())
    Arc::unlock_strong_count(self);
  }
}
```

~~Another possible wrapper would be:~~ this one is unsound, see https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=a70acf048225b351d6620c226661e8d3 (found by @SkiFire13 )

```rust
struct Static<T: ?Sized + 'static>(T);
impl<T: ?Sized + 'static> Static<T> {
  fn with_mut(self: &mut Arc<Self>, f: impl FnOnce(&mut T)) {
    if !Arc::lock_strong_count(self) {
      panic!("Arc in use");
    }
    f(unsafe { Arc::get_mut_unchecked(self) }.0)
    Arc::unlock_strong_count(self);
  }
}
```

These can be compared to `new_cyclic` and are arguably just an extension of existing `get_mut` semantics. In particular, they allow safely mutating an owning `Arc` while there are `Weak`s around, by preventing them from being `upgrade`d. Note that this condition alone is necessary, but not sufficient: `Arc` is covariant by default, so these wrappers are in fact necessary, because the following example would blow up otherwise:

```rust
let x: Arc<&'static str> = Arc::new("foo");
let y = Arc::downgrade(&x);
make_fuckup(x, &String::new("bar")); // transfers ownership of the only strong ref, which hypothetically is safe to mutate, but make_fuckup takes it as the lifetime of the &String!
y.upgrade(); // uh oh we now have a dangling &'static str
```

This is trivially a compile-time error when using `Arc<Static<T>>` or `Arc<Invariant<T>>`.

Anyway, mostly throwing this here to hopefully get a perf run on it more than anything. This adds an extra atomic load on clone.

Also note that dropping a locked `Arc` would lead to an abort when upgrading a Weak, or a leak otherwise, and `make_mut` would also make it leak. These are all safe so there's no reason to make locking/unlocking unsafe. `get_mut` also fails, by design. `strong_count` will return 0 on locked `Arc`s and the documentation should be updated to reflect that, or otherwise massaged, if this feature is decided to be added. (We'd prefer it to return 0, similar to how `Weak::strong_count` returns 0 when `Arc::new_cyclic` is used.)