### PR TITLE
Allow redirecting subprocess stdout to our stderr etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
           - name: x86_64-gnu-tools
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: x86_64-msvc-1
+            env:
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
+              SCRIPT: make ci-msvc
+            tidy: false
+            os: windows-2019-8core-32gb
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,15 @@ jobs:
           - name: x86_64-gnu-llvm-14
             os: ubuntu-20.04-16core-64gb
             env: {}
-          - name: x86_64-gnu-tools
-            os: ubuntu-20.04-16core-64gb
-            env: {}
           - name: x86_64-msvc-1
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
               SCRIPT: make ci-msvc
             tidy: false
             os: windows-2019-8core-32gb
+          - name: x86_64-gnu-tools
+            os: ubuntu-20.04-16core-64gb
+            env: {}
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1492,32 +1492,6 @@ impl From<fs::File> for Stdio {
 }
 
 #[stable(feature = "stdio_from_stdio", since = "1.58.0")]
-impl From<io::Stdin> for Stdio {
-    /// Specify to inherit our stdin.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// #![feature(exit_status_error)]
-    /// use std::io;
-    /// use std::process::Command;
-    ///
-    /// # fn test() -> Result<(), Box<dyn std::error::Error>> {
-    /// let output = Command::new("wc").arg("-l")
-    ///     .stdin(io::stdin())
-    ///     .output()?;
-    /// output.status.exit_ok()?;
-    /// let input_lines: u64 = std::str::from_utf8(&output.stdout)?.trim().parse()?;
-    /// eprintln!("our standard input had {} lines", input_lines);
-    /// # Ok(())
-    /// # }
-    /// ```
-    fn from(inherit: io::Stdin) -> Stdio {
-        Stdio::from_inner(inherit.into())
-    }
-}
-
-#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
 impl From<io::Stdout> for Stdio {
     /// Redirect command stdout/stderr to our stdout
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1491,7 +1491,7 @@ impl From<fs::File> for Stdio {
     }
 }
 
-#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
+#[stable(feature = "stdio_from_stdio", since = "CURRENT_RUSTC_VERSION")]
 impl From<io::Stdout> for Stdio {
     /// Redirect command stdout/stderr to our stdout
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1491,6 +1491,92 @@ impl From<fs::File> for Stdio {
     }
 }
 
+#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
+impl From<io::Stdin> for Stdio {
+    /// Specify to inherit our stdin.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// #![feature(exit_status_error)]
+    /// use std::io;
+    /// use std::process::Command;
+    ///
+    /// # fn test() -> Result<(), Box<dyn std::error::Error>> {
+    /// let output = Command::new("wc").arg("-l")
+    ///     .stdin(io::stdin())
+    ///     .output()?;
+    /// output.status.exit_ok()?;
+    /// let input_lines: u64 = std::str::from_utf8(&output.stdout)?.trim().parse()?;
+    /// eprintln!("our standard input had {} lines", input_lines);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn from(inherit: io::Stdin) -> Stdio {
+        Stdio::from_inner(inherit.into())
+    }
+}
+
+#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
+impl From<io::Stdout> for Stdio {
+    /// Redirect command stdout/stderr to our stdout
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(exit_status_error)]
+    /// use std::io;
+    /// use std::process::Command;
+    ///
+    /// # fn test() -> Result<(), Box<dyn std::error::Error>> {
+    /// let output = Command::new("whoami")
+    // "whoami" is a command which exists on both Unix and Winodows,
+    // and which succeeds, producing some stdout output but no stderr.
+    ///     .stdout(io::stdout())
+    ///     .output()?;
+    /// output.status.exit_ok()?;
+    /// assert!(output.stdout.is_empty());
+    /// # Ok(())
+    /// # }
+    /// #
+    /// # if cfg!(unix) {
+    /// #     test().unwrap();
+    /// # }
+    /// ```
+    fn from(inherit: io::Stdout) -> Stdio {
+        Stdio::from_inner(inherit.into())
+    }
+}
+
+#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
+impl From<io::Stderr> for Stdio {
+    /// Redirect command stdout/stderr to our stderr
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(exit_status_error)]
+    /// use std::io;
+    /// use std::process::Command;
+    ///
+    /// # fn test() -> Result<(), Box<dyn std::error::Error>> {
+    /// let output = Command::new("whoami")
+    ///     .stdout(io::stderr())
+    ///     .output()?;
+    /// output.status.exit_ok()?;
+    /// assert!(output.stdout.is_empty());
+    /// # Ok(())
+    /// # }
+    /// #
+    /// # if cfg!(unix) {
+    /// #     test().unwrap();
+    /// # }
+    /// ```
+    fn from(inherit: io::Stderr) -> Stdio {
+        Stdio::from_inner(inherit.into())
+    }
+}
+
 /// Describes the result of a process after it has terminated.
 ///
 /// This `struct` is used to represent the exit status or other termination of a child process.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1522,7 +1522,7 @@ impl From<io::Stdout> for Stdio {
     }
 }
 
