### PR TITLE
Concrete regions can show up in mir borrowck if the originated from there

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/region_infer/opaque_types.rs
+++ b/compiler/rustc_mir/src/borrow_check/region_infer/opaque_types.rs
@@ -82,15 +82,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                             .find(|ur_vid| self.eval_equal(vid, **ur_vid))
                             .and_then(|ur_vid| self.definitions[*ur_vid].external_name)
                             .unwrap_or(infcx.tcx.lifetimes.re_root_empty),
-                        ty::ReLateBound(..) => region,
-                        ty::ReStatic => region,
-                        _ => {
-                            infcx.tcx.sess.delay_span_bug(
-                                span,
-                                &format!("unexpected concrete region in borrowck: {:?}", region),
-                            );
-                            region
-                        }
+                        _ => region,
                     });
 
                 debug!(?universal_concrete_type, ?universal_substs);


### PR DESCRIPTION
We used to not encounter them here, because we took regions from typeck's opaque type resolution by renumbering them. We don't do that anymore. Instead mir borrock does all the logic, and it can handle concrete regions just fine, as long as it created them itself.

fixes #83190 which was introduced by #87287

r? @spastorino 