### PR TITLE
Fix dataflow graphviz bug, make dataflow graphviz modules public

### DIFF
--- a/compiler/rustc_mir/src/dataflow/framework/fmt.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/fmt.rs
@@ -33,7 +33,7 @@ pub trait DebugWithContext<C>: Eq + fmt::Debug {
         }
 
         write!(f, "\u{001f}-")?;
-        self.fmt_with(ctxt, f)
+        old.fmt_with(ctxt, f)
     }
 }
 

--- a/compiler/rustc_mir/src/dataflow/framework/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/mod.rs
@@ -42,7 +42,7 @@ mod cursor;
 mod direction;
 mod engine;
 pub mod fmt;
-mod graphviz;
+pub mod graphviz;
 pub mod lattice;
 mod visitor;
 

--- a/compiler/rustc_mir/src/dataflow/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/mod.rs
@@ -5,7 +5,7 @@ use rustc_span::symbol::{sym, Symbol};
 
 pub(crate) use self::drop_flag_effects::*;
 pub use self::framework::{
-    fmt, lattice, visit_results, Analysis, AnalysisDomain, Backward, BorrowckFlowState,
+    fmt, graphviz, lattice, visit_results, Analysis, AnalysisDomain, Backward, BorrowckFlowState,
     BorrowckResults, Engine, Forward, GenKill, GenKillAnalysis, JoinSemiLattice, Results,
     ResultsCursor, ResultsRefCursor, ResultsVisitor, SwitchIntEdgeEffects,
 };

--- a/compiler/rustc_mir/src/util/mod.rs
+++ b/compiler/rustc_mir/src/util/mod.rs
@@ -18,4 +18,4 @@ pub use self::alignment::is_disaligned;
 pub use self::find_self_call::find_self_call;
 pub use self::generic_graph::graphviz_safe_def_name;
 pub use self::graphviz::write_mir_graphviz;
-pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
+pub use self::pretty::{dump_enabled, dump_mir, write_mir_fn, write_mir_pretty, PassWhere};


### PR DESCRIPTION
I'm working on a rustc plugin that uses the dataflow framework for MIR analysis. I've found the graphviz utilities extremely helpful for debugging. However, I had to fork the compiler to expose them since they're currently private. I would appreciate if they could be made public so I can build against a nightly instead of a custom fork. Specifically, this PR:

* Makes public the `rustc_mir::dataflow::framework::graphviz` module.
* Makes public the `rustc_mir::util::pretty::write_mir_fn` function.

Here's a concrete example of how I'm using the graphviz module: https://github.com/willcrichton/flowistry/blob/97b843b8b06b4004fbb79b5fcfca3e33c7143bc0/src/slicing/mod.rs#L186-L203

Additionally, this PR fixes a small bug in the diff code that incorrectly shows the updated object as the old object.

r? @ecstatic-morse 