### PR TITLE
Fix drop handling for `if let` expressions

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1187,6 +1187,7 @@ pub struct Arm<'hir> {
 #[derive(Debug, HashStable_Generic)]
 pub enum Guard<'hir> {
     If(&'hir Expr<'hir>),
+    // FIXME use ExprKind::Let for this.
     IfLet(&'hir Pat<'hir>, &'hir Expr<'hir>),
 }
 

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -94,6 +94,7 @@ impl fmt::Debug for Scope {
             ScopeData::CallSite => write!(fmt, "CallSite({:?})", self.id),
             ScopeData::Arguments => write!(fmt, "Arguments({:?})", self.id),
             ScopeData::Destruction => write!(fmt, "Destruction({:?})", self.id),
+            ScopeData::IfThen => write!(fmt, "IfThen({:?})", self.id),
             ScopeData::Remainder(fsi) => write!(
                 fmt,
                 "Remainder {{ block: {:?}, first_statement_index: {}}}",
@@ -119,6 +120,10 @@ pub enum ScopeData {
 
     /// Scope of destructors for temporaries of node-id.
     Destruction,
+
+    /// Scope of the condition and then block of an if expression
+    /// Used for variables introduced in an if-let expression.
+    IfThen,
 
     /// Scope following a `let id = expr;` binding in a block.
     Remainder(FirstStatementIndex),

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -223,6 +223,7 @@ pub enum ExprKind<'tcx> {
     },
     /// An `if` expression.
     If {
+        if_then_scope: region::Scope,
         cond: ExprId,
         then: ExprId,
         else_opt: Option<ExprId>,

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Let { expr, ref pat } => {
                 let scope = this.local_scope();
                 let (true_block, false_block) = this.in_if_then_scope(scope, |this| {
-                    this.lower_let_else(block, &this.thir[expr], pat, scope, expr_span)
+                    this.lower_let_expr(block, &this.thir[expr], pat, scope, expr_span)
                 });
 
                 let join_block = this.cfg.start_new_block();

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -52,11 +52,33 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Match { scrutinee, ref arms } => {
                 this.match_expr(destination, expr_span, block, &this.thir[scrutinee], arms)
             }
-            ExprKind::If { cond, then, else_opt } => {
-                let local_scope = this.local_scope();
-                let (mut then_blk, mut else_blk) =
-                    this.then_else_blocks(block, &this.thir[cond], local_scope, source_info);
-                unpack!(then_blk = this.expr_into_dest(destination, then_blk, &this.thir[then]));
+            ExprKind::If { cond, then, else_opt, if_then_scope } => {
+                let then_blk;
+                let then_expr = &this.thir[then];
+                let then_source_info = this.source_info(then_expr.span);
+                let condition_scope = this.local_scope();
+
+                let mut else_blk = unpack!(
+                    then_blk = this.in_scope(
+                        (if_then_scope, then_source_info),
+                        LintLevel::Inherited,
+                        |this| {
+                            let (then_block, else_block) =
+                                this.in_if_then_scope(condition_scope, |this| {
+                                    let then_blk = unpack!(this.then_else_break(
+                                        block,
+                                        &this.thir[cond],
+                                        condition_scope,
+                                        condition_scope,
+                                        then_expr.span,
+                                    ));
+                                    this.expr_into_dest(destination, then_blk, then_expr)
+                                });
+                            then_block.and(else_block)
+                        },
+                    )
+                );
+
                 else_blk = if let Some(else_opt) = else_opt {
                     unpack!(this.expr_into_dest(destination, else_blk, &this.thir[else_opt]))
                 } else {
@@ -81,9 +103,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 join_block.unit()
             }
-            ExprKind::Let { ref pat, expr } => {
-                let (true_block, false_block) =
-                    this.lower_let(block, &this.thir[expr], pat, expr_span);
+            ExprKind::Let { expr, ref pat } => {
+                let scope = this.local_scope();
+                let (true_block, false_block) = this.in_if_then_scope(scope, |this| {
+                    this.lower_let_else(block, &this.thir[expr], pat, scope, expr_span)
+                });
 
                 let join_block = this.cfg.start_new_block();
 

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 })
             }
             ExprKind::Let { expr, ref pat } => {
-                this.lower_let_else(block, &this.thir[expr], pat, break_scope, variable_scope_span)
+                this.lower_let_expr(block, &this.thir[expr], pat, break_scope, variable_scope_span)
             }
             _ => {
                 let mutability = Mutability::Mut;
@@ -1754,7 +1754,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 // Pat binding - used for `let` and function parameters as well.
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
-    crate fn lower_let_else(
+    crate fn lower_let_expr(
         &mut self,
         mut block: BasicBlock,
         expr: &Expr<'tcx>,
@@ -1962,7 +1962,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     Guard::IfLet(ref pat, scrutinee) => {
                         let s = &this.thir[scrutinee];
                         guard_span = s.span;
-                        this.lower_let_else(block, s, pat, match_scope, arm_span)
+                        this.lower_let_expr(block, s, pat, match_scope, arm_span)
                     }
                 });
 

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -63,7 +63,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.lower_let_else(block, &this.thir[expr], pat, break_scope, variable_scope_span)
             }
             _ => {
-                // TODO `as_temp`?
                 let mutability = Mutability::Mut;
                 let place =
                     unpack!(block = this.as_temp(block, Some(temp_scope), expr, mutability));

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -35,42 +35,49 @@ use std::convert::TryFrom;
 use std::mem;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
-    pub(crate) fn then_else_blocks(
+    pub(crate) fn then_else_break(
         &mut self,
         mut block: BasicBlock,
         expr: &Expr<'tcx>,
-        scope: region::Scope,
-        source_info: SourceInfo,
-    ) -> (BasicBlock, BasicBlock) {
+        temp_scope: region::Scope,
+        break_scope: region::Scope,
+        variable_scope_span: Span,
+    ) -> BlockAnd<()> {
         let this = self;
         let expr_span = expr.span;
 
         match expr.kind {
             ExprKind::Scope { region_scope, lint_level, value } => {
-                let region_scope = (region_scope, source_info);
-                let then_block;
-                let else_block = unpack!(
-                    then_block = this.in_scope(region_scope, lint_level, |this| {
-                        let (then_block, else_block) =
-                            this.then_else_blocks(block, &this.thir[value], scope, source_info);
-                        then_block.and(else_block)
-                    })
-                );
-                (then_block, else_block)
+                let region_scope = (region_scope, this.source_info(expr_span));
+                this.in_scope(region_scope, lint_level, |this| {
+                    this.then_else_break(
+                        block,
+                        &this.thir[value],
+                        temp_scope,
+                        break_scope,
+                        variable_scope_span,
+                    )
+                })
             }
             ExprKind::Let { expr, ref pat } => {
-                // FIXME: Use correct span.
-                this.lower_let(block, &this.thir[expr], pat, expr_span)
+                this.lower_let_else(block, &this.thir[expr], pat, break_scope, variable_scope_span)
             }
             _ => {
+                // TODO `as_temp`?
                 let mutability = Mutability::Mut;
-                let place = unpack!(block = this.as_temp(block, Some(scope), expr, mutability));
+                let place =
+                    unpack!(block = this.as_temp(block, Some(temp_scope), expr, mutability));
                 let operand = Operand::Move(Place::from(place));
+
                 let then_block = this.cfg.start_new_block();
                 let else_block = this.cfg.start_new_block();
                 let term = TerminatorKind::if_(this.tcx, operand, then_block, else_block);
+
+                let source_info = this.source_info(expr_span);
                 this.cfg.terminate(block, source_info, term);
-                (then_block, else_block)
+                this.break_for_else(else_block, break_scope, source_info);
+
+                then_block.unit()
             }
         }
     }
@@ -302,6 +309,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 let arm_source_info = self.source_info(arm.span);
                 let arm_scope = (arm.scope, arm_source_info);
+                let match_scope = self.local_scope();
                 self.in_scope(arm_scope, arm.lint_level, |this| {
                     // `try_upvars_resolved` may fail if it is unable to resolve the given
                     // `PlaceBuilder` inside a closure. In this case, we don't want to include
@@ -340,6 +348,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         scrutinee_span,
                         Some(arm.span),
                         Some(arm.scope),
+                        Some(match_scope),
                     );
 
                     if let Some(source_scope) = scope {
@@ -384,6 +393,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_span: Span,
         arm_span: Option<Span>,
         arm_scope: Option<region::Scope>,
+        match_scope: Option<region::Scope>,
     ) -> BasicBlock {
         if candidate.subcandidates.is_empty() {
             // Avoid generating another `BasicBlock` when we only have one
@@ -395,6 +405,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 fake_borrow_temps,
                 scrutinee_span,
                 arm_span,
+                match_scope,
                 true,
             )
         } else {
@@ -431,6 +442,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         &fake_borrow_temps,
                         scrutinee_span,
                         arm_span,
+                        match_scope,
                         schedule_drops,
                     );
                     if arm_scope.is_none() {
@@ -614,6 +626,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             None,
             &fake_borrow_temps,
             irrefutable_pat.span,
+            None,
             None,
             None,
         )
@@ -1742,13 +1755,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 // Pat binding - used for `let` and function parameters as well.
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
-    pub fn lower_let(
+    crate fn lower_let_else(
         &mut self,
         mut block: BasicBlock,
         expr: &Expr<'tcx>,
         pat: &Pat<'tcx>,
+        else_target: region::Scope,
         span: Span,
-    ) -> (BasicBlock, BasicBlock) {
+    ) -> BlockAnd<()> {
         let expr_span = expr.span;
         let expr_place_builder = unpack!(block = self.lower_scrutinee(block, expr, expr_span));
         let mut guard_candidate = Candidate::new(expr_place_builder.clone(), &pat, false);
@@ -1769,6 +1783,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             expr_place = expr_builder.into_place(self.tcx, self.typeck_results);
             opt_expr_place = Some((Some(&expr_place), expr_span));
         }
+        let otherwise_post_guard_block = otherwise_candidate.pre_binding_block.unwrap();
+        self.break_for_else(otherwise_post_guard_block, else_target, self.source_info(expr_span));
+
         self.declare_bindings(None, pat.span.to(span), pat, ArmHasGuard(false), opt_expr_place);
         let post_guard_block = self.bind_pattern(
             self.source_info(pat.span),
@@ -1778,9 +1795,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             expr.span,
             None,
             None,
+            None,
         );
-        let otherwise_post_guard_block = otherwise_candidate.pre_binding_block.unwrap();
-        (post_guard_block, otherwise_post_guard_block)
+
+        post_guard_block.unit()
     }
 
     /// Initializes each of the bindings from the candidate by
@@ -1799,6 +1817,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         fake_borrows: &Vec<(Place<'tcx>, Local)>,
         scrutinee_span: Span,
         arm_span: Option<Span>,
+        match_scope: Option<region::Scope>,
         schedule_drops: bool,
     ) -> BasicBlock {
         debug!("bind_and_guard_matched_candidate(candidate={:?})", candidate);
@@ -1929,17 +1948,25 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.push_assign(block, scrutinee_source_info, Place::from(temp), borrow);
             }
 
-            let (guard_span, (post_guard_block, otherwise_post_guard_block)) = match *guard {
-                Guard::If(e) => {
-                    let e = &self.thir[e];
-                    let source_info = self.source_info(e.span);
-                    (e.span, self.test_bool(block, e, source_info))
-                }
-                Guard::IfLet(ref pat, scrutinee) => {
-                    let s = &self.thir[scrutinee];
-                    (s.span, self.lower_let(block, s, pat, arm_span.unwrap()))
-                }
-            };
+            let arm_span = arm_span.unwrap();
+            let arm_scope = self.local_scope();
+            let match_scope = match_scope.unwrap();
+            let mut guard_span = rustc_span::DUMMY_SP;
+
+            let (post_guard_block, otherwise_post_guard_block) =
+                self.in_if_then_scope(match_scope, |this| match *guard {
+                    Guard::If(e) => {
+                        let e = &this.thir[e];
+                        guard_span = e.span;
+                        this.then_else_break(block, e, arm_scope, match_scope, arm_span)
+                    }
+                    Guard::IfLet(ref pat, scrutinee) => {
+                        let s = &this.thir[scrutinee];
+                        guard_span = s.span;
+                        this.lower_let_else(block, s, pat, match_scope, arm_span)
+                    }
+                });
+
             let source_info = self.source_info(guard_span);
             let guard_end = self.source_info(tcx.sess.source_map().end_point(guard_span));
             let guard_frame = self.guard_context.pop().unwrap();
@@ -1955,10 +1982,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.terminate(unreachable, source_info, TerminatorKind::Unreachable);
                 unreachable
             });
-            let outside_scope = self.cfg.start_new_block();
-            self.exit_top_scope(otherwise_post_guard_block, outside_scope, source_info);
             self.false_edges(
-                outside_scope,
+                otherwise_post_guard_block,
                 otherwise_block,
                 candidate.next_candidate_pre_binding_block,
                 source_info,

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -81,6 +81,8 @@ that contains only loops and breakable blocks. It tracks where a `break`,
 
 */
 
+use std::mem;
+
 use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder, CFG};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::vec::IndexVec;
@@ -93,8 +95,12 @@ use rustc_span::{Span, DUMMY_SP};
 #[derive(Debug)]
 pub struct Scopes<'tcx> {
     scopes: Vec<Scope>,
+
     /// The current set of breakable scopes. See module comment for more details.
     breakable_scopes: Vec<BreakableScope<'tcx>>,
+
+    /// The scope of the innermost if-then currently being lowered.
+    if_then_scope: Option<IfThenScope>,
 
     /// Drops that need to be done on unwind paths. See the comment on
     /// [DropTree] for more details.
@@ -164,6 +170,14 @@ struct BreakableScope<'tcx> {
     continue_drops: Option<DropTree>,
 }
 
+#[derive(Debug)]
+struct IfThenScope {
+    /// The if-then scope or arm scope
+    region_scope: region::Scope,
+    /// Drops that happen on the `else` path.
+    else_drops: DropTree,
+}
+
 /// The target of an expression that breaks out of a scope
 #[derive(Clone, Copy, Debug)]
 crate enum BreakableTarget {
@@ -183,6 +197,7 @@ const ROOT_NODE: DropIdx = DropIdx::from_u32(0);
 /// * Drops on unwind paths
 /// * Drops on generator drop paths (when a suspended generator is dropped)
 /// * Drops on return and loop exit paths
+/// * Drops on the else path in an `if let` chain
 ///
 /// Once no more nodes could be added to the tree, we lower it to MIR in one go
 /// in `build_mir`.
@@ -394,6 +409,7 @@ impl<'tcx> Scopes<'tcx> {
         Self {
             scopes: Vec::new(),
             breakable_scopes: Vec::new(),
+            if_then_scope: None,
             unwind_drops: DropTree::new(),
             generator_drops: DropTree::new(),
         }
@@ -481,6 +497,45 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 target.unit()
             }
         }
+    }
+
+    /// Start an if-then scope which tracks drop for `if` expressions and `if`
+    /// guards.
+    ///
+    /// For an if-let chain:
+    ///
+    /// if let Some(x) = a && let Some(y) = b && let Some(z) = c { ... }
+    ///
+    /// there are three possible ways the condition can be false and we may have
+    /// to drop `x`, `x` and `y`, or neither depending on which binding fails.
+    /// To handle this correctly we use a `DropTree` in a similar way to a
+    /// `loop` expression and 'break' out on all of the 'else' paths.
+    ///
+    /// Notes:
+    /// - We don't need to keep a stack of scopes in the `Builder` because the
+    ///   'else' paths will only leave the innermost scope.
+    /// - This is also used for match guards.
+    crate fn in_if_then_scope<F>(
+        &mut self,
+        region_scope: region::Scope,
+        f: F,
+    ) -> (BasicBlock, BasicBlock)
+    where
+        F: FnOnce(&mut Builder<'a, 'tcx>) -> BlockAnd<()>,
+    {
+        let scope = IfThenScope { region_scope, else_drops: DropTree::new() };
+        let previous_scope = mem::replace(&mut self.scopes.if_then_scope, Some(scope));
+
+        let then_block = unpack!(f(self));
+
+        let if_then_scope = mem::replace(&mut self.scopes.if_then_scope, previous_scope).unwrap();
+        assert!(if_then_scope.region_scope == region_scope);
+
+        let else_block = self
+            .build_exit_tree(if_then_scope.else_drops, None)
+            .map_or_else(|| self.cfg.start_new_block(), |else_block_and| unpack!(else_block_and));
+
+        (then_block, else_block)
     }
 
     crate fn in_opt_scope<F, R>(
@@ -651,22 +706,42 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.cfg.start_new_block().unit()
     }
 
+    crate fn break_for_else(
+        &mut self,
+        block: BasicBlock,
+        target: region::Scope,
+        source_info: SourceInfo,
+    ) {
+        let scope_index = self.scopes.scope_index(target, source_info.span);
+        let if_then_scope = self
+            .scopes
+            .if_then_scope
+            .as_mut()
+            .unwrap_or_else(|| span_bug!(source_info.span, "no if-then scope found"));
+
+        assert_eq!(if_then_scope.region_scope, target, "breaking to incorrect scope");
+
+        let mut drop_idx = ROOT_NODE;
+        let drops = &mut if_then_scope.else_drops;
+        for scope in &self.scopes.scopes[scope_index + 1..] {
+            for drop in &scope.drops {
+                drop_idx = drops.add_drop(*drop, drop_idx);
+            }
+        }
+        drops.add_entry(block, drop_idx);
+
+        // `build_drop_tree` doesn't have access to our source_info, so we
+        // create a dummy terminator now. `TerminatorKind::Resume` is used
+        // because MIR type checking will panic if it hasn't been overwritten.
+        self.cfg.terminate(block, source_info, TerminatorKind::Resume);
+    }
+
     // Add a dummy `Assign` statement to the CFG, with the span for the source code's `continue`
     // statement.
     fn add_dummy_assignment(&mut self, span: &Span, block: BasicBlock, source_info: SourceInfo) {
         let local_decl = LocalDecl::new(self.tcx.mk_unit(), *span).internal();
         let temp_place = Place::from(self.local_decls.push(local_decl));
         self.cfg.push_assign_unit(block, source_info, temp_place, self.tcx);
-    }
-
-    crate fn exit_top_scope(
-        &mut self,
-        mut block: BasicBlock,
-        target: BasicBlock,
-        source_info: SourceInfo,
-    ) {
-        block = self.leave_top_scope(block);
-        self.cfg.terminate(block, source_info, TerminatorKind::Goto { target });
     }
 
     fn leave_top_scope(&mut self, block: BasicBlock) -> BasicBlock {
@@ -927,61 +1002,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     // Other
     // =====
-    /// Branch based on a boolean condition.
-    ///
-    /// This is a special case because the temporary for the condition needs to
-    /// be dropped on both the true and the false arm.
-    crate fn test_bool(
-        &mut self,
-        mut block: BasicBlock,
-        condition: &Expr<'tcx>,
-        source_info: SourceInfo,
-    ) -> (BasicBlock, BasicBlock) {
-        let cond = unpack!(block = self.as_local_operand(block, condition));
-        let true_block = self.cfg.start_new_block();
-        let false_block = self.cfg.start_new_block();
-        let term = TerminatorKind::if_(self.tcx, cond.clone(), true_block, false_block);
-        self.cfg.terminate(block, source_info, term);
-
-        match cond {
-            // Don't try to drop a constant
-            Operand::Constant(_) => (),
-            Operand::Copy(place) | Operand::Move(place) => {
-                if let Some(cond_temp) = place.as_local() {
-                    // Manually drop the condition on both branches.
-                    let top_scope = self.scopes.scopes.last_mut().unwrap();
-                    let top_drop_data = top_scope.drops.pop().unwrap();
-                    if self.generator_kind.is_some() {
-                        top_scope.invalidate_cache();
-                    }
-
-                    match top_drop_data.kind {
-                        DropKind::Value { .. } => {
-                            bug!("Drop scheduled on top of condition variable")
-                        }
-                        DropKind::Storage => {
-                            let source_info = top_drop_data.source_info;
-                            let local = top_drop_data.local;
-                            assert_eq!(local, cond_temp, "Drop scheduled on top of condition");
-                            self.cfg.push(
-                                true_block,
-                                Statement { source_info, kind: StatementKind::StorageDead(local) },
-                            );
-                            self.cfg.push(
-                                false_block,
-                                Statement { source_info, kind: StatementKind::StorageDead(local) },
-                            );
-                        }
-                    }
-                } else {
-                    bug!("Expected as_local_operand to produce a temporary");
-                }
-            }
-        }
-
-        (true_block, false_block)
-    }
-
     /// Returns the [DropIdx] for the innermost drop if the function unwound at
     /// this point. The `DropIdx` will be created if it doesn't already exist.
     fn diverge_cleanup(&mut self) -> DropIdx {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -594,6 +594,10 @@ impl<'tcx> Cx<'tcx> {
                 ExprKind::Let { expr: self.mirror_expr(expr), pat: self.pattern_from_hir(pat) }
             }
             hir::ExprKind::If(cond, then, else_opt) => ExprKind::If {
+                if_then_scope: region::Scope {
+                    id: then.hir_id.local_id,
+                    data: region::ScopeData::IfThen,
+                },
                 cond: self.mirror_expr(cond),
                 then: self.mirror_expr(then),
                 else_opt: else_opt.map(|el| self.mirror_expr(el)),

--- a/compiler/rustc_mir_build/src/thir/visit.rs
+++ b/compiler/rustc_mir_build/src/thir/visit.rs
@@ -34,7 +34,7 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
             visitor.visit_expr(&visitor.thir()[value])
         }
         Box { value } => visitor.visit_expr(&visitor.thir()[value]),
-        If { cond, then, else_opt } => {
+        If { cond, then, else_opt, if_then_scope: _ } => {
             visitor.visit_expr(&visitor.thir()[cond]);
             visitor.visit_expr(&visitor.thir()[then]);
             if let Some(else_expr) = else_opt {

--- a/compiler/rustc_passes/src/region.rs
+++ b/compiler/rustc_passes/src/region.rs
@@ -391,21 +391,22 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
         }
 
         hir::ExprKind::If(ref cond, ref then, Some(ref otherwise)) => {
-            // FIXME(matthewjasper): ideally the scope we use here would only
-            // contain the condition and then expression. This works, but
-            // can result in some extra drop flags.
+            let expr_cx = visitor.cx;
+            visitor.enter_scope(Scope { id: then.hir_id.local_id, data: ScopeData::IfThen });
             visitor.cx.var_parent = visitor.cx.parent;
             visitor.visit_expr(cond);
-            visitor.cx.var_parent = prev_cx.var_parent;
             visitor.visit_expr(then);
+            visitor.cx = expr_cx;
             visitor.visit_expr(otherwise);
         }
 
         hir::ExprKind::If(ref cond, ref then, None) => {
+            let expr_cx = visitor.cx;
+            visitor.enter_scope(Scope { id: then.hir_id.local_id, data: ScopeData::IfThen });
             visitor.cx.var_parent = visitor.cx.parent;
             visitor.visit_expr(cond);
-            visitor.cx.var_parent = prev_cx.var_parent;
             visitor.visit_expr(then);
+            visitor.cx = expr_cx;
         }
 
         _ => intravisit::walk_expr(visitor, expr),

--- a/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Ne(move _3, const true);    // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:3:16: 3:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:3:5: 3:34
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Ne(const true, move _3);    // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:8:5: 8:34
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Eq(move _3, const false);   // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:13:17: 13:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:13:5: 13:35
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
       }
   
       bb1: {

--- a/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Eq(const false, move _3);   // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
 +         _2 = Not(move _3);               // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
           StorageDead(_3);                 // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:18:5: 18:35
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
       }
   
       bb1: {

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -29,7 +29,7 @@
 -     }
 - 
 -     bb3: {
--         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+-         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
 -     bb4: {

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -9,9 +9,9 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
 -         _1 = const <bool as NeedsDrop>::NEEDS; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
--         switchInt(move _1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:5: 14:6
+-         switchInt(move _1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
 +         _1 = const false;                // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
-+         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:5: 14:6
++         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
       }
   
       bb1: {

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -18,22 +18,22 @@
           ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31
-+         switchInt(const 1_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb1: {
-          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
       bb3: {
-          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -18,22 +18,22 @@
           ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
--         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31
-+         switchInt(const 1_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
++         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb1: {
-          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
-          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
+          switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
       bb2: {
-          switchInt(((_3 as Some).0: bool)) -> [false: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
+          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
       bb3: {
-          _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
+          _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -12,7 +12,7 @@
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
-          switchInt(move _3) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
+          switchInt(move _3) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
       }
   
       bb1: {

--- a/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
@@ -36,7 +36,7 @@
       }
   
       bb2: {
-          switchInt(move _3) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:15:13: 20:6
+          switchInt(move _3) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:15:16: 15:22
       }
   
       bb3: {

--- a/src/test/mir-opt/equal_true.opt.InstCombine.diff
+++ b/src/test/mir-opt/equal_true.opt.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Eq(move _3, const true);    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
 +         _2 = move _3;                    // scope 0 at $DIR/equal_true.rs:4:8: 4:17
           StorageDead(_3);                 // scope 0 at $DIR/equal_true.rs:4:16: 4:17
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:4:5: 4:34
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:4:8: 4:17
       }
   
       bb1: {

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -73,25 +73,10 @@
       bb5: {
           StorageDead(_8);                 // scope 2 at $DIR/funky_arms.rs:24:44: 24:45
           _9 = discriminant(_7);           // scope 2 at $DIR/funky_arms.rs:24:12: 24:27
-          switchInt(move _9) -> [1_isize: bb7, otherwise: bb6]; // scope 2 at $DIR/funky_arms.rs:24:12: 24:27
+          switchInt(move _9) -> [1_isize: bb6, otherwise: bb8]; // scope 2 at $DIR/funky_arms.rs:24:12: 24:27
       }
   
       bb6: {
-          StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
-          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
-          StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
-          _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
-          StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
-          _20 = _6;                        // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
-          StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
-          _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
-          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:28:9: 28:68
-                                           // mir::Constant
-                                           // + span: $DIR/funky_arms.rs:28:9: 28:45
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb7: {
           StorageLive(_10);                // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           _10 = ((_7 as Some).0: usize);   // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           StorageLive(_11);                // scope 2 at $DIR/funky_arms.rs:26:43: 26:46
@@ -110,19 +95,35 @@
           StorageDead(_15);                // scope 2 at $DIR/funky_arms.rs:26:78: 26:79
           StorageLive(_17);                // scope 2 at $DIR/funky_arms.rs:26:81: 26:86
           _17 = _3;                        // scope 2 at $DIR/funky_arms.rs:26:81: 26:86
-          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb8; // scope 2 at $DIR/funky_arms.rs:26:9: 26:87
+          _0 = float_to_exponential_common_exact::<T>(move _11, move _12, move _13, move _14, move _17) -> bb7; // scope 2 at $DIR/funky_arms.rs:26:9: 26:87
                                            // mir::Constant
                                            // + span: $DIR/funky_arms.rs:26:9: 26:42
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, u32, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb8: {
+      bb7: {
           StorageDead(_17);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_14);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_13);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_12);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_11);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
+          StorageDead(_10);                // scope 2 at $DIR/funky_arms.rs:27:5: 27:6
           goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:24:5: 29:6
+      }
+  
+      bb8: {
+          StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
+          _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
+          StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
+          _19 = _2;                        // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
+          StorageLive(_20);                // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
+          _20 = _6;                        // scope 2 at $DIR/funky_arms.rs:28:56: 28:60
+          StorageLive(_21);                // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
+          _21 = _3;                        // scope 2 at $DIR/funky_arms.rs:28:62: 28:67
+          _0 = float_to_exponential_common_shortest::<T>(move _18, move _19, move _20, move _21) -> bb9; // scope 2 at $DIR/funky_arms.rs:28:9: 28:68
+                                           // mir::Constant
+                                           // + span: $DIR/funky_arms.rs:28:9: 28:45
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb9: {
@@ -134,7 +135,6 @@
       }
   
       bb10: {
-          StorageDead(_10);                // scope 2 at $DIR/funky_arms.rs:29:5: 29:6
           StorageDead(_6);                 // scope 1 at $DIR/funky_arms.rs:30:1: 30:2
           StorageDead(_4);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2
           StorageDead(_7);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2

--- a/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
           _2 = _1;                         // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:17:5: 17:26
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
       }
   
       bb1: {

--- a/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
@@ -13,7 +13,7 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
           _2 = Eq(move _3, const -42f32);  // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
           StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:53:17: 53:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:53:5: 53:35
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
       }
   
       bb1: {

--- a/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
@@ -13,20 +13,20 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
 -         _2 = Eq(move _3, const 'x');     // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:15: 21:16
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:21:15: 21:16
-+         switchInt(move _3) -> ['x': bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
++         switchInt(move _3) -> ['x': bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:21:19: 21:20
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:21:30: 21:31
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
       }

--- a/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
@@ -13,20 +13,20 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
 -         _2 = Eq(move _3, const 42_i8);   // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:14: 25:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:25:14: 25:15
-+         switchInt(move _3) -> [42_i8: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
++         switchInt(move _3) -> [42_i8: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:25:18: 25:19
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:25:29: 25:30
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
       }

--- a/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
@@ -15,39 +15,39 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
 -         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:14: 33:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:33:14: 33:15
-+         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
++         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:34:9: 34:10
           goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
           StorageLive(_4);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           StorageLive(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
           _5 = _1;                         // scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
 -         _4 = Ne(move _5, const 21_u32);  // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
 -         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:21: 35:22
--         switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
+-         switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:35:21: 35:22
-+         switchInt(move _5) -> [21_u32: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
++         switchInt(move _5) -> [21_u32: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
       }
   
       bb3: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
++         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:36:9: 36:10
           goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
       }
   
       bb4: {
-+         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
++         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           _0 = const 2_u32;                // scope 0 at $DIR/if-condition-int.rs:38:9: 38:10
           goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
       }

--- a/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
@@ -13,20 +13,20 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
 -         _2 = Eq(move _3, const -42_i32); // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:15: 29:16
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:29:15: 29:16
-+         switchInt(move _3) -> [-42_i32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
++         switchInt(move _3) -> [-42_i32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:29:19: 29:20
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:29:30: 29:31
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
       }

--- a/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
@@ -13,20 +13,20 @@
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
 -         _2 = Eq(move _3, const 42_u32);  // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
 -         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:14: 12:15
--         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
+-         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
 +         nop;                             // scope 0 at $DIR/if-condition-int.rs:12:14: 12:15
-+         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
++         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
       }
   
       bb1: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:12:18: 12:19
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
       }
   
       bb2: {
-+         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
++         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:12:29: 12:30
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
       }

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -19,7 +19,7 @@
           _3 = _1;                         // scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
           _2 = Gt(move _3, const 0_i32);   // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
           StorageDead(_3);                 // scope 0 at $DIR/inline-diverging.rs:13:12: 13:13
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/inline-diverging.rs:13:5: 17:6
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
       }
   
       bb1: {

--- a/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
+++ b/src/test/mir-opt/instrument_coverage.main.InstrumentCoverage.diff
@@ -21,7 +21,7 @@
       }
   
       bb2: {
-          switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at /the/src/instrument_coverage.rs:12:9: 14:10
+          switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at /the/src/instrument_coverage.rs:12:12: 12:17
       }
   
       bb3: {

--- a/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
@@ -26,7 +26,7 @@ fn main() -> () {
         StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
         StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
-        switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
+        switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
     }
 
     bb3: {

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -26,14 +26,14 @@ fn main() -> () {
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
-        _2 = cond() -> [return: bb1, unwind: bb12]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
+        _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
                                          // mir::Constant
                                          // + span: $DIR/issue-41888.rs:8:8: 8:12
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        switchInt(move _2) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        switchInt(move _2) -> [false: bb7, otherwise: bb2]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
     }
 
     bb2: {
@@ -42,22 +42,26 @@ fn main() -> () {
         _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
         _3 = E::F(move _4);              // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageDead(_4);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-        goto -> bb15;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb3: {
-        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:14:6: 14:6
-        goto -> bb9;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
     }
 
     bb4: {
-        goto -> bb5;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+        StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+        _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
+        switchInt(move _5) -> [0_isize: bb5, otherwise: bb6]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
     }
 
     bb5: {
-        StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
-        _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
-        switchInt(move _5) -> [0_isize: bb7, otherwise: bb6]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
+        StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
+        _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
+        _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
+        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:10:29: 13:10
+        StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
     bb6: {
@@ -66,24 +70,16 @@ fn main() -> () {
     }
 
     bb7: {
-        StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
-        _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
-        _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
-        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:10:29: 13:10
-        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
+        _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:14:6: 14:6
+        goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
     bb8: {
-        StorageDead(_6);                 // scope 1 at $DIR/issue-41888.rs:13:9: 13:10
-        goto -> bb9;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
+        StorageDead(_2);                 // scope 1 at $DIR/issue-41888.rs:14:5: 14:6
+        goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb9: {
-        StorageDead(_2);                 // scope 1 at $DIR/issue-41888.rs:14:5: 14:6
-        goto -> bb21;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb10: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _9 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
@@ -91,66 +87,66 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
     }
 
+    bb10 (cleanup): {
+        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+    }
+
     bb11 (cleanup): {
-        goto -> bb12;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb12 (cleanup): {
-        goto -> bb13;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb13 (cleanup): {
         resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
     }
 
-    bb14 (cleanup): {
+    bb13 (cleanup): {
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+    }
+
+    bb14: {
+        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
+        goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
     bb15: {
-        _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        _1 = move _3;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-        goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
-    }
-
-    bb16: {
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        goto -> bb10;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb17 (cleanup): {
-        goto -> bb13;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb16 (cleanup): {
+        goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb18: {
-        drop(_1) -> [return: bb16, unwind: bb13]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb17: {
+        drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb19 (cleanup): {
-        drop(_1) -> bb13;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb18 (cleanup): {
+        drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    }
+
+    bb19: {
+        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _10) -> [0_isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb20: {
-        _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _10) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb21: {
-        switchInt(_7) -> [false: bb16, otherwise: bb20]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+    bb21 (cleanup): {
+        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(move _11) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
     bb22 (cleanup): {
-        _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-        switchInt(move _11) -> [0_isize: bb17, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
-    }
-
-    bb23 (cleanup): {
-        switchInt(_7) -> [false: bb13, otherwise: bb22]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
+        switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 }

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -43,27 +43,27 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb1: {
-        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
+        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         StorageLive(_3);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
         StorageLive(_4);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:29
         _4 = _1;                         // scope 0 at $DIR/issue-59352.rs:14:26: 14:29
-        _3 = char::methods::<impl char>::to_digit(move _4, const 8_u32) -> bb3; // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
+        _3 = char::methods::<impl char>::to_digit(move _4, const 8_u32) -> bb2; // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
                                          // mir::Constant
                                          // + span: $DIR/issue-59352.rs:14:30: 14:38
                                          // + literal: Const { ty: fn(char, u32) -> std::option::Option<u32> {std::char::methods::<impl char>::to_digit}, val: Value(Scalar(<ZST>)) }
     }
 
     bb2: {
-        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
-        _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:14:60: 14:61
-        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
-    }
-
-    bb3: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:14:40: 14:41
         StorageLive(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
         _10 = discriminant(_3);          // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+    }
+
+    bb3: {
+        StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
+        _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:14:60: 14:61
+        goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
     }
 
     bb4: {
@@ -82,7 +82,7 @@ fn num_to_digit(_1: char) -> u32 {
         StorageDead(_7);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
         StorageDead(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         StorageDead(_2);                 // scope 0 at $DIR/issue-59352.rs:14:22: 14:23
-        switchInt(move _11) -> [1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
+        switchInt(move _11) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
     }
 
     bb6: {

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -32,54 +32,54 @@
   
       bb1: {
           StorageDead(_3);                 // scope 2 at $DIR/issue-75439.rs:7:52: 7:53
-          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
+          switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb2: {
-          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
+          switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb3: {
-          switchInt(_2[2 of 4]) -> [0_u32: bb6, 4294901760_u32: bb7, otherwise: bb4]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
+          switchInt(_2[2 of 4]) -> [0_u32: bb5, 4294901760_u32: bb6, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb4: {
-          discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
-          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
-      }
-  
-      bb5: {
           StorageLive(_5);                 // scope 1 at $DIR/issue-75439.rs:10:14: 10:38
           StorageLive(_6);                 // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
           _6 = _4;                         // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
-          _5 = transmute::<u32, [u8; 4]>(move _6) -> bb8; // scope 4 at $DIR/issue-75439.rs:10:23: 10:36
+          _5 = transmute::<u32, [u8; 4]>(move _6) -> bb7; // scope 4 at $DIR/issue-75439.rs:10:23: 10:36
                                            // mir::Constant
                                            // + span: $DIR/issue-75439.rs:10:23: 10:32
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4] {std::intrinsics::transmute::<u32, [u8; 4]>}, val: Value(Scalar(<ZST>)) }
       }
   
+      bb5: {
+          StorageLive(_4);                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
+          _4 = _2[3 of 4];                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
+          goto -> bb4;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
+      }
+  
       bb6: {
           StorageLive(_4);                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
           _4 = _2[3 of 4];                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
-          goto -> bb5;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
+          goto -> bb4;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
       bb7: {
-          StorageLive(_4);                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
-          _4 = _2[3 of 4];                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
-          goto -> bb5;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
-      }
-  
-      bb8: {
           StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:10:35: 10:36
           ((_0 as Some).0: [u8; 4]) = move _5; // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           discriminant(_0) = 1;            // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           StorageDead(_5);                 // scope 1 at $DIR/issue-75439.rs:10:38: 10:39
+          StorageDead(_4);                 // scope 1 at $DIR/issue-75439.rs:11:5: 11:6
+          goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
+      }
+  
+      bb8: {
+          discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
           goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
       }
   
       bb9: {
-          StorageDead(_4);                 // scope 1 at $DIR/issue-75439.rs:13:5: 13:6
           StorageDead(_2);                 // scope 0 at $DIR/issue-75439.rs:14:1: 14:2
           return;                          // scope 0 at $DIR/issue-75439.rs:14:2: 14:2
       }

--- a/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
@@ -16,7 +16,7 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/loop_test.rs:10:5: 12:6
         StorageLive(_2);                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
         _2 = const true;                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
-        switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:5: 12:6
+        switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:8: 10:12
     }
 
     bb1: {

--- a/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
+++ b/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
@@ -33,7 +33,7 @@
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
-          switchInt(move _3) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
+          switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
       }
   
       bb2: {
@@ -41,17 +41,17 @@
           _7 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
           _8 = Len((*_2));                 // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
           _9 = Lt(_7, _8);                 // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb4; // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
+          assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb3; // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
       }
   
       bb3: {
-          _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:8:9: 8:11
+          _0 = (*_2)[_7];                  // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
+          StorageDead(_7);                 // scope 0 at $DIR/lower_slice_len.rs:7:5: 7:6
           goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
       }
   
       bb4: {
-          _0 = (*_2)[_7];                  // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
-          StorageDead(_7);                 // scope 0 at $DIR/lower_slice_len.rs:7:5: 7:6
+          _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:8:9: 8:11
           goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
       }
   

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -85,8 +85,8 @@
           StorageLive(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
           StorageLive(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
           _10 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(move _10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _10) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(move _10) -> [false: bb10, otherwise: bb9]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
++         switchInt(move _10) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
       }
   
 -     bb9: {
@@ -101,14 +101,13 @@
 -     bb10: {
 +     bb7: {
           _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
-          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         switchInt(move _9) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 +         switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
 -     bb11: {
 +     bb8: {
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -123,6 +122,7 @@
   
 -     bb12: {
 +     bb9: {
+          StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
@@ -141,8 +141,8 @@
           StorageLive(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
           StorageLive(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
           _13 = _1;                        // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
--         switchInt(move _13) -> [false: bb15, otherwise: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
-+         switchInt(move _13) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
+-         switchInt(move _13) -> [false: bb15, otherwise: bb14]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
++         switchInt(move _13) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
       }
   
 -     bb14: {
@@ -157,14 +157,13 @@
 -     bb15: {
 +     bb12: {
           _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
-          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         switchInt(move _12) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 +         switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
 -     bb16: {
 +     bb13: {
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -179,6 +178,7 @@
   
 -     bb17: {
 +     bb14: {
+          StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
@@ -190,6 +190,7 @@
 +     bb15: {
           StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -72,7 +72,6 @@ fn full_tested_match() -> () {
     }
 
     bb7: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
@@ -82,6 +81,7 @@ fn full_tested_match() -> () {
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:16:31: 16:37
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
     }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -70,7 +70,6 @@ fn full_tested_match2() -> () {
     }
 
     bb7: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
@@ -80,6 +79,7 @@ fn full_tested_match2() -> () {
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:27:31: 27:37
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
     }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -78,13 +78,13 @@ fn main() -> () {
     }
 
     bb7: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
     }
@@ -117,23 +117,24 @@ fn main() -> () {
     }
 
     bb11: {
-        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
     bb12: {
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
     }
 
     bb13: {
+        StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -75,9 +75,9 @@ fn main() -> () {
     }
 
     bb10: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:13:23: 13:24
     }
 

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -4,105 +4,80 @@
   fn match_nested_if() -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
       let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
-      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
       scope 1 {
           debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
-          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
--         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+-         switchInt(move _4) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 -     }
 - 
 -     bb1: {
--         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
+-         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb2: {
--         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
+-         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb3: {
-+         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
-+         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++         _5 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++         _3 = Ne(_5, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
++         StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
+-         switchInt(move _3) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb4: {
--         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
+-         _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb5: {
--         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
+-         _2 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb6: {
-+         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
-+         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
--         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _6 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _2 = Ne(_6, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
++         StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
+-         switchInt(move _2) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb7: {
--         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:42:13: 42:17
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -     }
 - 
 -     bb8: {
--         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+-         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
 -     bb9: {
-+         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
-+         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
--         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
--     }
-- 
--     bb10: {
-+         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--     }
-- 
--     bb11: {
--         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--     }
-- 
--     bb12: {
-+         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
-+         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:50:6: 50:7
++         _1 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
++         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
           StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
           return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -4,105 +4,80 @@
   fn match_nested_if() -> bool {
       let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
       let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
-      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-+     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+      let mut _2: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
       scope 1 {
           debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
-          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
-          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
--         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+-         switchInt(move _4) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 -     }
 - 
 -     bb1: {
--         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
+-         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb2: {
--         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
+-         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb3: {
-+         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-+         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
-+         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
-          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
--         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++         _5 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++         _3 = Ne(_5, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
++         StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
+-         switchInt(move _3) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb4: {
--         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
+-         _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb5: {
--         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
+-         _2 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb6: {
-+         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-+         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
-+         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
-          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
--         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _6 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _2 = Ne(_6, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
++         StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
+-         switchInt(move _2) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb7: {
--         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:42:13: 42:17
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
 -     }
 - 
 -     bb8: {
--         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+-         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
 -     bb9: {
-+         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
-+         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
--         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
--     }
-- 
--     bb10: {
-+         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-+         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--     }
-- 
--     bb11: {
--         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
--     }
-- 
--     bb12: {
-+         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
-+         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:50:6: 50:7
++         _1 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
++         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
           StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
           return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -5,16 +5,16 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
 | '_#2r | U0 | {}
 | '_#3r | U0 | {bb1[0..=7], bb2[0..=2]}
 | '_#4r | U0 | {bb1[1..=7], bb2[0..=2]}
 | '_#5r | U0 | {bb1[4..=7], bb2[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
 | '_#3r live at {bb1[0]}
 | '_#4r live at {bb1[1..=3]}
 | '_#5r live at {bb1[4..=7], bb2[0..=2]}
@@ -63,32 +63,32 @@ fn main() -> () {
         FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
         StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
         _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
     }
 
     bb2: {
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb4, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb5, unwind: bb7]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
+        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb4: {
-        StorageDead(_9);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb6;                     // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+                                         // mir::Constant
+                                         // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
+                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
     bb5: {

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -5,16 +5,16 @@
 | '_#1r | Local | ['_#1r]
 |
 | Inferred Region Values
-| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
-| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
+| '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
+| '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
 | '_#2r | U0 | {}
 | '_#3r | U0 | {bb1[0..=7], bb2[0..=2]}
 | '_#4r | U0 | {bb1[1..=7], bb2[0..=2]}
 | '_#5r | U0 | {bb1[4..=7], bb2[0..=2]}
 |
 | Inference Constraints
-| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
+| '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
 | '_#3r live at {bb1[0]}
 | '_#4r live at {bb1[1..=3]}
 | '_#5r live at {bb1[4..=7], bb2[0..=2]}
@@ -63,32 +63,32 @@ fn main() -> () {
         FakeRead(ForLet(None), _6);      // bb1[4]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
         StorageLive(_7);                 // bb1[5]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
         _7 = const Const(Value(Scalar(0x01)): bool); // bb1[6]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
-        switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb3, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
     }
 
     bb2: {
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
-        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb4, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
+        _8 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(move _9) -> [return: bb3, unwind: bb7]; // bb2[3]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
                                          // mir::Constant
                                          // + span: $DIR/region-subtyping-basic.rs:21:9: 21:14
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        StorageLive(_10);                // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb5, unwind: bb7]; // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
-                                         // mir::Constant
-                                         // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
-                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
+        StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
+        StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
+        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
+        goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
     bb4: {
-        StorageDead(_9);                 // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
-        StorageDead(_8);                 // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
-        _0 = const Const(Value(Scalar(<ZST>)): ()); // bb4[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
-        goto -> bb6;                     // bb4[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
+        StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+        _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
+                                         // mir::Constant
+                                         // + span: $DIR/region-subtyping-basic.rs:23:9: 23:14
+                                         // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
     bb5: {

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -14,7 +14,7 @@
 -         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
 +         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
           StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:17: 4:18
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
       }
   
       bb1: {

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -47,7 +47,6 @@
       }
   
       bb5: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _6);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
@@ -57,6 +56,7 @@
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
           _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
           goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
       }
   

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -21,9 +21,9 @@
       }
   
 -     bb2: {
--         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 +     bb1: {
-+         switchInt(move _2) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
++         switchInt(move _2) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       }
   
 -     bb3: {

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -13,12 +13,12 @@
       }
   
       bb1: {
--         falseUnwind -> [real: bb2, cleanup: bb10]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
+-         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
 -     }
 - 
 -     bb2: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
--         _2 = bar() -> [return: bb3, unwind: bb10]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
+-         _2 = bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 +         _2 = bar() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
                                            // mir::Constant
                                            // + span: $DIR/simplify_cfg.rs:9:12: 9:15
@@ -26,23 +26,21 @@
       }
   
 -     bb3: {
--         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 +     bb2: {
-+         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
++         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       }
   
 -     bb4: {
 +     bb3: {
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
--         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
+-         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
 +         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
 +         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
       }
   
 -     bb5: {
-+     bb4: {
-          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
--         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 -     }
 - 
 -     bb6: {
@@ -50,21 +48,27 @@
 -     }
 - 
 -     bb7: {
--         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
 -     }
 - 
 -     bb8: {
++     bb4: {
+          _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
+-         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
+-     }
+- 
+-     bb9: {
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
 -         goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
 +         goto -> bb0;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
--     bb9: {
+-     bb10: {
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
 -         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
 -     }
 - 
--     bb10 (cleanup): {
+-     bb11 (cleanup): {
 +     bb5 (cleanup): {
           resume;                          // scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
       }

--- a/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyBranches-after-const-prop.diff
@@ -9,26 +9,26 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
           _1 = const false;                // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
--         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
-+         goto -> bb2;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
+-         switchInt(const false) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
++         goto -> bb3;                     // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
       }
   
       bb1: {
           StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
-          _2 = noop() -> bb3;              // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
+          _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
                                            // mir::Constant
                                            // + span: $DIR/simplify_if.rs:7:9: 7:13
                                            // + literal: Const { ty: fn() {noop}, val: Value(Scalar(<ZST>)) }
       }
   
       bb2: {
-          nop;                             // scope 0 at $DIR/simplify_if.rs:8:6: 8:6
+          StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:7:15: 7:16
+          nop;                             // scope 0 at $DIR/simplify_if.rs:6:14: 8:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   
       bb3: {
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:7:15: 7:16
-          nop;                             // scope 0 at $DIR/simplify_if.rs:6:14: 8:6
+          nop;                             // scope 0 at $DIR/simplify_if.rs:8:6: 8:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -43,11 +43,11 @@
 -         _7 = Gt(move _8, const 42_u8);   // scope 0 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
 -         StorageDead(_8);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:5:19: 5:20
 -         StorageDead(_7);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:7:9: 7:10
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:8:5: 8:6
           goto -> bb3;                     // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
       }
   
       bb3: {
-          StorageDead(_6);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:8:5: 8:6
           drop(_1) -> bb4;                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:1: 9:2
       }
   

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -27,44 +27,43 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable.rs:9:12: 9:20
--         switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable.rs:9:12: 9:20
+-         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/unreachable.rs:9:12: 9:20
 +         goto -> bb2;                     // scope 0 at $DIR/unreachable.rs:9:12: 9:20
       }
   
       bb2: {
-          _0 = const ();                   // scope 0 at $DIR/unreachable.rs:19:6: 19:6
-          StorageDead(_3);                 // scope 0 at $DIR/unreachable.rs:19:5: 19:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:20:1: 20:2
-          return;                          // scope 0 at $DIR/unreachable.rs:20:2: 20:2
--     }
-- 
--     bb3: {
 -         StorageLive(_3);                 // scope 0 at $DIR/unreachable.rs:9:17: 9:19
 -         _3 = move ((_1 as Some).0: Empty); // scope 0 at $DIR/unreachable.rs:9:17: 9:19
 -         StorageLive(_4);                 // scope 0 at $DIR/unreachable.rs:10:13: 10:19
 -         StorageLive(_5);                 // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -         StorageLive(_6);                 // scope 2 at $DIR/unreachable.rs:12:12: 12:16
 -         _6 = const true;                 // scope 2 at $DIR/unreachable.rs:12:12: 12:16
--         switchInt(move _6) -> [false: bb5, otherwise: bb4]; // scope 2 at $DIR/unreachable.rs:12:9: 16:10
+-         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable.rs:12:12: 12:16
+-     }
+- 
+-     bb3: {
+-         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
+-         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:12:17: 14:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 
 -     bb4: {
--         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
--         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:12:17: 14:10
--         goto -> bb6;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
+-         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
+-         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:14:16: 16:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 
 -     bb5: {
--         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
--         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:14:16: 16:10
--         goto -> bb6;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
--     }
-- 
--     bb6: {
 -         StorageDead(_6);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
 -         StorageDead(_5);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
 -         StorageLive(_7);                 // scope 2 at $DIR/unreachable.rs:18:9: 18:21
 -         unreachable;                     // scope 2 at $DIR/unreachable.rs:18:15: 18:17
+-     }
+- 
+-     bb6: {
+          _0 = const ();                   // scope 0 at $DIR/unreachable.rs:19:6: 19:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:20:1: 20:2
+          return;                          // scope 0 at $DIR/unreachable.rs:20:2: 20:2
       }
   }
   

--- a/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
@@ -30,39 +30,32 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
-          switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
+          switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/unreachable_asm.rs:11:12: 11:20
       }
   
       bb2: {
-          _0 = const ();                   // scope 0 at $DIR/unreachable_asm.rs:23:6: 23:6
-          StorageDead(_3);                 // scope 0 at $DIR/unreachable_asm.rs:23:5: 23:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm.rs:24:1: 24:2
-          return;                          // scope 0 at $DIR/unreachable_asm.rs:24:2: 24:2
-      }
-  
-      bb3: {
           StorageLive(_3);                 // scope 0 at $DIR/unreachable_asm.rs:11:17: 11:19
           _3 = move ((_1 as Some).0: Empty); // scope 0 at $DIR/unreachable_asm.rs:11:17: 11:19
           StorageLive(_4);                 // scope 0 at $DIR/unreachable_asm.rs:12:13: 12:19
           StorageLive(_5);                 // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
           StorageLive(_6);                 // scope 2 at $DIR/unreachable_asm.rs:14:12: 14:16
           _6 = const true;                 // scope 2 at $DIR/unreachable_asm.rs:14:12: 14:16
-          switchInt(move _6) -> [false: bb5, otherwise: bb4]; // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
+          switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_asm.rs:14:12: 14:16
+      }
+  
+      bb3: {
+          _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm.rs:15:13: 15:20
+          _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:14:17: 16:10
+          goto -> bb5;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
       }
   
       bb4: {
-          _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm.rs:15:13: 15:20
-          _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:14:17: 16:10
-          goto -> bb6;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
+          _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm.rs:17:13: 17:20
+          _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:16:16: 18:10
+          goto -> bb5;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
       }
   
       bb5: {
-          _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm.rs:17:13: 17:20
-          _5 = const ();                   // scope 2 at $DIR/unreachable_asm.rs:16:16: 18:10
-          goto -> bb6;                     // scope 2 at $DIR/unreachable_asm.rs:14:9: 18:10
-      }
-  
-      bb6: {
           StorageDead(_6);                 // scope 2 at $DIR/unreachable_asm.rs:18:9: 18:10
           StorageDead(_5);                 // scope 2 at $DIR/unreachable_asm.rs:18:9: 18:10
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:9: 21:37
@@ -71,6 +64,12 @@
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:36: 21:37
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm.rs:22:9: 22:21
           unreachable;                     // scope 2 at $DIR/unreachable_asm.rs:22:15: 22:17
+      }
+  
+      bb6: {
+          _0 = const ();                   // scope 0 at $DIR/unreachable_asm.rs:23:6: 23:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm.rs:24:1: 24:2
+          return;                          // scope 0 at $DIR/unreachable_asm.rs:24:2: 24:2
       }
   }
   

--- a/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
@@ -33,53 +33,53 @@
   
       bb1: {
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
-          switchInt(move _2) -> [1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
+-         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
++         switchInt(move _2) -> [1_isize: bb2, otherwise: bb5]; // scope 0 at $DIR/unreachable_asm_2.rs:11:12: 11:20
       }
   
       bb2: {
-          _0 = const ();                   // scope 0 at $DIR/unreachable_asm_2.rs:25:6: 25:6
-          StorageDead(_3);                 // scope 0 at $DIR/unreachable_asm_2.rs:25:5: 25:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm_2.rs:26:1: 26:2
-          return;                          // scope 0 at $DIR/unreachable_asm_2.rs:26:2: 26:2
-      }
-  
-      bb3: {
           StorageLive(_3);                 // scope 0 at $DIR/unreachable_asm_2.rs:11:17: 11:19
           _3 = move ((_1 as Some).0: Empty); // scope 0 at $DIR/unreachable_asm_2.rs:11:17: 11:19
           StorageLive(_4);                 // scope 0 at $DIR/unreachable_asm_2.rs:12:13: 12:19
           StorageLive(_5);                 // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
           StorageLive(_6);                 // scope 2 at $DIR/unreachable_asm_2.rs:14:12: 14:16
           _6 = const true;                 // scope 2 at $DIR/unreachable_asm_2.rs:14:12: 14:16
-          switchInt(move _6) -> [false: bb5, otherwise: bb4]; // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
+          switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable_asm_2.rs:14:12: 14:16
       }
   
-      bb4: {
+      bb3: {
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:13: 16:41
           llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm_2.rs:16:22: 16:39
           _7 = const ();                   // scope 3 at $DIR/unreachable_asm_2.rs:16:13: 16:41
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:40: 16:41
           _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:17:13: 17:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm_2.rs:14:17: 18:10
--         goto -> bb6;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
 +         unreachable;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
       }
   
-      bb5: {
+      bb4: {
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:13: 20:41
           llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 4 at $DIR/unreachable_asm_2.rs:20:22: 20:39
           _8 = const ();                   // scope 4 at $DIR/unreachable_asm_2.rs:20:13: 20:41
           StorageDead(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:40: 20:41
           _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:21:13: 21:20
           _5 = const ();                   // scope 2 at $DIR/unreachable_asm_2.rs:18:16: 22:10
--         goto -> bb6;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
--     }
-- 
--     bb6: {
+-         goto -> bb5;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
++         unreachable;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
+      }
+  
+      bb5: {
 -         StorageDead(_6);                 // scope 2 at $DIR/unreachable_asm_2.rs:22:9: 22:10
 -         StorageDead(_5);                 // scope 2 at $DIR/unreachable_asm_2.rs:22:9: 22:10
 -         StorageLive(_9);                 // scope 2 at $DIR/unreachable_asm_2.rs:24:9: 24:21
 -         unreachable;                     // scope 2 at $DIR/unreachable_asm_2.rs:24:15: 24:17
-+         unreachable;                     // scope 2 at $DIR/unreachable_asm_2.rs:14:9: 22:10
+-     }
+- 
+-     bb6: {
+          _0 = const ();                   // scope 0 at $DIR/unreachable_asm_2.rs:25:6: 25:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable_asm_2.rs:26:1: 26:2
+          return;                          // scope 0 at $DIR/unreachable_asm_2.rs:26:2: 26:2
       }
   }
   

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -29,45 +29,46 @@
   
       bb1: {
           _3 = discriminant(_2);           // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
-          switchInt(move _3) -> [1_isize: bb3, otherwise: bb2]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
+-         switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
++         switchInt(move _3) -> [1_isize: bb2, otherwise: bb5]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
       }
   
       bb2: {
-          _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:19:6: 19:6
-          StorageDead(_4);                 // scope 1 at $DIR/unreachable_diverging.rs:19:5: 19:6
-          StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
-          StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
-          return;                          // scope 0 at $DIR/unreachable_diverging.rs:20:2: 20:2
-      }
-  
-      bb3: {
           StorageLive(_4);                 // scope 1 at $DIR/unreachable_diverging.rs:14:17: 14:21
           _4 = move ((_2 as Some).0: Empty); // scope 1 at $DIR/unreachable_diverging.rs:14:17: 14:21
           StorageLive(_5);                 // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
           StorageLive(_6);                 // scope 1 at $DIR/unreachable_diverging.rs:15:12: 15:13
           _6 = _1;                         // scope 1 at $DIR/unreachable_diverging.rs:15:12: 15:13
--         switchInt(move _6) -> [false: bb5, otherwise: bb4]; // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
-+         goto -> bb4;                     // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
+-         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/unreachable_diverging.rs:15:12: 15:13
++         goto -> bb3;                     // scope 1 at $DIR/unreachable_diverging.rs:15:12: 15:13
       }
   
-      bb4: {
--         _5 = loop_forever() -> bb6;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
-+         _5 = loop_forever() -> bb5;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
+      bb3: {
+-         _5 = loop_forever() -> bb5;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
++         _5 = loop_forever() -> bb4;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
                                            // mir::Constant
                                            // + span: $DIR/unreachable_diverging.rs:16:13: 16:25
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb5: {
+      bb4: {
 -         _5 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:17:10: 17:10
--         goto -> bb6;                     // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
+-         goto -> bb5;                     // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
 -     }
 - 
--     bb6: {
+-     bb5: {
           StorageDead(_6);                 // scope 1 at $DIR/unreachable_diverging.rs:17:9: 17:10
           StorageDead(_5);                 // scope 1 at $DIR/unreachable_diverging.rs:17:9: 17:10
           StorageLive(_7);                 // scope 1 at $DIR/unreachable_diverging.rs:18:9: 18:22
           unreachable;                     // scope 1 at $DIR/unreachable_diverging.rs:18:15: 18:19
+      }
+  
+-     bb6: {
++     bb5: {
+          _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:19:6: 19:6
+          StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
+          StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
+          return;                          // scope 0 at $DIR/unreachable_diverging.rs:20:2: 20:2
       }
   }
   

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
@@ -21,26 +21,26 @@
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
           discriminant(_3) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
 -         _4 = discriminant(_3);           // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
--         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
 +         _4 = const 0_isize;              // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
-+         switchInt(const 0_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
++         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
       bb1: {
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
+      }
+  
+      bb2: {
+          _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
+          nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
+          goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
+      }
+  
+      bb3: {
           StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           goto -> bb4;                     // scope 1 at no-location
-      }
-  
-      bb2: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
-      }
-  
-      bb3: {
-          _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
-          nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
-          goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   
       bb4: {

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
@@ -21,26 +21,26 @@
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
           discriminant(_3) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
 -         _4 = discriminant(_3);           // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
--         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
+-         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
 +         _4 = const 0_isize;              // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
-+         switchInt(const 0_isize) -> [1_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
++         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
       bb1: {
+          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
+      }
+  
+      bb2: {
+          _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
+          nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
+          goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
+      }
+  
+      bb3: {
           StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           goto -> bb4;                     // scope 1 at no-location
-      }
-  
-      bb2: {
-          switchInt(((_3 as Some).0: u32)) -> [0_u32: bb3, otherwise: bb1]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
-      }
-  
-      bb3: {
-          _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
-          nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
-          goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   
       bb4: {

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -20,37 +20,37 @@ fn while_loop(_1: bool) -> () {
 
     bb1: {
         StorageDead(_3);                 // scope 0 at $DIR/while-storage.rs:10:21: 10:22
-        switchInt(move _2) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/while-storage.rs:10:5: 14:6
+        switchInt(move _2) -> [false: bb6, otherwise: bb2]; // scope 0 at $DIR/while-storage.rs:10:11: 10:22
     }
 
     bb2: {
         StorageLive(_4);                 // scope 0 at $DIR/while-storage.rs:11:12: 11:23
         StorageLive(_5);                 // scope 0 at $DIR/while-storage.rs:11:21: 11:22
         _5 = _1;                         // scope 0 at $DIR/while-storage.rs:11:21: 11:22
-        _4 = get_bool(move _5) -> bb4;   // scope 0 at $DIR/while-storage.rs:11:12: 11:23
+        _4 = get_bool(move _5) -> bb3;   // scope 0 at $DIR/while-storage.rs:11:12: 11:23
                                          // mir::Constant
                                          // + span: $DIR/while-storage.rs:11:12: 11:20
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        goto -> bb7;                     // scope 0 at no-location
+        StorageDead(_5);                 // scope 0 at $DIR/while-storage.rs:11:22: 11:23
+        switchInt(move _4) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/while-storage.rs:11:12: 11:23
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 0 at $DIR/while-storage.rs:11:22: 11:23
-        switchInt(move _4) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/while-storage.rs:11:9: 13:10
+        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
+        goto -> bb7;                     // scope 0 at no-location
     }
 
     bb5: {
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
-        goto -> bb7;                     // scope 0 at no-location
+        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
+        goto -> bb0;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
     bb6: {
-        StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
-        StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
-        goto -> bb0;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
+        goto -> bb7;                     // scope 0 at no-location
     }
 
     bb7: {

--- a/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.uses_inline_crate.txt
+++ b/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.uses_inline_crate.txt
@@ -42,12 +42,12 @@
    40|      2|    println!("used_only_from_bin_crate_generic_function with {:?}", arg);
    41|      2|}
   ------------------
-  | used_inline_crate::used_only_from_bin_crate_generic_function::<&alloc::vec::Vec<i32>>:
+  | used_inline_crate::used_only_from_bin_crate_generic_function::<&str>:
   |   39|      1|pub fn used_only_from_bin_crate_generic_function<T: Debug>(arg: T) {
   |   40|      1|    println!("used_only_from_bin_crate_generic_function with {:?}", arg);
   |   41|      1|}
   ------------------
-  | used_inline_crate::used_only_from_bin_crate_generic_function::<&str>:
+  | used_inline_crate::used_only_from_bin_crate_generic_function::<&alloc::vec::Vec<i32>>:
   |   39|      1|pub fn used_only_from_bin_crate_generic_function<T: Debug>(arg: T) {
   |   40|      1|    println!("used_only_from_bin_crate_generic_function with {:?}", arg);
   |   41|      1|}
@@ -61,12 +61,12 @@
    46|      4|    println!("used_only_from_this_lib_crate_generic_function with {:?}", arg);
    47|      4|}
   ------------------
-  | used_inline_crate::used_only_from_this_lib_crate_generic_function::<alloc::vec::Vec<i32>>:
+  | used_inline_crate::used_only_from_this_lib_crate_generic_function::<&str>:
   |   45|      2|pub fn used_only_from_this_lib_crate_generic_function<T: Debug>(arg: T) {
   |   46|      2|    println!("used_only_from_this_lib_crate_generic_function with {:?}", arg);
   |   47|      2|}
   ------------------
-  | used_inline_crate::used_only_from_this_lib_crate_generic_function::<&str>:
+  | used_inline_crate::used_only_from_this_lib_crate_generic_function::<alloc::vec::Vec<i32>>:
   |   45|      2|pub fn used_only_from_this_lib_crate_generic_function<T: Debug>(arg: T) {
   |   46|      2|    println!("used_only_from_this_lib_crate_generic_function with {:?}", arg);
   |   47|      2|}

--- a/src/test/ui/consts/const-eval/infinite_loop.stderr
+++ b/src/test/ui/consts/const-eval/infinite_loop.stderr
@@ -1,8 +1,8 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite_loop.rs:7:17
+  --> $DIR/infinite_loop.rs:7:20
    |
 LL |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
+   |                    ^^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_limit/const_eval_limit_reached.stderr
+++ b/src/test/ui/consts/const_limit/const_eval_limit_reached.stderr
@@ -1,19 +1,15 @@
 error: any use of this value will cause an error
-  --> $DIR/const_eval_limit_reached.rs:6:5
+  --> $DIR/const_eval_limit_reached.rs:6:11
    |
-LL |  / const X: usize = {
-LL |  |     let mut x = 0;
-LL |  |     while x != 1000 {
-   |  |_____^
-LL | ||
-LL | ||
-LL | ||         x += 1;
-LL | ||     }
-   | ||_____^ exceeded interpreter step limit (see `#[const_eval_limit]`)
-LL |  |
-LL |  |     x
-LL |  | };
-   |  |__-
+LL | / const X: usize = {
+LL | |     let mut x = 0;
+LL | |     while x != 1000 {
+   | |           ^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
+LL | |
+...  |
+LL | |     x
+LL | | };
+   | |__-
    |
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/drop/drop-if-let-binding.rs
+++ b/src/test/ui/drop/drop-if-let-binding.rs
@@ -1,0 +1,7 @@
+// build-pass
+// regression test for issue #88307
+// compile-flags: -C opt-level=s
+
+fn main() {
+    if let Some(_val) = Option::<String>::None {}
+}


### PR DESCRIPTION
MIR lowering for `if let` expressions is now more complicated now that
`if let` exists in HIR. This PR adds a scope for the variables bound in
an `if let` expression and then uses an approach similar to how we
handle loops to ensure that we reliably drop the correct variables.

Closes #88307
cc @flip1995 @richkadel @c410-f3r 