### PR TITLE
Add test case for using `slice::fill` with MaybeUninit

### DIFF
--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 use core::cmp::Ordering;
+use core::mem::MaybeUninit;
 use core::result::Result::{Err, Ok};
 
 #[test]
@@ -2148,8 +2149,6 @@ fn test_slice_run_destructors() {
 #[test]
 fn test_slice_fill_with_uninit() {
     // This should not UB. See #87891
-    use core::mem::MaybeUninit;
-
     let mut a = [MaybeUninit::<u8>::uninit(); 10];
     a.fill(MaybeUninit::uninit());
 }

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2144,3 +2144,12 @@ fn test_slice_run_destructors() {
 
     assert_eq!(x.get(), 1);
 }
+
+#[test]
+fn test_slice_fill_with_uninit() {
+    // This should not UB. See #87891
+    use core::mem::MaybeUninit;
+
+    let mut a = [MaybeUninit::<u8>::uninit(); 10];
+    a.fill(MaybeUninit::uninit());
+}


### PR DESCRIPTION
Adds test for #87891 

Looks alright? @RalfJung 
Fixes #87891 