### PR TITLE
S390x inline asm

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -314,6 +314,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => {}
                 InlineAsmArch::Hexagon => {}
                 InlineAsmArch::Mips | InlineAsmArch::Mips64 => {}
+                InlineAsmArch::s390 => {}
                 InlineAsmArch::SpirV => {}
                 InlineAsmArch::Wasm32 => {}
                 InlineAsmArch::Bpf => {}
@@ -633,6 +634,8 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => "r",
             InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::reg) => "r",
             InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::wreg) => "w",
+            InlineAsmRegClass::s390x(s390xInlineAsmRegClass::reg) => "r",
+            InlineAsmRegClass::s390x(s390xInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
@@ -711,6 +714,7 @@ fn modifier_to_llvm(
         }
         InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => None,
         InlineAsmRegClass::Bpf(_) => None,
+        InlineAsmRegClass::s390x(_) => None,
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
@@ -769,6 +773,8 @@ fn dummy_output_type(cx: &CodegenCx<'ll, 'tcx>, reg: InlineAsmRegClass) -> &'ll 
         InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => cx.type_i32(),
         InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::reg) => cx.type_i64(),
         InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::wreg) => cx.type_i32(),
+        InlineAsmRegClass::s390x(s390xInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::s390x(s390xInlineAsmRegClass::freg) => cx.type_f64(),
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -314,7 +314,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => {}
                 InlineAsmArch::Hexagon => {}
                 InlineAsmArch::Mips | InlineAsmArch::Mips64 => {}
-                InlineAsmArch::s390 => {}
+                InlineAsmArch::S390x => {}
                 InlineAsmArch::SpirV => {}
                 InlineAsmArch::Wasm32 => {}
                 InlineAsmArch::Bpf => {}
@@ -634,8 +634,8 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => "r",
             InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::reg) => "r",
             InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::wreg) => "w",
-            InlineAsmRegClass::s390x(s390xInlineAsmRegClass::reg) => "r",
-            InlineAsmRegClass::s390x(s390xInlineAsmRegClass::freg) => "f",
+            InlineAsmRegClass::S390x(S390xInlineAsmRegClass::reg) => "r",
+            InlineAsmRegClass::S390x(S390xInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
@@ -714,7 +714,7 @@ fn modifier_to_llvm(
         }
         InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => None,
         InlineAsmRegClass::Bpf(_) => None,
-        InlineAsmRegClass::s390x(_) => None,
+        InlineAsmRegClass::S390x(_) => None,
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
@@ -773,8 +773,8 @@ fn dummy_output_type(cx: &CodegenCx<'ll, 'tcx>, reg: InlineAsmRegClass) -> &'ll 
         InlineAsmRegClass::Wasm(WasmInlineAsmRegClass::local) => cx.type_i32(),
         InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::reg) => cx.type_i64(),
         InlineAsmRegClass::Bpf(BpfInlineAsmRegClass::wreg) => cx.type_i32(),
-        InlineAsmRegClass::s390x(s390xInlineAsmRegClass::reg) => cx.type_i32(),
-        InlineAsmRegClass::s390x(s390xInlineAsmRegClass::freg) => cx.type_f64(),
+        InlineAsmRegClass::S390x(S390xInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::S390x(S390xInlineAsmRegClass::freg) => cx.type_f64(),
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -257,7 +257,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
-	        Self::S390x(r) => r.name(),
+            Self::S390x(r) => r.name(),
             Self::Bpf(r) => r.name(),
             Self::Err => "<reg>",
         }
