### PR TITLE
Update release note for 1.55.0.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -70,6 +70,7 @@ Cargo
 - [The package definition in `cargo metadata` now includes the `"default_run"`
   field from the manifest.][cargo/9550]
 - [Added `cargo d` as an alias for `cargo doc`.][cargo/9680]
+- [Added `{lib}` as formatting option for `cargo tree` to print the "lib_name" of packages.][cargo/9663]
 
 Rustdoc
 -------


### PR DESCRIPTION
Added a line about new formatting option, `{lib}`, for `cargo
tree` (https://github.com/rust-lang/cargo/pull/9663).