### PR TITLE
ast_lowering: Introduce `lower_span` for catching all spans entering HIR

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -158,7 +158,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     pub(super) fn lower_mod(&mut self, items: &[P<Item>], inner: Span) -> hir::Mod<'hir> {
         hir::Mod {
-            inner,
+            inner: self.lower_span(inner),
             item_ids: self.arena.alloc_from_iter(items.iter().flat_map(|x| self.lower_item_id(x))),
         }
     }
@@ -214,7 +214,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let hir_id = self.lower_node_id(i.id);
         let attrs = self.lower_attrs(hir_id, &i.attrs);
         let kind = self.lower_item_kind(i.span, i.id, hir_id, &mut ident, attrs, &mut vis, &i.kind);
-        Some(hir::Item { def_id: hir_id.expect_owner(), ident, kind, vis, span: i.span })
+        Some(hir::Item {
+            def_id: hir_id.expect_owner(),
+            ident: self.lower_ident(ident),
+            kind,
+            vis,
+            span: self.lower_span(i.span),
+        })
     }
 
     fn lower_item_kind(
@@ -278,7 +284,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let sig = hir::FnSig {
                         decl,
                         header: this.lower_fn_header(header, fn_sig_span, id),
-                        span: fn_sig_span,
+                        span: this.lower_span(fn_sig_span),
                     };
                     hir::ItemKind::Fn(sig, generics, body_id)
                 })
@@ -407,6 +413,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // to not cause an assertion failure inside the `lower_defaultness` function.
                 let has_val = true;
                 let (defaultness, defaultness_span) = self.lower_defaultness(defaultness, has_val);
+                let polarity = match polarity {
+                    ImplPolarity::Positive => ImplPolarity::Positive,
+                    ImplPolarity::Negative(s) => ImplPolarity::Negative(self.lower_span(s)),
+                };
                 hir::ItemKind::Impl(hir::Impl {
                     unsafety: self.lower_unsafety(unsafety),
                     polarity,
@@ -525,10 +535,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                         this.insert_item(hir::Item {
                             def_id: new_id.expect_owner(),
-                            ident,
+                            ident: this.lower_ident(ident),
                             kind,
                             vis,
-                            span,
+                            span: this.lower_span(span),
                         });
                     });
                 }
@@ -599,10 +609,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                         this.insert_item(hir::Item {
                             def_id: new_hir_id.expect_owner(),
-                            ident,
+                            ident: this.lower_ident(ident),
                             kind,
                             vis,
-                            span: use_tree.span,
+                            span: this.lower_span(use_tree.span),
                         });
                     });
                 }
@@ -621,7 +631,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir::VisibilityKind::Public
                     | hir::VisibilityKind::Crate(_)
                     | hir::VisibilityKind::Inherited => {
-                        *vis = respan(prefix.span.shrink_to_lo(), hir::VisibilityKind::Inherited);
+                        *vis = respan(
+                            self.lower_span(prefix.span.shrink_to_lo()),
+                            hir::VisibilityKind::Inherited,
+                        );
                     }
                     hir::VisibilityKind::Restricted { .. } => {
                         // Do nothing here, as described in the comment on the match.
@@ -664,7 +677,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
             }
         };
-        respan(vis.span, vis_kind)
+        respan(self.lower_span(vis.span), vis_kind)
     }
 
     fn lower_foreign_item(&mut self, i: &ForeignItem) -> hir::ForeignItem<'hir> {
@@ -673,7 +686,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.lower_attrs(hir_id, &i.attrs);
         hir::ForeignItem {
             def_id,
-            ident: i.ident,
+            ident: self.lower_ident(i.ident),
             kind: match i.kind {
                 ForeignItemKind::Fn(box FnKind(_, ref sig, ref generics, _)) => {
                     let fdec = &sig.decl;
@@ -700,15 +713,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ForeignItemKind::MacCall(_) => panic!("macro shouldn't exist here"),
             },
             vis: self.lower_visibility(&i.vis, None),
-            span: i.span,
+            span: self.lower_span(i.span),
         }
     }
 
     fn lower_foreign_item_ref(&mut self, i: &ForeignItem) -> hir::ForeignItemRef<'hir> {
         hir::ForeignItemRef {
             id: hir::ForeignItemId { def_id: self.lower_node_id(i.id).expect_owner() },
-            ident: i.ident,
-            span: i.span,
+            ident: self.lower_ident(i.ident),
+            span: self.lower_span(i.span),
             vis: self.lower_visibility(&i.vis, Some(i.id)),
         }
     }
