### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,9 +1723,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
8 commits in b51439fd8b505d4800a257acfecf3c69f81e35cf..e96bdb0c3d0a418e7fcd7fbd69be08abf830b4bc
2021-08-09 18:40:05 +0000 to 2021-08-17 22:58:47 +0000
- Support using rustbot to ping the Windows group (rust-lang/cargo#9802)
- Show information about abnormal `fix` errors. (rust-lang/cargo#9799)
- Bump jobserver. (rust-lang/cargo#9798)
- Render build-std web links as hyperlinks (rust-lang/cargo#9795)
- Teach cargo to failfast on recursive/corecursive aliases (rust-lang/cargo#9791)
- Fix value-after-table error with profiles. (rust-lang/cargo#9789)
- Fix plugin registrar change. (rust-lang/cargo#9790)
- Ability to specify the output name for a bin target different from the crate name (rust-lang/cargo#9627)