### PR TITLE
Fix prelude collision suggestions for glob imported traits. 

### DIFF
--- a/compiler/rustc_typeck/src/check/method/prelude2021.rs
+++ b/compiler/rustc_typeck/src/check/method/prelude2021.rs
@@ -7,7 +7,7 @@ use rustc_hir as hir;
 use rustc_middle::ty::subst::InternalSubsts;
 use rustc_middle::ty::{Adt, Ref, Ty};
 use rustc_session::lint::builtin::RUST_2021_PRELUDE_COLLISIONS;
-use rustc_span::symbol::kw::Underscore;
+use rustc_span::symbol::kw::{Empty, Underscore};
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::Span;
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -322,7 +322,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .filter_map(|item| if item.ident.name != Underscore { Some(item.ident) } else { None })
             .next();
         if let Some(any_id) = any_id {
-            return Some(format!("{}", any_id));
+            if any_id.name == Empty {
+                // Glob import, so just use its name.
+                return None;
+            } else {
+                return Some(format!("{}", any_id));
+            }
         }
 
         // All that is left is `_`! We need to use the full path. It doesn't matter which one we pick,

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.fixed
@@ -56,4 +56,15 @@ mod c {
     }
 }
 
+mod d {
+    use super::m::*;
+
+    fn main() {
+        // See https://github.com/rust-lang/rust/issues/88471
+        let _: u32 = TryIntoU32::try_into(3u8).unwrap();
+        //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+        //~^^ WARNING this is accepted in the current edition
+    }
+}
+
 fn main() {}

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.rs
@@ -56,4 +56,15 @@ mod c {
     }
 }
 
+mod d {
+    use super::m::*;
+
+    fn main() {
+        // See https://github.com/rust-lang/rust/issues/88471
+        let _: u32 = 3u8.try_into().unwrap();
+        //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+        //~^^ WARNING this is accepted in the current edition
+    }
+}
+
 fn main() {}

--- a/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -30,5 +30,14 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
 
-warning: 3 warnings emitted
+warning: trait method `try_into` will become ambiguous in Rust 2021
+  --> $DIR/future-prelude-collision-imported.rs:64:22
+   |
+LL |         let _: u32 = 3u8.try_into().unwrap();
+   |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+
+warning: 4 warnings emitted
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/88471

cc @nikomatsakis