### PR TITLE
Add needs-asm-support to more tests

### DIFF
--- a/src/test/codegen/naked-noinline.rs
+++ b/src/test/codegen/naked-noinline.rs
@@ -1,5 +1,6 @@
 // Checks that naked functions are never inlined.
 // compile-flags: -O -Zmir-opt-level=3
+// needs-asm-support
 // ignore-wasm32
 #![crate_type = "lib"]
 #![feature(asm)]

--- a/src/test/ui/feature-gates/feature-gate-global_asm.rs
+++ b/src/test/ui/feature-gates/feature-gate-global_asm.rs
@@ -1,3 +1,5 @@
+// needs-asm-support
+
 global_asm!(""); //~ ERROR `global_asm!` is not stable
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-global_asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-global_asm.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'global_asm': `global_asm!` is not stable enough for use and is subject to change
-  --> $DIR/feature-gate-global_asm.rs:1:1
+  --> $DIR/feature-gate-global_asm.rs:3:1
    |
 LL | global_asm!("");
    | ^^^^^^^^^^

--- a/src/test/ui/macros/macro-expanded-include/test.rs
+++ b/src/test/ui/macros/macro-expanded-include/test.rs
@@ -1,4 +1,4 @@
-// ignore-emscripten no llvm_asm! support
+// needs-asm-support
 // build-pass (FIXME(62277): could be check-pass?)
 #![feature(asm)]
 #![allow(unused)]

--- a/src/test/ui/unsafe/inline_asm.mir.stderr
+++ b/src/test/ui/unsafe/inline_asm.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:9:5
+  --> $DIR/inline_asm.rs:10:5
    |
 LL |     asm!("nop");
    |     ^^^^^^^^^^^^ use of inline assembly
@@ -7,7 +7,7 @@ LL |     asm!("nop");
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:10:5
+  --> $DIR/inline_asm.rs:11:5
    |
 LL |     llvm_asm!("nop");
    |     ^^^^^^^^^^^^^^^^^ use of inline assembly

--- a/src/test/ui/unsafe/inline_asm.rs
+++ b/src/test/ui/unsafe/inline_asm.rs
@@ -1,5 +1,6 @@
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
+// needs-asm-support
 
 #![feature(llvm_asm)]
 #![feature(asm)]

--- a/src/test/ui/unsafe/inline_asm.thir.stderr
+++ b/src/test/ui/unsafe/inline_asm.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:9:5
+  --> $DIR/inline_asm.rs:10:5
    |
 LL |     asm!("nop");
    |     ^^^^^^^^^^^^ use of inline assembly
@@ -7,7 +7,7 @@ LL |     asm!("nop");
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/inline_asm.rs:10:5
+  --> $DIR/inline_asm.rs:11:5
    |
 LL |     llvm_asm!("nop");
    |     ^^^^^^^^^^^^^^^^^ use of inline assembly


### PR DESCRIPTION
These were found as test failures on s390x for RHEL and Fedora.