@@ -720,8 +733,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
             id,
             data: self.lower_variant_data(id, &v.data),
             disr_expr: v.disr_expr.as_ref().map(|e| self.lower_anon_const(e)),
-            ident: v.ident,
-            span: v.span,
+            ident: self.lower_ident(v.ident),
+            span: self.lower_span(v.span),
         }
     }
 
@@ -773,12 +786,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let hir_id = self.lower_node_id(f.id);
         self.lower_attrs(hir_id, &f.attrs);
         hir::FieldDef {
-            span: f.span,
+            span: self.lower_span(f.span),
             hir_id,
             ident: match f.ident {
-                Some(ident) => ident,
+                Some(ident) => self.lower_ident(ident),
                 // FIXME(jseyfried): positional field hygiene.
-                None => Ident::new(sym::integer(index), f.span),
+                None => Ident::new(sym::integer(index), self.lower_span(f.span)),
             },
             vis: self.lower_visibility(&f.vis, None),
             ty,
@@ -829,7 +842,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
 
         self.lower_attrs(hir_id, &i.attrs);
-        hir::TraitItem { def_id: trait_item_def_id, ident: i.ident, generics, kind, span: i.span }
+        hir::TraitItem {
+            def_id: trait_item_def_id,
+            ident: self.lower_ident(i.ident),
+            generics,
+            kind,
+            span: self.lower_span(i.span),
+        }
     }
 
     fn lower_trait_item_ref(&mut self, i: &AssocItem) -> hir::TraitItemRef {
@@ -845,7 +864,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
         let id = hir::TraitItemId { def_id: self.lower_node_id(i.id).expect_owner() };
         let defaultness = hir::Defaultness::Default { has_value: has_default };
-        hir::TraitItemRef { id, ident: i.ident, span: i.span, defaultness, kind }
+        hir::TraitItemRef {
+            id,
+            ident: self.lower_ident(i.ident),
+            span: self.lower_span(i.span),
+            defaultness,
+            kind,
+        }
     }
 
     /// Construct `ExprKind::Err` for the given `span`.
@@ -910,12 +935,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.lower_attrs(hir_id, &i.attrs);
         hir::ImplItem {
             def_id: hir_id.expect_owner(),
-            ident: i.ident,
+            ident: self.lower_ident(i.ident),
             generics,
             vis: self.lower_visibility(&i.vis, None),
             defaultness,
             kind,
-            span: i.span,
+            span: self.lower_span(i.span),
         }
     }
 
@@ -925,8 +950,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let (defaultness, _) = self.lower_defaultness(i.kind.defaultness(), has_value);
         hir::ImplItemRef {
             id: hir::ImplItemId { def_id: self.lower_node_id(i.id).expect_owner() },
-            ident: i.ident,
-            span: i.span,
+            ident: self.lower_ident(i.ident),
+            span: self.lower_span(i.span),
             vis: self.lower_visibility(&i.vis, Some(i.id)),
             defaultness,
             kind: match &i.kind {
@@ -969,7 +994,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             VisibilityKind::Inherited => hir::VisibilityKind::Inherited,
         };
-        respan(v.span, node)
+        respan(self.lower_span(v.span), node)
     }
 
     fn lower_defaultness(
@@ -978,7 +1003,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         has_value: bool,
     ) -> (hir::Defaultness, Option<Span>) {
         match d {
-            Defaultness::Default(sp) => (hir::Defaultness::Default { has_value }, Some(sp)),
+            Defaultness::Default(sp) => {
+                (hir::Defaultness::Default { has_value }, Some(self.lower_span(sp)))
+            }
             Defaultness::Final => {
                 assert!(has_value);
                 (hir::Defaultness::Final, None)
@@ -1016,8 +1043,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         hir::Param {
             hir_id,
             pat: self.lower_pat(&param.pat),
-            ty_span: param.ty.span,
-            span: param.span,
+            ty_span: self.lower_span(param.ty.span),
+            span: self.lower_span(param.span),
         }
     }
 
@@ -1151,8 +1178,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let new_parameter = hir::Param {
                     hir_id: parameter.hir_id,
                     pat: new_parameter_pat,
-                    ty_span: parameter.ty_span,
-                    span: parameter.span,
+                    ty_span: this.lower_span(parameter.ty_span),
+                    span: this.lower_span(parameter.span),
                 };
 
                 if is_simple_parameter {
@@ -1285,7 +1312,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 )
             },
         );
