### PR TITLE
rustdoc: Don't panic on ambiguous inherent associated types

### DIFF
--- a/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.rs
+++ b/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.rs
@@ -1,0 +1,17 @@
+// This test ensures that rustdoc does not panic on inherented associated types
+// that are referred to without fully-qualified syntax.
+
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+pub struct Struct;
+
+impl Struct {
+    pub type AssocTy = usize;
+    pub const AssocConst: Self::AssocTy = 42;
+    //~^ ERROR ambiguous associated type
+    //~| HELP use fully-qualified syntax
+    // FIXME: for some reason, the error is shown twice with rustdoc but only once with rustc
+    //~| ERROR ambiguous associated type
+    //~| HELP use fully-qualified syntax
+}

--- a/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.stderr
+++ b/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.stderr
@@ -1,0 +1,15 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/ambiguous-inherent-assoc-ty.rs:11:27
+   |
+LL |     pub const AssocConst: Self::AssocTy = 42;
+   |                           ^^^^^^^^^^^^^ help: use fully-qualified syntax: `<Struct as Trait>::AssocTy`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/ambiguous-inherent-assoc-ty.rs:11:27
+   |
+LL |     pub const AssocConst: Self::AssocTy = 42;
+   |                           ^^^^^^^^^^^^^ help: use fully-qualified syntax: `<Struct as Trait>::AssocTy`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Instead, return `Type::Infer` since compilation should fail anyway.
That's how rustdoc handles `hir::TyKind::Err`s, so this just extends
that behavior to `ty::Err`s when analyzing associated types.

For some reason, the error is printed twice with rustdoc (though only
once with rustc). I'm not sure why that is, but it's better than
panicking.

This commit also makes rustdoc fail early in the non-projection,
non-error case, instead of returning a `Res::Err` that would likely
cause rustdoc to panic later on. This change is originally from #88379.

r? @GuillaumeGomez
