### PR TITLE
Make specifying repr optional for fieldless enums

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0732.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0732.md
@@ -4,16 +4,19 @@ Erroneous code example:
 
 ```compile_fail,E0732
 enum Enum { // error!
-    Unit = 1,
-    Tuple() = 2,
-    Struct{} = 3,
+    Unit = 3,
+    Tuple(u16) = 2,
+    Struct {
+        a: u8,
+        b: u16,
+    } = 1,
 }
 # fn main() {}
 ```
 
-A `#[repr(inttype)]` must be provided on an `enum` if it has a non-unit
-variant with a discriminant, or where there are both unit variants with
-discriminants and non-unit variants. This restriction ensures that there
+A `#[repr(inttype)]` must be provided on an `enum` if it not fieldless and
+has a discriminant, or where there are both fieldless variants with
+discriminants and variants that have fields. This restriction ensures that there
 is a well-defined way to extract a variant's discriminant from a value;
 for instance:
 

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.rs
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.rs
@@ -1,8 +1,9 @@
-#![crate_type="lib"]
-
+#![crate_type = "lib"]
 enum Enum {
-//~^ ERROR `#[repr(inttype)]` must be specified
-  Unit = 1,
-  Tuple() = 2,
-  Struct{} = 3,
+    //~^ ERROR `#[repr(inttype)]` must be specified
+    Unit = 5,
+    Tuple(u8) = 3,
+    Struct {
+        foo: u16
+    } = 1,
 }

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
@@ -1,11 +1,12 @@
 error[E0732]: `#[repr(inttype)]` must be specified
-  --> $DIR/arbitrary_enum_discriminant-no-repr.rs:3:1
+  --> $DIR/arbitrary_enum_discriminant-no-repr.rs:2:1
    |
 LL | / enum Enum {
 LL | |
-LL | |   Unit = 1,
-LL | |   Tuple() = 2,
-LL | |   Struct{} = 3,
+LL | |     Unit = 5,
+LL | |     Tuple(u8) = 3,
+...  |
+LL | |     } = 1,
 LL | | }
    | |_^
 

--- a/src/test/ui/enum-discriminant/fieldless-no-repr.rs
+++ b/src/test/ui/enum-discriminant/fieldless-no-repr.rs
@@ -1,0 +1,8 @@
+// check-pass
+#![crate_type="lib"]
+
+enum Enum {
+  Unit = 1,
+  Tuple() = 2,
+  Struct{} = 3,
+}


### PR DESCRIPTION
This makes it consistent for another behavior, which is casting an enum to its discriminant.

We can currently cast "fieldless" enums to its discriminants, but only "c-like" (only unit variants) enums are allowed to leave the repr unspecified. See https://github.com/rust-lang/reference/pull/1055#discussion_r691748964 for previous discussion.