### PR TITLE
Handle type ascription type ops in NLL HRTB diagnostics

### DIFF
--- a/compiler/rustc_traits/src/lib.rs
+++ b/compiler/rustc_traits/src/lib.rs
@@ -19,7 +19,7 @@ mod normalize_erasing_regions;
 mod normalize_projection_ty;
 mod type_op;
 
-pub use type_op::type_op_prove_predicate_with_span;
+pub use type_op::{type_op_ascribe_user_type_with_span, type_op_prove_predicate_with_span};
 
 use rustc_middle::ty::query::Providers;
 

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -40,18 +40,28 @@ fn type_op_ascribe_user_type<'tcx>(
     canonicalized: Canonical<'tcx, ParamEnvAnd<'tcx, AscribeUserType<'tcx>>>,
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, ()>>, NoSolution> {
     tcx.infer_ctxt().enter_canonical_trait_query(&canonicalized, |infcx, fulfill_cx, key| {
-        let (param_env, AscribeUserType { mir_ty, def_id, user_substs }) = key.into_parts();
-
-        debug!(
-            "type_op_ascribe_user_type: mir_ty={:?} def_id={:?} user_substs={:?}",
-            mir_ty, def_id, user_substs
-        );
-
-        let mut cx = AscribeUserTypeCx { infcx, param_env, fulfill_cx };
-        cx.relate_mir_and_user_ty(mir_ty, def_id, user_substs)?;
-
-        Ok(())
+        type_op_ascribe_user_type_with_span(infcx, fulfill_cx, key, None)
     })
+}
+
+/// The core of the `type_op_ascribe_user_type` query: for diagnostics purposes in NLL HRTB errors,
+/// this query can be re-run to better track the span of the obligation cause, and improve the error
+/// message. Do not call directly unless you're in that very specific context.
+pub fn type_op_ascribe_user_type_with_span<'a, 'tcx: 'a>(
+    infcx: &'a InferCtxt<'a, 'tcx>,
+    fulfill_cx: &'a mut dyn TraitEngine<'tcx>,
+    key: ParamEnvAnd<'tcx, AscribeUserType<'tcx>>,
+    span: Option<Span>,
+) -> Result<(), NoSolution> {
+    let (param_env, AscribeUserType { mir_ty, def_id, user_substs }) = key.into_parts();
+    debug!(
+        "type_op_ascribe_user_type: mir_ty={:?} def_id={:?} user_substs={:?}",
+        mir_ty, def_id, user_substs
+    );
+
+    let mut cx = AscribeUserTypeCx { infcx, param_env, fulfill_cx };
+    cx.relate_mir_and_user_ty(mir_ty, def_id, user_substs, span)?;
+    Ok(())
 }
 
 struct AscribeUserTypeCx<'me, 'tcx> {
@@ -85,10 +95,15 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         Ok(())
     }
 
-    fn prove_predicate(&mut self, predicate: Predicate<'tcx>) {
+    fn prove_predicate(&mut self, predicate: Predicate<'tcx>, span: Option<Span>) {
+        let cause = if let Some(span) = span {
+            ObligationCause::dummy_with_span(span)
+        } else {
+            ObligationCause::dummy()
+        };
         self.fulfill_cx.register_predicate_obligation(
             self.infcx,
-            Obligation::new(ObligationCause::dummy(), self.param_env, predicate),
+            Obligation::new(cause, self.param_env, predicate),
         );
     }
 
@@ -108,6 +123,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         mir_ty: Ty<'tcx>,
         def_id: DefId,
         user_substs: UserSubsts<'tcx>,
+        span: Option<Span>,
     ) -> Result<(), NoSolution> {
         let UserSubsts { user_self_ty, substs } = user_substs;
         let tcx = self.tcx();
@@ -129,7 +145,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         debug!(?instantiated_predicates.predicates);
         for instantiated_predicate in instantiated_predicates.predicates {
             let instantiated_predicate = self.normalize(instantiated_predicate);
-            self.prove_predicate(instantiated_predicate);
+            self.prove_predicate(instantiated_predicate, span);
         }
 
         if let Some(UserSelfTy { impl_def_id, self_ty }) = user_self_ty {
@@ -141,6 +157,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
 
             self.prove_predicate(
                 ty::PredicateKind::WellFormed(impl_self_ty.into()).to_predicate(self.tcx()),
+                span,
             );
         }
 
@@ -155,7 +172,10 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         // them?  This would only be relevant if some input
         // type were ill-formed but did not appear in `ty`,
         // which...could happen with normalization...
-        self.prove_predicate(ty::PredicateKind::WellFormed(ty.into()).to_predicate(self.tcx()));
+        self.prove_predicate(
+            ty::PredicateKind::WellFormed(ty.into()).to_predicate(self.tcx()),
+            span,
+        );
         Ok(())
     }
 }

