### PR TITLE
Keep turbofish in prelude collision lint.

### DIFF
--- a/compiler/rustc_typeck/src/check/method/prelude2021.rs
+++ b/compiler/rustc_typeck/src/check/method/prelude2021.rs
@@ -163,8 +163,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             sp,
                             "disambiguate the associated function",
                             format!(
-                                "{}::{}({}{})",
-                                trait_name, segment.ident.name, self_adjusted, args
+                                "{}::{}{}({}{})",
+                                trait_name,
+                                segment.ident.name,
+                                if let Some(args) = segment.args.as_ref().and_then(|args| self
+                                    .sess()
+                                    .source_map()
+                                    .span_to_snippet(args.span_ext)
+                                    .ok())
+                                {
+                                    // Keep turbofish.
+                                    format!("::{}", args)
+                                } else {
+                                    String::new()
+                                },
+                                self_adjusted,
+                                args,
                             ),
                             Applicability::MachineApplicable,
                         );

--- a/src/test/ui/rust-2021/future-prelude-collision-turbofish.fixed
+++ b/src/test/ui/rust-2021/future-prelude-collision-turbofish.fixed
@@ -1,0 +1,28 @@
+// See https://github.com/rust-lang/rust/issues/88442
+// run-rustfix
+// edition:2018
+// check-pass
+#![allow(unused)]
+#![warn(rust_2021_prelude_collisions)]
+
+trait AnnotatableTryInto {
+    fn try_into<T>(self) -> Result<T, Self::Error>
+    where Self: std::convert::TryInto<T> {
+        std::convert::TryInto::try_into(self)
+    }
+}
+
+impl<T> AnnotatableTryInto for T where T: From<u8> {}
+
+fn main() -> Result<(), &'static str> {
+    let x: u64 = 1;
+    AnnotatableTryInto::try_into::<usize>(x).or(Err("foo"))?.checked_sub(1);
+    //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+    //~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+
+    AnnotatableTryInto::try_into::<usize>(x).or(Err("foo"))?;
+    //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+    //~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+
+    Ok(())
+}

--- a/src/test/ui/rust-2021/future-prelude-collision-turbofish.rs
+++ b/src/test/ui/rust-2021/future-prelude-collision-turbofish.rs
@@ -1,0 +1,28 @@
+// See https://github.com/rust-lang/rust/issues/88442
+// run-rustfix
+// edition:2018
+// check-pass
+#![allow(unused)]
+#![warn(rust_2021_prelude_collisions)]
+
+trait AnnotatableTryInto {
+    fn try_into<T>(self) -> Result<T, Self::Error>
+    where Self: std::convert::TryInto<T> {
+        std::convert::TryInto::try_into(self)
+    }
+}
+
+impl<T> AnnotatableTryInto for T where T: From<u8> {}
+
+fn main() -> Result<(), &'static str> {
+    let x: u64 = 1;
+    x.try_into::<usize>().or(Err("foo"))?.checked_sub(1);
+    //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+    //~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+
+    x.try_into::<usize>().or(Err("foo"))?;
+    //~^ WARNING trait method `try_into` will become ambiguous in Rust 2021
+    //~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+
+    Ok(())
+}

--- a/src/test/ui/rust-2021/future-prelude-collision-turbofish.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-turbofish.stderr
@@ -1,0 +1,25 @@
+warning: trait method `try_into` will become ambiguous in Rust 2021
+  --> $DIR/future-prelude-collision-turbofish.rs:19:5
+   |
+LL |     x.try_into::<usize>().or(Err("foo"))?.checked_sub(1);
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
+   |
+note: the lint level is defined here
+  --> $DIR/future-prelude-collision-turbofish.rs:6:9
+   |
+LL | #![warn(rust_2021_prelude_collisions)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+
+warning: trait method `try_into` will become ambiguous in Rust 2021
+  --> $DIR/future-prelude-collision-turbofish.rs:23:5
+   |
+LL |     x.try_into::<usize>().or(Err("foo"))?;
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/88442