### PR TITLE
Partially stabilize `array_methods`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -368,14 +368,14 @@ impl<T, const N: usize> [T; N] {
     }
 
     /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
-    #[unstable(feature = "array_methods", issue = "76118")]
-    pub fn as_slice(&self) -> &[T] {
+    #[stable(feature = "array_as_slice", since = "1.57.0")]
+    pub const fn as_slice(&self) -> &[T] {
         self
     }
 
     /// Returns a mutable slice containing the entire array. Equivalent to
     /// `&mut s[..]`.
-    #[unstable(feature = "array_methods", issue = "76118")]
+    #[stable(feature = "array_as_slice", since = "1.57.0")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self
     }


### PR DESCRIPTION
This stabilizes `<[T; N]>::as_slice` and `<[T; N]>::as_mut_slice`, which is forms part of the `array_methods` feature: #76118.

This also makes `<[T; N]>::as_slice` const due to its trivial nature.