-        (generics, hir::FnSig { header, decl, span: sig.span })
+        (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })
     }
 
     fn lower_fn_header(&mut self, h: FnHeader, span: Span, id: NodeId) -> hir::FnHeader {
@@ -1385,7 +1412,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         GenericsCtor {
             params: self.lower_generic_params_mut(&generics.params, &add_bounds, itctx).collect(),
             where_clause: self.lower_where_clause(&generics.where_clause),
-            span: generics.span,
+            span: self.lower_span(generics.span),
         }
     }
 
@@ -1404,7 +1431,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 predicates: this.arena.alloc_from_iter(
                     wc.predicates.iter().map(|predicate| this.lower_where_predicate(predicate)),
                 ),
-                span: wc.span,
+                span: this.lower_span(wc.span),
             }
         })
     }
@@ -1433,12 +1460,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                                 // `suggest_constraining_type_param`. This will need to change if
                                 // we ever allow something *other* than `?Sized`.
                                 GenericBound::Trait(p, TraitBoundModifier::Maybe) => {
-                                    hir::GenericBound::Unsized(p.span)
+                                    hir::GenericBound::Unsized(this.lower_span(p.span))
                                 }
                                 _ => this.lower_param_bound(bound, ImplTraitContext::disallowed()),
                             },
                         )),
-                        span,
+                        span: this.lower_span(span),
                     })
                 })
             }
@@ -1447,7 +1474,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ref bounds,
                 span,
             }) => hir::WherePredicate::RegionPredicate(hir::WhereRegionPredicate {
-                span,
+                span: self.lower_span(span),
                 lifetime: self.lower_lifetime(lifetime),
                 bounds: self.lower_param_bounds(bounds, ImplTraitContext::disallowed()),
             }),
@@ -1456,7 +1483,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir_id: self.lower_node_id(id),
                     lhs_ty: self.lower_ty(lhs_ty, ImplTraitContext::disallowed()),
                     rhs_ty: self.lower_ty(rhs_ty, ImplTraitContext::disallowed()),
-                    span,
+                    span: self.lower_span(span),
                 })
             }
         }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -760,6 +760,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         result
     }
 
+    /// Intercept all spans entering HIR.
+    /// For now we are not doing anything with the intercepted spans.
+    fn lower_span(&self, span: Span) -> Span {
+        span
+    }
+
+    fn lower_ident(&self, ident: Ident) -> Ident {
+        Ident::new(ident.name, self.lower_span(ident.span))
+    }
+
     /// Creates a new `hir::GenericParam` for every new lifetime and
     /// type parameter encountered while evaluating `f`. Definitions
     /// are created with the parent provided. If no `parent_id` is
@@ -828,7 +838,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             hir_id: self.lower_node_id(node_id),
             name: hir_name,
             bounds: &[],
-            span,
+            span: self.lower_span(span),
             pure_wrt_drop: false,
             kind: hir::GenericParamKind::Lifetime { kind },
         }
@@ -989,7 +999,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             AttrKind::DocComment(comment_kind, data) => AttrKind::DocComment(comment_kind, data),
         };
 
-        Attribute { kind, id: attr.id, style: attr.style, span: attr.span }
+        Attribute { kind, id: attr.id, style: attr.style, span: self.lower_span(attr.span) }
     }
 
     fn alias_attrs(&mut self, id: hir::HirId, target_id: hir::HirId) {
@@ -1117,7 +1127,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     .0
                 }
             };
-            self.arena.alloc(gen_args_ctor.into_generic_args(&self.arena))
+            gen_args_ctor.into_generic_args(self)
         } else {
             self.arena.alloc(hir::GenericArgs::none())
         };
@@ -1198,7 +1208,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             &Ty {
                                 id: node_id,
                                 kind: TyKind::ImplTrait(impl_trait_node_id, bounds.clone()),
-                                span: constraint.span,
+                                span: this.lower_span(constraint.span),
                                 tokens: None,
                             },
                             itctx,
