### PR TITLE
Add regression test for a spurious import

### DIFF
--- a/src/test/run-make/wasm-spurious-import/Makefile
+++ b/src/test/run-make/wasm-spurious-import/Makefile
@@ -1,0 +1,7 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# only-wasm32-bare
+
+all:
+	$(RUSTC) main.rs -C overflow-checks=yes -C panic=abort -C lto -C opt-level=z --target wasm32-unknown-unknown
+	$(NODE) verify.js $(TMPDIR)/main.wasm

--- a/src/test/run-make/wasm-spurious-import/main.rs
+++ b/src/test/run-make/wasm-spurious-import/main.rs
@@ -1,0 +1,14 @@
+#![crate_type = "cdylib"]
+#![no_std]
+
+#[panic_handler]
+fn my_panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub fn multer(a: i128, b: i128) -> i128 {
+    // Trigger usage of the __multi3 compiler intrinsic which then leads to an imported
+    // panic function in case of a bug. We verify that no imports exist in our verifier.
+    a * b
+}

--- a/src/test/run-make/wasm-spurious-import/verify.js
+++ b/src/test/run-make/wasm-spurious-import/verify.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const process = require('process');
+const assert = require('assert');
+const buffer = fs.readFileSync(process.argv[2]);
+
+let m = new WebAssembly.Module(buffer);
+let imports = WebAssembly.Module.imports(m);
+console.log('imports', imports);
+assert.strictEqual(imports.length, 0);


### PR DESCRIPTION
This PR adds a test that verifies that the bug described in the linked issue does not creep back into the code. In essence it checks that compiling some specific code (that uses 128 bit multiplication) with a specific set of compiler options does not lead to a spurious import of a panic function.

I noticed that other wasm tests use `# only-wasm32-bare` in their `Makefile`. This will skip the test for me. I did not find out how to run this test locally. Maybe someone can help.

closes #78744
r? @jyn514