### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.44+curl-7.77.0"
+version = "0.4.45+curl-7.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
+checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
19 commits in e96bdb0c3d0a418e7fcd7fbd69be08abf830b4bc..f559c109cc79fe413a8535fb620a5a58b3823d94
2021-08-17 22:58:47 +0000 to 2021-08-26 22:54:55 +0000
- Fix test not to rely on `cargo` in PATH. (rust-lang/cargo#9843)
- Improve resolver message to include dependency requirements (rust-lang/cargo#9827)
- Add hint for cargo metadata in environment section (rust-lang/cargo#9836)
- Fix panic with build-std of a proc-macro. (rust-lang/cargo#9834)
- Fix typos “a”→“an” (rust-lang/cargo#9821)
- Fix typo in git-authentication.md (rust-lang/cargo#9832)
- Add some debug logging for `cargo fix` (rust-lang/cargo#9831)
- Add documentation about third-party registries. (rust-lang/cargo#9830)
- unset the FIX_ENV when executing the real rustc (rust-lang/cargo#9818)
- Allow crate download by checksum (rust-lang/cargo#9801)
- Emit warning for migrating to unstable edition in stable channel (rust-lang/cargo#9792)
- Warning for no lib dependencies (rust-lang/cargo#9771)
- Temporarily disable extern-html-root-url test. (rust-lang/cargo#9824)
- Move `tmp` test directory. (rust-lang/cargo#9814)
- Fix test incorrectly validating CARGO_PKG_LICENSE_FILE. (rust-lang/cargo#9813)
- Implement `[future-incompat-report]` config section (rust-lang/cargo#9774)
- Bump curl. (rust-lang/cargo#9809)
- Determine packages to install prior to installing (rust-lang/cargo#9793)
- Show feature resolver differences for dev-dependencies. (rust-lang/cargo#9803)