@@ -1218,10 +1228,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         hir::TypeBinding {
             hir_id: self.lower_node_id(constraint.id),
-            ident: constraint.ident,
+            ident: self.lower_ident(constraint.ident),
             gen_args,
             kind,
-            span: constraint.span,
+            span: self.lower_span(constraint.span),
         }
     }
 
@@ -1235,10 +1245,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ast::GenericArg::Type(ty) => {
                 match ty.kind {
                     TyKind::Infer if self.sess.features_untracked().generic_arg_infer => {
-                        let hir_id = self.lower_node_id(ty.id);
                         return GenericArg::Infer(hir::InferArg {
-                            hir_id,
-                            span: ty.span,
+                            hir_id: self.lower_node_id(ty.id),
+                            span: self.lower_span(ty.span),
                             kind: InferKind::Type,
                         });
                     }
@@ -1269,10 +1278,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                     ty.span,
                                 );
 
+                                let span = self.lower_span(ty.span);
                                 let path_expr = Expr {
                                     id: ty.id,
                                     kind: ExprKind::Path(qself.clone(), path.clone()),
-                                    span: ty.span,
+                                    span,
                                     attrs: AttrVec::new(),
                                     tokens: None,
                                 };
@@ -1281,7 +1291,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                     hir_id: this.lower_node_id(node_id),
                                     body: this.lower_const_body(path_expr.span, Some(&path_expr)),
                                 });
-                                return GenericArg::Const(ConstArg { value: ct, span: ty.span });
+                                return GenericArg::Const(ConstArg { value: ct, span });
                             }
                         }
                     }
@@ -1291,7 +1301,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
             ast::GenericArg::Const(ct) => GenericArg::Const(ConstArg {
                 value: self.lower_anon_const(&ct),
-                span: ct.value.span,
+                span: self.lower_span(ct.value.span),
             }),
         }
     }
@@ -1318,7 +1328,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn ty(&mut self, span: Span, kind: hir::TyKind<'hir>) -> hir::Ty<'hir> {
-        hir::Ty { hir_id: self.next_id(), kind, span }
+        hir::Ty { hir_id: self.next_id(), kind, span: self.lower_span(span) }
     }
 
     fn ty_tup(&mut self, span: Span, tys: &'hir [hir::Ty<'hir>]) -> hir::Ty<'hir> {
@@ -1386,7 +1396,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         segments: arena_vec![self; hir::PathSegment::from_ident(
                             Ident::with_dummy_span(kw::SelfUpper)
                         )],
-                        span: t.span,
+                        span: self.lower_span(t.span),
                     }),
                 ))
             }
@@ -1467,10 +1477,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         let ident = Ident::from_str_and_span(&pprust::ty_to_string(t), span);
                         in_band_ty_params.push(hir::GenericParam {
                             hir_id: self.lower_node_id(def_node_id),
-                            name: ParamName::Plain(ident),
+                            name: ParamName::Plain(self.lower_ident(ident)),
                             pure_wrt_drop: false,
                             bounds: hir_bounds,
-                            span,
+                            span: self.lower_span(span),
                             kind: hir::GenericParamKind::Type {
                                 default: None,
                                 synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
@@ -1480,9 +1490,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         hir::TyKind::Path(hir::QPath::Resolved(
                             None,
                             self.arena.alloc(hir::Path {
-                                span,
+                                span: self.lower_span(span),
                                 res: Res::Def(DefKind::TyParam, def_id.to_def_id()),
-                                segments: arena_vec![self; hir::PathSegment::from_ident(ident)],
+                                segments: arena_vec![self; hir::PathSegment::from_ident(self.lower_ident(ident))],
                             }),
                         ))
                     }
@@ -1509,7 +1519,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
         };
 
-        hir::Ty { kind, span: t.span, hir_id: self.lower_node_id(t.id) }
+        hir::Ty { kind, span: self.lower_span(t.span), hir_id: self.lower_node_id(t.id) }
     }
 
     fn lower_opaque_impl_trait(
@@ -1554,8 +1564,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             let opaque_ty_item = hir::OpaqueTy {
                 generics: hir::Generics {
                     params: lifetime_defs,
-                    where_clause: hir::WhereClause { predicates: &[], span },
-                    span,
+                    where_clause: hir::WhereClause { predicates: &[], span: lctx.lower_span(span) },
+                    span: lctx.lower_span(span),
                 },
                 bounds: hir_bounds,
                 impl_trait_fn: fn_def_id,
@@ -1586,8 +1596,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             def_id: opaque_ty_id,
             ident: Ident::invalid(),
             kind: opaque_ty_item_kind,
-            vis: respan(span.shrink_to_lo(), hir::VisibilityKind::Inherited),
-            span: opaque_ty_span,
+            vis: respan(self.lower_span(span.shrink_to_lo()), hir::VisibilityKind::Inherited),
+            span: self.lower_span(opaque_ty_span),
         };
 
         // Insert the item into the global item list. This usually happens
@@ -1714,7 +1724,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                     self.output_lifetimes.push(hir::GenericArg::Lifetime(hir::Lifetime {
                         hir_id: self.context.next_id(),
-                        span: lifetime.span,
+                        span: self.context.lower_span(lifetime.span),
                         name,
                     }));
 
@@ -1739,11 +1749,17 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         }
                         _ => panic!("expected `LifetimeName::Param` or `ParamName::Plain`"),
                     };
