### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,7 @@ dependencies = [
  "rustc_parse",
  "rustc_session",
  "rustc_span",
+ "rustc_target",
  "tracing",
 ]
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -283,7 +283,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     );
                     let sig = hir::FnSig {
                         decl,
-                        header: this.lower_fn_header(header, fn_sig_span, id),
+                        header: this.lower_fn_header(header),
                         span: this.lower_span(fn_sig_span),
                     };
                     hir::ItemKind::Fn(sig, generics, body_id)
@@ -295,17 +295,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 ModKind::Unloaded => panic!("`mod` items should have been loaded by now"),
             },
-            ItemKind::ForeignMod(ref fm) => {
-                if fm.abi.is_none() {
-                    self.maybe_lint_missing_abi(span, id, abi::Abi::C { unwind: false });
-                }
-                hir::ItemKind::ForeignMod {
-                    abi: fm.abi.map_or(abi::Abi::C { unwind: false }, |abi| self.lower_abi(abi)),
-                    items: self
-                        .arena
-                        .alloc_from_iter(fm.items.iter().map(|x| self.lower_foreign_item_ref(x))),
-                }
-            }
+            ItemKind::ForeignMod(ref fm) => hir::ItemKind::ForeignMod {
+                abi: fm.abi.map_or(abi::Abi::FALLBACK, |abi| self.lower_abi(abi)),
+                items: self
+                    .arena
+                    .alloc_from_iter(fm.items.iter().map(|x| self.lower_foreign_item_ref(x))),
+            },
             ItemKind::GlobalAsm(ref asm) => {
                 hir::ItemKind::GlobalAsm(self.lower_inline_asm(span, asm))
             }
@@ -811,7 +806,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             AssocItemKind::Fn(box FnKind(_, ref sig, ref generics, None)) => {
                 let names = self.lower_fn_params_to_names(&sig.decl);
                 let (generics, sig) =
-                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None, i.id);
+                    self.lower_method_sig(generics, sig, trait_item_def_id, false, None);
                 (generics, hir::TraitItemKind::Fn(sig, hir::TraitFn::Required(names)))
             }
             AssocItemKind::Fn(box FnKind(_, ref sig, ref generics, Some(ref body))) => {
@@ -824,7 +819,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     trait_item_def_id,
                     false,
                     asyncness.opt_return_id(),
-                    i.id,
                 );
                 (generics, hir::TraitItemKind::Fn(sig, hir::TraitFn::Provided(body_id)))
             }
@@ -901,7 +895,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     impl_item_def_id,
                     impl_trait_return_allow,
                     asyncness.opt_return_id(),
-                    i.id,
                 );
 
                 (generics, hir::ImplItemKind::Fn(sig, body_id))
@@ -1296,9 +1289,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         fn_def_id: LocalDefId,
         impl_trait_return_allow: bool,
         is_async: Option<NodeId>,
-        id: NodeId,
     ) -> (hir::Generics<'hir>, hir::FnSig<'hir>) {
-        let header = self.lower_fn_header(sig.header, sig.span, id);
+        let header = self.lower_fn_header(sig.header);
         let (generics, decl) = self.add_in_band_defs(
             generics,
             fn_def_id,
@@ -1315,12 +1307,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
         (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })
     }
 
-    fn lower_fn_header(&mut self, h: FnHeader, span: Span, id: NodeId) -> hir::FnHeader {
+    fn lower_fn_header(&mut self, h: FnHeader) -> hir::FnHeader {
         hir::FnHeader {
             unsafety: self.lower_unsafety(h.unsafety),
             asyncness: self.lower_asyncness(h.asyncness),
             constness: self.lower_constness(h.constness),
-            abi: self.lower_extern(h.ext, span, id),
+            abi: self.lower_extern(h.ext),
         }
     }
 
@@ -1331,13 +1323,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    pub(super) fn lower_extern(&mut self, ext: Extern, span: Span, id: NodeId) -> abi::Abi {
+    pub(super) fn lower_extern(&mut self, ext: Extern) -> abi::Abi {
         match ext {
             Extern::None => abi::Abi::Rust,
-            Extern::Implicit => {
-                self.maybe_lint_missing_abi(span, id, abi::Abi::C { unwind: false });
-                abi::Abi::C { unwind: false }
-            }
+            Extern::Implicit => abi::Abi::FALLBACK,
             Extern::Explicit(abi) => self.lower_abi(abi),
         }
     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -53,7 +53,7 @@ use rustc_hir::definitions::{DefKey, DefPathData, Definitions};
 use rustc_hir::intravisit;
 use rustc_hir::{ConstArg, GenericArg, InferKind, ParamName};
 use rustc_index::vec::{Idx, IndexVec};
-use rustc_session::lint::builtin::{BARE_TRAIT_OBJECTS, MISSING_ABI};
+use rustc_session::lint::builtin::BARE_TRAIT_OBJECTS;
 use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::utils::{FlattenNonterminals, NtToTokenstream};
 use rustc_session::Session;
@@ -62,7 +62,6 @@ use rustc_span::hygiene::ExpnId;
 use rustc_span::source_map::{respan, CachingSourceMapView, DesugaringKind};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
-use rustc_target::spec::abi::Abi;
 
 use smallvec::{smallvec, SmallVec};
 use std::collections::BTreeMap;
@@ -1360,7 +1359,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             }
             TyKind::BareFn(ref f) => self.with_in_scope_lifetime_defs(&f.generic_params, |this| {
                 this.with_anonymous_lifetime_mode(AnonymousLifetimeMode::PassThrough, |this| {
-                    let span = this.sess.source_map().next_point(t.span.shrink_to_lo());
                     hir::TyKind::BareFn(this.arena.alloc(hir::BareFnTy {
                         generic_params: this.lower_generic_params(
                             &f.generic_params,
@@ -1368,7 +1366,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             ImplTraitContext::disallowed(),
                         ),
                         unsafety: this.lower_unsafety(f.unsafety),
-                        abi: this.lower_extern(f.ext, span, t.id),
+                        abi: this.lower_extern(f.ext),
                         decl: this.lower_fn_decl(&f.decl, None, false, None),
                         param_names: this.lower_fn_params_to_names(&f.decl),
                     }))
@@ -2840,26 +2838,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 );
                 err.emit();
             }
-        }
-    }
-
-    fn maybe_lint_missing_abi(&mut self, span: Span, id: NodeId, default: Abi) {
-        // FIXME(davidtwco): This is a hack to detect macros which produce spans of the
-        // call site which do not have a macro backtrace. See #61963.
-        let is_macro_callsite = self
-            .sess
-            .source_map()
-            .span_to_snippet(span)
-            .map(|snippet| snippet.starts_with("#["))
-            .unwrap_or(true);
-        if !is_macro_callsite {
-            self.resolver.lint_buffer().buffer_lint_with_diagnostic(
-                MISSING_ABI,
-                id,
-                span,
-                "extern declarations without an explicit ABI are deprecated",
-                BuiltinLintDiagnostics::MissingAbi(span, default),
-            )
         }
     }
 }

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -14,4 +14,5 @@ rustc_feature = { path = "../rustc_feature" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+rustc_target = { path = "../rustc_target" }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -15,12 +15,13 @@ use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{error_code, pluralize, struct_span_err, Applicability};
 use rustc_parse::validate_attr;
-use rustc_session::lint::builtin::PATTERNS_IN_FNS_WITHOUT_BODY;
+use rustc_session::lint::builtin::{MISSING_ABI, PATTERNS_IN_FNS_WITHOUT_BODY};
 use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::Session;
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::Span;
+use rustc_target::spec::abi;
 use std::mem;
 use std::ops::DerefMut;
 
@@ -844,6 +845,10 @@ impl<'a> AstValidator<'a> {
                     .emit();
                 });
                 self.check_late_bound_lifetime_defs(&bfty.generic_params);
+                if let Extern::Implicit = bfty.ext {
+                    let sig_span = self.session.source_map().next_point(ty.span.shrink_to_lo());
+                    self.maybe_lint_missing_abi(sig_span, ty.id);
+                }
             }
             TyKind::TraitObject(ref bounds, ..) => {
                 let mut any_lifetime_bounds = false;
@@ -892,6 +897,26 @@ impl<'a> AstValidator<'a> {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn maybe_lint_missing_abi(&mut self, span: Span, id: NodeId) {
+        // FIXME(davidtwco): This is a hack to detect macros which produce spans of the
+        // call site which do not have a macro backtrace. See #61963.
+        let is_macro_callsite = self
+            .session
+            .source_map()
+            .span_to_snippet(span)
+            .map(|snippet| snippet.starts_with("#["))
+            .unwrap_or(true);
+        if !is_macro_callsite {
+            self.lint_buffer.buffer_lint_with_diagnostic(
+                MISSING_ABI,
+                id,
+                span,
+                "extern declarations without an explicit ABI are deprecated",
+                BuiltinLintDiagnostics::MissingAbi(span, abi::Abi::FALLBACK),
+            )
         }
     }
 }
@@ -1178,7 +1203,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 walk_list!(self, visit_attribute, &item.attrs);
                 return; // Avoid visiting again.
             }
