### PR TITLE
Add ability to spawn Windows process with Proc Thread Attributes

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -4,7 +4,7 @@
 
 #![stable(feature = "process_extensions", since = "1.2.0")]
 
-use crate::ffi::{c_void, OsStr};
+use crate::ffi::OsStr;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
 };
@@ -166,17 +166,14 @@ pub trait CommandExt: Sealed {
     ///
     /// # Safety
     ///
-    /// - The data pointed to by `value` pointer must not be moved or aliased for the entire lifetime of
-    ///   the `Command`.
-    /// - The data pointed to by `value` pointer must be initialized.
-    /// - `size` must not exceed the size of the object pointed to by the `value` pointer.
-    /// - It must be safe to read the data pointed to by `value` from another thread.
+    /// - The attribute and value pair must be supplied in accordance with [Win32 API usage][1].
+    ///
+    /// [1]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute
     #[unstable(feature = "windows_process_extensions_proc_thread_attributes", issue = "none")]
-    unsafe fn process_thread_attribute(
+    unsafe fn process_thread_attribute<T: Copy + Send + Sync + 'static>(
         &mut self,
         attribute: usize,
-        value: *mut c_void,
-        size: usize,
+        value: T,
     ) -> &mut process::Command;
 }
 
@@ -196,13 +193,12 @@ impl CommandExt for process::Command {
         self.as_inner_mut().raw_arg(raw_text.as_ref());
         self
     }
-    unsafe fn process_thread_attribute(
+    unsafe fn process_thread_attribute<T: Copy + Send + Sync + 'static>(
         &mut self,
         attribute: usize,
-        value: *mut c_void,
-        size: usize,
+        value: T,
     ) -> &mut process::Command {
-        self.as_inner_mut().process_thread_attribute(attribute, value, size);
+        self.as_inner_mut().process_thread_attribute(attribute, value);
         self
     }
 }

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -412,17 +412,15 @@ fn test_creation_flags() {
 fn test_proc_thread_attributes() {
     use crate::os::windows::io::AsRawHandle;
     use crate::os::windows::process::CommandExt;
-    use crate::sys::c::{DWORD_PTR, HANDLE};
+    use crate::sys::c::DWORD_PTR;
     const PROC_THREAD_ATTRIBUTE_PARENT_PROCESS: DWORD_PTR = 0x00020000;
-    let mut parent = Command::new("cmd.exe").spawn().unwrap();
-    let mut parent_handle: HANDLE = parent.as_raw_handle();
 
+    let mut parent = Command::new("cmd.exe").spawn().unwrap();
     let mut child_cmd = Command::new("cmd.exe");
     unsafe {
         child_cmd.process_thread_attribute(
             PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
-            &mut parent_handle as *mut _ as *mut _,
-            crate::mem::size_of::<HANDLE>(),
+            parent.as_raw_handle() as isize,
         );
     }
     let mut child = child_cmd.spawn().unwrap();

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -51,6 +51,7 @@ pub type LPCWSTR = *const WCHAR;
 pub type LPDWORD = *mut DWORD;
 pub type LPHANDLE = *mut HANDLE;
 pub type LPOVERLAPPED = *mut OVERLAPPED;
+pub type LPPROC_THREAD_ATTRIBUTE_LIST = *mut c_void;
 pub type LPPROCESS_INFORMATION = *mut PROCESS_INFORMATION;
 pub type LPSECURITY_ATTRIBUTES = *mut SECURITY_ATTRIBUTES;
 pub type LPSTARTUPINFO = *mut STARTUPINFO;
@@ -68,6 +69,7 @@ pub type LPWSAOVERLAPPED_COMPLETION_ROUTINE = *mut c_void;
 
 pub type PCONDITION_VARIABLE = *mut CONDITION_VARIABLE;
 pub type PLARGE_INTEGER = *mut c_longlong;
+pub type PSIZE_T = *mut usize;
 pub type PSRWLOCK = *mut SRWLOCK;
 
 pub type SOCKET = crate::os::windows::raw::SOCKET;
@@ -196,6 +198,7 @@ pub const SRWLOCK_INIT: SRWLOCK = SRWLOCK { ptr: ptr::null_mut() };
 pub const DETACHED_PROCESS: DWORD = 0x00000008;
 pub const CREATE_NEW_PROCESS_GROUP: DWORD = 0x00000200;
 pub const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
+pub const EXTENDED_STARTUPINFO_PRESENT: DWORD = 0x00080000;
 pub const STARTF_USESTDHANDLES: DWORD = 0x00000100;
 
 pub const AF_INET: c_int = 2;
@@ -585,6 +588,12 @@ pub struct STARTUPINFO {
     pub hStdInput: HANDLE,
     pub hStdOutput: HANDLE,
     pub hStdError: HANDLE,
+}
+
+#[repr(C)]
+pub struct STARTUPINFOEX {
+    pub StartupInfo: STARTUPINFO,
+    pub lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
 }
 
 #[repr(C)]
@@ -1078,6 +1087,22 @@ extern "system" {
         lpFilePart: *mut LPWSTR,
     ) -> DWORD;
     pub fn GetFileAttributesW(lpFileName: LPCWSTR) -> DWORD;
+    pub fn InitializeProcThreadAttributeList(
+        lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
+        dwAttributeCount: DWORD,
+        dwFlags: DWORD,
+        lpSize: PSIZE_T,
+    ) -> BOOL;
+    pub fn UpdateProcThreadAttribute(
+        lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST,
+        dwFlags: DWORD,
+        Attribute: DWORD_PTR,
+        lpValue: LPVOID,
+        cbSize: SIZE_T,
+        lpPreviousValue: LPVOID,
+        lpReturnSize: PSIZE_T,
+    ) -> BOOL;
+    pub fn DeleteProcThreadAttributeList(lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST);
 }
 
 #[link(name = "ws2_32")]


### PR DESCRIPTION
This adds a Windows-specific extension method on `Command` that allows users to include proc thread attributes. The test uses the PROC_THREAD_ATTRIBUTE_PARENT_PROCESS attribute to spawn a process with a custom parent process, and then verifies the child's parent matches the expected parent. That seemed to me the easiest way to test.

Without this, it is not possible to implement anything requiring these attributes without re-implementing `Command` (and friends) from scratch as a separate crate.

In particular, I would like to use this to make use of the Windows [ConPTY](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/#using-the-conpty-api) API. I've already succesfully implemented this in my own library, but don't like the thought of having to maintain my own copy of what is already in the standard library, potentially missing any future bug fixes or security updates.

This addition requires a minimum of Windows Vista or Server 2008, which as far as I understand should now be acceptable to add to the standard library since XP support is not required any longer.

The exposed API is pretty much the bare minimum to make this work, but it may be possible to improve the API in the future.

I can open a tracking issue and update the PR with that in a bit.