### PR TITLE
Remove mutable aliasing in `from_raw_parts` docs.

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -515,6 +515,7 @@ impl<T> Vec<T> {
     /// let p = v.as_mut_ptr();
     /// let len = v.len();
     /// let cap = v.capacity();
+    /// let _ = v;
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6
@@ -662,6 +663,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let len = v.len();
     /// let cap = v.capacity();
     /// let alloc = v.allocator();
+    /// let _ = v;
     ///
     /// unsafe {
     ///     // Overwrite memory with 4, 5, 6


### PR DESCRIPTION
The examples currently alias the raw memory behind the vector through two different vectors: `v` and `rebuilt`. One can observe the aliasing by adding the following snippet to the bottom of that unsafe block:

```rs
let mut rebuilt = rebuilt;
println!("{:?}", rebuilt);
rebuilt[0] = 1;
println!("{:?}", rebuilt);
v[0] = 2;
println!("{:?}", rebuilt);
```

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=372234ed24fee37f938067f28d1e0605

Output:

```rs
[4, 5, 6]
[1, 5, 6]
[2, 5, 6]
```

I don't think this is UB per se: there are not, at the same moment in time, two different `&mut T` references to the same data in this code, because `Vec` just uses a `*mut`.

But it is dangerous and can easily cause UB in safe code, and so probably not an example one should copy paste.

---

I think it'd be safe to call `std::mem::drop(v);` instead of `let _ = v;` -- but once again, only because `Vec` is using pointers, not references. For example, the following code is UB, flagged by Miri:

```rs
fn raw_ptr_passthrough(x: &mut i32) -> &mut i32 {
    let ptr = x as *mut _;
    std::mem::drop(x);
    unsafe {&mut *ptr} // UB -- best as I understand, because we passed ownership to Drop
}
```

By analogy, I figure it's probably best not to call `drop()` at all when deleting mutable aliases, since it'd so frequently be UB, but I can change to `drop()` if that's in fact the idiom.