### PR TITLE
ErrorKind::ProcessFailed and impl From<ExitStatusError>

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -289,7 +289,7 @@ pub enum ErrorKind {
     /// A subprocess (eg, run by a
     /// [`Command`](crate::process::Command)) failed.
     ///
-    /// Often wraps an
+    /// Often an [`io::Error`](`crate::io::Error`) with this kind wraps an
     /// [`ExitStatusError`](crate::process::ExitStatusError),
     /// (perhaps via `?` and `Into`), in which case
     /// [`io::Error::get_ref`](crate::io::Error::get_ref) or

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -287,7 +287,7 @@ pub enum ErrorKind {
     /// Subprocess failed.
     ///
     /// A subprocess (eg, run by a
-    /// [`Command`](care::process::Command)) failed.
+    /// [`Command`](crate::process::Command)) failed.
     ///
     /// Often wraps an
     /// [`ExitStatusError`](crate::process::ExitStatusError),

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -292,7 +292,7 @@ pub enum ErrorKind {
     /// Often wraps an
     /// [`ExitStatusError`](crate::process::ExitStatusError),
     /// (perhaps via `?` and `Into`), in which case
-    /// [`io::Error::get_ref`](crate::io::error::get_ref) or
+    /// [`io::Error::get_ref`](crate::io::Error::get_ref) or
     /// [`std::error::Error::source`](crate::error::Error::source)
     /// is the `ExitStatusError`,
     /// allowing the subprocess's exit status to be obtained.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1636,6 +1636,13 @@ impl fmt::Display for ExitStatusError {
 #[unstable(feature = "exit_status_error", issue = "84908")]
 impl crate::error::Error for ExitStatusError {}
 
+#[unstable(feature = "exit_status_error", issue = "84908")]
+impl From<ExitStatusError> for io::Error {
+    fn from(ese: ExitStatusError) -> io::Error {
+        io::Error::new(io::ErrorKind::SubprocessFailed, ese)
+    }
+}
+
 /// This type represents the status code a process can return to its
 /// parent under normal termination.
 ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1530,6 +1530,9 @@ impl crate::sealed::Sealed for ExitStatusError {}
 ///
 /// Produced by the [`.exit_ok`](ExitStatus::exit_ok) method on [`ExitStatus`].
 ///
+/// Implements [`Into<io::Error>`], producing an [`io::Error`]
+/// of kind [`Subprocessfailed`](io::ErrorKind::SubprocessFailed).
+///
 /// # Examples
 ///
 /// ```

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -129,7 +129,11 @@ fn test_process_status() {
 #[test]
 fn test_process_output_fail_to_start() {
     match Command::new("/no-binary-by-this-name-should-exist").output() {
-        Err(e) => assert_eq!(e.kind(), ErrorKind::NotFound),
+        Err(e) => {
+            assert_eq!(e.kind(), ErrorKind::NotFound);
+            #[cfg(unix)] // Feel free to adjust/disable if this varies on some platform
+            assert_eq!(e.to_string(), "No such file or directory (os error 2)");
+        },
         Ok(..) => panic!(),
     }
 }

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -133,7 +133,7 @@ fn test_process_output_fail_to_start() {
             assert_eq!(e.kind(), ErrorKind::NotFound);
             #[cfg(unix)] // Feel free to adjust/disable if this varies on some platform
             assert_eq!(e.to_string(), "No such file or directory (os error 2)");
-        },
+        }
         Ok(..) => panic!(),
     }
 }


### PR DESCRIPTION
I think this impl makes process error handling a lot more ergonomic.  Look at the new example to see what I mean.

If we are going to do this, it makes more sense to do it now, while `ExitStatusError` is unstable.  We can experiment with how we like the results, without insta-stably providing the trait impl.

There is a possible concern related to the resulting error messages.  Because of the way `io::Error`'s `Display` impl simply forwards to the underlying error, the message `"subprocess failed"` won't be part of those errors.

But the `Display` impl on `ExitStatusError` prefixes the message from `ExitStatus` with `"process exited unsuccessfully"`, which is nicely unambiguous.

https://github.com/rust-lang/rust/issues/84908#issuecomment-864580297 has more discussion about this in the context of the other possible messages arising from process handling, in particular `Command::status()`.

### Other possibilities

This ability to represent a subprocess failure status as an `io::Error` will be useful in other situations:

This would make it possible to provide an `exit_ok` method on `Command`, improving the ergonomics of simple subprocess executions.

It would also make it much more possible to provide a version of `Command::output` that is less prone to the programmer accidentally losing the exit status.  It would even be possible to provide a "streaming" version of the output: a type which would encompass the `Child` and the pipe, and `impl io::Read`, and which would give a read error if the child failed.

Just the `ErrorKind` could be helpful for some other libraries that can otherwise use `io::Error` for their error handling.

**Note** this MR branch is on top of #88298 which has already been approved and I expect to land soon.

Let me see if I can get highfive to do what I want:
r? @yaahc 
