### PR TITLE
Force warn improvements

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0602.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0602.md
@@ -1,4 +1,4 @@
-An unknown lint was used on the command line.
+An unknown or invalid lint was used on the command line.
 
 Erroneous code example:
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -332,7 +332,16 @@ impl LintStore {
         crate_attrs: &[ast::Attribute],
     ) {
         let (tool_name, lint_name_only) = parse_lint_and_tool_name(lint_name);
-
+        if lint_name_only == crate::WARNINGS.name_lower() && level == Level::ForceWarn {
+            return struct_span_err!(
+                sess,
+                DUMMY_SP,
+                E0602,
+                "`{}` lint group is not supported with ´--force-warn´",
+                crate::WARNINGS.name_lower()
+            )
+            .emit();
+        }
         let db = match self.check_lint_name(sess, lint_name_only, tool_name, crate_attrs) {
             CheckLintNameResult::Ok(_) => None,
             CheckLintNameResult::Warning(ref msg, _) => Some(sess.struct_warn(msg)),

--- a/src/test/ui/lint/force-warn/allow-warnings.rs
+++ b/src/test/ui/lint/force-warn/allow-warnings.rs
@@ -1,3 +1,5 @@
+// --force-warn $LINT causes $LINT (which is warn-by-default) to warn
+// despite allowing all warnings in module
 // compile-flags: --force-warn dead_code -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/allow-warnings.stderr
+++ b/src/test/ui/lint/force-warn/allow-warnings.stderr
@@ -1,5 +1,5 @@
 warning: function is never used: `dead_function`
-  --> $DIR/force-allowed-warning.rs:6:4
+  --> $DIR/allow-warnings.rs:8:4
    |
 LL | fn dead_function() {}
    |    ^^^^^^^^^^^^^

--- a/src/test/ui/lint/force-warn/allowed-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-by-default-lint.rs
@@ -1,3 +1,4 @@
+// --force-warn $LINT causes $LINT (which is allow-by-default) to warn
 // compile-flags: --force-warn elided_lifetimes_in_paths -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/allowed-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: hidden lifetime parameters in types are deprecated
-  --> $DIR/force-allowed-by-default-lint.rs:8:12
+  --> $DIR/allowed-by-default-lint.rs:9:12
    |
 LL | fn foo(x: &Foo) {}
    |            ^^^- help: indicate the anonymous lifetime: `<'_>`

--- a/src/test/ui/lint/force-warn/allowed-cli-deny-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-cli-deny-by-default-lint.rs
@@ -1,0 +1,10 @@
+// --force-warn $LINT causes $LINT (which is deny-by-default) to warn
+// despite $LINT being allowed on command line
+// compile-flags: -A const_err --force-warn const_err -Zunstable-options
+// check-pass
+
+const C: i32 = 1 / 0;
+//~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler
+
+fn main() {}

--- a/src/test/ui/lint/force-warn/allowed-cli-deny-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-cli-deny-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: any use of this value will cause an error
-  --> $DIR/force-allowed-deny-by-default-lint.rs:5:16
+  --> $DIR/allowed-cli-deny-by-default-lint.rs:6:16
    |
 LL | const C: i32 = 1 / 0;
    | ---------------^^^^^-

--- a/src/test/ui/lint/force-warn/allowed-deny-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-deny-by-default-lint.rs
@@ -1,6 +1,9 @@
+// --force-warn $LINT causes $LINT (which is deny-by-default) to warn
+// despite $LINT being allowed in module
 // compile-flags: --force-warn const_err -Zunstable-options
 // check-pass
 
+#![allow(const_err)]
 const C: i32 = 1 / 0;
 //~^ WARN any use of this value will cause an error
 //~| WARN this was previously accepted by the compiler

--- a/src/test/ui/lint/force-warn/allowed-deny-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-deny-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: any use of this value will cause an error
-  --> $DIR/force-deny-by-default-lint.rs:4:16
+  --> $DIR/allowed-deny-by-default-lint.rs:7:16
    |
 LL | const C: i32 = 1 / 0;
    | ---------------^^^^^-

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
@@ -1,4 +1,6 @@
-// compile-flags: --force-warn rust_2018_idioms -Zunstable-options
+// --force-warn $LINT causes $LINT (which is warn-by-default) to warn
+// despite $LINT_GROUP (which contains $LINT) being allowed
+// compile-flags: --force-warn bare_trait_objects -Zunstable-options
 // check-pass
 
 #![allow(rust_2018_idioms)]

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -1,10 +1,10 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/force-warn-group.rs:8:25
+  --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
    |
-   = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
+   = note: requested on the command line with `--force-warn bare-trait-objects`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 

--- a/src/test/ui/lint/force-warn/allowed-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-warn-by-default-lint.rs
@@ -1,3 +1,5 @@
+// --force-warn $LINT causes $LINT (which is warn-by-default) to warn
+// despite $LINT being allowed in module
 // compile-flags: --force-warn dead_code -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-warn-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: function is never used: `dead_function`
-  --> $DIR/force-lint-allow-all-warnings.rs:6:4
+  --> $DIR/allowed-warn-by-default-lint.rs:8:4
    |
 LL | fn dead_function() {}
    |    ^^^^^^^^^^^^^

--- a/src/test/ui/lint/force-warn/cap-lints-allow.rs
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.rs
@@ -1,3 +1,5 @@
+// --force-warn $LINT casuses $LINT to warn despite --cap-lints
+// set to allow
 // compile-flags: --cap-lints allow  --force-warn bare_trait_objects -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/force-lint-in-allowed-group.rs:8:25
+  --> $DIR/cap-lints-allow.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`

--- a/src/test/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.rs
@@ -1,3 +1,5 @@
+// --force-warn $LINT_GROUP causes $LINT to warn despite $LINT being
+// allowed in module and cap-lints set to warn
 // compile-flags: --cap-lints warn  --force-warn rust-2021-compatibility -Zunstable-options
 // check-pass
 #![allow(ellipsis_inclusive_range_patterns)]

--- a/src/test/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: `...` range patterns are deprecated
-  --> $DIR/force-warn-cap-lints-warn.rs:8:10
+  --> $DIR/cap-lints-warn-allowed-warn-by-default-lint.rs:10:10
    |
 LL |         0...100 => true,
    |          ^^^ help: use `..=` for an inclusive range

--- a/src/test/ui/lint/force-warn/deny-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/deny-by-default-lint.rs
@@ -1,7 +1,7 @@
+// --force-warn $LINT causes $LINT (which is deny-by-default) to warn
 // compile-flags: --force-warn const_err -Zunstable-options
 // check-pass
 
-#![allow(const_err)]
 const C: i32 = 1 / 0;
 //~^ WARN any use of this value will cause an error
 //~| WARN this was previously accepted by the compiler

--- a/src/test/ui/lint/force-warn/deny-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/deny-by-default-lint.stderr
@@ -1,0 +1,14 @@
+warning: any use of this value will cause an error
+  --> $DIR/deny-by-default-lint.rs:5:16
+   |
+LL | const C: i32 = 1 / 0;
+   | ---------------^^^^^-
+   |                |
+   |                attempt to divide `1_i32` by zero
+   |
+   = note: requested on the command line with `--force-warn const-err`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/force-warn/lint-group-allow-warnings.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allow-warnings.rs
@@ -1,3 +1,6 @@
+// --force-warn $LINT_GROUP causes $LINT in $LINT_GROUP to warn
+// despite all warnings being allowed in module
+// warn-by-default lint to warn
 // compile-flags: --force-warn nonstandard_style -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/lint-group-allow-warnings.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allow-warnings.stderr
@@ -1,5 +1,5 @@
 warning: function `FUNCTION` should have a snake case name
-  --> $DIR/force-lint-group-allow-all-warnings.rs:6:8
+  --> $DIR/lint-group-allow-warnings.rs:9:8
    |
 LL | pub fn FUNCTION() {}
    |        ^^^^^^^^ help: convert the identifier to snake case: `function`

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
@@ -1,0 +1,12 @@
+// --force-warn $LINT_GROUP causes $LINT (which is warn-by-default) to warn
+// despite $LINT being allowed on command line
+// compile-flags: -A bare-trait-objects --force-warn rust-2018-idioms -Zunstable-options
+// check-pass
+
+pub trait SomeTrait {}
+
+pub fn function(_x: Box<SomeTrait>) {}
+//~^ WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+
+fn main() {}

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -1,10 +1,10 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/force-warn-cap-lints-allow.rs:6:25
+  --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
    |
-   = note: requested on the command line with `--force-warn bare-trait-objects`
+   = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.rs
@@ -1,4 +1,6 @@
-// compile-flags: --force-warn bare_trait_objects -Zunstable-options
+// --force-warn $LINT_GROUP causes $LINT to warn despite
+// $LINT_GROUP being allowed in module
+// compile-flags: --force-warn rust_2018_idioms -Zunstable-options
 // check-pass
 
 #![allow(rust_2018_idioms)]

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -1,0 +1,12 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-lint-group.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
@@ -1,3 +1,5 @@
+// --force-warn $LINT_GROUP causes $LINT (which is warn-by-default) to warn
+// despite $LINT being allowed in module
 // compile-flags: --force-warn rust-2018-idioms -Zunstable-options
 // check-pass
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/force-warn-group-allow-warning.rs:8:25
+  --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`

--- a/src/test/ui/lint/force-warn/warn-by-default-lint-two-modules.rs
+++ b/src/test/ui/lint/force-warn/warn-by-default-lint-two-modules.rs
@@ -1,0 +1,18 @@
+// --force-warn $LINT causes $LINT (which is warn-by-default) to warn
+// despite being allowed in one submodule (but not the other)
+// compile-flags: --force-warn dead_code -Zunstable-options
+// check-pass
+
+mod one {
+    #![allow(dead_code)]
+
+    fn dead_function() {}
+    //~^ WARN function is never used
+}
+
+mod two {
+    fn dead_function() {}
+    //~^ WARN function is never used
+}
+
+fn main() {}

--- a/src/test/ui/lint/force-warn/warn-by-default-lint-two-modules.stderr
+++ b/src/test/ui/lint/force-warn/warn-by-default-lint-two-modules.stderr
@@ -1,0 +1,16 @@
+warning: function is never used: `dead_function`
+  --> $DIR/warn-by-default-lint-two-modules.rs:9:8
+   |
+LL |     fn dead_function() {}
+   |        ^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `--force-warn dead-code`
+
+warning: function is never used: `dead_function`
+  --> $DIR/warn-by-default-lint-two-modules.rs:14:8
+   |
+LL |     fn dead_function() {}
+   |        ^^^^^^^^^^^^^
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/force-warn/warnings-lint-group.rs
+++ b/src/test/ui/lint/force-warn/warnings-lint-group.rs
@@ -1,0 +1,5 @@
+// --force-warn warnings is an error
+// compile-flags: --force-warn warnings -Zunstable-options
+// error-pattern: `warnings` lint group is not supported
+
+fn main() {}

--- a/src/test/ui/lint/force-warn/warnings-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/warnings-lint-group.stderr
@@ -1,0 +1,9 @@
+error[E0602]: `warnings` lint group is not supported with ´--force-warn´
+
+error[E0602]: `warnings` lint group is not supported with ´--force-warn´
+
+error[E0602]: `warnings` lint group is not supported with ´--force-warn´
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0602`.


### PR DESCRIPTION
As part of stablization of the `--force-warn` option (#86516) I've made the following changes:
* Error when the `warnings` lint group is based to the `--force-warn` option
* Tests have been updated to make it easier to understand the semantics of `--force-warn`

r? @nikomatsakis