### PR TITLE
[beta] Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.44+curl-7.77.0"
+version = "0.4.45+curl-7.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
+checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
2 commits in 1f76a218bc7f326606dda811b58c42b7e1e21168..32da73ab19417aa89686e1d85c1440b72fdf877d
2021-07-29 22:22:25 +0000 to 2021-08-23 18:16:08 +0000
- [beta] Move `tmp` test directory. (rust-lang/cargo#9819)
- [beta] Bump curl (rust-lang/cargo#9810)