### PR TITLE
rustdoc-json: Don't ignore impls for primitive types

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -218,6 +218,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         ConstantItem(c) => ItemEnum::Constant(c.into_tcx(tcx)),
         MacroItem(m) => ItemEnum::Macro(m.source),
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_tcx(tcx)),
+        PrimitiveItem(p) => ItemEnum::PrimitiveType(p.as_sym().to_string()),
         AssocConstItem(t, s) => ItemEnum::AssocConst { type_: t.into_tcx(tcx), default: s },
         AssocTypeItem(g, t) => ItemEnum::AssocType {
             bounds: g.into_iter().map(|x| x.into_tcx(tcx)).collect(),
@@ -225,7 +226,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         },
         // `convert_item` early returns `None` for striped items
         StrippedItem(_) => unreachable!(),
-        PrimitiveItem(_) | KeywordItem(_) => {
+        KeywordItem(_) => {
             panic!("{:?} is not supported for JSON output", item)
         }
         ExternCrateItem { ref src } => ItemEnum::ExternCrate {

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -69,7 +69,21 @@ impl JsonRenderer<'tcx> {
                     .iter()
                     .filter_map(|i| {
                         let item = &i.impl_item;
-                        if item.def_id.is_local() {
+
+                        // HACK(hkmatsumoto): For impls of primitive types, we index them
+                        // regardless of whether they're local. This is because users can
+                        // document primitive items in an arbitrary crate by using
+                        // `doc(primitive)`.
+                        let mut is_primitive_impl = false;
+                        if let clean::types::ItemKind::ImplItem(ref impl_) = *item.kind {
+                            if impl_.trait_.is_none() {
+                                if let clean::types::Type::Primitive(_) = impl_.for_ {
+                                    is_primitive_impl = true;
+                                }
+                            }
+                        }
+
+                        if item.def_id.is_local() || is_primitive_impl {
                             self.item(item.clone()).unwrap();
                             Some(from_item_id(item.def_id))
                         } else {
@@ -189,6 +203,11 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
 
     fn after_krate(&mut self) -> Result<(), Error> {
         debug!("Done with crate");
+
+        for primitive in Rc::clone(&self.cache).primitive_locations.values() {
+            self.get_impls(primitive.clone());
+        }
+
         let mut index = (*self.index).clone().into_inner();
         index.extend(self.get_trait_items());
         // This needs to be the default HashMap for compatibility with the public interface for
@@ -234,7 +253,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 7,
+            format_version: 8,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -221,6 +221,8 @@ pub enum ItemEnum {
     Macro(String),
     ProcMacro(ProcMacro),
 
+    PrimitiveType(String),
+
     AssocConst {
         #[serde(rename = "type")]
         type_: Type,

--- a/src/test/rustdoc-json/primitive.rs
+++ b/src/test/rustdoc-json/primitive.rs
@@ -1,0 +1,14 @@
+// edition:2018
+
+#![feature(doc_primitive)]
+
+#[doc(primitive = "usize")]
+mod usize {}
+
+// @set local_crate_id = primitive.json "$.index[*][?(@.name=='primitive')].crate_id"
+
+// @has - "$.index[*][?(@.name=='log10')]"
+// @!is - "$.index[*][?(@.name=='log10')].crate_id" $local_crate_id
+// @has - "$.index[*][?(@.name=='checked_add')]"
+// @!is - "$.index[*][?(@.name=='checked_add')]" $local_crate_id
+// @!has - "$.index[*][?(@.name=='is_ascii_uppercase')]"


### PR DESCRIPTION
Fix the issue discussed at [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/.E2.9C.94.20Json.20output.20lacks.20some.20item.20which.20are.20supposed.20to.20be.20there)

r? @jyn514 