### PR TITLE
Stabilise raw_os_nonzero (NonZero_c_* integers)

### DIFF
--- a/library/std/src/os/raw/mod.rs
+++ b/library/std/src/os/raw/mod.rs
@@ -39,7 +39,7 @@ macro_rules! type_alias {
         type_alias_no_nz! { $Docfile, $Alias = $Real; $( $Cfg )* }
 
         #[doc = concat!("Type alias for `NonZero` version of [`", stringify!($Alias), "`]")]
-        #[unstable(feature = "raw_os_nonzero", issue = "82363")]
+        #[stable(feature = "raw_os_nonzero", since = "1.56.0")]
         $( $Cfg )*
         pub type $NZAlias = $NZReal;
     }


### PR DESCRIPTION
This stabilises `raw_os_nonzero`, `NonZero_c_int` etc.  Tracking issue #82363, FCP needed.

This was implemented in #82228 and merged in February.

There is one outstanding question, that of naming: should we be consistent with `c_int`, `c_long`, etc., or with `NonZeroU32` etc. ?  I chose the former and that's what's been in nightly since February.  There are arguments for the latter.  This is a bikeshed issue, but we do need to fix the colour of the paint before stabilisation.