--- a/src/test/ui/hrtb/due-to-where-clause.nll.stderr
+++ b/src/test/ui/hrtb/due-to-where-clause.nll.stderr
@@ -1,8 +1,0 @@
-error: higher-ranked subtype error
-  --> $DIR/due-to-where-clause.rs:2:5
-   |
-LL |     test::<FooS>(&mut 42);
-   |     ^^^^^^^^^^^^
-
-error: aborting due to previous error
-

--- a/src/test/ui/hrtb/hrtb-cache-issue-54302.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-cache-issue-54302.nll.stderr
@@ -1,8 +1,0 @@
-error: higher-ranked subtype error
-  --> $DIR/hrtb-cache-issue-54302.rs:19:5
-   |
-LL |     assert_deserialize_owned::<&'static str>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
-

--- a/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
@@ -17,11 +17,14 @@ LL |     want_hrtb::<&'a u32>()
    |
    = help: consider replacing `'a` with `'static`
 
-error: higher-ranked subtype error
+error: implementation of `Foo` is not general enough
   --> $DIR/hrtb-just-for-static.rs:30:5
    |
 LL |     want_hrtb::<&'a u32>()
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `Foo<&'0 isize>` would have to be implemented for the type `&u32`, for any lifetime `'0`...
+   = note: ...but `Foo<&'1 isize>` is actually implemented for the type `&'1 u32`, for some specific lifetime `'1`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-54302.nll.stderr
+++ b/src/test/ui/issues/issue-54302.nll.stderr
@@ -1,8 +1,0 @@
-error: higher-ranked subtype error
-  --> $DIR/issue-54302.rs:13:5
-   |
-LL |     assert_deserialize_owned::<&'static str>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
-


### PR DESCRIPTION
Currently, there are still a few cases of the "higher-ranked subtype error" of yore, 4 of which are related to type ascription. 

This PR is a follow-up to #86700, adding support for type ascription type ops, and makes 3 of these tests output the same diagnostics in NLL mode as the migrate mode (and 1 is now much closer, especially if you ignore that it already outputs an additional error in NLL mode -- which could be a duplicate caused by a lack of normalization like [these comments point out](https://github.com/rust-lang/rust/blob/9583fd1bdd0127328e25e5b8c24dff575ec2c86b/compiler/rustc_traits/src/type_op.rs#L122-L157), or an imprecision in some parts of normalization as [described here](https://github.com/rust-lang/rust/pull/86700#discussion_r689086688)).

Since we discussed these recently:
- [here](https://github.com/rust-lang/rust/pull/86700#discussion_r689158868), cc @matthewjasper, 
- and [here](https://github.com/rust-lang/rust/issues/57374#issuecomment-901500856), cc @Aaron1011.

It should only leave [this TAIT test](https://github.com/rust-lang/rust/blob/9583fd1bdd0127328e25e5b8c24dff575ec2c86b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.rs) as still emitting [the terse error](https://github.com/rust-lang/rust/blob/9583fd1bdd0127328e25e5b8c24dff575ec2c86b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr).

r? @estebank (so that they shake their fist at NLL's general direction less often) or @nikomatsakis or matthew or aaron, the more the merrier.