### PR TITLE
Add `LetSource` to `hir::ExprKind::Let`

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -95,7 +95,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         Some(ConditionScope::Guard) => hir::LetSource::Guard,
                         Some(ConditionScope::If) => hir::LetSource::If,
                         Some(ConditionScope::While) => hir::LetSource::While,
-                        _ => hir::LetSource::Local,
+                        None => hir::LetSource::Local,
                     };
                     hir::ExprKind::Let(
                         self.lower_pat(pat),

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1732,7 +1732,7 @@ pub enum ExprKind<'hir> {
     ///
     /// These are not `Local` and only occur as expressions.
     /// The `let Some(x) = foo()` in `if let Some(x) = foo()` is an example of `Let(..)`.
-    Let(&'hir Pat<'hir>, &'hir Expr<'hir>, Span),
+    Let(&'hir Pat<'hir>, &'hir Expr<'hir>, Span, LetSource),
     /// An `if` block, with an optional else block.
     ///
     /// I.e., `if <expr> { <expr> } else { <expr> }`.
@@ -1884,6 +1884,15 @@ pub enum LocalSource {
     /// A desugared `expr = expr`, where the LHS is a tuple, struct or array.
     /// The span is that of the `=` sign.
     AssignDesugar(Span),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Encodable, Hash, Debug)]
+#[derive(HashStable_Generic)]
+pub enum LetSource {
+    Guard,
+    If,
+    Local,
+    While,
 }
 
 /// Hints at the original code for a `match _ { .. }`.

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1163,7 +1163,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
         ExprKind::DropTemps(ref subexpression) => {
             visitor.visit_expr(subexpression);
         }
