### PR TITLE
Display associated types of implementors

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -453,6 +453,7 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", false)
             .into(),
+        ("auto-collapse-implementors", "Auto-hide implementors of a trait", true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result", false)
             .into(),
         ("line-numbers", "Show line numbers on code examples", false).into(),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -453,7 +453,6 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", false)
             .into(),
-        ("auto-collapse-implementors", "Auto-hide implementors of a trait", true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result", false)
             .into(),
         ("line-numbers", "Show line numbers on code examples", false).into(),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -16,8 +16,7 @@ use rustc_span::symbol::{kw, sym, Symbol};
 use super::{
     collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, notable_traits_decl,
     render_assoc_item, render_assoc_items, render_attributes_in_code, render_attributes_in_pre,
-    render_impl, render_impl_summary, render_stability_since_raw, write_srclink, AssocItemLink,
-    Context,
+    render_impl, render_stability_since_raw, write_srclink, AssocItemLink, Context,
 };
 use crate::clean::{self, GetDefId};
 use crate::formats::item_type::ItemType;
@@ -740,7 +739,9 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     None,
                     true,
                     false,
+                    true,
                     &[],
+                    false,
                 );
             }
         }
@@ -1388,16 +1389,20 @@ fn render_implementor(
         } => implementor_dups[&path.last()].1,
         _ => false,
     };
-    render_impl_summary(
+    render_impl(
         w,
         cx,
         implementor,
         trait_,
-        trait_,
+        AssocItemLink::Anchor(None),
+        RenderMode::Normal,
         false,
         Some(use_absolute),
         false,
+        false,
+        false,
         aliases,
+        false,
     );
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -17,6 +17,7 @@ use super::{
     collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, notable_traits_decl,
     render_assoc_item, render_assoc_items, render_attributes_in_code, render_attributes_in_pre,
     render_impl, render_stability_since_raw, write_srclink, AssocItemLink, Context,
+    ImplRenderingParameters,
 };
 use crate::clean::{self, GetDefId};
 use crate::formats::item_type::ItemType;
@@ -735,13 +736,15 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     it,
                     assoc_link,
                     RenderMode::Normal,
-                    false,
                     None,
-                    true,
-                    false,
-                    true,
                     &[],
-                    false,
+                    ImplRenderingParameters {
+                        show_def_docs: false,
+                        is_on_foreign_type: true,
+                        show_default_items: false,
+                        show_non_assoc_items: true,
+                        toggle_open_by_default: false,
+                    },
                 );
             }
         }
@@ -1396,13 +1399,15 @@ fn render_implementor(
         trait_,
         AssocItemLink::Anchor(None),
         RenderMode::Normal,
-        false,
         Some(use_absolute),
-        false,
-        false,
-        false,
         aliases,
-        false,
+        ImplRenderingParameters {
+            show_def_docs: false,
+            is_on_foreign_type: false,
+            show_default_items: false,
+            show_non_assoc_items: false,
+            toggle_open_by_default: false,
+        },
     );
 }
 

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -789,6 +789,7 @@ function hideThemeButtonState() {
         }
 
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
+        var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
         var hideImplementations = getSettingValue("auto-hide-trait-implementations") === "true";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
