### PR TITLE
rustdoc: Fix ICE with `doc(hidden)` on tuple variant fields

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -942,15 +942,15 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
 }
 
 fn print_tuple_struct_fields(w: &mut Buffer, cx: &Context<'_>, s: &[clean::Item]) {
-    for (i, ty) in s
-        .iter()
-        .map(|f| if let clean::StructFieldItem(ref ty) = *f.kind { ty } else { unreachable!() })
-        .enumerate()
-    {
+    for (i, ty) in s.iter().enumerate() {
         if i > 0 {
             w.write_str(",&nbsp;");
         }
-        write!(w, "{}", ty.print(cx));
+        match *ty.kind {
+            clean::StrippedItem(box clean::StructFieldItem(_)) => w.write_str("_"),
+            clean::StructFieldItem(ref ty) => write!(w, "{}", ty.print(cx)),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -1066,24 +1066,27 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                     name = variant.name.as_ref().unwrap(),
                 );
                 for field in fields {
-                    use crate::clean::StructFieldItem;
-                    if let StructFieldItem(ref ty) = *field.kind {
-                        let id = cx.derive_id(format!(
-                            "variant.{}.field.{}",
-                            variant.name.as_ref().unwrap(),
-                            field.name.as_ref().unwrap()
-                        ));
-                        write!(
-                            w,
-                            "<span id=\"{id}\" class=\"variant small-section-header\">\
-                                 <a href=\"#{id}\" class=\"anchor field\"></a>\
-                                 <code>{f}:&nbsp;{t}</code>\
-                             </span>",
-                            id = id,
-                            f = field.name.as_ref().unwrap(),
-                            t = ty.print(cx)
-                        );
-                        document(w, cx, field, Some(variant));
+                    match *field.kind {
+                        clean::StrippedItem(box clean::StructFieldItem(_)) => {}
+                        clean::StructFieldItem(ref ty) => {
+                            let id = cx.derive_id(format!(
+                                "variant.{}.field.{}",
+                                variant.name.as_ref().unwrap(),
+                                field.name.as_ref().unwrap()
+                            ));
+                            write!(
+                                w,
+                                "<span id=\"{id}\" class=\"variant small-section-header\">\
+                                    <a href=\"#{id}\" class=\"anchor field\"></a>\
+                                    <code>{f}:&nbsp;{t}</code>\
+                                </span>",
+                                id = id,
+                                f = field.name.as_ref().unwrap(),
+                                t = ty.print(cx)
+                            );
+                            document(w, cx, field, Some(variant));
+                        }
+                        _ => unreachable!(),
                     }
                 }
                 w.write_str("</div></div>");

--- a/src/test/rustdoc/issue-88600.rs
+++ b/src/test/rustdoc/issue-88600.rs
@@ -1,0 +1,34 @@
+// This test ensure that #[doc(hidden)] is applied correctly in enum variant fields.
+
+// Denotes a field which should be hidden.
+pub struct H;
+
+// Denotes a field which should not be hidden (shown).
+pub struct S;
+
+// @has issue_88600/enum.FooEnum.html
+pub enum FooEnum {
+    // @has - '//*[@id="variant.HiddenTupleItem"]//code' 'HiddenTupleItem(_)'
+    // @count - '//*[@id="variant.HiddenTupleItem.field.0"]' 0
+    HiddenTupleItem(#[doc(hidden)] H),
+    // @has - '//*[@id="variant.MultipleHidden"]//code' 'MultipleHidden(_, _)'
+    // @count - '//*[@id="variant.MultipleHidden.field.0"]' 0
+    // @count - '//*[@id="variant.MultipleHidden.field.1"]' 0
+    MultipleHidden(#[doc(hidden)] H, #[doc(hidden)] H),
+    // @has - '//*[@id="variant.MixedHiddenFirst"]//code' 'MixedHiddenFirst(_, S)'
+    // @count - '//*[@id="variant.MixedHiddenFirst.field.0"]' 0
+    // @has - '//*[@id="variant.MixedHiddenFirst.field.1"]' '1: S'
+    MixedHiddenFirst(#[doc(hidden)] H, S),
+    // @has - '//*[@id="variant.MixedHiddenLast"]//code' 'MixedHiddenLast(S, _)'
+    // @has - '//*[@id="variant.MixedHiddenLast.field.0"]' '0: S'
+    // @count - '//*[@id="variant.MixedHiddenLast.field.1"]' 0
+    MixedHiddenLast(S, #[doc(hidden)] H),
+    // @has - '//*[@id="variant.HiddenStruct"]//code' 'HiddenStruct'
+    // @count - '//*[@id="variant.HiddenStruct.field.h"]' 0
+    // @has - '//*[@id="variant.HiddenStruct.field.s"]' 's: S'
+    HiddenStruct {
+        #[doc(hidden)]
+        h: H,
+        s: S,
+    },
+}


### PR DESCRIPTION
Fixes #88600.

```rust
pub struct H;
pub struct S;

pub enum FooEnum {
    HiddenTupleItem(#[doc(hidden)] H),
    MultipleHidden(#[doc(hidden)] H, #[doc(hidden)] H),
    MixedHiddenFirst(#[doc(hidden)] H, S),
    MixedHiddenLast(S, #[doc(hidden)] H),
    HiddenStruct {
        #[doc(hidden)]
        h: H,
        s: S,
    },
}
```

Generates
![image](https://user-images.githubusercontent.com/1502855/132259152-382f9517-c2a0-41d8-acd0-64e5993931fc.png)
