### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1380,7 +1380,17 @@ pub fn noop_flat_map_stmt<T: MutVisitor>(
 ) -> SmallVec<[Stmt; 1]> {
     vis.visit_id(&mut id);
     vis.visit_span(&mut span);
-    noop_flat_map_stmt_kind(kind, vis).into_iter().map(|kind| Stmt { id, kind, span }).collect()
+    let stmts: SmallVec<_> = noop_flat_map_stmt_kind(kind, vis)
+        .into_iter()
+        .map(|kind| Stmt { id, kind, span })
+        .collect();
+    if stmts.len() > 1 {
+        panic!(
+            "cloning statement `NodeId`s is prohibited by default, \
+             the visitor should implement custom statement visiting"
+        );
+    }
+    stmts
 }
 
 pub fn noop_flat_map_stmt_kind<T: MutVisitor>(

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -66,7 +66,7 @@ impl<'tcx> DebugContext<'tcx> {
             rustc_interface::util::version_str().unwrap_or("unknown version"),
             cranelift_codegen::VERSION,
         );
-        let comp_dir = tcx.sess.opts.working_dir.to_string_lossy(false).into_owned();
+        let comp_dir = tcx.sess.opts.working_dir.to_string_lossy(FileNameDisplayPreference::Remapped).into_owned();
         let (name, file_info) = match tcx.sess.local_crate_source_file.clone() {
             Some(path) => {
                 let name = path.to_string_lossy().into_owned();

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -74,7 +74,7 @@ mod vtable;
 mod prelude {
     pub(crate) use std::convert::{TryFrom, TryInto};
 
-    pub(crate) use rustc_span::Span;
+    pub(crate) use rustc_span::{Span, FileNameDisplayPreference};
 
     pub(crate) use rustc_hir::def_id::{DefId, LOCAL_CRATE};
     pub(crate) use rustc_middle::bug;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -35,6 +35,7 @@ use rustc_middle::ty::{self, AdtKind, GeneratorSubsts, ParamEnv, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_session::config::{self, DebugInfo};
 use rustc_span::symbol::{Interner, Symbol};
+use rustc_span::FileNameDisplayPreference;
 use rustc_span::{self, SourceFile, SourceFileHash, Span};
 use rustc_target::abi::{Abi, Align, HasDataLayout, Integer, LayoutOf, TagEncoding};
 use rustc_target::abi::{Int, Pointer, F32, F64};
@@ -771,7 +772,13 @@ pub fn file_metadata(cx: &CodegenCx<'ll, '_>, source_file: &SourceFile) -> &'ll 
     let hash = Some(&source_file.src_hash);
     let file_name = Some(source_file.name.prefer_remapped().to_string());
     let directory = if source_file.is_real_file() && !source_file.is_imported() {
-        Some(cx.sess().opts.working_dir.to_string_lossy(false).to_string())
+        Some(
+            cx.sess()
+                .opts
+                .working_dir
+                .to_string_lossy(FileNameDisplayPreference::Remapped)
+                .to_string(),
+        )
     } else {
         // If the path comes from an upstream crate we assume it has been made
         // independent of the compiler's working directory one way or another.
@@ -999,7 +1006,7 @@ pub fn compile_unit_metadata(
     let producer = format!("clang LLVM ({})", rustc_producer);
 
     let name_in_debuginfo = name_in_debuginfo.to_string_lossy();
-    let work_dir = tcx.sess.opts.working_dir.to_string_lossy(false);
+    let work_dir = tcx.sess.opts.working_dir.to_string_lossy(FileNameDisplayPreference::Remapped);
     let flags = "\0";
     let output_filenames = tcx.output_filenames(());
     let out_dir = &output_filenames.out_directory;

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -126,7 +126,7 @@ impl AnnotateSnippetEmitterWriter {
             }
             // owned: line source, line index, annotations
             type Owned = (String, usize, Vec<crate::snippet::Annotation>);
-            let filename = primary_lo.file.name.prefer_local();
+            let filename = source_map.filename_for_diagnostics(&primary_lo.file.name);
             let origin = filename.to_string_lossy();
             let annotated_files: Vec<Owned> = annotated_files
                 .into_iter()

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1320,7 +1320,7 @@ impl EmitterWriter {
                         buffer_msg_line_offset,
                         &format!(
                             "{}:{}:{}",
-                            loc.file.name.prefer_local(),
+                            sm.filename_for_diagnostics(&loc.file.name),
                             sm.doctest_offset_line(&loc.file.name, loc.line),
                             loc.col.0 + 1,
                         ),
@@ -1334,7 +1334,7 @@ impl EmitterWriter {
                         0,
                         &format!(
                             "{}:{}:{}: ",
-                            loc.file.name.prefer_local(),
+                            sm.filename_for_diagnostics(&loc.file.name),
                             sm.doctest_offset_line(&loc.file.name, loc.line),
                             loc.col.0 + 1,
                         ),
@@ -1362,12 +1362,12 @@ impl EmitterWriter {
                     };
                     format!(
                         "{}:{}{}",
-                        annotated_file.file.name.prefer_local(),
+                        sm.filename_for_diagnostics(&annotated_file.file.name),
                         sm.doctest_offset_line(&annotated_file.file.name, first_line.line_index),
                         col
                     )
                 } else {
-                    format!("{}", annotated_file.file.name.prefer_local())
+                    format!("{}", sm.filename_for_diagnostics(&annotated_file.file.name))
                 };
                 buffer.append(buffer_msg_line_offset + 1, &loc, Style::LineAndColumn);
                 for _ in 0..max_line_num_len {

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -464,7 +464,7 @@ impl DiagnosticSpan {
         });
 
         DiagnosticSpan {
-            file_name: start.file.name.prefer_local().to_string(),
+            file_name: je.sm.filename_for_diagnostics(&start.file.name).to_string(),
             byte_start: start.file.original_relative_byte_pos(span.lo()).0,
             byte_end: start.file.original_relative_byte_pos(span.hi()).0,
             line_start: start.line,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1113,7 +1113,7 @@ impl<'a> ExtCtxt<'a> {
                         span,
                         &format!(
                             "cannot resolve relative path in non-file source `{}`",
-                            other.prefer_local()
+                            self.source_map().filename_for_diagnostics(&other)
                         ),
                     ));
                 }

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(proc_macro_span)]
 #![feature(try_blocks)]
 #![cfg_attr(bootstrap, allow(incomplete_features))] // if_let_guard
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1626,14 +1626,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 (TypeError::Sorts(values), extra) => {
                     let sort_string = |ty: Ty<'tcx>| match (extra, ty.kind()) {
                         (true, ty::Opaque(def_id, _)) => {
-                            let pos = self
-                                .tcx
-                                .sess
-                                .source_map()
-                                .lookup_char_pos(self.tcx.def_span(*def_id).lo());
+                            let sm = self.tcx.sess.source_map();
+                            let pos = sm.lookup_char_pos(self.tcx.def_span(*def_id).lo());
                             format!(
                                 " (opaque type at <{}:{}:{}>)",
-                                pos.file.name.prefer_local(),
+                                sm.filename_for_diagnostics(&pos.file.name),
                                 pos.line,
                                 pos.col.to_usize() + 1,
                             )

--- a/compiler/rustc_mir/src/interpret/eval_context.rs
+++ b/compiler/rustc_mir/src/interpret/eval_context.rs
@@ -272,11 +272,12 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
                 write!(f, "inside `{}`", self.instance)?;
             }
             if !self.span.is_dummy() {
-                let lo = tcx.sess.source_map().lookup_char_pos(self.span.lo());
+                let sm = tcx.sess.source_map();
+                let lo = sm.lookup_char_pos(self.span.lo());
                 write!(
                     f,
                     " at {}:{}:{}",
-                    lo.file.name.prefer_local(),
+                    sm.filename_for_diagnostics(&lo.file.name),
                     lo.line,
                     lo.col.to_usize() + 1
                 )?;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -190,7 +190,7 @@ pub fn maybe_file_to_stream(
     let src = source_file.src.as_ref().unwrap_or_else(|| {
         sess.span_diagnostic.bug(&format!(
             "cannot lex `source_file` without source: {}",
-            source_file.name.prefer_local()
+            sess.source_map().filename_for_diagnostics(&source_file.name)
         ));
     });
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1432,12 +1432,22 @@ impl<'a> Parser<'a> {
                 // the most sense, which is immediately after the last token:
                 //
                 //  {foo(bar {}}
-                //      -      ^
+                //      ^      ^
                 //      |      |
                 //      |      help: `)` may belong here
                 //      |
                 //      unclosed delimiter
                 if let Some(sp) = unmatched.unclosed_span {
+                    let mut primary_span: Vec<Span> =
+                        err.span.primary_spans().iter().cloned().collect();
+                    primary_span.push(sp);
+                    let mut primary_span: MultiSpan = primary_span.into();
+                    for span_label in err.span.span_labels() {
+                        if let Some(label) = span_label.label {
+                            primary_span.push_span_label(span_label.span, label);
+                        }
+                    }
+                    err.set_span(primary_span);
                     err.span_label(sp, "unclosed delimiter");
                 }
                 // Backticks should be removed to apply suggestions.

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -427,7 +427,7 @@ impl SourceMap {
         }
     }
 
-    fn span_to_string(&self, sp: Span, prefer_local: bool) -> String {
+    fn span_to_string(&self, sp: Span, filename_display_pref: FileNameDisplayPreference) -> String {
         if self.files.borrow().source_files.is_empty() || sp.is_dummy() {
             return "no-location".to_string();
         }
@@ -436,7 +436,7 @@ impl SourceMap {
         let hi = self.lookup_char_pos(sp.hi());
         format!(
             "{}:{}:{}: {}:{}",
-            if prefer_local { lo.file.name.prefer_local() } else { lo.file.name.prefer_remapped() },
+            lo.file.name.display(filename_display_pref),
             lo.line,
             lo.col.to_usize() + 1,
             hi.line,
@@ -446,18 +446,22 @@ impl SourceMap {
 
     /// Format the span location suitable for embedding in build artifacts
     pub fn span_to_embeddable_string(&self, sp: Span) -> String {
-        self.span_to_string(sp, false)
+        self.span_to_string(sp, FileNameDisplayPreference::Remapped)
     }
 
     /// Format the span location to be printed in diagnostics. Must not be emitted
     /// to build artifacts as this may leak local file paths. Use span_to_embeddable_string
     /// for string suitable for embedding.
     pub fn span_to_diagnostic_string(&self, sp: Span) -> String {
-        self.span_to_string(sp, true)
+        self.span_to_string(sp, self.path_mapping.filename_display_for_diagnostics)
     }
 
     pub fn span_to_filename(&self, sp: Span) -> FileName {
         self.lookup_char_pos(sp.lo()).file.name.clone()
+    }
+
+    pub fn filename_for_diagnostics<'a>(&self, filename: &'a FileName) -> FileNameDisplay<'a> {
+        filename.display(self.path_mapping.filename_display_for_diagnostics)
     }
 
     pub fn is_multiline(&self, sp: Span) -> bool {
@@ -1002,15 +1006,22 @@ impl SourceMap {
 #[derive(Clone)]
 pub struct FilePathMapping {
     mapping: Vec<(PathBuf, PathBuf)>,
+    filename_display_for_diagnostics: FileNameDisplayPreference,
 }
 
 impl FilePathMapping {
     pub fn empty() -> FilePathMapping {
-        FilePathMapping { mapping: vec![] }
+        FilePathMapping::new(Vec::new())
     }
 
     pub fn new(mapping: Vec<(PathBuf, PathBuf)>) -> FilePathMapping {
-        FilePathMapping { mapping }
+        let filename_display_for_diagnostics = if mapping.is_empty() {
+            FileNameDisplayPreference::Local
+        } else {
+            FileNameDisplayPreference::Remapped
+        };
+
+        FilePathMapping { mapping, filename_display_for_diagnostics }
     }
 
     /// Applies any path prefix substitution as defined by the mapping.

--- a/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_solaris.rs
@@ -1,4 +1,4 @@
-use crate::spec::{LinkerFlavor, StackProbeType, Target};
+use crate::spec::{LinkerFlavor, SanitizerSet, StackProbeType, Target};
 
 pub fn target() -> Target {
     let mut base = super::solaris_base::opts();
@@ -8,6 +8,7 @@ pub fn target() -> Target {
     base.max_atomic_width = Some(64);
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;
+    base.supported_sanitizers = SanitizerSet::ADDRESS;
 
     Target {
         llvm_target: "x86_64-pc-solaris".to_string(),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_illumos.rs
@@ -1,10 +1,11 @@
-use crate::spec::{LinkerFlavor, Target};
+use crate::spec::{LinkerFlavor, SanitizerSet, Target};
 
 pub fn target() -> Target {
     let mut base = super::illumos_base::opts();
     base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".to_string(), "-std=c99".to_string()]);
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
+    base.supported_sanitizers = SanitizerSet::ADDRESS;
 
     Target {
         // LLVM does not currently have a separate illumos target,

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -120,7 +120,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     // Luckily the only types contained in default substs are type
     // parameters which don't matter here.
     //
-    // FIXME(const_param_types): Once complex const parameter types
+    // FIXME(adt_const_params): Once complex const parameter types
     // are allowed, this might be incorrect. I think that we will still be
     // fine, as all outlives relations of the const param types should also
     // be part of the adt containing it, but we should still both update the

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -120,7 +120,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     // Luckily the only types contained in default substs are type
     // parameters which don't matter here.
     //
-    // FIXME(const_generics): Once more complex const parameter types
+    // FIXME(const_param_types): Once complex const parameter types
     // are allowed, this might be incorrect. I think that we will still be
     // fine, as all outlives relations of the const param types should also
     // be part of the adt containing it, but we should still both update the

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -660,6 +660,18 @@ impl<T: Clone> Clone for Reverse<T> {
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the top-to-bottom declaration order of the struct's members.
 /// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
+/// This means variants at the top are less than variants at the bottom.
+/// Here's an example:
+///
+/// ```
+/// #[derive(PartialEq, PartialOrd)]
+/// enum Size {
+///     Small,
+///     Large,
+/// }
+///
+/// assert!(Size::Small < Size::Large);
+/// ```
 ///
 /// ## Lexicographical comparison
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -182,10 +182,6 @@ mod mut_ptr;
 /// // Ensure that the last item was dropped.
 /// assert!(weak.upgrade().is_none());
 /// ```
-///
-/// Notice that the compiler performs this copy automatically when dropping packed structs,
-/// i.e., you do not usually have to worry about such issues unless you call `drop_in_place`
-/// manually.
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[lang = "drop_in_place"]
 #[allow(unconditional_recursion)]

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -839,6 +839,8 @@ fn supported_sanitizers(
         "x86_64-unknown-netbsd" => {
             common_libs("netbsd", "x86_64", &["asan", "lsan", "msan", "tsan"])
         }
+        "x86_64-unknown-illumos" => common_libs("illumos", "x86_64", &["asan"]),
+        "x86_64-pc-solaris" => common_libs("solaris", "x86_64", &["asan"]),
         "x86_64-unknown-linux-gnu" => {
             common_libs("linux", "x86_64", &["asan", "lsan", "msan", "tsan"])
         }

--- a/src/test/run-make/wasm-spurious-import/Makefile
+++ b/src/test/run-make/wasm-spurious-import/Makefile
@@ -1,0 +1,7 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# only-wasm32-bare
+
+all:
+	$(RUSTC) main.rs -C overflow-checks=yes -C panic=abort -C lto -C opt-level=z --target wasm32-unknown-unknown
+	$(NODE) verify.js $(TMPDIR)/main.wasm

--- a/src/test/run-make/wasm-spurious-import/main.rs
+++ b/src/test/run-make/wasm-spurious-import/main.rs
@@ -1,0 +1,14 @@
+#![crate_type = "cdylib"]
+#![no_std]
+
+#[panic_handler]
+fn my_panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub fn multer(a: i128, b: i128) -> i128 {
+    // Trigger usage of the __multi3 compiler intrinsic which then leads to an imported
+    // panic function in case of a bug. We verify that no imports exist in our verifier.
+    a * b
+}

--- a/src/test/run-make/wasm-spurious-import/verify.js
+++ b/src/test/run-make/wasm-spurious-import/verify.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const process = require('process');
+const assert = require('assert');
+const buffer = fs.readFileSync(process.argv[2]);
+
+let m = new WebAssembly.Module(buffer);
+let imports = WebAssembly.Module.imports(m);
+console.log('imports', imports);
+assert.strictEqual(imports.length, 0);

--- a/src/test/ui/macros/issue-87877.rs
+++ b/src/test/ui/macros/issue-87877.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+macro_rules! two_items {
+    () => {
+        extern "C" {}
+        extern "C" {}
+    };
+}
+
+macro_rules! single_expr_funneler {
+    ($expr:expr) => {
+        $expr; // note the semicolon, it changes the statement kind during parsing
+    };
+}
+
+macro_rules! single_item_funneler {
+    ($item:item) => {
+        $item
+    };
+}
+
+fn main() {
+    single_expr_funneler! { two_items! {} }
+    single_item_funneler! { two_items! {} }
+}

--- a/src/test/ui/parser/issue-10636-1.stderr
+++ b/src/test/ui/parser/issue-10636-1.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-10636-1.rs:4:1
+  --> $DIR/issue-10636-1.rs:1:12
    |
 LL | struct Obj {
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 ...
 LL | )
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/issue-10636-2.stderr
+++ b/src/test/ui/parser/issue-10636-2.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/issue-10636-2.rs:5:25
+  --> $DIR/issue-10636-2.rs:5:15
    |
 LL |     option.map(|some| 42;
-   |               -         ^ help: `)` may belong here
+   |               ^         ^ help: `)` may belong here
    |               |
    |               unclosed delimiter
 

--- a/src/test/ui/parser/issue-58856-1.stderr
+++ b/src/test/ui/parser/issue-58856-1.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, or `:`, found `>`
-  --> $DIR/issue-58856-1.rs:3:14
+  --> $DIR/issue-58856-1.rs:3:9
    |
 LL |     fn b(self>
-   |         -    ^ help: `)` may belong here
+   |         ^    ^ help: `)` may belong here
    |         |
    |         unclosed delimiter
 

--- a/src/test/ui/parser/issue-58856-2.stderr
+++ b/src/test/ui/parser/issue-58856-2.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)` or `,`, found `->`
-  --> $DIR/issue-58856-2.rs:6:26
+  --> $DIR/issue-58856-2.rs:6:19
    |
 LL |     fn how_are_you(&self -> Empty {
-   |                   -     -^^
+   |                   ^     -^^
    |                   |     |
    |                   |     help: `)` may belong here
    |                   unclosed delimiter

--- a/src/test/ui/parser/issue-60075.stderr
+++ b/src/test/ui/parser/issue-60075.stderr
@@ -17,10 +17,10 @@ LL |     }
    |     - item list ends here
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-60075.rs:6:10
+  --> $DIR/issue-60075.rs:4:31
    |
 LL |     fn qux() -> Option<usize> {
-   |                               - unclosed delimiter
+   |                               ^ unclosed delimiter
 LL |         let _ = if true {
 LL |         });
    |          ^ mismatched closing delimiter

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -21,10 +21,10 @@ LL |
    |  ^
 
 error: expected one of `,` or `}`, found `{`
-  --> $DIR/issue-62973.rs:6:25
+  --> $DIR/issue-62973.rs:6:8
    |
 LL | fn p() { match s { v, E { [) {) }
-   |        -       -       -^ expected one of `,` or `}`
+   |        ^       -       -^ expected one of `,` or `}`
    |        |       |       |
    |        |       |       help: `}` may belong here
    |        |       while parsing this struct
@@ -56,18 +56,18 @@ LL |
    |  ^ expected one of `.`, `?`, `{`, or an operator
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-62973.rs:6:28
+  --> $DIR/issue-62973.rs:6:27
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                           -^ mismatched closing delimiter
+   |                           ^^ mismatched closing delimiter
    |                           |
    |                           unclosed delimiter
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/issue-62973.rs:6:31
+  --> $DIR/issue-62973.rs:6:30
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                              -^ mismatched closing delimiter
+   |                              ^^ mismatched closing delimiter
    |                              |
    |                              unclosed delimiter
 

--- a/src/test/ui/parser/issue-63116.stderr
+++ b/src/test/ui/parser/issue-63116.stderr
@@ -13,10 +13,10 @@ LL | impl W <s(f;Y(;]
    |            ^ expected one of 7 possible tokens
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-63116.rs:3:16
+  --> $DIR/issue-63116.rs:3:14
    |
 LL | impl W <s(f;Y(;]
-   |              - ^ mismatched closing delimiter
+   |              ^ ^ mismatched closing delimiter
    |              |
    |              unclosed delimiter
 

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
@@ -5,10 +5,10 @@ LL | fn f() { |[](* }
    |             ^ expected one of `,` or `:`
 
 error: expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`
-  --> $DIR/issue-66357-unexpected-unreachable.rs:12:14
+  --> $DIR/issue-66357-unexpected-unreachable.rs:12:13
    |
 LL | fn f() { |[](* }
-   |             -^ help: `)` may belong here
+   |             ^^ help: `)` may belong here
    |             |
    |             unclosed delimiter
 

--- a/src/test/ui/parser/issue-67377-invalid-syntax-in-enum-discriminant.stderr
+++ b/src/test/ui/parser/issue-67377-invalid-syntax-in-enum-discriminant.stderr
@@ -1,107 +1,107 @@
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:42
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:5:27
    |
 LL |         V = [PhantomData; { [ () ].len() ].len() as isize,
-   |             -             -              ^ mismatched closing delimiter
+   |             -             ^              ^ mismatched closing delimiter
    |             |             |
    |             |             unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:15:24
    |
 LL |         V = [Vec::new; { [].len()  ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this
 
 error: mismatched closing delimiter: `]`
-  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:36
+  --> $DIR/issue-67377-invalid-syntax-in-enum-discriminant.rs:26:24
    |
 LL |         V = [Vec::new; { [0].len() ].len() as isize,
-   |             -          -           ^ mismatched closing delimiter
+   |             -          ^           ^ mismatched closing delimiter
    |             |          |
    |             |          unclosed delimiter
    |             closing delimiter possibly meant for this

--- a/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-brace-paren.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/macro-mismatched-delim-brace-paren.rs:6:5
+  --> $DIR/macro-mismatched-delim-brace-paren.rs:4:10
    |
 LL |     foo! {
-   |          - unclosed delimiter
+   |          ^ unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
+++ b/src/test/ui/parser/macro-mismatched-delim-paren-brace.stderr
@@ -10,10 +10,10 @@ LL | }
    | ^ unexpected closing delimiter
 
 error: mismatched closing delimiter: `}`
-  --> $DIR/macro-mismatched-delim-paren-brace.rs:4:5
+  --> $DIR/macro-mismatched-delim-paren-brace.rs:2:10
    |
 LL |     foo! (
-   |          - unclosed delimiter
+   |          ^ unclosed delimiter
 LL |         bar, "baz", 1, 2.0
 LL |     }
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/parser-recovery-2.stderr
+++ b/src/test/ui/parser/parser-recovery-2.stderr
@@ -5,10 +5,10 @@ LL |     let x = y.;
    |               ^
 
 error: mismatched closing delimiter: `)`
-  --> $DIR/parser-recovery-2.rs:6:5
+  --> $DIR/parser-recovery-2.rs:4:14
    |
 LL |     fn bar() {
-   |              - unclosed delimiter
+   |              ^ unclosed delimiter
 LL |         let x = foo();
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
+++ b/src/test/ui/parser/unclosed-delimiter-in-dep.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/unclosed_delim_mod.rs:7:1
+  --> $DIR/unclosed_delim_mod.rs:5:7
    |
 LL | pub fn new() -> Result<Value, ()> {
    |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - unclosed delimiter
+   |       ^ unclosed delimiter
 LL |     }
 LL | }
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/unclosed_delim_mod.stderr
+++ b/src/test/ui/parser/unclosed_delim_mod.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/unclosed_delim_mod.rs:7:1
+  --> $DIR/unclosed_delim_mod.rs:5:7
    |
 LL | pub fn new() -> Result<Value, ()> {
    |                                   - closing delimiter possibly meant for this
 LL |     Ok(Value {
-   |       - unclosed delimiter
+   |       ^ unclosed delimiter
 LL |     }
 LL | }
    | ^ mismatched closing delimiter

--- a/src/test/ui/parser/use-unclosed-brace.stderr
+++ b/src/test/ui/parser/use-unclosed-brace.stderr
@@ -8,10 +8,10 @@ LL | fn main() {}
    |              ^
 
 error: expected one of `,`, `::`, `as`, or `}`, found `;`
-  --> $DIR/use-unclosed-brace.rs:4:19
+  --> $DIR/use-unclosed-brace.rs:4:10
    |
 LL | use foo::{bar, baz;
-   |          -        ^
+   |          ^        ^
    |          |        |
    |          |        expected one of `,`, `::`, `as`, or `}`
    |          |        help: `}` may belong here

--- a/src/test/ui/remap-path-prefix.rs
+++ b/src/test/ui/remap-path-prefix.rs
@@ -1,0 +1,5 @@
+// compile-flags: --remap-path-prefix={{src-base}}=remapped
+
+fn main() {
+    ferris //~ ERROR cannot find value `ferris` in this scope
+}

--- a/src/test/ui/remap-path-prefix.rs
+++ b/src/test/ui/remap-path-prefix.rs
@@ -1,5 +1,9 @@
 // compile-flags: --remap-path-prefix={{src-base}}=remapped
 
 fn main() {
-    ferris //~ ERROR cannot find value `ferris` in this scope
+    // We cannot actually put an ERROR marker here because
+    // the file name in the error message is not what the
+    // test framework expects (since the filename gets remapped).
+    // We still test the expected error in the stderr file.
+    ferris
 }

--- a/src/test/ui/remap-path-prefix.stderr
+++ b/src/test/ui/remap-path-prefix.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `ferris` in this scope
+  --> remapped/remap-path-prefix.rs:4:5
+   |
+LL |     ferris
+   |     ^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/remap-path-prefix.stderr
+++ b/src/test/ui/remap-path-prefix.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `ferris` in this scope
-  --> remapped/remap-path-prefix.rs:4:5
+  --> remapped/remap-path-prefix.rs:8:5
    |
 LL |     ferris
    |     ^^^^^^ not found in this scope

--- a/src/test/ui/resolve/token-error-correct-2.stderr
+++ b/src/test/ui/resolve/token-error-correct-2.stderr
@@ -1,8 +1,8 @@
 error: mismatched closing delimiter: `)`
-  --> $DIR/token-error-correct-2.rs:6:5
+  --> $DIR/token-error-correct-2.rs:4:12
    |
 LL |     if foo {
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 LL |
 LL |     )
    |     ^ mismatched closing delimiter

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/token-error-correct-3.rs:13:35
+  --> $DIR/token-error-correct-3.rs:13:21
    |
 LL |             callback(path.as_ref();
-   |                     -             ^ help: `)` may belong here
+   |                     ^             ^ help: `)` may belong here
    |                     |
    |                     unclosed delimiter
 

--- a/src/test/ui/resolve/token-error-correct-4.stderr
+++ b/src/test/ui/resolve/token-error-correct-4.stderr
@@ -1,8 +1,8 @@
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
-  --> $DIR/token-error-correct-4.rs:9:21
+  --> $DIR/token-error-correct-4.rs:9:12
    |
 LL |     setsuna(kazusa();
-   |            -        ^ help: `)` may belong here
+   |            ^        ^ help: `)` may belong here
    |            |
    |            unclosed delimiter
 

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -1,10 +1,10 @@
 error: mismatched closing delimiter: `}`
-  --> $DIR/token-error-correct.rs:6:1
+  --> $DIR/token-error-correct.rs:4:12
    |
 LL | fn main() {
    |           - closing delimiter possibly meant for this
 LL |     foo(bar(;
-   |            - unclosed delimiter
+   |            ^ unclosed delimiter
 LL |
 LL | }
    | ^ mismatched closing delimiter

--- a/src/tools/clippy/clippy_lints/src/macro_use.rs
+++ b/src/tools/clippy/clippy_lints/src/macro_use.rs
@@ -47,11 +47,8 @@ pub struct MacroRefData {
 
 impl MacroRefData {
     pub fn new(name: String, callee: Span, cx: &LateContext<'_>) -> Self {
-        let mut path = cx
-            .sess()
-            .source_map()
-            .span_to_filename(callee)
-            .prefer_local()
+        let sm = cx.sess().source_map();
+        let mut path = sm.filename_for_diagnostics(&sm.span_to_filename(callee))
             .to_string();
 
         // std lib paths are <::std::module::file type>


### PR DESCRIPTION
Successful merges:

 - #88202 (Add an example for deriving PartialOrd on enums)
 - #88363 (Path remapping: Make behavior of diagnostics output dependent on presence of --remap-path-prefix.)
 - #88386 (Point at unclosed delimiters as part of the primary MultiSpan)
 - #88428 (expand: Treat more macro calls as statement macro calls)
 - #88454 (sunos systems add sanitizer supported.)
 - #88478 (:arrow_up: rust-analyzer)
 - #88482 (Add regression test for a spurious import)
 - #88483 (Fix LLVM libunwind build for non-musl targets)
 - #88557 (small const generics cleanup)
 - #88579 (remove redundant / misplaced sentence from docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88202,88363,88386,88428,88454,88478,88482,88483,88557,88579)
<!-- homu-ignore:end -->