### PR TITLE
Improve `Cow::clone_from`

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -204,9 +204,12 @@ impl<B: ?Sized + ToOwned> Clone for Cow<'_, B> {
     }
 
     fn clone_from(&mut self, source: &Self) {
-        match (self, source) {
-            (&mut Owned(ref mut dest), &Owned(ref o)) => o.borrow().clone_into(dest),
-            (t, s) => *t = s.clone(),
+        match self {
+            Owned(dest) => {
+                let src: &B = source.borrow();
+                src.clone_into(dest);
+            }
+            dest => *dest = source.clone(),
         }
     }
 }


### PR DESCRIPTION
Previously this code would cause an allocation:

```rust
let mut dst = Cow::Owned("Hello".to_string());
let src = Cow::Borrowed("Hi");

dst.clone_from(src);
dst.to_mut()
```

After this PR this is no longer the case.