### PR TITLE
Remove SmallVector mention

### DIFF
--- a/compiler/rustc_data_structures/src/thin_vec.rs
+++ b/compiler/rustc_data_structures/src/thin_vec.rs
@@ -2,7 +2,7 @@ use crate::stable_hasher::{HashStable, StableHasher};
 
 use std::iter::FromIterator;
 
-/// A vector type optimized for cases where this size is usually 0 (cf. `SmallVector`).
+/// A vector type optimized for cases where this size is usually 0 (cf. `SmallVec`).
 /// The `Option<Box<..>>` wrapping allows us to represent a zero sized vector with `None`,
 /// which uses only a single (null) pointer.
 #[derive(Clone, Encodable, Decodable, Debug)]


### PR DESCRIPTION
SmallVector is long gone, as it's been first replaced
by OneVector in commit e5e6375352636360add297c1f5a1f37ce71506e9,
which then has been removed entirely in favour of SmallVec in
commit 130a32fa7259d348dc3a684b38e688da398c30bb.