@@ -312,7 +312,7 @@ impl InlineAsmReg {
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
-    	    InlineAsmArch::S390x => {
+            InlineAsmArch::S390x => {
                 Self::S390x(S390xInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
             InlineAsmArch::SpirV => {
@@ -715,11 +715,11 @@ pub fn allocatable_registers(
             mips::fill_reg_map(arch, has_feature, target, &mut map);
             map
         }
-	    InlineAsmArch::S390x => {
-	        let mut map = s390x::regclass_map();
+        InlineAsmArch::S390x => {
+            let mut map = s390x::regclass_map();
             s390x::fill_reg_map(arch, has_feature, target, &mut map);
             map
-	    }
+        }
         InlineAsmArch::SpirV => {
             let mut map = spirv::regclass_map();
             spirv::fill_reg_map(arch, has_feature, target, &mut map);

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -167,7 +167,7 @@ pub use mips::{MipsInlineAsmReg, MipsInlineAsmRegClass};
 pub use nvptx::{NvptxInlineAsmReg, NvptxInlineAsmRegClass};
 pub use powerpc::{PowerPCInlineAsmReg, PowerPCInlineAsmRegClass};
 pub use riscv::{RiscVInlineAsmReg, RiscVInlineAsmRegClass};
-pub use s390x::{s390xInlineAsmReg, s390xInlineAsmRegClass};
+pub use s390x::{S390xInlineAsmReg, S390xInlineAsmRegClass};
 pub use spirv::{SpirVInlineAsmReg, SpirVInlineAsmRegClass};
 pub use wasm::{WasmInlineAsmReg, WasmInlineAsmRegClass};
 pub use x86::{X86InlineAsmReg, X86InlineAsmRegClass};
@@ -186,7 +186,7 @@ pub enum InlineAsmArch {
     Mips64,
     PowerPC,
     PowerPC64,
-    s390x,
+    S390x,
     SpirV,
     Wasm32,
     Bpf,
@@ -209,7 +209,7 @@ impl FromStr for InlineAsmArch {
             "hexagon" => Ok(Self::Hexagon),
             "mips" => Ok(Self::Mips),
             "mips64" => Ok(Self::Mips64),
-            "s390x" => Ok(Self::s390x),
+            "s390x" => Ok(Self::S390x),
             "spirv" => Ok(Self::SpirV),
             "wasm32" => Ok(Self::Wasm32),
             "bpf" => Ok(Self::Bpf),
@@ -239,7 +239,7 @@ pub enum InlineAsmReg {
     PowerPC(PowerPCInlineAsmReg),
     Hexagon(HexagonInlineAsmReg),
     Mips(MipsInlineAsmReg),
-    s390x(InlineAsmReg),
+    S390x(S390xInlineAsmReg),
     SpirV(SpirVInlineAsmReg),
     Wasm(WasmInlineAsmReg),
     Bpf(BpfInlineAsmReg),
@@ -257,7 +257,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
-	        Self::s390x(r) => r.name(),
+	        Self::S390x(r) => r.name(),
             Self::Bpf(r) => r.name(),
             Self::Err => "<reg>",
         }
@@ -272,7 +272,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => InlineAsmRegClass::PowerPC(r.reg_class()),
             Self::Hexagon(r) => InlineAsmRegClass::Hexagon(r.reg_class()),
             Self::Mips(r) => InlineAsmRegClass::Mips(r.reg_class()),
-            Self::s390x(r) => InlineAsmRegClass::s390x(r.reg_class()),
+            Self::S390x(r) => InlineAsmRegClass::S390x(r.reg_class()),
             Self::Bpf(r) => InlineAsmRegClass::Bpf(r.reg_class()),
             Self::Err => InlineAsmRegClass::Err,
         }
@@ -312,8 +312,8 @@ impl InlineAsmReg {
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
-    	    InlineAsmArch::s390x => {
-                Self::s390x(s390xInlineAsmReg::parse(arch, has_feature, target, &name)?)
+    	    InlineAsmArch::S390x => {
+                Self::S390x(S390xInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
             InlineAsmArch::SpirV => {
                 Self::SpirV(SpirVInlineAsmReg::parse(arch, has_feature, target, &name)?)
@@ -343,7 +343,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
-            Self::s390x(r) => r.emit(out, arch, modifier),
+            Self::S390x(r) => r.emit(out, arch, modifier),
             Self::Bpf(r) => r.emit(out, arch, modifier),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
@@ -358,7 +358,7 @@ impl InlineAsmReg {
             Self::PowerPC(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
-            Self::s390x(_) => cb(self),
+            Self::S390x(_) => cb(self),
             Self::Bpf(r) => r.overlapping_regs(|r| cb(Self::Bpf(r))),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
@@ -386,7 +386,7 @@ pub enum InlineAsmRegClass {
     PowerPC(PowerPCInlineAsmRegClass),
     Hexagon(HexagonInlineAsmRegClass),
     Mips(MipsInlineAsmRegClass),
-    s390x(s390xInlineAsmRegClass),
+    S390x(S390xInlineAsmRegClass),
     SpirV(SpirVInlineAsmRegClass),
     Wasm(WasmInlineAsmRegClass),
     Bpf(BpfInlineAsmRegClass),
@@ -405,7 +405,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
-            Self::s390x(r) => r.name(),
+            Self::S390x(r) => r.name(),
             Self::SpirV(r) => r.name(),
             Self::Wasm(r) => r.name(),
             Self::Bpf(r) => r.name(),
@@ -426,7 +426,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::PowerPC),
             Self::Hexagon(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Hexagon),
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
-            Self::s390x(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::s390x),
+            Self::S390x(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::S390x),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
             Self::Bpf(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Bpf),
@@ -454,7 +454,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.suggest_modifier(arch, ty),
             Self::Hexagon(r) => r.suggest_modifier(arch, ty),
             Self::Mips(r) => r.suggest_modifier(arch, ty),
-            Self::s390x(r) => r.suggest_modifier(arch, ty),
+            Self::S390x(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
             Self::Bpf(r) => r.suggest_modifier(arch, ty),
@@ -478,7 +478,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.default_modifier(arch),
             Self::Hexagon(r) => r.default_modifier(arch),
             Self::Mips(r) => r.default_modifier(arch),
-            Self::s390x(r) => r.default_modifier(arch),
+            Self::S390x(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
             Self::Bpf(r) => r.default_modifier(arch),
@@ -501,7 +501,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.supported_types(arch),
             Self::Hexagon(r) => r.supported_types(arch),
             Self::Mips(r) => r.supported_types(arch),
-            Self::s390x(r) => r.supported_types(arch),
+            Self::S390x(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
             Self::Bpf(r) => r.supported_types(arch),
@@ -527,7 +527,7 @@ impl InlineAsmRegClass {
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmRegClass::parse(arch, name)?)
             }
-            InlineAsmArch::s390x => Self::s390x(s390xInlineAsmRegClass::parse(arch, name)?),
+            InlineAsmArch::S390x => Self::S390x(S390xInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::SpirV => Self::SpirV(SpirVInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::Wasm32 => Self::Wasm(WasmInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::Bpf => Self::Bpf(BpfInlineAsmRegClass::parse(arch, name)?),
@@ -546,7 +546,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.valid_modifiers(arch),
             Self::Hexagon(r) => r.valid_modifiers(arch),
             Self::Mips(r) => r.valid_modifiers(arch),
-            Self::s390x(r) => r.valid_modifiers(arch),
+            Self::S390x(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
             Self::Bpf(r) => r.valid_modifiers(arch),
@@ -715,11 +715,11 @@ pub fn allocatable_registers(
             mips::fill_reg_map(arch, has_feature, target, &mut map);
             map
         }
-	InlineAsmArch::s390x => {
-	    let mut map = s390x::regclass_map();
+	    InlineAsmArch::S390x => {
+	        let mut map = s390x::regclass_map();
             s390x::fill_reg_map(arch, has_feature, target, &mut map);
             map
-	}
+	    }
         InlineAsmArch::SpirV => {
             let mut map = spirv::regclass_map();
             spirv::fill_reg_map(arch, has_feature, target, &mut map);

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -154,6 +154,7 @@ mod mips;
 mod nvptx;
 mod powerpc;
 mod riscv;
+mod s390x;
 mod spirv;
 mod wasm;
 mod x86;
@@ -166,6 +167,7 @@ pub use mips::{MipsInlineAsmReg, MipsInlineAsmRegClass};
 pub use nvptx::{NvptxInlineAsmReg, NvptxInlineAsmRegClass};
 pub use powerpc::{PowerPCInlineAsmReg, PowerPCInlineAsmRegClass};
 pub use riscv::{RiscVInlineAsmReg, RiscVInlineAsmRegClass};
+pub use s390x::{s390xInlineAsmReg, s390xInlineAsmRegClass};
 pub use spirv::{SpirVInlineAsmReg, SpirVInlineAsmRegClass};
 pub use wasm::{WasmInlineAsmReg, WasmInlineAsmRegClass};
 pub use x86::{X86InlineAsmReg, X86InlineAsmRegClass};
@@ -184,6 +186,7 @@ pub enum InlineAsmArch {
     Mips64,
     PowerPC,
     PowerPC64,
+    s390x,
     SpirV,
     Wasm32,
     Bpf,
@@ -206,6 +209,7 @@ impl FromStr for InlineAsmArch {
             "hexagon" => Ok(Self::Hexagon),
             "mips" => Ok(Self::Mips),
             "mips64" => Ok(Self::Mips64),
+            "s390x" => Ok(Self::s390x),
             "spirv" => Ok(Self::SpirV),
             "wasm32" => Ok(Self::Wasm32),
             "bpf" => Ok(Self::Bpf),
@@ -235,6 +239,7 @@ pub enum InlineAsmReg {
     PowerPC(PowerPCInlineAsmReg),
     Hexagon(HexagonInlineAsmReg),
     Mips(MipsInlineAsmReg),
+    s390x(InlineAsmReg),
     SpirV(SpirVInlineAsmReg),
     Wasm(WasmInlineAsmReg),
     Bpf(BpfInlineAsmReg),
@@ -252,6 +257,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
+	        Self::s390x(r) => r.name(),
             Self::Bpf(r) => r.name(),
             Self::Err => "<reg>",
         }
@@ -266,6 +272,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => InlineAsmRegClass::PowerPC(r.reg_class()),
             Self::Hexagon(r) => InlineAsmRegClass::Hexagon(r.reg_class()),
             Self::Mips(r) => InlineAsmRegClass::Mips(r.reg_class()),
+            Self::s390x(r) => InlineAsmRegClass::s390x(r.reg_class()),
             Self::Bpf(r) => InlineAsmRegClass::Bpf(r.reg_class()),
             Self::Err => InlineAsmRegClass::Err,
         }
@@ -305,6 +312,9 @@ impl InlineAsmReg {
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
+    	    InlineAsmArch::s390x => {
+                Self::s390x(s390xInlineAsmReg::parse(arch, has_feature, target, &name)?)
+            }
             InlineAsmArch::SpirV => {
                 Self::SpirV(SpirVInlineAsmReg::parse(arch, has_feature, target, &name)?)
             }
@@ -333,6 +343,7 @@ impl InlineAsmReg {
             Self::PowerPC(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
+            Self::s390x(r) => r.emit(out, arch, modifier),
             Self::Bpf(r) => r.emit(out, arch, modifier),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
@@ -347,6 +358,7 @@ impl InlineAsmReg {
             Self::PowerPC(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
+            Self::s390x(_) => cb(self),
             Self::Bpf(r) => r.overlapping_regs(|r| cb(Self::Bpf(r))),
             Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
@@ -374,6 +386,7 @@ pub enum InlineAsmRegClass {
     PowerPC(PowerPCInlineAsmRegClass),
     Hexagon(HexagonInlineAsmRegClass),
     Mips(MipsInlineAsmRegClass),
+    s390x(s390xInlineAsmRegClass),
     SpirV(SpirVInlineAsmRegClass),
     Wasm(WasmInlineAsmRegClass),
     Bpf(BpfInlineAsmRegClass),
@@ -392,6 +405,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
+            Self::s390x(r) => r.name(),
             Self::SpirV(r) => r.name(),
             Self::Wasm(r) => r.name(),
             Self::Bpf(r) => r.name(),
@@ -412,6 +426,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::PowerPC),
             Self::Hexagon(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Hexagon),
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
+            Self::s390x(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::s390x),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
             Self::Bpf(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Bpf),
@@ -439,6 +454,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.suggest_modifier(arch, ty),
             Self::Hexagon(r) => r.suggest_modifier(arch, ty),
             Self::Mips(r) => r.suggest_modifier(arch, ty),
+            Self::s390x(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
             Self::Bpf(r) => r.suggest_modifier(arch, ty),
@@ -462,6 +478,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.default_modifier(arch),
             Self::Hexagon(r) => r.default_modifier(arch),
             Self::Mips(r) => r.default_modifier(arch),
+            Self::s390x(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
             Self::Bpf(r) => r.default_modifier(arch),
@@ -484,6 +501,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.supported_types(arch),
             Self::Hexagon(r) => r.supported_types(arch),
             Self::Mips(r) => r.supported_types(arch),
+            Self::s390x(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
             Self::Bpf(r) => r.supported_types(arch),
@@ -509,6 +527,7 @@ impl InlineAsmRegClass {
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
                 Self::Mips(MipsInlineAsmRegClass::parse(arch, name)?)
             }
+            InlineAsmArch::s390x => Self::s390x(s390xInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::SpirV => Self::SpirV(SpirVInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::Wasm32 => Self::Wasm(WasmInlineAsmRegClass::parse(arch, name)?),
             InlineAsmArch::Bpf => Self::Bpf(BpfInlineAsmRegClass::parse(arch, name)?),
@@ -527,6 +546,7 @@ impl InlineAsmRegClass {
             Self::PowerPC(r) => r.valid_modifiers(arch),
             Self::Hexagon(r) => r.valid_modifiers(arch),
             Self::Mips(r) => r.valid_modifiers(arch),
+            Self::s390x(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
             Self::Bpf(r) => r.valid_modifiers(arch),
@@ -695,6 +715,11 @@ pub fn allocatable_registers(
             mips::fill_reg_map(arch, has_feature, target, &mut map);
             map
         }
+	InlineAsmArch::s390x => {
+	    let mut map = s390x::regclass_map();
+            s390x::fill_reg_map(arch, has_feature, target, &mut map);
+            map
+	}
         InlineAsmArch::SpirV => {
             let mut map = spirv::regclass_map();
             spirv::fill_reg_map(arch, has_feature, target, &mut map);

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -1,0 +1,156 @@
+use super::{InlineAsmArch, InlineAsmType};
+use rustc_macros::HashStable_Generic;
+use std::fmt;
+
+def_reg_class! {
+    s390x s390xInlineAsmRegClass {
+        reg,
+        freg,
+    }
+}
+
+impl s390xInlineAsmRegClass {
+    pub fn valid_modifiers(self, _arch: super::InlineAsmArch) -> &'static [char] {
+        &[]
+    }
+
+    pub fn suggest_class(self, _arch: InlineAsmArch, _ty: InlineAsmType) -> Option<Self> {
+        None
+    }
+
+    pub fn suggest_modifier(
+        self,
+        _arch: InlineAsmArch,
+        _ty: InlineAsmType,
+    ) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn default_modifier(self, _arch: InlineAsmArch) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn supported_types(
+        self,
+        arch: InlineAsmArch,
+    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+        match (self, arch) {
+            (Self::reg, _) => types! { _: I8, I16, I32; },
+            (Self::freg, _) => types! { _: F32, F64; },
+        }
+    }
+}
+
+def_regs! {
+    s390x s390xInlineAsmReg s390xInlineAsmRegClass {
+        r0: req = ["r0"],
+        r1: reg = ["r1"],
+        r2: reg = ["r2"],
+        r3: reg = ["r3"],
+        r4: reg = ["r4"],
+        r5: reg = ["r5"],
+        r6: reg = ["r6"],
+        r7: reg = ["r7"],
+        r8: reg = ["r8"],
+        r9: reg = ["r9"],
+        r10: reg = ["r10"],
+        r11: reg = ["r11"],
+        r12: reg = ["r12"],
+        r14: reg = ["r14"],
+        f0: freg = ["f0"],
+        f1: freg = ["f1"],
+        f2: freg = ["f2"],
+        f3: freg = ["f3"],
+        f4: freg = ["f4"],
+        f5: freg = ["f5"],
+        f6: freg = ["f6"],
+        f7: freg = ["f7"],
+        f8: freg = ["f8"],
+        f9: freg = ["f9"],
+        f10: freg = ["f10"],
+        f11: freg = ["f11"],
+        f12: freg = ["f12"],
+        f13: freg = ["f13"],
+        f14: freg = ["f14"],
+        f15: freg = ["f15"],
+        #error = ["r13"] =>
+            "The base pointer cannot be used as an operand for inline asm",
+        #error = ["r15"] =>
+            "The stack pointer cannot be used as an operand for inline asm",
+        #error = ["a0"] =>
+            "This pointer is reserved on s390x and cannot be used as an operand for inline asm",
+        #error = ["a1"] =>
+            "This pointer is reserved on z/Arch and cannot be used as an operand for inline asm",
+        #error = ["c0"] =>
+            "c0 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c1"] =>
+            "c1 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c2"] =>
+            "c2 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c3"] =>
+            "c3 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c4"] =>
+            "c4 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c5"] =>
+            "c5 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c6"] =>
+            "c6 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c7"] =>
+            "c7 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c8"] =>
+            "c8 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c9"] =>
+            "c9 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c10"] =>
+            "c10 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c11"] =>
+            "c11 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c12"] =>
+            "c12 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c13"] =>
+            "c13 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c14"] =>
+            "c14 is reserved by the kernel and cannot be used as an operand for inline asm",
+        #error = ["c15"] =>
+            "c15 is reserved by the kernel and cannot be used as an operand for inline asm",
+	    #error = ["a2"] =>
+            "a2 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a3"] =>
+            "a3 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a4"] =>
+            "a4 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a5"] =>
+            "a5 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a6"] =>
+            "a6 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a7"] =>
+            "a7 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a8"] =>
+            "a8 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a9"] =>
+            "a9 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a10"] =>
+            "a10 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a11"] =>
+            "a11 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a12"] =>
+            "a12 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a13"] =>
+            "a13 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a14"] =>
+            "a14 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = ["a15"] =>
+            "a15 is not supported by LLVM and cannot be used as an operand for inline asm",
+    }
+}
+
+impl s390xInlineAsmReg {
+    pub fn emit(
+        self,
+        out: &mut dyn fmt::Write,
+        _arch: InlineAsmArch,
+        _modifier: Option<char>,
+    ) -> fmt::Result {
+        out.write_str(self.name())
+    }
+}

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -35,7 +35,7 @@ impl S390xInlineAsmRegClass {
         arch: InlineAsmArch,
     ) -> &'static [(InlineAsmType, Option<&'static str>)] {
         match (self, arch) {
-            (Self::reg, _) => types! { _: I8, I16, I32; },
+            (Self::reg, _) => types! { _: I8, I16, I32, I64; },
             (Self::freg, _) => types! { _: F32, F64; },
         }
     }

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -101,6 +101,6 @@ impl S390xInlineAsmReg {
         _arch: InlineAsmArch,
         _modifier: Option<char>,
     ) -> fmt::Result {
-        out.write_str(&format!("%{}", self.name()))
+        write!(out, "%{}", self.name())
     }
 }

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -54,8 +54,8 @@ def_regs! {
         r8: reg = ["r8"],
         r9: reg = ["r9"],
         r10: reg = ["r10"],
-        r11: reg = ["r11"],
         r12: reg = ["r12"],
+        r13: reg = ["r13"],
         r14: reg = ["r14"],
         f0: freg = ["f0"],
         f1: freg = ["f1"],
@@ -73,74 +73,24 @@ def_regs! {
         f13: freg = ["f13"],
         f14: freg = ["f14"],
         f15: freg = ["f15"],
-        #error = ["r13"] =>
-            "The base pointer cannot be used as an operand for inline asm",
+        #error = ["r11"] =>
+            "The frame pointer cannot be used as an operand for inline asm",
         #error = ["r15"] =>
             "The stack pointer cannot be used as an operand for inline asm",
-        #error = ["a0"] =>
-            "This pointer is reserved on s390x and cannot be used as an operand for inline asm",
-        #error = ["a1"] =>
-            "This pointer is reserved on z/Arch and cannot be used as an operand for inline asm",
-        #error = ["c0"] =>
-            "c0 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c1"] =>
-            "c1 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c2"] =>
-            "c2 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c3"] =>
-            "c3 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c4"] =>
-            "c4 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c5"] =>
-            "c5 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c6"] =>
-            "c6 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c7"] =>
-            "c7 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c8"] =>
-            "c8 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c9"] =>
-            "c9 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c10"] =>
-            "c10 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c11"] =>
-            "c11 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c12"] =>
-            "c12 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c13"] =>
-            "c13 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c14"] =>
-            "c14 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["c15"] =>
-            "c15 is reserved by the kernel and cannot be used as an operand for inline asm",
-        #error = ["a2"] =>
-            "a2 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a3"] =>
-            "a3 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a4"] =>
-            "a4 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a5"] =>
-            "a5 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a6"] =>
-            "a6 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a7"] =>
-            "a7 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a8"] =>
-            "a8 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a9"] =>
-            "a9 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a10"] =>
-            "a10 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a11"] =>
-            "a11 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a12"] =>
-            "a12 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a13"] =>
-            "a13 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a14"] =>
-            "a14 is not supported by LLVM and cannot be used as an operand for inline asm",
-        #error = ["a15"] =>
-            "a15 is not supported by LLVM and cannot be used as an operand for inline asm",
+        #error = [
+            "c0", "c1", "c2", "c3",
+            "c4", "c5", "c6", "c7",
+            "c8", "c9", "c10", "c11",
+            "c12", "c13", "c14", "c15"
+        ] =>
+            "control registers are reserved by the kernel and cannot be used as operands for inline asm",
+        #error = [
+            "a0", "a1", "a2", "a3",
+            "a4", "a5", "a6", "a7",
+            "a8", "a9", "a10", "a11",
+            "a12", "a13", "a14", "a15"
+        ] =>
+            "access registers are not supported and cannot be used as operands for inline asm",
     }
 }
 
