### PR TITLE
Remove most box syntax uses from the testsuite except for src/test/ui/issues 

### DIFF
--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -63,7 +63,6 @@
 // lldbr-check:(f64) *unique_val_interior_ref_2 = 26.5
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -79,7 +78,7 @@ fn main() {
     let stack_val_interior_ref_2: &f64 = &stack_val.y;
     let ref_to_unnamed: &SomeStruct = &SomeStruct { x: 11, y: 24.5 };
 
-    let unique_val: Box<_> = box SomeStruct { x: 13, y: 26.5 };
+    let unique_val: Box<_> = Box::new(SomeStruct { x: 13, y: 26.5 });
     let unique_val_ref: &SomeStruct = &*unique_val;
     let unique_val_interior_ref_1: &isize = &unique_val.x;
     let unique_val_interior_ref_2: &f64 = &unique_val.y;

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -37,7 +37,6 @@
 
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -46,7 +45,7 @@ fn main() {
     let stack_val_ref: &(i16, f32) = &stack_val;
     let ref_to_unnamed: &(i16, f32) = &(-15, -20f32);
 
-    let unique_val: Box<(i16, f32)> = box (-17, -22f32);
+    let unique_val: Box<(i16, f32)> = Box::new((-17, -22f32));
     let unique_val_ref: &(i16, f32) = &*unique_val;
 
     zzz(); // #break

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -116,51 +116,50 @@
 // lldbr-check:(f64) *f64_ref = 3.5
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
 fn main() {
-    let bool_box: Box<bool> = box true;
+    let bool_box: Box<bool> = Box::new(true);
     let bool_ref: &bool = &*bool_box;
 
-    let int_box: Box<isize> = box -1;
+    let int_box: Box<isize> = Box::new(-1);
     let int_ref: &isize = &*int_box;
 
-    let char_box: Box<char> = box 'a';
+    let char_box: Box<char> = Box::new('a');
     let char_ref: &char = &*char_box;
 
-    let i8_box: Box<i8> = box 68;
+    let i8_box: Box<i8> = Box::new(68);
     let i8_ref: &i8 = &*i8_box;
 
-    let i16_box: Box<i16> = box -16;
+    let i16_box: Box<i16> = Box::new(-16);
     let i16_ref: &i16 = &*i16_box;
 
-    let i32_box: Box<i32> = box -32;
+    let i32_box: Box<i32> = Box::new(-32);
     let i32_ref: &i32 = &*i32_box;
 
-    let i64_box: Box<i64> = box -64;
+    let i64_box: Box<i64> = Box::new(-64);
     let i64_ref: &i64 = &*i64_box;
 
-    let uint_box: Box<usize> = box 1;
+    let uint_box: Box<usize> = Box::new(1);
     let uint_ref: &usize = &*uint_box;
 
-    let u8_box: Box<u8> = box 100;
+    let u8_box: Box<u8> = Box::new(100);
     let u8_ref: &u8 = &*u8_box;
 
-    let u16_box: Box<u16> = box 16;
+    let u16_box: Box<u16> = Box::new(16);
     let u16_ref: &u16 = &*u16_box;
 
-    let u32_box: Box<u32> = box 32;
+    let u32_box: Box<u32> = Box::new(32);
     let u32_ref: &u32 = &*u32_box;
 
-    let u64_box: Box<u64> = box 64;
+    let u64_box: Box<u64> = Box::new(64);
     let u64_ref: &u64 = &*u64_box;
 
-    let f32_box: Box<f32> = box 2.5;
+    let f32_box: Box<f32> = Box::new(2.5);
     let f32_ref: &f32 = &*f32_box;
 
-    let f64_box: Box<f64> = box 3.5;
+    let f64_box: Box<f64> = Box::new(3.5);
     let f64_ref: &f64 = &*f64_box;
 
     zzz(); // #break

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -24,13 +24,12 @@
 // lldbr-check:((i32, f64)) *b = { 0 = 2 1 = 3.5 }
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
 fn main() {
-    let a = box 1;
-    let b = box (2, 3.5f64);
+    let a = Box::new(1);
+    let b = Box::new((2, 3.5f64));
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -28,7 +28,6 @@
 // lldbr-check:(boxed_struct::StructWithDestructor) *boxed_with_dtor = { x = 77 y = 777 z = 7777 w = 77777 }
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -52,9 +51,19 @@ impl Drop for StructWithDestructor {
 
 fn main() {
 
-    let boxed_with_padding: Box<_> = box StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 };
+    let boxed_with_padding: Box<_> = Box::new(StructWithSomePadding {
+        x: 99,
+        y: 999,
+        z: 9999,
+        w: 99999,
+    });
 
-    let boxed_with_dtor: Box<_> = box StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 };
+    let boxed_with_dtor: Box<_> = Box::new(StructWithDestructor {
+        x: 77,
+        y: 777,
+        z: 7777,
+        w: 77777,
+    });
     zzz(); // #break
 }
 

--- a/src/test/debuginfo/closure-in-generic-function.rs
+++ b/src/test/debuginfo/closure-in-generic-function.rs
@@ -39,7 +39,6 @@
 // lldbr-check:(i32) *y = 110
 // lldb-command:continue
 
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -358,7 +358,6 @@
 
 #![allow(unused_variables)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -480,7 +479,7 @@ fn main() {
     managed_box(&(34, 35));
     borrowed_pointer(&(36, 37));
     contained_borrowed_pointer((&38, 39));
-    unique_pointer(box (40, 41, 42));
+    unique_pointer(Box::new((40, 41, 42)));
     ref_binding((43, 44, 45));
     ref_binding_in_tuple((46, (47, 48)));
     ref_binding_in_struct(Struct { a: 49, b: 50 });

--- a/src/test/debuginfo/destructured-for-loop-variable.rs
+++ b/src/test/debuginfo/destructured-for-loop-variable.rs
@@ -173,7 +173,6 @@
 
 #![allow(unused_variables)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -214,7 +213,7 @@ fn main() {
             y: -300001.5,
             z: true
          },
-         box 854237.5);
+         Box::new(854237.5));
 
     for &(v1,
           &Struct { x: x1, y: ref y1, z: z1 },

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -285,7 +285,6 @@
 
 #![allow(unused_variables)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -345,7 +344,7 @@ fn main() {
     let (&cc, _) = (&38, 39);
 
     // unique pointer
-    let box dd = box (40, 41, 42);
+    let box dd = Box::new((40, 41, 42));
 
     // ref binding
     let ref ee = (43, 44, 45);

--- a/src/test/debuginfo/generic-method-on-generic-struct.rs
+++ b/src/test/debuginfo/generic-method-on-generic-struct.rs
@@ -123,7 +123,6 @@
 // lldbr-check:(f32) arg2 = -10.5
 // lldb-command:continue
 
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -155,7 +154,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, 2_u16);
     let _ = stack.self_by_val(-3, -4_i16);
 
-    let owned: Box<_> = box Struct { x: 1234.5f64 };
+    let owned: Box<_> = Box::new(Struct { x: 1234.5f64 });
     let _ = owned.self_by_ref(-5, -6_i32);
     let _ = owned.self_by_val(-7, -8_i64);
     let _ = owned.self_owned(-9, -10.5_f32);

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -107,7 +107,6 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -140,7 +139,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box Enum::Variant1{ x: 1799, y: 1799 };
+    let owned: Box<_> = Box::new(Enum::Variant1{ x: 1799, y: 1799 });
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/method-on-generic-struct.rs
+++ b/src/test/debuginfo/method-on-generic-struct.rs
@@ -123,8 +123,6 @@
 // lldbr-check:(isize) arg2 = -10
 // lldb-command:continue
 
-
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -156,7 +154,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box Struct { x: 1234.5f64 };
+    let owned: Box<_> = Box::new(Struct { x: 1234.5f64 });
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/method-on-struct.rs
+++ b/src/test/debuginfo/method-on-struct.rs
@@ -121,8 +121,6 @@
 // lldbr-check:(isize) arg2 = -10
 // lldb-command:continue
 
-
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -154,7 +152,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box Struct { x: 200 };
+    let owned: Box<_> = Box::new(Struct { x: 200 });
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/method-on-trait.rs
+++ b/src/test/debuginfo/method-on-trait.rs
@@ -121,8 +121,6 @@
 // lldbr-check:(isize) arg2 = -10
 // lldb-command:continue
 
-
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -160,7 +158,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box Struct { x: 200 };
+    let owned: Box<_> = Box::new(Struct { x: 200 });
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/method-on-tuple-struct.rs
+++ b/src/test/debuginfo/method-on-tuple-struct.rs
@@ -121,8 +121,6 @@
 // lldbr-check:(isize) arg2 = -10
 // lldb-command:continue
 
-
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -152,7 +150,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box TupleStruct(200, -200.5);
+    let owned: Box<_> = Box::new(TupleStruct(200, -200.5));
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -52,20 +52,20 @@
 // gdb-command:print long_cycle4.value
 // gdb-check:$18 = 29.5
 
-// gdbr-command:print long_cycle_w_anonymous_types.value
+// gdbr-command:print long_cycle_w_anon_types.value
 // gdb-check:$19 = 30
 
-// gdbr-command:print long_cycle_w_anonymous_types.next.val.value
+// gdbr-command:print long_cycle_w_anon_types.next.val.value
 // gdb-check:$20 = 31
 
 // gdb-command:continue
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
 use self::Opt::{Empty, Val};
