### PR TITLE
Remove `Session.if_let_suggestions`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -215,7 +215,6 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                     "let ".to_string(),
                     Applicability::MaybeIncorrect,
                 );
-                self.r.session.if_let_suggestions.borrow_mut().insert(*span);
             }
             _ => {}
         }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -209,9 +209,6 @@ pub struct Session {
 
     /// Set of enabled features for the current target.
     pub target_features: FxHashSet<Symbol>,
-
-    /// `Span`s for `if` conditions that we have suggested turning into `if let`.
-    pub if_let_suggestions: Lock<FxHashSet<Span>>,
 }
 
 pub struct PerfStats {
@@ -1328,7 +1325,6 @@ pub fn build_session(
         miri_unleashed_features: Lock::new(Default::default()),
         asm_arch,
         target_features: FxHashSet::default(),
-        if_let_suggestions: Default::default(),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -919,9 +919,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             }
 
-            if self.sess().if_let_suggestions.borrow().get(&expr.span).is_some() {
-                // We already emitted an `if let` suggestion due to an identifier not found.
-                err.delay_as_bug();
+            // If the assignment expression itself is ill-formed, don't
+            // bother emitting another error
+            if lhs_ty.references_error() || rhs_ty.references_error() {
+                err.delay_as_bug()
             } else {
                 err.emit();
             }

--- a/src/test/ui/suggestions/if-let-typo.rs
+++ b/src/test/ui/suggestions/if-let-typo.rs
@@ -10,4 +10,5 @@ fn main() {
     if Some(3) = foo {} //~ ERROR mismatched types
     //~^ ERROR destructuring assignments are unstable
     //~^^ ERROR invalid left-hand side of assignment
+    if x = 5 {}  //~ ERROR cannot find value `x` in this scope
 }

--- a/src/test/ui/suggestions/if-let-typo.stderr
+++ b/src/test/ui/suggestions/if-let-typo.stderr
@@ -9,6 +9,17 @@ help: you might have meant to use pattern matching
 LL |     if let Some(x) = foo {}
    |        +++
 
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/if-let-typo.rs:13:8
+   |
+LL |     if x = 5 {}
+   |        ^ not found in this scope
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     if let x = 5 {}
+   |        +++
+
 error[E0658]: destructuring assignments are unstable
   --> $DIR/if-let-typo.rs:4:16
    |
@@ -79,7 +90,7 @@ error[E0308]: mismatched types
 LL |     if Some(3) = foo {}
    |        ^^^^^^^^^^^^^ expected `bool`, found `()`
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0425, E0658.
 For more information about an error, try `rustc --explain E0070`.


### PR DESCRIPTION
We can instead if either the LHS or RHS types contain
`TyKind::Error`. In addition to covering the case where
we would have previously updated `if_let_suggestions`, this might
also prevent redundant errors in other cases as well.