### PR TITLE
Document `std::env::current_exe` possible rename behaviour

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -616,6 +616,9 @@ pub fn temp_dir() -> PathBuf {
 /// return the path of the symbolic link and other platforms will return the
 /// path of the symbolic link’s target.
 ///
+/// If the executable is renamed while it is running, platforms may return the
+/// path at the time it was loaded instead of the new path.
+///
 /// # Errors
 ///
 /// Acquiring the path of the current executable is a platform-specific operation


### PR DESCRIPTION
It might not be obvious that the "path of the current running executable" may (or may not) imply "at the time it was loaded".

This came up recently in chat so I thought it might be worth documenting.