### PR TITLE
Revert "Auto merge of #82776 - jyn514:extern-url-fallback"

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -168,7 +168,6 @@ impl ExternalCrate {
     crate fn location(
         &self,
         extern_url: Option<&str>,
-        extern_url_takes_precedence: bool,
         dst: &std::path::Path,
         tcx: TyCtxt<'_>,
     ) -> ExternalLocation {
@@ -190,10 +189,8 @@ impl ExternalCrate {
             return Local;
         }
 
-        if extern_url_takes_precedence {
-            if let Some(url) = extern_url {
-                return to_remote(url);
-            }
+        if let Some(url) = extern_url {
+            return to_remote(url);
         }
 
         // Failing that, see if there's an attribute specifying where to find this
@@ -205,7 +202,6 @@ impl ExternalCrate {
             .filter_map(|a| a.value_str())
             .map(to_remote)
             .next()
-            .or(extern_url.map(to_remote)) // NOTE: only matters if `extern_url_takes_precedence` is false
             .unwrap_or(Unknown) // Well, at least we tried.
     }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -233,8 +233,6 @@ crate struct RenderOptions {
     crate extension_css: Option<PathBuf>,
     /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
     crate extern_html_root_urls: BTreeMap<String, String>,
-    /// Whether to give precedence to `html_root_url` or `--exten-html-root-url`.
-    crate extern_html_root_takes_precedence: bool,
     /// A map of the default settings (values are as for DOM storage API). Keys should lack the
     /// `rustdoc-` prefix.
     crate default_settings: FxHashMap<String, String>,
@@ -660,8 +658,6 @@ impl Options {
         let show_type_layout = matches.opt_present("show-type-layout");
         let nocapture = matches.opt_present("nocapture");
         let generate_link_to_definition = matches.opt_present("generate-link-to-definition");
-        let extern_html_root_takes_precedence =
-            matches.opt_present("extern-html-root-takes-precedence");
 
         if generate_link_to_definition && (show_coverage || output_format != OutputFormat::Html) {
             diag.struct_err(
@@ -717,7 +713,6 @@ impl Options {
                 themes,
                 extension_css,
                 extern_html_root_urls,
-                extern_html_root_takes_precedence,
                 default_settings,
                 resource_suffix,
                 enable_minification,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -499,7 +499,9 @@ crate fn run_global_ctxt(
 
     let render_options = ctxt.render_options;
     let mut cache = ctxt.cache;
-    krate = tcx.sess.time("create_format_cache", || cache.populate(krate, tcx, &render_options));
+    krate = tcx.sess.time("create_format_cache", || {
+        cache.populate(krate, tcx, &render_options.extern_html_root_urls, &render_options.output)
+    });
 
     // The main crate doc comments are always collapsed.
     krate.collapsed = true;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -295,13 +295,6 @@ fn opts() -> Vec<RustcOptGroup> {
                 "NAME=URL",
             )
         }),
-        unstable("extern-html-root-takes-precedence", |o| {
-            o.optflagmulti(
-                "",
-                "extern-html-root-takes-precedence",
-                "give precedence to `--extern-html-root-url`, not `html_root_url`",
-            )
-        }),
         stable("plugin-path", |o| o.optmulti("", "plugin-path", "removed", "DIR")),
         stable("C", |o| {
             o.optmulti("C", "codegen", "pass a codegen option to rustc", "OPT[=VALUE]")

--- a/src/test/rustdoc/auxiliary/html_root.rs
+++ b/src/test/rustdoc/auxiliary/html_root.rs
@@ -1,2 +1,0 @@
-#![doc(html_root_url="https://example.com/html_root")]
-pub fn foo() {}

--- a/src/test/rustdoc/auxiliary/no_html_root.rs
+++ b/src/test/rustdoc/auxiliary/no_html_root.rs
@@ -1,1 +1,0 @@
-pub fn bar() {}

--- a/src/test/rustdoc/extern-html-root-url-precedence.rs
+++ b/src/test/rustdoc/extern-html-root-url-precedence.rs
@@ -1,7 +1,0 @@
-// compile-flags:-Z unstable-options --extern-html-root-url core=https://example.com/core/0.1.0 --extern-html-root-takes-precedence
-
-// @has extern_html_root_url_precedence/index.html
-// --extern-html-root should take precedence if `--takes-precedence` is passed
-// @has - '//a/@href' 'https://example.com/core/0.1.0/core/iter/index.html'
-#[doc(no_inline)]
-pub use std::iter;

--- a/src/test/rustdoc/extern-html-root-url.rs
+++ b/src/test/rustdoc/extern-html-root-url.rs
@@ -1,18 +1,6 @@
-// compile-flags:-Z unstable-options --extern-html-root-url html_root=https://example.com/override --extern-html-root-url no_html_root=https://example.com/override
-// aux-build:html_root.rs
-// aux-build:no_html_root.rs
-// NOTE: intentionally does not build any auxiliary docs
-
-extern crate html_root;
-extern crate no_html_root;
+// compile-flags:-Z unstable-options --extern-html-root-url core=https://example.com/core/0.1.0
 
 // @has extern_html_root_url/index.html
-// `html_root_url` should override `--extern-html-root-url`
-// @has - '//a/@href' 'https://example.com/html_root/html_root/fn.foo.html'
+// @has - '//a/@href' 'https://example.com/core/0.1.0/core/iter/index.html'
 #[doc(no_inline)]
-pub use html_root::foo;
-
-#[doc(no_inline)]
-// `--extern-html-root-url` should apply if no `html_root_url` is given
-// @has - '//a/@href' 'https://example.com/override/no_html_root/fn.bar.html'
-pub use no_html_root::bar;
+pub use std::iter;


### PR DESCRIPTION
This reverts commit b1928aa3b4a8a2df462e408b67ad29737a3f8f31, reversing
changes made to 99b73e81b351d036449e76ad753160853625c5b6.

I don't have time to follow up on this right now, and @ehuss said it was breaking things for cargo in the meantime.

r? @ehuss (this is just a straight revert, so I don't expect you to review the code changes, just that tests pass and you think it's a good idea.)