### PR TITLE
add #[inline] to Path comparison fast path

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -993,6 +993,7 @@ impl cmp::Ord for Components<'_> {
     }
 }
 
+#[inline]
 fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
     // Fast path for long shared prefixes
     //


### PR DESCRIPTION
Let's see if this fixes the regression noted in https://github.com/rust-lang/rust/pull/86898#issuecomment-905524405