+                    let name = match name {
+                        hir::ParamName::Plain(ident) => {
+                            hir::ParamName::Plain(self.context.lower_ident(ident))
+                        }
+                        name => name,
+                    };
 
                     self.output_lifetime_params.push(hir::GenericParam {
                         hir_id,
                         name,
-                        span: lifetime.span,
+                        span: self.context.lower_span(lifetime.span),
                         pure_wrt_drop: false,
                         bounds: &[],
                         kind: hir::GenericParamKind::Lifetime { kind },
@@ -1790,7 +1806,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ty,
             pat: self.lower_pat(&l.pat),
             init,
-            span: l.span,
+            span: self.lower_span(l.span),
             source: hir::LocalSource::Normal,
         }
     }
@@ -1804,8 +1820,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             inputs = &inputs[..inputs.len() - 1];
         }
         self.arena.alloc_from_iter(inputs.iter().map(|param| match param.pat.kind {
-            PatKind::Ident(_, ident, _) => ident,
-            _ => Ident::new(kw::Empty, param.pat.span),
+            PatKind::Ident(_, ident, _) => self.lower_ident(ident),
+            _ => Ident::new(kw::Empty, self.lower_span(param.pat.span)),
         }))
     }
 
@@ -1889,7 +1905,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     };
                     hir::FnRetTy::Return(self.lower_ty(ty, context))
                 }
-                FnRetTy::Default(span) => hir::FnRetTy::DefaultReturn(span),
+                FnRetTy::Default(span) => hir::FnRetTy::DefaultReturn(self.lower_span(span)),
             }
         };
 
@@ -2046,8 +2062,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             let opaque_ty_item = hir::OpaqueTy {
                 generics: hir::Generics {
                     params: generic_params,
-                    where_clause: hir::WhereClause { predicates: &[], span },
-                    span,
+                    where_clause: hir::WhereClause { predicates: &[], span: this.lower_span(span) },
+                    span: this.lower_span(span),
                 },
                 bounds: arena_vec![this; future_bound],
                 impl_trait_fn: Some(fn_def_id),
@@ -2082,7 +2098,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 // Input lifetime like `'a` or `'1`:
                 GenericArg::Lifetime(hir::Lifetime {
                     hir_id: self.next_id(),
-                    span,
+                    span: self.lower_span(span),
                     name: hir::LifetimeName::Param(hir_name),
                 })
             },
@@ -2091,7 +2107,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // Output lifetime like `'_`.
             GenericArg::Lifetime(hir::Lifetime {
                 hir_id: self.next_id(),
-                span,
+                span: self.lower_span(span),
                 name: hir::LifetimeName::Implicit,
             })));
         let generic_args = self.arena.alloc_from_iter(generic_args);
@@ -2139,7 +2155,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::GenericBound::LangItemTrait(
             // ::std::future::Future<future_params>
             hir::LangItem::Future,
-            span,
+            self.lower_span(span),
             self.next_id(),
             future_args,
         )
