### PR TITLE
Fix 2021 `dyn` suggestion that used code as label

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -945,7 +945,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     Ok(s) if s.starts_with('<') => sugg,
                     _ => format!("<{}>", sugg),
                 };
-                let replace = String::from("use `dyn`");
+                let sugg_label = "use `dyn`";
                 if self.sess().edition() >= Edition::Edition2021 {
                     let mut err = rustc_errors::struct_span_err!(
                         self.sess(),
@@ -956,8 +956,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     );
                     err.span_suggestion(
                         self_ty.span,
-                        &sugg,
-                        replace,
+                        sugg_label,
+                        sugg,
                         Applicability::MachineApplicable,
                     )
                     .emit();
@@ -968,7 +968,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self_ty.span,
                         |lint| {
                             let mut db = lint.build(msg);
-                            db.span_suggestion(self_ty.span, &replace, sugg, app);
+                            db.span_suggestion(self_ty.span, sugg_label, sugg, app);
                             db.emit()
                         },
                     );

--- a/src/test/ui/editions/dyn-trait-sugg-2021.rs
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.rs
@@ -1,0 +1,12 @@
+// edition:2021
+
+trait Foo<T> {}
+
+impl<T> dyn Foo<T> {
+    fn hi(_x: T)  {}
+}
+
+fn main() {
+    Foo::hi(123);
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+}

--- a/src/test/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.stderr
@@ -1,0 +1,9 @@
+error[E0783]: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-trait-sugg-2021.rs:10:5
+   |
+LL |     Foo::hi(123);
+   |     ^^^ help: use `dyn`: `<dyn Foo>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0783`.


### PR DESCRIPTION
The arguments to `span_suggestion` were in the wrong order, so the error
looked like this:

    error[E0783]: trait objects without an explicit `dyn` are deprecated
      --> src/test/ui/editions/dyn-trait-sugg-2021.rs:10:5
       |
    10 |     Foo::hi(123);
       |     ^^^ help: <dyn Foo>: `use `dyn``

Now the error looks like this, as expected:

    error[E0783]: trait objects without an explicit `dyn` are deprecated
      --> src/test/ui/editions/dyn-trait-sugg-2021.rs:10:5
       |
    10 |     Foo::hi(123);
       |     ^^^ help: use `dyn`: `<dyn Foo>`

This issue was only present in the 2021 error; the 2018 lint was
correct.

r? @m-ou-se