@@ -151,6 +101,6 @@ impl S390xInlineAsmReg {
         _arch: InlineAsmArch,
         _modifier: Option<char>,
     ) -> fmt::Result {
-        out.write_str(self.name())
+        out.write_str(&format!("%{}", self.name()))
     }
 }

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -113,7 +113,7 @@ def_regs! {
             "c14 is reserved by the kernel and cannot be used as an operand for inline asm",
         #error = ["c15"] =>
             "c15 is reserved by the kernel and cannot be used as an operand for inline asm",
-	    #error = ["a2"] =>
+        #error = ["a2"] =>
             "a2 is not supported by LLVM and cannot be used as an operand for inline asm",
         #error = ["a3"] =>
             "a3 is not supported by LLVM and cannot be used as an operand for inline asm",

--- a/compiler/rustc_target/src/asm/s390x.rs
+++ b/compiler/rustc_target/src/asm/s390x.rs
@@ -3,13 +3,13 @@ use rustc_macros::HashStable_Generic;
 use std::fmt;
 
 def_reg_class! {
-    s390x s390xInlineAsmRegClass {
+    S390x S390xInlineAsmRegClass {
         reg,
         freg,
     }
 }
 
-impl s390xInlineAsmRegClass {
+impl S390xInlineAsmRegClass {
     pub fn valid_modifiers(self, _arch: super::InlineAsmArch) -> &'static [char] {
         &[]
     }
@@ -42,8 +42,8 @@ impl s390xInlineAsmRegClass {
 }
 
 def_regs! {
-    s390x s390xInlineAsmReg s390xInlineAsmRegClass {
-        r0: req = ["r0"],
+    S390x S390xInlineAsmReg S390xInlineAsmRegClass {
+        r0: reg = ["r0"],
         r1: reg = ["r1"],
         r2: reg = ["r2"],
         r3: reg = ["r3"],
@@ -144,7 +144,7 @@ def_regs! {
     }
 }
 
-impl s390xInlineAsmReg {
+impl S390xInlineAsmReg {
     pub fn emit(
         self,
         out: &mut dyn fmt::Write,

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -60,7 +60,7 @@ macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
 };}
 
 macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
-    
+    #[no_mangle]    
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!(func));
 
@@ -70,17 +70,57 @@ macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
     }
 };}
 
-// systemz-LABEL: sym_fn_32:
-// systemz: #APP
-// systemz: brasl %r14, extern_func@PLT
-// systemz: #NO_APP
+// CHECK-LABEL: sym_fn_32:
+// CHECK: #APP
+// CHECK: brasl %r14, extern_func
+// CHECK: #NO_APP
 #[cfg(s390x)]
+#[no_mangle]
 pub unsafe fn sym_fn_32() {
     asm!("brasl %r14, {}", sym extern_func);
 }
 
+// CHECK-LABEL: sym_static:
+// CHECK: #APP
+// CHECK: brasl %r14, extern_static
+// CHECK: #NO_APP
+#[no_mangle]
+pub unsafe fn sym_static() {
+    asm!("brasl %r14, {}", sym extern_static);
+}
+
+// CHECK-LABEL: reg_i8:
+// CHECK: #APP
+// CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i8, i8, reg, "lgr");
+
+// CHECK-LABEL: reg_i16:
+// CHECK: #APP
+// CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i16, i16, reg, "lgr");
+
 // CHECK-LABEL: reg_i32:
 // CHECK: #APP
-// CHECK: lgr r{{[0-15]+}}, r{{[0-15]+}}
+// CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
 // CHECK: #NO_APP
 check!(reg_i32, i32, reg, "lgr");
+
+// CHECK-LABEL: reg_i64:
+// CHECK: #APP
+// CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_i64, i64, reg, "lgr");
+
+// CHECK-LABEL: reg_f32:
+// CHECK: #APP
+// CHECK: ler %f{{[0-9]+}}, %f{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_f32, f32, freg, "ler");
+
+// CHECK-LABEL: reg_f64:
+// CHECK: #APP
+// CHECK: ldr %f{{[0-9]+}}, %f{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_f64, f64, freg, "ldr");

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -1,0 +1,86 @@
+// min-llvm-version: 10.0.1
+// revisions: s390x
+// assembly-output: emit-asm
+//[s390x] compile-flags: --target s390x-unknown-linux-gnu
+//[s390x] needs-llvm-components: systemz
+
+#![feature(no_core, lang_items, rustc_attrs, repr_simd)]
+#![crate_type = "rlib"]
+#![no_core]
+#![allow(asm_sub_register, non_camel_case_types)]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[rustc_builtin_macro]
+macro_rules! concat {
+    () => {};
+}
+#[rustc_builtin_macro]
+macro_rules! stringify {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+type ptr = *const i32;
+
+impl Copy for i8 {}
+impl Copy for u8 {}
+impl Copy for i16 {}
+impl Copy for i32 {}
+impl Copy for i64 {}
+impl Copy for f32 {}
+impl Copy for f64 {}
+impl Copy for ptr {}
+
+extern "C" {
+    fn extern_func();
+    static extern_static: u8;
+}
+
+// Hack to avoid function merging
+extern "Rust" {
+    fn dont_merge(s: &str);
+}
+
+macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
+    
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!(func));
+
+        let y;
+        asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
+        y
+    }
+};}
+
+macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
+    
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!(func));
+
+        let y;
+        asm!(concat!($mov, " ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+        y
+    }
+};}
+
+// systemz-LABEL: sym_fn_32:
+// systemz: #APP
+// systemz: brasl %r14, extern_func@PLT
+// systemz: #NO_APP
+#[cfg(s390x)]
+pub unsafe fn sym_fn_32() {
+    asm!("brasl %r14, {}", sym extern_func);
+}
+
+// CHECK-LABEL: reg_i32:
+// CHECK: #APP
+// CHECK: lgr r{{[0-15]+}}, r{{[0-15]+}}
+// CHECK: #NO_APP
+check!(reg_i32, i32, reg, "lgr");

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -51,7 +51,7 @@ extern "Rust" {
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
     #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
-        dont_merge(stringify!(func));
+        dont_merge(stringify!($func));
 
         let y;
         asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
@@ -62,7 +62,7 @@ macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
 macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
     #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
-        dont_merge(stringify!(func));
+        dont_merge(stringify!($func));
 
         let y;
         asm!(concat!($mov, " ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
@@ -124,3 +124,9 @@ check!(reg_f32, f32, freg, "ler");
 // CHECK: ldr %f{{[0-9]+}}, %f{{[0-9]+}}
 // CHECK: #NO_APP
 check!(reg_f64, f64, freg, "ldr");
+
+// CHECK-LABEL: reg_ptr:
+// CHECK: #APP
+// CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
+// CHECK: #NO_APP
+check!(reg_ptr, ptr, reg, "lgr");

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -49,7 +49,7 @@ extern "Rust" {
 }
 
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
-    #[no_mangle]     
+    #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!(func));
 
@@ -60,7 +60,7 @@ macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
 };}
 
 macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
-    #[no_mangle]    
+    #[no_mangle]
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!(func));
 

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -75,6 +75,7 @@ macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
 // systemz: brasl %r14, extern_func@PLT
 // systemz: #NO_APP
 #[cfg(s390x)]