@@ -2162,7 +2178,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_lifetime(&mut self, l: &Lifetime) -> hir::Lifetime {
-        let span = l.ident.span;
+        let span = self.lower_span(l.ident.span);
         match l.ident {
             ident if ident.name == kw::StaticLifetime => {
                 self.new_named_lifetime(l.id, span, hir::LifetimeName::Static)
@@ -2181,7 +2197,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             },
             ident => {
                 self.maybe_collect_in_band_lifetime(ident);
-                let param_name = ParamName::Plain(ident);
+                let param_name = ParamName::Plain(self.lower_ident(ident));
                 self.new_named_lifetime(l.id, span, hir::LifetimeName::Param(param_name))
             }
         }
@@ -2193,7 +2209,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         span: Span,
         name: hir::LifetimeName,
     ) -> hir::Lifetime {
-        hir::Lifetime { hir_id: self.lower_node_id(id), span, name }
+        hir::Lifetime { hir_id: self.lower_node_id(id), span: self.lower_span(span), name }
     }
 
     fn lower_generic_params_mut<'s>(
@@ -2276,7 +2292,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         .next(),
                 };
 
-                (hir::ParamName::Plain(param.ident), kind)
+                (hir::ParamName::Plain(self.lower_ident(param.ident)), kind)
             }
             GenericParamKind::Const { ref ty, kw_span: _, ref default } => {
                 let ty = self
@@ -2284,8 +2300,15 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         this.lower_ty(&ty, ImplTraitContext::disallowed())
                     });
                 let default = default.as_ref().map(|def| self.lower_anon_const(def));
-                (hir::ParamName::Plain(param.ident), hir::GenericParamKind::Const { ty, default })
+                (
+                    hir::ParamName::Plain(self.lower_ident(param.ident)),
+                    hir::GenericParamKind::Const { ty, default },
+                )
             }
+        };
+        let name = match name {
+            hir::ParamName::Plain(ident) => hir::ParamName::Plain(self.lower_ident(ident)),
+            name => name,
         };
 
         let hir_id = self.lower_node_id(param.id);
@@ -2293,7 +2316,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::GenericParam {
             hir_id,
             name,
-            span: param.ident.span,
+            span: self.lower_span(param.ident.span),
             pure_wrt_drop: self.sess.contains_name(&param.attrs, sym::may_dangle),
             bounds: self.arena.alloc_from_iter(bounds),
             kind,
@@ -2350,7 +2373,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             res
         });
 
-        hir::PolyTraitRef { bound_generic_params, trait_ref, span: p.span }
+        hir::PolyTraitRef { bound_generic_params, trait_ref, span: self.lower_span(p.span) }
     }
 
     fn lower_mt(&mut self, mt: &MutTy, itctx: ImplTraitContext<'_, 'hir>) -> hir::MutTy<'hir> {
@@ -2387,7 +2410,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let rules = self.lower_block_check_mode(&b.rules);
         let hir_id = self.lower_node_id(b.id);
 
-        hir::Block { hir_id, stmts, expr, rules, span: b.span, targeted_by_break }
+        hir::Block { hir_id, stmts, expr, rules, span: self.lower_span(b.span), targeted_by_break }
     }
 
     /// Lowers a block directly to an expression, presuming that it
@@ -2413,7 +2436,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 return smallvec![hir::Stmt {
                     hir_id,
                     kind: hir::StmtKind::Local(self.arena.alloc(l)),
-                    span: s.span,
+                    span: self.lower_span(s.span),
                 }];
             }
             StmtKind::Item(ref it) => {
@@ -2428,7 +2451,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             .map(|id| self.lower_node_id(id))
                             .unwrap_or_else(|| self.next_id());
 
-                        hir::Stmt { hir_id, kind: hir::StmtKind::Item(item_id), span: s.span }
+                        hir::Stmt {
+                            hir_id,
+                            kind: hir::StmtKind::Item(item_id),
+                            span: self.lower_span(s.span),
+                        }
                     })
                     .collect();
             }
@@ -2447,7 +2474,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             StmtKind::Empty => return smallvec![],
             StmtKind::MacCall(..) => panic!("shouldn't exist here"),
         };
