### PR TITLE
Improve structured tuple struct suggestion

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1514,7 +1514,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                     );
                     err.span_label(field.ident.span, "field does not exist");
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         expr_span,
                         &format!(
                             "`{adt}::{variant}` is a tuple {kind_name}, use the appropriate syntax",
@@ -1532,7 +1532,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => {
                     err.span_label(variant.ident.span, format!("`{adt}` defined here", adt = ty));
                     err.span_label(field.ident.span, "field does not exist");
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         expr_span,
                         &format!(
                             "`{adt}` is a tuple {kind_name}, use the appropriate syntax",

--- a/src/test/ui/issues/issue-4736.stderr
+++ b/src/test/ui/issues/issue-4736.stderr
@@ -5,10 +5,12 @@ LL | struct NonCopyable(());
    |        ----------- `NonCopyable` defined here
 ...
 LL |     let z = NonCopyable{ p: () };
-   |             -------------^------
-   |             |            |
-   |             |            field does not exist
-   |             help: `NonCopyable` is a tuple struct, use the appropriate syntax: `NonCopyable(/* fields */)`
+   |                          ^ field does not exist
+   |
+help: `NonCopyable` is a tuple struct, use the appropriate syntax
+   |
+LL |     let z = NonCopyable(/* fields */);
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-4736.stderr
+++ b/src/test/ui/issues/issue-4736.stderr
@@ -5,8 +5,9 @@ LL | struct NonCopyable(());
    |        ----------- `NonCopyable` defined here
 ...
 LL |     let z = NonCopyable{ p: () };
-   |             -----------  ^ field does not exist
-   |             |
+   |             -------------^------
+   |             |            |
+   |             |            field does not exist
    |             help: `NonCopyable` is a tuple struct, use the appropriate syntax: `NonCopyable(/* fields */)`
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-80607.stderr
+++ b/src/test/ui/issues/issue-80607.stderr
@@ -5,10 +5,12 @@ LL |     V1(i32),
    |     -- `Enum::V1` defined here
 ...
 LL |     Enum::V1 { x }
-   |     -----------^--
-   |     |          |
-   |     |          field does not exist
-   |     help: `Enum::V1` is a tuple variant, use the appropriate syntax: `Enum::V1(/* fields */)`
+   |                ^ field does not exist
+   |
+help: `Enum::V1` is a tuple variant, use the appropriate syntax
+   |
+LL |     Enum::V1(/* fields */)
+   |     ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-80607.stderr
+++ b/src/test/ui/issues/issue-80607.stderr
@@ -5,8 +5,9 @@ LL |     V1(i32),
    |     -- `Enum::V1` defined here
 ...
 LL |     Enum::V1 { x }
-   |     --------   ^ field does not exist
-   |     |
+   |     -----------^--
+   |     |          |
+   |     |          field does not exist
    |     help: `Enum::V1` is a tuple variant, use the appropriate syntax: `Enum::V1(/* fields */)`
 
 error: aborting due to previous error

--- a/src/test/ui/numeric/numeric-fields.stderr
+++ b/src/test/ui/numeric/numeric-fields.stderr
@@ -5,10 +5,12 @@ LL | struct S(u8, u16);
    |        - `S` defined here
 ...
 LL |     let s = S{0b1: 10, 0: 11};
-   |             --^^^------------
-   |             | |
-   |             | field does not exist
-   |             help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |               ^^^ field does not exist
+   |
+help: `S` is a tuple struct, use the appropriate syntax
+   |
+LL |     let s = S(/* fields */);
+   |             ~~~~~~~~~~~~~~~
 
 error[E0026]: struct `S` does not have a field named `0x1`
   --> $DIR/numeric-fields.rs:7:17

--- a/src/test/ui/numeric/numeric-fields.stderr
+++ b/src/test/ui/numeric/numeric-fields.stderr
@@ -5,8 +5,9 @@ LL | struct S(u8, u16);
    |        - `S` defined here
 ...
 LL |     let s = S{0b1: 10, 0: 11};
-   |             - ^^^ field does not exist
-   |             |
+   |             --^^^------------
+   |             | |
+   |             | field does not exist
    |             help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
 
 error[E0026]: struct `S` does not have a field named `0x1`

--- a/src/test/ui/suggestions/nested-non-tuple-tuple-struct.rs
+++ b/src/test/ui/suggestions/nested-non-tuple-tuple-struct.rs
@@ -1,0 +1,18 @@
+pub struct S(f32, f32);
+
+pub enum E {
+    V(f32, f32),
+}
+
+fn main() {
+    let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
+    //~^ ERROR struct `S` has no field named `x`
+    //~| ERROR struct `S` has no field named `y`
+    //~| ERROR struct `S` has no field named `x`
+    //~| ERROR struct `S` has no field named `y`
+    let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
+    //~^ ERROR variant `E::V` has no field named `x`
+    //~| ERROR variant `E::V` has no field named `y`
+    //~| ERROR variant `E::V` has no field named `x`
+    //~| ERROR variant `E::V` has no field named `y`
+}

--- a/src/test/ui/suggestions/nested-non-tuple-tuple-struct.stderr
+++ b/src/test/ui/suggestions/nested-non-tuple-tuple-struct.stderr
@@ -1,0 +1,100 @@
+error[E0560]: struct `S` has no field named `x`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:8:19
+   |
+LL | pub struct S(f32, f32);
+   |            - `S` defined here
+...
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
+   |               ----^---------------
+   |               |   |
+   |               |   field does not exist
+   |               help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+
+error[E0560]: struct `S` has no field named `y`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:8:27
+   |
+LL | pub struct S(f32, f32);
+   |            - `S` defined here
+...
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
+   |               ------------^-------
+   |               |           |
+   |               |           field does not exist
+   |               help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+
+error[E0560]: struct `S` has no field named `x`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:8:41
+   |
+LL | pub struct S(f32, f32);
+   |            - `S` defined here
+...
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
+   |                                     ----^---------------
+   |                                     |   |
+   |                                     |   field does not exist
+   |                                     help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+
+error[E0560]: struct `S` has no field named `y`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:8:49
+   |
+LL | pub struct S(f32, f32);
+   |            - `S` defined here
+...
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
+   |                                     ------------^-------
+   |                                     |           |
+   |                                     |           field does not exist
+   |                                     help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+
+error[E0559]: variant `E::V` has no field named `x`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:13:22
+   |
+LL |     V(f32, f32),
+   |     - `E::V` defined here
+...
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
+   |               -------^---------------
+   |               |      |
+   |               |      field does not exist
+   |               help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+
+error[E0559]: variant `E::V` has no field named `y`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:13:30
+   |
+LL |     V(f32, f32),
+   |     - `E::V` defined here
+...
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
+   |               ---------------^-------
+   |               |              |
+   |               |              field does not exist
+   |               help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+
+error[E0559]: variant `E::V` has no field named `x`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:13:47
+   |
+LL |     V(f32, f32),
+   |     - `E::V` defined here
+...
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
+   |                                        -------^---------------
+   |                                        |      |
+   |                                        |      field does not exist
+   |                                        help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+
+error[E0559]: variant `E::V` has no field named `y`
+  --> $DIR/nested-non-tuple-tuple-struct.rs:13:55
+   |
+LL |     V(f32, f32),
+   |     - `E::V` defined here
+...
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
+   |                                        ---------------^-------
+   |                                        |              |
+   |                                        |              field does not exist
+   |                                        help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0559, E0560.
+For more information about an error, try `rustc --explain E0559`.

--- a/src/test/ui/suggestions/nested-non-tuple-tuple-struct.stderr
+++ b/src/test/ui/suggestions/nested-non-tuple-tuple-struct.stderr
@@ -5,10 +5,12 @@ LL | pub struct S(f32, f32);
    |            - `S` defined here
 ...
 LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
-   |               ----^---------------
-   |               |   |
-   |               |   field does not exist
-   |               help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |                   ^ field does not exist
+   |
+help: `S` is a tuple struct, use the appropriate syntax
+   |
+LL |     let _x = (S(/* fields */), S { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:27
@@ -17,10 +19,12 @@ LL | pub struct S(f32, f32);
    |            - `S` defined here
 ...
 LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
-   |               ------------^-------
-   |               |           |
-   |               |           field does not exist
-   |               help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |                           ^ field does not exist
+   |
+help: `S` is a tuple struct, use the appropriate syntax
+   |
+LL |     let _x = (S(/* fields */), S { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:41
@@ -29,10 +33,12 @@ LL | pub struct S(f32, f32);
    |            - `S` defined here
 ...
 LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
-   |                                     ----^---------------
-   |                                     |   |
-   |                                     |   field does not exist
-   |                                     help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |                                         ^ field does not exist
+   |
+help: `S` is a tuple struct, use the appropriate syntax
+   |
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* fields */));
+   |                                     ~~~~~~~~~~~~~~~
 
 error[E0560]: struct `S` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:8:49
@@ -41,10 +47,12 @@ LL | pub struct S(f32, f32);
    |            - `S` defined here
 ...
 LL |     let _x = (S { x: 1.0, y: 2.0 }, S { x: 3.0, y: 4.0 });
-   |                                     ------------^-------
-   |                                     |           |
-   |                                     |           field does not exist
-   |                                     help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |                                                 ^ field does not exist
+   |
+help: `S` is a tuple struct, use the appropriate syntax
+   |
+LL |     let _x = (S { x: 1.0, y: 2.0 }, S(/* fields */));
+   |                                     ~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:22
@@ -53,10 +61,12 @@ LL |     V(f32, f32),
    |     - `E::V` defined here
 ...
 LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
-   |               -------^---------------
-   |               |      |
-   |               |      field does not exist
-   |               help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+   |                      ^ field does not exist
+   |
+help: `E::V` is a tuple variant, use the appropriate syntax
+   |
+LL |     let _y = (E::V(/* fields */), E::V { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:30
@@ -65,10 +75,12 @@ LL |     V(f32, f32),
    |     - `E::V` defined here
 ...
 LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
-   |               ---------------^-------
-   |               |              |
-   |               |              field does not exist
-   |               help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+   |                              ^ field does not exist
+   |
+help: `E::V` is a tuple variant, use the appropriate syntax
+   |
+LL |     let _y = (E::V(/* fields */), E::V { x: 3.0, y: 4.0 });
+   |               ~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `x`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:47
@@ -77,10 +89,12 @@ LL |     V(f32, f32),
    |     - `E::V` defined here
 ...
 LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
-   |                                        -------^---------------
-   |                                        |      |
-   |                                        |      field does not exist
-   |                                        help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+   |                                               ^ field does not exist
+   |
+help: `E::V` is a tuple variant, use the appropriate syntax
+   |
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* fields */));
+   |                                        ~~~~~~~~~~~~~~~~~~
 
 error[E0559]: variant `E::V` has no field named `y`
   --> $DIR/nested-non-tuple-tuple-struct.rs:13:55
@@ -89,10 +103,12 @@ LL |     V(f32, f32),
    |     - `E::V` defined here
 ...
 LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V { x: 3.0, y: 4.0 });
-   |                                        ---------------^-------
-   |                                        |              |
-   |                                        |              field does not exist
-   |                                        help: `E::V` is a tuple variant, use the appropriate syntax: `E::V(/* fields */)`
+   |                                                       ^ field does not exist
+   |
+help: `E::V` is a tuple variant, use the appropriate syntax
+   |
+LL |     let _y = (E::V { x: 1.0, y: 2.0 }, E::V(/* fields */));
+   |                                        ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Previously, the span was just for the constructor name, which meant it
would result in syntactically-invalid code when applied. Now, the span
is for the entire expression.

I also changed it to use `span_suggestion_verbose`, for two reasons:

1. Now that the suggestion span has been corrected, the output is a bit
   cluttered and hard to read. Putting the suggestion its own window
   creates more space.

2. It's easier to see what's being suggested, since now the version
   after the suggestion is applied is shown.

r? @davidtwco
