### PR TITLE
Implement `Termination` for `Result<Infallible, E>`

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -106,6 +106,7 @@ mod tests;
 
 use crate::io::prelude::*;
 
+use crate::convert::Infallible;
 use crate::ffi::OsStr;
 use crate::fmt;
 use crate::fs;
@@ -2044,6 +2045,15 @@ impl Termination for ! {
 
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 impl<E: fmt::Debug> Termination for Result<!, E> {
+    fn report(self) -> i32 {
+        let Err(err) = self;
+        eprintln!("Error: {:?}", err);
+        ExitCode::FAILURE.report()
+    }
+}
+
+#[unstable(feature = "termination_trait_lib", issue = "43301")]
+impl<E: fmt::Debug> Termination for Result<Infallible, E> {
     fn report(self) -> i32 {
         let Err(err) = self;
         eprintln!("Error: {:?}", err);

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2056,8 +2056,7 @@ impl<E: fmt::Debug> Termination for Result<!, E> {
 impl<E: fmt::Debug> Termination for Result<Infallible, E> {
     fn report(self) -> i32 {
         let Err(err) = self;
-        eprintln!("Error: {:?}", err);
-        ExitCode::FAILURE.report()
+        Err::<!, _>(err).report()
     }
 }
 


### PR DESCRIPTION
As noted in #43301, `Result<!, E>` is not usable on stable.