-        ExprKind::Let(ref pat, ref expr, _) => {
+        ExprKind::Let(ref pat, ref expr, ..) => {
             visitor.visit_expr(expr);
             visitor.visit_pat(pat);
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1526,7 +1526,7 @@ impl<'a> State<'a> {
                 // Print `}`:
                 self.bclose_maybe_open(expr.span, true);
             }
-            hir::ExprKind::Let(ref pat, ref scrutinee, _) => {
+            hir::ExprKind::Let(ref pat, ref scrutinee, ..) => {
                 self.print_let(pat, scrutinee);
             }
             hir::ExprKind::If(ref test, ref blk, ref elseopt) => {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -590,7 +590,7 @@ impl<'tcx> Cx<'tcx> {
                 },
                 Err(err) => bug!("invalid loop id for continue: {}", err),
             },
-            hir::ExprKind::Let(ref pat, ref expr, _) => {
+            hir::ExprKind::Let(ref pat, ref expr, ..) => {
                 ExprKind::Let { expr: self.mirror_expr(expr), pat: self.pattern_from_hir(pat) }
             }
             hir::ExprKind::If(cond, then, else_opt) => ExprKind::If {

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -857,7 +857,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 })
             }
 
-            hir::ExprKind::Let(ref pat, ref scrutinee, _) => {
+            hir::ExprKind::Let(ref pat, ref scrutinee, ..) => {
                 let succ = self.propagate_through_expr(scrutinee, succ);
                 self.define_bindings_in_pat(pat, succ)
             }

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -266,7 +266,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             ExprKind::Ret(ref expr_opt) => self.check_expr_return(expr_opt.as_deref(), expr),
-            ExprKind::Let(pat, let_expr, _) => self.check_expr_let(let_expr, pat),
+            ExprKind::Let(pat, let_expr, ..) => self.check_expr_let(let_expr, pat),
             ExprKind::Loop(body, _, source, _) => {
                 self.check_expr_loop(body, source, expected, expr)
             }

--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                 }
             }
 
-            hir::ExprKind::Let(ref pat, ref expr, _) => {
+            hir::ExprKind::Let(ref pat, ref expr, ..) => {
                 self.walk_local(expr, pat, |t| t.borrow_expr(&expr, ty::ImmBorrow));
             }
 

--- a/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
@@ -111,7 +111,7 @@ fn never_loop_expr(expr: &Expr<'_>, main_loop_id: HirId) -> NeverLoopResult {
         | ExprKind::Unary(_, e)
         | ExprKind::Cast(e, _)
         | ExprKind::Type(e, _)
-        | ExprKind::Let(_, e, _)
+        | ExprKind::Let(_, e, ..)
         | ExprKind::Field(e, _)
         | ExprKind::AddrOf(_, _, e)
         | ExprKind::Struct(_, _, Some(e))

--- a/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
@@ -117,7 +117,7 @@ impl<'tcx> LateLintPass<'tcx> for PatternTypeMismatch {
                 }
             }
         }
-        if let ExprKind::Let(let_pat, let_expr, _) = expr.kind {
+        if let ExprKind::Let(let_pat, let_expr, ..) = expr.kind {
             if let Some(ref expr_ty) = cx.typeck_results().node_type_opt(let_expr.hir_id) {
                 if in_external_macro(cx.sess(), let_pat.span) {
                     return;

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -208,7 +208,7 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
         print!("    if let ExprKind::");
         let current = format!("{}.kind", self.current);
         match expr.kind {
-            ExprKind::Let(pat, expr, _) => {
+            ExprKind::Let(pat, expr, ..) => {
                 let let_pat = self.next("pat");
                 let let_expr = self.next("expr");
                 println!("    Let(ref {}, ref {}, _) = {};", let_pat, let_expr, current);

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -142,7 +142,7 @@ fn print_expr(cx: &LateContext<'_>, expr: &hir::Expr<'_>, indent: usize) {
                 print_expr(cx, arg, indent + 1);
             }
         },
-        hir::ExprKind::Let(ref pat, ref expr, _) => {
+        hir::ExprKind::Let(ref pat, ref expr, ..) => {
             print_pat(cx, pat, indent + 1);
             print_expr(cx, expr, indent + 1);
         },

--- a/src/tools/clippy/clippy_utils/src/higher.rs
+++ b/src/tools/clippy/clippy_utils/src/higher.rs
@@ -90,7 +90,7 @@ impl<'hir> IfLet<'hir> {
     pub const fn hir(expr: &Expr<'hir>) -> Option<Self> {
         if let ExprKind::If(
             Expr {
-                kind: ExprKind::Let(let_pat, let_expr, _),
+                kind: ExprKind::Let(let_pat, let_expr, ..),
                 ..
             },
             if_then,
@@ -329,7 +329,7 @@ impl<'hir> WhileLet<'hir> {
                 kind:
                     ExprKind::If(
                         Expr {
-                            kind: ExprKind::Let(let_pat, let_expr, _),
+                            kind: ExprKind::Let(let_pat, let_expr, ..),
                             ..
                         },
                         if_then,

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -232,8 +232,8 @@ impl HirEqInterExpr<'_, '_, '_> {
             (&ExprKind::If(lc, lt, ref le), &ExprKind::If(rc, rt, ref re)) => {
                 self.eq_expr(lc, rc) && self.eq_expr(&**lt, &**rt) && both(le, re, |l, r| self.eq_expr(l, r))
             },
-            (&ExprKind::Let(ref lp, ref le, _), &ExprKind::Let(ref rp, ref re, _)) => {
-                self.eq_pat(lp, rp) && self.eq_expr(le, re)
+            (&ExprKind::Let(ref lp, ref le, _, ls), &ExprKind::Let(ref rp, ref re, _, rs)) => {
+                self.eq_pat(lp, rp) && self.eq_expr(le, re) && ls == rs
             },
             (&ExprKind::Lit(ref l), &ExprKind::Lit(ref r)) => l.node == r.node,
             (&ExprKind::Loop(lb, ref ll, ref lls, _), &ExprKind::Loop(rb, ref rl, ref rls, _)) => {
@@ -668,9 +668,10 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                     }
                 }
             },
-            ExprKind::Let(ref pat, ref expr, _) => {
+            ExprKind::Let(ref pat, ref expr, _, source) => {
                 self.hash_expr(expr);
                 self.hash_pat(pat);
+                std::mem::discriminant(&source).hash(&mut self.s);
             },
             ExprKind::LlvmInlineAsm(..) | ExprKind::Err => {},
             ExprKind::Lit(ref l) => {


### PR DESCRIPTION
...instead of determining `LetSource` using `hir::Map`. This is used in #87688. And it may also be useful for factoring out `Guard::IfLet`.