-        smallvec![hir::Stmt { hir_id, kind, span: s.span }]
+        smallvec![hir::Stmt { hir_id, kind, span: self.lower_span(s.span) }]
     }
 
     fn lower_block_check_mode(&mut self, b: &BlockCheckMode) -> hir::BlockCheckMode {
@@ -2482,7 +2509,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     // Helper methods for building HIR.
 
     fn stmt(&mut self, span: Span, kind: hir::StmtKind<'hir>) -> hir::Stmt<'hir> {
-        hir::Stmt { span, kind, hir_id: self.next_id() }
+        hir::Stmt { span: self.lower_span(span), kind, hir_id: self.next_id() }
     }
 
     fn stmt_expr(&mut self, span: Span, expr: hir::Expr<'hir>) -> hir::Stmt<'hir> {
@@ -2502,7 +2529,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             debug_assert!(!a.is_empty());
             self.attrs.insert(hir_id, a);
         }
-        let local = hir::Local { hir_id, init, pat, source, span, ty: None };
+        let local = hir::Local { hir_id, init, pat, source, span: self.lower_span(span), ty: None };
         self.stmt(span, hir::StmtKind::Local(self.arena.alloc(local)))
     }
 
@@ -2521,7 +2548,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             expr,
             hir_id: self.next_id(),
             rules: hir::BlockCheckMode::DefaultBlock,
-            span,
+            span: self.lower_span(span),
             targeted_by_break: false,
         };
         self.arena.alloc(blk)
@@ -2553,10 +2580,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> &'hir [hir::PatField<'hir>] {
         let field = hir::PatField {
             hir_id: self.next_id(),
-            ident: Ident::new(sym::integer(0), span),
+            ident: Ident::new(sym::integer(0), self.lower_span(span)),
             is_shorthand: false,
             pat,
-            span,
+            span: self.lower_span(span),
         };
         arena_vec![self; field]
     }
@@ -2567,7 +2594,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         lang_item: hir::LangItem,
         fields: &'hir [hir::PatField<'hir>],
     ) -> &'hir hir::Pat<'hir> {
-        let qpath = hir::QPath::LangItem(lang_item, span);
+        let qpath = hir::QPath::LangItem(lang_item, self.lower_span(span));
         self.pat(span, hir::PatKind::Struct(qpath, fields, false))
     }
 
@@ -2600,8 +2627,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         (
             hir::Pat {
                 hir_id,
-                kind: hir::PatKind::Binding(bm, hir_id, ident.with_span_pos(span), None),
-                span,
+                kind: hir::PatKind::Binding(bm, hir_id, self.lower_ident(ident), None),
+                span: self.lower_span(span),
                 default_binding_modes: true,
             },
             hir_id,
@@ -2612,13 +2639,18 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.arena.alloc(hir::Pat {
             hir_id: self.next_id(),
             kind,
-            span,
+            span: self.lower_span(span),
             default_binding_modes: true,
         })
     }
 
     fn pat_without_dbm(&mut self, span: Span, kind: hir::PatKind<'hir>) -> hir::Pat<'hir> {
-        hir::Pat { hir_id: self.next_id(), kind, span, default_binding_modes: false }
+        hir::Pat {
+            hir_id: self.next_id(),
+            kind,
+            span: self.lower_span(span),
+            default_binding_modes: false,
+        }
     }
 
     fn ty_path(
@@ -2635,7 +2667,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         let principal = hir::PolyTraitRef {
                             bound_generic_params: &[],
                             trait_ref: hir::TraitRef { path, hir_ref_id: hir_id },
-                            span,
+                            span: self.lower_span(span),
                         };
 
                         // The original ID is taken by the `PolyTraitRef`,
@@ -2653,7 +2685,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             _ => hir::TyKind::Path(qpath),
         };
 
-        hir::Ty { hir_id, kind, span }
+        hir::Ty { hir_id, kind, span: self.lower_span(span) }
     }
 
     /// Invoked to create the lifetime argument for a type `&T`
@@ -2668,7 +2700,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 let fresh_name = self.collect_fresh_in_band_lifetime(span);
                 hir::Lifetime {
                     hir_id: self.next_id(),
-                    span,
+                    span: self.lower_span(span),
                     name: hir::LifetimeName::Param(fresh_name),
                 }
             }
@@ -2763,7 +2795,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         let r = hir::Lifetime {
             hir_id: self.next_id(),
-            span,
+            span: self.lower_span(span),
             name: hir::LifetimeName::ImplicitObjectLifetimeDefault,
         };
         debug!("elided_dyn_bound: r={:?}", r);
