### PR TITLE
Add a better error message for #39364

### DIFF
--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -248,7 +248,11 @@ impl<T> Packet<T> {
     // Returns true if blocking should proceed.
     fn decrement(&self, token: SignalToken) -> StartResult {
         unsafe {
-            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0, "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364");
+            assert_eq!(
+                self.to_wake.load(Ordering::SeqCst),
+                0,
+                "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364"
+            );
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);
 

--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -248,7 +248,7 @@ impl<T> Packet<T> {
     // Returns true if blocking should proceed.
     fn decrement(&self, token: SignalToken) -> StartResult {
         unsafe {
-            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0);
+            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0, "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364");
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);
 

--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -251,7 +251,7 @@ impl<T> Packet<T> {
             assert_eq!(
                 self.to_wake.load(Ordering::SeqCst),
                 0,
-                "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364"
+                "This is a known bug in the Rust standard library. See https://github.com/rust-lang/rust/issues/39364"
             );
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);


### PR DESCRIPTION
There is a known bug in the implementation of mpsc channels in rust.
This adds a clearer error message when the bug occurs, so that developers don't lose too much time looking for the origin of the bug.
See https://github.com/rust-lang/rust/issues/39364