### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh
         if: success() && !env.SKIP_JOB
+      - name: ensure backported commits are in upstream branches
+        run: src/ci/scripts/verify-backported-commits.sh
+        if: success() && !env.SKIP_JOB
       - name: run the build
         run: src/ci/scripts/run-build-from-ci.sh
         env:
@@ -499,6 +502,9 @@ jobs:
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh
         if: success() && !env.SKIP_JOB
+      - name: ensure backported commits are in upstream branches
+        run: src/ci/scripts/verify-backported-commits.sh
+        if: success() && !env.SKIP_JOB
       - name: run the build
         run: src/ci/scripts/run-build-from-ci.sh
         env:
@@ -608,6 +614,9 @@ jobs:
         if: success() && !env.SKIP_JOB
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh
+        if: success() && !env.SKIP_JOB
+      - name: ensure backported commits are in upstream branches
+        run: src/ci/scripts/verify-backported-commits.sh
         if: success() && !env.SKIP_JOB
       - name: run the build
         run: src/ci/scripts/run-build-from-ci.sh

--- a/.mailmap
+++ b/.mailmap
@@ -101,6 +101,7 @@ Falco Hirschenberger <falco.hirschenberger@gmail.com> <hirschen@itwm.fhg.de>
 Felix S. Klock II <pnkfelix@pnkfx.org> Felix S Klock II <pnkfelix@pnkfx.org>
 Flaper Fesp <flaper87@gmail.com>
 Florian Wilkens <mrfloya_github@outlook.com> Florian Wilkens <floya@live.de>
+Frank Steffahn <fdsteffahn@gmail.com> <frank.steffahn@stu.uni-kiel.de>
 Gareth Daniel Smith <garethdanielsmith@gmail.com> gareth <gareth@gareth-N56VM.(none)>
 Gareth Daniel Smith <garethdanielsmith@gmail.com> Gareth Smith <garethdanielsmith@gmail.com>
 Georges Dubus <georges.dubus@gmail.com> <georges.dubus@compiletoi.net>

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -70,6 +70,7 @@ Cargo
 - [The package definition in `cargo metadata` now includes the `"default_run"`
   field from the manifest.][cargo/9550]
 - [Added `cargo d` as an alias for `cargo doc`.][cargo/9680]
+- [Added `{lib}` as formatting option for `cargo tree` to print the "lib_name" of packages.][cargo/9663]
 
 Rustdoc
 -------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,17 +4,12 @@ Version 1.54.0 (2021-07-29)
 Language
 -----------------------
 
