### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -120,7 +120,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     // Luckily the only types contained in default substs are type
     // parameters which don't matter here.
     //
-    // FIXME(const_param_types): Once complex const parameter types
+    // FIXME(adt_const_params): Once complex const parameter types
     // are allowed, this might be incorrect. I think that we will still be
     // fine, as all outlives relations of the const param types should also
     // be part of the adt containing it, but we should still both update the

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -120,7 +120,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     // Luckily the only types contained in default substs are type
     // parameters which don't matter here.
     //
-    // FIXME(const_generics): Once more complex const parameter types
+    // FIXME(const_param_types): Once complex const parameter types
     // are allowed, this might be incorrect. I think that we will still be
     // fine, as all outlives relations of the const param types should also
     // be part of the adt containing it, but we should still both update the

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -37,7 +37,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// Creates a new iterator over the given `array`.
     ///
     /// *Note*: this method might be deprecated in the future,
-    /// after [`IntoIterator` is implemented for arrays][array-into-iter].
+    /// since [`IntoIterator`] is now implemented for arrays.
     ///
     /// # Examples
     ///
@@ -48,8 +48,13 @@ impl<T, const N: usize> IntoIter<T, N> {
     ///     // The type of `value` is an `i32` here, instead of `&i32`
     ///     let _: i32 = value;
     /// }
+    ///
+    /// // Since Rust 1.53, arrays implement IntoIterator directly:
+    /// for value in [1, 2, 3, 4, 5] {
+    ///     // The type of `value` is an `i32` here, instead of `&i32`
+    ///     let _: i32 = value;
+    /// }
     /// ```
-    /// [array-into-iter]: https://github.com/rust-lang/rust/pull/65819
     #[stable(feature = "array_value_iter", since = "1.51.0")]
     pub fn new(array: [T; N]) -> Self {
         // SAFETY: The transmute here is actually safe. The docs of `MaybeUninit`

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -660,6 +660,18 @@ impl<T: Clone> Clone for Reverse<T> {
 /// This trait can be used with `#[derive]`. When `derive`d on structs, it will produce a
 /// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the top-to-bottom declaration order of the struct's members.
 /// When `derive`d on enums, variants are ordered by their top-to-bottom discriminant order.
+/// This means variants at the top are less than variants at the bottom.
+/// Here's an example:
+///
+/// ```
+/// #[derive(PartialEq, PartialOrd)]
+/// enum Size {
+///     Small,
+///     Large,
+/// }
+///
+/// assert!(Size::Small < Size::Large);
+/// ```
 ///
 /// ## Lexicographical comparison
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -182,10 +182,6 @@ mod mut_ptr;
 /// // Ensure that the last item was dropped.
 /// assert!(weak.upgrade().is_none());
 /// ```
-///
-/// Notice that the compiler performs this copy automatically when dropping packed structs,
-/// i.e., you do not usually have to worry about such issues unless you call `drop_in_place`
-/// manually.
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[lang = "drop_in_place"]
 #[allow(unconditional_recursion)]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 use core::cmp::Ordering;
+use core::mem::MaybeUninit;
 use core::result::Result::{Err, Ok};
 
 #[test]
@@ -2148,8 +2149,6 @@ fn test_slice_run_destructors() {
 #[test]
 fn test_slice_fill_with_uninit() {
     // This should not UB. See #87891
-    use core::mem::MaybeUninit;
-
     let mut a = [MaybeUninit::<u8>::uninit(); 10];
     a.fill(MaybeUninit::uninit());
 }

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2144,3 +2144,12 @@ fn test_slice_run_destructors() {
 
     assert_eq!(x.get(), 1);
 }
+
+#[test]
+fn test_slice_fill_with_uninit() {
+    // This should not UB. See #87891
+    use core::mem::MaybeUninit;
+
+    let mut a = [MaybeUninit::<u8>::uninit(); 10];
+    a.fill(MaybeUninit::uninit());
+}

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -581,6 +581,8 @@ mod prim_pointer {}
 /// might be made consistent to the behavior of later editions.
 ///
 /// ```rust,edition2018
+/// // Rust 2015 and 2018:
+///
 /// # #![allow(array_into_iter)] // override our `deny(warnings)`
 /// let array: [i32; 3] = [0; 3];
 ///
@@ -604,11 +606,13 @@ mod prim_pointer {}
 /// }
 /// ```
 ///
-/// Starting in the 2021 edition, `array.into_iter()` will use `IntoIterator` normally to iterate
+/// Starting in the 2021 edition, `array.into_iter()` uses `IntoIterator` normally to iterate
 /// by value, and `iter()` should be used to iterate by reference like previous editions.
 ///
-/// ```rust,edition2021,ignore
-/// # // FIXME: ignored because 2021 testing is still unstable
+#[cfg_attr(bootstrap, doc = "```rust,edition2021,ignore")]
+#[cfg_attr(not(bootstrap), doc = "```rust,edition2021")]
+/// // Rust 2021:
+///
 /// let array: [i32; 3] = [0; 3];
 ///
 /// // This iterates by reference:
@@ -631,12 +635,12 @@ mod prim_pointer {}
 /// avoid the `into_iter` syntax on those editions. If an edition update is not
 /// viable/desired, there are multiple alternatives:
 /// * use `iter`, equivalent to the old behavior, creating references
-/// * use [`array::IntoIter`], equivalent to the post-2021 behavior (Rust 1.51+)
+/// * use [`IntoIterator::into_iter`], equivalent to the post-2021 behavior (Rust 1.53+)
 /// * replace `for ... in array.into_iter() {` with `for ... in array {`,
 ///   equivalent to the post-2021 behavior (Rust 1.53+)
 ///
 /// ```rust,edition2018
-/// use std::array::IntoIter;
+/// // Rust 2015 and 2018:
 ///
 /// let array: [i32; 3] = [0; 3];
 ///
@@ -647,7 +651,7 @@ mod prim_pointer {}
 /// }
 ///
 /// // This iterates by value:
-/// for item in IntoIter::new(array) {
+/// for item in IntoIterator::into_iter(array) {
 ///     let x: i32 = item;
 ///     println!("{}", x);
 /// }
@@ -660,7 +664,7 @@ mod prim_pointer {}
 ///
 /// // IntoIter can also start a chain.
 /// // This iterates by value:
-/// for item in IntoIter::new(array).enumerate() {
+/// for item in IntoIterator::into_iter(array).enumerate() {
 ///     let (i, x): (usize, i32) = item;
 ///     println!("array[{}] = {}", i, x);
 /// }


### PR DESCRIPTION
Successful merges:

 - #88202 (Add an example for deriving PartialOrd on enums)
 - #88483 (Fix LLVM libunwind build for non-musl targets)
 - #88507 (Add test case for using `slice::fill` with MaybeUninit)
 - #88557 (small const generics cleanup)
 - #88579 (remove redundant / misplaced sentence from docs)
 - #88610 (Update outdated docs of array::IntoIter::new.)
 - #88613 (Update primitive docs for rust 2021.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88202,88483,88507,88557,88579,88610,88613)
<!-- homu-ignore:end -->