@@ -804,6 +805,10 @@ function hideThemeButtonState() {
         if (hideImplementations) {
             setImplementorsTogglesOpen("trait-implementations-list", false);
             setImplementorsTogglesOpen("blanket-implementations-list", false);
+        }
+
+        if (!hideImplementors) {
+            setImplementorsTogglesOpen("implementors-list", true);
         }
 
         onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -789,7 +789,6 @@ function hideThemeButtonState() {
         }
 
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
-        var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
         var hideImplementations = getSettingValue("auto-hide-trait-implementations") === "true";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
@@ -805,10 +804,6 @@ function hideThemeButtonState() {
         if (hideImplementations) {
             setImplementorsTogglesOpen("trait-implementations-list", false);
             setImplementorsTogglesOpen("blanket-implementations-list", false);
-        }
-
-        if (!hideImplementors) {
-            setImplementorsTogglesOpen("implementors-list", true);
         }
 
         onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {

--- a/src/test/rustdoc-gui/implementors.goml
+++ b/src/test/rustdoc-gui/implementors.goml
@@ -3,14 +3,14 @@
 goto: file://|DOC_PATH|/implementors/trait.Whatever.html
 assert: "#implementors-list"
 // There are supposed to be two implementors listed.
-assert-count: ("#implementors-list > .impl", 2)
+assert-count: ("#implementors-list .impl", 2)
 // Now we check that both implementors have an anchor, an ID and a similar DOM.
-assert: ("#implementors-list > .impl:nth-child(1) > a.anchor")
-assert-attribute: ("#implementors-list > .impl:nth-child(1)", {"id": "impl-Whatever"})
-assert-attribute: ("#implementors-list > .impl:nth-child(1) > a.anchor", {"href": "#impl-Whatever"})
-assert: "#implementors-list > .impl:nth-child(1) > .code-header.in-band"
+assert: ("#implementors-list .impl:nth-child(1) > a.anchor")
+assert-attribute: ("#implementors-list .impl:nth-child(1)", {"id": "impl-Whatever"})
+assert-attribute: ("#implementors-list .impl:nth-child(1) > a.anchor", {"href": "#impl-Whatever"})
+assert: "#implementors-list .impl:nth-child(1) > .code-header.in-band"
 
-assert: ("#implementors-list > .impl:nth-child(2) > a.anchor")
-assert-attribute: ("#implementors-list > .impl:nth-child(2)", {"id": "impl-Whatever-1"})
-assert-attribute: ("#implementors-list > .impl:nth-child(2) > a.anchor", {"href": "#impl-Whatever-1"})
-assert: "#implementors-list > .impl:nth-child(2) > .code-header.in-band"
+assert: ("#implementors-list .impl:nth-child(2) > a.anchor")
+assert-attribute: ("#implementors-list .impl:nth-child(2)", {"id": "impl-Whatever-1"})
+assert-attribute: ("#implementors-list .impl:nth-child(2) > a.anchor", {"href": "#impl-Whatever-1"})
+assert: "#implementors-list .impl:nth-child(2) > .code-header.in-band"

--- a/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
@@ -1,7 +1,11 @@
 pub trait Whatever {
+    type Foo;
+
     fn method() {}
 }
 
 pub struct Struct;
 
-impl Whatever for Struct {}
+impl Whatever for Struct {
+    type Foo = u8;
+}

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -38,7 +38,9 @@ impl Trait for Foo {
 }
 
 
-impl implementors::Whatever for Foo {}
+impl implementors::Whatever for Foo {
+    type Foo = u32;
+}
 
 pub mod sub_mod {
     /// ```txt

--- a/src/test/rustdoc-gui/toggle-implementors.goml
+++ b/src/test/rustdoc-gui/toggle-implementors.goml
@@ -1,0 +1,13 @@
+// This test ensures two things:
+//
+// 1. The implementors toggle are not open by default.
+// 2. The "auto-collapse-implementors" setting is working as expected.
+goto: file://|DOC_PATH|/implementors/trait.Whatever.html
+
+// First, checking that they are not open by default.
+assert-attribute-false: ("#implementors-list > details", {"open": ""}, ALL)
+
+// Second, checking "auto-collapse-implementors" setting.
+local-storage: {"rustdoc-auto-collapse-implementors": false}
+reload:
+assert-attribute: ("#implementors-list > details", {"open": ""}, ALL)

--- a/src/test/rustdoc-gui/toggle-implementors.goml
+++ b/src/test/rustdoc-gui/toggle-implementors.goml
@@ -1,13 +1,4 @@
-// This test ensures two things:
-//
-// 1. The implementors toggle are not open by default.
-// 2. The "auto-collapse-implementors" setting is working as expected.
+// This test ensures that the implementors toggle are not open by default.
 goto: file://|DOC_PATH|/implementors/trait.Whatever.html
 
-// First, checking that they are not open by default.
 assert-attribute-false: ("#implementors-list > details", {"open": ""}, ALL)
-
-// Second, checking "auto-collapse-implementors" setting.
-local-storage: {"rustdoc-auto-collapse-implementors": false}
-reload:
-assert-attribute: ("#implementors-list > details", {"open": ""}, ALL)

--- a/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
+++ b/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
@@ -1,6 +1,6 @@
 pub trait MyTrait {
     type Assoc;
-    const VALUE: u32;
+    const VALUE: u32 = 12;
     fn trait_function(&self);
     fn defaulted(&self) {}
     fn defaulted_override(&self) {}
@@ -38,9 +38,11 @@ impl MyTrait for Vec<u8> {
 }
 
 impl MyTrait for MyStruct {
+    // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedtype.Assoc-3"]//a[@class="anchor"]/@href' #associatedtype.Assoc-3
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedtype.Assoc"]//a[@class="type"]/@href' trait.MyTrait.html#associatedtype.Assoc
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedtype.Assoc"]//a[@class="anchor"]/@href' #associatedtype.Assoc
     type Assoc = bool;
+    // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-3"]//a[@class="anchor"]/@href' #associatedconstant.VALUE-3
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedconstant.VALUE"]//a[@class="constant"]/@href' trait.MyTrait.html#associatedconstant.VALUE
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedconstant.VALUE"]//a[@class="anchor"]/@href' #associatedconstant.VALUE
     const VALUE: u32 = 20;
@@ -55,3 +57,10 @@ impl MyTrait for MyStruct {
 }
 
 pub struct MyStruct;
+
+// We check that associated items with default values aren't generated in the implementors list.
+impl MyTrait for (u8, u8) {
+    // @!has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]'
+    type Assoc = bool;
+    fn trait_function(&self) {}
+}


### PR DESCRIPTION
Fixes #86631.

Contrary to before, it doesn't display methods. I also had to "resurrect" the `auto-hide-trait-implementations` setting. :3

Only question at this point: should I move the `render_impl` boolean arguments into one struct? We're starting to have quite a lot of them...

cc @cynecx
r? @camelid 