### PR TITLE
Allow iOS dynamic linking

### DIFF
--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -50,7 +50,7 @@ pub fn opts(os: &str, arch: Arch) -> TargetOptions {
     TargetOptions {
         abi: target_abi(arch),
         cpu: target_cpu(arch),
-        dynamic_linking: false,
+        dynamic_linking: true,
         executables: true,
         link_env_remove: link_env_remove(arch),
         has_elf_tls: false,


### PR DESCRIPTION
This reverts PR #77716.
Since Apple LLVM actually supported compiling .dylibs on/to iOS targets, there is no reason to prevent dynamic linking on a platform that supports it.
aarch64-apple-ios as a Tier 2 target that was 'promised to be compiled', should be allowed to access such a basic feature. Once dynamic library are prohibited to be built, some common libraries such as [Cryptography](https://github.com/pyca/cryptography) would no longer able to run on iOS targets, it is theoretically feasible though.
I was trying to get [mitmproxy](https://www.mitmproxy.org) working on my iPhone 12, as dynamic libraries written in rust cannot be compiled to this target, causing a lot of problems when attempting to run open source projects on an iOS device which was quite capable.