### PR TITLE
Stabilize `Iterator::intersperse()`

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -4,7 +4,7 @@ use super::Peekable;
 ///
 /// This `struct` is created by [`Iterator::intersperse`]. See its documentation
 /// for more information.
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 #[derive(Debug, Clone)]
 pub struct Intersperse<I: Iterator>
 where
@@ -24,7 +24,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 impl<I> Iterator for Intersperse<I>
 where
     I: Iterator,
@@ -61,7 +61,7 @@ where
 ///
 /// This `struct` is created by [`Iterator::intersperse_with`]. See its
 /// documentation for more information.
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 pub struct IntersperseWith<I, G>
 where
     I: Iterator,
@@ -71,7 +71,7 @@ where
     needs_sep: bool,
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 impl<I, G> crate::fmt::Debug for IntersperseWith<I, G>
 where
     I: Iterator + crate::fmt::Debug,
@@ -87,7 +87,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 impl<I, G> crate::clone::Clone for IntersperseWith<I, G>
 where
     I: Iterator + crate::clone::Clone,
@@ -113,7 +113,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 impl<I, G> Iterator for IntersperseWith<I, G>
 where
     I: Iterator,

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -42,7 +42,7 @@ pub use self::flatten::Flatten;
 #[stable(feature = "iter_copied", since = "1.36.0")]
 pub use self::copied::Copied;
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 pub use self::intersperse::{Intersperse, IntersperseWith};
 
 #[unstable(feature = "iter_map_while", reason = "recently added", issue = "68537")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -414,7 +414,7 @@ pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,
     Skip, SkipWhile, Take, TakeWhile, Zip,
 };
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[stable(feature = "iter_intersperse", since = "1.56.0")]
 pub use self::adapters::{Intersperse, IntersperseWith};
 
 pub(crate) use self::adapters::process_results;

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -535,8 +535,6 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(iter_intersperse)]
-    ///
     /// let mut a = [0, 1, 2].iter().intersperse(&100);
     /// assert_eq!(a.next(), Some(&0));   // The first element from `a`.
     /// assert_eq!(a.next(), Some(&100)); // The separator.
@@ -547,9 +545,8 @@ pub trait Iterator {
     /// ```
     ///
     /// `intersperse` can be very useful to join an iterator's items using a common element:
-    /// ```
-    /// #![feature(iter_intersperse)]
     ///
+    /// ```
     /// let hello = ["Hello", "World", "!"].iter().copied().intersperse(" ").collect::<String>();
     /// assert_eq!(hello, "Hello World !");
     /// ```
@@ -557,7 +554,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse_with`]: Iterator::intersperse_with
     #[inline]
-    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[stable(feature = "iter_intersperse", since = "1.56.0")]
     fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
     where
         Self: Sized,
@@ -582,8 +579,6 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(iter_intersperse)]
-    ///
     /// #[derive(PartialEq, Debug)]
     /// struct NotClone(usize);
     ///
@@ -600,9 +595,8 @@ pub trait Iterator {
     ///
     /// `intersperse_with` can be used in situations where the separator needs
     /// to be computed:
-    /// ```
-    /// #![feature(iter_intersperse)]
     ///
+    /// ```
     /// let src = ["Hello", "to", "all", "people", "!!"].iter().copied();
     ///
     /// // The closure mutably borrows its context to generate an item.
@@ -615,7 +609,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse`]: Iterator::intersperse
     #[inline]
-    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[stable(feature = "iter_intersperse", since = "1.56.0")]
     fn intersperse_with<G>(self, separator: G) -> IntersperseWith<Self, G>
     where
         Self: Sized,

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -48,7 +48,6 @@
 #![feature(int_log)]
 #![feature(iter_advance_by)]
 #![feature(iter_partition_in_place)]
-#![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(iter_map_while)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -13,7 +13,6 @@
 #![feature(never_type)]
 #![feature(once_cell)]
 #![feature(type_ascription)]
-#![feature(iter_intersperse)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
 


### PR DESCRIPTION
This PR stabilizes the methods `Iterator::intersperse()` and `Iterator::intersperse_with()`. The FCP has [already completed](https://github.com/rust-lang/rust/issues/79524#issuecomment-909663616).

Closes #79524.