### PR TITLE
Add bit removal methods to SparseBitMatrix and factor *BitSet relational methods into more extensible trait

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -956,7 +956,7 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         Self { num_columns, rows: IndexVec::new() }
     }
 
-    fn ensure_row(&mut self, row: R) -> &mut HybridBitSet<C> {
+    pub fn ensure_row(&mut self, row: R) -> &mut HybridBitSet<C> {
         // Instantiate any missing rows up to and including row `row` with an
         // empty HybridBitSet.
         self.rows.ensure_contains_elem(row, || None);

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -272,7 +272,7 @@ fn dense_sparse_intersect<T: Idx>(
     sparse: &SparseBitSet<T>,
 ) -> (SparseBitSet<T>, bool) {
     let mut sparse_copy = sparse.clone();
-    sparse_intersect(&mut sparse_copy, |el| !dense.contains(*el));
+    sparse_intersect(&mut sparse_copy, |el| dense.contains(*el));
     let n = sparse_copy.len();
     (sparse_copy, n != dense.count())
 }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -274,7 +274,7 @@ fn sparse_intersect<T: Idx>(
 // Optimization of dense/sparse intersection. The resulting set is
 // guaranteed to be at most the size of the sparse set, and hence can be
 // represented as a sparse set. Therefore the sparse set is copied and filtered,
-// then returned as the new set. 
+// then returned as the new set.
 fn dense_sparse_intersect<T: Idx>(
     dense: &BitSet<T>,
     sparse: &SparseBitSet<T>,
@@ -312,7 +312,7 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for BitSet<T> {
             HybridBitSet::Sparse(sparse) => {
                 let (updated, changed) = dense_sparse_intersect(self, sparse);
 
-                // We can't directly assign the BitSet to the SparseBitSet, and 
+                // We can't directly assign the BitSet to the SparseBitSet, and
                 // doing `*self = updated.to_dense()` would cause a drop / reallocation. Instead,
                 // the BitSet is cleared and `updated` is copied into `self`.
                 self.clear();

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -363,7 +363,7 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for BitSet<T> {
             HybridBitSet::Sparse(sparse) => {
                 let (updated, changed) = dense_sparse_intersect(self, sparse);
 
-                // We can't directly assign the BitSet to the SparseBitSet, and
+                // We can't directly assign the SparseBitSet to the BitSet, and
                 // doing `*self = updated.to_dense()` would cause a drop / reallocation. Instead,
                 // the BitSet is cleared and `updated` is copied into `self`.
                 self.clear();
@@ -1071,7 +1071,7 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         Self { num_columns, rows: IndexVec::new() }
     }
 
-    pub fn ensure_row(&mut self, row: R) -> &mut HybridBitSet<C> {
+    fn ensure_row(&mut self, row: R) -> &mut HybridBitSet<C> {
         // Instantiate any missing rows up to and including row `row` with an
         // empty HybridBitSet.
         self.rows.ensure_contains_elem(row, || None);

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -271,10 +271,10 @@ fn dense_sparse_intersect<T: Idx>(
     dense: &BitSet<T>,
     sparse: &SparseBitSet<T>,
 ) -> (SparseBitSet<T>, bool) {
-    let n = dense.count();
     let mut sparse_copy = sparse.clone();
     sparse_intersect(&mut sparse_copy, |el| !dense.contains(*el));
-    (sparse_copy, dense.count() != n)
+    let n = sparse_copy.len();
+    (sparse_copy, n != dense.count())
 }
 
 impl<T: Idx> BitRelations<HybridBitSet<T>> for BitSet<T> {
@@ -303,7 +303,10 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for BitSet<T> {
         match other {
             HybridBitSet::Sparse(sparse) => {
                 let (updated, changed) = dense_sparse_intersect(self, sparse);
-                *self = updated.to_dense();
+                self.clear();
+                for elem in updated.iter() {
+                    self.insert(*elem);
+                }
                 changed
             }
             HybridBitSet::Dense(dense) => self.intersect(dense),

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -379,9 +379,9 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for HybridBitSet<T> {
     fn union(&mut self, other: &HybridBitSet<T>) -> bool {
         assert_eq!(self.domain_size(), other.domain_size());
         match self {
-            HybridBitSet::Sparse(self_sparse) => {
+            HybridBitSet::Sparse(_) => {
                 match other {
-                    HybridBitSet::Sparse(_) => {
+                    HybridBitSet::Sparse(other_sparse) => {
                         // Both sets are sparse. Add the elements in
                         // `other_sparse` to `self` one at a time. This
                         // may or may not cause `self` to be densified.

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -289,6 +289,7 @@ fn dense_sparse_intersect<T: Idx>(
 // hybrid REL dense
 impl<T: Idx> BitRelations<BitSet<T>> for HybridBitSet<T> {
     fn union(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
         match self {
             HybridBitSet::Sparse(sparse) => {
                 // `self` is sparse and `other` is dense. To
@@ -316,6 +317,7 @@ impl<T: Idx> BitRelations<BitSet<T>> for HybridBitSet<T> {
     }
 
     fn subtract(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
         match self {
             HybridBitSet::Sparse(sparse) => {
                 sequential_update(|elem| sparse.remove(elem), other.iter())
@@ -325,6 +327,7 @@ impl<T: Idx> BitRelations<BitSet<T>> for HybridBitSet<T> {
     }
 
     fn intersect(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
         match self {
             HybridBitSet::Sparse(sparse) => sparse_intersect(sparse, |elem| other.contains(*elem)),
             HybridBitSet::Dense(dense) => dense.intersect(other),
@@ -385,7 +388,6 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for HybridBitSet<T> {
                         // Both sets are sparse. Add the elements in
                         // `other_sparse` to `self` one at a time. This
                         // may or may not cause `self` to be densified.
-                        assert_eq!(self.domain_size(), other.domain_size());
                         let mut changed = false;
                         for elem in other_sparse.iter() {
                             changed |= self.insert(*elem);

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1087,6 +1087,11 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         self.ensure_row(row).insert(column)
     }
 
+    /// Sets the cell at `(row, column)` to false. Put another way, delete
+    /// `column` from the bitset for `row`. Has no effect if `row` does not
+    /// exist.
+    ///
+    /// Returns `true` if this changed the matrix.
     pub fn remove(&mut self, row: R, column: C) -> bool {
         match self.rows.get_mut(row) {
             Some(Some(row)) => row.remove(column),
@@ -1094,6 +1099,8 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         }
     }
 
+    /// Sets all columns at `row` to false. Has no effect if `row` does
+    /// not exist.
     pub fn clear(&mut self, row: R) {
         if let Some(Some(row)) = self.rows.get_mut(row) {
             row.clear();
@@ -1147,6 +1154,10 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         if let Some(Some(row)) = self.rows.get(row) { Some(row) } else { None }
     }
 
+    /// Interescts `row` with `set`. `set` can be either `BitSet` or
+    /// `HybridBitSet`. Has no effect if `row` does not exist.
+    ///
+    /// Returns true if the row was changed.
     pub fn intersect_row<Set>(&mut self, row: R, set: &Set) -> bool
     where
         HybridBitSet<C>: BitRelations<Set>,
@@ -1157,6 +1168,10 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         }
     }
 
+    /// Subtracts `set from `row`. `set` can be either `BitSet` or
+    /// `HybridBitSet`. Has no effect if `row` does not exist.
+    ///
+    /// Returns true if the row was changed.
     pub fn subtract_row<Set>(&mut self, row: R, set: &Set) -> bool
     where
         HybridBitSet<C>: BitRelations<Set>,
@@ -1167,6 +1182,10 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
         }
     }
 
+    /// Unions `row` with `set`. `set` can be either `BitSet` or
+    /// `HybridBitSet`.
+    ///
+    /// Returns true if the row was changed.
     pub fn union_row<Set>(&mut self, row: R, set: &Set) -> bool
     where
         HybridBitSet<C>: BitRelations<Set>,

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -104,7 +104,7 @@ fn hybrid_bitset() {
     assert!(dense10.superset(&dense10)); // dense + dense (self)
     assert!(dense256.superset(&dense10)); // dense + dense
 
-    let mut hybrid = sparse038;
+    let mut hybrid = sparse038.clone();
     assert!(!sparse01358.union(&hybrid)); // no change
     assert!(hybrid.union(&sparse01358));
     assert!(hybrid.superset(&sparse01358) && sparse01358.superset(&hybrid));

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -304,6 +304,72 @@ fn sparse_matrix_iter() {
     assert!(iter.next().is_none());
 }
 
+#[test]
+fn sparse_matrix_operations() {
+    let mut matrix: SparseBitMatrix<usize, usize> = SparseBitMatrix::new(100);
+    matrix.insert(3, 22);
+    matrix.insert(3, 75);
+    matrix.insert(2, 99);
+    matrix.insert(4, 0);
+
+    let mut disjoint: HybridBitSet<usize> = HybridBitSet::new_empty(100);
+    disjoint.insert(33);
+
+    let mut superset = HybridBitSet::new_empty(100);
+    superset.insert(22);
+    superset.insert(75);
+    superset.insert(33);
+
+    let mut subset = HybridBitSet::new_empty(100);
+    subset.insert(22);
+
+    // SparseBitMatrix::remove
+    {
+        let mut matrix = matrix.clone();
+        matrix.remove(3, 22);
+        assert!(!matrix.row(3).unwrap().contains(22));
+        matrix.remove(0, 0);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::clear
+    {
+        let mut matrix = matrix.clone();
+        matrix.clear(3);
+        assert!(!matrix.row(3).unwrap().contains(75));
+        matrix.clear(0);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::intersect_row
+    {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.intersect_row(2, &superset));
+        assert!(matrix.intersect_row(2, &subset));
+        matrix.intersect_row(0, &disjoint);
+        assert!(matrix.row(0).is_none());
+    }
+
+     // SparseBitMatrix::subtract_row
+     {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.subtract_row(2, &disjoint));
+        assert!(matrix.subtract_row(2, &subset));
+        assert!(matrix.subtract_row(2, &superset));
+        matrix.intersect_row(0, &disjoint);
+        assert!(matrix.row(0).is_none());
+     }
+
+     // SparseBitMatrix::union_row 
+     {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.union_row(2, &subset));
+        assert!(matrix.union_row(2, &disjoint));
+        matrix.union_row(0, &disjoint);
+        assert!(matrix.row(0).is_some());
+     }
+}
+
 /// Merge dense hybrid set into empty sparse hybrid set.
 #[bench]
 fn union_hybrid_sparse_empty_to_dense(b: &mut Bencher) {

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -350,24 +350,24 @@ fn sparse_matrix_operations() {
         assert!(matrix.row(0).is_none());
     }
 
-     // SparseBitMatrix::subtract_row
-     {
+    // SparseBitMatrix::subtract_row
+    {
         let mut matrix = matrix.clone();
         assert!(!matrix.subtract_row(3, &disjoint));
         assert!(matrix.subtract_row(3, &subset));
         assert!(matrix.subtract_row(3, &superset));
         matrix.intersect_row(0, &disjoint);
         assert!(matrix.row(0).is_none());
-     }
+    }
 
-     // SparseBitMatrix::union_row 
-     {
+    // SparseBitMatrix::union_row
+    {
         let mut matrix = matrix.clone();
         assert!(!matrix.union_row(3, &subset));
         assert!(matrix.union_row(3, &disjoint));
         matrix.union_row(0, &disjoint);
         assert!(matrix.row(0).is_some());
-     }
+    }
 }
 
 /// Merge dense hybrid set into empty sparse hybrid set.

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -120,12 +120,12 @@ fn hybrid_bitset() {
 
     // dense / sparse where sparse superset dense
     let dense038 = sparse038.to_dense();
-    assert!(!sparse0381.clone().union(&dense038));
-    assert!(dense038.clone().union(&sparse0381));
-    assert!(sparse0381.clone().intersect(&dense038));
-    assert!(!dense038.clone().intersect(&sparse0381));
-    assert!(sparse0381.clone().subtract(&dense038));
-    assert!(dense038.clone().subtract(&sparse0381));
+    assert!(!sparse01358.clone().union(&dense038));
+    assert!(dense038.clone().union(&sparse01358));
+    assert!(sparse01358.clone().intersect(&dense038));
+    assert!(!dense038.clone().intersect(&sparse01358));
+    assert!(sparse01358.clone().subtract(&dense038));
+    assert!(dense038.clone().subtract(&sparse01358));
 
     let mut dense = dense10.clone();
     assert!(dense.union(&dense256));

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -344,8 +344,8 @@ fn sparse_matrix_operations() {
     // SparseBitMatrix::intersect_row
     {
         let mut matrix = matrix.clone();
-        assert!(!matrix.intersect_row(2, &superset));
-        assert!(matrix.intersect_row(2, &subset));
+        assert!(!matrix.intersect_row(3, &superset));
+        assert!(matrix.intersect_row(3, &subset));
         matrix.intersect_row(0, &disjoint);
         assert!(matrix.row(0).is_none());
     }
@@ -353,9 +353,9 @@ fn sparse_matrix_operations() {
      // SparseBitMatrix::subtract_row
      {
         let mut matrix = matrix.clone();
-        assert!(!matrix.subtract_row(2, &disjoint));
-        assert!(matrix.subtract_row(2, &subset));
-        assert!(matrix.subtract_row(2, &superset));
+        assert!(!matrix.subtract_row(3, &disjoint));
+        assert!(matrix.subtract_row(3, &subset));
+        assert!(matrix.subtract_row(3, &superset));
         matrix.intersect_row(0, &disjoint);
         assert!(matrix.row(0).is_none());
      }
@@ -363,8 +363,8 @@ fn sparse_matrix_operations() {
      // SparseBitMatrix::union_row 
      {
         let mut matrix = matrix.clone();
-        assert!(!matrix.union_row(2, &subset));
-        assert!(matrix.union_row(2, &disjoint));
+        assert!(!matrix.union_row(3, &subset));
+        assert!(matrix.union_row(3, &disjoint));
         matrix.union_row(0, &disjoint);
         assert!(matrix.row(0).is_some());
      }

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -110,11 +110,22 @@ fn hybrid_bitset() {
     assert!(hybrid.superset(&sparse01358) && sparse01358.superset(&hybrid));
     assert!(!dense10.union(&sparse01358));
     assert!(!dense256.union(&dense10));
-    let mut dense = dense10;
+
+    assert!(dense10.clone().intersect(&sparse01358));
+    assert!(!sparse01358.clone().intersect(&dense10));
+    assert!(dense10.clone().subtract(&sparse01358));
+    assert!(sparse01358.clone().subtract(&dense10));
+
+    let mut dense = dense10.clone();
     assert!(dense.union(&dense256));
     assert!(dense.superset(&dense256) && dense256.superset(&dense));
     assert!(hybrid.union(&dense256));
     assert!(hybrid.superset(&dense256) && dense256.superset(&hybrid));
+
+    assert!(!dense10.clone().intersect(&dense256));
+    assert!(dense256.clone().intersect(&dense10));
+    assert!(dense10.clone().subtract(&dense256));
+    assert!(dense256.clone().subtract(&dense10));
 
     assert_eq!(dense256.iter().count(), 256);
     let mut dense0 = dense256;

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -108,13 +108,24 @@ fn hybrid_bitset() {
     assert!(!sparse01358.union(&hybrid)); // no change
     assert!(hybrid.union(&sparse01358));
     assert!(hybrid.superset(&sparse01358) && sparse01358.superset(&hybrid));
-    assert!(!dense10.union(&sparse01358));
     assert!(!dense256.union(&dense10));
 
+    // dense / sparse where dense superset sparse
+    assert!(!dense10.clone().union(&sparse01358));
+    assert!(sparse01358.clone().union(&dense10));
     assert!(dense10.clone().intersect(&sparse01358));
     assert!(!sparse01358.clone().intersect(&dense10));
     assert!(dense10.clone().subtract(&sparse01358));
     assert!(sparse01358.clone().subtract(&dense10));
+
+    // dense / sparse where sparse superset dense
+    let dense038 = sparse038.to_dense();
+    assert!(!sparse0381.clone().union(&dense038));
+    assert!(dense038.clone().union(&sparse0381));
+    assert!(sparse0381.clone().intersect(&dense038));
+    assert!(!dense038.clone().intersect(&sparse0381));
+    assert!(sparse0381.clone().subtract(&dense038));
+    assert!(dense038.clone().subtract(&sparse0381));
 
     let mut dense = dense10.clone();
     assert!(dense.union(&dense256));

--- a/compiler/rustc_mir/src/borrow_check/region_infer/values.rs
+++ b/compiler/rustc_mir/src/borrow_check/region_infer/values.rs
@@ -160,7 +160,7 @@ impl<N: Idx> LivenessValues<N> {
     /// region. Returns whether any of them are newly added.
     crate fn add_elements(&mut self, row: N, locations: &HybridBitSet<PointIndex>) -> bool {
         debug!("LivenessValues::add_elements(row={:?}, locations={:?})", row, locations);
-        self.points.union_into_row(row, locations)
+        self.points.union_row(row, locations)
     }
 
     /// Adds all the control-flow points to the values for `r`.
@@ -294,7 +294,7 @@ impl<N: Idx> RegionValues<N> {
     /// the region `to` in `self`.
     crate fn merge_liveness<M: Idx>(&mut self, to: N, from: M, values: &LivenessValues<M>) {
         if let Some(set) = values.points.row(from) {
-            self.points.union_into_row(to, set);
+            self.points.union_row(to, set);
         }
     }
 

--- a/compiler/rustc_mir/src/transform/generator.rs
+++ b/compiler/rustc_mir/src/transform/generator.rs
@@ -626,7 +626,7 @@ fn compute_storage_conflicts(
     // Locals that are always live or ones that need to be stored across
     // suspension points are not eligible for overlap.
     let mut ineligible_locals = always_live_locals.into_inner();
-    ineligible_locals.intersect(saved_locals);
+    ineligible_locals.intersect(&**saved_locals);
 
     // Compute the storage conflicts for all eligible locals.
     let mut visitor = StorageConflictVisitor {
@@ -701,7 +701,7 @@ impl<'body, 'tcx, 's> StorageConflictVisitor<'body, 'tcx, 's> {
         }
 
         let mut eligible_storage_live = flow_state.clone();
-        eligible_storage_live.intersect(&self.saved_locals);
+        eligible_storage_live.intersect(&**self.saved_locals);
 
         for local in eligible_storage_live.iter() {
             self.local_conflicts.union_row_with(&eligible_storage_live, local);


### PR DESCRIPTION
I need the ability to clear the bits out of a row from `SparseBitMatrix`. Currently, all the mutating methods only allow insertion of bits, and there is no way to get access to the underlying data. 

One approach is simply to make `ensure_row` public, since it grants `&mut` access to the underlying `HybridBitSet`. This PR adds the `pub` modifier. However, presumably this method was private for a reason, so I'm open to other designs. I would prefer general mutable access to the rows, because that way I can add many mutating operations (`clear`, `intersect`, etc.) without filing a PR each time :-)

r? @ecstatic-morse 