+#[no_mangle]
 pub unsafe fn sym_fn_32() {
     asm!("brasl %r14, {}", sym extern_func);
 }
@@ -83,4 +84,5 @@ pub unsafe fn sym_fn_32() {
 // CHECK: #APP
 // CHECK: lgr r{{[0-15]+}}, r{{[0-15]+}}
 // CHECK: #NO_APP
+#[no_mangle]
 check!(reg_i32, i32, reg, "lgr");

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -49,7 +49,7 @@ extern "Rust" {
 }
 
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
-    
+    #[no_mangle]     
     pub unsafe fn $func(x: $ty) -> $ty {
         dont_merge(stringify!(func));
 
@@ -75,7 +75,6 @@ macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
 // systemz: brasl %r14, extern_func@PLT
 // systemz: #NO_APP
 #[cfg(s390x)]
-#[no_mangle]
 pub unsafe fn sym_fn_32() {
     asm!("brasl %r14, {}", sym extern_func);
 }
@@ -84,5 +83,4 @@ pub unsafe fn sym_fn_32() {
 // CHECK: #APP
 // CHECK: lgr r{{[0-15]+}}, r{{[0-15]+}}
 // CHECK: #NO_APP
-#[no_mangle]
 check!(reg_i32, i32, reg, "lgr");

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -65,7 +65,7 @@ macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
         dont_merge(stringify!($func));
 
         let y;
-        asm!(concat!($mov, " ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+        asm!(concat!($mov, " %", $reg, ", %", $reg), lateout($reg) y, in($reg) x);
         y
     }
 };}
@@ -130,3 +130,39 @@ check!(reg_f64, f64, freg, "ldr");
 // CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
 // CHECK: #NO_APP
 check!(reg_ptr, ptr, reg, "lgr");
+
+// CHECK-LABEL: r0_i8:
+// CHECK: #APP
+// CHECK: lr %r0, %r0
+// CHECK: #NO_APP
+check_reg!(r0_i8, i8, "r0", "lr");
+
+// CHECK-LABEL: r0_i16:
+// CHECK: #APP
+// CHECK: lr %r0, %r0
+// CHECK: #NO_APP
+check_reg!(r0_i16, i16, "r0", "lr");
+
+// CHECK-LABEL: r0_i32:
+// CHECK: #APP
+// CHECK: lr %r0, %r0
+// CHECK: #NO_APP
+check_reg!(r0_i32, i32, "r0", "lr");
+
+// CHECK-LABEL: r0_i64:
+// CHECK: #APP
+// CHECK: lr %r0, %r0
+// CHECK: #NO_APP
+check_reg!(r0_i64, i64, "r0", "lr");
+
+// CHECK-LABEL: f0_f32:
+// CHECK: #APP
+// CHECK: ler %f0, %f0
+// CHECK: #NO_APP
+check_reg!(f0_f32, f32, "f0", "ler");
+
+// CHECK-LABEL: f0_f64:
+// CHECK: #APP
+// CHECK: ldr %f0, %f0
+// CHECK: #NO_APP
+check_reg!(f0_f64, f64, "f0", "ldr");


### PR DESCRIPTION
This adds register definitions and constraint codes for the s390x general and floating point registers necessary for fixing #85931; as well as a few tests. 

Further testing is needed, but I am a little unsure of what specific tests should be added to `src/test/assembly/asm/s390x.rs` to address this.