### PR TITLE
Add `c_size_t` and `c_ssize_t` to `std::os::raw`.

### DIFF
--- a/library/std/src/os/raw/mod.rs
+++ b/library/std/src/os/raw/mod.rs
@@ -156,12 +156,12 @@ pub use core::ffi::c_void;
 ///
 /// This type is currently always [`usize`], however in the future there may be
 /// platforms where this is not the case.
-#[unstable(feature = "c_size_t", issue = "none")]
+#[unstable(feature = "c_size_t", issue = "88345")]
 pub type c_size_t = usize;
 
 /// Equivalent to C's `ssize_t` type, from `stddef.h` (or `cstddef` for C++).
 ///
 /// This type is currently always [`isize`], however in the future there may be
 /// platforms where this is not the case.
-#[unstable(feature = "c_size_t", issue = "none")]
+#[unstable(feature = "c_size_t", issue = "88345")]
 pub type c_ssize_t = isize;

--- a/library/std/src/os/raw/mod.rs
+++ b/library/std/src/os/raw/mod.rs
@@ -151,3 +151,17 @@ type_alias_no_nz! { "double.md", c_double = f64; }
 #[stable(feature = "raw_os", since = "1.1.0")]
 #[doc(no_inline)]
 pub use core::ffi::c_void;
+
+/// Equivalent to C's `size_t` type, from `stddef.h` (or `cstddef` for C++).
+///
+/// This type is currently always [`usize`], however in the future there may be
+/// platforms where this is not the case.
+#[unstable(feature = "c_size_t", issue = "none")]
+pub type c_size_t = usize;
+
+/// Equivalent to C's `ssize_t` type, from `stddef.h` (or `cstddef` for C++).
+///
+/// This type is currently always [`isize`], however in the future there may be
+/// platforms where this is not the case.
+#[unstable(feature = "c_size_t", issue = "none")]
+pub type c_ssize_t = isize;


### PR DESCRIPTION
Apparently these aren't guaranteed to be the same, and are merely "always the same in practice" (see https://rust-lang.zulipchat.com/#narrow/stream/136281-t-lang.2Fwg-unsafe-code-guidelines/topic/.60usize.60.20vs.20.60size_t.60).

This is a big footgun, but I suspect it can be alleviated if we expose this and start migrating people to it in advance of any platforms that ever have this as different.

I'll file a tracking issue after this gets some traction.