### PR TITLE
Backport PR 87483

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/region_infer/opaque_types.rs
+++ b/compiler/rustc_mir/src/borrow_check/region_infer/opaque_types.rs
@@ -83,6 +83,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                             .and_then(|ur_vid| self.definitions[*ur_vid].external_name)
                             .unwrap_or(infcx.tcx.lifetimes.re_root_empty),
                         ty::ReLateBound(..) => region,
+                        ty::ReStatic => region,
                         _ => {
                             infcx.tcx.sess.delay_span_bug(
                                 span,

--- a/src/test/ui/type-alias-impl-trait/issue-87455-static-lifetime-ice.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-87455-static-lifetime-ice.rs
@@ -1,0 +1,73 @@
+// check-pass
+
+use std::error::Error as StdError;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub trait Stream {
+    type Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+pub trait TryStream: Stream {
+    type Ok;
+    type Error;
+
+    fn try_poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Ok, Self::Error>>>;
+}
+
+impl<S, T, E> TryStream for S
+where
+    S: ?Sized + Stream<Item = Result<T, E>>,
+{
+    type Ok = T;
+    type Error = E;
+
+    fn try_poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Ok, Self::Error>>> {
+        self.poll_next(cx)
+    }
+}
+
+pub trait ServerSentEvent: Sized + Send + Sync + 'static {}
+
+impl<T: Send + Sync + 'static> ServerSentEvent for T {}
+
+struct SseKeepAlive<S> {
+    event_stream: S,
+}
+
+struct SseComment<T>(T);
+
+impl<S> Stream for SseKeepAlive<S>
+where
+    S: TryStream + Send + 'static,
+    S::Ok: ServerSentEvent,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    type Item = Result<SseComment<&'static str>, ()>;
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Item>> {
+        unimplemented!()
+    }
+}
+
+pub fn keep<S>(
+    event_stream: S,
+) -> impl TryStream<Ok = impl ServerSentEvent + Send + 'static, Error = ()> + Send + 'static
+where
+    S: TryStream + Send + 'static,
+    S::Ok: ServerSentEvent + Send,
+    S::Error: StdError + Send + Sync + 'static,
+{
+    SseKeepAlive { event_stream }
+}
+
+fn main() {}


### PR DESCRIPTION
Backport of PR #87483: "Mir borrowck does not generate lifetime variables for 'static lifetimes during opaque type resolution"

Fix #87455: "ICE: unexpected concrete region in borrowck: ReStatic"