### PR TITLE
ARMv6K Nintendo 3DS Tier 3 target added

### DIFF
--- a/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
@@ -1,0 +1,45 @@
+use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, RelocModel, Target, TargetOptions};
+
+/// A base target for Nintendo 3DS devices using the devkitARM toolchain.
+///
+/// Requires the devkitARM toolchain for 3DS targets on the host system.
+
+pub fn target() -> Target {
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(
+        LinkerFlavor::Gcc,
+        vec![
+            "-specs=3dsx.specs".to_string(),
+            "-g".to_string(),
+            "-march=armv6k".to_string(),
+            "-mtune=mpcore".to_string(),
+            "-mfloat-abi=hard".to_string(),
+            "-mtp=soft".to_string(),
+        ],
+    );
+
+    Target {
+        llvm_target: "arm-none-eabihf".to_string(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+
+        options: TargetOptions {
+            os: "horizon".to_string(),
+            env: "newlib".to_string(),
+            vendor: "nintendo".to_string(),
+            abi: "eabihf".to_string(),
+            linker_flavor: LinkerFlavor::Gcc,
+            cpu: "mpcore".to_string(),
+            executables: true,
+            families: vec!["unix".to_string()],
+            linker: Some("arm-none-eabi-gcc".to_string()),
+            relocation_model: RelocModel::Static,
+            features: "+vfp2".to_string(),
+            pre_link_args,
+            exe_suffix: ".elf".to_string(),
+            panic_strategy: PanicStrategy::Abort,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
@@ -10,8 +10,6 @@ pub fn target() -> Target {
         LinkerFlavor::Gcc,
         vec![
             "-specs=3dsx.specs".to_string(),
-            "-g".to_string(),
-            "-march=armv6k".to_string(),
             "-mtune=mpcore".to_string(),
             "-mfloat-abi=hard".to_string(),
             "-mtp=soft".to_string(),
@@ -19,7 +17,7 @@ pub fn target() -> Target {
     );
 
     Target {
-        llvm_target: "arm-none-eabihf".to_string(),
+        llvm_target: "armv6k-none-eabihf".to_string(),
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -941,6 +941,8 @@ supported_targets! {
 
     ("bpfeb-unknown-none", bpfeb_unknown_none),
     ("bpfel-unknown-none", bpfel_unknown_none),
+
+    ("armv6k-nintendo-3ds", armv6k_nintendo_3ds),
 }
 
 /// Warnings encountered when parsing the target `json`.

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -217,6 +217,7 @@ target | std | host | notes
 `armv5te-unknown-linux-uclibceabi` | ? |  | ARMv5TE Linux with uClibc
 `armv6-unknown-freebsd` | ✓ | ✓ | ARMv6 FreeBSD
 `armv6-unknown-netbsd-eabihf` | ? |  |
+`armv6k-nintendo-3ds` | * |  | ARMv6K Nintendo 3DS, Horizon (Requires devkitARM toolchain)
 `armv7-apple-ios` | ✓ |  | ARMv7 iOS, Cortex-a8
 `armv7-unknown-freebsd` | ✓ | ✓ | ARMv7 FreeBSD
 `armv7-unknown-netbsd-eabihf` | ✓ | ✓ |


### PR DESCRIPTION
Addition of the target specifications to build .elf files for Nintendo 3DS (ARMv6K, Horizon). Requires devkitARM 3DS toolkit for system libraries and arm-none-eabi-gcc linker.