### PR TITLE
Handle stack_t.ss_sp type change for DragonFlyBSD

### DIFF
--- a/library/std/src/sys/unix/stack_overflow.rs
+++ b/library/std/src/sys/unix/stack_overflow.rs
@@ -161,22 +161,8 @@ mod imp {
         stackp.add(page_size())
     }
 
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "solaris",
-        target_os = "illumos"
-    ))]
     unsafe fn get_stack() -> libc::stack_t {
         libc::stack_t { ss_sp: get_stackp(), ss_flags: 0, ss_size: SIGSTKSZ }
-    }
-
-    #[cfg(target_os = "dragonfly")]
-    unsafe fn get_stack() -> libc::stack_t {
-        libc::stack_t { ss_sp: get_stackp() as *mut i8, ss_flags: 0, ss_size: SIGSTKSZ }
     }
 
     pub unsafe fn make_handler() -> Handler {


### PR DESCRIPTION
stack_t.ss_sp is now c_void on DragonFlyBSD, like the rest of the BSDs.

Changed in https://github.com/rust-lang/libc/commit/02922ef7504906589d02c2e4d97d1172fa247cc3.