### PR TITLE
Manual Debug for Unix ExitCode ExitStatus ExitStatusError

### DIFF
--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -457,8 +457,14 @@ impl fmt::Debug for Command {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct ExitCode(u8);
+
+impl fmt::Debug for ExitCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("unix_exit_status").field(&self.0).finish()
+    }
+}
 
 impl ExitCode {
     pub const SUCCESS: ExitCode = ExitCode(EXIT_SUCCESS as _);

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -607,8 +607,14 @@ impl Process {
 }
 
 /// Unix exit statuses
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct ExitStatus(c_int);
+
+impl fmt::Debug for ExitStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("unix_wait_status").field(&self.0).finish()
+    }
+}
 
 impl ExitStatus {
     pub fn new(status: c_int) -> ExitStatus {
@@ -683,12 +689,18 @@ impl fmt::Display for ExitStatus {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct ExitStatusError(NonZero_c_int);
 
 impl Into<ExitStatus> for ExitStatusError {
     fn into(self) -> ExitStatus {
         ExitStatus(self.0.into())
+    }
+}
+
+impl fmt::Debug for ExitStatusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("unix_wait_status").field(&self.0).finish()
     }
 }
 


### PR DESCRIPTION
These structs have misleading names.  An ExitStatus[Error] is actually a Unix wait status; an ExitCode is actually an exit status.  These misleading names appear in the `Debug` output.

The `Display` impls on Unix have been improved, but the `Debug` impls are still misleading, as reported in #74832.

Fix this by pretending that these internal structs are called `unix_exit_status` and `unix_wait_status` as applicable.  (We can't actually rename the structs because of the way that the cross-platform machinery works: the names are cross-platform.)

After this change, this program
```
#![feature(exit_status_error)]
fn main(){
    let x = std::process::Command::new("false").status().unwrap();
    dbg!(x.exit_ok());
    eprintln!("x={:?}",x);
}
```
produces this output
```
[src/main.rs:4] x.exit_ok() = Err(
    ExitStatusError(
        unix_wait_status(
            256,
        ),
    ),
)
x=ExitStatus(unix_wait_status(256))
```

Closes #74832