### PR TITLE
rustdoc: Clean up handling of lifetime bounds

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -331,9 +331,10 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 match br {
                     // We only care about named late bound regions, as we need to add them
                     // to the 'for<>' section
-                    ty::BrNamed(_, name) => {
-                        Some(GenericParamDef { name, kind: GenericParamDefKind::Lifetime })
-                    }
+                    ty::BrNamed(_, name) => Some(GenericParamDef {
+                        name,
+                        kind: GenericParamDefKind::Lifetime { outlives: vec![] },
+                    }),
                     _ => None,
                 }
             })
@@ -659,7 +660,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                         bounds.insert(0, GenericBound::maybe_sized(self.cx));
                     }
                 }
-                GenericParamDefKind::Lifetime => {}
+                GenericParamDefKind::Lifetime { .. } => {}
                 GenericParamDefKind::Const { ref mut default, .. } => {
                     // We never want something like `impl<const N: usize = 10>`
                     default.take();

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1231,7 +1231,9 @@ impl WherePredicate {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate enum GenericParamDefKind {
-    Lifetime,
+    Lifetime {
+        outlives: Vec<Lifetime>,
+    },
     Type {
         did: DefId,
         bounds: Vec<GenericBound>,
@@ -1257,7 +1259,7 @@ impl GenericParamDefKind {
         match self {
             GenericParamDefKind::Type { default, .. } => default.clone(),
             GenericParamDefKind::Const { ty, .. } => Some(ty.clone()),
-            GenericParamDefKind::Lifetime => None,
+            GenericParamDefKind::Lifetime { .. } => None,
         }
     }
 }
@@ -1271,7 +1273,7 @@ crate struct GenericParamDef {
 impl GenericParamDef {
     crate fn is_synthetic_type_param(&self) -> bool {
         match self.kind {
-            GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => false,
+            GenericParamDefKind::Lifetime { .. } | GenericParamDefKind::Const { .. } => false,
             GenericParamDefKind::Type { ref synthetic, .. } => synthetic.is_some(),
         }
     }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -326,7 +326,9 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
     fn from_tcx(kind: clean::GenericParamDefKind, tcx: TyCtxt<'_>) -> Self {
         use clean::GenericParamDefKind::*;
         match kind {
-            Lifetime => GenericParamDefKind::Lifetime,
+            Lifetime { outlives } => GenericParamDefKind::Lifetime {
+                outlives: outlives.into_iter().map(|lt| lt.0.to_string()).collect(),
+            },
             Type { did: _, bounds, default, synthetic: _ } => GenericParamDefKind::Type {
                 bounds: bounds.into_iter().map(|x| x.into_tcx(tcx)).collect(),
                 default: default.map(|x| x.into_tcx(tcx)),

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -234,7 +234,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 6,
+            format_version: 7,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -4,6 +4,7 @@
 )]
 #![feature(rustc_private)]
 #![feature(array_methods)]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(in_band_lifetimes)]

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -323,7 +323,7 @@ pub struct GenericParamDef {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum GenericParamDefKind {
-    Lifetime,
+    Lifetime { outlives: Vec<String> },
     Type { bounds: Vec<GenericBound>, default: Option<Type> },
     Const { ty: Type, default: Option<String> },
 }

--- a/src/test/rustdoc-json/structs/with_primitives.rs
+++ b/src/test/rustdoc-json/structs/with_primitives.rs
@@ -1,7 +1,7 @@
 // @has with_primitives.json "$.index[*][?(@.name=='WithPrimitives')].visibility" \"public\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].kind" \"struct\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.generics.params[0].name" \"\'a\"
-// @has - "$.index[*][?(@.name=='WithPrimitives')].inner.generics.params[0].kind" \"lifetime\"
+// @has - "$.index[*][?(@.name=='WithPrimitives')].inner.generics.params[0].kind.lifetime.outlives" []
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.struct_type" \"plain\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.fields_stripped" true
 pub struct WithPrimitives<'a> {

--- a/src/test/rustdoc-ui/bounded-hr-lifetime.rs
+++ b/src/test/rustdoc-ui/bounded-hr-lifetime.rs
@@ -1,0 +1,9 @@
+// This test ensures that rustdoc doesn't panic on higher-ranked lifetimes
+// with bounds, because an error should have already been emitted by rustc.
+
+pub fn hrlt<'b, 'c>()
+where
+    for<'a: 'b + 'c> &'a (): std::fmt::Debug,
+    //~^ ERROR lifetime bounds cannot be used in this context
+{
+}

--- a/src/test/rustdoc-ui/bounded-hr-lifetime.stderr
+++ b/src/test/rustdoc-ui/bounded-hr-lifetime.stderr
@@ -1,0 +1,10 @@
+error: lifetime bounds cannot be used in this context
+  --> $DIR/bounded-hr-lifetime.rs:6:13
+   |
+LL |     for<'a: 'b + 'c> &'a (): std::fmt::Debug,
+   |             ^^   ^^
+
+error: Compilation failed, aborting rustdoc
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Previously, rustdoc recorded lifetime bounds by rendering them into the
name of the lifetime parameter. Now, it leaves the name as the actual
name and instead records lifetime bounds in an `outlives` list, similar
to how type parameter bounds are recorded.

Also, higher-ranked lifetimes cannot currently have bounds, so I simplified
the code to reflect that.

r? @GuillaumeGomez
