### PR TITLE
Treat types in unnormalized function signatures as well-formed

### DIFF
--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -908,6 +908,7 @@ fn check_where_clauses<'tcx, 'fcx>(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(fcx, span, hir_decl))]
 fn check_fn_or_method<'fcx, 'tcx>(
     fcx: &FnCtxt<'fcx, 'tcx>,
     span: Span,
@@ -917,6 +918,11 @@ fn check_fn_or_method<'fcx, 'tcx>(
     implied_bounds: &mut Vec<Ty<'tcx>>,
 ) {
     let sig = fcx.tcx.liberate_late_bound_regions(def_id, sig);
+
+    // Unnormalized types in signature are WF too
+    implied_bounds.extend(sig.inputs());
+    // FIXME(#27579) return types should not be implied bounds
+    implied_bounds.push(sig.output());
 
     // Normalize the input and output types one at a time, using a different
     // `WellFormedLoc` for each. We cannot call `normalize_associated_types`
@@ -967,8 +973,10 @@ fn check_fn_or_method<'fcx, 'tcx>(
         ObligationCauseCode::ReturnType,
     );
 
-    // FIXME(#25759) return types should not be implied bounds
+    // FIXME(#27579) return types should not be implied bounds
     implied_bounds.push(sig.output());
+
+    debug!(?implied_bounds);
 
     check_where_clauses(fcx, span, def_id, Some((sig.output(), hir_decl.output.span())));
 }
@@ -1116,6 +1124,7 @@ const HELP_FOR_SELF_TYPE: &str = "consider changing to `self`, `&self`, `&mut se
      `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one \
      of the previous types except `Self`)";
 
+#[tracing::instrument(level = "debug", skip(fcx))]
 fn check_method_receiver<'fcx, 'tcx>(
     fcx: &FnCtxt<'fcx, 'tcx>,
     fn_sig: &hir::FnSig<'_>,

--- a/src/test/ui/generic-associated-types/issue-87748.rs
+++ b/src/test/ui/generic-associated-types/issue-87748.rs
@@ -1,0 +1,30 @@
+// Checks that we properly add implied bounds from unnormalized projections in
+// inputs when typechecking functions.
+
+// check-pass
+
+#![feature(generic_associated_types)]
+
+trait MyTrait {
+    type Assoc<'a, 'b> where 'b: 'a;
+    fn do_sth(arg: Self::Assoc<'_, '_>);
+}
+
+struct A;
+struct B;
+struct C;
+
+impl MyTrait for A {
+    type Assoc<'a, 'b> where 'b: 'a = u32;
+    fn do_sth(_: u32) {}
+}
+impl MyTrait for B {
+    type Assoc<'a, 'b> where 'b: 'a = u32;
+    fn do_sth(_: Self::Assoc<'_, '_>) {}
+}
+impl MyTrait for C {
+    type Assoc<'a, 'b> where 'b: 'a = u32;
+    fn do_sth(_: Self::Assoc<'static, 'static>) {}
+}
+
+fn main () {}


### PR DESCRIPTION
Fixes #87748

r? @nikomatsakis 