### PR TITLE
Point at unclosed delimiters as part of the primary MultiSpan

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1432,12 +1432,22 @@ impl<'a> Parser<'a> {
                 // the most sense, which is immediately after the last token:
                 //
                 //  {foo(bar {}}
-                //      -      ^
+                //      ^      ^
                 //      |      |
                 //      |      help: `)` may belong here
                 //      |
                 //      unclosed delimiter
                 if let Some(sp) = unmatched.unclosed_span {
+                    let mut primary_span: Vec<Span> =
+                        err.span.primary_spans().iter().cloned().collect();
+                    primary_span.push(sp);
+                    let mut primary_span: MultiSpan = primary_span.into();
+                    for span_label in err.span.span_labels() {
+                        if let Some(label) = span_label.label {
+                            primary_span.push_span_label(span_label.span, label);
+                        }
+                    }
+                    err.set_span(primary_span);
                     err.span_label(sp, "unclosed delimiter");
                 }
                 // Backticks should be removed to apply suggestions.

--- a/src/test/ui/parser/issue-10636-1.stderr
+++ b/src/test/ui/parser/issue-10636-1.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-10636-1.rs:4:1
+  --> $DIR/issue-10636-1.rs:1:12
    |
 LL | struct Obj {
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 ...
 LL | )
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/issue-10636-2.stderr
+++ b/src/test/ui/parser/issue-10636-2.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/issue-10636-2.rs:5:25
+  --> $DIR/issue-10636-2.rs:5:15
    |
 LL |     option.map(|some| 42;
-   |               -         ^ help: `)` may belong here
+   |               ^         ^ help: `)` may belong here
    |               |
    |               unclosed delimiter
 

--- a/src/test/ui/parser/issue-58856-1.stderr
+++ b/src/test/ui/parser/issue-58856-1.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, or `:`, found `>`
-  --> $DIR/issue-58856-1.rs:3:14
+  --> $DIR/issue-58856-1.rs:3:9
    |
 LL |     fn b(self>
-   |         -    ^ help: `)` may belong here
+   |         ^    ^ help: `)` may belong here
    |         |
    |         unclosed delimiter
 

--- a/src/test/ui/parser/issue-58856-2.stderr
+++ b/src/test/ui/parser/issue-58856-2.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)` or `,`, found `->`
-  --> $DIR/issue-58856-2.rs:6:26
+  --> $DIR/issue-58856-2.rs:6:19
    |
 LL |     fn how_are_you(&self -> Empty {
-   |                   -     -^^
+   |                   ^     -^^
    |                   |     |
    |                   |     help: `)` may belong here
    |                   unclosed delimiter

--- a/src/test/ui/parser/issue-60075.stderr
+++ b/src/test/ui/parser/issue-60075.stderr
@@ -17,10 +17,10 @@ LL |     }
    |     - item list ends here
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-60075.rs:6:10
+  --> $DIR/issue-60075.rs:4:31
    |
 LL |     fn qux() -> Option<usize> {
-   |                               - unclosed delimiter
+   |                               ^ unclosed delimiter
 LL |         let _ = if true {
 LL |         });
    |          ^ mismatched closing delimiter

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -21,10 +21,10 @@ LL |
    |  ^
 
 error: expected one of `,` or `}`, found `{`
-  --> $DIR/issue-62973.rs:6:25
+  --> $DIR/issue-62973.rs:6:8
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        -       -       -^ expected one of `,` or `}`
+   |        ^       -       -^ expected one of `,` or `}`
    |        |       |       |
    |        |       |       help: `}` may belong here
    |        |       while parsing this struct
@@ -56,18 +56,18 @@ LL |
    |  ^ expected one of `.`, `?`, `{`, or an operator
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-62973.rs:6:28
+  --> $DIR/issue-62973.rs:6:27
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                           -^ mismatched closing delimiter
+   |                           ^^ mismatched closing delimiter
    |                           |
    |                           unclosed delimiter
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-62973.rs:6:31
+  --> $DIR/issue-62973.rs:6:30
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                              -^ mismatched closing delimiter
+   |                              ^^ mismatched closing delimiter
    |                              |
    |                              unclosed delimiter
 

--- a/src/test/ui/parser/issue-63116.stderr
+++ b/src/test/ui/parser/issue-63116.stderr
@@ -13,10 +13,10 @@ LL | impl W <s(f;Y(;]
    |            ^ expected one of 7 possible tokens
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-63116.rs:3:16
+  --> $DIR/issue-63116.rs:3:14
    |
 LL | impl W <s(f;Y(;]
-   |              - ^ mismatched closing delimiter
+   |              ^ ^ mismatched closing delimiter
    |              |
    |              unclosed delimiter
 

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
@@ -5,10 +5,10 @@ LL | fn f() { |[](* }
    |             ^ expected one of `,` or `:`
 
 error: expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`
-  --> $DIR/issue-66357-unexpected-unreachable.rs:12:14
+  --> $DIR/issue-66357-unexpected-unreachable.rs:12:13
    |
 LL | fn f() { |[](* }
-   |             -^ help: `)` may belong here
+   |             ^^ help: `)` may belong here
    |             |
    |             unclosed delimiter
 

--- a/src/test/ui/parser/issue-67377-invalid-syntax-in-enum-discriminant.stderr
+++ b/src/test/ui/parser/issue-67377-invalid-syntax-in-enum-discriminant.stderr
@@ -1,107 +1,107 @@
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this

--- a/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/macro-mismatched-delim-brace-paren.rs:6:5
+  --> $DIR/macro-mismatched-delim-brace-paren.rs:4:10
    |
 LL |     foo! {
-   |          - unclosed delimiter
+   |          ^ unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
@@ -10,10 +10,10 @@ LL | }
    | ^ unexpected closing delimiter
 
 error: mismatched closing delimiter: `}`
-  --> $DIR/macro-mismatched-delim-paren-brace.rs:4:5
+  --> $DIR/macro-mismatched-delim-paren-brace.rs:2:10
    |
 LL |     foo! (
-   |          - unclosed delimiter
+   |          ^ unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     }
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/parser-recovery-2.stderr
+++ b/src/test/ui/parser/parser-recovery-2.stderr
@@ -5,10 +5,10 @@ LL |     let x = y.;
    |               ^
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/parser-recovery-2.rs:6:5
+  --> $DIR/parser-recovery-2.rs:4:14
    |
 LL |     fn bar() {
-   |              - unclosed delimiter
+   |              ^ unclosed delimiter
 LL |         let x = foo();
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
+++ b/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/unclosed_delim_mod.rs:7:1
+  --> $DIR/unclosed_delim_mod.rs:5:7
    |
 LL | pub fn new() -> Result<Value, ()> {
    |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - unclosed delimiter
+   |       ^ unclosed delimiter
 LL |     }
 LL | }
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/unclosed_delim_mod.stderr
+++ b/src/test/ui/parser/unclosed_delim_mod.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/unclosed_delim_mod.rs:7:1
+  --> $DIR/unclosed_delim_mod.rs:5:7
    |
 LL | pub fn new() -> Result<Value, ()> {
    |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - unclosed delimiter
+   |       ^ unclosed delimiter
 LL |     }
 LL | }
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/use-unclosed-brace.stderr
+++ b/src/test/ui/parser/use-unclosed-brace.stderr
@@ -8,10 +8,10 @@ LL | fn main() {}
    |              ^
 
 error: expected one of `,`, `::`, `as`, or `}`, found `;`
-  --> $DIR/use-unclosed-brace.rs:4:19
+  --> $DIR/use-unclosed-brace.rs:4:10
    |
 LL | use foo::{bar, baz;
-   |          -        ^
+   |          ^        ^
    |          |        |
    |          |        expected one of `,`, `::`, `as`, or `}`
    |          |        help: `}` may belong here

--- a/src/test/ui/resolve/token-error-correct-2.stderr
+++ b/src/test/ui/resolve/token-error-correct-2.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/token-error-correct-2.rs:6:5
+  --> $DIR/token-error-correct-2.rs:4:12
    |
 LL |     if foo {
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 LL |
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/token-error-correct-3.rs:13:35
+  --> $DIR/token-error-correct-3.rs:13:21
    |
 LL |             callback(path.as_ref();
-   |                     -             ^ help: `)` may belong here
+   |                     ^             ^ help: `)` may belong here
    |                     |
    |                     unclosed delimiter
 

--- a/src/test/ui/resolve/token-error-correct-4.stderr
+++ b/src/test/ui/resolve/token-error-correct-4.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/token-error-correct-4.rs:9:21
+  --> $DIR/token-error-correct-4.rs:9:12
    |
 LL |     setsuna(kazusa();
-   |            -        ^ help: `)` may belong here
+   |            ^        ^ help: `)` may belong here
    |            |
    |            unclosed delimiter
 

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/token-error-correct.rs:6:1
+  --> $DIR/token-error-correct.rs:4:12
    |
 LL | fn main() {
    |           - closing delimiter possibly meant for this
 LL |     foo(bar(;
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 LL |
 LL | }
    | ^ mismatched closing delimiter


### PR DESCRIPTION
Both the place where the parser encounters a needed closed delimiter and
the unclosed opening delimiter are important, so they should get the
same level of highlighting in the output.

_Context: https://twitter.com/mwk4/status/1430631546432675840_