### PR TITLE
add `slice::swap_unchecked`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -560,8 +560,8 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn swap(&mut self, a: usize, b: usize) {
-        assert_in_bounds(self.len(), a);
-        assert_in_bounds(self.len(), b);
+        let _ = &self[a];
+        let _ = &self[b];
 
         // SAFETY: we just checked that both `a` and `b` are in bounds
         unsafe { self.swap_unchecked(a, b) }
@@ -598,8 +598,8 @@ impl<T> [T] {
     pub unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
         #[cfg(debug_assertions)]
         {
-            assert_in_bounds(self.len(), a);
-            assert_in_bounds(self.len(), b);
+            let _ = &self[a];
+            let _ = &self[b];
         }
 
         let ptr = self.as_mut_ptr();
@@ -3499,12 +3499,6 @@ impl<T> [T] {
         P: FnMut(&T) -> bool,
     {
         self.binary_search_by(|x| if pred(x) { Less } else { Greater }).unwrap_or_else(|i| i)
-    }
-}
-
-fn assert_in_bounds(len: usize, idx: usize) {
-    if idx >= len {
-        panic!("index out of bounds: the len is {} but the index is {}", len, idx);
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -707,11 +707,7 @@ impl<T> [T] {
             // The resulting pointers `pa` and `pb` are therefore valid and
             // aligned, and can be read from and written to.
             unsafe {
-                // Unsafe swap to avoid the bounds check in safe swap.
-                let ptr = self.as_mut_ptr();
-                let pa = ptr.add(i);
-                let pb = ptr.add(ln - i - 1);
-                ptr::swap(pa, pb);
+                self.swap_unchecked(i, ln - i - 1);
             }
             i += 1;
         }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -583,6 +583,8 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
+    /// #![feature(slice_swap_unchecked)]
+    ///
     /// let mut v = ["a", "b", "c", "d"];
     /// // SAFETY: we know that 1 and 3 are both indices of the slice
     /// unsafe { v.swap_unchecked(1, 3) };

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2152,3 +2152,42 @@ fn test_slice_fill_with_uninit() {
     let mut a = [MaybeUninit::<u8>::uninit(); 10];
     a.fill(MaybeUninit::uninit());
 }
+
+#[test]
+fn test_swap() {
+    let mut x = ["a", "b", "c", "d"];
+    x.swap(1, 3);
+    assert_eq!(x, ["a", "d", "c", "b"]);
+    x.swap(0, 3);
+    assert_eq!(x, ["b", "d", "c", "a"]);
+}
+
+mod swap_panics {
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 4 but the index is 4")]
+    fn index_a_equals_len() {
+        let mut x = ["a", "b", "c", "d"];
+        x.swap(4, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 4 but the index is 4")]
+    fn index_b_equals_len() {
+        let mut x = ["a", "b", "c", "d"];
+        x.swap(2, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 4 but the index is 5")]
+    fn index_a_greater_than_len() {
+        let mut x = ["a", "b", "c", "d"];
+        x.swap(5, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 4 but the index is 5")]
+    fn index_b_greater_than_len() {
+        let mut x = ["a", "b", "c", "d"];
+        x.swap(2, 5);
+    }
+}


### PR DESCRIPTION
An unsafe version of `slice::swap` that does not do bounds checking.