### PR TITLE
bootstrap.py: recognize riscv64 when auto-detect

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -301,6 +301,7 @@ def default_build_triple(verbose):
         'ppc': 'powerpc',
         'ppc64': 'powerpc64',
         'ppc64le': 'powerpc64le',
+        'riscv64': 'riscv64gc',
         's390x': 's390x',
         'x64': 'x86_64',
         'x86': 'i686',


### PR DESCRIPTION
The architecture auto-detect table has no entry for riscv64 (which rustc
uses riscv64gc for the first part of triplet, assuming it's a generic
Linux distro).

Add it to the table to allow riscv64 systems to bootstrap Rust.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>