### PR TITLE
Reapply "cg_llvm: `fewer_names` in `uncached_llvm_type`"

### DIFF
--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -43,7 +43,9 @@ fn uncached_llvm_type<'a, 'tcx>(
         // FIXME(eddyb) producing readable type names for trait objects can result
         // in problematically distinct types due to HRTB and subtyping (see #47638).
         // ty::Dynamic(..) |
-        ty::Adt(..) | ty::Closure(..) | ty::Foreign(..) | ty::Generator(..) | ty::Str => {
+        ty::Adt(..) | ty::Closure(..) | ty::Foreign(..) | ty::Generator(..) | ty::Str
+            if !cx.sess().fewer_names() =>
+        {
             let mut name = with_no_trimmed_paths(|| layout.ty.to_string());
             if let (&ty::Adt(def, _), &Variants::Single { index }) =
                 (layout.ty.kind(), &layout.variants)
@@ -58,6 +60,12 @@ fn uncached_llvm_type<'a, 'tcx>(
                 write!(&mut name, "::{}", ty::GeneratorSubsts::variant_name(index)).unwrap();
             }
             Some(name)
+        }
+        ty::Adt(..) => {
+            // If `Some` is returned then a named struct is created in LLVM. Name collisions are
+            // avoided by LLVM (with increasing suffixes). If rustc doesn't generate names then that
+            // can improve perf.
+            Some(String::new())
         }
         _ => None,
     };

--- a/src/test/ui/const-generics/issues/issue-75763.rs
+++ b/src/test/ui/const-generics/issues/issue-75763.rs
@@ -1,5 +1,4 @@
-// ignore-test
-// FIXME(const_generics): This test causes an ICE after reverting #76030.
+// build-pass
 
 #![allow(incomplete_features)]
 #![feature(const_generics)]


### PR DESCRIPTION
This reapplies #76030, which was reverted by #80122.

The underlying LLVM issue (https://bugs.llvm.org/show_bug.cgi?id=48340, per https://github.com/rust-lang/rust/issues/79564#issuecomment-736102763) was fixed in LLVM 13 by https://reviews.llvm.org/D91250 (and related patches), so we should be able to reland the original change.

I successfully ran the repro steps from https://github.com/rust-lang/rust/issues/79564#issuecomment-735883858 using a rustc built with this change.

We should do another perf run to make sure this still has the same effect.

cc @davidtwco