### PR TITLE
Enable new pass manager with LLVM 13

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -370,8 +370,9 @@ fn get_pgo_use_path(config: &ModuleConfig) -> Option<CString> {
 }
 
 pub(crate) fn should_use_new_llvm_pass_manager(config: &ModuleConfig) -> bool {
-    // The new pass manager is disabled by default.
-    config.new_llvm_pass_manager.unwrap_or(false)
+    // The new pass manager is enabled by default for LLVM >= 13.
+    // This matches Clang, which also enables it since Clang 13.
+    config.new_llvm_pass_manager.unwrap_or_else(|| llvm_util::get_version() >= (13, 0, 0))
 }
 
 pub(crate) unsafe fn optimize_with_new_llvm_pass_manager(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1004,7 +1004,10 @@ LLVMRustOptimizeWithNewPassManager(
 #endif
   bool NeedThinLTOBufferPasses = UseThinLTOBuffers;
   if (!NoPrepopulatePasses) {
-    if (OptLevel == OptimizationLevel::O0) {
+    // The pre-link pipelines don't support O0 and require using budilO0DefaultPipeline() instead.
+    // At the same time, the LTO pipelines do support O0 and using them is required.
+    bool IsLTO = OptStage == LLVMRustOptStage::ThinLTO || OptStage == LLVMRustOptStage::FatLTO;
+    if (OptLevel == OptimizationLevel::O0 && !IsLTO) {
 #if LLVM_VERSION_GE(12, 0)
       for (const auto &C : PipelineStartEPCallbacks)
         PB.registerPipelineStartEPCallback(C);

--- a/src/test/codegen/panic-in-drop-abort.rs
+++ b/src/test/codegen/panic-in-drop-abort.rs
@@ -1,7 +1,14 @@
-// compile-flags: -Z panic-in-drop=abort -O
+// compile-flags: -Z panic-in-drop=abort -O -Z new-llvm-pass-manager=no
 
 // Ensure that unwinding code paths are eliminated from the output after
 // optimization.
+
+// This test uses -Z new-llvm-pass-manager=no, because the expected optimization does not happen
+// on targets using SEH exceptions (i.e. MSVC) anymore. The core issue is that Rust promises that
+// the drop_in_place() function can't unwind, but implements it in a way that *can*, because we
+// currently go out of our way to allow longjmps, which also use the unwinding mechanism on MSVC
+// targets. We should either forbid longjmps, or not assume nounwind, making this optimization
+// incompatible with the current behavior of running cleanuppads on longjmp unwinding.
 
 // CHECK-NOT: {{(call|invoke).*}}should_not_appear_in_output
 

--- a/src/test/codegen/panic-in-drop-abort.rs
+++ b/src/test/codegen/panic-in-drop-abort.rs
@@ -3,6 +3,8 @@
 // Ensure that unwinding code paths are eliminated from the output after
 // optimization.
 
+// CHECK-NOT: {{(call|invoke).*}}should_not_appear_in_output
+
 #![crate_type = "lib"]
 use std::any::Any;
 use std::mem::forget;
@@ -35,8 +37,6 @@ impl Drop for AssertNeverDrop {
     }
 }
 
-// CHECK-LABEL: normal_drop
-// CHECK-NOT: should_not_appear_in_output
 #[no_mangle]
 pub fn normal_drop(x: ExternDrop) {
     let guard = AssertNeverDrop;
@@ -44,8 +44,6 @@ pub fn normal_drop(x: ExternDrop) {
     forget(guard);
 }
 
-// CHECK-LABEL: indirect_drop
-// CHECK-NOT: should_not_appear_in_output
 #[no_mangle]
 pub fn indirect_drop(x: Box<dyn Any>) {
     let guard = AssertNeverDrop;


### PR DESCRIPTION
The new pass manager is enabled by default in clang since Clang/LLVM 13. Per the recent discussion on llvm-dev (https://lists.llvm.org/pipermail/llvm-dev/2021-August/152305.html) the legacy pass manager will be unmaintained in LLVM 14 and removed entirely in LLVM 15.

This switches us to use the new pass manager if LLVM >= 13 is used. It's possible to still use the old pass manager using `-Z new-llvm-pass-manager=no`.