### PR TITLE
Optimize BinaryHeap::extend from Vec

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1584,6 +1584,14 @@ impl<T: Ord, I: IntoIterator<Item = T>> SpecExtend<I> for BinaryHeap<T> {
     }
 }
 
+impl<T: Ord> SpecExtend<Vec<T>> for BinaryHeap<T> {
+    fn spec_extend(&mut self, ref mut other: Vec<T>) {
+        let start = self.data.len();
+        self.data.append(other);
+        self.rebuild_tail(start);
+    }
+}
+
 impl<T: Ord> SpecExtend<BinaryHeap<T>> for BinaryHeap<T> {
     fn spec_extend(&mut self, ref mut other: BinaryHeap<T>) {
         self.append(other);


### PR DESCRIPTION
This improves the performance of extending `BinaryHeap`s from vectors directly. Future work may involve extending this optimization to other, similar, cases where the length of the added elements is well-known, but this is not yet done in this PR.