### PR TITLE
Bump vulnerable crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils 0.7.2",
@@ -2368,9 +2368,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.15.0+1.1.1k"
+version = "111.16.0+1.1.1l"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
 dependencies = [
  "cc",
 ]
@@ -4967,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
crossbeam-deque v0.7.3 -> v0.7.4:
    https://rustsec.org/advisories/RUSTSEC-2021-0093
    https://github.com/crossbeam-rs/crossbeam/pull/728/files

openssl-src v111.15.0+1.1.1k -> v111.16.0+1.1.1l:
    https://rustsec.org/advisories/RUSTSEC-2021-0097
    https://rustsec.org/advisories/RUSTSEC-2021-0098
    https://www.openssl.org/news/vulnerabilities-1.1.1.html

tar v0.4.35 -> v0.4.37:
    https://rustsec.org/advisories/RUSTSEC-2021-0080
    updated to 0.4.37 as there breaking change in 0.4.36: https://github.com/alexcrichton/tar-rs/pull/260