### PR TITLE
Tracking issue for `UNSUPPORTED_CALLING_CONVENTIONS`

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3384,7 +3384,7 @@ declare_lint! {
     Warn,
     "use of unsupported calling convention",
     @future_incompatible = FutureIncompatibleInfo {
-        reference: "issue #00000 <https://github.com/rust-lang/rust/issues/00000>",
+        reference: "issue #87678 <https://github.com/rust-lang/rust/issues/87678>",
     };
 }
 

--- a/src/test/ui/abi/unsupported.aarch64.stderr
+++ b/src/test/ui/abi/unsupported.aarch64.stderr
@@ -42,7 +42,7 @@ LL | extern "stdcall" fn stdcall() {}
    |
    = note: `#[warn(unsupported_calling_conventions)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #00000 <https://github.com/rust-lang/rust/issues/00000>
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
 warning: use of calling convention not supported on this target
   --> $DIR/unsupported.rs:44:1
@@ -51,7 +51,7 @@ LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #00000 <https://github.com/rust-lang/rust/issues/00000>
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
 error: aborting due to 6 previous errors; 2 warnings emitted
 

--- a/src/test/ui/abi/unsupported.x64.stderr
+++ b/src/test/ui/abi/unsupported.x64.stderr
@@ -42,7 +42,7 @@ LL | extern "stdcall" fn stdcall() {}
    |
    = note: `#[warn(unsupported_calling_conventions)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #00000 <https://github.com/rust-lang/rust/issues/00000>
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
 warning: use of calling convention not supported on this target
   --> $DIR/unsupported.rs:44:1
@@ -51,7 +51,7 @@ LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #00000 <https://github.com/rust-lang/rust/issues/00000>
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
 error: aborting due to 6 previous errors; 2 warnings emitted
 


### PR DESCRIPTION
This was previously forgotten. Nominating for 1.55 as this lint will make it into stable in that release.

r? @Mark-Simulacrum 