-#[stable(feature = "stdio_from_stdio", since = "1.58.0")]
+#[stable(feature = "stdio_from_stdio", since = "CURRENT_RUSTC_VERSION")]
 impl From<io::Stderr> for Stdio {
     /// Redirect command stdout/stderr to our stderr
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1504,7 +1504,7 @@ impl From<io::Stdout> for Stdio {
     ///
     /// # fn test() -> Result<(), Box<dyn std::error::Error>> {
     /// let output = Command::new("whoami")
-    // "whoami" is a command which exists on both Unix and Winodows,
+    // "whoami" is a command which exists on both Unix and Windows,
     // and which succeeds, producing some stdout output but no stderr.
     ///     .stdout(io::stdout())
     ///     .output()?;

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -510,15 +510,6 @@ impl From<File> for Stdio {
     }
 }
 
-impl From<io::Stdin> for Stdio {
-    fn from(_: io::Stdin) -> Stdio {
-        // What this ought to be is Stdio::StaticFd(input_argument.as_fd()).
-        // But there is no AsStaticFd trait or anything.
-        // https://github.com/rust-lang/rust/issues/90809
-        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) })
-    }
-}
-
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
         Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDOUT_FILENO) })

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -512,6 +512,9 @@ impl From<File> for Stdio {
 
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
+        // What this ought to be is Stdio::StaticFd(input_argument.as_fd()).
+        // But there is no AsStaticFd trait or anything.
+        // https://github.com/rust-lang/rust/issues/90809
         Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDOUT_FILENO) })
     }
 }

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -515,19 +515,19 @@ impl From<io::Stdin> for Stdio {
         // What this ought to be is Stdio::StaticFd(input_argument.as_fd()).
         // But there is no AsStaticFd trait or anything.
         // https://github.com/rust-lang/rust/issues/90809
-        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw_fd(libc::STDIN_FILENO) })
+        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) })
     }
 }
 
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
-        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw_fd(libc::STDOUT_FILENO) })
+        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDOUT_FILENO) })
     }
 }
 
 impl From<io::Stderr> for Stdio {
     fn from(_: io::Stderr) -> Stdio {
-        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw_fd(libc::STDERR_FILENO) })
+        Stdio::StaticFd(unsafe { BorrowedFd::borrow_raw(libc::STDERR_FILENO) })
     }
 }
 

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -170,6 +170,7 @@ pub struct Command {
 
 pub enum Stdio {
     Inherit,
+    InheritSpecific { from_stdio_id: c::DWORD },
     Null,
     MakePipe,
     Pipe(AnonPipe),
@@ -533,6 +534,7 @@ impl Stdio {
         };
         match *self {
             Stdio::Inherit => use_stdio_id(stdio_id),
+            Stdio::InheritSpecific { from_stdio_id } => use_stdio_id(from_stdio_id),
 
             Stdio::MakePipe => {
                 let ours_readable = stdio_id != c::STD_INPUT_HANDLE;
@@ -577,6 +579,24 @@ impl From<AnonPipe> for Stdio {
 impl From<File> for Stdio {
     fn from(file: File) -> Stdio {
         Stdio::Handle(file.into_inner())
+    }
+}
+
+impl From<io::Stdin> for Stdio {
+    fn from(_: io::Stdin) -> Stdio {
+        Stdio::InheritSpecific { from_stdio_id: c::STD_INPUT_HANDLE }
+    }
+}
+
+impl From<io::Stdout> for Stdio {
+    fn from(_: io::Stdout) -> Stdio {
+        Stdio::InheritSpecific { from_stdio_id: c::STD_OUTPUT_HANDLE }
+    }
+}
+
+impl From<io::Stderr> for Stdio {
+    fn from(_: io::Stderr) -> Stdio {
+        Stdio::InheritSpecific { from_stdio_id: c::STD_ERROR_HANDLE }
     }
 }
 

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -582,12 +582,6 @@ impl From<File> for Stdio {
     }
 }
 
-impl From<io::Stdin> for Stdio {
-    fn from(_: io::Stdin) -> Stdio {
-        Stdio::InheritSpecific { from_stdio_id: c::STD_INPUT_HANDLE }
-    }
-}
-
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
         Stdio::InheritSpecific { from_stdio_id: c::STD_OUTPUT_HANDLE }

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -326,6 +326,13 @@ jobs:
           - name: x86_64-gnu-llvm-14
             <<: *job-linux-16c
 
+          - name: x86_64-msvc-1
+            env:
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+              SCRIPT: make ci-msvc
+            <<: *job-windows-xl
+            tidy: false
+
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -330,7 +330,7 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
               SCRIPT: make ci-msvc
-            <<: *job-windows-xl
+            <<: *job-windows-8c
             tidy: false
 
           - name: x86_64-gnu-tools


### PR DESCRIPTION
Currently there is no safe or portable way to redirect a `Command`s stdout to the invoking program's stderr, nor vice versa.

There a comment in the source that suggests that this was intended, and trying to handle the fd shuffling problem properly, but it can never be reached other than by crazy unsafe stunts.

Instead, provide appropriate `From` impls.

<strike>I have only tested the implementation for Unix because I know how to do that.</strike>  There is now a Windows implementation which seems to pass the CI.  This branch currently contains a DO NOT MERGE commit to enable the Windows CI build on this MR branch.  That should be removed after code review and before merge.

Being trait impls, these are insta-stable.  The question is just whether we want to support platforms that cannot do this, and if so, whether we want that to be a compile error or are happy for it to be detected by `Command` methods returning errors.

Closes #79731