### PR TITLE
[Experimental] Split out an `UnsafeCoerceUnsized` trait from `CoerceUnsized`

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -12,13 +12,18 @@ pub trait Sized {}
 #[lang = "unsize"]
 pub trait Unsize<T: ?Sized> {}
 
-#[lang = "coerce_unsized"]
-pub trait CoerceUnsized<T> {}
+#[lang = "unsafe_coerce_unsized"]
+pub trait UnsafeCoerceUnsized<T> {}
 
-impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
+#[lang = "coerce_unsized"]
+pub unsafe trait CoerceUnsized<T>: UnsafeCoerceUnsized<T> {}
+
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<&'a U> for &'b T {}
+unsafe impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<&'a mut U> for &'a mut T {}
+unsafe impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*const U> for *const T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*mut U> for *mut T {}
 
 #[lang = "dispatch_from_dyn"]
 pub trait DispatchFromDyn<T> {}

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -165,108 +165,109 @@ where
 }
 
 language_item_table! {
-//  Variant name,            Name,                     Method name,                Target;
-    Bool,                    sym::bool,                bool_impl,                  Target::Impl;
-    Char,                    sym::char,                char_impl,                  Target::Impl;
-    Str,                     sym::str,                 str_impl,                   Target::Impl;
-    Array,                   sym::array,               array_impl,                 Target::Impl;
-    Slice,                   sym::slice,               slice_impl,                 Target::Impl;
-    SliceU8,                 sym::slice_u8,            slice_u8_impl,              Target::Impl;
-    StrAlloc,                sym::str_alloc,           str_alloc_impl,             Target::Impl;
-    SliceAlloc,              sym::slice_alloc,         slice_alloc_impl,           Target::Impl;
-    SliceU8Alloc,            sym::slice_u8_alloc,      slice_u8_alloc_impl,        Target::Impl;
-    ConstPtr,                sym::const_ptr,           const_ptr_impl,             Target::Impl;
-    MutPtr,                  sym::mut_ptr,             mut_ptr_impl,               Target::Impl;
-    ConstSlicePtr,           sym::const_slice_ptr,     const_slice_ptr_impl,       Target::Impl;
-    MutSlicePtr,             sym::mut_slice_ptr,       mut_slice_ptr_impl,         Target::Impl;
-    I8,                      sym::i8,                  i8_impl,                    Target::Impl;
-    I16,                     sym::i16,                 i16_impl,                   Target::Impl;
-    I32,                     sym::i32,                 i32_impl,                   Target::Impl;
-    I64,                     sym::i64,                 i64_impl,                   Target::Impl;
-    I128,                    sym::i128,                i128_impl,                  Target::Impl;
-    Isize,                   sym::isize,               isize_impl,                 Target::Impl;
-    U8,                      sym::u8,                  u8_impl,                    Target::Impl;
-    U16,                     sym::u16,                 u16_impl,                   Target::Impl;
-    U32,                     sym::u32,                 u32_impl,                   Target::Impl;
-    U64,                     sym::u64,                 u64_impl,                   Target::Impl;
-    U128,                    sym::u128,                u128_impl,                  Target::Impl;
-    Usize,                   sym::usize,               usize_impl,                 Target::Impl;
-    F32,                     sym::f32,                 f32_impl,                   Target::Impl;
-    F64,                     sym::f64,                 f64_impl,                   Target::Impl;
-    F32Runtime,              sym::f32_runtime,         f32_runtime_impl,           Target::Impl;
-    F64Runtime,              sym::f64_runtime,         f64_runtime_impl,           Target::Impl;
+//  Variant name,            Name,                       Method name,                 Target;
+    Bool,                    sym::bool,                  bool_impl,                   Target::Impl;
+    Char,                    sym::char,                  char_impl,                   Target::Impl;
+    Str,                     sym::str,                   str_impl,                    Target::Impl;
+    Array,                   sym::array,                 array_impl,                  Target::Impl;
+    Slice,                   sym::slice,                 slice_impl,                  Target::Impl;
+    SliceU8,                 sym::slice_u8,              slice_u8_impl,               Target::Impl;
+    StrAlloc,                sym::str_alloc,             str_alloc_impl,              Target::Impl;
+    SliceAlloc,              sym::slice_alloc,           slice_alloc_impl,            Target::Impl;
+    SliceU8Alloc,            sym::slice_u8_alloc,        slice_u8_alloc_impl,         Target::Impl;
+    ConstPtr,                sym::const_ptr,             const_ptr_impl,              Target::Impl;
+    MutPtr,                  sym::mut_ptr,               mut_ptr_impl,                Target::Impl;
+    ConstSlicePtr,           sym::const_slice_ptr,       const_slice_ptr_impl,        Target::Impl;
+    MutSlicePtr,             sym::mut_slice_ptr,         mut_slice_ptr_impl,          Target::Impl;
+    I8,                      sym::i8,                    i8_impl,                     Target::Impl;
+    I16,                     sym::i16,                   i16_impl,                    Target::Impl;
+    I32,                     sym::i32,                   i32_impl,                    Target::Impl;
+    I64,                     sym::i64,                   i64_impl,                    Target::Impl;
+    I128,                    sym::i128,                  i128_impl,                   Target::Impl;
+    Isize,                   sym::isize,                 isize_impl,                  Target::Impl;
+    U8,                      sym::u8,                    u8_impl,                     Target::Impl;
+    U16,                     sym::u16,                   u16_impl,                    Target::Impl;
+    U32,                     sym::u32,                   u32_impl,                    Target::Impl;
+    U64,                     sym::u64,                   u64_impl,                    Target::Impl;
+    U128,                    sym::u128,                  u128_impl,                   Target::Impl;
+    Usize,                   sym::usize,                 usize_impl,                  Target::Impl;
+    F32,                     sym::f32,                   f32_impl,                    Target::Impl;
+    F64,                     sym::f64,                   f64_impl,                    Target::Impl;
+    F32Runtime,              sym::f32_runtime,           f32_runtime_impl,            Target::Impl;
+    F64Runtime,              sym::f64_runtime,           f64_runtime_impl,            Target::Impl;
 
-    Sized,                   sym::sized,               sized_trait,                Target::Trait;
-    Unsize,                  sym::unsize,              unsize_trait,               Target::Trait;
+    Sized,                   sym::sized,                 sized_trait,                 Target::Trait;
+    Unsize,                  sym::unsize,                unsize_trait,                Target::Trait;
     /// Trait injected by `#[derive(PartialEq)]`, (i.e. "Partial EQ").
-    StructuralPeq,           sym::structural_peq,      structural_peq_trait,       Target::Trait;
+    StructuralPeq,           sym::structural_peq,        structural_peq_trait,        Target::Trait;
     /// Trait injected by `#[derive(Eq)]`, (i.e. "Total EQ"; no, I will not apologize).
-    StructuralTeq,           sym::structural_teq,      structural_teq_trait,       Target::Trait;
-    Copy,                    sym::copy,                copy_trait,                 Target::Trait;
-    Clone,                   sym::clone,               clone_trait,                Target::Trait;
-    Sync,                    sym::sync,                sync_trait,                 Target::Trait;
-    DiscriminantKind,        sym::discriminant_kind,   discriminant_kind_trait,    Target::Trait;
+    StructuralTeq,           sym::structural_teq,        structural_teq_trait,        Target::Trait;
+    Copy,                    sym::copy,                  copy_trait,                  Target::Trait;
+    Clone,                   sym::clone,                 clone_trait,                 Target::Trait;
+    Sync,                    sym::sync,                  sync_trait,                  Target::Trait;
+    DiscriminantKind,        sym::discriminant_kind,     discriminant_kind_trait,     Target::Trait;
     /// The associated item of the [`DiscriminantKind`] trait.
-    Discriminant,            sym::discriminant_type,   discriminant_type,          Target::AssocTy;
+    Discriminant,            sym::discriminant_type,     discriminant_type,           Target::AssocTy;
 
-    PointeeTrait,            sym::pointee_trait,       pointee_trait,              Target::Trait;
-    Metadata,                sym::metadata_type,       metadata_type,              Target::AssocTy;
-    DynMetadata,             sym::dyn_metadata,        dyn_metadata,               Target::Struct;
+    PointeeTrait,            sym::pointee_trait,         pointee_trait,               Target::Trait;
+    Metadata,                sym::metadata_type,         metadata_type,               Target::AssocTy;
+    DynMetadata,             sym::dyn_metadata,          dyn_metadata,                Target::Struct;
 
-    Freeze,                  sym::freeze,              freeze_trait,               Target::Trait;
+    Freeze,                  sym::freeze,                freeze_trait,                Target::Trait;
 
-    Drop,                    sym::drop,                drop_trait,                 Target::Trait;
+    Drop,                    sym::drop,                  drop_trait,                  Target::Trait;
 
-    CoerceUnsized,           sym::coerce_unsized,      coerce_unsized_trait,       Target::Trait;
-    DispatchFromDyn,         sym::dispatch_from_dyn,   dispatch_from_dyn_trait,    Target::Trait;
+    UnsafeCoerceUnsized,     sym::unsafe_coerce_unsized, unsafe_coerce_unsized_trait, Target::Trait;
+    CoerceUnsized,           sym::coerce_unsized,        coerce_unsized_trait,        Target::Trait;
+    DispatchFromDyn,         sym::dispatch_from_dyn,     dispatch_from_dyn_trait,     Target::Trait;
 
-    Add(Op),                 sym::add,                 add_trait,                  Target::Trait;
-    Sub(Op),                 sym::sub,                 sub_trait,                  Target::Trait;
-    Mul(Op),                 sym::mul,                 mul_trait,                  Target::Trait;
-    Div(Op),                 sym::div,                 div_trait,                  Target::Trait;
-    Rem(Op),                 sym::rem,                 rem_trait,                  Target::Trait;
-    Neg(Op),                 sym::neg,                 neg_trait,                  Target::Trait;
-    Not(Op),                 sym::not,                 not_trait,                  Target::Trait;
-    BitXor(Op),              sym::bitxor,              bitxor_trait,               Target::Trait;
-    BitAnd(Op),              sym::bitand,              bitand_trait,               Target::Trait;
-    BitOr(Op),               sym::bitor,               bitor_trait,                Target::Trait;
-    Shl(Op),                 sym::shl,                 shl_trait,                  Target::Trait;
-    Shr(Op),                 sym::shr,                 shr_trait,                  Target::Trait;
-    AddAssign(Op),           sym::add_assign,          add_assign_trait,           Target::Trait;
-    SubAssign(Op),           sym::sub_assign,          sub_assign_trait,           Target::Trait;
-    MulAssign(Op),           sym::mul_assign,          mul_assign_trait,           Target::Trait;
-    DivAssign(Op),           sym::div_assign,          div_assign_trait,           Target::Trait;
-    RemAssign(Op),           sym::rem_assign,          rem_assign_trait,           Target::Trait;
-    BitXorAssign(Op),        sym::bitxor_assign,       bitxor_assign_trait,        Target::Trait;
-    BitAndAssign(Op),        sym::bitand_assign,       bitand_assign_trait,        Target::Trait;
-    BitOrAssign(Op),         sym::bitor_assign,        bitor_assign_trait,         Target::Trait;
-    ShlAssign(Op),           sym::shl_assign,          shl_assign_trait,           Target::Trait;
-    ShrAssign(Op),           sym::shr_assign,          shr_assign_trait,           Target::Trait;
-    Index(Op),               sym::index,               index_trait,                Target::Trait;
-    IndexMut(Op),            sym::index_mut,           index_mut_trait,            Target::Trait;
+    Add(Op),                 sym::add,                   add_trait,                   Target::Trait;
+    Sub(Op),                 sym::sub,                   sub_trait,                   Target::Trait;
+    Mul(Op),                 sym::mul,                   mul_trait,                   Target::Trait;
+    Div(Op),                 sym::div,                   div_trait,                   Target::Trait;
+    Rem(Op),                 sym::rem,                   rem_trait,                   Target::Trait;
+    Neg(Op),                 sym::neg,                   neg_trait,                   Target::Trait;
+    Not(Op),                 sym::not,                   not_trait,                   Target::Trait;
+    BitXor(Op),              sym::bitxor,                bitxor_trait,                Target::Trait;
+    BitAnd(Op),              sym::bitand,                bitand_trait,                Target::Trait;
+    BitOr(Op),               sym::bitor,                 bitor_trait,                 Target::Trait;
+    Shl(Op),                 sym::shl,                   shl_trait,                   Target::Trait;
+    Shr(Op),                 sym::shr,                   shr_trait,                   Target::Trait;
+    AddAssign(Op),           sym::add_assign,            add_assign_trait,            Target::Trait;
+    SubAssign(Op),           sym::sub_assign,            sub_assign_trait,            Target::Trait;
+    MulAssign(Op),           sym::mul_assign,            mul_assign_trait,            Target::Trait;
+    DivAssign(Op),           sym::div_assign,            div_assign_trait,            Target::Trait;
+    RemAssign(Op),           sym::rem_assign,            rem_assign_trait,            Target::Trait;
+    BitXorAssign(Op),        sym::bitxor_assign,         bitxor_assign_trait,         Target::Trait;
+    BitAndAssign(Op),        sym::bitand_assign,         bitand_assign_trait,         Target::Trait;
+    BitOrAssign(Op),         sym::bitor_assign,          bitor_assign_trait,          Target::Trait;
+    ShlAssign(Op),           sym::shl_assign,            shl_assign_trait,            Target::Trait;
+    ShrAssign(Op),           sym::shr_assign,            shr_assign_trait,            Target::Trait;
+    Index(Op),               sym::index,                 index_trait,                 Target::Trait;
+    IndexMut(Op),            sym::index_mut,             index_mut_trait,             Target::Trait;
 
-    UnsafeCell,              sym::unsafe_cell,         unsafe_cell_type,           Target::Struct;
-    VaList,                  sym::va_list,             va_list,                    Target::Struct;
+    UnsafeCell,              sym::unsafe_cell,           unsafe_cell_type,            Target::Struct;
+    VaList,                  sym::va_list,               va_list,                     Target::Struct;
 
-    Deref,                   sym::deref,               deref_trait,                Target::Trait;
-    DerefMut,                sym::deref_mut,           deref_mut_trait,            Target::Trait;
-    DerefTarget,             sym::deref_target,        deref_target,               Target::AssocTy;
-    Receiver,                sym::receiver,            receiver_trait,             Target::Trait;
+    Deref,                   sym::deref,                 deref_trait,                 Target::Trait;
+    DerefMut,                sym::deref_mut,             deref_mut_trait,             Target::Trait;
+    DerefTarget,             sym::deref_target,          deref_target,                Target::AssocTy;
+    Receiver,                sym::receiver,              receiver_trait,              Target::Trait;
 
-    Fn,                      kw::Fn,                   fn_trait,                   Target::Trait;
-    FnMut,                   sym::fn_mut,              fn_mut_trait,               Target::Trait;
-    FnOnce,                  sym::fn_once,             fn_once_trait,              Target::Trait;
+    Fn,                      kw::Fn,                     fn_trait,                    Target::Trait;
+    FnMut,                   sym::fn_mut,                fn_mut_trait,                Target::Trait;
+    FnOnce,                  sym::fn_once,               fn_once_trait,               Target::Trait;
 
-    FnOnceOutput,            sym::fn_once_output,      fn_once_output,             Target::AssocTy;
+    FnOnceOutput,            sym::fn_once_output,        fn_once_output,              Target::AssocTy;
 
-    Future,                  sym::future_trait,        future_trait,               Target::Trait;
-    GeneratorState,          sym::generator_state,     gen_state,                  Target::Enum;
-    Generator,               sym::generator,           gen_trait,                  Target::Trait;
-    Unpin,                   sym::unpin,               unpin_trait,                Target::Trait;
-    Pin,                     sym::pin,                 pin_type,                   Target::Struct;
+    Future,                  sym::future_trait,          future_trait,                Target::Trait;
+    GeneratorState,          sym::generator_state,       gen_state,                   Target::Enum;
+    Generator,               sym::generator,             gen_trait,                   Target::Trait;
+    Unpin,                   sym::unpin,                 unpin_trait,                 Target::Trait;
+    Pin,                     sym::pin,                   pin_type,                    Target::Struct;
 
-    PartialEq,               sym::eq,                  eq_trait,                   Target::Trait;
-    PartialOrd,              sym::partial_ord,         partial_ord_trait,          Target::Trait;
+    PartialEq,               sym::eq,                    eq_trait,                    Target::Trait;
+    PartialOrd,              sym::partial_ord,           partial_ord_trait,           Target::Trait;
 
     // A number of panic-related lang items. The `panic` item corresponds to divide-by-zero and
     // various panic cases with `match`. The `panic_bounds_check` item is for indexing arrays.
@@ -275,80 +276,80 @@ language_item_table! {
     // in the sense that a crate is not required to have it defined to use it, but a final product
     // is required to define it somewhere. Additionally, there are restrictions on crates that use
     // a weak lang item, but do not have it defined.
-    Panic,                   sym::panic,               panic_fn,                   Target::Fn;
-    PanicFmt,                sym::panic_fmt,           panic_fmt,                  Target::Fn;
-    PanicStr,                sym::panic_str,           panic_str,                  Target::Fn;
-    ConstPanicFmt,           sym::const_panic_fmt,     const_panic_fmt,            Target::Fn;
-    PanicBoundsCheck,        sym::panic_bounds_check,  panic_bounds_check_fn,      Target::Fn;
-    PanicInfo,               sym::panic_info,          panic_info,                 Target::Struct;
-    PanicLocation,           sym::panic_location,      panic_location,             Target::Struct;
-    PanicImpl,               sym::panic_impl,          panic_impl,                 Target::Fn;
+    Panic,                   sym::panic,                 panic_fn,                    Target::Fn;
+    PanicFmt,                sym::panic_fmt,             panic_fmt,                   Target::Fn;
+    PanicStr,                sym::panic_str,             panic_str,                   Target::Fn;
+    ConstPanicFmt,           sym::const_panic_fmt,       const_panic_fmt,             Target::Fn;
+    PanicBoundsCheck,        sym::panic_bounds_check,    panic_bounds_check_fn,       Target::Fn;
+    PanicInfo,               sym::panic_info,            panic_info,                  Target::Struct;
+    PanicLocation,           sym::panic_location,        panic_location,              Target::Struct;
+    PanicImpl,               sym::panic_impl,            panic_impl,                  Target::Fn;
     /// libstd panic entry point. Necessary for const eval to be able to catch it
-    BeginPanic,              sym::begin_panic,         begin_panic_fn,             Target::Fn;
-    BeginPanicFmt,           sym::begin_panic_fmt,     begin_panic_fmt,            Target::Fn;
+    BeginPanic,              sym::begin_panic,           begin_panic_fn,              Target::Fn;
+    BeginPanicFmt,           sym::begin_panic_fmt,       begin_panic_fmt,             Target::Fn;
 
-    ExchangeMalloc,          sym::exchange_malloc,     exchange_malloc_fn,         Target::Fn;
-    BoxFree,                 sym::box_free,            box_free_fn,                Target::Fn;
-    DropInPlace,             sym::drop_in_place,       drop_in_place_fn,           Target::Fn;
-    Oom,                     sym::oom,                 oom,                        Target::Fn;
-    AllocLayout,             sym::alloc_layout,        alloc_layout,               Target::Struct;
+    ExchangeMalloc,          sym::exchange_malloc,       exchange_malloc_fn,          Target::Fn;
+    BoxFree,                 sym::box_free,              box_free_fn,                 Target::Fn;
+    DropInPlace,             sym::drop_in_place,         drop_in_place_fn,            Target::Fn;
+    Oom,                     sym::oom,                   oom,                         Target::Fn;
+    AllocLayout,             sym::alloc_layout,          alloc_layout,                Target::Struct;
 
-    Start,                   sym::start,               start_fn,                   Target::Fn;
+    Start,                   sym::start,                 start_fn,                    Target::Fn;
 
-    EhPersonality,           sym::eh_personality,      eh_personality,             Target::Fn;
-    EhCatchTypeinfo,         sym::eh_catch_typeinfo,   eh_catch_typeinfo,          Target::Static;
+    EhPersonality,           sym::eh_personality,        eh_personality,              Target::Fn;
+    EhCatchTypeinfo,         sym::eh_catch_typeinfo,     eh_catch_typeinfo,           Target::Static;
 
-    OwnedBox,                sym::owned_box,           owned_box,                  Target::Struct;
+    OwnedBox,                sym::owned_box,             owned_box,                   Target::Struct;
 
-    PhantomData,             sym::phantom_data,        phantom_data,               Target::Struct;
+    PhantomData,             sym::phantom_data,          phantom_data,                Target::Struct;
 
-    ManuallyDrop,            sym::manually_drop,       manually_drop,              Target::Struct;
+    ManuallyDrop,            sym::manually_drop,         manually_drop,               Target::Struct;
 
-    MaybeUninit,             sym::maybe_uninit,        maybe_uninit,               Target::Union;
+    MaybeUninit,             sym::maybe_uninit,          maybe_uninit,                Target::Union;
 
     /// Align offset for stride != 1; must not panic.
-    AlignOffset,             sym::align_offset,        align_offset_fn,            Target::Fn;
+    AlignOffset,             sym::align_offset,          align_offset_fn,             Target::Fn;
 
-    Termination,             sym::termination,         termination,                Target::Trait;
+    Termination,             sym::termination,           termination,                 Target::Trait;
 
-    Try,                     sym::Try,                 try_trait,                  Target::Trait;
+    Try,                     sym::Try,                   try_trait,                   Target::Trait;
 
-    SliceLen,                sym::slice_len_fn,        slice_len_fn,               Target::Method(MethodKind::Inherent);
+    SliceLen,                sym::slice_len_fn,          slice_len_fn,                Target::Method(MethodKind::Inherent);
 
     // Language items from AST lowering
-    TryTraitFromResidual,    sym::from_residual,       from_residual_fn,           Target::Method(MethodKind::Trait { body: false });
-    TryTraitFromOutput,      sym::from_output,         from_output_fn,             Target::Method(MethodKind::Trait { body: false });
-    TryTraitBranch,          sym::branch,              branch_fn,                  Target::Method(MethodKind::Trait { body: false });
+    TryTraitFromResidual,    sym::from_residual,         from_residual_fn,            Target::Method(MethodKind::Trait { body: false });
+    TryTraitFromOutput,      sym::from_output,           from_output_fn,              Target::Method(MethodKind::Trait { body: false });
+    TryTraitBranch,          sym::branch,                branch_fn,                   Target::Method(MethodKind::Trait { body: false });
 
-    PollReady,               sym::Ready,               poll_ready_variant,         Target::Variant;
-    PollPending,             sym::Pending,             poll_pending_variant,       Target::Variant;
+    PollReady,               sym::Ready,                 poll_ready_variant,          Target::Variant;
+    PollPending,             sym::Pending,               poll_pending_variant,        Target::Variant;
 
-    FromGenerator,           sym::from_generator,      from_generator_fn,          Target::Fn;
-    GetContext,              sym::get_context,         get_context_fn,             Target::Fn;
+    FromGenerator,           sym::from_generator,        from_generator_fn,           Target::Fn;
+    GetContext,              sym::get_context,           get_context_fn,              Target::Fn;
 
-    FuturePoll,              sym::poll,                future_poll_fn,             Target::Method(MethodKind::Trait { body: false });
+    FuturePoll,              sym::poll,                  future_poll_fn,              Target::Method(MethodKind::Trait { body: false });
 
-    FromFrom,                sym::from,                from_fn,                    Target::Method(MethodKind::Trait { body: false });
+    FromFrom,                sym::from,                  from_fn,                     Target::Method(MethodKind::Trait { body: false });
 
-    OptionSome,              sym::Some,                option_some_variant,        Target::Variant;
-    OptionNone,              sym::None,                option_none_variant,        Target::Variant;
+    OptionSome,              sym::Some,                  option_some_variant,         Target::Variant;
+    OptionNone,              sym::None,                  option_none_variant,         Target::Variant;
 
-    ResultOk,                sym::Ok,                  result_ok_variant,          Target::Variant;
-    ResultErr,               sym::Err,                 result_err_variant,         Target::Variant;
+    ResultOk,                sym::Ok,                    result_ok_variant,           Target::Variant;
+    ResultErr,               sym::Err,                   result_err_variant,          Target::Variant;
 
-    ControlFlowContinue,     sym::Continue,            cf_continue_variant,        Target::Variant;
-    ControlFlowBreak,        sym::Break,               cf_break_variant,           Target::Variant;
+    ControlFlowContinue,     sym::Continue,              cf_continue_variant,         Target::Variant;
+    ControlFlowBreak,        sym::Break,                 cf_break_variant,            Target::Variant;
 
-    IntoIterIntoIter,        sym::into_iter,           into_iter_fn,               Target::Method(MethodKind::Trait { body: false });
-    IteratorNext,            sym::next,                next_fn,                    Target::Method(MethodKind::Trait { body: false});
+    IntoIterIntoIter,        sym::into_iter,             into_iter_fn,                Target::Method(MethodKind::Trait { body: false });
+    IteratorNext,            sym::next,                  next_fn,                     Target::Method(MethodKind::Trait { body: false});
 
-    PinNewUnchecked,         sym::new_unchecked,       new_unchecked_fn,           Target::Method(MethodKind::Inherent);
+    PinNewUnchecked,         sym::new_unchecked,         new_unchecked_fn,            Target::Method(MethodKind::Inherent);
 
-    RangeFrom,               sym::RangeFrom,           range_from_struct,          Target::Struct;
-    RangeFull,               sym::RangeFull,           range_full_struct,          Target::Struct;
-    RangeInclusiveStruct,    sym::RangeInclusive,      range_inclusive_struct,     Target::Struct;
-    RangeInclusiveNew,       sym::range_inclusive_new, range_inclusive_new_method, Target::Method(MethodKind::Inherent);
-    Range,                   sym::Range,               range_struct,               Target::Struct;
-    RangeToInclusive,        sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct;
-    RangeTo,                 sym::RangeTo,             range_to_struct,            Target::Struct;
+    RangeFrom,               sym::RangeFrom,             range_from_struct,           Target::Struct;
+    RangeFull,               sym::RangeFull,             range_full_struct,           Target::Struct;
+    RangeInclusiveStruct,    sym::RangeInclusive,        range_inclusive_struct,      Target::Struct;
+    RangeInclusiveNew,       sym::range_inclusive_new,   range_inclusive_new_method,  Target::Method(MethodKind::Inherent);
+    Range,                   sym::Range,                 range_struct,                Target::Struct;
+    RangeToInclusive,        sym::RangeToInclusive,      range_to_inclusive_struct,   Target::Struct;
+    RangeTo,                 sym::RangeTo,               range_to_struct,             Target::Struct;
 }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1437,10 +1437,10 @@ impl EncodeContext<'a, 'tcx> {
                     None
                 };
 
-                // if this is an impl of `CoerceUnsized`, create its
+                // if this is an impl of `UnsafeCoerceUnsized`, create its
                 // "unsized info", else just store None
                 let coerce_unsized_info = trait_ref.and_then(|t| {
-                    if Some(t.def_id) == self.tcx.lang_items().coerce_unsized_trait() {
+                    if Some(t.def_id) == self.tcx.lang_items().unsafe_coerce_unsized_trait() {
                         Some(self.tcx.at(item.span).coerce_unsized_info(def_id))
                     } else {
                         None

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -41,6 +41,7 @@ pub enum UnsafetyViolationDetails {
     MutationOfLayoutConstrainedField,
     BorrowOfLayoutConstrainedField,
     CallToFunctionWith,
+    UnsafeCoerceUnsized,
 }
 
 impl UnsafetyViolationDetails {
@@ -101,6 +102,11 @@ impl UnsafetyViolationDetails {
             CallToFunctionWith => (
                 "call to function with `#[target_feature]`",
                 "can only be called if the required target features are available",
+            ),
+            UnsafeCoerceUnsized => (
+                "performing unsizing coercion",
+                "unsizing coercion performed on a type that did not implement `CoerceUnsized` \
+                 will cause undefined behavior if data is invalid",
             ),
         }
     }

--- a/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
@@ -2109,8 +2109,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     CastKind::Pointer(PointerCast::Unsize) => {
                         let &ty = ty;
                         let trait_ref = ty::TraitRef {
-                            def_id: tcx
-                                .require_lang_item(LangItem::CoerceUnsized, Some(self.last_span)),
+                            def_id: tcx.require_lang_item(
+                                LangItem::UnsafeCoerceUnsized,
+                                Some(self.last_span),
+                            ),
                             substs: tcx.mk_substs_trait(op.ty(body, tcx), &[ty.into()]),
                         };
 

--- a/compiler/rustc_mir/src/monomorphize/mod.rs
+++ b/compiler/rustc_mir/src/monomorphize/mod.rs
@@ -14,7 +14,7 @@ fn custom_coerce_unsize_info<'tcx>(
     source_ty: Ty<'tcx>,
     target_ty: Ty<'tcx>,
 ) -> CustomCoerceUnsized {
-    let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
+    let def_id = tcx.require_lang_item(LangItem::UnsafeCoerceUnsized, None);
 
     let trait_ref = ty::Binder::dummy(ty::TraitRef {
         def_id,

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -225,6 +225,7 @@ impl LanguageItemCollector<'tcx> {
 
             // Miscellaneous
             | LangItem::Unsize
+            | LangItem::UnsafeCoerceUnsized
             | LangItem::CoerceUnsized
             | LangItem::DispatchFromDyn
             | LangItem::Fn

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1361,6 +1361,7 @@ symbols! {
         unrestricted_attribute_tokens,
         unsafe_block_in_unsafe_fn,
         unsafe_cell,
+        unsafe_coerce_unsized,
         unsafe_no_drop_flag,
         unsize,
         unsized_fn_params,

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -139,7 +139,8 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             Some(chalk_solve::rust_ir::WellKnownTrait::Unsize)
         } else if lang_items.unpin_trait() == Some(def_id) {
             Some(chalk_solve::rust_ir::WellKnownTrait::Unpin)
-        } else if lang_items.coerce_unsized_trait() == Some(def_id) {
+        } else if lang_items.unsafe_coerce_unsized_trait() == Some(def_id) {
+            // FIXME: Rename to UnsafeCoerceUnsized
             Some(chalk_solve::rust_ir::WellKnownTrait::CoerceUnsized)
         } else {
             None
@@ -566,7 +567,8 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             FnOnce => lang_items.fn_once_trait(),
             Unsize => lang_items.unsize_trait(),
             Unpin => lang_items.unpin_trait(),
-            CoerceUnsized => lang_items.coerce_unsized_trait(),
+            // FIXME: Should actually be UnsafeCoerceUnsized here.
+            CoerceUnsized => lang_items.unsafe_coerce_unsized_trait(),
             DiscriminantKind => lang_items.discriminant_kind_trait(),
         };
         def_id.map(chalk_ir::TraitId)

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -146,6 +146,7 @@ use core::marker::{Unpin, Unsize};
 use core::mem;
 use core::ops::{
     CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Generator, GeneratorState, Receiver,
+    UnsafeCoerceUnsized,
 };
 use core::pin::Pin;
 use core::ptr::{self, Unique};
@@ -1652,7 +1653,10 @@ impl<Args, F: Fn<Args> + ?Sized, A: Allocator> Fn<Args> for Box<F, A> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> CoerceUnsized<Box<U, A>> for Box<T, A> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> UnsafeCoerceUnsized<Box<U, A>> for Box<T, A> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> CoerceUnsized<Box<U, A>> for Box<T, A> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T, Global> {}

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -492,6 +492,7 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
     }
 }
 
+#[cfg_attr(bootstrap, allow(unused_unsafe))]
 impl<'a, K, V, Type> NodeRef<marker::ValMut<'a>, K, V, Type> {
     /// # Safety
     /// - The node has more than `idx` initialized elements.
@@ -503,8 +504,8 @@ impl<'a, K, V, Type> NodeRef<marker::ValMut<'a>, K, V, Type> {
         let keys = unsafe { ptr::addr_of!((*leaf).keys) };
         let vals = unsafe { ptr::addr_of_mut!((*leaf).vals) };
         // We must coerce to unsized array pointers because of Rust issue #74679.
-        let keys: *const [_] = keys;
-        let vals: *mut [_] = vals;
+        let keys: *const [_] = unsafe { keys };
+        let vals: *mut [_] = unsafe { vals };
         let key = unsafe { (&*keys.get_unchecked(idx)).assume_init_ref() };
         let val = unsafe { (&mut *vals.get_unchecked_mut(idx)).assume_init_mut() };
         (key, val)

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -261,7 +261,7 @@ use core::marker::{self, PhantomData, Unpin, Unsize};
 #[cfg(not(no_global_oom_handling))]
 use core::mem::size_of_val;
 use core::mem::{self, align_of_val_raw, forget};
-use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
+use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver, UnsafeCoerceUnsized};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(not(no_global_oom_handling))]
 use core::pin::Pin;
@@ -319,7 +319,10 @@ impl<T: ?Sized> !marker::Sync for Rc<T> {}
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for Rc<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<Rc<U>> for Rc<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Rc<U>> for Rc<T> {}
@@ -2026,7 +2029,10 @@ impl<T: ?Sized> !marker::Send for Weak<T> {}
 impl<T: ?Sized> !marker::Sync for Weak<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<Weak<U>> for Weak<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Weak<U>> for Weak<T> {}

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -18,7 +18,7 @@ use core::marker::{PhantomData, Unpin, Unsize};
 #[cfg(not(no_global_oom_handling))]
 use core::mem::size_of_val;
 use core::mem::{self, align_of_val_raw};
-use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver};
+use core::ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver, UnsafeCoerceUnsized};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::pin::Pin;
 use core::ptr::{self, NonNull};
@@ -245,7 +245,10 @@ unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> {}
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for Arc<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<Arc<U>> for Arc<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Arc<U>> for Arc<T> {}
@@ -297,7 +300,9 @@ unsafe impl<T: ?Sized + Sync + Send> Send for Weak<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for Weak<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<Weak<U>> for Weak<T> {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Weak<U>> for Weak<T> {}
 

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -196,7 +196,7 @@ use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
 use crate::marker::Unsize;
 use crate::mem;
-use crate::ops::{CoerceUnsized, Deref, DerefMut};
+use crate::ops::{CoerceUnsized, Deref, DerefMut, UnsafeCoerceUnsized};
 use crate::ptr;
 
 /// A mutable memory location.
@@ -553,7 +553,10 @@ impl<T: Default> Cell<T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
+impl<T: UnsafeCoerceUnsized<U>, U> UnsafeCoerceUnsized<Cell<U>> for Cell<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
@@ -1223,7 +1226,10 @@ impl<T> From<T> for RefCell<T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: CoerceUnsized<U>, U> CoerceUnsized<RefCell<U>> for RefCell<T> {}
+impl<T: UnsafeCoerceUnsized<U>, U> UnsafeCoerceUnsized<RefCell<U>> for RefCell<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: CoerceUnsized<U>, U> CoerceUnsized<RefCell<U>> for RefCell<T> {}
 
 struct BorrowRef<'b> {
     borrow: &'b Cell<BorrowFlag>,
@@ -1441,7 +1447,10 @@ impl<'b, T: ?Sized> Ref<'b, T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Ref<'b, U>> for Ref<'b, T> {}
+impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<Ref<'b, U>> for Ref<'b, T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Ref<'b, U>> for Ref<'b, T> {}
 
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for Ref<'_, T> {
@@ -1683,7 +1692,10 @@ impl<T: ?Sized> DerefMut for RefMut<'_, T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefMut<'b, T> {}
+impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<RefMut<'b, U>> for RefMut<'b, T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefMut<'b, T> {}
 
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
@@ -1953,7 +1965,10 @@ impl<T> From<T> for UnsafeCell<T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
+impl<T: UnsafeCoerceUnsized<U>, U> UnsafeCoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
 
 #[allow(unused)]
 fn assert_coerce_unsized(a: UnsafeCell<&i32>, b: Cell<&i32>, c: RefCell<&i32>) {

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -111,12 +111,13 @@ pub trait Sized {
 ///   - `T` is not part of the type of any other fields
 ///   - `Bar<T>: Unsize<Bar<U>>`, if the last field of `Foo` has type `Bar<T>`
 ///
-/// `Unsize` is used along with [`ops::CoerceUnsized`] to allow
+/// `Unsize` is used along with [`ops::CoerceUnsized`] and [`ops::UnsafeCoerceUnsized`] to allow
 /// "user-defined" containers such as [`Rc`] to contain dynamically-sized
 /// types. See the [DST coercion RFC][RFC982] and [the nomicon entry on coercion][nomicon-coerce]
 /// for more details.
 ///
 /// [`ops::CoerceUnsized`]: crate::ops::CoerceUnsized
+/// [`ops::UnsafeCoerceUnsized`]: crate::ops::UnsafeCoerceUnsized
 /// [`Rc`]: ../../std/rc/struct.Rc.html
 /// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
 /// [nomicon-coerce]: ../../nomicon/coercions.html

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -194,7 +194,7 @@ pub(crate) use self::try_trait::Try as TryV2;
 pub use self::generator::{Generator, GeneratorState};
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-pub use self::unsize::CoerceUnsized;
+pub use self::unsize::{CoerceUnsized, UnsafeCoerceUnsized};
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 pub use self::unsize::DispatchFromDyn;

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -32,41 +32,78 @@ use crate::marker::Unsize;
 /// [unsize]: crate::marker::Unsize
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "coerce_unsized", issue = "27732")]
+#[cfg_attr(not(bootstrap), lang = "unsafe_coerce_unsized")]
+pub trait UnsafeCoerceUnsized<T: ?Sized> {
+    // Empty.
+}
+
+/// Trait that indicates that this is a pointer or a wrapper for one,
+/// where unsizing can be performed on the pointee.
+///
+/// See the [DST coercion RFC][dst-coerce] and [the nomicon entry on coercion][nomicon-coerce]
+/// for more details.
+///
+/// When this trait is implemented in addition to [`UnsafeCoerceUnsized`](unsafe-coerce-unsized),
+/// performing this unsizing doesn't need to happen inside an unsafe block.
+///
+/// [dst-coerce]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
+/// [nomicon-coerce]: ../../nomicon/coercions.html
+/// [unsafe-coerce-unsized]: crate::ops::UnsafeCoerceUnsized
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 #[lang = "coerce_unsized"]
-pub trait CoerceUnsized<T: ?Sized> {
+pub unsafe trait CoerceUnsized<T: ?Sized>: UnsafeCoerceUnsized<T> {
     // Empty.
 }
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<&'a mut U> for &'a mut T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b mut T {}
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<&'a U> for &'b mut T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b mut T {}
 // &mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*mut U> for &'a mut T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for &'a mut T {}
 // &mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*const U> for &'a mut T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a mut T {}
 
 // &T -> &U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<&'a U> for &'b T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
 // &T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a T {}
-
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*const U> for &'a T {}
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a T {}
 // *mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*mut U> for *mut T {}
+#[cfg(bootstrap)]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
 // *mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
-
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*const U> for *mut T {}
+#[cfg(bootstrap)]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 // *const T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> UnsafeCoerceUnsized<*const U> for *const T {}
+#[cfg(bootstrap)]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 
 /// This is used for object safety, to check that a method's receiver type can be dispatched on.
 ///

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -385,7 +385,7 @@ use crate::cmp::{self, PartialEq, PartialOrd};
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::marker::{Sized, Unpin};
-use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Receiver};
+use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Receiver, UnsafeCoerceUnsized};
 
 /// A pinned pointer.
 ///
@@ -893,13 +893,16 @@ impl<P: fmt::Pointer> fmt::Pointer for Pin<P> {
     }
 }
 
-// Note: this means that any impl of `CoerceUnsized` that allows coercing from
+// Note: this means that any impl of `UnsafeCoerceUnsized` that allows coercing from
 // a type that impls `Deref<Target=impl !Unpin>` to a type that impls
 // `Deref<Target=Unpin>` is unsound. Any such impl would probably be unsound
 // for other reasons, though, so we just need to take care not to allow such
 // impls to land in std.
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P, U> CoerceUnsized<Pin<U>> for Pin<P> where P: CoerceUnsized<U> {}
+impl<P, U> UnsafeCoerceUnsized<Pin<U>> for Pin<P> where P: UnsafeCoerceUnsized<U> {}
+
+#[stable(feature = "pin", since = "1.33.0")]
+unsafe impl<P, U> CoerceUnsized<Pin<U>> for Pin<P> where P: CoerceUnsized<U> {}
 
 #[stable(feature = "pin", since = "1.33.0")]
 impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P> where P: DispatchFromDyn<U> {}

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -4,7 +4,7 @@ use crate::fmt;
 use crate::hash;
 use crate::marker::Unsize;
 use crate::mem::{self, MaybeUninit};
-use crate::ops::{CoerceUnsized, DispatchFromDyn};
+use crate::ops::{DispatchFromDyn, UnsafeCoerceUnsized};
 use crate::ptr::Unique;
 use crate::slice::{self, SliceIndex};
 
@@ -630,7 +630,14 @@ impl<T: ?Sized> Clone for NonNull<T> {
 impl<T: ?Sized> Copy for NonNull<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
+impl<T: ?Sized, U: ?Sized> UnsafeCoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
+
+#[cfg(bootstrap)]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+unsafe impl<T: ?Sized, U: ?Sized> crate::ops::CoerceUnsized<NonNull<U>> for NonNull<T> where
+    T: Unsize<U>
+{
+}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -2,7 +2,7 @@ use crate::convert::From;
 use crate::fmt;
 use crate::marker::{PhantomData, Unsize};
 use crate::mem;
-use crate::ops::{CoerceUnsized, DispatchFromDyn};
+use crate::ops::{DispatchFromDyn, UnsafeCoerceUnsized};
 
 /// A wrapper around a raw non-null `*mut T` that indicates that the possessor
 /// of this wrapper owns the referent. Useful for building abstractions like
@@ -152,7 +152,14 @@ impl<T: ?Sized> Clone for Unique<T> {
 impl<T: ?Sized> Copy for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
-impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
+impl<T: ?Sized, U: ?Sized> UnsafeCoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
+
+#[cfg(bootstrap)]
+#[unstable(feature = "ptr_internals", issue = "none")]
+unsafe impl<T: ?Sized, U: ?Sized> crate::ops::CoerceUnsized<Unique<U>> for Unique<T> where
+    T: Unsize<U>
+{
+}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -503,8 +503,9 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     struct StrPanicPayload(&'static str);
 
     unsafe impl BoxMeUp for StrPanicPayload {
+        #[cfg_attr(bootstrap, allow(unused_unsafe))]
         fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(Box::new(self.0))
+            unsafe { Box::into_raw(Box::new(self.0)) }
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -555,6 +556,7 @@ pub fn begin_panic<M: Any + Send>(msg: M) -> ! {
     }
 
     unsafe impl<A: Send + 'static> BoxMeUp for PanicPayload<A> {
+        #[cfg_attr(bootstrap, allow(unused_unsafe))]
         fn take_box(&mut self) -> *mut (dyn Any + Send) {
             // Note that this should be the only allocation performed in this code path. Currently
             // this means that panic!() on OOM will invoke this code path, but then again we're not
@@ -565,7 +567,7 @@ pub fn begin_panic<M: Any + Send>(msg: M) -> ! {
                 Some(a) => Box::new(a) as Box<dyn Any + Send>,
                 None => process::abort(),
             };
-            Box::into_raw(data)
+            unsafe { Box::into_raw(data) }
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -650,8 +652,9 @@ pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
     struct RewrapBox(Box<dyn Any + Send>);
 
     unsafe impl BoxMeUp for RewrapBox {
+        #[cfg_attr(bootstrap, allow(unused_unsafe))]
         fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(mem::replace(&mut self.0, Box::new(())))
+            unsafe { Box::into_raw(mem::replace(&mut self.0, Box::new(()))) }
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {

--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -2,7 +2,7 @@
 
 use crate::cell::UnsafeCell;
 use crate::mem;
-use crate::ops::{CoerceUnsized, Deref, DerefMut, Index, IndexMut};
+use crate::ops::{CoerceUnsized, Deref, DerefMut, Index, IndexMut, UnsafeCoerceUnsized};
 use crate::ptr::{self, NonNull};
 use crate::slice;
 use crate::slice::SliceIndex;
@@ -565,7 +565,10 @@ where
 }
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
-impl<T: CoerceUnsized<U>, U> CoerceUnsized<UserRef<U>> for UserRef<T> {}
+impl<T: UnsafeCoerceUnsized<U>, U> UnsafeCoerceUnsized<UserRef<U>> for UserRef<T> {}
+
+#[unstable(feature = "sgx_platform", issue = "56975")]
+unsafe impl<T: CoerceUnsized<U>, U> CoerceUnsized<UserRef<U>> for UserRef<T> {}
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
 impl<T, I> Index<I> for UserRef<[T]>


### PR DESCRIPTION
This is taking a more aggressive but more neutral approach than #88010. 

Currently this doesn't fully work, and it's just a prototype meant for discussion.
# Motivation
In current rust, this code compiles:
```rust
#![feature(unsize)]

use std::marker::Unsize;

fn unsize<A, B>(v: *mut A) -> *mut B
where
    B: ?Sized,
    A: Unsize<B>,
{
    v
}
```
However, there's no guarentee at all that v points to a valid `A` typed value. What's more, when v is a fat pointer, it's pointee metadata might be any scalar value, if the pointer is created with something like `std::ptr::from_raw_parts`.

On the other hand, the unsizing coercion itself is based on the proof of `A: Unsize<B>`, basically saying that this is a type `A` that can be “unsized” to a dynamically-sized type `B`. It's reasonable to base this on `A` value is valid.

In recently implemented trait upcasting coercion feature(see #65991) we especially need this assumption to hold, because during the actual conversioin, we'll read the vtable metadata to retrieve the new metadata after the conversion. This is impossible if the input is not a valid pointer for A type (we need the metadata be valid, including when the pointer itself is a null pointer).

So i'm experimentally make this change, by marking raw pointer unsizing operations unsafe. It's up to the user to guarentee the pointer validity before performing the unsizing conversion. The code fragment above will need an unsafe block to pass compilation.

# Changes in this PR
* Splitted the `CoerceUnsized` trait into `trait UnsafeCoerceUnsized{} ` and `unsafe trait CoerceUnsized: UnsafeCoerceUnsized{}`, the former for typechecking and the later for user-facing usages and unsafety checking.
* Migrated all typechecking usages to use `UnsafeCoerceUnsized`
* Removed implementation of `CoerceUnsized` for raw pointers, leaving only `UnsafeCoerceUnsized` implementation for them.
* During unsafety checking, check whether `CoerceUnsized` obligation is fulfilled, if not, raise unsafety violation, so if it's not in an unsafe block environment, it will create a compilation error.

# Status
Remaining issues if this approach is taken:
* Trait name might need to be changed: Currently `UncheckedCoerceUnsized` is suggested in review.
* Maybe a future-incompat-lint is needed for migrating all the existing code that performs unsizing on raw pointers.
* There is a problem in unsafety checking code that for code in this pattern:
```rust
{
    other_statements;
    unsafe { ... }
}
```
the coercion cast of the tail expression should be considered "inside" the unsafe block, but it doesn't, and report an unsafe block needed error. (This is blocking CI).
* Unnecessary unsizing operations:
```rust
trait Foo {}

fn foo(v: * mut dyn Foo) -> * mut dyn Foo { v }
```
is currently an unsizing cast at MIR level: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e99e4181ea4edcfbb74e56352b899572
* Rename `CoerceUnsized` to `UnsafeCoerceUnsized` in the ir code that chalk is using.
* Tests and error code documentation update.

I think this will need a broader discussion first.

r? @RalfJung 

