### PR TITLE
Fix non-capturing closure return type coercion

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -941,6 +941,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             exprs.len()
         );
 
+        // The following check fixes #88097, where the compiler erroneously
+        // attempted to coerce a closure type to itself via a function pointer.
         if prev_ty == new_ty {
             return Ok(prev_ty);
         }

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -941,6 +941,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             exprs.len()
         );
 
+        if prev_ty == new_ty {
+            return Ok(prev_ty);
+        }
+
         // Special-case that coercion alone cannot handle:
         // Function items or non-capturing closures of differing IDs or InternalSubsts.
         let (a_sig, b_sig) = {

--- a/src/test/ui/coercion/issue-88097.rs
+++ b/src/test/ui/coercion/issue-88097.rs
@@ -1,0 +1,31 @@
+// In #88097, the compiler attempted to coerce a closure type to itself via
+// a function pointer, which caused an unnecessary error. Check that this
+// behavior has been fixed.
+
+// check-pass
+
+fn peculiar() -> impl Fn(u8) -> u8 {
+    return |x| x + 1
+}
+
+fn peculiar2() -> impl Fn(u8) -> u8 {
+    return |x| x + 1;
+}
+
+fn peculiar3() -> impl Fn(u8) -> u8 {
+    let f = |x| x + 1;
+    return f
+}
+
+fn peculiar4() -> impl Fn(u8) -> u8 {
+    let f = |x| x + 1;
+    f
+}
+
+fn peculiar5() -> impl Fn(u8) -> u8 {
+    let f = |x| x + 1;
+    let g = |x| x + 2;
+    return if true { f } else { g }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #88097. For the example given there:
```rust
fn peculiar() -> impl Fn(u8) -> u8 {
    return |x| x + 1
}
```
which incorrectly reports an error, I noticed something weird in the debug log:
```
DEBUG rustc_typeck::check::coercion coercion::try_find_coercion_lub([closure@test.rs:2:12: 2:21], [closure@test.rs:2:12: 2:21], exprs=1 exprs)
```
Apparently, `try_find_coercion_lub()` thinks that the LUB for two closure types always has to be a function pointer (which explains the `expected closure, found fn pointer` error in #88097). There is one corner case where that isn't true, though — namely, when the two closure types are equal, in which case the trivial LUB is the type itself. This PR fixes this by inserting an explicit check for type equality in `try_find_coercion_lub()`.