### PR TITLE
Simplify `bootstrap.py`

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -400,7 +400,7 @@ class RustBuild(object):
         Each downloaded tarball is extracted, after that, the script
         will move all the content to the right place.
         """
-        if rustc_channel is None:
+        if not rustc_channel:
             rustc_channel = self.rustc_channel
         rustfmt_channel = self.rustfmt_channel
         bin_root = self.bin_root(stage0)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -515,11 +515,8 @@ class RustBuild(object):
     def _download_component_helper(
         self, filename, pattern, tarball_suffix, stage0=True, key=None
     ):
-        if key is None:
-            if stage0:
-                key = self.date
-            else:
-                key = self.rustc_commit
+        if not key:
+            key = self.date if stage0 else self.rustc_commit
         cache_dst = os.path.join(self.build_dir, "cache")
         rustc_cache = os.path.join(cache_dst, key)
         if not os.path.exists(rustc_cache):
@@ -654,7 +651,7 @@ class RustBuild(object):
     def maybe_download_ci_toolchain(self):
         # If `download-rustc` is not set, default to rebuilding.
         download_rustc = self.get_toml("download-rustc", section="rust")
-        if download_rustc is None or download_rustc == "false":
+        if not download_rustc or download_rustc == "false":
             return None
         assert download_rustc == "true" or download_rustc == "if-unchanged", download_rustc
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -868,9 +868,8 @@ class RustBuild(object):
     @staticmethod
     def exe_suffix():
         """Return a suffix for executables"""
-        if sys.platform == 'win32':
-            return '.exe'
-        return ''
+        return '.exe' if sys.platform == 'win32' else ''
+
 
     def bootstrap_binary(self):
         """Return the path of the bootstrap binary

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -742,10 +742,7 @@ class RustBuild(object):
         >>> rb.bin_root(True) == os.path.join("build", "devel", "stage0")
         True
         """
-        if stage0:
-            subdir = "stage0"
-        else:
-            subdir = "ci-rustc"
+        subdir = "stage0" if stage0 else "ci-rustc"
         return os.path.join(self.build_dir, self.build, subdir)
 
     def llvm_root(self):

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -812,9 +812,7 @@ class RustBuild(object):
 
     def rustfmt(self):
         """Return config path for rustfmt"""
-        if not self.rustfmt_channel:
-            return None
-        return self.program_config('rustfmt')
+        return None if not self.rustfmt_channel else self.program_config('rustfmt')
 
     def program_config(self, program, stage0=True):
         """Return config path for the given program at the given stage
@@ -866,7 +864,6 @@ class RustBuild(object):
     def exe_suffix():
         """Return a suffix for executables"""
         return '.exe' if sys.platform == 'win32' else ''
-
 
     def bootstrap_binary(self):
         """Return the path of the bootstrap binary
@@ -942,9 +939,7 @@ class RustBuild(object):
         so use `self.build` where possible.
         """
         config = self.get_toml('build')
-        if config:
-            return config
-        return default_build_triple(self.verbose)
+        return config if config else default_build_triple(self.verbose)
 
     def check_submodule(self, module, slow_submodules):
         if not slow_submodules:
@@ -952,8 +947,7 @@ class RustBuild(object):
                                            cwd=os.path.join(self.rust_root, module),
                                            stdout=subprocess.PIPE)
             return checked_out
-        else:
-            return None
+        return None
 
     def update_submodule(self, module, checked_out, recorded_submodules):
         module_path = os.path.join(self.rust_root, module)


### PR DESCRIPTION
Using Python's ternary expression is more readable.