### PR TITLE
Shrink `Try` code size

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -1,4 +1,4 @@
-use crate::{convert, ops};
+use crate::ops;
 
 /// Used to tell an operation whether it should exit early or go on as usual.
 ///
@@ -65,7 +65,7 @@ pub enum ControlFlow<B, C = ()> {
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<B, C> ops::Try for ControlFlow<B, C> {
     type Output = C;
-    type Residual = ControlFlow<B, convert::Infallible>;
+    type Residual = B;
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -74,20 +74,15 @@ impl<B, C> ops::Try for ControlFlow<B, C> {
 
     #[inline]
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
-        match self {
-            ControlFlow::Continue(c) => ControlFlow::Continue(c),
-            ControlFlow::Break(b) => ControlFlow::Break(ControlFlow::Break(b)),
-        }
+        self
     }
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<B, C> ops::FromResidual for ControlFlow<B, C> {
     #[inline]
-    fn from_residual(residual: ControlFlow<B, convert::Infallible>) -> Self {
-        match residual {
-            ControlFlow::Break(b) => ControlFlow::Break(b),
-        }
+    fn from_residual(residual: B) -> Self {
+        ControlFlow::Break(residual)
     }
 }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -499,7 +499,7 @@
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::pin::Pin;
 use crate::{
-    convert, hint, mem,
+    hint, mem,
     ops::{self, ControlFlow, Deref, DerefMut},
 };
 
@@ -2015,7 +2015,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T> ops::Try for Option<T> {
     type Output = T;
-    type Residual = Option<convert::Infallible>;
+    type Residual = ();
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -2026,7 +2026,7 @@ impl<T> ops::Try for Option<T> {
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self {
             Some(v) => ControlFlow::Continue(v),
-            None => ControlFlow::Break(None),
+            None => ControlFlow::Break(()),
         }
     }
 }
@@ -2034,10 +2034,8 @@ impl<T> ops::Try for Option<T> {
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T> ops::FromResidual for Option<T> {
     #[inline]
-    fn from_residual(residual: Option<convert::Infallible>) -> Self {
-        match residual {
-            None => None,
-        }
+    fn from_residual(_: ()) -> Self {
+        None
     }
 }
 

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1891,7 +1891,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T, E> ops::Try for Result<T, E> {
     type Output = T;
-    type Residual = Result<convert::Infallible, E>;
+    type Residual = E;
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -1902,17 +1902,15 @@ impl<T, E> ops::Try for Result<T, E> {
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self {
             Ok(v) => ControlFlow::Continue(v),
-            Err(e) => ControlFlow::Break(Err(e)),
+            Err(e) => ControlFlow::Break(e),
         }
     }
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277")]
-impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
+impl<T, E, F: From<E>> ops::FromResidual<E> for Result<T, F> {
     #[inline]
-    fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
-        match residual {
-            Err(e) => Err(From::from(e)),
-        }
+    fn from_residual(residual: E) -> Self {
+        Err(From::from(residual))
     }
 }


### PR DESCRIPTION
This generates smaller `.rodata` on my local machine.