@@ -2771,7 +2803,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn new_implicit_lifetime(&mut self, span: Span) -> hir::Lifetime {
-        hir::Lifetime { hir_id: self.next_id(), span, name: hir::LifetimeName::Implicit }
+        hir::Lifetime {
+            hir_id: self.next_id(),
+            span: self.lower_span(span),
+            name: hir::LifetimeName::Implicit,
+        }
     }
 
     fn maybe_lint_bare_trait(&mut self, span: Span, id: NodeId, is_global: bool) {
@@ -2849,12 +2885,13 @@ impl<'hir> GenericArgsCtor<'hir> {
         self.args.is_empty() && self.bindings.is_empty() && !self.parenthesized
     }
 
-    fn into_generic_args(self, arena: &'hir Arena<'hir>) -> hir::GenericArgs<'hir> {
-        hir::GenericArgs {
-            args: arena.alloc_from_iter(self.args),
+    fn into_generic_args(self, this: &LoweringContext<'_, 'hir>) -> &'hir hir::GenericArgs<'hir> {
+        let ga = hir::GenericArgs {
+            args: this.arena.alloc_from_iter(self.args),
             bindings: self.bindings,
             parenthesized: self.parenthesized,
-            span_ext: self.span,
-        }
+            span_ext: this.lower_span(self.span),
+        };
+        this.arena.alloc(ga)
     }
 }

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -62,10 +62,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                         let fs = self.arena.alloc_from_iter(fields.iter().map(|f| hir::PatField {
                             hir_id: self.next_id(),
-                            ident: f.ident,
+                            ident: self.lower_ident(f.ident),
                             pat: self.lower_pat(&f.pat),
                             is_shorthand: f.is_shorthand,
-                            span: f.span,
+                            span: self.lower_span(f.span),
                         }));
                         break hir::PatKind::Struct(qpath, fs, etc);
                     }
@@ -247,16 +247,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 hir::PatKind::Binding(
                     self.lower_binding_mode(binding_mode),
                     self.lower_node_id(canonical_id),
-                    ident,
+                    self.lower_ident(ident),
                     lower_sub(self),
                 )
             }
             Some(res) => hir::PatKind::Path(hir::QPath::Resolved(
                 None,
                 self.arena.alloc(hir::Path {
-                    span: ident.span,
+                    span: self.lower_span(ident.span),
                     res: self.lower_res(res),
-                    segments: arena_vec![self; hir::PathSegment::from_ident(ident)],
+                    segments: arena_vec![self; hir::PathSegment::from_ident(self.lower_ident(ident))],
                 }),
             )),
         }
@@ -280,7 +280,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::Pat {
             hir_id: self.lower_node_id(p.id),
             kind,
-            span: p.span,
+            span: self.lower_span(p.span),
             default_binding_modes: true,
         }
     }

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -110,9 +110,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     )
                 },
             )),
-            span: p.segments[..proj_start]
-                .last()
-                .map_or(path_span_lo, |segment| path_span_lo.to(segment.span())),
+            span: self.lower_span(
+                p.segments[..proj_start]
+                    .last()
+                    .map_or(path_span_lo, |segment| path_span_lo.to(segment.span())),
+            ),
         });
 
         // Simple case, either no projections, or only fully-qualified.
@@ -198,7 +200,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     explicit_owner,
                 )
             })),
-            span: p.span,
+            span: self.lower_span(p.span),
         })
     }
 
@@ -370,14 +372,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         );
 
         hir::PathSegment {
-            ident: segment.ident,
+            ident: self.lower_ident(segment.ident),
             hir_id: Some(id),
             res: Some(self.lower_res(res)),
             infer_args,
             args: if generic_args.is_empty() && generic_args.span.is_empty() {
                 None
             } else {
-                Some(self.arena.alloc(generic_args.into_generic_args(self.arena)))
+                Some(generic_args.into_generic_args(self))
             },
         }
     }
@@ -459,6 +461,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             parenthesized: false,
             span_ext: DUMMY_SP,
         });
-        hir::TypeBinding { hir_id: self.next_id(), gen_args, span, ident, kind }
+        hir::TypeBinding {
+            hir_id: self.next_id(),
+            gen_args,
+            span: self.lower_span(span),
+            ident,
+            kind,
+        }
     }
 }


### PR DESCRIPTION
This PR cherry-picks the `fn lower_span` change from https://github.com/rust-lang/rust/pull/84373.
I also introduced `fn lower_ident` for lowering spans in identifiers, and audited places where HIR structures with spans or identifiers are constructed and added a few missing `lower_span`s/`lower_ident`s.

Having a hook for spans entering HIR can be useful for things other than https://github.com/rust-lang/rust/pull/84373, e.g. https://github.com/rust-lang/rust/issues/35148.
I also want to check whether this change causes perf regressions due to some accidental inlining issues.

r? @cjgillot 