-- [You can now use macros for values in built-in attribute macros.][83366]
-  While a seemingly minor addition on its own, this enables a lot of
-  powerful functionality when combined correctly. Most notably you can
-  now include external documentation in your crate by writing the following.
+- [You can now use macros for values in some built-in attributes.][83366]
+  This primarily allows you to call macros within the `#[doc]` attribute. For
+  example, to include external documentation in your crate, you can now write
+  the following:
   ```rust
   #![doc = include_str!("README.md")]
-  ```
-  You can also use this to include auto-generated modules:
-  ```rust
-  #[path = concat!(env!("OUT_DIR"), "/generated.rs")]
-  mod generated;
   ```
 
 - [You can now cast between unsized slice types (and types which contain

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -166,11 +166,6 @@ pub fn check(build: &mut Build) {
     }
 
     for target in &build.targets {
-        // Can't compile for iOS unless we're on macOS
-        if target.contains("apple-ios") && !build.build.contains("apple-darwin") {
-            panic!("the iOS target is only supported on macOS");
-        }
-
         build
             .config
             .target_config

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -206,6 +206,10 @@ x--expand-yaml-anchors--remove:
         run: src/ci/scripts/verify-line-endings.sh
         <<: *step
 
+      - name: ensure backported commits are in upstream branches
+        run: src/ci/scripts/verify-backported-commits.sh
+        <<: *step
+
       - name: run the build
         run: src/ci/scripts/run-build-from-ci.sh
         env:

--- a/src/ci/scripts/verify-backported-commits.sh
+++ b/src/ci/scripts/verify-backported-commits.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Ensure commits in beta are in master & commits in stable are in beta + master.
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+# We don't care about commits that predate this automation check, so we pass a
+# `<limit>` argument to `git cherry`.
+BETA_LIMIT="53fd98ca776cb875bc9e5514f56b52eb74f9e7a9"
+STABLE_LIMIT="a178d0322ce20e33eac124758e837cbd80a6f633"
+
+verify_backported_commits_main() {
+  ci_base_branch=$(ciBaseBranch)
+
+  if [[ "$ci_base_branch" != "beta" && "$ci_base_branch" != "stable" ]]; then
+    echo 'Skipping. This is only run when merging to the beta or stable branches.'
+    exit 0
+  fi
+
+  echo 'git: unshallowing the repository so we can check commits'
+  git fetch \
+    --no-tags \
+    --no-recurse-submodules \
+    --progress \
+    --prune \
+    --unshallow
+
+  if [[ $ci_base_branch == "beta" ]]; then
+    verify_cherries master "$BETA_LIMIT" \
+      || exit 1
+
+  elif [[ $ci_base_branch == "stable" ]]; then
+    (verify_cherries master "$STABLE_LIMIT" \
+      & verify_cherries beta "$STABLE_LIMIT") \
+      || exit 1
+
+  fi
+}
+
+# Verify all commits in `HEAD` are backports of a commit in <upstream>. See
+# https://git-scm.com/docs/git-cherry for an explanation of the arguments.
+#
+# $1 = <upstream>
+# $2 = <limit>
+verify_cherries() {
+  # commits that lack a `backport-of` comment.
+  local no_backports=()
+  # commits with an incorrect `backport-of` comment.
+  local bad_backports=()
+
+  commits=$(git cherry "origin/$1" HEAD "$2")
+
+  if [[ -z "$commits" ]]; then
+    echo "All commits in \`HEAD\` are present in \`$1\`"
+    return 0
+  fi
+
+  commits=$(echo "$commits" | grep '^\+' | cut -c 3-)
+
+  while read sha; do
+    # Check each commit in <current>..<upstream>
+    backport_sha=$(get_backport "$sha")
+
+    if [[ -z "$backport_sha" ]]; then
+      no_backports+=("$sha")
+      continue
+    fi
+
+    if ! is_in_master "$backport_sha"; then
+      bad_backports+=("$sha")
+      continue
+    fi
+
+    echo "✓ \`$sha\` backports \`$backport_sha\`"
+  done <<< "$commits"
+
+  failure=0
+
+  if [ ${#no_backports[@]} -ne 0 ]; then
+        echo 'Error: Could not find backports for all commits.'
+        echo
+        echo 'All commits in \`HEAD\` are required to have a corresponding upstream commit.'
+        echo 'It looks like the following commits:'
+        echo
+        for commit in "${no_backports[@]}"; do
+          echo "    $commit"
+        done
+        echo
+        echo "do not match any commits in \`$1\`. If this was intended, add the text"
+        echo '\`backport-of: <SHA of a commit already in master>\` somewhere in the'
+        echo 'message of each of these commits.'
+        echo
+        failure=1
+  fi
+
+  if [ ${#bad_backports[@]} -ne 0 ]; then
+        echo 'Error: Found incorrectly marked commits.'
+        echo
+        echo 'The following commits:'
+        echo
+        for commit in "${bad_backports[@]}"; do
+          echo "    $commit"
+        done
+        echo
+        echo 'have commit messages marked \`backport-of: <SHA>\`, but the SHA is not in'
+        echo '\`master\`.'
+        echo
+        failure=1
+  fi
+
+  return $failure
+}
+
+# Get the backport of a commit, or empty string if it does not exist.
+#
+# $1 = <sha>
+get_backport() {
+  git show -s --format=%B "$1" \
+    | sed -n 's/^.*backport-of:\s\?\([a-f0-9]\+\).*/\1/p'
+}
+
+# Check if a commit is in master.
+#
+# $1 = <sha>
+is_in_master() {
+  git merge-base --is-ancestor "$1" origin/master 2> /dev/null
+}
+
+verify_backported_commits_main

--- a/src/test/ui/type-alias-impl-trait/defining-use-submodule.rs
+++ b/src/test/ui/type-alias-impl-trait/defining-use-submodule.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+// test that the type alias impl trait defining use is in a submodule
+
+fn main() {}
+
+type Foo = impl std::fmt::Display;
+type Bar = impl std::fmt::Display;
+
+mod foo {
+    pub fn foo() -> super::Foo {
+        "foo"
+    }
+
+    pub mod bar {
+        pub fn bar() -> crate::Bar {
+            1
+        }
+    }
+}

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.rs
@@ -3,8 +3,7 @@
 fn main() {}
 
 trait Trait {}
-type Underconstrained<T: Trait> = impl 'static;
-//~^ ERROR: at least one trait must be specified
+type Underconstrained<T: Trait> = impl Send;
 
 // no `Trait` bound
 fn underconstrain<T>(_: T) -> Underconstrained<T> {

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -1,11 +1,5 @@
-error: at least one trait must be specified
-  --> $DIR/generic_underconstrained.rs:6:35
-   |
-LL | type Underconstrained<T: Trait> = impl 'static;
-   |                                   ^^^^^^^^^^^^
-
 error[E0277]: the trait bound `T: Trait` is not satisfied
-  --> $DIR/generic_underconstrained.rs:10:31
+  --> $DIR/generic_underconstrained.rs:9:31
    |
 LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
    |                               ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
@@ -13,13 +7,13 @@ LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
 note: required by a bound in `Underconstrained`
   --> $DIR/generic_underconstrained.rs:6:26
    |
-LL | type Underconstrained<T: Trait> = impl 'static;
+LL | type Underconstrained<T: Trait> = impl Send;
    |                          ^^^^^ required by this bound in `Underconstrained`
 help: consider restricting type parameter `T`
    |
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
    |                    +++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.rs
@@ -2,8 +2,7 @@
 
 fn main() {}
 
-type Underconstrained<T: std::fmt::Debug> = impl 'static;
-//~^ ERROR: at least one trait must be specified
+type Underconstrained<T: std::fmt::Debug> = impl Send;
 
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained<U>(_: U) -> Underconstrained<U> {
@@ -11,8 +10,7 @@ fn underconstrained<U>(_: U) -> Underconstrained<U> {
     5u32
 }
 
-type Underconstrained2<T: std::fmt::Debug> = impl 'static;
-//~^ ERROR: at least one trait must be specified
+type Underconstrained2<T: std::fmt::Debug> = impl Send;
 
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -1,17 +1,5 @@
-error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:5:45
-   |
-LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
-   |                                             ^^^^^^^^^^^^
-
-error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:14:46
-   |
-LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
-   |                                              ^^^^^^^^^^^^
-
 error[E0277]: `U` doesn't implement `Debug`
-  --> $DIR/generic_underconstrained2.rs:9:33
+  --> $DIR/generic_underconstrained2.rs:8:33
    |
 LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
    |                                 ^^^^^^^^^^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
@@ -19,7 +7,7 @@ LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
 note: required by a bound in `Underconstrained`
   --> $DIR/generic_underconstrained2.rs:5:26
    |
-LL | type Underconstrained<T: std::fmt::Debug> = impl 'static;
+LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound in `Underconstrained`
 help: consider restricting type parameter `U`
    |
@@ -27,21 +15,21 @@ LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
 
 error[E0277]: `V` doesn't implement `Debug`
-  --> $DIR/generic_underconstrained2.rs:18:43
+  --> $DIR/generic_underconstrained2.rs:16:43
    |
 LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
    |                                           ^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 note: required by a bound in `Underconstrained2`
-  --> $DIR/generic_underconstrained2.rs:14:27
+  --> $DIR/generic_underconstrained2.rs:13:27
    |
-LL | type Underconstrained2<T: std::fmt::Debug> = impl 'static;
+LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound in `Underconstrained2`
 help: consider restricting type parameter `V`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/incomplete-inference.rs
+++ b/src/test/ui/type-alias-impl-trait/incomplete-inference.rs
@@ -1,0 +1,15 @@
+#![feature(type_alias_impl_trait)]
+
+type Foo = impl Sized;
+
+fn bar() -> Foo {
+    None
+    //~^ ERROR: type annotations needed [E0282]
+}
+
+fn baz() -> Foo {
+    //~^ ERROR: concrete type differs from previous defining opaque type use
+    Some(())
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/incomplete-inference.stderr
+++ b/src/test/ui/type-alias-impl-trait/incomplete-inference.stderr
@@ -1,0 +1,21 @@
+error[E0282]: type annotations needed
+  --> $DIR/incomplete-inference.rs:6:5
+   |
+LL |     None
+   |     ^^^^ cannot infer type for type parameter `T` declared on the enum `Option`
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/incomplete-inference.rs:10:1
+   |
+LL | fn baz() -> Foo {
+   | ^^^^^^^^^^^^^^^ expected `[type error]`, got `Option<()>`
+   |
+note: previous use here
+  --> $DIR/incomplete-inference.rs:5:1
+   |
+LL | fn bar() -> Foo {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-assoc-dyn.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-assoc-dyn.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+type Foo = Box<dyn Iterator<Item = impl Send>>;
+
+fn make_foo() -> Foo {
+    Box::new(vec![1, 2, 3].into_iter())
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-assoc-impl-trait.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-assoc-impl-trait.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+type Foo = impl Iterator<Item = impl Send>;
+
+fn make_foo() -> Foo {
+    vec![1, 2].into_iter()
+}
+
+type Bar = impl Send;
+type Baz = impl Iterator<Item = Bar>;
+
+fn make_baz() -> Baz {
+    vec!["1", "2"].into_iter()
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.rs
@@ -1,0 +1,13 @@
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+// FIXME: this is ruled out for now but should work
+
+type Foo = fn() -> impl Send;
+//~^ ERROR: `impl Trait` not allowed outside of function and method return types
+
+fn make_foo() -> Foo {
+    || 15
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-fn-type.stderr
@@ -1,0 +1,9 @@
+error[E0562]: `impl Trait` not allowed outside of function and method return types
+  --> $DIR/type-alias-impl-trait-fn-type.rs:6:20
+   |
+LL | type Foo = fn() -> impl Send;
+   |                    ^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0562`.

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-struct.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-struct.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+#![allow(dead_code)]
+
+type Foo = Vec<impl Send>;
+
+fn make_foo() -> Foo {
+    vec![true, false]
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait-tuple.rs
@@ -7,27 +7,24 @@ pub trait MyTrait {}
 
 impl MyTrait for bool {}
 
+type Foo = impl MyTrait;
+
 struct Blah {
     my_foo: Foo,
-    my_u8: u8
+    my_u8: u8,
 }
 
 impl Blah {
     fn new() -> Blah {
-        Blah {
-            my_foo: make_foo(),
-            my_u8: 12
-        }
+        Blah { my_foo: make_foo(), my_u8: 12 }
     }
-    fn into_inner(self) -> (Foo, u8) {
-        (self.my_foo, self.my_u8)
+    fn into_inner(self) -> (Foo, u8, Foo) {
+        (self.my_foo, self.my_u8, make_foo())
     }
 }
 
 fn make_foo() -> Foo {
     true
 }
-
-type Foo = impl MyTrait;
 
 fn main() {}

--- a/src/test/ui/type-alias-impl-trait/type-alias-impl-trait.rs
+++ b/src/test/ui/type-alias-impl-trait/type-alias-impl-trait.rs
@@ -11,7 +11,6 @@ fn main() {
     assert_eq!(bar2().to_string(), "bar2");
     let mut x = bar1();
     x = bar2();
-    assert_eq!(boo::boo().to_string(), "boo");
     assert_eq!(my_iter(42u8).collect::<Vec<u8>>(), vec![42u8]);
 }
 
@@ -31,15 +30,6 @@ fn bar1() -> Bar {
 
 fn bar2() -> Bar {
     "bar2"
-}
-
-// definition in submodule
-type Boo = impl std::fmt::Display;
-
-mod boo {
-    pub fn boo() -> super::Boo {
-        "boo"
-    }
 }
 
 type MyIter<T> = impl Iterator<Item = T>;

--- a/src/tools/cherry-pick.sh
+++ b/src/tools/cherry-pick.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+print_error() {
+  echo "Error: \`$1\` is not a valid commit. To debug, run:"
+  echo
+  echo "    git rev-parse --verify $1"
+  echo
+}
+
+full_sha() {
+  git rev-parse \
+    --verify \
+    --quiet \
+    "$1^{object}" || print_error $1
+}
+
+commit_message_with_backport_note() {
+  message=$(git log --format=%B -n 1 $1)
+  echo $message | awk "NR==1{print; print \"\n(backport-of: $1)\"} NR!=1"
+}
+
+cherry_pick_commit() {
+  sha=$(full_sha $1)
+  git cherry-pick $sha > /dev/null
+  git commit \
+    --amend \
+    --file <(commit_message_with_backport_note $sha)
+}
+
+for arg ; do
+  cherry_pick_commit $arg
+done


### PR DESCRIPTION
Successful merges:

 - #87604 (CI: Verify commits in beta & stable are in upstream branches.)
 - #88057 (Update RELEASES to clarify attribute macro values.)
 - #88072 (Allow the iOS toolchain to be built on Linux)
 - #88170 (Update release note for 1.55.0.)
 - #88172 (Test that type alias impl trait happens in a submodule)
 - #88179 (Mailmap entry for myself)
 - #88182 (We meant to use a trait instead of lifetime here)
 - #88183 (test TAIT in different positions)
 - #88189 (Add TAIT struct test)
 - #88192 (Use of impl trait in an impl as the value for an associated type in a dyn)
 - #88194 (Test use of impl Trait in an impl as the value for an associated type in an impl trait)
 - #88197 (Test tait use in a fn type)
 - #88201 (Test that incomplete inference for TAITs fail)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87604,88057,88072,88170,88172,88179,88182,88183,88189,88192,88194,88197,88201)
<!-- homu-ignore:end -->