+use std::boxed::Box as B;
 
 enum Opt<T> {
     Empty,
@@ -120,75 +120,75 @@ struct LongCycleWithAnonymousTypes {
 fn main() {
     let stack_unique: UniqueNode<u16> = UniqueNode {
         next: Val {
-            val: box UniqueNode {
+            val: Box::new(UniqueNode {
                 next: Empty,
                 value: 1,
-            }
+            })
         },
         value: 0,
     };
 
-    let unique_unique: Box<UniqueNode<u32>> = box UniqueNode {
+    let unique_unique: Box<UniqueNode<u32>> = Box::new(UniqueNode {
         next: Val {
-            val: box UniqueNode {
+            val: Box::new(UniqueNode {
                 next: Empty,
                 value: 3,
-            }
+            })
         },
         value: 2,
-    };
+    });
 
     let vec_unique: [UniqueNode<f32>; 1] = [UniqueNode {
         next: Val {
-            val: box UniqueNode {
+            val: Box::new(UniqueNode {
                 next: Empty,
                 value: 7.5,
-            }
+            })
         },
         value: 6.5,
     }];
 
     let borrowed_unique: &UniqueNode<f64> = &UniqueNode {
         next: Val {
-            val: box UniqueNode {
+            val: Box::new(UniqueNode {
                 next: Empty,
                 value: 9.5,
-            }
+            })
         },
         value: 8.5,
     };
 
     // LONG CYCLE
     let long_cycle1: LongCycle1<u16> = LongCycle1 {
-        next: box LongCycle2 {
-            next: box LongCycle3 {
-                next: box LongCycle4 {
+        next: Box::new(LongCycle2 {
+            next: Box::new(LongCycle3 {
+                next: Box::new(LongCycle4 {
                     next: None,
                     value: 23,
-                },
+                }),
                 value: 22,
-            },
+            }),
             value: 21
-        },
+        }),
         value: 20
     };
 
     let long_cycle2: LongCycle2<u32> = LongCycle2 {
-        next: box LongCycle3 {
-            next: box LongCycle4 {
+        next: Box::new(LongCycle3 {
+            next: Box::new(LongCycle4 {
                 next: None,
                 value: 26,
-            },
+            }),
             value: 25,
-        },
+        }),
         value: 24
     };
 
     let long_cycle3: LongCycle3<u64> = LongCycle3 {
-        next: box LongCycle4 {
+        next: Box::new(LongCycle4 {
             next: None,
             value: 28,
-        },
+        }),
         value: 27,
     };
 
@@ -199,15 +199,15 @@ fn main() {
 
     // It's important that LongCycleWithAnonymousTypes is encountered only at the end of the
     // `box` chain.
-    let long_cycle_w_anonymous_types = box box box box box LongCycleWithAnonymousTypes {
+    let long_cycle_w_anon_types = B::new(B::new(B::new(B::new(B::new(LongCycleWithAnonymousTypes {
         next: Val {
-            val: box box box box box LongCycleWithAnonymousTypes {
+            val: Box::new(Box::new(Box::new(Box::new(Box::new(LongCycleWithAnonymousTypes {
                 next: Empty,
                 value: 31,
-            }
+            })))))
         },
         value: 30
-    };
+    })))));
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/self-in-default-method.rs
+++ b/src/test/debuginfo/self-in-default-method.rs
@@ -121,7 +121,6 @@
 // lldbr-check:(isize) arg2 = -10
 // lldb-command:continue
 
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -154,7 +153,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, -2);
     let _ = stack.self_by_val(-3, -4);
 
-    let owned: Box<_> = box Struct { x: 200 };
+    let owned: Box<_> = Box::new(Struct { x: 200 });
     let _ = owned.self_by_ref(-5, -6);
     let _ = owned.self_by_val(-7, -8);
     let _ = owned.self_owned(-9, -10);

--- a/src/test/debuginfo/self-in-generic-default-method.rs
+++ b/src/test/debuginfo/self-in-generic-default-method.rs
@@ -121,7 +121,6 @@
 // lldbr-check:(f32) arg2 = -10.5
 // lldb-command:continue
 
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -155,7 +154,7 @@ fn main() {
     let _ = stack.self_by_ref(-1, 2_u16);
     let _ = stack.self_by_val(-3, -4_i16);
 
-    let owned: Box<_> = box Struct { x: 879 };
+    let owned: Box<_> = Box::new(Struct { x: 879 });
     let _ = owned.self_by_ref(-5, -6_i32);
     let _ = owned.self_by_val(-7, -8_i64);
     let _ = owned.self_owned(-9, -10.5_f32);

--- a/src/test/debuginfo/trait-pointers.rs
+++ b/src/test/debuginfo/trait-pointers.rs
@@ -5,7 +5,6 @@
 // lldb-command:run
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -24,5 +23,5 @@ impl Trait for Struct {}
 fn main() {
     let stack_struct = Struct { a:0, b: 1.0 };
     let reference: &Trait = &stack_struct as &Trait;
-    let unique: Box<Trait> = box Struct { a:2, b: 3.0 } as Box<Trait>;
+    let unique: Box<Trait> = Box::new(Struct { a:2, b: 3.0 }) as Box<Trait>;
 }

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -262,7 +262,6 @@
 // cdb-check:struct ForeignType2 * foreign2 = [...]
 // cdb-check:struct ForeignType1 * foreign1 = [...]
 
-#![feature(box_syntax)]
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
@@ -373,8 +372,8 @@ fn main() {
     let tuple2 = ((Struct1, mod1::mod2::Struct3), mod1::Variant1, 'x');
 
     // Box
-    let box1 = (box 1f32, 0i32);
-    let box2 = (box mod1::mod2::Variant2(1f32), 0i32);
+    let box1 = (Box::new(1f32), 0i32);
+    let box2 = (Box::new(mod1::mod2::Variant2(1f32)), 0i32);
 
     // References
     let ref1 = (&Struct1, 0i32);
@@ -404,14 +403,14 @@ fn main() {
     let slice2 = &*vec2;
 
     // Trait Objects
-    let box_trait = (box 0_isize) as Box<dyn Trait1>;
+    let box_trait = Box::new(0_isize) as Box<dyn Trait1>;
     let ref_trait = &0_isize as &dyn Trait1;
     let mut mut_int1 = 0_isize;
     let mut_ref_trait = (&mut mut_int1) as &mut dyn Trait1;
-    let no_principal_trait = (box 0_isize) as Box<(dyn Send + Sync)>;
+    let no_principal_trait = Box::new(0_isize) as Box<(dyn Send + Sync)>;
     let has_associated_type_trait = &0_isize as &(dyn Trait3<u32, AssocType = isize> + Send);
 
-    let generic_box_trait = (box 0_isize) as Box<dyn Trait2<i32, mod1::Struct2>>;
+    let generic_box_trait = Box::new(0_isize) as Box<dyn Trait2<i32, mod1::Struct2>>;
     let generic_ref_trait = (&0_isize) as &dyn Trait2<Struct1, Struct1>;
 
     let mut generic_mut_ref_trait_impl = 0_isize;

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -32,7 +32,6 @@
 // lldbr-check:(unique_enum::Univariant) *univariant = { TheOnlyCase = { = 123234 } }
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -59,15 +58,15 @@ fn main() {
     // 0b01111100011111000111110001111100 = 2088533116
     // 0b0111110001111100 = 31868
     // 0b01111100 = 124
-    let the_a: Box<_> = box ABC::TheA { x: 0, y: 8970181431921507452 };
+    let the_a: Box<_> = Box::new(ABC::TheA { x: 0, y: 8970181431921507452 });
 
     // 0b0001000100010001000100010001000100010001000100010001000100010001 = 1229782938247303441
     // 0b00010001000100010001000100010001 = 286331153
     // 0b0001000100010001 = 4369
     // 0b00010001 = 17
-    let the_b: Box<_> = box ABC::TheB (0, 286331153, 286331153);
+    let the_b: Box<_> = Box::new(ABC::TheB (0, 286331153, 286331153));
 
-    let univariant: Box<_> = box Univariant::TheOnlyCase(123234);
+    let univariant: Box<_> = Box::new(Univariant::TheOnlyCase(123234));
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -133,7 +133,6 @@
 // cdb-check:closure_local    : 8 [Type: [...]]
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -154,7 +153,7 @@ fn main() {
     };
 
     let struct_ref = &a_struct;
-    let owned: Box<_> = box 6;
+    let owned: Box<_> = Box::new(6);
 
     let mut closure = || {
         let closure_local = 8;

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -34,7 +34,6 @@
 // lldbr-check:(isize) *owned = 5
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -53,7 +52,7 @@ fn main() {
         c: 4
     };
 
-    let owned: Box<_> = box 5;
+    let owned: Box<_> = Box::new(5);
 
     let closure = move || {
         zzz(); // #break

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -115,7 +115,6 @@
 // cdb-command: dx owned
 // cdb-check:owned            : 0x[...] : 6 [Type: [...] *]
 
-#![feature(box_syntax)]
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
@@ -137,7 +136,7 @@ fn main() {
     };
 
     let struct_ref = &a_struct;
-    let owned: Box<_> = box 6;
+    let owned: Box<_> = Box::new(6);
 
     {
         let mut first_closure = || {

--- a/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax, plugin, rustc_private)]
+#![feature(plugin, rustc_private)]
 #![crate_type = "dylib"]
 
 extern crate rustc_ast_pretty;
@@ -21,7 +21,7 @@ use rustc_span::source_map;
 #[no_mangle]
 fn __rustc_plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&MISSING_ALLOWED_ATTR]);
-    reg.lint_store.register_late_pass(|| box MissingAllowedAttrPass);
+    reg.lint_store.register_late_pass(|| Box::new(MissingAllowedAttrPass));
 }
 
 declare_lint! {

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
@@ -1,7 +1,6 @@
 // force-host
 
 #![feature(rustc_private)]
-#![feature(box_syntax)]
 
 extern crate rustc_driver;
 extern crate rustc_hir;
@@ -73,7 +72,7 @@ fn __rustc_plugin_registrar(reg: &mut Registry) {
         &CRATE_NOT_GREY,
         &CRATE_NOT_GREEN,
     ]);
-    reg.lint_store.register_late_pass(|| box PassOkay);
-    reg.lint_store.register_late_pass(|| box PassRedBlue);
-    reg.lint_store.register_late_pass(|| box PassGreyGreen);
+    reg.lint_store.register_late_pass(|| Box::new(PassOkay));
+    reg.lint_store.register_late_pass(|| Box::new(PassRedBlue));
+    reg.lint_store.register_late_pass(|| Box::new(PassGreyGreen));
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
@@ -1,7 +1,6 @@
 // force-host
 
 #![feature(rustc_private)]
-#![feature(box_syntax)]
 
 extern crate rustc_driver;
 extern crate rustc_hir;
@@ -41,5 +40,5 @@ impl<'tcx> LateLintPass<'tcx> for Pass {
 #[no_mangle]
 fn __rustc_plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&CRATE_NOT_OKAY]);
-    reg.lint_store.register_late_pass(|| box Pass);
+    reg.lint_store.register_late_pass(|| Box::new(Pass));
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
@@ -1,6 +1,6 @@
 // force-host
 
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 // Load rustc as a plugin to get macros.
 extern crate rustc_driver;
@@ -36,7 +36,7 @@ impl<'tcx> LateLintPass<'tcx> for Pass {
 #[no_mangle]
 fn __rustc_plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&TEST_LINT, &PLEASE_LINT]);
-    reg.lint_store.register_late_pass(|| box Pass);
+    reg.lint_store.register_late_pass(|| Box::new(Pass));
     reg.lint_store.register_group(
         true,
         "lint_me",

--- a/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
@@ -1,6 +1,6 @@
 // force-host
 
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate rustc_ast;
 
@@ -31,5 +31,5 @@ impl EarlyLintPass for Pass {
 #[no_mangle]
 fn __rustc_plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&TEST_LINT]);
-    reg.lint_store.register_early_pass(|| box Pass);
+    reg.lint_store.register_early_pass(|| Box::new(Pass));
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
@@ -1,4 +1,4 @@
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate rustc_ast;
 
@@ -46,7 +46,7 @@ impl EarlyLintPass for Pass {
 #[no_mangle]
 fn __rustc_plugin_registrar(reg: &mut Registry) {
     reg.lint_store.register_lints(&[&TEST_RUSTC_TOOL_LINT, &TEST_LINT, &TEST_GROUP]);
-    reg.lint_store.register_early_pass(|| box Pass);
+    reg.lint_store.register_early_pass(|| Box::new(Pass));
     reg.lint_store.register_group(
         true,
         "clippy::group",

--- a/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
+++ b/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
@@ -1,6 +1,6 @@
 // force-host
 
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate rustc_middle;
 extern crate rustc_driver;
@@ -20,5 +20,5 @@ impl Drop for Foo {
 #[no_mangle]
 fn __rustc_plugin_registrar(_: &mut Registry) {
     thread_local!(static FOO: RefCell<Option<Box<Any+Send>>> = RefCell::new(None));
-    FOO.with(|s| *s.borrow_mut() = Some(box Foo { foo: 10 } as Box<Any+Send>));
+    FOO.with(|s| *s.borrow_mut() = Some(Box::new(Foo { foo: 10 }) as Box<Any+Send>));
 }

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -1,7 +1,6 @@
 // run-pass
 
 #![allow(unused_imports)]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 
 extern crate rustc_macros;

--- a/src/test/ui/alignment-gep-tup-like-1.rs
+++ b/src/test/ui/alignment-gep-tup-like-1.rs
@@ -3,8 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-#![feature(box_syntax)]
-
 struct pair<A,B> {
     a: A, b: B
 }
@@ -25,10 +23,10 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<dyn Invokable<A>+'static> {
-    box Invoker {
+    Box::new(Invoker {
         a: a,
         b: b,
-    } as Box<dyn Invokable<A>+'static>
+    }) as Box<dyn Invokable<A>+'static>
 }
 
 pub fn main() {

--- a/src/test/ui/array-slice-vec/vec-dst.rs
+++ b/src/test/ui/array-slice-vec/vec-dst.rs
@@ -1,11 +1,9 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    // Tests for indexing into box/& [T; n]
+    // Tests for indexing into Box<[T; n]>/& [T; n]
     let x: [isize; 3] = [1, 2, 3];
-    let mut x: Box<[isize; 3]> = box x;
+    let mut x: Box<[isize; 3]> = x.into();
     assert_eq!(x[0], 1);
     assert_eq!(x[1], 2);
     assert_eq!(x[2], 3);

--- a/src/test/ui/array-slice-vec/vector-no-ann-2.rs
+++ b/src/test/ui/array-slice-vec/vector-no-ann-2.rs
@@ -2,6 +2,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
-pub fn main() { let _quux: Box<Vec<usize>> = box Vec::new(); }
+pub fn main() {
+    let _quux: Box<Vec<usize>> = Box::new(Vec::new());
+}

--- a/src/test/ui/associated-types/associated-types-doubleendediterator-object.rs
+++ b/src/test/ui/associated-types/associated-types-doubleendediterator-object.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn pairwise_sub(mut t: Box<dyn DoubleEndedIterator<Item=isize>>) -> isize {
     let mut result = 0;

--- a/src/test/ui/autoderef-full-lval.rs
+++ b/src/test/ui/autoderef-full-lval.rs
@@ -1,23 +1,23 @@
-#![feature(box_syntax)]
-
 struct Clam {
     x: Box<isize>,
     y: Box<isize>,
 }
+
+
 
 struct Fish {
     a: Box<isize>,
 }
 
 fn main() {
-    let a: Clam = Clam{x: box 1, y: box 2};
-    let b: Clam = Clam{x: box 10, y: box 20};
+    let a: Clam = Clam{ x: Box::new(1), y: Box::new(2) };
+    let b: Clam = Clam{ x: Box::new(10), y: Box::new(20) };
     let z: isize = a.x + b.y;
     //~^ ERROR cannot add `Box<isize>` to `Box<isize>`
     println!("{}", z);
     assert_eq!(z, 21);
-    let forty: Fish = Fish{a: box 40};
-    let two: Fish = Fish{a: box 2};
+    let forty: Fish = Fish{ a: Box::new(40) };
+    let two: Fish = Fish{ a: Box::new(2) };
     let answer: isize = forty.a + two.a;
     //~^ ERROR cannot add `Box<isize>` to `Box<isize>`
     println!("{}", answer);

--- a/src/test/ui/autoref-autoderef/autoderef-method-on-trait.rs
+++ b/src/test/ui/autoref-autoderef/autoderef-method-on-trait.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> usize;
@@ -11,6 +10,6 @@ impl double for usize {
 }
 
 pub fn main() {
-    let x: Box<_> = box (box 3usize as Box<dyn double>);
+    let x: Box<_> = Box::new(Box::new(3usize) as Box<dyn double>);
     assert_eq!(x.double(), 6);
 }

--- a/src/test/ui/autoref-autoderef/autoderef-method-priority.rs
+++ b/src/test/ui/autoref-autoderef/autoderef-method-priority.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait double {
     fn double(self) -> usize;
@@ -15,6 +14,6 @@ impl double for Box<usize> {
 }
 
 pub fn main() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     assert_eq!(x.double(), 6);
 }

--- a/src/test/ui/autoref-autoderef/autoderef-method-twice-but-not-thrice.rs
+++ b/src/test/ui/autoref-autoderef/autoderef-method-twice-but-not-thrice.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> usize;
@@ -11,6 +10,6 @@ impl double for Box<usize> {
 }
 
 pub fn main() {
-    let x: Box<Box<Box<Box<Box<_>>>>> = box box box box box 3;
+    let x: Box<Box<Box<Box<Box<_>>>>> = Box::new(Box::new(Box::new(Box::new(Box::new(3)))));
     assert_eq!(x.double(), 6);
 }

--- a/src/test/ui/autoref-autoderef/autoderef-method-twice.rs
+++ b/src/test/ui/autoref-autoderef/autoderef-method-twice.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> usize;
@@ -11,6 +10,6 @@ impl double for usize {
 }
 
 pub fn main() {
-    let x: Box<Box<_>> = box box 3;
+    let x: Box<Box<_>> = Box::new(Box::new(3));
     assert_eq!(x.double(), 6);
 }

--- a/src/test/ui/autoref-autoderef/autoderef-method.rs
+++ b/src/test/ui/autoref-autoderef/autoderef-method.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> usize;
@@ -11,6 +10,6 @@ impl double for usize {
 }
 
 pub fn main() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     assert_eq!(x.double(), 6);
 }

--- a/src/test/ui/autoref-autoderef/autoref-intermediate-types-issue-3585.rs
+++ b/src/test/ui/autoref-autoderef/autoref-intermediate-types-issue-3585.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 trait Foo {
     fn foo(&self) -> String;
@@ -18,6 +17,6 @@ impl Foo for usize {
 }
 
 pub fn main() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     assert_eq!(x.foo(), "box 3".to_string());
 }

--- a/src/test/ui/binding/expr-match-generic-unique1.rs
+++ b/src/test/ui/binding/expr-match-generic-unique1.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn test_generic<T: Clone, F>(expected: Box<T>, eq: F) where F: FnOnce(Box<T>, Box<T>) -> bool {
     let actual: Box<T> = match true {
@@ -13,7 +12,7 @@ fn test_box() {
     fn compare_box(b1: Box<bool>, b2: Box<bool>) -> bool {
         return *b1 == *b2;
     }
-    test_generic::<bool, _>(box true, compare_box);
+    test_generic::<bool, _>(Box::new(true), compare_box);
 }
 
 pub fn main() { test_box(); }

--- a/src/test/ui/binding/expr-match-generic-unique2.rs
+++ b/src/test/ui/binding/expr-match-generic-unique2.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn test_generic<T: Clone, F>(expected: T, eq: F) where F: FnOnce(T, T) -> bool {
     let actual: T = match true {
@@ -11,7 +10,7 @@ fn test_generic<T: Clone, F>(expected: T, eq: F) where F: FnOnce(T, T) -> bool {
 
 fn test_vec() {
     fn compare_box(v1: Box<isize>, v2: Box<isize>) -> bool { return v1 == v2; }
-    test_generic::<Box<isize>, _>(box 1, compare_box);
+    test_generic::<Box<isize>, _>(Box::new(1), compare_box);
 }
 
 pub fn main() { test_vec(); }

--- a/src/test/ui/binding/expr-match-unique.rs
+++ b/src/test/ui/binding/expr-match-unique.rs
@@ -1,9 +1,8 @@
 // run-pass
-#![feature(box_syntax)]
 
 // Tests for match as expressions resulting in boxed types
 fn test_box() {
-    let res: Box<_> = match true { true => { box 100 }, _ => panic!() };
+    let res: Box<_> = match true { true => { Box::new(100) }, _ => panic!() };
     assert_eq!(*res, 100);
 }
 

--- a/src/test/ui/binding/func-arg-incomplete-pattern.rs
+++ b/src/test/ui/binding/func-arg-incomplete-pattern.rs
@@ -3,8 +3,6 @@
 // Test that we do not leak when the arg pattern must drop part of the
 // argument (in this case, the `y` field).
 
-#![feature(box_syntax)]
-
 struct Foo {
     x: Box<usize>,
     y: Box<usize>,
@@ -16,9 +14,9 @@ fn foo(Foo {x, ..}: Foo) -> *const usize {
 }
 
 pub fn main() {
-    let obj: Box<_> = box 1;
+    let obj: Box<_> = Box::new(1);
     let objptr: *const usize = &*obj;
-    let f = Foo {x: obj, y: box 2};
+    let f = Foo { x: obj, y: Box::new(2) };
     let xptr = foo(f);
     assert_eq!(objptr, xptr);
 }

--- a/src/test/ui/binding/func-arg-ref-pattern.rs
+++ b/src/test/ui/binding/func-arg-ref-pattern.rs
@@ -5,7 +5,6 @@
 // pattern.
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn getaddr(box ref x: Box<usize>) -> *const usize {
     let addr: *const usize = &*x;
@@ -17,11 +16,11 @@ fn checkval(box ref x: Box<usize>) -> usize {
 }
 
 pub fn main() {
-    let obj: Box<_> = box 1;
+    let obj: Box<_> = Box::new(1);
     let objptr: *const usize = &*obj;
     let xptr = getaddr(obj);
     assert_eq!(objptr, xptr);
 
-    let obj = box 22;
+    let obj = Box::new(22);
     assert_eq!(checkval(obj), 22);
 }

--- a/src/test/ui/binding/let-assignability.rs
+++ b/src/test/ui/binding/let-assignability.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f() {
-    let a: Box<_> = box 1;
+    let a: Box<_> = Box::new(1);
     let b: &isize = &*a;
     println!("{}", b);
 }

--- a/src/test/ui/binding/match-implicit-copy-unique.rs
+++ b/src/test/ui/binding/match-implicit-copy-unique.rs
@@ -1,16 +1,15 @@
 // run-pass
 #![allow(non_shorthand_field_patterns)]
-#![feature(box_syntax)]
 
 struct Pair { a: Box<isize>, b: Box<isize> }
 
 pub fn main() {
-    let mut x: Box<_> = box Pair {a: box 10, b: box 20};
+    let mut x: Box<_> = Box::new(Pair { a: Box::new(10), b: Box::new(20) });
     let x_internal = &mut *x;
     match *x_internal {
       Pair {a: ref mut a, b: ref mut _b} => {
         assert_eq!(**a, 10);
-        *a = box 30;
+        *a = Box::new(30);
         assert_eq!(**a, 30);
       }
     }

--- a/src/test/ui/binding/match-unique-bind.rs
+++ b/src/test/ui/binding/match-unique-bind.rs
@@ -1,9 +1,8 @@
 // run-pass
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 pub fn main() {
-    match box 100 {
+    match Box::new(100) {
       box x => {
         println!("{}", x);
         assert_eq!(x, 100);

--- a/src/test/ui/binding/match-value-binding-in-guard-3291.rs
+++ b/src/test/ui/binding/match-value-binding-in-guard-3291.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn foo(x: Option<Box<isize>>, b: bool) -> isize {
     match x {
       None => { 1 }
@@ -12,8 +10,8 @@ fn foo(x: Option<Box<isize>>, b: bool) -> isize {
 }
 
 pub fn main() {
-    foo(Some(box 22), true);
-    foo(Some(box 22), false);
+    foo(Some(Box::new(22)), true);
+    foo(Some(Box::new(22)), false);
     foo(None, true);
     foo(None, false);
 }

--- a/src/test/ui/borrowck/borrow-tuple-fields.rs
+++ b/src/test/ui/borrowck/borrow-tuple-fields.rs
@@ -1,13 +1,13 @@
-#![feature(box_syntax)]
-
-
-
 struct Foo(Box<isize>, isize);
 
 struct Bar(isize, isize);
 
+
+
+
+
 fn main() {
-    let x: (Box<_>, _) = (box 1, 2);
+    let x: (Box<_>, _) = (Box::new(1), 2);
     let r = &x.0;
     let y = x; //~ ERROR cannot move out of `x` because it is borrowed
 
@@ -23,7 +23,7 @@ fn main() {
     let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable more than once at a time
     a.use_ref();
 
-    let x = Foo(box 1, 2);
+    let x = Foo(Box::new(1), 2);
     let r = &x.0;
     let y = x; //~ ERROR cannot move out of `x` because it is borrowed
     r.use_ref();

--- a/src/test/ui/borrowck/borrowck-bad-nested-calls-free.rs
+++ b/src/test/ui/borrowck/borrowck-bad-nested-calls-free.rs
@@ -1,10 +1,10 @@
 // Test that we detect nested calls that could free pointers evaluated
 // for earlier arguments.
 
-#![feature(box_syntax)]
+
 
 fn rewrite(v: &mut Box<usize>) -> usize {
-    *v = box 22;
+    *v = Box::new(22);
     **v
 }
 
@@ -13,7 +13,7 @@ fn add(v: &usize, w: usize) -> usize {
 }
 
 fn implicit() {
-    let mut a: Box<_> = box 1;
+    let mut a: Box<_> = Box::new(1);
 
     // Note the danger here:
     //
@@ -26,7 +26,7 @@ fn implicit() {
 }
 
 fn explicit() {
-    let mut a: Box<_> = box 1;
+    let mut a: Box<_> = Box::new(1);
     add(
         &*a,
         rewrite(&mut a)); //~ ERROR cannot borrow

--- a/src/test/ui/borrowck/borrowck-bad-nested-calls-move.rs
+++ b/src/test/ui/borrowck/borrowck-bad-nested-calls-move.rs
@@ -1,10 +1,10 @@
 // Test that we detect nested calls that could free pointers evaluated
 // for earlier arguments.
 
-#![feature(box_syntax)]
+
 
 fn rewrite(v: &mut Box<usize>) -> usize {
-    *v = box 22;
+    *v = Box::new(22);
     **v
 }
 
@@ -13,7 +13,7 @@ fn add(v: &usize, w: Box<usize>) -> usize {
 }
 
 fn implicit() {
-    let mut a: Box<_> = box 1;
+    let mut a: Box<_> = Box::new(1);
 
     // Note the danger here:
     //
@@ -26,7 +26,7 @@ fn implicit() {
 }
 
 fn explicit() {
-    let mut a: Box<_> = box 1;
+    let mut a: Box<_> = Box::new(1);
     add(
         &*a,
         a); //~ ERROR cannot move

--- a/src/test/ui/borrowck/borrowck-borrow-from-expr-block.rs
+++ b/src/test/ui/borrowck/borrowck-borrow-from-expr-block.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn borrow<F>(x: &isize, f: F) where F: FnOnce(&isize) {
     f(x)
@@ -14,5 +13,5 @@ fn test1(x: &Box<isize>) {
 }
 
 pub fn main() {
-    test1(&box 22);
+    test1(&Box::new(22));
 }

--- a/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.rs
+++ b/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 struct A;
 
 impl A {
@@ -7,8 +5,10 @@ impl A {
     }
 }
 
+
+
 pub fn main() {
-    let a: Box<_> = box A;
+    let a: Box<_> = Box::new(A);
     a.foo();
     //~^ ERROR cannot borrow `*a` as mutable, as `a` is not declared as mutable [E0596]
 }

--- a/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
+++ b/src/test/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
@@ -1,7 +1,7 @@
 error[E0596]: cannot borrow `*a` as mutable, as `a` is not declared as mutable
   --> $DIR/borrowck-borrow-immut-deref-of-box-as-mut.rs:12:5
    |
-LL |     let a: Box<_> = box A;
+LL |     let a: Box<_> = Box::new(A);
    |         - help: consider changing this to be mutable: `mut a`
 LL |     a.foo();
    |     ^ cannot borrow as mutable

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue.rs
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue.rs
@@ -1,8 +1,8 @@
-//buggy.rs
-
-#![feature(box_syntax)]
-
 use std::collections::HashMap;
+
+
+
+
 
 fn main() {
     let tmp: Box<_>;
@@ -10,6 +10,6 @@ fn main() {
     buggy_map.insert(42, &*Box::new(1)); //~ ERROR temporary value dropped while borrowed
 
     // but it is ok if we use a temporary
-    tmp = box 2;
+    tmp = Box::new(2);
     buggy_map.insert(43, &*tmp);
 }

--- a/src/test/ui/borrowck/borrowck-box-sensitivity.rs
+++ b/src/test/ui/borrowck/borrowck-box-sensitivity.rs
@@ -3,8 +3,6 @@
 
 // run-pass
 
-#![feature(box_syntax)]
-
 struct A {
     x: Box<isize>,
     y: isize,
@@ -26,97 +24,97 @@ struct D {
 }
 
 fn copy_after_move() {
-    let a: Box<_> = box A { x: box 0, y: 1 };
+    let a: Box<_> = Box::new(A { x: Box::new(0), y: 1 });
     let _x = a.x;
     let _y = a.y;
 }
 
 fn move_after_move() {
-    let a: Box<_> = box B { x: box 0, y: box 1 };
+    let a: Box<_> = Box::new(B { x: Box::new(0), y: Box::new(1) });
     let _x = a.x;
     let _y = a.y;
 }
 
 fn borrow_after_move() {
-    let a: Box<_> = box A { x: box 0, y: 1 };
+    let a: Box<_> = Box::new(A { x: Box::new(0), y: 1 });
     let _x = a.x;
     let _y = &a.y;
 }
 
 fn move_after_borrow() {
-    let a: Box<_> = box B { x: box 0, y: box 1 };
+    let a: Box<_> = Box::new(B { x: Box::new(0), y: Box::new(1) });
     let _x = &a.x;
     let _y = a.y;
     use_imm(_x);
 }
 fn copy_after_mut_borrow() {
-    let mut a: Box<_> = box A { x: box 0, y: 1 };
+    let mut a: Box<_> = Box::new(A { x: Box::new(0), y: 1 });
     let _x = &mut a.x;
     let _y = a.y;
     use_mut(_x);
 }
 fn move_after_mut_borrow() {
-    let mut a: Box<_> = box B { x: box 0, y: box 1 };
+    let mut a: Box<_> = Box::new(B { x: Box::new(0), y: Box::new(1) });
     let _x = &mut a.x;
     let _y = a.y;
     use_mut(_x);
 }
 fn borrow_after_mut_borrow() {
-    let mut a: Box<_> = box A { x: box 0, y: 1 };
+    let mut a: Box<_> = Box::new(A { x: Box::new(0), y: 1 });
     let _x = &mut a.x;
     let _y = &a.y;
     use_mut(_x);
 }
 fn mut_borrow_after_borrow() {
-    let mut a: Box<_> = box A { x: box 0, y: 1 };
+    let mut a: Box<_> = Box::new(A { x: Box::new(0), y: 1 });
     let _x = &a.x;
     let _y = &mut a.y;
     use_imm(_x);
 }
 fn copy_after_move_nested() {
-    let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let a: Box<_> = Box::new(C { x: Box::new(A { x: Box::new(0), y: 1 }), y: 2 });
     let _x = a.x.x;
     let _y = a.y;
 }
 
 fn move_after_move_nested() {
-    let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let a: Box<_> = Box::new(D { x: Box::new(A { x: Box::new(0), y: 1 }), y: Box::new(2) });
     let _x = a.x.x;
     let _y = a.y;
 }
 
 fn borrow_after_move_nested() {
-    let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let a: Box<_> = Box::new(C { x: Box::new(A { x: Box::new(0), y: 1 }), y: 2 });
     let _x = a.x.x;
     let _y = &a.y;
 }
 
 fn move_after_borrow_nested() {
-    let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let a: Box<_> = Box::new(D { x: Box::new(A { x: Box::new(0), y: 1 }), y: Box::new(2) });
     let _x = &a.x.x;
     let _y = a.y;
     use_imm(_x);
 }
 fn copy_after_mut_borrow_nested() {
-    let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let mut a: Box<_> = Box::new(C { x: Box::new(A { x: Box::new(0), y: 1 }), y: 2 });
     let _x = &mut a.x.x;
     let _y = a.y;
     use_mut(_x);
 }
 fn move_after_mut_borrow_nested() {
-    let mut a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let mut a: Box<_> = Box::new(D { x: Box::new(A { x: Box::new(0), y: 1 }), y: Box::new(2) });
     let _x = &mut a.x.x;
     let _y = a.y;
     use_mut(_x);
 }
 fn borrow_after_mut_borrow_nested() {
-    let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let mut a: Box<_> = Box::new(C { x: Box::new(A { x: Box::new(0), y: 1 }), y: 2 });
     let _x = &mut a.x.x;
     let _y = &a.y;
     use_mut(_x);
 }
 fn mut_borrow_after_borrow_nested() {
-    let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let mut a: Box<_> = Box::new(C { x: Box::new(A { x: Box::new(0), y: 1 }), y: 2 });
     let _x = &a.x.x;
     let _y = &mut a.y;
     use_imm(_x);

--- a/src/test/ui/borrowck/borrowck-closures-mut-and-imm.rs
+++ b/src/test/ui/borrowck/borrowck-closures-mut-and-imm.rs
@@ -1,8 +1,6 @@
 // Tests that two closures cannot simultaneously have mutable
 // and immutable access to the variable. Issue #6801.
 
-#![feature(box_syntax)]
-
 fn get(x: &isize) -> isize {
     *x
 }
@@ -10,6 +8,8 @@ fn get(x: &isize) -> isize {
 fn set(x: &mut isize) {
     *x = 4;
 }
+
+
 
 fn a() {
     let mut x = 3;
@@ -52,7 +52,7 @@ fn e() {
 }
 
 fn f() {
-    let mut x: Box<_> = box 3;
+    let mut x: Box<_> = Box::new(3);
     let c1 = || get(&*x);
     *x = 5;
     //~^ ERROR cannot assign to `*x` because it is borrowed
@@ -64,7 +64,7 @@ fn g() {
         f: Box<isize>
     }
 
-    let mut x: Box<_> = box Foo { f: box 3 };
+    let mut x: Box<_> = Box::new(Foo { f: Box::new(3) });
     let c1 = || get(&*x.f);
     *x.f = 5;
     //~^ ERROR cannot assign to `*x.f` because it is borrowed
@@ -76,7 +76,7 @@ fn h() {
         f: Box<isize>
     }
 
-    let mut x: Box<_> = box Foo { f: box 3 };
+    let mut x: Box<_> = Box::new(Foo { f: Box::new(3) });
     let c1 = || get(&*x.f);
     let c2 = || *x.f = 5;
     //~^ ERROR cannot borrow `x` as mutable because it is also borrowed as immutable

--- a/src/test/ui/borrowck/borrowck-closures-two-mut-fail.rs
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut-fail.rs
@@ -2,7 +2,7 @@
 // access to the variable, whether that mutable access be used
 // for direct assignment or for taking mutable ref. Issue #6801.
 
-#![feature(box_syntax)]
+
 
 
 
@@ -48,7 +48,7 @@ fn g() {
         f: Box<isize>
     }
 
-    let mut x: Box<_> = box Foo { f: box 3 };
+    let mut x: Box<_> = Box::new(Foo { f: Box::new(3) });
     let c1 = to_fn_mut(|| set(&mut *x.f));
     let c2 = to_fn_mut(|| set(&mut *x.f));
     //~^ ERROR cannot borrow `x` as mutable more than once

--- a/src/test/ui/borrowck/borrowck-closures-two-mut.rs
+++ b/src/test/ui/borrowck/borrowck-closures-two-mut.rs
@@ -2,7 +2,7 @@
 // access to the variable, whether that mutable access be used
 // for direct assignment or for taking mutable ref. Issue #6801.
 
-#![feature(box_syntax)]
+
 
 fn to_fn_mut<F: FnMut()>(f: F) -> F { f }
 
@@ -44,7 +44,7 @@ fn g() {
         f: Box<isize>
     }
 
-    let mut x: Box<_> = box Foo { f: box 3 };
+    let mut x: Box<_> = Box::new(Foo { f: Box::new(3) });
     let c1 = to_fn_mut(|| set(&mut *x.f));
     let c2 = to_fn_mut(|| set(&mut *x.f));
     //~^ ERROR cannot borrow `x` as mutable more than once

--- a/src/test/ui/borrowck/borrowck-closures-use-after-free.rs
+++ b/src/test/ui/borrowck/borrowck-closures-use-after-free.rs
@@ -2,8 +2,6 @@
 // cannot also be supplied a borrowed version of that
 // variable's contents. Issue #11192.
 
-#![feature(box_syntax)]
-
 struct Foo {
   x: isize
 }
@@ -14,10 +12,12 @@ impl Drop for Foo {
   }
 }
 
+
+
 fn main() {
-  let mut ptr: Box<_> = box Foo { x: 0 };
+  let mut ptr: Box<_> = Box::new(Foo { x: 0 });
   let mut test = |foo: &Foo| {
-    ptr = box Foo { x: ptr.x + 1 };
+    ptr = Box::new(Foo { x: ptr.x + 1 });
   };
   test(&*ptr); //~ ERROR cannot borrow `*ptr`
 }

--- a/src/test/ui/borrowck/borrowck-closures-use-after-free.stderr
+++ b/src/test/ui/borrowck/borrowck-closures-use-after-free.stderr
@@ -3,7 +3,7 @@ error[E0502]: cannot borrow `*ptr` as immutable because it is also borrowed as m
    |
 LL |   let mut test = |foo: &Foo| {
    |                  ----------- mutable borrow occurs here
-LL |     ptr = box Foo { x: ptr.x + 1 };
+LL |     ptr = Box::new(Foo { x: ptr.x + 1 });
    |     --- first borrow occurs due to use of `ptr` in closure
 LL |   };
 LL |   test(&*ptr);

--- a/src/test/ui/borrowck/borrowck-field-sensitivity-rpass.rs
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity-rpass.rs
@@ -3,89 +3,87 @@
 #![allow(unused_variables)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 struct A { a: isize, b: Box<isize> }
 struct B { a: Box<isize>, b: Box<isize> }
 
 fn move_after_copy() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.a);
     drop(x.b);
 }
 
 fn move_after_fu_copy() {
-    let x = A { a: 1, b: box 2 };
-    let _y = A { b: box 3, .. x };
+    let x = A { a: 1, b: Box::new(2) };
+    let _y = A { b: Box::new(3), .. x };
     drop(x.b);
 }
 
 fn fu_move_after_copy() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.a);
     let _y = A { a: 3, .. x };
 }
 
 fn fu_move_after_fu_copy() {
-    let x = A { a: 1, b: box 2 };
-    let _y = A { b: box 3, .. x };
+    let x = A { a: 1, b: Box::new(2) };
+    let _y = A { b: Box::new(3), .. x };
     let _z = A { a: 4, .. x };
 }
 
 fn copy_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     drop(x.a);
 }
 
 fn copy_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let y = A { a: 3, .. x };
     drop(x.a);
 }
 
 fn fu_copy_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    let _y = A { b: box 3, .. x };
+    let _y = A { b: Box::new(3), .. x };
 }
 
 fn fu_copy_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    let _z = A { b: box 3, .. x };
+    let _z = A { b: Box::new(3), .. x };
 }
 
 fn borrow_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     let p = &x.a;
     drop(*p);
 }
 
 fn borrow_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
     let p = &x.a;
     drop(*p);
 }
 
 fn move_after_borrow() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let p = &x.a;
     drop(x.b);
     drop(*p);
 }
 
 fn fu_move_after_borrow() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let p = &x.a;
     let _y = A { a: 3, .. x };
     drop(*p);
 }
 
 fn mut_borrow_after_mut_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.a;
     let q = &mut x.b;
     drop(*p);
@@ -93,134 +91,134 @@ fn mut_borrow_after_mut_borrow() {
 }
 
 fn move_after_move() {
-    let x = B { a: box 1, b: box 2 };
+    let x = B { a: Box::new(1), b: Box::new(2) };
     drop(x.a);
     drop(x.b);
 }
 
 fn move_after_fu_move() {
-    let x = B { a: box 1, b: box 2 };
-    let y = B { a: box 3, .. x };
+    let x = B { a: Box::new(1), b: Box::new(2) };
+    let y = B { a: Box::new(3), .. x };
     drop(x.a);
 }
 
 fn fu_move_after_move() {
-    let x = B { a: box 1, b: box 2 };
+    let x = B { a: Box::new(1), b: Box::new(2) };
     drop(x.a);
-    let z = B { a: box 3, .. x };
+    let z = B { a: Box::new(3), .. x };
     drop(z.b);
 }
 
 fn fu_move_after_fu_move() {
-    let x = B { a: box 1, b: box 2 };
-    let _y = B { b: box 3, .. x };
-    let _z = B { a: box 4, .. x };
+    let x = B { a: Box::new(1), b: Box::new(2) };
+    let _y = B { b: Box::new(3), .. x };
+    let _z = B { a: Box::new(4), .. x };
 }
 
 fn copy_after_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     drop(*x.b);
 }
 
 fn copy_after_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     drop(*x.b);
 }
 
 fn copy_after_field_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    x.b = box 3;
+    x.b = Box::new(3);
     drop(*x.b);
 }
 
 fn copy_after_field_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x.b = box 3;
+    x.b = Box::new(3);
     drop(*x.b);
 }
 
 fn borrow_after_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     let p = &x.b;
     drop(**p);
 }
 
 fn borrow_after_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     let p = &x.b;
     drop(**p);
 }
 
 fn borrow_after_field_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    x.b = box 3;
+    x.b = Box::new(3);
     let p = &x.b;
     drop(**p);
 }
 
 fn borrow_after_field_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x.b = box 3;
+    x.b = Box::new(3);
     let p = &x.b;
     drop(**p);
 }
 
 fn move_after_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = x.b;
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     drop(x.b);
 }
 
 fn move_after_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x = A { a: 3, b: box 4 };
+    x = A { a: 3, b: Box::new(4) };
     drop(x.b);
 }
 
 fn move_after_field_assign_after_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     drop(x.b);
-    x.b = box 3;
+    x.b = Box::new(3);
     drop(x.b);
 }
 
 fn move_after_field_assign_after_fu_move() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
-    x.b = box 3;
+    x.b = Box::new(3);
     drop(x.b);
 }
 
 fn copy_after_assign_after_uninit() {
     let mut x: A;
-    x = A { a: 1, b: box 2 };
+    x = A { a: 1, b: Box::new(2) };
     drop(x.a);
 }
 
 fn borrow_after_assign_after_uninit() {
     let mut x: A;
-    x = A { a: 1, b: box 2 };
+    x = A { a: 1, b: Box::new(2) };
     let p = &x.a;
     drop(*p);
 }
 
 fn move_after_assign_after_uninit() {
     let mut x: A;
-    x = A { a: 1, b: box 2 };
+    x = A { a: 1, b: Box::new(2) };
     drop(x.b);
 }
 

--- a/src/test/ui/borrowck/borrowck-field-sensitivity.rs
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity.rs
@@ -1,49 +1,49 @@
-#![feature(box_syntax)]
-
 struct A { a: isize, b: Box<isize> }
 
+
+
 fn deref_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     drop(*x.b); //~ ERROR use of moved value: `x.b`
 }
 
 fn deref_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let y = A { a: 3, .. x };
     drop(*x.b); //~ ERROR use of moved value: `x.b`
 }
 
 fn borrow_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     let p = &x.b; //~ ERROR borrow of moved value: `x.b`
     drop(**p);
 }
 
 fn borrow_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
     let p = &x.b; //~ ERROR borrow of moved value: `x.b`
     drop(**p);
 }
 
 fn move_after_borrow() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let p = &x.b;
     drop(x.b); //~ ERROR cannot move out of `x.b` because it is borrowed
     drop(**p);
 }
 
 fn fu_move_after_borrow() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let p = &x.b;
     let _y = A { a: 3, .. x }; //~ ERROR cannot move out of `x.b` because it is borrowed
     drop(**p);
 }
 
 fn mut_borrow_after_mut_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.a;
     let q = &mut x.a; //~ ERROR cannot borrow `x.a` as mutable more than once at a time
     drop(*p);
@@ -51,25 +51,25 @@ fn mut_borrow_after_mut_borrow() {
 }
 
 fn move_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     drop(x.b);  //~ ERROR use of moved value: `x.b`
 }
 
 fn move_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
     drop(x.b);  //~ ERROR use of moved value: `x.b`
 }
 
 fn fu_move_after_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     drop(x.b);
     let _z = A { a: 3, .. x };  //~ ERROR use of moved value: `x.b`
 }
 
 fn fu_move_after_fu_move() {
-    let x = A { a: 1, b: box 2 };
+    let x = A { a: 1, b: Box::new(2) };
     let _y = A { a: 3, .. x };
     let _z = A { a: 4, .. x };  //~ ERROR use of moved value: `x.b`
 }
@@ -91,7 +91,7 @@ fn borrow_after_field_assign_after_uninit() {
 
 fn move_after_field_assign_after_uninit() {
     let mut x: A;
-    x.b = box 1; //~ ERROR assign to part of possibly-uninitialized variable: `x`
+    x.b = Box::new(1); //~ ERROR assign to part of possibly-uninitialized variable: `x`
     drop(x.b);
 }
 

--- a/src/test/ui/borrowck/borrowck-field-sensitivity.stderr
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity.stderr
@@ -123,7 +123,7 @@ LL |     x.a = 1;
 error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-field-sensitivity.rs:94:5
    |
-LL |     x.b = box 1;
+LL |     x.b = Box::new(1);
    |     ^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.rs
+++ b/src/test/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.rs
@@ -1,6 +1,6 @@
 // Issue #16205.
 
-#![feature(box_syntax)]
+
 
 struct Foo {
     a: [Box<isize>; 3],
@@ -13,12 +13,12 @@ fn main() {
     }
 
     let f = Foo {
-        a: [box 3, box 4, box 5],
+        a: [Box::new(3), Box::new(4), Box::new(5)],
     };
     for &a in &f.a {  //~ ERROR cannot move out
     }
 
-    let x: Option<Box<_>> = Some(box 1);
+    let x: Option<Box<_>> = Some(Box::new(1));
     for &a in x.iter() {    //~ ERROR cannot move out
     }
 }

--- a/src/test/ui/borrowck/borrowck-issue-14498.rs
+++ b/src/test/ui/borrowck/borrowck-issue-14498.rs
@@ -4,14 +4,14 @@
 // Also includes tests of the errors reported when the Box in question
 // is immutable (#14270).
 
-#![feature(box_syntax)]
+
 
 struct A { a: isize }
 struct B<'a> { a: Box<&'a mut isize> }
 
 fn indirect_write_to_imm_box() {
     let mut x: isize = 1;
-    let y: Box<_> = box &mut x;
+    let y: Box<_> = Box::new(&mut x);
     let p = &y;
     ***p = 2; //~ ERROR cannot assign to `***p`
     drop(p);
@@ -19,7 +19,7 @@ fn indirect_write_to_imm_box() {
 
 fn borrow_in_var_from_var() {
     let mut x: isize = 1;
-    let mut y: Box<_> = box &mut x;
+    let mut y: Box<_> = Box::new(&mut x);
     let p = &y;
     let q = &***p;
     **y = 2; //~ ERROR cannot assign to `**y` because it is borrowed
@@ -29,7 +29,7 @@ fn borrow_in_var_from_var() {
 
 fn borrow_in_var_from_var_via_imm_box() {
     let mut x: isize = 1;
-    let y: Box<_> = box &mut x;
+    let y: Box<_> = Box::new(&mut x);
     let p = &y;
     let q = &***p;
     **y = 2; //~ ERROR cannot assign to `**y` because it is borrowed
@@ -39,7 +39,7 @@ fn borrow_in_var_from_var_via_imm_box() {
 
 fn borrow_in_var_from_field() {
     let mut x = A { a: 1 };
-    let mut y: Box<_> = box &mut x.a;
+    let mut y: Box<_> = Box::new(&mut x.a);
     let p = &y;
     let q = &***p;
     **y = 2; //~ ERROR cannot assign to `**y` because it is borrowed
@@ -49,7 +49,7 @@ fn borrow_in_var_from_field() {
 
 fn borrow_in_var_from_field_via_imm_box() {
     let mut x = A { a: 1 };
-    let y: Box<_> = box &mut x.a;
+    let y: Box<_> = Box::new(&mut x.a);
     let p = &y;
     let q = &***p;
     **y = 2; //~ ERROR cannot assign to `**y` because it is borrowed
@@ -59,7 +59,7 @@ fn borrow_in_var_from_field_via_imm_box() {
 
 fn borrow_in_field_from_var() {
     let mut x: isize = 1;
-    let mut y = B { a: box &mut x };
+    let mut y = B { a: Box::new(&mut x) };
     let p = &y.a;
     let q = &***p;
     **y.a = 2; //~ ERROR cannot assign to `**y.a` because it is borrowed
@@ -69,7 +69,7 @@ fn borrow_in_field_from_var() {
 
 fn borrow_in_field_from_var_via_imm_box() {
     let mut x: isize = 1;
-    let y = B { a: box &mut x };
+    let y = B { a: Box::new(&mut x) };
     let p = &y.a;
     let q = &***p;
     **y.a = 2; //~ ERROR cannot assign to `**y.a` because it is borrowed
@@ -79,7 +79,7 @@ fn borrow_in_field_from_var_via_imm_box() {
 
 fn borrow_in_field_from_field() {
     let mut x = A { a: 1 };
-    let mut y = B { a: box &mut x.a };
+    let mut y = B { a: Box::new(&mut x.a) };
     let p = &y.a;
     let q = &***p;
     **y.a = 2; //~ ERROR cannot assign to `**y.a` because it is borrowed
@@ -89,7 +89,7 @@ fn borrow_in_field_from_field() {
 
 fn borrow_in_field_from_field_via_imm_box() {
     let mut x = A { a: 1 };
-    let y = B { a: box &mut x.a };
+    let y = B { a: Box::new(&mut x.a) };
     let p = &y.a;
     let q = &***p;
     **y.a = 2; //~ ERROR cannot assign to `**y.a` because it is borrowed

--- a/src/test/ui/borrowck/borrowck-issue-2657-1.rs
+++ b/src/test/ui/borrowck/borrowck-issue-2657-1.rs
@@ -1,9 +1,9 @@
-#![feature(box_syntax)]
-
+trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
+impl<T> Fake for T { }
 
 
 fn main() {
-    let x: Option<Box<_>> = Some(box 1);
+    let x: Option<Box<_>> = Some(Box::new(1));
     match x {
       Some(ref _y) => {
         let _a = x; //~ ERROR cannot move
@@ -12,6 +12,3 @@ fn main() {
       _ => {}
     }
 }
-
-trait Fake { fn use_mut(&mut self) { } fn use_ref(&self) { }  }
-impl<T> Fake for T { }

--- a/src/test/ui/borrowck/borrowck-issue-2657-2.rs
+++ b/src/test/ui/borrowck/borrowck-issue-2657-2.rs
@@ -1,7 +1,7 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let x: Option<Box<_>> = Some(box 1);
+
+    let x: Option<Box<_>> = Some(Box::new(1));
+
     match x {
       Some(ref y) => {
         let _b = *y; //~ ERROR cannot move out

--- a/src/test/ui/borrowck/borrowck-lend-flow-if.rs
+++ b/src/test/ui/borrowck/borrowck-lend-flow-if.rs
@@ -4,7 +4,7 @@
 // either genuine or would require more advanced changes.  The latter
 // cases are noted.
 
-#![feature(box_syntax)]
+
 
 fn borrow(_v: &isize) {}
 fn borrow_mut(_v: &mut isize) {}
@@ -13,15 +13,15 @@ fn for_func<F>(_f: F) where F: FnOnce() -> bool { panic!() }
 fn produce<T>() -> T { panic!(); }
 
 fn inc(v: &mut Box<isize>) {
-    *v = box (**v + 1);
+    *v = Box::new(**v + 1);
 }
 
 fn pre_freeze_cond() {
     // In this instance, the freeze is conditional and starts before
     // the mut borrow.
 
-    let u = box 0;
-    let mut v: Box<_> = box 3;
+    let u = Box::new(0);
+    let mut v: Box<_> = Box::new(3);
     let mut _w = &u;
     if cond() {
         _w = &v;
@@ -34,8 +34,8 @@ fn pre_freeze_else() {
     // In this instance, the freeze and mut borrow are on separate sides
     // of the if.
 
-    let u = box 0;
-    let mut v: Box<_> = box 3;
+    let u = Box::new(0);
+    let mut v: Box<_> = Box::new(3);
     let mut _w = &u;
     if cond() {
         _w = &v;

--- a/src/test/ui/borrowck/borrowck-lend-flow-loop.rs
+++ b/src/test/ui/borrowck/borrowck-lend-flow-loop.rs
@@ -1,18 +1,18 @@
-#![feature(box_syntax)]
-
 fn borrow(_v: &isize) {}
 fn borrow_mut(_v: &mut isize) {}
 fn cond() -> bool { panic!() }
 fn produce<T>() -> T { panic!(); }
 
+
 fn inc(v: &mut Box<isize>) {
-    *v = box (**v + 1);
+    *v = Box::new(**v + 1);
 }
+
 
 fn loop_overarching_alias_mut() {
     // In this instance, the borrow ends on the line before the loop
 
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     let mut x = &mut v;
     **x += 1;
     loop {
@@ -23,18 +23,18 @@ fn loop_overarching_alias_mut() {
 fn block_overarching_alias_mut() {
     // In this instance, the borrow encompasses the entire closure call.
 
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     let mut x = &mut v;
     for _ in 0..3 {
         borrow(&*v); //~ ERROR cannot borrow
     }
-    *x = box 5;
+    *x = Box::new(5);
 }
 fn loop_aliased_mut() {
     // In this instance, the borrow ends right after each assignment to _x
 
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut _x = &w;
     loop {
         borrow_mut(&mut *v); // OK
@@ -45,8 +45,8 @@ fn loop_aliased_mut() {
 fn while_aliased_mut() {
     // In this instance, the borrow ends right after each assignment to _x
 
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut _x = &w;
     while cond() {
         borrow_mut(&mut *v); // OK
@@ -58,8 +58,8 @@ fn while_aliased_mut() {
 fn loop_aliased_mut_break() {
     // In this instance, the borrow ends right after each assignment to _x
 
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut _x = &w;
     loop {
         borrow_mut(&mut *v);
@@ -72,8 +72,8 @@ fn loop_aliased_mut_break() {
 fn while_aliased_mut_break() {
     // In this instance, the borrow ends right after each assignment to _x
 
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut _x = &w;
     while cond() {
         borrow_mut(&mut *v);
@@ -84,8 +84,8 @@ fn while_aliased_mut_break() {
 }
 
 fn while_aliased_mut_cond(cond: bool, cond2: bool) {
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut x = &mut w;
     while cond {
         **x += 1;

--- a/src/test/ui/borrowck/borrowck-lend-flow-loop.stderr
+++ b/src/test/ui/borrowck/borrowck-lend-flow-loop.stderr
@@ -7,7 +7,7 @@ LL |     for _ in 0..3 {
 LL |         borrow(&*v);
    |                ^^^ immutable borrow occurs here
 LL |     }
-LL |     *x = box 5;
+LL |     *x = Box::new(5);
    |     -- mutable borrow later used here
 
 error[E0502]: cannot borrow `*v` as immutable because it is also borrowed as mutable

--- a/src/test/ui/borrowck/borrowck-lend-flow.rs
+++ b/src/test/ui/borrowck/borrowck-lend-flow.rs
@@ -4,7 +4,7 @@
 // either genuine or would require more advanced changes.  The latter
 // cases are noted.
 
-#![feature(box_syntax)]
+
 
 fn borrow(_v: &isize) {}
 fn borrow_mut(_v: &mut isize) {}
@@ -13,13 +13,13 @@ fn for_func<F>(_f: F) where F: FnOnce() -> bool { panic!() }
 fn produce<T>() -> T { panic!(); }
 
 fn inc(v: &mut Box<isize>) {
-    *v = box (**v + 1);
+    *v = Box::new(**v + 1);
 }
 
 fn pre_freeze() {
     // In this instance, the freeze starts before the mut borrow.
 
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     let _w = &v;
     borrow_mut(&mut *v); //~ ERROR cannot borrow
     _w.use_ref();
@@ -28,7 +28,7 @@ fn pre_freeze() {
 fn post_freeze() {
     // In this instance, the const alias starts after the borrow.
 
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     borrow_mut(&mut *v);
     let _w = &v;
 }

--- a/src/test/ui/borrowck/borrowck-loan-blocks-move-cc.rs
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-move-cc.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use std::thread;
 
 
@@ -8,8 +6,10 @@ fn borrow<F>(v: &isize, f: F) where F: FnOnce(&isize) {
     f(v);
 }
 
+
+
 fn box_imm() {
-    let v: Box<_> = box 3;
+    let v: Box<_> = Box::new(3);
     let w = &v;
     thread::spawn(move|| {
     //~^ ERROR cannot move out of `v` because it is borrowed
@@ -19,7 +19,7 @@ fn box_imm() {
 }
 
 fn box_imm_explicit() {
-    let v: Box<_> = box 3;
+    let v: Box<_> = Box::new(3);
     let w = &v;
     thread::spawn(move|| {
     //~^ ERROR cannot move

--- a/src/test/ui/borrowck/borrowck-loan-blocks-move.rs
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-move.rs
@@ -1,12 +1,12 @@
-#![feature(box_syntax)]
-
-
-
 fn take(_v: Box<isize>) {
 }
 
+
+
+
+
 fn box_imm() {
-    let v = box 3;
+    let v = Box::new(3);
     let w = &v;
     take(v); //~ ERROR cannot move out of `v` because it is borrowed
     w.use_ref();

--- a/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.rs
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.rs
@@ -1,14 +1,14 @@
-#![feature(box_syntax)]
-
 fn borrow<F>(v: &isize, f: F) where F: FnOnce(&isize) {
     f(v);
 }
 
+
+
 fn box_imm() {
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     borrow(&*v,
            |w| { //~ ERROR cannot borrow `v` as mutable
-            v = box 4;
+            v = Box::new(4);
             assert_eq!(*v, 3);
             assert_eq!(*w, 4);
         })

--- a/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-blocks-mut-uniq.stderr
@@ -7,7 +7,7 @@ LL |     borrow(&*v,
    |     immutable borrow later used by call
 LL |            |w| {
    |            ^^^ mutable borrow occurs here
-LL |             v = box 4;
+LL |             v = Box::new(4);
    |             - second borrow occurs due to use of `v` in closure
 
 error: aborting due to previous error

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.rs
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.rs
@@ -1,5 +1,5 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 
 use std::ops::Add;
 
@@ -12,12 +12,12 @@ impl Add for Foo {
     fn add(self, f: Foo) -> Foo {
         let Foo(box i) = self;
         let Foo(box j) = f;
-        Foo(box (i + j))
+        Foo(Box::new(i + j))
     }
 }
 
 fn main() {
-    let x = Foo(box 3);
+    let x = Foo(Box::new(3));
     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
     //~^ ERROR borrow of moved value: `x`
 }

--- a/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-in-overloaded-op.stderr
@@ -1,7 +1,7 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/borrowck-loan-in-overloaded-op.rs:21:20
    |
-LL |     let x = Foo(box 3);
+LL |     let x = Foo(Box::new(3));
    |         - move occurs because `x` has type `Foo`, which does not implement the `Copy` trait
 LL |     let _y = {x} + x.clone(); // the `{x}` forces a move to occur
    |               -    ^ value borrowed here after move

--- a/src/test/ui/borrowck/borrowck-macro-interaction-issue-6304.rs
+++ b/src/test/ui/borrowck/borrowck-macro-interaction-issue-6304.rs
@@ -6,9 +6,7 @@
 // Check that we do not ICE when compiling this
 // macro, which reuses the expression `$id`
 
-
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct Foo {
   a: isize
@@ -23,7 +21,7 @@ impl Foo {
     macro_rules! declare {
       ($id:expr, $rest:expr) => ({
         self.check_id($id);
-        box Bar::Bar2($id, $rest)
+        Box::new(Bar::Bar2($id, $rest))
       })
     }
     match s {

--- a/src/test/ui/borrowck/borrowck-move-by-capture-ok.rs
+++ b/src/test/ui/borrowck/borrowck-move-by-capture-ok.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let bar: Box<_> = box 3;
+    let bar: Box<_> = Box::new(3);
     let h = || -> isize { *bar };
     assert_eq!(h(), 3);
 }

--- a/src/test/ui/borrowck/borrowck-move-by-capture.rs
+++ b/src/test/ui/borrowck/borrowck-move-by-capture.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax,unboxed_closures)]
+#![feature(unboxed_closures)]
 
 fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
 fn to_fn_once<A,F:FnOnce<A>>(f: F) -> F { f }
 
 pub fn main() {
-    let bar: Box<_> = box 3;
+    let bar: Box<_> = Box::new(3);
     let _g = to_fn_mut(|| {
         let _h = to_fn_once(move || -> isize { *bar }); //~ ERROR cannot move out of
     });

--- a/src/test/ui/borrowck/borrowck-move-by-capture.stderr
+++ b/src/test/ui/borrowck/borrowck-move-by-capture.stderr
@@ -1,7 +1,7 @@
 error[E0507]: cannot move out of `bar`, a captured variable in an `FnMut` closure
   --> $DIR/borrowck-move-by-capture.rs:9:29
    |
-LL |       let bar: Box<_> = box 3;
+LL |       let bar: Box<_> = Box::new(3);
    |           --- captured outer variable
 LL |       let _g = to_fn_mut(|| {
    |  ________________________-

--- a/src/test/ui/borrowck/borrowck-move-error-with-note.rs
+++ b/src/test/ui/borrowck/borrowck-move-error-with-note.rs
@@ -1,14 +1,14 @@
-#![feature(box_syntax)]
-
 enum Foo {
     Foo1(Box<u32>, Box<u32>),
     Foo2(Box<u32>),
     Foo3,
 }
 
+
+
 fn blah() {
-    let f = &Foo::Foo1(box 1, box 2);
-    match *f {             //~ ERROR cannot move out of
+    let f = &Foo::Foo1(Box::new(1), Box::new(2));
+    match *f { //~ ERROR cannot move out of
         Foo::Foo1(num1,
                   num2) => (),
         Foo::Foo2(num) => (),
@@ -42,8 +42,8 @@ struct A {
 fn free<T>(_: T) {}
 
 fn blah2() {
-    let a = &A { a: box 1 };
-    match a.a {           //~ ERROR cannot move out of
+    let a = &A { a: Box::new(1) };
+    match a.a { //~ ERROR cannot move out of
         n => {
             free(n)
         }

--- a/src/test/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.rs
+++ b/src/test/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.rs
@@ -3,10 +3,10 @@
 
 
 
-#![feature(box_syntax)]
+
 
 fn main() {
-    let a: Box<Box<_>> = box box 2;
+    let a: Box<Box<_>> = Box::new(Box::new(2));
     let b = &a;
 
     let z = *a; //~ ERROR: cannot move out of `*a` because it is borrowed

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.rs
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.rs
@@ -1,11 +1,11 @@
-#![feature(box_syntax)]
-
 fn call_f<F:FnOnce() -> isize>(f: F) -> isize {
     f()
 }
 
+
+
 fn main() {
-    let t: Box<_> = box 3;
+    let t: Box<_> = Box::new(3);
 
     call_f(move|| { *t + 1 });
     call_f(move|| { *t + 1 }); //~ ERROR use of moved value

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `t`
   --> $DIR/borrowck-move-moved-value-into-closure.rs:11:12
    |
-LL |     let t: Box<_> = box 3;
+LL |     let t: Box<_> = Box::new(3);
    |         - move occurs because `t` has type `Box<isize>`, which does not implement the `Copy` trait
 LL | 
 LL |     call_f(move|| { *t + 1 });

--- a/src/test/ui/borrowck/borrowck-move-subcomponent.rs
+++ b/src/test/ui/borrowck/borrowck-move-subcomponent.rs
@@ -1,7 +1,7 @@
 // Tests that the borrow checker checks all components of a path when moving
 // out.
 
-#![feature(box_syntax)]
+
 
 struct S {
   x : Box<isize>
@@ -10,7 +10,7 @@ struct S {
 fn f<T>(_: T) {}
 
 fn main() {
-  let a : S = S { x : box 1 };
+  let a : S = S { x : Box::new(1) };
   let pb = &a;
   let S { x: ax } = a;  //~ ERROR cannot move out
   f(pb);

--- a/src/test/ui/borrowck/borrowck-multiple-captures.rs
+++ b/src/test/ui/borrowck/borrowck-multiple-captures.rs
@@ -1,13 +1,13 @@
-#![feature(box_syntax)]
-
 use std::thread;
+
 
 fn borrow<T>(_: &T) { }
 
+
 fn different_vars_after_borrows() {
-    let x1: Box<_> = box 1;
+    let x1: Box<_> = Box::new(1);
     let p1 = &x1;
-    let x2: Box<_> = box 2;
+    let x2: Box<_> = Box::new(2);
     let p2 = &x2;
     thread::spawn(move|| {
         //~^ ERROR cannot move out of `x1` because it is borrowed
@@ -20,9 +20,9 @@ fn different_vars_after_borrows() {
 }
 
 fn different_vars_after_moves() {
-    let x1: Box<_> = box 1;
+    let x1: Box<_> = Box::new(1);
     drop(x1);
-    let x2: Box<_> = box 2;
+    let x2: Box<_> = Box::new(2);
     drop(x2);
     thread::spawn(move|| {
         //~^ ERROR use of moved value: `x1`
@@ -33,7 +33,7 @@ fn different_vars_after_moves() {
 }
 
 fn same_var_after_borrow() {
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
     let p = &x;
     thread::spawn(move|| {
         //~^ ERROR cannot move out of `x` because it is borrowed
@@ -44,7 +44,7 @@ fn same_var_after_borrow() {
 }
 
 fn same_var_after_move() {
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
     drop(x);
     thread::spawn(move|| {
         //~^ ERROR use of moved value: `x`

--- a/src/test/ui/borrowck/borrowck-multiple-captures.stderr
+++ b/src/test/ui/borrowck/borrowck-multiple-captures.stderr
@@ -30,7 +30,7 @@ LL |     borrow(&*p2);
 error[E0382]: use of moved value: `x1`
   --> $DIR/borrowck-multiple-captures.rs:27:19
    |
-LL |     let x1: Box<_> = box 1;
+LL |     let x1: Box<_> = Box::new(1);
    |         -- move occurs because `x1` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x1);
    |          -- value moved here
@@ -44,7 +44,7 @@ LL |         drop(x1);
 error[E0382]: use of moved value: `x2`
   --> $DIR/borrowck-multiple-captures.rs:27:19
    |
-LL |     let x2: Box<_> = box 2;
+LL |     let x2: Box<_> = Box::new(2);
    |         -- move occurs because `x2` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x2);
    |          -- value moved here
@@ -91,7 +91,7 @@ LL |         drop(x);
 error[E0382]: use of moved value: `x`
   --> $DIR/borrowck-multiple-captures.rs:49:19
    |
-LL |     let x: Box<_> = box 1;
+LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     drop(x);
    |          - value moved here

--- a/src/test/ui/borrowck/borrowck-mut-uniq.rs
+++ b/src/test/ui/borrowck/borrowck-mut-uniq.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 use std::mem::swap;
 
@@ -20,7 +19,7 @@ fn iter_ints<F>(x: &Ints, mut f: F) -> bool where F: FnMut(&isize) -> bool {
 }
 
 pub fn main() {
-    let mut ints: Box<_> = box Ints {sum: box 0, values: Vec::new()};
+    let mut ints: Box<_> = Box::new(Ints {sum: Box::new(0), values: Vec::new()});
     add_int(&mut *ints, 22);
     add_int(&mut *ints, 44);
 

--- a/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.rs
+++ b/src/test/ui/borrowck/borrowck-no-cycle-in-exchange-heap.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 struct Node_ {
     a: Box<Cycle>
 }
@@ -8,8 +6,10 @@ enum Cycle {
     Node(Node_),
     Empty,
 }
+
 fn main() {
-    let mut x: Box<_> = box Cycle::Node(Node_ {a: box Cycle::Empty});
+    let mut x: Box<_> = Box::new(Cycle::Node(Node_ {a: Box::new(Cycle::Empty)}));
+
     // Create a cycle!
     match *x {
       Cycle::Node(ref mut y) => {

--- a/src/test/ui/borrowck/borrowck-overloaded-index-move-from-vec.rs
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-move-from-vec.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use std::ops::Index;
 
 struct MyVec<T> {
@@ -14,8 +12,10 @@ impl<T> Index<usize> for MyVec<T> {
     }
 }
 
+
+
 fn main() {
-    let v = MyVec::<Box<_>> { data: vec![box 1, box 2, box 3] };
+    let v = MyVec::<Box<_>> { data: vec![Box::new(1), Box::new(2), Box::new(3)] };
     let good = &v[0]; // Shouldn't fail here
     let bad = v[0];
     //~^ ERROR cannot move out of index of `MyVec<Box<i32>>`

--- a/src/test/ui/borrowck/borrowck-uniq-via-lend.rs
+++ b/src/test/ui/borrowck/borrowck-uniq-via-lend.rs
@@ -1,17 +1,17 @@
-#![feature(box_syntax)]
-
-
-
 fn borrow(_v: &isize) {}
 
+
+
+
+
 fn local() {
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     borrow(&*v);
 }
 
 fn local_rec() {
     struct F { f: Box<isize> }
-    let mut v = F {f: box 3};
+    let mut v = F {f: Box::new(3)};
     borrow(&*v.f);
 }
 
@@ -19,35 +19,35 @@ fn local_recs() {
     struct F { f: G }
     struct G { g: H }
     struct H { h: Box<isize> }
-    let mut v = F {f: G {g: H {h: box 3}}};
+    let mut v = F {f: G {g: H {h: Box::new(3)}}};
     borrow(&*v.f.g.h);
 }
 
 fn aliased_imm() {
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     let w = &v;
     borrow(&*v);
     w.use_ref();
 }
 
 fn aliased_mut() {
-    let mut v: Box<_> = box 3;
+    let mut v: Box<_> = Box::new(3);
     let w = &mut v;
     borrow(&*v); //~ ERROR cannot borrow `*v`
     w.use_mut();
 }
 
 fn aliased_other() {
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let x = &mut w;
     borrow(&*v);
     x.use_mut();
 }
 
 fn aliased_other_reassign() {
-    let mut v: Box<_> = box 3;
-    let mut w: Box<_> = box 4;
+    let mut v: Box<_> = Box::new(3);
+    let mut w: Box<_> = Box::new(4);
     let mut x = &mut w;
     x = &mut v;
     borrow(&*v); //~ ERROR cannot borrow `*v`

--- a/src/test/ui/borrowck/borrowck-use-mut-borrow-rpass.rs
+++ b/src/test/ui/borrowck/borrowck-use-mut-borrow-rpass.rs
@@ -1,41 +1,39 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 struct A { a: isize, b: Box<isize> }
 
 fn field_copy_after_field_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.b;
     drop(x.a);
     **p = 3;
 }
 
 fn fu_field_copy_after_field_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.b;
-    let y = A { b: box 3, .. x };
+    let y = A { b: Box::new(3), .. x };
     drop(y);
     **p = 4;
 }
 
 fn field_deref_after_field_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.a;
     drop(*x.b);
     *p = 3;
 }
 
 fn field_move_after_field_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.a;
     drop(x.b);
     *p = 3;
 }
 
 fn fu_field_move_after_field_borrow() {
-    let mut x = A { a: 1, b: box 2 };
+    let mut x = A { a: 1, b: Box::new(2) };
     let p = &mut x.a;
     let y = A { a: 3, .. x };
     drop(y);

--- a/src/test/ui/borrowck/borrowck-use-mut-borrow.rs
+++ b/src/test/ui/borrowck/borrowck-use-mut-borrow.rs
@@ -1,9 +1,9 @@
-#![feature(box_syntax)]
-
 #[derive(Copy, Clone)]
 struct A { a: isize, b: isize }
 
 struct B { a: isize, b: Box<isize> }
+
+
 
 fn var_copy_after_var_borrow() {
     let mut x: isize = 1;
@@ -50,21 +50,21 @@ fn fu_field_copy_after_field_borrow() {
 }
 
 fn var_deref_after_var_borrow() {
-    let mut x: Box<isize> = box 1;
+    let mut x: Box<isize> = Box::new(1);
     let p = &mut x;
     drop(*x); //~ ERROR cannot use `*x` because it was mutably borrowed
     **p = 2;
 }
 
 fn field_deref_after_var_borrow() {
-    let mut x = B { a: 1, b: box 2 };
+    let mut x = B { a: 1, b: Box::new(2) };
     let p = &mut x;
     drop(*x.b); //~ ERROR cannot use `*x.b` because it was mutably borrowed
     p.a = 3;
 }
 
 fn field_deref_after_field_borrow() {
-    let mut x = B { a: 1, b: box 2 };
+    let mut x = B { a: 1, b: Box::new(2) };
     let p = &mut x.b;
     drop(*x.b); //~ ERROR cannot use `*x.b` because it was mutably borrowed
     **p = 3;

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -1,12 +1,12 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 
 fn a() {
-    let mut vec = [box 1, box 2, box 3];
+    let mut vec = [Box::new(1), Box::new(2), Box::new(3)];
     match vec {
         [box ref _a, _, _] => {
         //~^ NOTE borrow of `vec[_]` occurs here
-            vec[0] = box 4; //~ ERROR cannot assign
+            vec[0] = Box::new(4); //~ ERROR cannot assign
             //~^ NOTE assignment to borrowed `vec[_]` occurs here
             _a.use_ref();
             //~^ NOTE borrow later used here
@@ -15,12 +15,12 @@ fn a() {
 }
 
 fn b() {
-    let mut vec = vec![box 1, box 2, box 3];
+    let mut vec = vec![Box::new(1), Box::new(2), Box::new(3)];
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         &mut [ref _b @ ..] => {
         //~^ borrow of `vec[_]` occurs here
-            vec[0] = box 4; //~ ERROR cannot assign
+            vec[0] = Box::new(4); //~ ERROR cannot assign
             //~^ NOTE assignment to borrowed `vec[_]` occurs here
             _b.use_ref();
             //~^ NOTE borrow later used here
@@ -29,7 +29,7 @@ fn b() {
 }
 
 fn c() {
-    let mut vec = vec![box 1, box 2, box 3];
+    let mut vec = vec![Box::new(1), Box::new(2), Box::new(3)];
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         //~^ ERROR cannot move out
@@ -50,7 +50,7 @@ fn c() {
 }
 
 fn d() {
-    let mut vec = vec![box 1, box 2, box 3];
+    let mut vec = vec![Box::new(1), Box::new(2), Box::new(3)];
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         //~^ ERROR cannot move out
@@ -69,7 +69,7 @@ fn d() {
 }
 
 fn e() {
-    let mut vec = vec![box 1, box 2, box 3];
+    let mut vec = vec![Box::new(1), Box::new(2), Box::new(3)];
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         //~^ ERROR cannot move out

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -4,7 +4,7 @@ error[E0506]: cannot assign to `vec[_]` because it is borrowed
 LL |         [box ref _a, _, _] => {
    |              ------ borrow of `vec[_]` occurs here
 LL |
-LL |             vec[0] = box 4;
+LL |             vec[0] = Box::new(4);
    |             ^^^^^^ assignment to borrowed `vec[_]` occurs here
 LL |
 LL |             _a.use_ref();
@@ -16,7 +16,7 @@ error[E0506]: cannot assign to `vec[_]` because it is borrowed
 LL |         &mut [ref _b @ ..] => {
    |               ----------- borrow of `vec[_]` occurs here
 LL |
-LL |             vec[0] = box 4;
+LL |             vec[0] = Box::new(4);
    |             ^^^^^^ assignment to borrowed `vec[_]` occurs here
 LL |
 LL |             _b.use_ref();

--- a/src/test/ui/borrowck/fsu-moves-and-copies.rs
+++ b/src/test/ui/borrowck/fsu-moves-and-copies.rs
@@ -5,7 +5,7 @@
 // Issue 4691: Ensure that functional-struct-updates operates
 // correctly and moves rather than copy when appropriate.
 
-#![feature(box_syntax, core)]
+#![feature(core)]
 
 struct ncint { v: isize }
 fn ncint(v: isize) -> ncint { ncint { v: v } }
@@ -17,7 +17,7 @@ impl NoFoo {
 
 struct MoveFoo { copied: isize, moved: Box<isize>, }
 impl MoveFoo {
-    fn new(x:isize,y:isize) -> MoveFoo { MoveFoo { copied: x, moved: box y } }
+    fn new(x:isize,y:isize) -> MoveFoo { MoveFoo { copied: x, moved: Box::new(y) } }
 }
 
 struct DropNoFoo { inner: NoFoo }
@@ -53,8 +53,8 @@ fn test0() {
 
     // Case 2: Owned
     let f = DropMoveFoo::new(5, 6);
-    let b = DropMoveFoo { inner: MoveFoo { moved: box 7, ..f.inner }};
-    let c = DropMoveFoo { inner: MoveFoo { moved: box 8, ..f.inner }};
+    let b = DropMoveFoo { inner: MoveFoo { moved: Box::new(7), ..f.inner }};
+    let c = DropMoveFoo { inner: MoveFoo { moved: Box::new(8), ..f.inner }};
     assert_eq!(f.inner.copied,    5);
     assert_eq!(*f.inner.moved,    6);
 
@@ -69,7 +69,7 @@ fn test1() {
     // copying move-by-default fields from `f`, so it moves:
     let f = MoveFoo::new(11, 12);
 
-    let b = MoveFoo {moved: box 13, ..f};
+    let b = MoveFoo {moved: Box::new(13), ..f};
     let c = MoveFoo {copied: 14, ..f};
     assert_eq!(b.copied,    11);
     assert_eq!(*b.moved,    13);

--- a/src/test/ui/borrowck/issue-17263.rs
+++ b/src/test/ui/borrowck/issue-17263.rs
@@ -1,14 +1,12 @@
 // check-pass
 
-#![feature(box_syntax)]
-
 struct Foo { a: isize, b: isize }
 
 fn main() {
-    let mut x: Box<_> = box Foo { a: 1, b: 2 };
+    let mut x: Box<_> = Box::new(Foo { a: 1, b: 2 });
     let (a, b) = (&mut x.a, &mut x.b);
 
-    let mut foo: Box<_> = box Foo { a: 1, b: 2 };
+    let mut foo: Box<_> = Box::new(Foo { a: 1, b: 2 });
     let (c, d) = (&mut foo.a, &foo.b);
 
     // We explicitly use the references created above to illustrate that the

--- a/src/test/ui/cancel-clean-via-immediate-rvalue-ref.rs
+++ b/src/test/ui/cancel-clean-via-immediate-rvalue-ref.rs
@@ -1,12 +1,10 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn foo(x: &mut Box<u8>) {
-    *x = box 5;
+    *x = Box::new(5);
 }
 
 pub fn main() {
-    foo(&mut box 4);
+    foo(&mut Box::new(4));
 }

--- a/src/test/ui/class-cast-to-trait.rs
+++ b/src/test/ui/class-cast-to-trait.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 trait Noisy {
   fn speak(&self);
 }
@@ -48,7 +46,9 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> Cat {
     }
 }
 
+
+
 fn main() {
-  let nyan: Box<dyn Noisy> = box cat(0, 2, "nyan".to_string()) as Box<dyn Noisy>;
+  let nyan: Box<dyn Noisy> = Box::new(cat(0, 2, "nyan".to_string())) as Box<dyn Noisy>;
   nyan.eat(); //~ ERROR no method named `eat` found
 }

--- a/src/test/ui/cleanup-arm-conditional.rs
+++ b/src/test/ui/cleanup-arm-conditional.rs
@@ -7,7 +7,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax, os)]
+#![feature(os)]
 
 use std::os;
 
@@ -15,7 +15,7 @@ struct Test { x: isize }
 
 impl Test {
     fn get_x(&self) -> Option<Box<isize>> {
-        Some(box self.x)
+        Some(Box::new(self.x))
     }
 }
 

--- a/src/test/ui/cleanup-rvalue-scopes.rs
+++ b/src/test/ui/cleanup-rvalue-scopes.rs
@@ -7,7 +7,6 @@
 // lifetime rules.
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 use std::ops::Drop;
 
@@ -106,8 +105,8 @@ pub fn main() {
     end_of_block!(AddFlags { bits: ref _x }, AddFlags(1));
     end_of_block!(&AddFlags { bits }, &AddFlags(1));
     end_of_block!((_, ref _y), (AddFlags(1), 22));
-    end_of_block!(box ref _x, box AddFlags(1));
-    end_of_block!(box _x, box AddFlags(1));
+    end_of_block!(box ref _x, std::boxed::Box::new(AddFlags(1)));
+    end_of_block!(box _x, std::boxed::Box::new(AddFlags(1)));
     end_of_block!(_, { { check_flags(0); &AddFlags(1) } });
     end_of_block!(_, &((Box { f: AddFlags(1) }).f));
     end_of_block!(_, &(([AddFlags(1)])[0]));

--- a/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -21,8 +21,6 @@
 
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 
 enum Conzabble {
@@ -40,7 +38,7 @@ fn get_bar(x: usize) -> Vec<usize> { vec![x * 2] }
 pub fn fails() {
     let x = 2;
     let mut y: Vec<Box<_>> = Vec::new();
-    y.push(box Conzabble::Bickwick(do_it(&get_bar(x))));
+    y.push(Box::new(Conzabble::Bickwick(do_it(&get_bar(x)))));
 }
 
 pub fn main() {

--- a/src/test/ui/clone-with-exterior.rs
+++ b/src/test/ui/clone-with-exterior.rs
@@ -3,8 +3,6 @@
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 
 struct Pair {
@@ -13,7 +11,7 @@ struct Pair {
 }
 
 pub fn main() {
-    let z: Box<_> = box Pair { a : 10, b : 12};
+    let z: Box<_> = Box::new(Pair { a : 10, b : 12});
 
     thread::spawn(move|| {
         assert_eq!(z.a, 10);

--- a/src/test/ui/close-over-big-then-small-data.rs
+++ b/src/test/ui/close-over-big-then-small-data.rs
@@ -5,8 +5,6 @@
 // storing closure data (as we used to do), the u64 would
 // overwrite the u16.
 
-#![feature(box_syntax)]
-
 struct Pair<A,B> {
     a: A, b: B
 }
@@ -27,10 +25,10 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<dyn Invokable<A>+'static> {
-    box Invoker {
+    Box::new(Invoker {
         a: a,
         b: b,
-    } as Box<dyn Invokable<A>+'static>
+    }) as Box<dyn Invokable<A>+'static>
 }
 
 pub fn main() {

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-closures-mut-and-imm.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-closures-mut-and-imm.rs
@@ -1,9 +1,9 @@
 // edition:2021
 
+
+
 // Tests that two closures cannot simultaneously have mutable
 // and immutable access to the variable. Issue #6801.
-
-#![feature(box_syntax)]
 
 #[derive(Debug)]
 struct Point {

--- a/src/test/ui/coercion/coerce-expect-unsized.rs
+++ b/src/test/ui/coercion/coerce-expect-unsized.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(unused_braces)]
-#![feature(box_syntax)]
 
 use std::cell::RefCell;
 use std::fmt::Debug;

--- a/src/test/ui/crate-method-reexport-grrrrrrr.rs
+++ b/src/test/ui/crate-method-reexport-grrrrrrr.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 // This is a regression test that the metadata for the
 // name_pool::methods impl in the other crate is reachable from this
 // crate.
@@ -14,7 +12,7 @@ extern crate crate_method_reexport_grrrrrrr2;
 pub fn main() {
     use crate_method_reexport_grrrrrrr2::rust::add;
     use crate_method_reexport_grrrrrrr2::rust::cx;
-    let x: Box<_> = box ();
+    let x: Box<_> = Box::new(());
     x.cx();
     let y = ();
     y.add("hi".to_string());

--- a/src/test/ui/cross-crate/auxiliary/cci_nested_lib.rs
+++ b/src/test/ui/cross-crate/auxiliary/cci_nested_lib.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use std::cell::RefCell;
 
 pub struct Entry<A,B> {
@@ -37,7 +35,7 @@ pub fn new_int_alist<B:'static>() -> alist<isize, B> {
     fn eq_int(a: isize, b: isize) -> bool { a == b }
     return alist {
         eq_fn: eq_int,
-        data: box RefCell::new(Vec::new()),
+        data: Box::new(RefCell::new(Vec::new())),
     };
 }
 
@@ -47,6 +45,6 @@ pub fn new_int_alist_2<B:'static>() -> alist<isize, B> {
     fn eq_int(a: isize, b: isize) -> bool { a == b }
     return alist {
         eq_fn: eq_int,
-        data: box RefCell::new(Vec::new()),
+        data: Box::new(RefCell::new(Vec::new())),
     };
 }

--- a/src/test/ui/cross-crate/cci_borrow.rs
+++ b/src/test/ui/cross-crate/cci_borrow.rs
@@ -1,13 +1,11 @@
 // run-pass
 // aux-build:cci_borrow_lib.rs
 
-#![feature(box_syntax)]
-
 extern crate cci_borrow_lib;
 use cci_borrow_lib::foo;
 
 pub fn main() {
-    let p: Box<_> = box 22;
+    let p: Box<_> = Box::new(22);
     let r = foo(&*p);
     println!("r={}", r);
     assert_eq!(r, 22);

--- a/src/test/ui/deref.rs
+++ b/src/test/ui/deref.rs
@@ -1,9 +1,7 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let x: Box<isize> = box 10;
+    let x: Box<isize> = Box::new(10);
     let _y: isize = *x;
 }

--- a/src/test/ui/deriving/deriving-default-box.rs
+++ b/src/test/ui/deriving/deriving-default-box.rs
@@ -1,6 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
-
 use std::default::Default;
 
 #[derive(Default)]

--- a/src/test/ui/destructure-trait-ref.rs
+++ b/src/test/ui/destructure-trait-ref.rs
@@ -2,10 +2,10 @@
 // reference work properly.
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 trait T { fn foo(&self) {} }
 impl T for isize {}
+
 
 fn main() {
     // For an expression of the form:
@@ -25,7 +25,7 @@ fn main() {
     // n == m
     let &x = &1isize as &dyn T;      //~ ERROR type `&dyn T` cannot be dereferenced
     let &&x = &(&1isize as &dyn T);  //~ ERROR type `&dyn T` cannot be dereferenced
-    let box x = box 1isize as Box<dyn T>;
+    let box x = Box::new(1isize) as Box<dyn T>;
     //~^ ERROR type `Box<dyn T>` cannot be dereferenced
 
     // n > m
@@ -37,7 +37,7 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected trait object `dyn T`
     //~| found reference `&_`
-    let box box x = box 1isize as Box<dyn T>;
+    let box box x = Box::new(1isize) as Box<dyn T>;
     //~^ ERROR mismatched types
     //~| expected trait object `dyn T`
     //~| found struct `Box<_>`

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -13,7 +13,7 @@ LL |     let &&x = &(&1isize as &dyn T);
 error[E0033]: type `Box<dyn T>` cannot be dereferenced
   --> $DIR/destructure-trait-ref.rs:28:9
    |
-LL |     let box x = box 1isize as Box<dyn T>;
+LL |     let box x = Box::new(1isize) as Box<dyn T>;
    |         ^^^^^ type `Box<dyn T>` cannot be dereferenced
 
 error[E0308]: mismatched types
@@ -43,8 +43,8 @@ LL |     let &&&x = &(&1isize as &dyn T);
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:40:13
    |
-LL |     let box box x = box 1isize as Box<dyn T>;
-   |             ^^^^^   ------------------------ this expression has type `Box<dyn T>`
+LL |     let box box x = Box::new(1isize) as Box<dyn T>;
+   |             ^^^^^   ------------------------------ this expression has type `Box<dyn T>`
    |             |
    |             expected trait object `dyn T`, found struct `Box`
    |

--- a/src/test/ui/drop/drop-on-empty-block-exit.rs
+++ b/src/test/ui/drop/drop-on-empty-block-exit.rs
@@ -2,11 +2,9 @@
 // pretty-expanded FIXME #23616
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 enum t { foo(Box<isize>), }
 
 pub fn main() {
-    let tt = t::foo(box 10);
+    let tt = t::foo(Box::new(10));
     match tt { t::foo(_z) => { } }
 }

--- a/src/test/ui/drop/drop-struct-as-object.rs
+++ b/src/test/ui/drop/drop-struct-as-object.rs
@@ -5,8 +5,6 @@
 // Test that destructor on a struct runs successfully after the struct
 // is boxed and converted to an object.
 
-#![feature(box_syntax)]
-
 static mut value: usize = 0;
 
 struct Cat {
@@ -29,7 +27,7 @@ impl Drop for Cat {
 
 pub fn main() {
     {
-        let x = box Cat {name: 22};
+        let x = Box::new(Cat {name: 22});
         let nyan: Box<dyn Dummy> = x as Box<dyn Dummy>;
     }
     unsafe {

--- a/src/test/ui/drop/drop-trait-enum.rs
+++ b/src/test/ui/drop/drop-trait-enum.rs
@@ -4,8 +4,6 @@
 #![allow(unused_variables)]
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 use std::sync::mpsc::{channel, Sender};
 
@@ -57,7 +55,7 @@ pub fn main() {
 
     let (sender, receiver) = channel();
     {
-        let v = Foo::NestedVariant(box 42, SendOnDrop { sender: sender.clone() }, sender);
+        let v = Foo::NestedVariant(Box::new(42), SendOnDrop { sender: sender.clone() }, sender);
     }
     assert_eq!(receiver.recv().unwrap(), Message::DestructorRan);
     assert_eq!(receiver.recv().unwrap(), Message::Dropped);
@@ -74,10 +72,10 @@ pub fn main() {
     let (sender, receiver) = channel();
     let t = {
         thread::spawn(move|| {
-            let mut v = Foo::NestedVariant(box 42, SendOnDrop {
+            let mut v = Foo::NestedVariant(Box::new(42), SendOnDrop {
                 sender: sender.clone()
             }, sender.clone());
-            v = Foo::NestedVariant(box 42,
+            v = Foo::NestedVariant(Box::new(42),
                                    SendOnDrop { sender: sender.clone() },
                                    sender.clone());
             v = Foo::SimpleVariant(sender.clone());

--- a/src/test/ui/dynamically-sized-types/dst-trait-tuple.rs
+++ b/src/test/ui/dynamically-sized-types/dst-trait-tuple.rs
@@ -2,7 +2,6 @@
 #![allow(type_alias_bounds)]
 
 #![allow(unused_features)]
-#![feature(box_syntax)]
 #![feature(unsized_tuple_coercion)]
 
 type Fat<T: ?Sized> = (isize, &'static str, T);

--- a/src/test/ui/dynamically-sized-types/dst-tuple.rs
+++ b/src/test/ui/dynamically-sized-types/dst-tuple.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(type_alias_bounds)]
 
-#![feature(box_syntax)]
 #![feature(unsized_tuple_coercion)]
 
 type Fat<T: ?Sized> = (isize, &'static str, T);
@@ -109,7 +108,7 @@ pub fn main() {
     assert_eq!((*f2)[1], 2);
 
     // Nested Box.
-    let f1 : Box<Fat<[isize; 3]>> = box (5, "some str", [1, 2, 3]);
+    let f1 : Box<Fat<[isize; 3]>> = Box::new((5, "some str", [1, 2, 3]));
     foo(&*f1);
     let f2 : Box<Fat<[isize]>> = f1;
     foo(&*f2);

--- a/src/test/ui/expr-block-generic-unique1.rs
+++ b/src/test/ui/expr-block-generic-unique1.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(unused_braces)]
-#![feature(box_syntax)]
 
 fn test_generic<T, F>(expected: Box<T>, eq: F) where T: Clone, F: FnOnce(Box<T>, Box<T>) -> bool {
     let actual: Box<T> = { expected.clone() };
@@ -13,7 +12,7 @@ fn test_box() {
         println!("{}", *b2);
         return *b1 == *b2;
     }
-    test_generic::<bool, _>(box true, compare_box);
+    test_generic::<bool, _>(Box::new(true), compare_box);
 }
 
 pub fn main() { test_box(); }

--- a/src/test/ui/expr-block-generic-unique2.rs
+++ b/src/test/ui/expr-block-generic-unique2.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(unused_braces)]
-#![feature(box_syntax)]
 
 fn test_generic<T, F>(expected: T, eq: F) where T: Clone, F: FnOnce(T, T) -> bool {
     let actual: T = { expected.clone() };
@@ -9,7 +8,7 @@ fn test_generic<T, F>(expected: T, eq: F) where T: Clone, F: FnOnce(T, T) -> boo
 
 fn test_vec() {
     fn compare_vec(v1: Box<isize>, v2: Box<isize>) -> bool { return v1 == v2; }
-    test_generic::<Box<isize>, _>(box 1, compare_vec);
+    test_generic::<Box<isize>, _>(Box::new(1), compare_vec);
 }
 
 pub fn main() { test_vec(); }

--- a/src/test/ui/expr-block-unique.rs
+++ b/src/test/ui/expr-block-unique.rs
@@ -1,5 +1,4 @@
 // run-pass
 #![allow(unused_braces)]
-#![feature(box_syntax)]
 
-pub fn main() { let x: Box<_> = { box 100 }; assert_eq!(*x, 100); }
+pub fn main() { let x: Box<_> = { Box::new(100) }; assert_eq!(*x, 100); }

--- a/src/test/ui/expr-if-unique.rs
+++ b/src/test/ui/expr-if-unique.rs
@@ -1,10 +1,8 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 // Tests for if as expressions returning boxed types
 fn test_box() {
-    let rs: Box<_> = if true { box 100 } else { box 101 };
+    let rs: Box<_> = if true { Box::new(100) } else { Box::new(101) };
     assert_eq!(*rs, 100);
 }
 

--- a/src/test/ui/fn/fn-trait-formatting.rs
+++ b/src/test/ui/fn/fn-trait-formatting.rs
@@ -1,17 +1,17 @@
-#![feature(box_syntax)]
-
 fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
 
+
+
 fn main() {
-    let _: () = (box |_: isize| {}) as Box<dyn FnOnce(isize)>;
+    let _: () = Box::new(|_: isize| {}) as Box<dyn FnOnce(isize)>;
     //~^ ERROR mismatched types
     //~| expected unit type `()`
     //~| found struct `Box<dyn FnOnce(isize)>`
-    let _: () = (box |_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
+    let _: () = Box::new(|_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
     //~^ ERROR mismatched types
     //~| expected unit type `()`
     //~| found struct `Box<dyn Fn(isize, isize)>`
-    let _: () = (box || -> isize { unimplemented!() }) as Box<dyn FnMut() -> isize>;
+    let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<dyn FnMut() -> isize>;
     //~^ ERROR mismatched types
     //~| expected unit type `()`
     //~| found struct `Box<dyn FnMut() -> isize>`

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
   --> $DIR/fn-trait-formatting.rs:6:17
    |
-LL |     let _: () = (box |_: isize| {}) as Box<dyn FnOnce(isize)>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
+LL |     let _: () = Box::new(|_: isize| {}) as Box<dyn FnOnce(isize)>;
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
    |            |
    |            expected due to this
    |
@@ -12,8 +12,8 @@ LL |     let _: () = (box |_: isize| {}) as Box<dyn FnOnce(isize)>;
 error[E0308]: mismatched types
   --> $DIR/fn-trait-formatting.rs:10:17
    |
-LL |     let _: () = (box |_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
+LL |     let _: () = Box::new(|_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
    |            |
    |            expected due to this
    |
@@ -23,8 +23,8 @@ LL |     let _: () = (box |_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
 error[E0308]: mismatched types
   --> $DIR/fn-trait-formatting.rs:14:17
    |
-LL |     let _: () = (box || -> isize { unimplemented!() }) as Box<dyn FnMut() -> isize>;
-   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
+LL |     let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<dyn FnMut() -> isize>;
+   |            --   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `Box`
    |            |
    |            expected due to this
    |
@@ -41,7 +41,7 @@ LL |     needs_fn(1);
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `{integer}`
 note: required by a bound in `needs_fn`
-  --> $DIR/fn-trait-formatting.rs:3:31
+  --> $DIR/fn-trait-formatting.rs:1:31
    |
 LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
    |                               ^^^^^^^^^^^^^^^^^^ required by this bound in `needs_fn`

--- a/src/test/ui/for-loop-while/cleanup-rvalue-during-if-and-while.rs
+++ b/src/test/ui/for-loop-while/cleanup-rvalue-during-if-and-while.rs
@@ -2,8 +2,6 @@
 // This test verifies that temporaries created for `while`'s and `if`
 // conditions are dropped after the condition is evaluated.
 
-#![feature(box_syntax)]
-
 struct Temporary;
 
 static mut DROPPED: isize = 0;
@@ -18,7 +16,7 @@ impl Temporary {
     fn do_stuff(&self) -> bool {true}
 }
 
-fn borrow() -> Box<Temporary> { box Temporary }
+fn borrow() -> Box<Temporary> { Box::new(Temporary) }
 
 
 pub fn main() {

--- a/src/test/ui/generics/generic-alias-unique.rs
+++ b/src/test/ui/generics/generic-alias-unique.rs
@@ -1,10 +1,9 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn id<T:Send>(t: T) -> T { return t; }
 
 pub fn main() {
-    let expected: Box<_> = box 100;
+    let expected: Box<_> = Box::new(100);
     let actual = id::<Box<isize>>(expected.clone());
     println!("{}", *actual);
     assert_eq!(*expected, *actual);

--- a/src/test/ui/generics/generic-exterior-unique.rs
+++ b/src/test/ui/generics/generic-exterior-unique.rs
@@ -1,9 +1,8 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct Recbox<T> {x: Box<T>}
 
-fn reclift<T>(t: T) -> Recbox<T> { return Recbox {x: box t}; }
+fn reclift<T>(t: T) -> Recbox<T> { return Recbox { x: Box::new(t) }; }
 
 pub fn main() {
     let foo: isize = 17;

--- a/src/test/ui/generics/generic-fn-unique.rs
+++ b/src/test/ui/generics/generic-fn-unique.rs
@@ -1,6 +1,8 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f<T>(x: Box<T>) -> Box<T> { return x; }
 
-pub fn main() { let x = f(box 3); println!("{}", *x); }
+pub fn main() {
+    let x = f(Box::new(3));
+    println!("{}", *x);
+}

--- a/src/test/ui/generics/generic-object.rs
+++ b/src/test/ui/generics/generic-object.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 trait Foo<T> {
     fn get(&self) -> T;
@@ -16,7 +15,7 @@ impl Foo<isize> for S {
 }
 
 pub fn main() {
-    let x = box S { x: 1 };
+    let x = Box::new(S { x: 1 });
     let y = x as Box<dyn Foo<isize>>;
     assert_eq!(y.get(), 1);
 }

--- a/src/test/ui/generics/generic-recursive-tag.rs
+++ b/src/test/ui/generics/generic-recursive-tag.rs
@@ -1,13 +1,12 @@
 // run-pass
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 enum list<T> { cons(Box<T>, Box<list<T>>), nil, }
 
 pub fn main() {
     let _a: list<isize> =
-        list::cons::<isize>(box 10,
-        box list::cons::<isize>(box 12,
-        box list::cons::<isize>(box 13,
-        box list::nil::<isize>)));
+        list::cons::<isize>(Box::new(10),
+        Box::new(list::cons::<isize>(Box::new(12),
+        Box::new(list::cons::<isize>(Box::new(13),
+        Box::new(list::nil::<isize>))))));
 }

--- a/src/test/ui/generics/generic-tag.rs
+++ b/src/test/ui/generics/generic-tag.rs
@@ -5,11 +5,10 @@
 // pretty-expanded FIXME #23616
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 
 enum option<T> { some(Box<T>), none, }
 
 pub fn main() {
-    let mut a: option<isize> = option::some::<isize>(box 10);
+    let mut a: option<isize> = option::some::<isize>(Box::new(10));
     a = option::none::<isize>;
 }

--- a/src/test/ui/generics/generic-unique.rs
+++ b/src/test/ui/generics/generic-unique.rs
@@ -1,10 +1,9 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct Triple<T> { x: T, y: T, z: T }
 
-fn box_it<T>(x: Triple<T>) -> Box<Triple<T>> { return box x; }
+fn box_it<T>(x: Triple<T>) -> Box<Triple<T>> { return Box::new(x); }
 
 pub fn main() {
     let x: Box<Triple<isize>> = box_it::<isize>(Triple{x: 1, y: 2, z: 3});

--- a/src/test/ui/infinite/infinite-autoderef.rs
+++ b/src/test/ui/infinite/infinite-autoderef.rs
@@ -1,6 +1,6 @@
 // error-pattern: reached the recursion limit while auto-dereferencing
 
-#![feature(box_syntax)]
+
 
 use std::ops::Deref;
 
@@ -17,7 +17,7 @@ impl Deref for Foo {
 pub fn main() {
     let mut x;
     loop {
-        x = box x;
+        x = Box::new(x);
         x.foo;
         x.bar();
     }

--- a/src/test/ui/infinite/infinite-autoderef.stderr
+++ b/src/test/ui/infinite/infinite-autoderef.stderr
@@ -1,13 +1,10 @@
 error[E0308]: mismatched types
   --> $DIR/infinite-autoderef.rs:20:13
    |
-LL |         x = box x;
-   |             ^^^^^ cyclic type of infinite size
-   |
-help: try using a conversion method
-   |
-LL |         x = (box x).to_string();
-   |             +     +++++++++++++
+LL |         x = Box::new(x);
+   |             ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
+   |             |
+   |             cyclic type of infinite size
 
 error[E0055]: reached the recursion limit while auto-dereferencing `Foo`
   --> $DIR/infinite-autoderef.rs:25:5

--- a/src/test/ui/init-res-into-things.rs
+++ b/src/test/ui/init-res-into-things.rs
@@ -2,7 +2,6 @@
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 use std::cell::Cell;
 
@@ -58,7 +57,7 @@ fn test_tup() {
 fn test_unique() {
     let i = &Cell::new(0);
     {
-        let _a: Box<_> = box r(i);
+        let _a: Box<_> = Box::new(r(i));
     }
     assert_eq!(i.get(), 1);
 }
@@ -66,9 +65,9 @@ fn test_unique() {
 fn test_unique_rec() {
     let i = &Cell::new(0);
     {
-        let _a: Box<_> = box BoxR {
+        let _a: Box<_> = Box::new(BoxR {
             x: r(i)
-        };
+        });
     }
     assert_eq!(i.get(), 1);
 }

--- a/src/test/ui/intrinsics/intrinsic-atomics.rs
+++ b/src/test/ui/intrinsics/intrinsic-atomics.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![feature(intrinsics)]
 
 mod rusti {
@@ -34,7 +33,7 @@ mod rusti {
 
 pub fn main() {
     unsafe {
-        let mut x: Box<_> = box 1;
+        let mut x: Box<_> = Box::new(1);
 
         assert_eq!(rusti::atomic_load(&*x), 1);
         *x = 5;

--- a/src/test/ui/kindck/kindck-impl-type-params-2.rs
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.rs
@@ -1,7 +1,7 @@
-#![feature(box_syntax)]
-
 trait Foo {
 }
+
+
 
 impl<T:Copy> Foo for T {
 }
@@ -9,7 +9,7 @@ impl<T:Copy> Foo for T {
 fn take_param<T:Foo>(foo: &T) { }
 
 fn main() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     take_param(&x);
     //~^ ERROR the trait bound `Box<{integer}>: Foo` is not satisfied
 }

--- a/src/test/ui/kindck/kindck-impl-type-params.rs
+++ b/src/test/ui/kindck/kindck-impl-type-params.rs
@@ -1,7 +1,7 @@
 // Issue #14061: tests the interaction between generic implementation
 // parameter bounds and trait objects.
 
-#![feature(box_syntax)]
+
 
 use std::marker;
 
@@ -34,7 +34,7 @@ fn foo<'a>() {
 }
 
 fn foo2<'a>() {
-    let t: Box<S<String>> = box S(marker::PhantomData);
+    let t: Box<S<String>> = Box::new(S(marker::PhantomData));
     let a = t as Box<dyn Gettable<String>>;
     //~^ ERROR : Copy` is not satisfied
 }
@@ -42,7 +42,7 @@ fn foo2<'a>() {
 fn foo3<'a>() {
     struct Foo; // does not impl Copy
 
-    let t: Box<S<Foo>> = box S(marker::PhantomData);
+    let t: Box<S<Foo>> = Box::new(S(marker::PhantomData));
     let a: Box<dyn Gettable<Foo>> = t;
     //~^ ERROR : Copy` is not satisfied
 }

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.rs
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.rs
@@ -3,7 +3,7 @@
 // revisions: curr object_safe_for_dispatch
 
 #![cfg_attr(object_safe_for_dispatch, feature(object_safe_for_dispatch))]
-#![feature(box_syntax)]
+
 
 use std::any::Any;
 
@@ -17,13 +17,13 @@ impl<T:Copy> Foo for T {
 fn take_param<T:Foo>(foo: &T) { }
 
 fn a() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     take_param(&x); //[curr]~ ERROR E0277
     //[object_safe_for_dispatch]~^ ERROR E0277
 }
 
 fn b() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     let y = &x;
     let z = &x as &dyn Foo;
     //[curr]~^ ERROR E0038

--- a/src/test/ui/last-use-is-capture.rs
+++ b/src/test/ui/last-use-is-capture.rs
@@ -3,13 +3,11 @@
 #![allow(dead_code)]
 // Make sure #1399 stays fixed
 
-#![feature(box_syntax)]
-
 struct A { a: Box<isize> }
 
 pub fn main() {
     fn invoke<F>(f: F) where F: FnOnce() { f(); }
-    let k: Box<_> = box 22;
+    let k: Box<_> = 22.into();
     let _u = A {a: k.clone()};
     invoke(|| println!("{}", k.clone()) )
 }

--- a/src/test/ui/leak-unique-as-tydesc.rs
+++ b/src/test/ui/leak-unique-as-tydesc.rs
@@ -1,8 +1,9 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn leaky<T>(_t: T) { }
 
-pub fn main() { let x = box 10; leaky::<Box<isize>>(x); }
+pub fn main() {
+    let x = Box::new(10);
+    leaky::<Box<isize>>(x);
+}

--- a/src/test/ui/lint/lint-owned-heap-memory.rs
+++ b/src/test/ui/lint/lint-owned-heap-memory.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 #![forbid(box_pointers)]
-#![feature(box_syntax)]
+
 
 struct Foo {
     x: Box<isize> //~ ERROR type uses owned
 }
 
 fn main() {
-    let _x : Foo = Foo {x : box 10};
+    let _x: Foo = Foo { x : Box::new(10) };
     //~^ ERROR type uses owned
 }

--- a/src/test/ui/lint/lint-owned-heap-memory.stderr
+++ b/src/test/ui/lint/lint-owned-heap-memory.stderr
@@ -13,8 +13,8 @@ LL | #![forbid(box_pointers)]
 error: type uses owned (Box type) pointers: Box<isize>
   --> $DIR/lint-owned-heap-memory.rs:10:29
    |
-LL |     let _x : Foo = Foo {x : box 10};
-   |                             ^^^^^^
+LL |     let _x: Foo = Foo { x : Box::new(10) };
+   |                             ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/unused/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/unused/issue-47390-unused-variable-in-struct-pattern.rs
@@ -1,7 +1,7 @@
 // check-pass
 
-#![feature(box_syntax)]
 #![feature(box_patterns)]
+
 #![warn(unused)] // UI tests pass `-A unused` (#43896)
 
 struct SoulHistory {
@@ -67,7 +67,7 @@ fn main() {
     };
 
     // Boxed struct
-    match box bag {
+    match Box::new(bag) {
         box Large::Suit { case } => {} //~ WARNING unused variable: `case`
     };
 

--- a/src/test/ui/list.rs
+++ b/src/test/ui/list.rs
@@ -3,8 +3,8 @@
 #![allow(non_camel_case_types)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 enum list { cons(isize, Box<list>), nil, }
 
-pub fn main() { list::cons(10, box list::cons(11, box list::cons(12, box list::nil))); }
+pub fn main() {
+    list::cons(10, Box::new(list::cons(11, Box::new(list::cons(12, Box::new(list::nil))))));
+}

--- a/src/test/ui/liveness/liveness-move-call-arg.rs
+++ b/src/test/ui/liveness/liveness-move-call-arg.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax)]
-
 fn take(_x: Box<isize>) {}
+
 
 fn main() {
 
-    let x: Box<isize> = box 25;
+    let x: Box<isize> = Box::new(25);
+
     loop {
         take(x); //~ ERROR use of moved value: `x`
     }

--- a/src/test/ui/liveness/liveness-move-call-arg.stderr
+++ b/src/test/ui/liveness/liveness-move-call-arg.stderr
@@ -1,9 +1,9 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/liveness-move-call-arg.rs:9:14
    |
-LL |     let x: Box<isize> = box 25;
+LL |     let x: Box<isize> = Box::new(25);
    |         - move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
-LL |     loop {
+...
 LL |         take(x);
    |              ^ value moved here, in previous iteration of loop
 

--- a/src/test/ui/liveness/liveness-move-in-loop.rs
+++ b/src/test/ui/liveness/liveness-move-in-loop.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let y: Box<isize> = box 42;
+
+    let y: Box<isize> = 42.into();
     let mut x: Box<isize>;
+
     loop {
         println!("{}", y);
         loop {

--- a/src/test/ui/liveness/liveness-move-in-loop.stderr
+++ b/src/test/ui/liveness/liveness-move-in-loop.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `y`
   --> $DIR/liveness-move-in-loop.rs:11:25
    |
-LL |     let y: Box<isize> = box 42;
+LL |     let y: Box<isize> = 42.into();
    |         - move occurs because `y` has type `Box<isize>`, which does not implement the `Copy` trait
 ...
 LL |                     x = y;

--- a/src/test/ui/liveness/liveness-move-in-while.rs
+++ b/src/test/ui/liveness/liveness-move-in-while.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let y: Box<isize> = box 42;
+
+    let y: Box<isize> = 42.into();
     let mut x: Box<isize>;
+
     loop {
         println!("{}", y); //~ ERROR borrow of moved value: `y`
         while true { while true { while true { x = y; x.clone(); } } }

--- a/src/test/ui/liveness/liveness-move-in-while.stderr
+++ b/src/test/ui/liveness/liveness-move-in-while.stderr
@@ -21,7 +21,7 @@ LL |         while true { while true { while true { x = y; x.clone(); } } }
 error[E0382]: borrow of moved value: `y`
   --> $DIR/liveness-move-in-while.rs:7:24
    |
-LL |     let y: Box<isize> = box 42;
+LL |     let y: Box<isize> = 42.into();
    |         - move occurs because `y` has type `Box<isize>`, which does not implement the `Copy` trait
 ...
 LL |         println!("{}", y);

--- a/src/test/ui/liveness/liveness-use-after-move.rs
+++ b/src/test/ui/liveness/liveness-use-after-move.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 fn main() {
-    let x: Box<_> = box 5;
+
+    let x: Box<_> = 5.into();
     let y = x;
+
     println!("{}", *x); //~ ERROR borrow of moved value: `x`
     y.clone();
 }

--- a/src/test/ui/liveness/liveness-use-after-move.stderr
+++ b/src/test/ui/liveness/liveness-use-after-move.stderr
@@ -1,10 +1,11 @@
 error[E0382]: borrow of moved value: `x`
   --> $DIR/liveness-use-after-move.rs:6:20
    |
-LL |     let x: Box<_> = box 5;
+LL |     let x: Box<_> = 5.into();
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     let y = x;
    |             - value moved here
+LL | 
 LL |     println!("{}", *x);
    |                    ^^ value borrowed here after move
 

--- a/src/test/ui/map-types.rs
+++ b/src/test/ui/map-types.rs
@@ -1,6 +1,6 @@
-#![feature(box_syntax)]
-
 use std::collections::HashMap;
+
+
 
 trait Map<K, V>
 {
@@ -12,7 +12,7 @@ impl<K, V> Map<K, V> for HashMap<K, V> {}
 // Test that trait types printed in error msgs include the type arguments.
 
 fn main() {
-    let x: Box<HashMap<isize, isize>> = box HashMap::new();
+    let x: Box<HashMap<isize, isize>> = HashMap::new().into();
     let x: Box<dyn Map<isize, isize>> = x;
     let y: Box<dyn Map<usize, isize>> = Box::new(x);
     //~^ ERROR `Box<dyn Map<isize, isize>>: Map<usize, isize>` is not satisfied

--- a/src/test/ui/methods/auxiliary/method_self_arg1.rs
+++ b/src/test/ui/methods/auxiliary/method_self_arg1.rs
@@ -1,7 +1,5 @@
 #![crate_type = "lib"]
 
-#![feature(box_syntax)]
-
 static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }
@@ -19,8 +17,8 @@ impl Foo {
         Foo::baz(self);
         Foo::baz(*x);
 
-        Foo::qux(box self);
-        Foo::qux(box *x);
+        Foo::qux(Box::new(self));
+        Foo::qux(Box::new(*x));
     }
 
     pub fn bar(&self) {

--- a/src/test/ui/methods/auxiliary/method_self_arg2.rs
+++ b/src/test/ui/methods/auxiliary/method_self_arg2.rs
@@ -1,7 +1,5 @@
 #![crate_type = "lib"]
 
-#![feature(box_syntax)]
-
 static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }
@@ -15,11 +13,11 @@ impl Foo {
         // Test internal call.
         Bar::foo1(&self);
         Bar::foo2(self);
-        Bar::foo3(box self);
+        Bar::foo3(Box::new(self));
 
         Bar::bar1(&self);
         Bar::bar2(self);
-        Bar::bar3(box self);
+        Bar::bar3(Box::new(self));
     }
 }
 

--- a/src/test/ui/methods/method-self-arg-aux1.rs
+++ b/src/test/ui/methods/method-self-arg-aux1.rs
@@ -1,8 +1,6 @@
 // run-pass
 // Test method calls with self as an argument (cross-crate)
 
-#![feature(box_syntax)]
-
 // aux-build:method_self_arg1.rs
 extern crate method_self_arg1;
 use method_self_arg1::Foo;
@@ -12,7 +10,7 @@ fn main() {
     // Test external call.
     Foo::bar(&x);
     Foo::baz(x);
-    Foo::qux(box x);
+    Foo::qux(Box::new(x));
 
     x.foo(&x);
 

--- a/src/test/ui/methods/method-self-arg-aux2.rs
+++ b/src/test/ui/methods/method-self-arg-aux2.rs
@@ -1,8 +1,6 @@
 // run-pass
 // Test method calls with self as an argument (cross-crate)
 
-#![feature(box_syntax)]
-
 // aux-build:method_self_arg2.rs
 extern crate method_self_arg2;
 use method_self_arg2::{Foo, Bar};
@@ -12,11 +10,11 @@ fn main() {
     // Test external call.
     Bar::foo1(&x);
     Bar::foo2(x);
-    Bar::foo3(box x);
+    Bar::foo3(Box::new(x));
 
     Bar::bar1(&x);
     Bar::bar2(x);
-    Bar::bar3(box x);
+    Bar::bar3(Box::new(x));
 
     x.run_trait();
 

--- a/src/test/ui/methods/method-self-arg-trait.rs
+++ b/src/test/ui/methods/method-self-arg-trait.rs
@@ -1,8 +1,6 @@
 // run-pass
 // Test method calls with self as an argument
 
-#![feature(box_syntax)]
-
 static mut COUNT: u64 = 1;
 
 #[derive(Copy, Clone)]
@@ -44,11 +42,11 @@ impl Foo {
         // Test internal call.
         Bar::foo1(&self);
         Bar::foo2(self);
-        Bar::foo3(box self);
+        Bar::foo3(Box::new(self));
 
         Bar::bar1(&self);
         Bar::bar2(self);
-        Bar::bar3(box self);
+        Bar::bar3(Box::new(self));
     }
 }
 
@@ -57,11 +55,11 @@ fn main() {
     // Test external call.
     Bar::foo1(&x);
     Bar::foo2(x);
-    Bar::foo3(box x);
+    Bar::foo3(Box::new(x));
 
     Bar::bar1(&x);
     Bar::bar2(x);
-    Bar::bar3(box x);
+    Bar::bar3(Box::new(x));
 
     x.baz();
 

--- a/src/test/ui/methods/method-self-arg.rs
+++ b/src/test/ui/methods/method-self-arg.rs
@@ -1,8 +1,6 @@
 // run-pass
 // Test method calls with self as an argument
 
-#![feature(box_syntax)]
-
 static mut COUNT: usize = 1;
 
 #[derive(Copy, Clone)]
@@ -18,8 +16,8 @@ impl Foo {
         Foo::baz(self);
         Foo::baz(*x);
 
-        Foo::qux(box self);
-        Foo::qux(box *x);
+        Foo::qux(Box::new(self));
+        Foo::qux(Box::new(*x));
     }
 
     fn bar(&self) {
@@ -40,7 +38,7 @@ fn main() {
     // Test external call.
     Foo::bar(&x);
     Foo::baz(x);
-    Foo::qux(box x);
+    Foo::qux(Box::new(x));
 
     x.foo(&x);
 

--- a/src/test/ui/methods/method-two-trait-defer-resolution-2.rs
+++ b/src/test/ui/methods/method-two-trait-defer-resolution-2.rs
@@ -10,8 +10,6 @@
 // codegen the call as `Foo::foo(&x)` and let the specific impl get
 // chosen later.
 
-#![feature(box_syntax)]
-
 trait Foo {
     fn foo(&self) -> isize;
 }
@@ -37,7 +35,7 @@ fn call_foo_copy() -> isize {
 fn call_foo_other() -> isize {
     let mut x: Vec<_> = Vec::new();
     let y = x.foo();
-    let z: Box<i32> = box 0;
+    let z: Box<i32> = Box::new(0);
     x.push(z);
     y
 }

--- a/src/test/ui/moves/move-1-unique.rs
+++ b/src/test/ui/moves/move-1-unique.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(unused_mut)]
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 #[derive(Clone)]
 struct Triple {
@@ -13,12 +12,12 @@ struct Triple {
 fn test(x: bool, foo: Box<Triple>) -> isize {
     let bar = foo;
     let mut y: Box<Triple>;
-    if x { y = bar; } else { y = box Triple{x: 4, y: 5, z: 6}; }
+    if x { y = bar; } else { y = Box::new(Triple{x: 4, y: 5, z: 6}); }
     return y.y;
 }
 
 pub fn main() {
-    let x: Box<_> = box Triple{x: 1, y: 2, z: 3};
+    let x: Box<_> = Box::new(Triple{x: 1, y: 2, z: 3});
     assert_eq!(test(true, x.clone()), 2);
     assert_eq!(test(true, x.clone()), 2);
     assert_eq!(test(true, x.clone()), 2);

--- a/src/test/ui/moves/move-2-unique.rs
+++ b/src/test/ui/moves/move-2-unique.rs
@@ -1,11 +1,10 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct X { x: isize, y: isize, z: isize }
 
 pub fn main() {
-    let x: Box<_> = box X{x: 1, y: 2, z: 3};
+    let x: Box<_> = Box::new(X {x: 1, y: 2, z: 3});
     let y = x;
     assert_eq!(y.y, 2);
 }

--- a/src/test/ui/moves/move-2.rs
+++ b/src/test/ui/moves/move-2.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct X { x: isize, y: isize, z: isize }
 
-pub fn main() { let x: Box<_> = box X {x: 1, y: 2, z: 3}; let y = x; assert_eq!(y.y, 2); }
+pub fn main() { let x: Box<_> = Box::new(X {x: 1, y: 2, z: 3}); let y = x; assert_eq!(y.y, 2); }

--- a/src/test/ui/moves/move-3-unique.rs
+++ b/src/test/ui/moves/move-3-unique.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![allow(unused_mut)]
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 #[derive(Clone)]
 struct Triple {
@@ -13,12 +12,12 @@ struct Triple {
 fn test(x: bool, foo: Box<Triple>) -> isize {
     let bar = foo;
     let mut y: Box<Triple>;
-    if x { y = bar; } else { y = box Triple {x: 4, y: 5, z: 6}; }
+    if x { y = bar; } else { y = Box::new(Triple {x: 4, y: 5, z: 6}); }
     return y.y;
 }
 
 pub fn main() {
-    let x: Box<_> = box Triple{x: 1, y: 2, z: 3};
+    let x: Box<_> = Box::new(Triple{x: 1, y: 2, z: 3});
     for _ in 0_usize..10000_usize {
         assert_eq!(test(true, x.clone()), 2);
     }

--- a/src/test/ui/moves/move-4-unique.rs
+++ b/src/test/ui/moves/move-4-unique.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct Triple {a: isize, b: isize, c: isize}
 
@@ -13,7 +12,7 @@ fn test(foo: Box<Triple>) -> Box<Triple> {
 }
 
 pub fn main() {
-    let x = box Triple{a: 1, b: 2, c: 3};
+    let x = Box::new(Triple{a: 1, b: 2, c: 3});
     let y = test(x);
     assert_eq!(y.c, 3);
 }

--- a/src/test/ui/moves/move-4.rs
+++ b/src/test/ui/moves/move-4.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct Triple { a: isize, b: isize, c: isize }
 
@@ -13,7 +12,7 @@ fn test(foo: Box<Triple>) -> Box<Triple> {
 }
 
 pub fn main() {
-    let x = box Triple{a: 1, b: 2, c: 3};
+    let x = Box::new(Triple{ a: 1, b: 2, c: 3 });
     let y = test(x);
     assert_eq!(y.c, 3);
 }

--- a/src/test/ui/moves/move-arg-2-unique.rs
+++ b/src/test/ui/moves/move-arg-2-unique.rs
@@ -1,13 +1,12 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn test(foo: Box<Vec<isize>> ) { assert_eq!((*foo)[0], 10); }
 
 pub fn main() {
-    let x = box vec![10];
+    let x = Box::new(vec![10]);
     // Test forgetting a local by move-in
     test(x);
 
     // Test forgetting a temporary by move-in.
-    test(box vec![10]);
+    test(Box::new(vec![10]));
 }

--- a/src/test/ui/moves/move-arg-2.rs
+++ b/src/test/ui/moves/move-arg-2.rs
@@ -1,13 +1,12 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn test(foo: Box<Vec<isize>>) { assert_eq!((*foo)[0], 10); }
 
 pub fn main() {
-    let x = box vec![10];
+    let x = Box::new(vec![10]);
     // Test forgetting a local by move-in
     test(x);
 
     // Test forgetting a temporary by move-in.
-    test(box vec![10]);
+    test(Box::new(vec![10]));
 }

--- a/src/test/ui/moves/move-guard-same-consts.rs
+++ b/src/test/ui/moves/move-guard-same-consts.rs
@@ -8,10 +8,10 @@
 // that assumption did not hold, at least not in the long run (namely,
 // overlapping patterns were turned into warnings rather than errors).
 
-#![feature(box_syntax)]
+
 
 fn main() {
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 

--- a/src/test/ui/moves/move-guard-same-consts.stderr
+++ b/src/test/ui/moves/move-guard-same-consts.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-same-consts.rs:20:24
    |
-LL |     let x: Box<_> = box 1;
+LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 ...
 LL |         (1, 2) if take(x) => (),

--- a/src/test/ui/moves/move-in-guard-1.rs
+++ b/src/test/ui/moves/move-in-guard-1.rs
@@ -1,7 +1,7 @@
-#![feature(box_syntax)]
-
 pub fn main() {
-    let x: Box<_> = box 1;
+
+
+    let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 

--- a/src/test/ui/moves/move-in-guard-1.stderr
+++ b/src/test/ui/moves/move-in-guard-1.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `x`
   --> $DIR/move-in-guard-1.rs:10:24
    |
-LL |     let x: Box<_> = box 1;
+LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 ...
 LL |         (1, _) if take(x) => (),

--- a/src/test/ui/moves/move-in-guard-2.rs
+++ b/src/test/ui/moves/move-in-guard-2.rs
@@ -1,7 +1,5 @@
-#![feature(box_syntax)]
-
 pub fn main() {
-    let x: Box<_> = box 1;
+    let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 

--- a/src/test/ui/moves/move-in-guard-2.stderr
+++ b/src/test/ui/moves/move-in-guard-2.stderr
@@ -1,7 +1,7 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/move-in-guard-2.rs:10:24
+  --> $DIR/move-in-guard-2.rs:8:24
    |
-LL |     let x: Box<_> = box 1;
+LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 ...
 LL |         (_, 2) if take(x) => (),

--- a/src/test/ui/moves/move-out-of-tuple-field.rs
+++ b/src/test/ui/moves/move-out-of-tuple-field.rs
@@ -1,13 +1,13 @@
-#![feature(box_syntax)]
-
 struct Foo(Box<isize>);
 
+
+
 fn main() {
-    let x: (Box<_>,) = (box 1,);
+    let x: (Box<_>,) = (Box::new(1),);
     let y = x.0;
     let z = x.0; //~ ERROR use of moved value: `x.0`
 
-    let x = Foo(box 1);
+    let x = Foo(Box::new(1));
     let y = x.0;
     let z = x.0; //~ ERROR use of moved value: `x.0`
 }

--- a/src/test/ui/moves/moves-based-on-type-block-bad.rs
+++ b/src/test/ui/moves/moves-based-on-type-block-bad.rs
@@ -1,5 +1,5 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 
 struct S {
     x: Box<E>
@@ -16,7 +16,7 @@ fn f<G>(s: &S, g: G) where G: FnOnce(&S) {
 }
 
 fn main() {
-    let s = S { x: box E::Bar(box 42) };
+    let s = S { x: Box::new(E::Bar(Box::new(42))) };
     loop {
         f(&s, |hellothere| {
             match hellothere.x { //~ ERROR cannot move out

--- a/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
+++ b/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 fn to_fn<A,F:Fn<A>>(f: F) -> F { f }
 
 fn test(_x: Box<usize>) {}
 
 fn main() {
-    let i = box 3;
+    let i = Box::new(3);
     let _f = to_fn(|| test(i)); //~ ERROR cannot move out
 }

--- a/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
+++ b/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
@@ -1,7 +1,7 @@
 error[E0507]: cannot move out of `i`, a captured variable in an `Fn` closure
   --> $DIR/moves-based-on-type-move-out-of-closure-env-issue-1965.rs:9:28
    |
-LL |     let i = box 3;
+LL |     let i = Box::new(3);
    |         - captured outer variable
 LL |     let _f = to_fn(|| test(i));
    |                    --------^-

--- a/src/test/ui/moves/moves-based-on-type-tuple.rs
+++ b/src/test/ui/moves/moves-based-on-type-tuple.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax)]
-
 fn dup(x: Box<isize>) -> Box<(Box<isize>,Box<isize>)> {
-    box (x, x)
+
+
+    Box::new((x, x))
     //~^ use of moved value: `x` [E0382]
 }
 
 fn main() {
-    dup(box 3);
+    dup(Box::new(3));
 }

--- a/src/test/ui/moves/moves-based-on-type-tuple.stderr
+++ b/src/test/ui/moves/moves-based-on-type-tuple.stderr
@@ -1,12 +1,13 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/moves-based-on-type-tuple.rs:4:13
+  --> $DIR/moves-based-on-type-tuple.rs:4:18
    |
 LL | fn dup(x: Box<isize>) -> Box<(Box<isize>,Box<isize>)> {
    |        - move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
-LL |     box (x, x)
-   |          -  ^ value used here after move
-   |          |
-   |          value moved here
+...
+LL |     Box::new((x, x))
+   |               -  ^ value used here after move
+   |               |
+   |               value moved here
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-sru-moved-field.rs
+++ b/src/test/ui/moves/moves-sru-moved-field.rs
@@ -1,6 +1,6 @@
-#![feature(box_syntax)]
-
 type Noncopyable = Box<isize>;
+
+
 
 struct Foo {
     copied: isize,
@@ -10,8 +10,8 @@ struct Foo {
 
 fn test0(f: Foo, g: Noncopyable, h: Noncopyable) {
     // just copy implicitly copyable fields from `f`, no moves:
-    let _b = Foo {moved: box 1, noncopyable: g, ..f};
-    let _c = Foo {moved: box 2, noncopyable: h, ..f};
+    let _b = Foo {moved: Box::new(1), noncopyable: g, ..f};
+    let _c = Foo {moved: Box::new(2), noncopyable: h, ..f};
 }
 
 fn test1(f: Foo, g: Noncopyable, h: Noncopyable) {

--- a/src/test/ui/mut-function-arguments.rs
+++ b/src/test/ui/mut-function-arguments.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 fn f(mut y: Box<isize>) {
     *y = 5;
     assert_eq!(*y, 5);
@@ -9,13 +7,13 @@ fn f(mut y: Box<isize>) {
 
 fn g() {
     let frob = |mut q: Box<isize>| { *q = 2; assert_eq!(*q, 2); };
-    let w = box 37;
+    let w = Box::new(37);
     frob(w);
 
 }
 
 pub fn main() {
-    let z = box 17;
+    let z = Box::new(17);
     f(z);
     g();
 }

--- a/src/test/ui/mut/mut-cross-borrowing.rs
+++ b/src/test/ui/mut/mut-cross-borrowing.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 fn f(_: &mut isize) {}
 
 fn main() {
-    let mut x: Box<_> = box 3;
+
+    let mut x: Box<_> = Box::new(3);
+
     f(x)    //~ ERROR mismatched types
 }

--- a/src/test/ui/new-box-syntax.rs
+++ b/src/test/ui/new-box-syntax.rs
@@ -5,7 +5,6 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 #![allow(dead_code, unused_variables)]
-#![feature(box_syntax)]
 
 // Tests that the new `box` syntax works with unique pointers.
 
@@ -17,12 +16,12 @@ struct Structure {
 }
 
 pub fn main() {
-    let y: Box<isize> = box 2;
-    let b: Box<isize> = box (1 + 2);
-    let c = box (3 + 4);
+    let y: Box<isize> = Box::new(2);
+    let b: Box<isize> = Box::new(1 + 2);
+    let c = Box::new(3 + 4);
 
-    let s: Box<Structure> = box Structure {
+    let s: Box<Structure> = Box::new(Structure {
         x: 3,
         y: 4,
-    };
+    });
 }

--- a/src/test/ui/new-box.rs
+++ b/src/test/ui/new-box.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 fn f(x: Box<isize>) {
     let y: &isize = &*x;
     println!("{}", *x);
@@ -27,6 +25,6 @@ fn g(x: Box<dyn Trait>) {
 }
 
 fn main() {
-    f(box 1234);
-    g(box Struct as Box<dyn Trait>);
+    f(Box::new(1234));
+    g(Box::new(Struct) as Box<dyn Trait>);
 }

--- a/src/test/ui/nll/issue-52663-trait-object.rs
+++ b/src/test/ui/nll/issue-52663-trait-object.rs
@@ -1,16 +1,16 @@
-#![feature(box_syntax)]
-
 trait Foo { fn get(&self); }
 
 impl<A> Foo for A {
     fn get(&self) { }
 }
 
+
+
 fn main() {
     let _ = {
         let tmp0 = 3;
         let tmp1 = &tmp0;
-        box tmp1 as Box<dyn Foo + '_>
+        Box::new(tmp1) as Box<dyn Foo + '_>
     };
     //~^^^ ERROR `tmp0` does not live long enough
 }

--- a/src/test/ui/nll/issue-52663-trait-object.stderr
+++ b/src/test/ui/nll/issue-52663-trait-object.stderr
@@ -3,8 +3,8 @@ error[E0597]: `tmp0` does not live long enough
    |
 LL |         let tmp1 = &tmp0;
    |                    ^^^^^ borrowed value does not live long enough
-LL |         box tmp1 as Box<dyn Foo + '_>
-   |         ----------------------------- borrow later used here
+LL |         Box::new(tmp1) as Box<dyn Foo + '_>
+   |         ----------------------------------- borrow later captured here by trait object
 LL |     };
    |     - `tmp0` dropped here while still borrowed
 

--- a/src/test/ui/nullable-pointer-iotareduction.rs
+++ b/src/test/ui/nullable-pointer-iotareduction.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 // Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,
 // which "says that a destructor applied to an object built from a constructor
 // behaves as expected".  -- https://coq.inria.fr/doc/language/core/conversion.html#iota-reduction
@@ -64,7 +62,7 @@ macro_rules! check_type {
 
 pub fn main() {
     check_type!(&17, &isize);
-    check_type!(box 18, Box<isize>);
+    check_type!(Box::new(18), Box<isize>);
     check_type!("foo".to_string(), String);
     check_type!(vec![20, 22], Vec<isize>);
     check_type!(main, fn(), |pthing| {

--- a/src/test/ui/objects-owned-object-borrowed-method-headerless.rs
+++ b/src/test/ui/objects-owned-object-borrowed-method-headerless.rs
@@ -3,9 +3,6 @@
 // closed over do not contain managed values, and thus the boxes do
 // not have headers.
 
-#![feature(box_syntax)]
-
-
 trait FooTrait {
     fn foo(&self) -> usize;
 }
@@ -22,9 +19,9 @@ impl FooTrait for BarStruct {
 
 pub fn main() {
     let foos: Vec<Box<dyn FooTrait>> = vec![
-        box BarStruct{ x: 0 } as Box<dyn FooTrait>,
-        box BarStruct{ x: 1 } as Box<dyn FooTrait>,
-        box BarStruct{ x: 2 } as Box<dyn FooTrait>
+        Box::new(BarStruct{ x: 0 }) as Box<dyn FooTrait>,
+        Box::new(BarStruct{ x: 1 }) as Box<dyn FooTrait>,
+        Box::new(BarStruct{ x: 2 }) as Box<dyn FooTrait>,
     ];
 
     for i in 0..foos.len() {

--- a/src/test/ui/objects-owned-object-owned-method.rs
+++ b/src/test/ui/objects-owned-object-owned-method.rs
@@ -3,8 +3,6 @@
 // closed over contain managed values. This implies that the boxes
 // will have headers that must be skipped over.
 
-#![feature(box_syntax)]
-
 trait FooTrait {
     fn foo(self: Box<Self>) -> usize;
 }
@@ -20,6 +18,6 @@ impl FooTrait for BarStruct {
 }
 
 pub fn main() {
-    let foo = box BarStruct{ x: 22 } as Box<dyn FooTrait>;
+    let foo = Box::new(BarStruct{ x: 22 }) as Box<dyn FooTrait>;
     assert_eq!(22, foo.foo());
 }

--- a/src/test/ui/occurs-check-2.rs
+++ b/src/test/ui/occurs-check-2.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax)]
-
 fn main() {
+
     let f;
     let g;
+
     g = f;
-    f = box g;
+    f = Box::new(g);
     //~^  ERROR mismatched types
     //~| cyclic type of infinite size
 }

--- a/src/test/ui/occurs-check-2.stderr
+++ b/src/test/ui/occurs-check-2.stderr
@@ -1,13 +1,10 @@
 error[E0308]: mismatched types
   --> $DIR/occurs-check-2.rs:7:9
    |
-LL |     f = box g;
-   |         ^^^^^ cyclic type of infinite size
-   |
-help: try using a conversion method
-   |
-LL |     f = (box g).to_string();
-   |         +     +++++++++++++
+LL |     f = Box::new(g);
+   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
+   |         |
+   |         cyclic type of infinite size
 
 error: aborting due to previous error
 

--- a/src/test/ui/occurs-check.rs
+++ b/src/test/ui/occurs-check.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 fn main() {
+
     let f;
-    f = box f;
+
+    f = Box::new(f);
     //~^ ERROR mismatched types
     //~| cyclic type of infinite size
 }

--- a/src/test/ui/occurs-check.stderr
+++ b/src/test/ui/occurs-check.stderr
@@ -1,13 +1,10 @@
 error[E0308]: mismatched types
   --> $DIR/occurs-check.rs:5:9
    |
-LL |     f = box f;
-   |         ^^^^^ cyclic type of infinite size
-   |
-help: try using a conversion method
-   |
-LL |     f = (box f).to_string();
-   |         +     +++++++++++++
+LL |     f = Box::new(f);
+   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
+   |         |
+   |         cyclic type of infinite size
 
 error: aborting due to previous error
 

--- a/src/test/ui/output-slot-variants.rs
+++ b/src/test/ui/output-slot-variants.rs
@@ -7,22 +7,21 @@
 
 #![allow(dead_assignment)]
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 
 struct A { a: isize, b: isize }
 struct Abox { a: Box<isize>, b: Box<isize> }
 
 fn ret_int_i() -> isize { 10 }
 
-fn ret_ext_i() -> Box<isize> { box 10 }
+fn ret_ext_i() -> Box<isize> { Box::new(10) }
 
 fn ret_int_rec() -> A { A {a: 10, b: 10} }
 
-fn ret_ext_rec() -> Box<A> { box A {a: 10, b: 10} }
+fn ret_ext_rec() -> Box<A> { Box::new(A {a: 10, b: 10}) }
 
-fn ret_ext_mem() -> Abox { Abox {a: box 10, b: box 10} }
+fn ret_ext_mem() -> Abox { Abox {a: Box::new(10), b: Box::new(10) } }
 
-fn ret_ext_ext_mem() -> Box<Abox> { box Abox{a: box 10, b: box 10} }
+fn ret_ext_ext_mem() -> Box<Abox> { Box::new(Abox{a: Box::new(10), b: Box::new(10) }) }
 
 pub fn main() {
     let mut int_i: isize;

--- a/src/test/ui/overloaded/overloaded-autoderef.rs
+++ b/src/test/ui/overloaded/overloaded-autoderef.rs
@@ -2,8 +2,6 @@
 #![allow(unused_variables)]
 #![allow(stable_features)]
 
-#![feature(box_syntax, core)]
-
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -14,7 +12,7 @@ struct Point {
 }
 
 pub fn main() {
-    let box_5: Box<_> = box 5_usize;
+    let box_5: Box<_> = Box::new(5_usize);
     let point = Rc::new(Point {x: 2, y: 4});
     assert_eq!(point.x, 2);
     assert_eq!(point.y, 4);

--- a/src/test/ui/overloaded/overloaded-index-autoderef.rs
+++ b/src/test/ui/overloaded/overloaded-index-autoderef.rs
@@ -3,8 +3,6 @@
 
 // Test overloaded indexing combined with autoderef.
 
-#![feature(box_syntax, core)]
-
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -47,10 +45,10 @@ impl Int for isize {
 }
 
 fn main() {
-    let mut f: Box<_> = box Foo {
+    let mut f: Box<_> = Box::new(Foo {
         x: 1,
         y: 2,
-    };
+    });
 
     assert_eq!(f[1], 2);
 

--- a/src/test/ui/panics/args-panic.rs
+++ b/src/test/ui/panics/args-panic.rs
@@ -2,12 +2,10 @@
 // error-pattern:meep
 // ignore-emscripten no processes
 
-#![feature(box_syntax)]
-
 fn f(_a: isize, _b: isize, _c: Box<isize>) {
     panic!("moop");
 }
 
 fn main() {
-    f(1, panic!("meep"), box 42);
+    f(1, panic!("meep"), Box::new(42));
 }

--- a/src/test/ui/panics/panic-macro-any.rs
+++ b/src/test/ui/panics/panic-macro-any.rs
@@ -2,9 +2,8 @@
 // error-pattern:panicked at 'Box<dyn Any>'
 // ignore-emscripten no processes
 
-#![feature(box_syntax)]
 #![allow(non_fmt_panics)]
 
 fn main() {
-    panic!(box 413 as Box<dyn std::any::Any + Send>);
+    panic!(Box::new(413) as Box<dyn std::any::Any + Send>);
 }

--- a/src/test/ui/parser/trailing-plus-in-bounds.rs
+++ b/src/test/ui/parser/trailing-plus-in-bounds.rs
@@ -1,10 +1,9 @@
 // build-pass (FIXME(62277): could be check-pass?)
 
-#![feature(box_syntax)]
 #![allow(bare_trait_objects)]
 
 use std::fmt::Debug;
 
 fn main() {
-    let x: Box<Debug+> = box 3 as Box<Debug+>; // Trailing `+` is OK
+    let x: Box<Debug+> = Box::new(3) as Box<Debug+>; // Trailing `+` is OK
 }

--- a/src/test/ui/pattern/usefulness/issue-12116.rs
+++ b/src/test/ui/pattern/usefulness/issue-12116.rs
@@ -1,8 +1,8 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![deny(unreachable_patterns)]
+
 
 enum IntList {
     Cons(isize, Box<IntList>),
@@ -12,9 +12,9 @@ enum IntList {
 fn tail(source_list: &IntList) -> IntList {
     match source_list {
         &IntList::Cons(val, box ref next_list) => tail(next_list),
-        &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, box IntList::Nil),
-//~^ ERROR unreachable pattern
-        _                          => panic!()
+        &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, Box::new(IntList::Nil)),
+        //~^ ERROR unreachable pattern
+        _ => panic!(),
     }
 }
 

--- a/src/test/ui/pattern/usefulness/issue-12116.stderr
+++ b/src/test/ui/pattern/usefulness/issue-12116.stderr
@@ -1,11 +1,11 @@
 error: unreachable pattern
   --> $DIR/issue-12116.rs:15:9
    |
-LL |         &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, box IntList::Nil),
+LL |         &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, Box::new(IntList::Nil)),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/issue-12116.rs:5:9
+  --> $DIR/issue-12116.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/pattern/usefulness/issue-3601.rs
+++ b/src/test/ui/pattern/usefulness/issue-3601.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct HTMLImageData {
     image: Option<String>
@@ -23,8 +22,9 @@ struct NodeData {
 
 fn main() {
     let mut id = HTMLImageData { image: None };
-    let ed = ElementData { kind: box ElementKind::HTMLImageElement(id) };
-    let n = NodeData {kind : box NodeKind::Element(ed)};
+    let ed = ElementData { kind: Box::new(ElementKind::HTMLImageElement(id)) };
+    let n = NodeData { kind: Box::new(NodeKind::Element(ed)) };
+
     // n.b. span could be better
     match n.kind {
         box NodeKind::Element(ed) => match ed.kind { //~ ERROR non-exhaustive patterns

--- a/src/test/ui/pure-sum.rs
+++ b/src/test/ui/pure-sum.rs
@@ -5,8 +5,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn sums_to(v: Vec<isize> , sum: isize) -> bool {
     let mut i = 0;
     let mut sum0 = 0;
@@ -19,7 +17,7 @@ fn sums_to(v: Vec<isize> , sum: isize) -> bool {
 
 fn sums_to_using_uniq(v: Vec<isize> , sum: isize) -> bool {
     let mut i = 0;
-    let mut sum0: Box<_> = box 0;
+    let mut sum0: Box<_> = 0.into();
     while i < v.len() {
         *sum0 += v[i];
         i += 1;
@@ -41,7 +39,7 @@ struct F<T> { f: T }
 
 fn sums_to_using_uniq_rec(v: Vec<isize> , sum: isize) -> bool {
     let mut i = 0;
-    let mut sum0 = F::<Box<_>> {f: box 0};
+    let mut sum0 = F::<Box<_>> {f: 0.into() };
     while i < v.len() {
         *sum0.f += v[i];
         i += 1;

--- a/src/test/ui/rcvr-borrowed-to-region.rs
+++ b/src/test/ui/rcvr-borrowed-to-region.rs
@@ -1,7 +1,6 @@
 // run-pass
 
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 
 trait get {
     fn get(self) -> isize;
@@ -17,7 +16,7 @@ impl<'a> get for &'a isize {
 }
 
 pub fn main() {
-    let x: Box<_> = box 6;
+    let x: Box<_> = 6.into();
     let y = x.get();
     println!("y={}", y);
     assert_eq!(y, 6);

--- a/src/test/ui/reachable/expr_again.rs
+++ b/src/test/ui/reachable/expr_again.rs
@@ -1,5 +1,5 @@
-#![feature(box_syntax)]
 #![allow(unused_variables)]
+
 #![deny(unreachable_code)]
 
 fn main() {

--- a/src/test/ui/reachable/unreachable-arm.rs
+++ b/src/test/ui/reachable/unreachable-arm.rs
@@ -1,5 +1,5 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 #![allow(dead_code)]
 #![deny(unreachable_patterns)]
 

--- a/src/test/ui/regions/issue-12470.rs
+++ b/src/test/ui/regions/issue-12470.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 trait X {
     fn get_i(&self) -> isize;
 }
+
+
 
 
 struct B {
@@ -24,7 +24,7 @@ fn make_a<'a>(p: &'a dyn X) -> A<'a> {
 }
 
 fn make_make_a<'a>() -> A<'a> {
-    let b: Box<B> = box B {i:1};
+    let b: Box<B> = Box::new(B { i: 1 });
     let bb: &B = &*b;
     make_a(bb)  //~ ERROR cannot return value referencing local data `*b`
 }

--- a/src/test/ui/regions/regions-borrow-at.rs
+++ b/src/test/ui/regions/regions-borrow-at.rs
@@ -1,12 +1,11 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn foo(x: &usize) -> usize {
     *x
 }
 
 pub fn main() {
-    let p: Box<_> = box 22;
+    let p: Box<_> = Box::new(22);
     let r = foo(&*p);
     println!("r={}", r);
     assert_eq!(r, 22);

--- a/src/test/ui/regions/regions-borrow-uniq.rs
+++ b/src/test/ui/regions/regions-borrow-uniq.rs
@@ -1,12 +1,11 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn foo(x: &usize) -> usize {
     *x
 }
 
 pub fn main() {
-    let p: Box<_> = box 3;
+    let p: Box<_> = Box::new(3);
     let r = foo(&*p);
     assert_eq!(r, 3);
 }

--- a/src/test/ui/regions/regions-close-associated-type-into-object.rs
+++ b/src/test/ui/regions/regions-close-associated-type-into-object.rs
@@ -1,6 +1,6 @@
-#![feature(box_syntax)]
-
 trait X {}
+
+
 
 trait Iter {
     type Item: X;
@@ -18,7 +18,7 @@ fn bad1<T: Iter>(v: T) -> Box<dyn X + 'static>
 fn bad2<T: Iter>(v: T) -> Box<dyn X + 'static>
     where Box<T::Item> : X
 {
-    let item: Box<_> = box v.into_item();
+    let item: Box<_> = Box::new(v.into_item());
     Box::new(item) //~ ERROR associated type `<T as Iter>::Item` may not live long enough
 }
 
@@ -31,7 +31,7 @@ fn bad3<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
 fn bad4<'a, T: Iter>(v: T) -> Box<dyn X + 'a>
     where Box<T::Item> : X
 {
-    let item: Box<_> = box v.into_item();
+    let item: Box<_> = Box::new(v.into_item());
     Box::new(item) //~ ERROR associated type `<T as Iter>::Item` may not live long enough
 }
 

--- a/src/test/ui/regions/regions-close-object-into-object-1.rs
+++ b/src/test/ui/regions/regions-close-object-into-object-1.rs
@@ -1,7 +1,7 @@
-#![feature(box_syntax)]
 #![allow(warnings)]
 
 trait A<T> { }
+
 struct B<'a, T:'a>(&'a (A<T>+'a));
 
 trait X { }
@@ -9,7 +9,7 @@ trait X { }
 impl<'a, T> X for B<'a, T> {}
 
 fn f<'a, T:'static, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot return value referencing local data `*v`
+    Box::new(B(&*v)) as Box<X> //~ ERROR cannot return value referencing local data `*v`
 }
 
 fn main() {}

--- a/src/test/ui/regions/regions-close-object-into-object-1.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-1.stderr
@@ -1,10 +1,10 @@
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-1.rs:12:5
    |
-LL |     box B(&*v) as Box<X>
-   |     ^^^^^^---^^^^^^^^^^^
-   |     |     |
-   |     |     `*v` is borrowed here
+LL |     Box::new(B(&*v)) as Box<X>
+   |     ^^^^^^^^^^^---^^^^^^^^^^^^
+   |     |          |
+   |     |          `*v` is borrowed here
    |     returns a value referencing data owned by the current function
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -1,20 +1,20 @@
 error: lifetime may not live long enough
-  --> $DIR/regions-close-object-into-object-2.rs:10:5
+  --> $DIR/regions-close-object-into-object-2.rs:9:5
    |
 LL | fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
-LL |     box B(&*v) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
    |
    = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
-  --> $DIR/regions-close-object-into-object-2.rs:10:5
+  --> $DIR/regions-close-object-into-object-2.rs:9:5
    |
-LL |     box B(&*v) as Box<dyn X>
-   |     ^^^^^^---^^^^^^^^^^^^^^^
-   |     |     |
-   |     |     `*v` is borrowed here
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^---^^^^^^^^^^^^^^^^
+   |     |          |
+   |     |          `*v` is borrowed here
    |     returns a value referencing data owned by the current function
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/regions/regions-close-object-into-object-2.rs
+++ b/src/test/ui/regions/regions-close-object-into-object-2.rs
@@ -1,13 +1,12 @@
-#![feature(box_syntax)]
-
 trait A<T> { }
+
 struct B<'a, T:'a>(&'a (dyn A<T> + 'a));
 
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
 fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
-    box B(&*v) as Box<dyn X> //~ ERROR E0759
+    Box::new(B(&*v)) as Box<dyn X> //~ ERROR E0759
 }
 
 fn main() { }

--- a/src/test/ui/regions/regions-close-object-into-object-2.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.stderr
@@ -1,10 +1,10 @@
 error[E0759]: `v` has lifetime `'a` but it needs to satisfy a `'static` lifetime requirement
-  --> $DIR/regions-close-object-into-object-2.rs:10:11
+  --> $DIR/regions-close-object-into-object-2.rs:9:16
    |
 LL | fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
    |                         ------------------ this data with lifetime `'a`...
-LL |     box B(&*v) as Box<dyn X>
-   |           ^^^ ...is captured here, requiring it to live as long as `'static`
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |                ^^^ ...is captured here, requiring it to live as long as `'static`
    |
 help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `v`
    |

--- a/src/test/ui/regions/regions-close-object-into-object-3.rs
+++ b/src/test/ui/regions/regions-close-object-into-object-3.rs
@@ -1,14 +1,14 @@
-#![feature(box_syntax)]
 #![allow(warnings)]
 
 trait A<T> { }
+
 struct B<'a, T:'a>(&'a (A<T>+'a));
 
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
 fn h<'a, T, U:'static>(v: Box<A<U>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot return value referencing local data `*v`
+    Box::new(B(&*v)) as Box<X> //~ ERROR cannot return value referencing local data `*v`
 }
 
 fn main() {}

--- a/src/test/ui/regions/regions-close-object-into-object-3.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-3.stderr
@@ -1,10 +1,10 @@
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-3.rs:11:5
    |
-LL |     box B(&*v) as Box<X>
-   |     ^^^^^^---^^^^^^^^^^^
-   |     |     |
-   |     |     `*v` is borrowed here
+LL |     Box::new(B(&*v)) as Box<X>
+   |     ^^^^^^^^^^^---^^^^^^^^^^^^
+   |     |          |
+   |     |          `*v` is borrowed here
    |     returns a value referencing data owned by the current function
 
 error: aborting due to previous error

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -1,39 +1,55 @@
 error[E0310]: the parameter type `U` may not live long enough
-  --> $DIR/regions-close-object-into-object-4.rs:10:5
+  --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
-LL |     box B(&*v) as Box<dyn X>
-   |     ^^^^^^^^^^
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `U: 'static`...
+
+error[E0310]: the parameter type `U` may not live long enough
+  --> $DIR/regions-close-object-into-object-4.rs:9:5
+   |
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `U: 'static`...
+
+error[E0310]: the parameter type `U` may not live long enough
+  --> $DIR/regions-close-object-into-object-4.rs:9:5
+   |
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `U: 'static`...
 
 error: lifetime may not live long enough
-  --> $DIR/regions-close-object-into-object-4.rs:10:5
+  --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
 LL | fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
-LL |     box B(&*v) as Box<dyn X>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
    |
    = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
-  --> $DIR/regions-close-object-into-object-4.rs:10:5
+  --> $DIR/regions-close-object-into-object-4.rs:9:5
    |
-LL |     box B(&*v) as Box<dyn X>
-   |     ^^^^^^---^^^^^^^^^^^^^^^
-   |     |     |
-   |     |     `*v` is borrowed here
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^---^^^^^^^^^^^^^^^^
+   |     |          |
+   |     |          `*v` is borrowed here
    |     returns a value referencing data owned by the current function
 
 error[E0310]: the parameter type `U` may not live long enough
-  --> $DIR/regions-close-object-into-object-4.rs:10:9
+  --> $DIR/regions-close-object-into-object-4.rs:9:14
    |
-LL |     box B(&*v) as Box<dyn X>
-   |         ^^^^^^
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |              ^^^^^^
    |
    = help: consider adding an explicit lifetime bound `U: 'static`...
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0310, E0515.
 For more information about an error, try `rustc --explain E0310`.

--- a/src/test/ui/regions/regions-close-object-into-object-4.rs
+++ b/src/test/ui/regions/regions-close-object-into-object-4.rs
@@ -1,13 +1,12 @@
-#![feature(box_syntax)]
-
 trait A<T> { }
+
 struct B<'a, T:'a>(&'a (dyn A<T> + 'a));
 
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
 fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
-    box B(&*v) as Box<dyn X> //~ ERROR E0759
+    Box::new(B(&*v)) as Box<dyn X> //~ ERROR E0759
 }
 
 fn main() {}

--- a/src/test/ui/regions/regions-close-object-into-object-4.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.stderr
@@ -1,10 +1,10 @@
 error[E0759]: `v` has lifetime `'a` but it needs to satisfy a `'static` lifetime requirement
-  --> $DIR/regions-close-object-into-object-4.rs:10:11
+  --> $DIR/regions-close-object-into-object-4.rs:9:16
    |
 LL | fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |                   ---------------- this data with lifetime `'a`...
-LL |     box B(&*v) as Box<dyn X>
-   |           ^^^ ...is captured here, requiring it to live as long as `'static`
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |                ^^^ ...is captured here, requiring it to live as long as `'static`
    |
 help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `v`
    |

--- a/src/test/ui/regions/regions-close-object-into-object-5.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-5.nll.stderr
@@ -1,29 +1,45 @@
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
-LL |     box B(&*v) as Box<X>
-   |     ^^^^^^^^^^
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: 'static`...
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/regions-close-object-into-object-5.rs:17:5
+   |
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `T: 'static`...
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/regions-close-object-into-object-5.rs:17:5
+   |
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `T: 'static`...
 
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
-LL |     box B(&*v) as Box<X>
-   |     ^^^^^^---^^^^^^^^^^^
-   |     |     |
-   |     |     `*v` is borrowed here
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^---^^^^^^^^^^^^^^^^
+   |     |          |
+   |     |          `*v` is borrowed here
    |     returns a value referencing data owned by the current function
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:9
+  --> $DIR/regions-close-object-into-object-5.rs:17:14
    |
-LL |     box B(&*v) as Box<X>
-   |         ^^^^^^
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |              ^^^^^^
    |
    = help: consider adding an explicit lifetime bound `T: 'static`...
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0310, E0515.
 For more information about an error, try `rustc --explain E0310`.

--- a/src/test/ui/regions/regions-close-object-into-object-5.rs
+++ b/src/test/ui/regions/regions-close-object-into-object-5.rs
@@ -1,5 +1,5 @@
-#![feature(box_syntax)]
 #![allow(warnings)]
+
 
 trait A<T>
 {
@@ -14,8 +14,9 @@ impl<'a, T> X for B<'a, T> {}
 
 fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
     // oh dear!
-    box B(&*v) as Box<X>
+    Box::new(B(&*v)) as Box<dyn X>
     //~^ ERROR the parameter type `T` may not live long enough
+    //~| ERROR the parameter type `T` may not live long enough
     //~| ERROR the parameter type `T` may not live long enough
     //~| ERROR the parameter type `T` may not live long enough
     //~| ERROR the parameter type `T` may not live long enough

--- a/src/test/ui/regions/regions-close-object-into-object-5.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-5.stderr
@@ -4,26 +4,8 @@ error[E0310]: the parameter type `T` may not live long enough
 LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |          - help: consider adding an explicit lifetime bound...: `T: 'static`
 LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |     ^^^^^^^^^^ ...so that the type `B<'_, T>` will meet its required lifetime bounds
-
-error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:9
-   |
-LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
-   |          - help: consider adding an explicit lifetime bound...: `T: 'static`
-LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |         ^ ...so that the type `T` will meet its required lifetime bounds
-
-error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:9
-   |
-LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
-   |          - help: consider adding an explicit lifetime bound...: `T: 'static`
-LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |         ^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/regions-close-object-into-object-5.rs:9:17
@@ -32,32 +14,65 @@ LL | struct B<'a, T: 'a>(&'a (A<T> + 'a));
    |                 ^^
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:11
+  --> $DIR/regions-close-object-into-object-5.rs:17:5
    |
 LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |          - help: consider adding an explicit lifetime bound...: `T: 'static`
 LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |           ^^^ ...so that the reference type `&dyn A<T>` does not outlive the data it points at
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |     ^^^^^^^^^^^^^^^^ ...so that the type `B<'_, T>` will meet its required lifetime bounds
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:11
+  --> $DIR/regions-close-object-into-object-5.rs:17:14
    |
 LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |          - help: consider adding an explicit lifetime bound...: `T: 'static`
 LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |           ^^^ ...so that the type `(dyn A<T> + 'static)` is not borrowed for too long
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |              ^ ...so that the type `T` will meet its required lifetime bounds
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:11
+  --> $DIR/regions-close-object-into-object-5.rs:17:14
    |
 LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
    |          - help: consider adding an explicit lifetime bound...: `T: 'static`
 LL |     // oh dear!
-LL |     box B(&*v) as Box<X>
-   |           ^^^ ...so that the type `(dyn A<T> + 'static)` is not borrowed for too long
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |              ^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |
+note: ...that is required by this bound
+  --> $DIR/regions-close-object-into-object-5.rs:9:17
+   |
+LL | struct B<'a, T: 'a>(&'a (A<T> + 'a));
+   |                 ^^
 
-error: aborting due to 6 previous errors
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/regions-close-object-into-object-5.rs:17:16
+   |
+LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
+   |          - help: consider adding an explicit lifetime bound...: `T: 'static`
+LL |     // oh dear!
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |                ^^^ ...so that the reference type `&dyn A<T>` does not outlive the data it points at
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/regions-close-object-into-object-5.rs:17:16
+   |
+LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
+   |          - help: consider adding an explicit lifetime bound...: `T: 'static`
+LL |     // oh dear!
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |                ^^^ ...so that the type `(dyn A<T> + 'static)` is not borrowed for too long
+
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/regions-close-object-into-object-5.rs:17:16
+   |
+LL | fn f<'a, T, U>(v: Box<A<T> + 'static>) -> Box<X + 'static> {
+   |          - help: consider adding an explicit lifetime bound...: `T: 'static`
+LL |     // oh dear!
+LL |     Box::new(B(&*v)) as Box<dyn X>
+   |                ^^^ ...so that the type `(dyn A<T> + 'static)` is not borrowed for too long
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/regions/regions-close-over-type-parameter-1.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-1.nll.stderr
@@ -1,16 +1,16 @@
 error[E0310]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:12:5
    |
-LL |     box v as Box<dyn SomeTrait + 'static>
-   |     ^^^^^
+LL |     Box::new(v) as Box<dyn SomeTrait + 'static>
+   |     ^^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `A: 'static`...
 
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:21:5
    |
-LL |     box v as Box<dyn SomeTrait + 'b>
-   |     ^^^^^
+LL |     Box::new(v) as Box<dyn SomeTrait + 'b>
+   |     ^^^^^^^^^^^
    |
    = help: consider adding an explicit lifetime bound `A: 'b`...
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-1.rs
+++ b/src/test/ui/regions/regions-close-over-type-parameter-1.rs
@@ -1,24 +1,24 @@
-#![feature(box_syntax)]
-
 // Test for what happens when a type parameter `A` is closed over into
 // an object. This should yield errors unless `A` (and the object)
 // both have suitable bounds.
+
 
 trait SomeTrait {
     fn get(&self) -> isize;
 }
 
+
 fn make_object1<A: SomeTrait>(v: A) -> Box<dyn SomeTrait + 'static> {
-    box v as Box<dyn SomeTrait + 'static>
+    Box::new(v) as Box<dyn SomeTrait + 'static>
     //~^ ERROR the parameter type `A` may not live long enough
 }
 
 fn make_object2<'a, A: SomeTrait + 'a>(v: A) -> Box<dyn SomeTrait + 'a> {
-    box v as Box<dyn SomeTrait + 'a>
+    Box::new(v) as Box<dyn SomeTrait + 'a>
 }
 
 fn make_object3<'a, 'b, A: SomeTrait + 'a>(v: A) -> Box<dyn SomeTrait + 'b> {
-    box v as Box<dyn SomeTrait + 'b>
+    Box::new(v) as Box<dyn SomeTrait + 'b>
     //~^ ERROR the parameter type `A` may not live long enough
 }
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-1.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-1.stderr
@@ -3,16 +3,16 @@ error[E0310]: the parameter type `A` may not live long enough
    |
 LL | fn make_object1<A: SomeTrait>(v: A) -> Box<dyn SomeTrait + 'static> {
    |                 -- help: consider adding an explicit lifetime bound...: `A: 'static +`
-LL |     box v as Box<dyn SomeTrait + 'static>
-   |     ^^^^^ ...so that the type `A` will meet its required lifetime bounds
+LL |     Box::new(v) as Box<dyn SomeTrait + 'static>
+   |     ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
 
 error[E0309]: the parameter type `A` may not live long enough
   --> $DIR/regions-close-over-type-parameter-1.rs:21:5
    |
 LL | fn make_object3<'a, 'b, A: SomeTrait + 'a>(v: A) -> Box<dyn SomeTrait + 'b> {
    |                         -- help: consider adding an explicit lifetime bound...: `A: 'b +`
-LL |     box v as Box<dyn SomeTrait + 'b>
-   |     ^^^^^ ...so that the type `A` will meet its required lifetime bounds
+LL |     Box::new(v) as Box<dyn SomeTrait + 'b>
+   |     ^^^^^^^^^^^ ...so that the type `A` will meet its required lifetime bounds
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
@@ -6,8 +6,8 @@ LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait +
    |                    |
    |                    lifetime `'a` defined here
 LL |     // A outlives 'a AND 'b...but not 'c.
-LL |     box v as Box<dyn SomeTrait + 'a>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'c`
+LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'c`
    |
    = help: consider adding the following bound: `'a: 'c`
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.rs
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.rs
@@ -1,23 +1,23 @@
-#![feature(box_syntax)]
-
 // Various tests where we over type parameters with multiple lifetime
 // bounds.
 
+
 trait SomeTrait { fn get(&self) -> isize; }
+
 
 fn make_object_good1<'a,'b,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'a> {
     // A outlives 'a AND 'b...
-    box v as Box<dyn SomeTrait + 'a> // ...hence this type is safe.
+    Box::new(v) as Box<dyn SomeTrait + 'a> // ...hence this type is safe.
 }
 
 fn make_object_good2<'a,'b,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'b> {
     // A outlives 'a AND 'b...
-    box v as Box<dyn SomeTrait + 'b> // ...hence this type is safe.
+    Box::new(v) as Box<dyn SomeTrait + 'b> // ...hence this type is safe.
 }
 
 fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'c> {
     // A outlives 'a AND 'b...but not 'c.
-    box v as Box<dyn SomeTrait + 'a> //~ ERROR cannot infer an appropriate lifetime
+    Box::new(v) as Box<dyn SomeTrait + 'a> //~ ERROR cannot infer an appropriate lifetime
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
@@ -1,8 +1,8 @@
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
   --> $DIR/regions-close-over-type-parameter-multiple.rs:20:5
    |
-LL |     box v as Box<dyn SomeTrait + 'a>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 18:20...
   --> $DIR/regions-close-over-type-parameter-multiple.rs:18:20
@@ -12,8 +12,8 @@ LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait +
 note: ...so that the declared lifetime parameter bounds are satisfied
   --> $DIR/regions-close-over-type-parameter-multiple.rs:20:5
    |
-LL |     box v as Box<dyn SomeTrait + 'a>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: but, the lifetime must be valid for the lifetime `'c` as defined on the function body at 18:26...
   --> $DIR/regions-close-over-type-parameter-multiple.rs:18:26
    |
@@ -22,8 +22,8 @@ LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait +
 note: ...so that the types are compatible
   --> $DIR/regions-close-over-type-parameter-multiple.rs:20:5
    |
-LL |     box v as Box<dyn SomeTrait + 'a>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `Box<(dyn SomeTrait + 'c)>`
               found `Box<dyn SomeTrait>`
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-successfully.rs
+++ b/src/test/ui/regions/regions-close-over-type-parameter-successfully.rs
@@ -2,8 +2,6 @@
 // A test where we (successfully) close over a reference into
 // an object.
 
-#![feature(box_syntax)]
-
 trait SomeTrait { fn get(&self) -> isize; }
 
 impl<'a> SomeTrait for &'a isize {
@@ -13,7 +11,7 @@ impl<'a> SomeTrait for &'a isize {
 }
 
 fn make_object<'a,A:SomeTrait+'a>(v: A) -> Box<dyn SomeTrait+'a> {
-    box v as Box<dyn SomeTrait+'a>
+    Box::new(v) as Box<dyn SomeTrait+'a>
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-dependent-addr-of.rs
+++ b/src/test/ui/regions/regions-dependent-addr-of.rs
@@ -3,7 +3,6 @@
 // Issue #3148.
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct A {
     value: B
@@ -81,7 +80,7 @@ pub fn main() {
                          v2: [23, 24, 25],
                          v3: vec![26, 27, 28],
                          v4: C { f: 29 },
-                         v5: box C { f: 30 },
+                         v5: Box::new(C { f: 30 }),
                          v6: Some(C { f: 31 })}};
 
     let p = get_v1(&a);

--- a/src/test/ui/regions/regions-early-bound-trait-param.rs
+++ b/src/test/ui/regions/regions-early-bound-trait-param.rs
@@ -2,8 +2,6 @@
 // Tests that you can use an early-bound lifetime parameter as
 // on of the generic parameters in a trait.
 
-#![feature(box_syntax)]
-
 trait Trait<'a> {
     fn long(&'a self) -> isize;
     fn short<'b>(&'b self) -> isize;
@@ -72,7 +70,7 @@ impl<'s> Trait<'s> for (isize,isize) {
 
 impl<'t> MakerTrait for Box<dyn Trait<'t>+'static> {
     fn mk() -> Box<dyn Trait<'t>+'static> {
-        let tup: Box<(isize, isize)> = box (4,5);
+        let tup: Box<(isize, isize)> = Box::new((4,5));
         tup as Box<dyn Trait>
     }
 }

--- a/src/test/ui/regions/regions-escape-into-other-fn.rs
+++ b/src/test/ui/regions/regions-escape-into-other-fn.rs
@@ -1,10 +1,8 @@
 // run-pass
-#![feature(box_syntax)]
-
 fn foo(x: &usize) -> &usize { x }
 fn bar(x: &usize) -> usize { *x }
 
 pub fn main() {
-    let p: Box<_> = box 3;
+    let p: Box<_> = Box::new(3);
     assert_eq!(bar(foo(&*p)), 3);
 }

--- a/src/test/ui/regions/regions-infer-borrow-scope-within-loop-ok.rs
+++ b/src/test/ui/regions/regions-infer-borrow-scope-within-loop-ok.rs
@@ -1,10 +1,9 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn borrow<T>(x: &T) -> &T {x}
 
 pub fn main() {
-    let x: Box<_> = box 3;
+    let x: Box<_> = Box::new(3);
     loop {
         let y = borrow(&*x);
         assert_eq!(*x, *y);

--- a/src/test/ui/regions/regions-infer-borrow-scope.rs
+++ b/src/test/ui/regions/regions-infer-borrow-scope.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 struct Point {x: isize, y: isize}
 
@@ -9,7 +8,7 @@ fn x_coord(p: &Point) -> &isize {
 }
 
 pub fn main() {
-    let p: Box<_> = box Point {x: 3, y: 4};
+    let p: Box<_> = Box::new(Point {x: 3, y: 4});
     let xc = x_coord(&*p);
     assert_eq!(*xc, 3);
 }

--- a/src/test/ui/regions/regions-lifetime-nonfree-late-bound.rs
+++ b/src/test/ui/regions/regions-lifetime-nonfree-late-bound.rs
@@ -15,19 +15,17 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
     fn explicit() {
         fn test<F>(_x: Option<Box<F>>) where F: FnMut(Box<dyn for<'a> FnMut(&'a isize)>) {}
-        test(Some(box |_f: Box<dyn for<'a> FnMut(&'a isize)>| {}));
+        test(Some(Box::new(|_f: Box<dyn for<'a> FnMut(&'a isize)>| {})));
     }
 
     // The code below is shorthand for the code above (and more likely
     // to represent what one encounters in practice).
     fn implicit() {
         fn test<F>(_x: Option<Box<F>>) where F: FnMut(Box<dyn        FnMut(&   isize)>) {}
-        test(Some(box |_f: Box<dyn        FnMut(&   isize)>| {}));
+        test(Some(Box::new(|_f: Box<dyn        FnMut(&   isize)>| {})));
     }
 
     explicit();

--- a/src/test/ui/regions/regions-ref-in-fn-arg.rs
+++ b/src/test/ui/regions/regions-ref-in-fn-arg.rs
@@ -1,11 +1,11 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
+
 
 fn arg_item(box ref x: Box<isize>) -> &'static isize {
     x //~ ERROR cannot return value referencing function parameter
 }
 
-fn with<R, F>(f: F) -> R where F: FnOnce(Box<isize>) -> R { f(box 3) }
+fn with<R, F>(f: F) -> R where F: FnOnce(Box<isize>) -> R { f(Box::new(3)) }
 
 fn arg_closure() -> &'static isize {
     with(|box ref x| x) //~ ERROR cannot return value referencing function parameter

--- a/src/test/ui/regions/regions-relate-bound-regions-on-closures-to-inference-variables.rs
+++ b/src/test/ui/regions/regions-relate-bound-regions-on-closures-to-inference-variables.rs
@@ -9,8 +9,6 @@
 // changes were caught. However, those uses in the compiler could
 // easily get changed or refactored away in the future.
 
-#![feature(box_syntax)]
-
 struct Ctxt<'tcx> {
     x: &'tcx Vec<isize>
 }

--- a/src/test/ui/regions/regions-trait-variance.rs
+++ b/src/test/ui/regions/regions-trait-variance.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 // Issue #12470.
 
 trait X {
@@ -31,9 +29,11 @@ fn make_a(p: &dyn X) -> A {
 }
 
 fn make_make_a<'a>() -> A<'a> {
-    let b: Box<B> = box B {
+
+    let b: Box<B> = Box::new(B {
         i: 1,
-    };
+    });
+
     let bb: &B = &*b;
     make_a(bb) //~ ERROR cannot return value referencing local data `*b`
 }

--- a/src/test/ui/rfcs/rfc-2005-default-binding-mode/box.rs
+++ b/src/test/ui/rfcs/rfc-2005-default-binding-mode/box.rs
@@ -1,11 +1,11 @@
 // run-pass
 #![allow(unreachable_patterns)]
-#![feature(box_syntax, box_patterns)]
+#![feature(box_patterns)]
 
 struct Foo{}
 
 pub fn main() {
-    let b = box Foo{};
+    let b = Box::new(Foo{});
     let box f = &b;
     let _: &Foo = f;
 

--- a/src/test/ui/self/explicit-self-generic.rs
+++ b/src/test/ui/self/explicit-self-generic.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 #[derive(Copy, Clone)]
 struct LM { resize_at: usize, size: usize }
@@ -24,6 +23,6 @@ impl<K,V> HashMap<K,V> {
 }
 
 pub fn main() {
-    let mut m: Box<_> = box linear_map::<(),()>();
+    let mut m: Box<_> = Box::new(linear_map::<(),()>());
     assert_eq!(m.len(), 0);
 }

--- a/src/test/ui/self/explicit-self-objects-uniq.rs
+++ b/src/test/ui/self/explicit-self-objects-uniq.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 trait Foo {
     fn f(self: Box<Self>);
@@ -16,7 +15,7 @@ impl Foo for S {
 }
 
 pub fn main() {
-    let x = box S { x: 3 };
+    let x = Box::new(S { x: 3 });
     let y = x as Box<dyn Foo>;
     y.f();
 }

--- a/src/test/ui/self/explicit-self.rs
+++ b/src/test/ui/self/explicit-self.rs
@@ -3,8 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-#![feature(box_syntax)]
-
 static tau: f64 = 2.0*3.14159265358979323;
 
 struct Point {x: f64, y: f64}
@@ -64,7 +62,7 @@ trait Nus { fn f(&self); }
 impl Nus for thing { fn f(&self) {} }
 
 pub fn main() {
-    let y: Box<_> = box thing(A {a: 10});
+    let y: Box<_> = Box::new(thing(A {a: 10}));
     assert_eq!(y.clone().bar(), 10);
     assert_eq!(y.quux(), 10);
 

--- a/src/test/ui/self/self-impl-2.rs
+++ b/src/test/ui/self/self-impl-2.rs
@@ -5,8 +5,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 struct Foo;
 
 // Test uses on inherent impl.
@@ -57,14 +55,14 @@ impl Bar<isize> for Box<Baz<isize>> {
         let _: Self::SuperQux = true;
         let _: <Self as SuperBar>::SuperQux = true;
 
-        box Baz { f: 42 }
+        Box::new(Baz { f: 42 })
     }
 }
 
 fn main() {
-    let _: Foo = Foo::foo(Foo, &Foo, box Foo);
-    let _: Box<Baz<isize>> = Bar::bar(box Baz { f: 42 },
-                                      &box Baz { f: 42 },
-                                      box box Baz { f: 42 },
+    let _: Foo = Foo::foo(Foo, &Foo, Box::new(Foo));
+    let _: Box<Baz<isize>> = Bar::bar(Box::new(Baz { f: 42 }),
+                                      &Box::new(Baz { f: 42 }),
+                                      Box::new(Box::new(Baz { f: 42 })),
                                       true);
 }

--- a/src/test/ui/self/self-in-mut-slot-default-method.rs
+++ b/src/test/ui/self/self-in-mut-slot-default-method.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct X {
     a: isize
@@ -30,7 +29,7 @@ pub fn main() {
     let new_x = x.change();
     assert_eq!(new_x.a, 55);
 
-    let x: Box<_> = box new_x;
+    let x: Box<_> = Box::new(new_x);
     let new_x = x.change_again();
     assert_eq!(new_x.a, 45);
 }

--- a/src/test/ui/self/self-re-assign.rs
+++ b/src/test/ui/self/self-re-assign.rs
@@ -2,13 +2,12 @@
 // Ensure assigning an owned or managed variable to itself works. In particular,
 // that we do not glue_drop before we glue_take (#3290).
 
-#![feature(box_syntax)]
 #![allow(dead_code)]
 
 use std::rc::Rc;
 
 pub fn main() {
-   let mut x: Box<_> = box 3;
+   let mut x: Box<_> = Box::new(3);
    x = x;
    assert_eq!(*x, 3);
 

--- a/src/test/ui/self/ufcs-explicit-self.rs
+++ b/src/test/ui/self/ufcs-explicit-self.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 #![allow(dead_code)]
 
 #[derive(Copy, Clone)]
@@ -37,13 +36,13 @@ impl<T> Bar<T> {
 }
 
 fn main() {
-    let foo: Box<_> = box Foo {
+    let foo: Box<_> = Box::new(Foo {
         f: 1,
-    };
+    });
     println!("{} {} {}", foo.foo(2), foo.bar(2), foo.baz(2));
-    let bar: Box<_> = box Bar {
+    let bar: Box<_> = Box::new(Bar {
         f: 1,
-    };
+    });
     println!("{} {} {}", bar.foo(2), bar.bar(2), bar.baz(2));
     let bar: Box<Bar<isize>> = bar;
     println!("{} {} {}", bar.foo(2), bar.bar(2), bar.baz(2));

--- a/src/test/ui/self/uniq-self-in-mut-slot.rs
+++ b/src/test/ui/self/uniq-self-in-mut-slot.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct X {
     a: isize
@@ -17,7 +16,7 @@ impl Changer for X {
 }
 
 pub fn main() {
-    let x: Box<_> = box X { a: 32 };
+    let x: Box<_> = Box::new(X { a: 32 });
     let new_x = x.change();
     assert_eq!(new_x.a, 55);
 }

--- a/src/test/ui/shadowed/shadowed-type-parameter.rs
+++ b/src/test/ui/shadowed/shadowed-type-parameter.rs
@@ -1,8 +1,8 @@
 // Test that shadowed lifetimes generate an error.
 
-#![feature(box_syntax)]
 
 struct Foo<T>(T);
+
 
 impl<T> Foo<T> {
     fn shadow_in_method<T>(&self) {}

--- a/src/test/ui/span/coerce-suggestions.rs
+++ b/src/test/ui/span/coerce-suggestions.rs
@@ -1,7 +1,7 @@
-#![feature(box_syntax)]
-
 fn test(_x: &mut String) {}
+
 fn test2(_x: &mut i32) {}
+
 
 fn main() {
     let x: usize = String::new();
@@ -14,7 +14,7 @@ fn main() {
     test2(&y);
     //~^ ERROR E0308
     let f;
-    f = box f;
+    f = Box::new(f);
     //~^ ERROR E0308
 
     let s = &mut String::new();

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -37,13 +37,10 @@ LL |     test2(&y);
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:17:9
    |
-LL |     f = box f;
-   |         ^^^^^ cyclic type of infinite size
-   |
-help: try using a conversion method
-   |
-LL |     f = (box f).to_string();
-   |         +     +++++++++++++
+LL |     f = Box::new(f);
+   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
+   |         |
+   |         cyclic type of infinite size
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:21:9

--- a/src/test/ui/span/issue-11925.rs
+++ b/src/test/ui/span/issue-11925.rs
@@ -1,10 +1,10 @@
-#![feature(box_syntax, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 fn to_fn_once<A,F:FnOnce<A>>(f: F) -> F { f }
 
 fn main() {
     let r = {
-        let x: Box<_> = box 42;
+        let x: Box<_> = Box::new(42);
         let f = to_fn_once(move|| &x); //~ ERROR cannot return reference to local data `x`
         f()
     };

--- a/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.rs
+++ b/src/test/ui/span/regions-close-over-borrowed-ref-in-obj.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 fn id<T>(x: T) -> T { x }
 
 trait Foo { }
@@ -7,10 +5,12 @@ trait Foo { }
 impl<'a> Foo for &'a isize { }
 
 fn main() {
+
     let blah;
+
     {
         let ss: &isize = &id(1);
         //~^ ERROR temporary value dropped while borrowed
-        blah = box ss as Box<dyn Foo>;
+        blah = Box::new(ss) as Box<dyn Foo>;
     }
 }

--- a/src/test/ui/span/regions-close-over-type-parameter-2.rs
+++ b/src/test/ui/span/regions-close-over-type-parameter-2.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 // Test for what happens when a type parameter `A` is closed over into
 // an object. This should yield errors unless `A` (and the object)
 // both have suitable bounds.
@@ -7,14 +5,16 @@
 trait Foo { fn get(&self); }
 
 impl<A> Foo for A {
-    fn get(&self) { }
+    fn get(&self) {
+    }
 }
 
 fn repeater3<'a,A:'a>(v: A) -> Box<dyn Foo + 'a> {
-    box v as Box<dyn Foo+'a>
+    Box::new(v) as Box<dyn Foo+'a>
 }
 
 fn main() {
+
     // Error results because the type of is inferred to be
     // ~Repeat<&'blk isize> where blk is the lifetime of the block below.
 

--- a/src/test/ui/static/static-region-bound.rs
+++ b/src/test/ui/static/static-region-bound.rs
@@ -1,12 +1,12 @@
-#![feature(box_syntax)]
-
 fn id<T>(x: T) -> T { x }
 
 fn f<T:'static>(_: T) {}
 
 fn main() {
-    let x: Box<_> = box 3;
+
+    let x: Box<_> = Box::new(3);
     f(x);
+
     let x = &id(3); //~ ERROR temporary value dropped while borrowed
     f(x);
 }

--- a/src/test/ui/structs-enums/class-cast-to-trait-cross-crate-2.rs
+++ b/src/test/ui/structs-enums/class-cast-to-trait-cross-crate-2.rs
@@ -1,8 +1,6 @@
 // run-pass
 // aux-build:cci_class_cast.rs
 
-#![feature(box_syntax)]
-
 extern crate cci_class_cast;
 
 use std::string::ToString;
@@ -15,6 +13,6 @@ fn print_out(thing: Box<dyn ToString>, expected: String) {
 }
 
 pub fn main() {
-  let nyan: Box<dyn ToString> = box cat(0, 2, "nyan".to_string()) as Box<dyn ToString>;
+  let nyan: Box<dyn ToString> = Box::new(cat(0, 2, "nyan".to_string())) as Box<dyn ToString>;
   print_out(nyan, "nyan".to_string());
 }

--- a/src/test/ui/structs-enums/class-separate-impl.rs
+++ b/src/test/ui/structs-enums/class-separate-impl.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 use std::fmt;
 
 struct cat {
@@ -60,6 +58,6 @@ fn print_out(thing: Box<dyn ToString>, expected: String) {
 }
 
 pub fn main() {
-  let nyan: Box<dyn ToString> = box cat(0, 2, "nyan".to_string()) as Box<dyn ToString>;
+  let nyan: Box<dyn ToString> = Box::new(cat(0, 2, "nyan".to_string())) as Box<dyn ToString>;
   print_out(nyan, "nyan".to_string());
 }

--- a/src/test/ui/structs-enums/enum-nullable-simplifycfg-misopt.rs
+++ b/src/test/ui/structs-enums/enum-nullable-simplifycfg-misopt.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 /*!
  * This is a regression test for a bug in LLVM, fixed in upstream r179587,
@@ -9,7 +8,7 @@
 
 enum List<X> { Nil, Cons(X, Box<List<X>>) }
 pub fn main() {
-    match List::Cons(10, box List::Nil) {
+    match List::Cons(10, Box::new(List::Nil)) {
         List::Cons(10, _) => {}
         List::Nil => {}
         _ => panic!()

--- a/src/test/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
+++ b/src/test/ui/threads-sendsync/sendfn-spawn-with-fn-arg.rs
@@ -1,8 +1,6 @@
 // run-pass
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 
 pub fn main() { test05(); }
@@ -12,7 +10,7 @@ fn test05_start<F:FnOnce(isize)>(f: F) {
 }
 
 fn test05() {
-    let three: Box<_> = box 3;
+    let three: Box<_> = Box::new(3);
     let fn_to_send = move|n:isize| {
         println!("{}", *three + n); // will copy x into the closure
         assert_eq!(*three, 3);

--- a/src/test/ui/threads-sendsync/task-spawn-move-and-copy.rs
+++ b/src/test/ui/threads-sendsync/task-spawn-move-and-copy.rs
@@ -2,15 +2,13 @@
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 use std::sync::mpsc::channel;
 
 pub fn main() {
     let (tx, rx) = channel::<usize>();
 
-    let x: Box<isize> = box 1;
+    let x: Box<isize> = Box::new(1);
     let x_in_parent = &(*x) as *const isize as usize;
 
     let t = thread::spawn(move || {

--- a/src/test/ui/traits/bound/in-arc.rs
+++ b/src/test/ui/traits/bound/in-arc.rs
@@ -5,8 +5,6 @@
 
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -67,10 +65,11 @@ pub fn main() {
         swim_speed: 998,
         name: "alec_guinness".to_string(),
     };
-    let arc = Arc::new(vec![box catte  as Box<dyn Pet+Sync+Send>,
-                            box dogge1 as Box<dyn Pet+Sync+Send>,
-                            box fishe  as Box<dyn Pet+Sync+Send>,
-                            box dogge2 as Box<dyn Pet+Sync+Send>]);
+    let arc = Arc::new(vec![
+        Box::new(catte)  as Box<dyn Pet+Sync+Send>,
+        Box::new(dogge1) as Box<dyn Pet+Sync+Send>,
+        Box::new(fishe)  as Box<dyn Pet+Sync+Send>,
+        Box::new(dogge2) as Box<dyn Pet+Sync+Send>]);
     let (tx1, rx1) = channel();
     let arc1 = arc.clone();
     let t1 = thread::spawn(move|| { check_legs(arc1); tx1.send(()); });

--- a/src/test/ui/traits/coercion.rs
+++ b/src/test/ui/traits/coercion.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 #![allow(unused_mut)]
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 
 use std::io::{self, Write};
 

--- a/src/test/ui/traits/conditional-dispatch.rs
+++ b/src/test/ui/traits/conditional-dispatch.rs
@@ -3,7 +3,6 @@
 // blanket impl for T:Copy coexists with an impl for Box<T>, because
 // Box does not impl Copy.
 
-#![feature(box_syntax)]
 
 trait Get {
     fn get(&self) -> Self;
@@ -20,7 +19,7 @@ impl<T:MyCopy> Get for T {
 }
 
 impl Get for Box<i32> {
-    fn get(&self) -> Box<i32> { box get_it(&**self) }
+    fn get(&self) -> Box<i32> { Box::new(get_it(&**self)) }
 }
 
 fn get_it<T:Get>(t: &T) -> T {

--- a/src/test/ui/traits/issue-6128.rs
+++ b/src/test/ui/traits/issue-6128.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(box_syntax)]
-
 use std::collections::HashMap;
 
 trait Graph<Node, Edge> {
@@ -19,6 +17,6 @@ impl<E> Graph<isize, E> for HashMap<isize, isize> {
 }
 
 pub fn main() {
-    let g : Box<HashMap<isize,isize>> = box HashMap::new();
+    let g : Box<HashMap<isize,isize>> = Box::new(HashMap::new());
     let _g2 : Box<dyn Graph<isize,isize>> = g as Box<dyn Graph<isize,isize>>;
 }

--- a/src/test/ui/traits/kindck-owned-contains-1.rs
+++ b/src/test/ui/traits/kindck-owned-contains-1.rs
@@ -2,8 +2,6 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 trait repeat<A> { fn get(&self) -> A; }
 
 impl<A:Clone + 'static> repeat<A> for Box<A> {
@@ -13,11 +11,11 @@ impl<A:Clone + 'static> repeat<A> for Box<A> {
 }
 
 fn repeater<A:Clone + 'static>(v: Box<A>) -> Box<dyn repeat<A>+'static> {
-    box v as Box<dyn repeat<A>+'static> // No
+    Box::new(v) as Box<dyn repeat<A>+'static> // No
 }
 
 pub fn main() {
     let x = 3;
-    let y = repeater(box x);
+    let y = repeater(Box::new(x));
     assert_eq!(x, y.get());
 }

--- a/src/test/ui/traits/object-one-type-two-traits.rs
+++ b/src/test/ui/traits/object-one-type-two-traits.rs
@@ -4,8 +4,6 @@
 // Testing creating two vtables with the same self type, but different
 // traits.
 
-#![feature(box_syntax)]
-
 use std::any::Any;
 
 trait Wrap {
@@ -27,7 +25,7 @@ fn is<T:Any>(x: &dyn Any) -> bool {
 }
 
 fn main() {
-    let x = box 22isize as Box<dyn Wrap>;
+    let x = Box::new(22isize) as Box<dyn Wrap>;
     println!("x={}", x.get());
     let y = x.wrap();
 }

--- a/src/test/ui/traits/object/generics.rs
+++ b/src/test/ui/traits/object/generics.rs
@@ -1,8 +1,6 @@
 // run-pass
 // test for #8664
 
-#![feature(box_syntax)]
-
 use std::marker;
 
 pub trait Trait2<A> {
@@ -38,6 +36,6 @@ impl<V> Trait<u8,V> for () {
 }
 
 pub fn main() {
-    let a = box () as Box<dyn Trait<u8, u8>>;
+    let a = Box::new(()) as Box<dyn Trait<u8, u8>>;
     assert_eq!(a.method(Type::Constant((1, 2))), 0);
 }

--- a/src/test/ui/traits/test-2.rs
+++ b/src/test/ui/traits/test-2.rs
@@ -1,6 +1,6 @@
-#![feature(box_syntax)]
-
 #[allow(non_camel_case_types)]
+
+
 trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
 impl bar for i32 { fn dup(&self) -> i32 { *self } fn blah<X>(&self) {} }
 impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
@@ -10,7 +10,8 @@ fn main() {
     //~^ ERROR this associated function takes 0 generic arguments but 1
     10.blah::<i32, i32>();
     //~^ ERROR this associated function takes 1 generic argument but 2
-    (box 10 as Box<dyn bar>).dup();
+    (Box::new(10) as Box<dyn bar>).dup();
     //~^ ERROR E0038
+    //~| ERROR E0038
     //~| ERROR E0038
 }

--- a/src/test/ui/traits/test-2.stderr
+++ b/src/test/ui/traits/test-2.stderr
@@ -27,10 +27,27 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
 
 error[E0038]: the trait `bar` cannot be made into an object
-  --> $DIR/test-2.rs:13:16
+  --> $DIR/test-2.rs:13:22
    |
-LL |     (box 10 as Box<dyn bar>).dup();
-   |                ^^^^^^^^^^^^ `bar` cannot be made into an object
+LL |     (Box::new(10) as Box<dyn bar>).dup();
+   |                      ^^^^^^^^^^^^ `bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/test-2.rs:4:30
+   |
+LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
+   |       ---                    ^^^^     ^^^^ ...because method `blah` has generic type parameters
+   |       |                      |
+   |       |                      ...because method `dup` references the `Self` type in its return type
+   |       this trait cannot be made into an object...
+   = help: consider moving `dup` to another trait
+   = help: consider moving `blah` to another trait
+
+error[E0038]: the trait `bar` cannot be made into an object
+  --> $DIR/test-2.rs:13:5
+   |
+LL |     (Box::new(10) as Box<dyn bar>).dup();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
@@ -46,8 +63,8 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
 error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/test-2.rs:13:6
    |
-LL |     (box 10 as Box<dyn bar>).dup();
-   |      ^^^^^^ `bar` cannot be made into an object
+LL |     (Box::new(10) as Box<dyn bar>).dup();
+   |      ^^^^^^^^^^^^ `bar` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
@@ -62,7 +79,7 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    = note: required because of the requirements on the impl of `CoerceUnsized<Box<dyn bar>>` for `Box<{integer}>`
    = note: required by cast to type `Box<dyn bar>`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0038, E0107.
 For more information about an error, try `rustc --explain E0038`.

--- a/src/test/ui/traits/trait-upcasting/issue-11515-upcast-fn_mut-fn.rs
+++ b/src/test/ui/traits/trait-upcasting/issue-11515-upcast-fn_mut-fn.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(box_syntax, trait_upcasting)]
+#![feature(trait_upcasting)]
 #![allow(incomplete_features)]
 
 struct Test {
@@ -8,6 +8,6 @@ struct Test {
 
 fn main() {
     let closure: Box<dyn Fn() + 'static> = Box::new(|| ());
-    let mut test = box Test { func: closure };
+    let mut test = Box::new(Test { func: closure });
     (test.func)();
 }

--- a/src/test/ui/type-param-constraints.rs
+++ b/src/test/ui/type-param-constraints.rs
@@ -4,8 +4,6 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 fn p_foo<T>(_pinned: T) { }
 fn s_foo<T>(_shared: T) { }
 fn u_foo<T:Send>(_unique: T) { }
@@ -27,13 +25,13 @@ fn r(i:isize) -> r {
 pub fn main() {
     p_foo(r(10));
 
-    p_foo::<Box<_>>(box r(10));
-    p_foo::<Box<_>>(box 10);
+    p_foo::<Box<_>>(Box::new(r(10)));
+    p_foo::<Box<_>>(Box::new(10));
     p_foo(10);
 
-    s_foo::<Box<_>>(box 10);
+    s_foo::<Box<_>>(Box::new(10));
     s_foo(10);
 
-    u_foo::<Box<_>>(box 10);
+    u_foo::<Box<_>>(Box::new(10));
     u_foo(10);
 }

--- a/src/test/ui/typeclasses-eq-example-static.rs
+++ b/src/test/ui/typeclasses-eq-example-static.rs
@@ -3,7 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 // Example from lkuper's intern talk, August 2012 -- now with static
 // methods!
@@ -59,11 +58,11 @@ pub fn main() {
     assert!(Equal::isEq(&leaf(cyan), &leaf(cyan)));
     assert!(!Equal::isEq(&leaf(cyan), &leaf(yellow)));
 
-    assert!(Equal::isEq(&branch(box leaf(magenta), box leaf(cyan)),
-                &branch(box leaf(magenta), box leaf(cyan))));
+    assert!(Equal::isEq(&branch(Box::new(leaf(magenta)), Box::new(leaf(cyan))),
+                &branch(Box::new(leaf(magenta)), Box::new(leaf(cyan)))));
 
-    assert!(!Equal::isEq(&branch(box leaf(magenta), box leaf(cyan)),
-                 &branch(box leaf(magenta), box leaf(magenta))));
+    assert!(!Equal::isEq(&branch(Box::new(leaf(magenta)), Box::new(leaf(cyan))),
+                 &branch(Box::new(leaf(magenta)), Box::new(leaf(magenta)))));
 
     println!("Assertions all succeeded!");
 }

--- a/src/test/ui/typeclasses-eq-example.rs
+++ b/src/test/ui/typeclasses-eq-example.rs
@@ -3,7 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(box_syntax)]
 
 // Example from lkuper's intern talk, August 2012.
 use Color::{cyan, magenta, yellow, black};
@@ -55,11 +54,11 @@ pub fn main() {
     assert!(leaf(cyan).isEq(&leaf(cyan)));
     assert!(!leaf(cyan).isEq(&leaf(yellow)));
 
-    assert!(branch(box leaf(magenta), box leaf(cyan))
-        .isEq(&branch(box leaf(magenta), box leaf(cyan))));
+    assert!(branch(Box::new(leaf(magenta)), Box::new(leaf(cyan)))
+        .isEq(&branch(Box::new(leaf(magenta)), Box::new(leaf(cyan)))));
 
-    assert!(!branch(box leaf(magenta), box leaf(cyan))
-        .isEq(&branch(box leaf(magenta), box leaf(magenta))));
+    assert!(!branch(Box::new(leaf(magenta)), Box::new(leaf(cyan)))
+        .isEq(&branch(Box::new(leaf(magenta)), Box::new(leaf(magenta)))));
 
     println!("Assertions all succeeded!");
 }

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 struct Foo {
     f: isize,
 }
+
+
 
 impl Foo {
     fn foo(self: isize, x: isize) -> isize {
@@ -48,12 +48,12 @@ impl<'a, T> SomeTrait for &'a Bar<T> {
 }
 
 fn main() {
-    let foo = box Foo {
+    let foo = Box::new(Foo {
         f: 1,
-    };
+    });
     println!("{}", foo.foo(2));
-    let bar = box Bar {
+    let bar = Box::new(Bar {
         f: 1,
-    };
+    });
     println!("{} {}", bar.foo(2), bar.bar(2));
 }

--- a/src/test/ui/unboxed-closures/unboxed-closures-boxed.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-boxed.rs
@@ -1,10 +1,9 @@
 // run-pass
-#![feature(box_syntax)]
 
 use std::ops::FnMut;
 
  fn make_adder(x: i32) -> Box<dyn FnMut(i32)->i32+'static> {
-    (box move |y: i32| -> i32 { x + y }) as
+    Box::new(move |y: i32| -> i32 { x + y }) as
         Box<dyn FnMut(i32)->i32+'static>
 }
 

--- a/src/test/ui/uninhabited/uninhabited-patterns.rs
+++ b/src/test/ui/uninhabited/uninhabited-patterns.rs
@@ -1,7 +1,7 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(never_type)]
 #![feature(exhaustive_patterns)]
+
 
 #![deny(unreachable_patterns)]
 

--- a/src/test/ui/unique-object-noncopyable.rs
+++ b/src/test/ui/unique-object-noncopyable.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 trait Foo {
     fn f(&self);
 }
@@ -18,8 +16,10 @@ impl Foo for Bar {
     }
 }
 
+
+
 fn main() {
-    let x = box Bar { x: 10 };
+    let x = Box::new(Bar { x: 10 });
     let y: Box<dyn Foo> = x as Box<dyn Foo>;
     let _z = y.clone(); //~ ERROR the method
 }

--- a/src/test/ui/unique/unique-assign-copy.rs
+++ b/src/test/ui/unique/unique-assign-copy.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let mut i: Box<_> = box 1;
+    let mut i: Box<_> = Box::new(1);
     // Should be a copy
     let mut j;
     j = i.clone();

--- a/src/test/ui/unique/unique-assign-drop.rs
+++ b/src/test/ui/unique/unique-assign-drop.rs
@@ -1,11 +1,9 @@
 // run-pass
 #![allow(unused_assignments)]
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let i: Box<_> = box 1;
-    let mut j: Box<_> = box 2;
+    let i: Box<_> = Box::new(1);
+    let mut j: Box<_> = Box::new(2);
     // Should drop the previous value of j
     j = i;
     assert_eq!(*j, 1);

--- a/src/test/ui/unique/unique-assign-generic.rs
+++ b/src/test/ui/unique/unique-assign-generic.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f<T>(t: T) -> T {
     let t1 = t;
@@ -7,6 +6,6 @@ fn f<T>(t: T) -> T {
 }
 
 pub fn main() {
-    let t = f::<Box<_>>(box 100);
-    assert_eq!(t, box 100);
+    let t = f::<Box<_>>(Box::new(100));
+    assert_eq!(t, Box::new(100));
 }

--- a/src/test/ui/unique/unique-assign.rs
+++ b/src/test/ui/unique/unique-assign.rs
@@ -1,9 +1,8 @@
 // run-pass
 #![allow(unused_mut)]
-#![feature(box_syntax)]
 
 pub fn main() {
     let mut i: Box<_>;
-    i = box 1;
+    i = Box::new(1);
     assert_eq!(*i, 1);
 }

--- a/src/test/ui/unique/unique-autoderef-field.rs
+++ b/src/test/ui/unique/unique-autoderef-field.rs
@@ -1,11 +1,10 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct J { j: isize }
 
 pub fn main() {
-    let i: Box<_> = box J {
+    let i: Box<_> = Box::new(J {
         j: 100
-    };
+    });
     assert_eq!(i.j, 100);
 }

--- a/src/test/ui/unique/unique-autoderef-index.rs
+++ b/src/test/ui/unique/unique-autoderef-index.rs
@@ -1,7 +1,6 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box vec![100];
+    let i: Box<_> = Box::new(vec![100]);
     assert_eq!((*i)[0], 100);
 }

--- a/src/test/ui/unique/unique-cmp.rs
+++ b/src/test/ui/unique/unique-cmp.rs
@@ -1,12 +1,11 @@
 // run-pass
 #![allow(unused_allocation)]
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
-    assert_eq!(i, box 100);
-    assert!(i < box 101);
-    assert!(i <= box 100);
-    assert!(i > box 99);
-    assert!(i >= box 99);
+    let i: Box<_> = Box::new(100);
+    assert_eq!(i, Box::new(100));
+    assert!(i < Box::new(101));
+    assert!(i <= Box::new(100));
+    assert!(i > Box::new(99));
+    assert!(i >= Box::new(99));
 }

--- a/src/test/ui/unique/unique-containing-tag.rs
+++ b/src/test/ui/unique/unique-containing-tag.rs
@@ -4,12 +4,10 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
     enum t { t1(isize), t2(isize), }
 
-    let _x: Box<_> = box t::t1(10);
+    let _x: Box<_> = Box::new(t::t1(10));
 
     /*alt *x {
       t1(a) {
@@ -19,9 +17,9 @@ pub fn main() {
     }*/
 
     /*alt x {
-      box t1(a) {
+      Box::new(t1(a) {
         assert_eq!(a, 10);
-      }
+      })
       _ { panic!(); }
     }*/
 }

--- a/src/test/ui/unique/unique-create.rs
+++ b/src/test/ui/unique/unique-create.rs
@@ -2,10 +2,8 @@
 #![allow(dead_code)]
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _: Box<_> = box 100;
+    let _: Box<_> = Box::new(100);
 }
 
 fn vec() {

--- a/src/test/ui/unique/unique-decl-init-copy.rs
+++ b/src/test/ui/unique/unique-decl-init-copy.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let mut i: Box<_> = box 1;
+    let mut i: Box<_> = Box::new(1);
     // Should be a copy
     let mut j = i.clone();
     *i = 2;

--- a/src/test/ui/unique/unique-decl-init.rs
+++ b/src/test/ui/unique/unique-decl-init.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 1;
+    let i: Box<_> = Box::new(1);
     let j = i;
     assert_eq!(*j, 1);
 }

--- a/src/test/ui/unique/unique-decl-move.rs
+++ b/src/test/ui/unique/unique-decl-move.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
     let j = i;
     assert_eq!(*j, 100);
 }

--- a/src/test/ui/unique/unique-deref.rs
+++ b/src/test/ui/unique/unique-deref.rs
@@ -1,7 +1,6 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
     assert_eq!(*i, 100);
 }

--- a/src/test/ui/unique/unique-destructure.rs
+++ b/src/test/ui/unique/unique-destructure.rs
@@ -1,10 +1,9 @@
 // run-pass
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct Foo { a: isize, b: isize }
 
 pub fn main() {
-    let box Foo{a, b} = box Foo{a: 100, b: 200};
+    let box Foo{ a, b } = Box::new(Foo { a: 100, b: 200 });
     assert_eq!(a + b, 300);
 }

--- a/src/test/ui/unique/unique-drop-complex.rs
+++ b/src/test/ui/unique/unique-drop-complex.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _x: Box<_> = box vec![0,0,0,0,0];
+    let _x: Box<_> = Box::new(vec![0,0,0,0,0]);
 }

--- a/src/test/ui/unique/unique-fn-arg-move.rs
+++ b/src/test/ui/unique/unique-fn-arg-move.rs
@@ -1,11 +1,10 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f(i: Box<isize>) {
     assert_eq!(*i, 100);
 }
 
 pub fn main() {
-    let i = box 100;
+    let i = Box::new(100);
     f(i);
 }

--- a/src/test/ui/unique/unique-fn-arg-mut.rs
+++ b/src/test/ui/unique/unique-fn-arg-mut.rs
@@ -1,12 +1,11 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f(i: &mut Box<isize>) {
-    *i = box 200;
+    *i = Box::new(200);
 }
 
 pub fn main() {
-    let mut i = box 100;
+    let mut i = Box::new(100);
     f(&mut i);
     assert_eq!(*i, 200);
 }

--- a/src/test/ui/unique/unique-fn-arg.rs
+++ b/src/test/ui/unique/unique-fn-arg.rs
@@ -1,12 +1,11 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f(i: Box<isize>) {
     assert_eq!(*i, 100);
 }
 
 pub fn main() {
-    f(box 100);
-    let i = box 100;
+    f(Box::new(100));
+    let i = Box::new(100);
     f(i);
 }

--- a/src/test/ui/unique/unique-fn-ret.rs
+++ b/src/test/ui/unique/unique-fn-ret.rs
@@ -1,10 +1,9 @@
 // run-pass
-#![feature(box_syntax)]
 
 fn f() -> Box<isize> {
-    box 100
+    Box::new(100)
 }
 
 pub fn main() {
-    assert_eq!(f(), box 100);
+    assert_eq!(f(), Box::new(100));
 }

--- a/src/test/ui/unique/unique-in-tag.rs
+++ b/src/test/ui/unique/unique-in-tag.rs
@@ -2,12 +2,10 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 fn test1() {
     enum bar { u(Box<isize>), w(isize), }
 
-    let x = bar::u(box 10);
+    let x = bar::u(Box::new(10));
     assert!(match x {
       bar::u(a) => {
         println!("{}", a);

--- a/src/test/ui/unique/unique-in-vec-copy.rs
+++ b/src/test/ui/unique/unique-in-vec-copy.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let mut a: Vec<Box<_>> = vec![box 10];
+    let mut a: Vec<Box<_>> = vec![Box::new(10)];
     let b = a.clone();
 
     assert_eq!(*a[0], 10);

--- a/src/test/ui/unique/unique-in-vec.rs
+++ b/src/test/ui/unique/unique-in-vec.rs
@@ -1,7 +1,6 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let vect : Vec<Box<_>> = vec![box 100];
-    assert_eq!(vect[0], box 100);
+    let vect : Vec<Box<_>> = vec![Box::new(100)];
+    assert_eq!(vect[0], Box::new(100));
 }

--- a/src/test/ui/unique/unique-init.rs
+++ b/src/test/ui/unique/unique-init.rs
@@ -1,8 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _i: Box<_> = box 100;
+    let _i: Box<_> = Box::new(100);
 }

--- a/src/test/ui/unique/unique-kinds.rs
+++ b/src/test/ui/unique/unique-kinds.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(box_syntax)]
 
 use std::cmp::PartialEq;
 use std::fmt::Debug;
@@ -14,11 +13,11 @@ fn sendable() {
         assert!(i != j);
     }
 
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(100);
     f(i, j);
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 101;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(101);
     g(i, j);
 }
 
@@ -32,11 +31,11 @@ fn copyable() {
         assert!(i != j);
     }
 
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(100);
     f(i, j);
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 101;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(101);
     g(i, j);
 }
 
@@ -50,11 +49,11 @@ fn noncopyable() {
         assert!(i != j);
     }
 
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(100);
     f(i, j);
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 101;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(101);
     g(i, j);
 }
 

--- a/src/test/ui/unique/unique-log.rs
+++ b/src/test/ui/unique/unique-log.rs
@@ -1,7 +1,6 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
     println!("{}", i);
 }

--- a/src/test/ui/unique/unique-move-drop.rs
+++ b/src/test/ui/unique/unique-move-drop.rs
@@ -1,11 +1,10 @@
 // run-pass
 
 #![allow(unused_variables)]
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
-    let j: Box<_> = box 200;
+    let i: Box<_> = Box::new(100);
+    let j: Box<_> = Box::new(200);
     let j = i;
     assert_eq!(*j, 100);
 }

--- a/src/test/ui/unique/unique-move-temp.rs
+++ b/src/test/ui/unique/unique-move-temp.rs
@@ -1,9 +1,8 @@
 // run-pass
 #![allow(unused_mut)]
-#![feature(box_syntax)]
 
 pub fn main() {
     let mut i: Box<_>;
-    i = box 100;
+    i = Box::new(100);
     assert_eq!(*i, 100);
 }

--- a/src/test/ui/unique/unique-move.rs
+++ b/src/test/ui/unique/unique-move.rs
@@ -1,9 +1,8 @@
 // run-pass
 #![allow(unused_mut)]
-#![feature(box_syntax)]
 
 pub fn main() {
-    let i: Box<_> = box 100;
+    let i: Box<_> = Box::new(100);
     let mut j;
     j = i;
     assert_eq!(*j, 100);

--- a/src/test/ui/unique/unique-mutable.rs
+++ b/src/test/ui/unique/unique-mutable.rs
@@ -1,8 +1,7 @@
 // run-pass
-#![feature(box_syntax)]
 
 pub fn main() {
-    let mut i: Box<_> = box 0;
+    let mut i: Box<_> = Box::new(0);
     *i = 1;
     assert_eq!(*i, 1);
 }

--- a/src/test/ui/unique/unique-object-move.rs
+++ b/src/test/ui/unique/unique-object-move.rs
@@ -4,8 +4,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub trait EventLoop { fn foo(&self) {} }
 
 pub struct UvEventLoop {
@@ -15,6 +13,6 @@ pub struct UvEventLoop {
 impl EventLoop for UvEventLoop { }
 
 pub fn main() {
-    let loop_: Box<dyn EventLoop> = box UvEventLoop { uvio: 0 } as Box<dyn EventLoop>;
+    let loop_: Box<dyn EventLoop> = Box::new(UvEventLoop { uvio: 0 }) as Box<dyn EventLoop>;
     let _loop2_ = loop_;
 }

--- a/src/test/ui/unique/unique-pat-2.rs
+++ b/src/test/ui/unique/unique-pat-2.rs
@@ -4,15 +4,15 @@
 #![allow(non_shorthand_field_patterns)]
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 struct Foo {a: isize, b: usize}
 
 enum bar { u(Box<Foo>), w(isize), }
 
 pub fn main() {
-    assert!(match bar::u(box Foo{a: 10, b: 40}) {
-              bar::u(box Foo{a: a, b: b}) => { a + (b as isize) }
-              _ => { 66 }
-            } == 50);
+    let v = match bar::u(Box::new(Foo{ a: 10, b: 40 })) {
+        bar::u(box Foo{ a: a, b: b }) => { a + (b as isize) }
+        _ => { 66 }
+    };
+    assert_eq!(v, 50);
 }

--- a/src/test/ui/unique/unique-pat-3.rs
+++ b/src/test/ui/unique/unique-pat-3.rs
@@ -2,16 +2,15 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-#![feature(box_syntax)]
-
 enum bar { u(Box<isize>), w(isize), }
 
 pub fn main() {
-    assert!(match bar::u(box 10) {
-      bar::u(a) => {
-        println!("{}", a);
-        *a
-      }
-      _ => { 66 }
-    } == 10);
+    let v = match bar::u(10.into()) {
+        bar::u(a) => {
+            println!("{}", a);
+            *a
+        }
+        _ => { 66 }
+    };
+    assert_eq!(v, 10);
 }

--- a/src/test/ui/unique/unique-pat.rs
+++ b/src/test/ui/unique/unique-pat.rs
@@ -1,10 +1,9 @@
 // run-pass
 
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 
 fn simple() {
-    match box true {
+    match Box::new(true) {
       box true => { }
       _ => { panic!(); }
     }

--- a/src/test/ui/unique/unique-rec.rs
+++ b/src/test/ui/unique/unique-rec.rs
@@ -1,10 +1,9 @@
 // run-pass
-#![feature(box_syntax)]
 
 struct X { x: isize }
 
 pub fn main() {
-    let x: Box<_> = box X {x: 1};
+    let x: Box<_> = Box::new(X {x: 1});
     let bar = x;
     assert_eq!(bar.x, 1);
 }

--- a/src/test/ui/unique/unique-send-2.rs
+++ b/src/test/ui/unique/unique-send-2.rs
@@ -2,13 +2,11 @@
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
 
 fn child(tx: &Sender<Box<usize>>, i: usize) {
-    tx.send(box i).unwrap();
+    tx.send(Box::new(i)).unwrap();
 }
 
 pub fn main() {

--- a/src/test/ui/unique/unique-send.rs
+++ b/src/test/ui/unique/unique-send.rs
@@ -1,11 +1,10 @@
 // run-pass
-#![feature(box_syntax)]
 
 use std::sync::mpsc::channel;
 
 pub fn main() {
     let (tx, rx) = channel::<Box<_>>();
-    tx.send(box 100).unwrap();
+    tx.send(Box::new(100)).unwrap();
     let v = rx.recv().unwrap();
-    assert_eq!(v, box 100);
+    assert_eq!(v, Box::new(100));
 }

--- a/src/test/ui/unique/unique-swap.rs
+++ b/src/test/ui/unique/unique-swap.rs
@@ -1,12 +1,11 @@
 // run-pass
-#![feature(box_syntax)]
 
 use std::mem::swap;
 
 pub fn main() {
-    let mut i: Box<_> = box 100;
-    let mut j: Box<_> = box 200;
+    let mut i: Box<_> = Box::new(100);
+    let mut j: Box<_> = Box::new(200);
     swap(&mut i, &mut j);
-    assert_eq!(i, box 200);
-    assert_eq!(j, box 100);
+    assert_eq!(i, Box::new(200));
+    assert_eq!(j, Box::new(100));
 }

--- a/src/test/ui/unsized/unsized2.rs
+++ b/src/test/ui/unsized/unsized2.rs
@@ -4,7 +4,6 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
-#![feature(box_syntax)]
 
 // Test sized-ness checking in substitution.
 
@@ -36,7 +35,7 @@ trait T2 {
 struct S;
 impl T2 for S {
     fn f() -> Box<S> {
-        box S
+        Box::new(S)
     }
 }
 fn f5<X: ?Sized+T2>(x: &X) {
@@ -51,7 +50,7 @@ trait T3 {
 }
 impl T3 for S {
     fn f() -> Box<S> {
-        box S
+        Box::new(S)
     }
 }
 fn f7<X: ?Sized+T3>(x: &X) {

--- a/src/test/ui/unsized/unsized3-rpass.rs
+++ b/src/test/ui/unsized/unsized3-rpass.rs
@@ -2,7 +2,7 @@
 // Test structs with always-unsized fields.
 
 #![allow(warnings)]
-#![feature(box_syntax, unsize, ptr_metadata)]
+#![feature(unsize, ptr_metadata)]
 
 use std::mem;
 use std::ptr;
@@ -58,7 +58,7 @@ pub fn main() {
             f: [T; 3],
         }
 
-        let data: Box<Foo_<i32>> = box Foo_ { f: [1, 2, 3] };
+        let data: Box<Foo_<i32>> = Box::new(Foo_ { f: [1, 2, 3] });
         let x: &Foo<i32> = mem::transmute(slice::from_raw_parts(&*data, 3));
         assert_eq!(x.f.len(), 3);
         assert_eq!(x.f[0], 1);
@@ -69,7 +69,7 @@ pub fn main() {
         }
 
         let data: Box<_> =
-            box Baz_ { f1: 42, f2: ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8] };
+            Box::new(Baz_ { f1: 42, f2: ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8] });
         let x: &Baz = mem::transmute(slice::from_raw_parts(&*data, 5));
         assert_eq!(x.f1, 42);
         let chs: Vec<char> = x.f2.chars().collect();
@@ -84,9 +84,9 @@ pub fn main() {
             f: St,
         }
 
-        let obj: Box<St> = box St { f: 42 };
+        let obj: Box<St> = Box::new(St { f: 42 });
         let obj: &Tr = &*obj;
-        let data: Box<_> = box Qux_ { f: St { f: 234 } };
+        let data: Box<_> = Box::new(Qux_ { f: St { f: 234 } });
         let x: &Qux = &*ptr::from_raw_parts::<Qux>((&*data as *const _).cast(), ptr::metadata(obj));
         assert_eq!(x.f.foo(), 234);
     }

--- a/src/test/ui/unused-move-capture.rs
+++ b/src/test/ui/unused-move-capture.rs
@@ -1,10 +1,8 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-#![feature(box_syntax)]
-
 pub fn main() {
-    let _x: Box<_> = box 1;
+    let _x: Box<_> = Box::new(1);
     let lam_move = || {};
     lam_move();
 }

--- a/src/test/ui/unused-move.rs
+++ b/src/test/ui/unused-move.rs
@@ -6,10 +6,8 @@
 // pretty-expanded FIXME #23616
 
 #![allow(path_statements)]
-#![feature(box_syntax)]
 
-pub fn main()
-{
-    let y: Box<_> = box 1;
+pub fn main() {
+    let y: Box<_> = Box::new(1);
     y;
 }

--- a/src/test/ui/unwind-unique.rs
+++ b/src/test/ui/unwind-unique.rs
@@ -1,12 +1,10 @@
 // run-pass
 // ignore-emscripten no threads support
 
-#![feature(box_syntax)]
-
 use std::thread;
 
 fn f() {
-    let _a: Box<_> = box 0;
+    let _a: Box<_> = Box::new(0);
     panic!();
 }
 

--- a/src/test/ui/use/use-after-move-implicity-coerced-object.rs
+++ b/src/test/ui/use/use-after-move-implicity-coerced-object.rs
@@ -1,5 +1,3 @@
-#![feature(box_syntax)]
-
 use std::fmt;
 
 struct Number {
@@ -22,9 +20,11 @@ impl List {
 }
 
 fn main() {
-    let n: Box<_> = box Number { n: 42 };
-    let mut l: Box<_> = box List { list: Vec::new() };
+
+    let n: Box<_> = Number { n: 42 }.into();
+    let mut l: Box<_> = List { list: Vec::new() }.into();
     l.push(n);
+
     let x = n.to_string();
     //~^ ERROR: borrow of moved value: `n`
 }

--- a/src/test/ui/use/use-after-move-implicity-coerced-object.stderr
+++ b/src/test/ui/use/use-after-move-implicity-coerced-object.stderr
@@ -1,11 +1,12 @@
 error[E0382]: borrow of moved value: `n`
   --> $DIR/use-after-move-implicity-coerced-object.rs:28:13
    |
-LL |     let n: Box<_> = box Number { n: 42 };
+LL |     let n: Box<_> = Number { n: 42 }.into();
    |         - move occurs because `n` has type `Box<Number>`, which does not implement the `Copy` trait
-LL |     let mut l: Box<_> = box List { list: Vec::new() };
+LL |     let mut l: Box<_> = List { list: Vec::new() }.into();
 LL |     l.push(n);
    |            - value moved here
+LL | 
 LL |     let x = n.to_string();
    |             ^ value borrowed here after move
 

--- a/src/test/ui/use/use-after-move-self.rs
+++ b/src/test/ui/use/use-after-move-self.rs
@@ -1,8 +1,8 @@
-#![feature(box_syntax)]
-
 struct S {
     x: Box<isize>,
 }
+
+
 
 impl S {
     pub fn foo(self) -> isize {
@@ -14,6 +14,6 @@ impl S {
 }
 
 fn main() {
-    let x = S { x: box 1 };
+    let x = S { x: 1.into() };
     println!("{}", x.foo());
 }


### PR DESCRIPTION
Removes most box syntax uses from the testsuite outside of the src/test/ui/issues directory. The goal was to only change tests where box syntax is an implementation detail instead of the actual feature being tested. So some tests were left out, like the regression test for #87935, or tests where the obtained error message changed significantly.

Mostly this replaces box syntax with `Box::new`, but there are some minor drive by improvements, like formatting improvements or `assert_eq` instead of `assert!( == )`.

Prior PR that removed box syntax from the compiler and tools: #87781