### PR TITLE
Fix: don't document private macros by default

### DIFF
--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -40,6 +40,7 @@ impl<'a> DocFolder for Stripper<'a> {
             | clean::UnionItem(..)
             | clean::AssocConstItem(..)
             | clean::TraitAliasItem(..)
+            | clean::MacroItem(..)
             | clean::ForeignTypeItem => {
                 if i.def_id.is_local() {
                     if !self.access_levels.is_exported(i.def_id.expect_def_id()) {
@@ -70,8 +71,8 @@ impl<'a> DocFolder for Stripper<'a> {
 
             clean::ImplItem(..) => {}
 
-            // tymethods/macros have no control over privacy
-            clean::MacroItem(..) | clean::TyMethodItem(..) => {}
+            // tymethods have no control over privacy
+            clean::TyMethodItem(..) => {}
 
             // Proc-macros are always public
             clean::ProcMacroItem(..) => {}

--- a/src/test/rustdoc/macro-private-not-documented.rs
+++ b/src/test/rustdoc/macro-private-not-documented.rs
@@ -1,0 +1,19 @@
+// Checks that private macros aren't documented by default. They
+// should be still be documented in `--document-private-items` mode,
+// but that's tested in `macro-document-private.rs`.
+//
+//
+// This is a regression text for issue #88453.
+#![feature(decl_macro)]
+
+// @!has macro_private_not_documented/index.html 'a_macro'
+// @!has macro_private_not_documented/macro.a_macro.html
+macro_rules! a_macro {
+    () => ()
+}
+
+// @!has macro_private_not_documented/index.html 'another_macro'
+// @!has macro_private_not_documented/macro.another_macro.html
+macro another_macro {
+    () => ()
+}


### PR DESCRIPTION
As part of #88019, I made it so private macros are documented in `--document-private-items` mode. Unfortunately, it appears that I also accidentally made them be documented when *not* in `--document-private-items` mode. This PR fixes that and adds a regression test.

r? @jyn514 (I hope you don't mind that I keep sending PRs your way)

Fixes #88453.