-            ItemKind::ForeignMod(ForeignMod { unsafety, .. }) => {
+            ItemKind::ForeignMod(ForeignMod { abi, unsafety, .. }) => {
                 let old_item = mem::replace(&mut self.extern_mod, Some(item));
                 self.invalid_visibility(
                     &item.vis,
@@ -1186,6 +1211,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 );
                 if let Unsafe::Yes(span) = unsafety {
                     self.err_handler().span_err(span, "extern block cannot be declared unsafe");
+                }
+                if abi.is_none() {
+                    self.maybe_lint_missing_abi(item.span, item.id);
                 }
                 visit::walk_item(self, item);
                 self.extern_mod = old_item;
@@ -1524,6 +1552,17 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 .span_label(*aspan, "`async` because of this")
                 .span_label(span, "") // Point at the fn header.
                 .emit();
+        }
+
+        if let FnKind::Fn(
+            _,
+            _,
+            FnSig { span: sig_span, header: FnHeader { ext: Extern::Implicit, .. }, .. },
+            _,
+            _,
+        ) = fk
+        {
+            self.maybe_lint_missing_abi(*sig_span, id);
         }
 
         // Functions without bodies cannot have patterns.

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -68,14 +68,13 @@ fn reuse_workproduct_for_cgu(
     cgu: &CodegenUnit<'_>,
     work_products: &mut FxHashMap<WorkProductId, WorkProduct>,
 ) -> CompiledModule {
-    let incr_comp_session_dir = tcx.sess.incr_comp_session_dir();
     let mut object = None;
     let work_product = cgu.work_product(tcx);
     if let Some(saved_file) = &work_product.saved_file {
         let obj_out =
             tcx.output_filenames(()).temp_path(OutputType::Object, Some(&cgu.name().as_str()));
         object = Some(obj_out.clone());
-        let source_file = rustc_incremental::in_incr_comp_dir(&incr_comp_session_dir, &saved_file);
+        let source_file = rustc_incremental::in_incr_comp_dir_sess(&tcx.sess, &saved_file);
         if let Err(err) = rustc_fs_util::link_or_copy(&source_file, &obj_out) {
             tcx.sess.err(&format!(
                 "unable to copy {} to {}: {}",

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -92,11 +92,12 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
-        mods: &mut ModuleLlvm,
+        module_llvm: &mut ModuleLlvm,
+        module_name: &str,
         kind: AllocatorKind,
         has_alloc_error_handler: bool,
     ) {
-        unsafe { allocator::codegen(tcx, mods, kind, has_alloc_error_handler) }
+        unsafe { allocator::codegen(tcx, module_llvm, module_name, kind, has_alloc_error_handler) }
     }
     fn compile_codegen_unit(
         &self,

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -538,12 +538,18 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     } else if let Some(kind) = tcx.allocator_kind(()) {
         let llmod_id =
             cgu_name_builder.build_cgu_name(LOCAL_CRATE, &["crate"], Some("allocator")).to_string();
-        let mut modules = backend.new_metadata(tcx, &llmod_id);
+        let mut module_llvm = backend.new_metadata(tcx, &llmod_id);
         tcx.sess.time("write_allocator_module", || {
-            backend.codegen_allocator(tcx, &mut modules, kind, tcx.lang_items().oom().is_some())
+            backend.codegen_allocator(
+                tcx,
+                &mut module_llvm,
+                &llmod_id,
+                kind,
+                tcx.lang_items().oom().is_some(),
+            )
         });
 
-        Some(ModuleCodegen { name: llmod_id, module_llvm: modules, kind: ModuleKind::Allocator })
+        Some(ModuleCodegen { name: llmod_id, module_llvm, kind: ModuleKind::Allocator })
     } else {
         None
     };

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -120,7 +120,8 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
-        mods: &mut Self::Module,
+        module_llvm: &mut Self::Module,
+        module_name: &str,
         kind: AllocatorKind,
         has_alloc_error_handler: bool,
     );

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -423,10 +423,10 @@ fn run_compiler(
             sess.print_perf_stats();
         }
 
-        if sess.print_fuel_crate.is_some() {
+        if sess.opts.debugging_opts.print_fuel.is_some() {
             eprintln!(
                 "Fuel used by {}: {}",
-                sess.print_fuel_crate.as_ref().unwrap(),
+                sess.opts.debugging_opts.print_fuel.as_ref().unwrap(),
                 sess.print_fuel.load(SeqCst)
             );
         }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -461,13 +461,16 @@ trait UnusedDelimLint {
         let lhs_needs_parens = {
             let mut innermost = inner;
             loop {
-                if let ExprKind::Binary(_, lhs, _rhs) = &innermost.kind {
-                    innermost = lhs;
-                    if !classify::expr_requires_semi_to_be_stmt(innermost) {
-                        break true;
-                    }
-                } else {
-                    break false;
+                innermost = match &innermost.kind {
+                    ExprKind::Binary(_, lhs, _rhs) => lhs,
+                    ExprKind::Call(fn_, _params) => fn_,
+                    ExprKind::Cast(expr, _ty) => expr,
+                    ExprKind::Type(expr, _ty) => expr,
+                    ExprKind::Index(base, _subscript) => base,
+                    _ => break false,
+                };
+                if !classify::expr_requires_semi_to_be_stmt(innermost) {
+                    break true;
                 }
             }
         };

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -412,8 +412,7 @@ impl<'tcx> Body<'tcx> {
     /// Returns an iterator over all function arguments.
     #[inline]
     pub fn args_iter(&self) -> impl Iterator<Item = Local> + ExactSizeIterator {
-        let arg_count = self.arg_count;
-        (1..arg_count + 1).map(Local::new)
+        (1..self.arg_count + 1).map(Local::new)
     }
 
     /// Returns an iterator over all user-defined variables and compiler-generated temporaries (all
@@ -422,9 +421,7 @@ impl<'tcx> Body<'tcx> {
     pub fn vars_and_temps_iter(
         &self,
     ) -> impl DoubleEndedIterator<Item = Local> + ExactSizeIterator {
-        let arg_count = self.arg_count;
-        let local_count = self.local_decls.len();
-        (arg_count + 1..local_count).map(Local::new)
+        (self.arg_count + 1..self.local_decls.len()).map(Local::new)
     }
 
     /// Changes a statement to a nop. This is both faster than deleting instructions and avoids

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -173,9 +173,6 @@ pub struct Session {
     /// Tracks fuel info if `-zfuel=crate=n` is specified.
     optimization_fuel: Lock<OptimizationFuel>,
 
-    // The next two are public because the driver needs to read them.
-    /// If `-zprint-fuel=crate`, `Some(crate)`.
-    pub print_fuel_crate: Option<String>,
     /// Always set to zero and incremented so that we can print fuel expended by a crate.
     pub print_fuel: AtomicU64,
 
@@ -900,7 +897,7 @@ impl Session {
                 }
             }
         }
-        if let Some(ref c) = self.print_fuel_crate {
+        if let Some(ref c) = self.opts.debugging_opts.print_fuel {
             if c == crate_name {
                 assert_eq!(self.threads(), 1);
                 self.print_fuel.fetch_add(1, SeqCst);
@@ -1262,7 +1259,6 @@ pub fn build_session(
         remaining: sopts.debugging_opts.fuel.as_ref().map_or(0, |i| i.1),
         out_of_fuel: false,
     });
-    let print_fuel_crate = sopts.debugging_opts.print_fuel.clone();
     let print_fuel = AtomicU64::new(0);
 
     let cgu_reuse_tracker = if sopts.debugging_opts.query_dep_graph {
@@ -1311,7 +1307,6 @@ pub fn build_session(
         },
         code_stats: Default::default(),
         optimization_fuel,
-        print_fuel_crate,
         print_fuel,
         jobserver: jobserver::client(),
         driver_lint_caps,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -170,9 +170,6 @@ pub struct Session {
     /// Data about code being compiled, gathered during compilation.
     pub code_stats: CodeStats,
 
-    /// If `-zfuel=crate=n` is specified, `Some(crate)`.
-    optimization_fuel_crate: Option<String>,
-
     /// Tracks fuel info if `-zfuel=crate=n` is specified.
     optimization_fuel: Lock<OptimizationFuel>,
 
@@ -890,7 +887,7 @@ impl Session {
     /// This expends fuel if applicable, and records fuel if applicable.
     pub fn consider_optimizing<T: Fn() -> String>(&self, crate_name: &str, msg: T) -> bool {
         let mut ret = true;
-        if let Some(ref c) = self.optimization_fuel_crate {
+        if let Some(c) = self.opts.debugging_opts.fuel.as_ref().map(|i| &i.0) {
             if c == crate_name {
                 assert_eq!(self.threads(), 1);
                 let mut fuel = self.optimization_fuel.lock();
@@ -1261,7 +1258,6 @@ pub fn build_session(
     let local_crate_source_file =
         local_crate_source_file.map(|path| file_path_mapping.map_prefix(path).0);
 
-    let optimization_fuel_crate = sopts.debugging_opts.fuel.as_ref().map(|i| i.0.clone());
     let optimization_fuel = Lock::new(OptimizationFuel {
         remaining: sopts.debugging_opts.fuel.as_ref().map_or(0, |i| i.1),
         out_of_fuel: false,
@@ -1314,7 +1310,6 @@ pub fn build_session(
             normalize_projection_ty: AtomicUsize::new(0),
         },
         code_stats: Default::default(),
-        optimization_fuel_crate,
         optimization_fuel,
         print_fuel_crate,
         print_fuel,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -190,6 +190,9 @@ pub struct Session {
     /// Tracks the current behavior of the CTFE engine when an error occurs.
     /// Options range from returning the error without a backtrace to returning an error
     /// and immediately printing the backtrace to stderr.
+    /// The `Lock` is only used by miri to allow setting `ctfe_backtrace` after analysis when
+    /// `MIRI_BACKTRACE` is set. This makes it only apply to miri's errors and not to all CTFE
+    /// errors.
     pub ctfe_backtrace: Lock<CtfeBacktrace>,
 
     /// This tracks where `-Zunleash-the-miri-inside-of-you` was used to get around a

--- a/compiler/rustc_target/src/spec/abi.rs
+++ b/compiler/rustc_target/src/spec/abi.rs
@@ -87,6 +87,9 @@ pub fn all_names() -> Vec<&'static str> {
 }
 
 impl Abi {
+    /// Default ABI chosen for `extern fn` declarations without an explicit ABI.
+    pub const FALLBACK: Abi = Abi::C { unwind: false };
+
     #[inline]
     pub fn index(self) -> usize {
         // N.B., this ordering MUST match the AbiDatas array above.

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -300,6 +300,9 @@ impl<T> LinkedList<T> {
         let tail = self.tail.take();
         let len = mem::replace(&mut self.len, 0);
         if let Some(head) = head {
+            // SAFETY: In a LinkedList, either both the head and tail are None because
+            // the list is empty, or both head and tail are Some because the list is populated.
+            // Since we have verified the head is Some, we are sure the tail is Some too.
             let tail = unsafe { tail.unwrap_unchecked() };
             Some((head, tail, len))
         } else {

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -300,7 +300,7 @@ impl<T> LinkedList<T> {
         let tail = self.tail.take();
         let len = mem::replace(&mut self.len, 0);
         if let Some(head) = head {
-            let tail = tail.unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
+            let tail = unsafe { tail.unwrap_unchecked() };
             Some((head, tail, len))
         } else {
             None

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -459,11 +459,8 @@ where
     debug_assert!(N <= iter.size_hint().1.unwrap_or(usize::MAX));
     debug_assert!(N <= iter.size_hint().0);
 
-    match collect_into_array(iter) {
-        Some(array) => array,
-        // SAFETY: covered by the function contract.
-        None => unsafe { crate::hint::unreachable_unchecked() },
-    }
+    // SAFETY: covered by the function contract.
+    unsafe { collect_into_array(iter).unwrap_unchecked() }
 }
 
 /// Pulls `N` items from `iter` and returns them as an array. If the iterator

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -1421,16 +1421,21 @@ impl<'a> Formatter<'a> {
             // If we're under the maximum length, and there's no minimum length
             // requirements, then we can just emit the string
             None => self.buf.write_str(s),
-            // If we're under the maximum width, check if we're over the minimum
-            // width, if so it's as easy as just emitting the string.
-            Some(width) if s.chars().count() >= width => self.buf.write_str(s),
-            // If we're under both the maximum and the minimum width, then fill
-            // up the minimum width with the specified string + some alignment.
             Some(width) => {
-                let align = rt::v1::Alignment::Left;
-                let post_padding = self.padding(width - s.chars().count(), align)?;
-                self.buf.write_str(s)?;
-                post_padding.write(self.buf)
+                let chars_count = s.chars().count();
+                // If we're under the maximum width, check if we're over the minimum
+                // width, if so it's as easy as just emitting the string.
+                if chars_count >= width {
+                    self.buf.write_str(s)
+                }
+                // If we're under both the maximum and the minimum width, then fill
+                // up the minimum width with the specified string + some alignment.
+                else {
+                    let align = rt::v1::Alignment::Left;
+                    let post_padding = self.padding(width - chars_count, align)?;
+                    self.buf.write_str(s)?;
+                    post_padding.write(self.buf)
+                }
             }
         }
     }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -402,7 +402,7 @@ impl<'a> Arguments<'a> {
 
         if self.args.is_empty() {
             pieces_length
-        } else if self.pieces[0] == "" && pieces_length < 16 {
+        } else if !self.pieces.is_empty() && self.pieces[0].is_empty() && pieces_length < 16 {
             // If the format string starts with an argument,
             // don't preallocate anything, unless length
             // of pieces is significant.
@@ -1163,7 +1163,7 @@ pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
                 }
                 // SAFETY: arg and args.args come from the same Arguments,
                 // which guarantees the indexes are always within bounds.
-                unsafe { run(&mut formatter, arg, &args.args) }?;
+                unsafe { run(&mut formatter, arg, args.args) }?;
                 idx += 1;
             }
         }
@@ -1409,7 +1409,7 @@ impl<'a> Formatter<'a> {
                 // we know that it can't panic. Use `get` + `unwrap_or` to avoid
                 // `unsafe` and otherwise don't emit any panic-related code
                 // here.
-                s.get(..i).unwrap_or(&s)
+                s.get(..i).unwrap_or(s)
             } else {
                 &s
             }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1198,11 +1198,8 @@ impl<T> Option<T> {
     pub fn insert(&mut self, value: T) -> &mut T {
         *self = Some(value);
 
-        match self {
-            Some(v) => v,
-            // SAFETY: the code above just filled the option
-            None => unsafe { hint::unreachable_unchecked() },
-        }
+        // SAFETY: the code above just filled the option
+        unsafe { self.as_mut().unwrap_unchecked() }
     }
 
     /// Inserts `value` into the option if it is [`None`], then

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -253,6 +253,7 @@
 #![feature(const_ip)]
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
+#![feature(const_option)]
 #![feature(const_raw_ptr_deref)]
 #![feature(const_socketaddr)]
 #![feature(container_error_extra)]

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -1,13 +1,18 @@
-#![allow(dead_code)] // runtime init functions not used during testing
+//! The Windows command line is just a string
+//! <https://docs.microsoft.com/en-us/archive/blogs/larryosterman/the-windows-command-line-is-just-a-string>
+//!
+//! This module implements the parsing necessary to turn that string into a list of arguments.
 
 #[cfg(test)]
 mod tests;
 
 use crate::ffi::OsString;
 use crate::fmt;
+use crate::marker::PhantomData;
+use crate::num::NonZeroU16;
 use crate::os::windows::prelude::*;
 use crate::path::PathBuf;
-use crate::slice;
+use crate::ptr::NonNull;
 use crate::sys::c;
 use crate::sys::windows::os::current_exe;
 use crate::vec;
@@ -15,9 +20,11 @@ use crate::vec;
 use core::iter;
 
 pub fn args() -> Args {
+    // SAFETY: `GetCommandLineW` returns a pointer to a null terminated UTF-16
+    // string so it's safe for `WStrUnits` to use.
     unsafe {
         let lp_cmd_line = c::GetCommandLineW();
-        let parsed_args_list = parse_lp_cmd_line(lp_cmd_line as *const u16, || {
+        let parsed_args_list = parse_lp_cmd_line(WStrUnits::new(lp_cmd_line), || {
             current_exe().map(PathBuf::into_os_string).unwrap_or_else(|_| OsString::new())
         });
 
@@ -28,129 +35,120 @@ pub fn args() -> Args {
 /// Implements the Windows command-line argument parsing algorithm.
 ///
 /// Microsoft's documentation for the Windows CLI argument format can be found at
-/// <https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)>.
+/// <https://docs.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?view=msvc-160#parsing-c-command-line-arguments>
 ///
-/// Windows includes a function to do this in shell32.dll,
-/// but linking with that DLL causes the process to be registered as a GUI application.
+/// A more in-depth explanation is here:
+/// <https://daviddeley.com/autohotkey/parameters/parameters.htm#WIN>
+///
+/// Windows includes a function to do command line parsing in shell32.dll.
+/// However, this is not used for two reasons:
+///
+/// 1. Linking with that DLL causes the process to be registered as a GUI application.
 /// GUI applications add a bunch of overhead, even if no windows are drawn. See
 /// <https://randomascii.wordpress.com/2018/12/03/a-not-called-function-can-cause-a-5x-slowdown/>.
 ///
-/// This function was tested for equivalence to the shell32.dll implementation in
-/// Windows 10 Pro v1803, using an exhaustive test suite available at
-/// <https://gist.github.com/notriddle/dde431930c392e428055b2dc22e638f5> or
-/// <https://paste.gg/p/anonymous/47d6ed5f5bd549168b1c69c799825223>.
-unsafe fn parse_lp_cmd_line<F: Fn() -> OsString>(
-    lp_cmd_line: *const u16,
+/// 2. It does not follow the modern C/C++ argv rules outlined in the first two links above.
+///
+/// This function was tested for equivalence to the C/C++ parsing rules using an
+/// extensive test suite available at
+/// <https://github.com/ChrisDenton/winarg/tree/std>.
+fn parse_lp_cmd_line<'a, F: Fn() -> OsString>(
+    lp_cmd_line: Option<WStrUnits<'a>>,
     exe_name: F,
 ) -> Vec<OsString> {
-    const BACKSLASH: u16 = '\\' as u16;
-    const QUOTE: u16 = '"' as u16;
-    const TAB: u16 = '\t' as u16;
-    const SPACE: u16 = ' ' as u16;
+    const BACKSLASH: NonZeroU16 = NonZeroU16::new(b'\\' as u16).unwrap();
+    const QUOTE: NonZeroU16 = NonZeroU16::new(b'"' as u16).unwrap();
+    const TAB: NonZeroU16 = NonZeroU16::new(b'\t' as u16).unwrap();
+    const SPACE: NonZeroU16 = NonZeroU16::new(b' ' as u16).unwrap();
+
     let mut ret_val = Vec::new();
-    if lp_cmd_line.is_null() || *lp_cmd_line == 0 {
+    // If the cmd line pointer is null or it points to an empty string then
+    // return the name of the executable as argv[0].
+    if lp_cmd_line.as_ref().and_then(|cmd| cmd.peek()).is_none() {
         ret_val.push(exe_name());
         return ret_val;
     }
-    let mut cmd_line = {
-        let mut end = 0;
-        while *lp_cmd_line.offset(end) != 0 {
-            end += 1;
-        }
-        slice::from_raw_parts(lp_cmd_line, end as usize)
-    };
+    let mut code_units = lp_cmd_line.unwrap();
+
     // The executable name at the beginning is special.
-    cmd_line = match cmd_line[0] {
-        // The executable name ends at the next quote mark,
-        // no matter what.
-        QUOTE => {
-            let args = {
-                let mut cut = cmd_line[1..].splitn(2, |&c| c == QUOTE);
-                if let Some(exe) = cut.next() {
-                    ret_val.push(OsString::from_wide(exe));
-                }
-                cut.next()
-            };
-            if let Some(args) = args {
-                args
-            } else {
-                return ret_val;
-            }
-        }
-        // Implement quirk: when they say whitespace here,
-        // they include the entire ASCII control plane:
-        // "However, if lpCmdLine starts with any amount of whitespace, CommandLineToArgvW
-        // will consider the first argument to be an empty string. Excess whitespace at the
-        // end of lpCmdLine is ignored."
-        0..=SPACE => {
-            ret_val.push(OsString::new());
-            &cmd_line[1..]
-        }
-        // The executable name ends at the next whitespace,
-        // no matter what.
-        _ => {
-            let args = {
-                let mut cut = cmd_line.splitn(2, |&c| c > 0 && c <= SPACE);
-                if let Some(exe) = cut.next() {
-                    ret_val.push(OsString::from_wide(exe));
-                }
-                cut.next()
-            };
-            if let Some(args) = args {
-                args
-            } else {
-                return ret_val;
-            }
-        }
-    };
-    let mut cur = Vec::new();
     let mut in_quotes = false;
-    let mut was_in_quotes = false;
-    let mut backslash_count: usize = 0;
-    for &c in cmd_line {
-        match c {
-            // backslash
-            BACKSLASH => {
-                backslash_count += 1;
-                was_in_quotes = false;
-            }
-            QUOTE if backslash_count % 2 == 0 => {
-                cur.extend(iter::repeat(b'\\' as u16).take(backslash_count / 2));
-                backslash_count = 0;
-                if was_in_quotes {
-                    cur.push('"' as u16);
-                    was_in_quotes = false;
-                } else {
-                    was_in_quotes = in_quotes;
-                    in_quotes = !in_quotes;
-                }
-            }
-            QUOTE if backslash_count % 2 != 0 => {
-                cur.extend(iter::repeat(b'\\' as u16).take(backslash_count / 2));
-                backslash_count = 0;
-                was_in_quotes = false;
-                cur.push(b'"' as u16);
-            }
-            SPACE | TAB if !in_quotes => {
-                cur.extend(iter::repeat(b'\\' as u16).take(backslash_count));
-                if !cur.is_empty() || was_in_quotes {
-                    ret_val.push(OsString::from_wide(&cur[..]));
-                    cur.truncate(0);
-                }
-                backslash_count = 0;
-                was_in_quotes = false;
-            }
-            _ => {
-                cur.extend(iter::repeat(b'\\' as u16).take(backslash_count));
-                backslash_count = 0;
-                was_in_quotes = false;
-                cur.push(c);
-            }
+    let mut cur = Vec::new();
+    for w in &mut code_units {
+        match w {
+            // A quote mark always toggles `in_quotes` no matter what because
+            // there are no escape characters when parsing the executable name.
+            QUOTE => in_quotes = !in_quotes,
+            // If not `in_quotes` then whitespace ends argv[0].
+            SPACE | TAB if !in_quotes => break,
+            // In all other cases the code unit is taken literally.
+            _ => cur.push(w.get()),
         }
     }
-    cur.extend(iter::repeat(b'\\' as u16).take(backslash_count));
-    // include empty quoted strings at the end of the arguments list
-    if !cur.is_empty() || was_in_quotes || in_quotes {
+    // Skip whitespace.
+    code_units.advance_while(|w| w == SPACE || w == TAB);
+    ret_val.push(OsString::from_wide(&cur));
+
+    // Parse the arguments according to these rules:
+    // * All code units are taken literally except space, tab, quote and backslash.
+    // * When not `in_quotes`, space and tab separate arguments. Consecutive spaces and tabs are
+    // treated as a single separator.
+    // * A space or tab `in_quotes` is taken literally.
+    // * A quote toggles `in_quotes` mode unless it's escaped. An escaped quote is taken literally.
+    // * A quote can be escaped if preceded by an odd number of backslashes.
+    // * If any number of backslashes is immediately followed by a quote then the number of
+    // backslashes is halved (rounding down).
+    // * Backslashes not followed by a quote are all taken literally.
+    // * If `in_quotes` then a quote can also be escaped using another quote
+    // (i.e. two consecutive quotes become one literal quote).
+    let mut cur = Vec::new();
+    let mut in_quotes = false;
+    while let Some(w) = code_units.next() {
+        match w {
+            // If not `in_quotes`, a space or tab ends the argument.
+            SPACE | TAB if !in_quotes => {
+                ret_val.push(OsString::from_wide(&cur[..]));
+                cur.truncate(0);
+
+                // Skip whitespace.
+                code_units.advance_while(|w| w == SPACE || w == TAB);
+            }
+            // Backslashes can escape quotes or backslashes but only if consecutive backslashes are followed by a quote.
+            BACKSLASH => {
+                let backslash_count = code_units.advance_while(|w| w == BACKSLASH) + 1;
+                if code_units.peek() == Some(QUOTE) {
+                    cur.extend(iter::repeat(BACKSLASH.get()).take(backslash_count / 2));
+                    // The quote is escaped if there are an odd number of backslashes.
+                    if backslash_count % 2 == 1 {
+                        code_units.next();
+                        cur.push(QUOTE.get());
+                    }
+                } else {
+                    // If there is no quote on the end then there is no escaping.
+                    cur.extend(iter::repeat(BACKSLASH.get()).take(backslash_count));
+                }
+            }
+            // If `in_quotes` and not backslash escaped (see above) then a quote either
+            // unsets `in_quote` or is escaped by another quote.
+            QUOTE if in_quotes => match code_units.peek() {
+                // Two consecutive quotes when `in_quotes` produces one literal quote.
+                Some(QUOTE) => {
+                    cur.push(QUOTE.get());
+                    code_units.next();
+                }
+                // Otherwise set `in_quotes`.
+                Some(_) => in_quotes = false,
+                // The end of the command line.
+                // Push `cur` even if empty, which we do by breaking while `in_quotes` is still set.
+                None => break,
+            },
+            // If not `in_quotes` and not BACKSLASH escaped (see above) then a quote sets `in_quote`.
+            QUOTE => in_quotes = true,
+            // Everything else is always taken literally.
+            _ => cur.push(w.get()),
+        }
+    }
+    // Push the final argument, if any.
+    if !cur.is_empty() || in_quotes {
         ret_val.push(OsString::from_wide(&cur[..]));
     }
     ret_val
@@ -185,5 +183,54 @@ impl DoubleEndedIterator for Args {
 impl ExactSizeIterator for Args {
     fn len(&self) -> usize {
         self.parsed_args_list.len()
+    }
+}
+
+/// A safe iterator over a LPWSTR
+/// (aka a pointer to a series of UTF-16 code units terminated by a NULL).
+struct WStrUnits<'a> {
+    // The pointer must never be null...
+    lpwstr: NonNull<u16>,
+    // ...and the memory it points to must be valid for this lifetime.
+    lifetime: PhantomData<&'a [u16]>,
+}
+impl WStrUnits<'_> {
+    /// Create the iterator. Returns `None` if `lpwstr` is null.
+    ///
+    /// SAFETY: `lpwstr` must point to a null-terminated wide string that lives
+    /// at least as long as the lifetime of this struct.
+    unsafe fn new(lpwstr: *const u16) -> Option<Self> {
+        Some(Self { lpwstr: NonNull::new(lpwstr as _)?, lifetime: PhantomData })
+    }
+    fn peek(&self) -> Option<NonZeroU16> {
+        // SAFETY: It's always safe to read the current item because we don't
+        // ever move out of the array's bounds.
+        unsafe { NonZeroU16::new(*self.lpwstr.as_ptr()) }
+    }
+    /// Advance the iterator while `predicate` returns true.
+    /// Returns the number of items it advanced by.
+    fn advance_while<P: FnMut(NonZeroU16) -> bool>(&mut self, mut predicate: P) -> usize {
+        let mut counter = 0;
+        while let Some(w) = self.peek() {
+            if !predicate(w) {
+                break;
+            }
+            counter += 1;
+            self.next();
+        }
+        counter
+    }
+}
+impl Iterator for WStrUnits<'_> {
+    // This can never return zero as that marks the end of the string.
+    type Item = NonZeroU16;
+    fn next(&mut self) -> Option<NonZeroU16> {
+        // SAFETY: If NULL is reached we immediately return.
+        // Therefore it's safe to advance the pointer after that.
+        unsafe {
+            let next = self.peek()?;
+            self.lpwstr = NonNull::new_unchecked(self.lpwstr.as_ptr().add(1));
+            Some(next)
+        }
     }
 }

--- a/library/std/src/sys/windows/args/tests.rs
+++ b/library/std/src/sys/windows/args/tests.rs
@@ -5,9 +5,9 @@ fn chk(string: &str, parts: &[&str]) {
     let mut wide: Vec<u16> = OsString::from(string).encode_wide().collect();
     wide.push(0);
     let parsed =
-        unsafe { parse_lp_cmd_line(wide.as_ptr() as *const u16, || OsString::from("TEST.EXE")) };
+        unsafe { parse_lp_cmd_line(WStrUnits::new(wide.as_ptr()), || OsString::from("TEST.EXE")) };
     let expected: Vec<OsString> = parts.iter().map(|k| OsString::from(k)).collect();
-    assert_eq!(parsed.as_slice(), expected.as_slice());
+    assert_eq!(parsed.as_slice(), expected.as_slice(), "{:?}", string);
 }
 
 #[test]
@@ -27,35 +27,65 @@ fn single_words() {
 #[test]
 fn official_examples() {
     chk(r#"EXE "abc" d e"#, &["EXE", "abc", "d", "e"]);
-    chk(r#"EXE a\\\b d"e f"g h"#, &["EXE", r#"a\\\b"#, "de fg", "h"]);
+    chk(r#"EXE a\\\b d"e f"g h"#, &["EXE", r"a\\\b", "de fg", "h"]);
     chk(r#"EXE a\\\"b c d"#, &["EXE", r#"a\"b"#, "c", "d"]);
-    chk(r#"EXE a\\\\"b c" d e"#, &["EXE", r#"a\\b c"#, "d", "e"]);
+    chk(r#"EXE a\\\\"b c" d e"#, &["EXE", r"a\\b c", "d", "e"]);
 }
 
 #[test]
 fn whitespace_behavior() {
-    chk(r#" test"#, &["", "test"]);
-    chk(r#"  test"#, &["", "test"]);
-    chk(r#" test test2"#, &["", "test", "test2"]);
-    chk(r#" test  test2"#, &["", "test", "test2"]);
-    chk(r#"test test2 "#, &["test", "test2"]);
-    chk(r#"test  test2 "#, &["test", "test2"]);
-    chk(r#"test "#, &["test"]);
+    chk(" test", &["", "test"]);
+    chk("  test", &["", "test"]);
+    chk(" test test2", &["", "test", "test2"]);
+    chk(" test  test2", &["", "test", "test2"]);
+    chk("test test2 ", &["test", "test2"]);
+    chk("test  test2 ", &["test", "test2"]);
+    chk("test ", &["test"]);
 }
 
 #[test]
 fn genius_quotes() {
     chk(r#"EXE "" """#, &["EXE", "", ""]);
-    chk(r#"EXE "" """"#, &["EXE", "", "\""]);
+    chk(r#"EXE "" """"#, &["EXE", "", r#"""#]);
     chk(
         r#"EXE "this is """all""" in the same argument""#,
-        &["EXE", "this is \"all\" in the same argument"],
+        &["EXE", r#"this is "all" in the same argument"#],
     );
-    chk(r#"EXE "a"""#, &["EXE", "a\""]);
-    chk(r#"EXE "a"" a"#, &["EXE", "a\"", "a"]);
+    chk(r#"EXE "a"""#, &["EXE", r#"a""#]);
+    chk(r#"EXE "a"" a"#, &["EXE", r#"a" a"#]);
     // quotes cannot be escaped in command names
     chk(r#""EXE" check"#, &["EXE", "check"]);
     chk(r#""EXE check""#, &["EXE check"]);
-    chk(r#""EXE """for""" check"#, &["EXE ", r#"for""#, "check"]);
-    chk(r#""EXE \"for\" check"#, &[r#"EXE \"#, r#"for""#, "check"]);
+    chk(r#""EXE """for""" check"#, &["EXE for check"]);
+    chk(r#""EXE \"for\" check"#, &[r"EXE \for\ check"]);
+    chk(r#""EXE \" for \" check"#, &[r"EXE \", "for", r#"""#, "check"]);
+    chk(r#"E"X"E test"#, &["EXE", "test"]);
+    chk(r#"EX""E test"#, &["EXE", "test"]);
+}
+
+// from https://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESEX
+#[test]
+fn post_2008() {
+    chk("EXE CallMeIshmael", &["EXE", "CallMeIshmael"]);
+    chk(r#"EXE "Call Me Ishmael""#, &["EXE", "Call Me Ishmael"]);
+    chk(r#"EXE Cal"l Me I"shmael"#, &["EXE", "Call Me Ishmael"]);
+    chk(r#"EXE CallMe\"Ishmael"#, &["EXE", r#"CallMe"Ishmael"#]);
+    chk(r#"EXE "CallMe\"Ishmael""#, &["EXE", r#"CallMe"Ishmael"#]);
+    chk(r#"EXE "Call Me Ishmael\\""#, &["EXE", r"Call Me Ishmael\"]);
+    chk(r#"EXE "CallMe\\\"Ishmael""#, &["EXE", r#"CallMe\"Ishmael"#]);
+    chk(r#"EXE a\\\b"#, &["EXE", r"a\\\b"]);
+    chk(r#"EXE "a\\\b""#, &["EXE", r"a\\\b"]);
+    chk(r#"EXE "\"Call Me Ishmael\"""#, &["EXE", r#""Call Me Ishmael""#]);
+    chk(r#"EXE "C:\TEST A\\""#, &["EXE", r"C:\TEST A\"]);
+    chk(r#"EXE "\"C:\TEST A\\\"""#, &["EXE", r#""C:\TEST A\""#]);
+    chk(r#"EXE "a b c"  d  e"#, &["EXE", "a b c", "d", "e"]);
+    chk(r#"EXE "ab\"c"  "\\"  d"#, &["EXE", r#"ab"c"#, r"\", "d"]);
+    chk(r#"EXE a\\\b d"e f"g h"#, &["EXE", r"a\\\b", "de fg", "h"]);
+    chk(r#"EXE a\\\"b c d"#, &["EXE", r#"a\"b"#, "c", "d"]);
+    chk(r#"EXE a\\\\"b c" d e"#, &["EXE", r"a\\b c", "d", "e"]);
+    // Double Double Quotes
+    chk(r#"EXE "a b c"""#, &["EXE", r#"a b c""#]);
+    chk(r#"EXE """CallMeIshmael"""  b  c"#, &["EXE", r#""CallMeIshmael""#, "b", "c"]);
+    chk(r#"EXE """Call Me Ishmael""""#, &["EXE", r#""Call Me Ishmael""#]);
+    chk(r#"EXE """"Call Me Ishmael"" b c"#, &["EXE", r#""Call"#, "Me", "Ishmael", "b", "c"]);
 }

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -781,7 +781,7 @@ extern "system" {
     pub fn RemoveDirectoryW(lpPathName: LPCWSTR) -> BOOL;
     pub fn SetFileAttributesW(lpFileName: LPCWSTR, dwFileAttributes: DWORD) -> BOOL;
     pub fn SetLastError(dwErrCode: DWORD);
-    pub fn GetCommandLineW() -> *mut LPCWSTR;
+    pub fn GetCommandLineW() -> LPWSTR;
     pub fn GetTempPathW(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD;
     pub fn GetCurrentProcess() -> HANDLE;
     pub fn GetCurrentThread() -> HANDLE;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -453,6 +453,7 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", false)
             .into(),
+        ("auto-collapse-implementors", "Auto-hide implementors of a trait", true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result", false)
             .into(),
         ("line-numbers", "Show line numbers on code examples", false).into(),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -453,7 +453,6 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", false)
             .into(),
-        ("auto-collapse-implementors", "Auto-hide implementors of a trait", true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result", false)
             .into(),
         ("line-numbers", "Show line numbers on code examples", false).into(),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -16,8 +16,7 @@ use rustc_span::symbol::{kw, sym, Symbol};
 use super::{
     collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, notable_traits_decl,
     render_assoc_item, render_assoc_items, render_attributes_in_code, render_attributes_in_pre,
-    render_impl, render_impl_summary, render_stability_since_raw, write_srclink, AssocItemLink,
-    Context,
+    render_impl, render_stability_since_raw, write_srclink, AssocItemLink, Context,
 };
 use crate::clean::{self, GetDefId};
 use crate::formats::item_type::ItemType;
@@ -740,7 +739,9 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     None,
                     true,
                     false,
+                    true,
                     &[],
+                    false,
                 );
             }
         }
@@ -1388,16 +1389,20 @@ fn render_implementor(
         } => implementor_dups[&path.last()].1,
         _ => false,
     };
-    render_impl_summary(
+    render_impl(
         w,
         cx,
         implementor,
         trait_,
-        trait_,
+        AssocItemLink::Anchor(None),
+        RenderMode::Normal,
         false,
         Some(use_absolute),
         false,
+        false,
+        false,
         aliases,
+        false,
     );
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -17,6 +17,7 @@ use super::{
     collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, notable_traits_decl,
     render_assoc_item, render_assoc_items, render_attributes_in_code, render_attributes_in_pre,
     render_impl, render_stability_since_raw, write_srclink, AssocItemLink, Context,
+    ImplRenderingParameters,
 };
 use crate::clean::{self, GetDefId};
 use crate::formats::item_type::ItemType;
@@ -735,13 +736,15 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     it,
                     assoc_link,
                     RenderMode::Normal,
-                    false,
                     None,
-                    true,
-                    false,
-                    true,
                     &[],
-                    false,
+                    ImplRenderingParameters {
+                        show_def_docs: false,
+                        is_on_foreign_type: true,
+                        show_default_items: false,
+                        show_non_assoc_items: true,
+                        toggle_open_by_default: false,
+                    },
                 );
             }
         }
@@ -1396,13 +1399,15 @@ fn render_implementor(
         trait_,
         AssocItemLink::Anchor(None),
         RenderMode::Normal,
-        false,
         Some(use_absolute),
-        false,
-        false,
-        false,
         aliases,
-        false,
+        ImplRenderingParameters {
+            show_def_docs: false,
+            is_on_foreign_type: false,
+            show_default_items: false,
+            show_non_assoc_items: false,
+            toggle_open_by_default: false,
+        },
     );
 }
 

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -789,6 +789,7 @@ function hideThemeButtonState() {
         }
 
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
+        var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
         var hideImplementations = getSettingValue("auto-hide-trait-implementations") === "true";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
@@ -804,6 +805,10 @@ function hideThemeButtonState() {
         if (hideImplementations) {
             setImplementorsTogglesOpen("trait-implementations-list", false);
             setImplementorsTogglesOpen("blanket-implementations-list", false);
+        }
+
+        if (!hideImplementors) {
+            setImplementorsTogglesOpen("implementors-list", true);
         }
 
         onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -789,7 +789,6 @@ function hideThemeButtonState() {
         }
 
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
-        var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
         var hideImplementations = getSettingValue("auto-hide-trait-implementations") === "true";
         var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
@@ -805,10 +804,6 @@ function hideThemeButtonState() {
         if (hideImplementations) {
             setImplementorsTogglesOpen("trait-implementations-list", false);
             setImplementorsTogglesOpen("blanket-implementations-list", false);
-        }
-
-        if (!hideImplementors) {
-            setImplementorsTogglesOpen("implementors-list", true);
         }
 
         onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {

--- a/src/test/rustdoc-gui/implementors.goml
+++ b/src/test/rustdoc-gui/implementors.goml
@@ -3,14 +3,14 @@
 goto: file://|DOC_PATH|/implementors/trait.Whatever.html
 assert: "#implementors-list"
 // There are supposed to be two implementors listed.
-assert-count: ("#implementors-list > .impl", 2)
+assert-count: ("#implementors-list .impl", 2)
 // Now we check that both implementors have an anchor, an ID and a similar DOM.
-assert: ("#implementors-list > .impl:nth-child(1) > a.anchor")
-assert-attribute: ("#implementors-list > .impl:nth-child(1)", {"id": "impl-Whatever"})
-assert-attribute: ("#implementors-list > .impl:nth-child(1) > a.anchor", {"href": "#impl-Whatever"})
-assert: "#implementors-list > .impl:nth-child(1) > .code-header.in-band"
+assert: ("#implementors-list .impl:nth-child(1) > a.anchor")
+assert-attribute: ("#implementors-list .impl:nth-child(1)", {"id": "impl-Whatever"})
+assert-attribute: ("#implementors-list .impl:nth-child(1) > a.anchor", {"href": "#impl-Whatever"})
+assert: "#implementors-list .impl:nth-child(1) > .code-header.in-band"
 
-assert: ("#implementors-list > .impl:nth-child(2) > a.anchor")
-assert-attribute: ("#implementors-list > .impl:nth-child(2)", {"id": "impl-Whatever-1"})
-assert-attribute: ("#implementors-list > .impl:nth-child(2) > a.anchor", {"href": "#impl-Whatever-1"})
-assert: "#implementors-list > .impl:nth-child(2) > .code-header.in-band"
+assert: ("#implementors-list .impl:nth-child(2) > a.anchor")
+assert-attribute: ("#implementors-list .impl:nth-child(2)", {"id": "impl-Whatever-1"})
+assert-attribute: ("#implementors-list .impl:nth-child(2) > a.anchor", {"href": "#impl-Whatever-1"})
+assert: "#implementors-list .impl:nth-child(2) > .code-header.in-band"

--- a/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/implementors/lib.rs
@@ -1,7 +1,11 @@
 pub trait Whatever {
+    type Foo;
+
     fn method() {}
 }
 
 pub struct Struct;
 
-impl Whatever for Struct {}
+impl Whatever for Struct {
+    type Foo = u8;
+}

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -38,7 +38,9 @@ impl Trait for Foo {
 }
 
 
-impl implementors::Whatever for Foo {}
+impl implementors::Whatever for Foo {
+    type Foo = u32;
+}
 
 pub mod sub_mod {
     /// ```txt

--- a/src/test/rustdoc-gui/toggle-implementors.goml
+++ b/src/test/rustdoc-gui/toggle-implementors.goml
@@ -1,0 +1,13 @@
+// This test ensures two things:
+//
+// 1. The implementors toggle are not open by default.
+// 2. The "auto-collapse-implementors" setting is working as expected.
+goto: file://|DOC_PATH|/implementors/trait.Whatever.html
+
+// First, checking that they are not open by default.
+assert-attribute-false: ("#implementors-list > details", {"open": ""}, ALL)
+
+// Second, checking "auto-collapse-implementors" setting.
+local-storage: {"rustdoc-auto-collapse-implementors": false}
+reload:
+assert-attribute: ("#implementors-list > details", {"open": ""}, ALL)

--- a/src/test/rustdoc-gui/toggle-implementors.goml
+++ b/src/test/rustdoc-gui/toggle-implementors.goml
@@ -1,13 +1,4 @@
-// This test ensures two things:
-//
-// 1. The implementors toggle are not open by default.
-// 2. The "auto-collapse-implementors" setting is working as expected.
+// This test ensures that the implementors toggle are not open by default.
 goto: file://|DOC_PATH|/implementors/trait.Whatever.html
 
-// First, checking that they are not open by default.
 assert-attribute-false: ("#implementors-list > details", {"open": ""}, ALL)
-
-// Second, checking "auto-collapse-implementors" setting.
-local-storage: {"rustdoc-auto-collapse-implementors": false}
-reload:
-assert-attribute: ("#implementors-list > details", {"open": ""}, ALL)

--- a/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
+++ b/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
@@ -1,6 +1,6 @@
 pub trait MyTrait {
     type Assoc;
-    const VALUE: u32;
+    const VALUE: u32 = 12;
     fn trait_function(&self);
     fn defaulted(&self) {}
     fn defaulted_override(&self) {}
@@ -38,9 +38,11 @@ impl MyTrait for Vec<u8> {
 }
 
 impl MyTrait for MyStruct {
+    // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedtype.Assoc-3"]//a[@class="anchor"]/@href' #associatedtype.Assoc-3
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedtype.Assoc"]//a[@class="type"]/@href' trait.MyTrait.html#associatedtype.Assoc
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedtype.Assoc"]//a[@class="anchor"]/@href' #associatedtype.Assoc
     type Assoc = bool;
+    // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-3"]//a[@class="anchor"]/@href' #associatedconstant.VALUE-3
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedconstant.VALUE"]//a[@class="constant"]/@href' trait.MyTrait.html#associatedconstant.VALUE
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//div[@id="associatedconstant.VALUE"]//a[@class="anchor"]/@href' #associatedconstant.VALUE
     const VALUE: u32 = 20;
@@ -55,3 +57,10 @@ impl MyTrait for MyStruct {
 }
 
 pub struct MyStruct;
+
+// We check that associated items with default values aren't generated in the implementors list.
+impl MyTrait for (u8, u8) {
+    // @!has trait_impl_items_links_and_anchors/trait.MyTrait.html '//div[@id="associatedconstant.VALUE-4"]'
+    type Assoc = bool;
+    fn trait_function(&self) {}
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.fixed
@@ -1,0 +1,25 @@
+// run-rustfix
+// edition:2018
+// check-pass
+#![warn(rust_2021_compatibility)]
+
+macro_rules! m {
+    (@ $body:expr) => {{
+        let f = || $body;
+        //~^ WARNING: drop order
+        f();
+    }};
+    ($body:block) => {{
+        m!(@ $body);
+    }};
+}
+
+fn main() {
+    let a = (1.to_string(), 2.to_string());
+    m!({
+        let _ = &a;
+        //~^ HELP: add a dummy
+        let x = a.0;
+        println!("{}", x);
+    });
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.rs
@@ -1,0 +1,24 @@
+// run-rustfix
+// edition:2018
+// check-pass
+#![warn(rust_2021_compatibility)]
+
+macro_rules! m {
+    (@ $body:expr) => {{
+        let f = || $body;
+        //~^ WARNING: drop order
+        f();
+    }};
+    ($body:block) => {{
+        m!(@ $body);
+    }};
+}
+
+fn main() {
+    let a = (1.to_string(), 2.to_string());
+    m!({
+        //~^ HELP: add a dummy
+        let x = a.0;
+        println!("{}", x);
+    });
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
@@ -1,0 +1,37 @@
+warning: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/closure-body-macro-fragment.rs:8:17
+   |
+LL |           let f = || $body;
+   |  _________________^
+LL | |
+LL | |         f();
+LL | |     }};
+   | |     - in Rust 2018, `a` is dropped here, but in Rust 2021, only `a.0` will be dropped here as part of the closure
+LL | |     ($body:block) => {{
+LL | |         m!(@ $body);
+   | |__________________^
+...
+LL | /     m!({
+LL | |
+LL | |         let x = a.0;
+   | |                 --- in Rust 2018, this closure captures all of `a`, but in Rust 2021, it will only capture `a.0`
+LL | |         println!("{}", x);
+LL | |     });
+   | |_______- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/closure-body-macro-fragment.rs:4:9
+   |
+LL | #![warn(rust_2021_compatibility)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(rust_2021_incompatible_closure_captures)]` implied by `#[warn(rust_2021_compatibility)]`
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add a dummy let to cause `a` to be fully captured
+   |
+LL ~     m!({
+LL +         let _ = &a;
+   |
+
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-83190.rs
+++ b/src/test/ui/issues/issue-83190.rs
@@ -1,0 +1,49 @@
+// check-pass
+
+// Regression test for issue #83190, triggering an ICE in borrowck.
+
+pub trait Any {}
+impl<T> Any for T {}
+
+pub trait StreamOnce {
+    type Range;
+}
+
+pub trait Parser<Input>: Sized {
+    type Output;
+    type PartialState;
+    fn map(self) -> Map<Self> {
+        todo!()
+    }
+}
+
+pub struct Map<P>(P);
+impl<I, P: Parser<I, Output = ()>> Parser<I> for Map<P> {
+    type Output = ();
+    type PartialState = P::PartialState;
+}
+
+struct TakeWhile1<Input>(Input);
+impl<I: StreamOnce> Parser<I> for TakeWhile1<I> {
+    type Output = I::Range;
+    type PartialState = ();
+}
+impl<I> TakeWhile1<I> {
+    fn new() -> Self {
+        todo!()
+    }
+}
+
+impl<I, A: Parser<I>> Parser<I> for (A,) {
+    type Output = ();
+    type PartialState = Map<A::Output>;
+}
+
+pub fn metric_stream_parser<'a, I>() -> impl Parser<I, Output = (), PartialState = impl Any + 'a>
+where
+    I: StreamOnce<Range = &'a [()]>,
+{
+    (TakeWhile1::new(),).map()
+}
+
+fn main() {}

--- a/src/test/ui/lint/unused/issue-88519-unused-paren.rs
+++ b/src/test/ui/lint/unused/issue-88519-unused-paren.rs
@@ -1,0 +1,94 @@
+// check-pass
+// Make sure unused parens lint doesn't emit a false positive.
+// See https://github.com/rust-lang/rust/issues/88519
+#![deny(unused_parens)]
+#![feature(type_ascription)]
+
+// binary ops are tested in issue-71290-unused-paren-binop.rs
+
+mod call {
+    fn noop() -> u8 { 0 }
+    fn outside() -> u8 {
+        ({ noop })()
+    }
+    fn inside() -> u8 {
+        ({ noop }())
+    }
+    fn outside_match() -> u8 {
+        (match noop { x => x })()
+    }
+    fn inside_match() -> u8 {
+        (match noop { x => x }())
+    }
+    fn outside_if() -> u8 {
+        (if false { noop } else { noop })()
+    }
+    fn inside_if() -> u8 {
+        (if false { noop } else { noop }())
+    }
+}
+
+mod casts {
+    fn outside() -> u8 {
+        ({ 0 }) as u8
+    }
+    fn inside() -> u8 {
+        ({ 0 } as u8)
+    }
+    fn outside_match() -> u8 {
+        (match 0 { x => x }) as u8
+    }
+    fn inside_match() -> u8 {
+        (match 0 { x => x } as u8)
+    }
+    fn outside_if() -> u8 {
+        (if false { 0 } else { 0 }) as u8
+    }
+    fn inside_if() -> u8 {
+        (if false { 0 } else { 0 } as u8)
+    }
+}
+
+mod typeascription {
+    fn outside() -> u8 {
+        ({ 0 }): u8
+    }
+    fn inside() -> u8 {
+        ({ 0 }: u8)
+    }
+    fn outside_match() -> u8 {
+        (match 0 { x => x }): u8
+    }
+    fn inside_match() -> u8 {
+        (match 0 { x => x }: u8)
+    }
+    fn outside_if() -> u8 {
+        (if false { 0 } else { 0 }): u8
+    }
+    fn inside_if() -> u8 {
+        (if false { 0 } else { 0 }: u8)
+    }
+}
+
+mod index {
+    fn outside(x: &[u8]) -> u8 {
+        ({ x })[0]
+    }
+    fn inside(x: &[u8]) -> u8 {
+        ({ x }[0])
+    }
+    fn outside_match(x: &[u8]) -> u8 {
+        (match x { x => x })[0]
+    }
+    fn inside_match(x: &[u8]) -> u8 {
+        (match x { x => x }[0])
+    }
+    fn outside_if(x: &[u8]) -> u8 {
+        (if false { x } else { x })[0]
+    }
+    fn inside_if(x: &[u8]) -> u8 {
+        (if false { x } else { x }[0])
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #87114 (Lint missing Abi in ast validation instead of lowering.)
 - #87580 (Update Windows Argument Parsing)
 - #88490 (Display associated types of implementors)
 - #88505 (Use `unwrap_unchecked` where possible)
 - #88530 (Shrink Session a bit)
 - #88532 (Remove single use variables)
 - #88543 (Improve closure dummy capture suggestion in macros.)
 - #88547 (fix(rustc_lint): better detect when parens are necessary)
 - #88550 (Include debug info for the allocator shim)
 - #88560 (`fmt::Formatter::pad`: don't call chars().count() more than one time)
 - #88565 (Add regression test for issue 83190)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87114,87580,88490,88505,88530,88532,88543,88547,88550,88560,88565)
<!-- homu-ignore:end -->