### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -945,7 +945,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     Ok(s) if s.starts_with('<') => sugg,
                     _ => format!("<{}>", sugg),
                 };
-                let replace = String::from("use `dyn`");
+                let sugg_label = "use `dyn`";
                 if self.sess().edition() >= Edition::Edition2021 {
                     let mut err = rustc_errors::struct_span_err!(
                         self.sess(),
@@ -956,8 +956,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     );
                     err.span_suggestion(
                         self_ty.span,
-                        &sugg,
-                        replace,
+                        sugg_label,
+                        sugg,
                         Applicability::MachineApplicable,
                     )
                     .emit();
@@ -968,7 +968,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         self_ty.span,
                         |lint| {
                             let mut db = lint.build(msg);
-                            db.span_suggestion(self_ty.span, &replace, sugg, app);
+                            db.span_suggestion(self_ty.span, sugg_label, sugg, app);
                             db.emit()
                         },
                     );

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -323,7 +323,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     pub fn reserve(&mut self, len: usize, additional: usize) {
         // Callers expect this function to be very cheap when there is already sufficient capacity.
         // Therefore, we move all the resizing and error-handling logic from grow_amortized and
-        // handle_reserve behind a call, while making sure that the this function is likely to be
+        // handle_reserve behind a call, while making sure that this function is likely to be
         // inlined as just a comparison and a call if the comparison fails.
         #[cold]
         fn do_reserve_and_handle<T, A: Allocator>(

--- a/src/test/ui/editions/dyn-trait-sugg-2021.rs
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.rs
@@ -1,0 +1,12 @@
+// edition:2021
+
+trait Foo<T> {}
+
+impl<T> dyn Foo<T> {
+    fn hi(_x: T)  {}
+}
+
+fn main() {
+    Foo::hi(123);
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+}

--- a/src/test/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.stderr
@@ -1,0 +1,9 @@
+error[E0783]: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-trait-sugg-2021.rs:10:5
+   |
+LL |     Foo::hi(123);
+   |     ^^^ help: use `dyn`: `<dyn Foo>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0783`.

--- a/src/test/ui/parser/attr-stmt-expr-attr-bad.stderr
+++ b/src/test/ui/parser/attr-stmt-expr-attr-bad.stderr
@@ -4,7 +4,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = box #![attr] 0; }
    |                                    ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected expression, found `]`
   --> $DIR/attr-stmt-expr-attr-bad.rs:7:40
@@ -24,7 +25,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = foo(#![attr]); }
    |                                    ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected expression, found `)`
   --> $DIR/attr-stmt-expr-attr-bad.rs:11:44
@@ -38,7 +40,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = x.foo(#![attr]); }
    |                                      ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected expression, found `)`
   --> $DIR/attr-stmt-expr-attr-bad.rs:14:46
@@ -52,7 +55,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = 0 + #![attr] 0; }
    |                                    ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:19:33
@@ -60,7 +64,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = !#![attr] 0; }
    |                                 ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:21:33
@@ -68,7 +73,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = -#![attr] 0; }
    |                                 ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:23:34
@@ -82,7 +88,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = || #![attr] foo; }
    |                                   ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:27:40
@@ -90,7 +97,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = move || #![attr] foo; }
    |                                        ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:29:35
@@ -98,7 +106,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = || #![attr] {foo}; }
    |                                   ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:31:40
@@ -106,7 +115,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = move || #![attr] {foo}; }
    |                                        ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected expression, found `..`
   --> $DIR/attr-stmt-expr-attr-bad.rs:33:40
@@ -126,7 +136,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = #[attr] &#![attr] 0; }
    |                                         ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/attr-stmt-expr-attr-bad.rs:39:45
@@ -134,7 +145,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = #[attr] &mut #![attr] 0; }
    |                                             ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:41:37
@@ -151,7 +163,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {#![attr]}; }
    |                                      ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected one of `.`, `;`, `?`, `else`, or an operator, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:45:40
@@ -174,7 +187,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {} else {#![attr]}; }
    |                                              ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:51:45
@@ -200,7 +214,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if 0 {} else if 0 {#![attr]}; }
    |                                                   ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:57:45
@@ -217,7 +232,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {#![attr]}; }
    |                                              ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: expected one of `.`, `;`, `?`, `else`, or an operator, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:61:48
@@ -240,7 +256,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else {#![attr]}; }
    |                                                      ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/attr-stmt-expr-attr-bad.rs:67:53
@@ -266,7 +283,8 @@ error: an inner attribute is not permitted in this context
 LL | #[cfg(FALSE)] fn e() { let _ = if let _ = 0 {} else if let _ = 0 {#![attr]}; }
    |                                                                   ^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:74:32
@@ -276,7 +294,8 @@ LL | #[cfg(FALSE)] fn s() { #[attr] #![attr] let _ = 0; }
    |                        |
    |                        previous outer attribute
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:76:32
@@ -286,37 +305,56 @@ LL | #[cfg(FALSE)] fn s() { #[attr] #![attr] 0; }
    |                        |
    |                        previous outer attribute
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:78:32
    |
 LL | #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!(); }
-   |                        ------- ^^^^^^^^ not permitted following an outer attribute
-   |                        |
+   |                        ------- ^^^^^^^^ ------- the inner attribute doesn't annotate this item macro invocation
+   |                        |       |
+   |                        |       not permitted following an outer attribute
    |                        previous outer attribute
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the item macro invocation, change the attribute from inner to outer style
+   |
+LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!(); }
+LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo!(); }
+   | 
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:80:32
    |
 LL | #[cfg(FALSE)] fn s() { #[attr] #![attr] foo![]; }
-   |                        ------- ^^^^^^^^ not permitted following an outer attribute
-   |                        |
+   |                        ------- ^^^^^^^^ ------- the inner attribute doesn't annotate this item macro invocation
+   |                        |       |
+   |                        |       not permitted following an outer attribute
    |                        previous outer attribute
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the item macro invocation, change the attribute from inner to outer style
+   |
+LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo![]; }
+LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo![]; }
+   | 
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:82:32
    |
 LL | #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!{}; }
-   |                        ------- ^^^^^^^^ not permitted following an outer attribute
-   |                        |
+   |                        ------- ^^^^^^^^ ------ the inner attribute doesn't annotate this item macro invocation
+   |                        |       |
+   |                        |       not permitted following an outer attribute
    |                        previous outer attribute
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the item macro invocation, change the attribute from inner to outer style
+   |
+LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!{}; }
+LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo!{}; }
+   | 
 
 error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:35

--- a/src/test/ui/parser/attr.stderr
+++ b/src/test/ui/parser/attr.stderr
@@ -3,8 +3,16 @@ error: an inner attribute is not permitted in this context
    |
 LL | #![lang = "foo"]
    | ^^^^^^^^^^^^^^^^
+LL |
+LL | fn foo() {}
+   | ----------- the inner attribute doesn't annotate this function
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the function, change the attribute from inner to outer style
+   |
+LL - #![lang = "foo"]
+LL + #[lang = "foo"]
+   | 
 
 error[E0522]: definition of an unknown language item: `foo`
   --> $DIR/attr.rs:5:1

--- a/src/test/ui/parser/doc-comment-in-if-statement.stderr
+++ b/src/test/ui/parser/doc-comment-in-if-statement.stderr
@@ -5,6 +5,11 @@ LL |     if true /*!*/ {}
    |             ^^^^^
    |
    = note: inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
+help: you might have meant to write a regular comment
+   |
+LL -     if true /*!*/ {}
+LL +     if true /**/ {}
+   | 
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/doc-comment-in-if-statement.rs:2:13

--- a/src/test/ui/parser/inner-attr-after-doc-comment.stderr
+++ b/src/test/ui/parser/inner-attr-after-doc-comment.stderr
@@ -8,8 +8,16 @@ LL | |  */
 LL | 
 LL |   #![recursion_limit="100"]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
+LL |
+LL |   fn main() {}
+   |   ------------ the inner attribute doesn't annotate this function
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the function, change the attribute from inner to outer style
+   |
+LL - #![recursion_limit="100"]
+LL + #[recursion_limit="100"]
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/inner-attr.stderr
+++ b/src/test/ui/parser/inner-attr.stderr
@@ -6,8 +6,15 @@ LL | #[feature(lang_items)]
 LL | 
 LL | #![recursion_limit="100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the function, change the attribute from inner to outer style
+   |
+LL - #![recursion_limit="100"]
+LL + #[recursion_limit="100"]
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-30318.fixed
+++ b/src/test/ui/parser/issue-30318.fixed
@@ -2,25 +2,25 @@
 #![allow(unused)]
 fn foo() { }
 
-//! Misplaced comment...
+/// Misplaced comment...
 //~^ ERROR expected outer doc comment
 fn bar() { } //~ NOTE the inner doc comment doesn't annotate this function
 
-#![test] //~ ERROR an inner attribute is not permitted in this context
+#[test] //~ ERROR an inner attribute is not permitted in this context
 fn baz() { } //~ NOTE the inner attribute doesn't annotate this function
 //~^^ NOTE inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually
 
-/*! Misplaced comment... */
+/** Misplaced comment... */
 //~^ ERROR expected outer doc comment
 fn bat() { } //~ NOTE the inner doc comment doesn't annotate this function
 
 fn main() { }
 
-//! Misplaced comment...
+// Misplaced comment...
 //~^ ERROR expected outer doc comment
 //~| NOTE inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
 //~| NOTE other attributes here
-/*! Misplaced comment... */
+/* Misplaced comment... */
 //~^ ERROR expected outer doc comment
 //~| NOTE this doc comment doesn't document anything
 //~| ERROR expected item after doc comment

--- a/src/test/ui/parser/issue-30318.stderr
+++ b/src/test/ui/parser/issue-30318.stderr
@@ -1,11 +1,81 @@
 error[E0753]: expected outer doc comment
-  --> $DIR/issue-30318.rs:3:1
+  --> $DIR/issue-30318.rs:5:1
+   |
+LL | //! Misplaced comment...
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn bar() { }
+   | ------------ the inner doc comment doesn't annotate this function
+   |
+help: to annotate the function, change the doc comment from inner to outer style
+   |
+LL | /// Misplaced comment...
+   |   ~
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/issue-30318.rs:9:1
+   |
+LL | #![test]
+   | ^^^^^^^^
+LL | fn baz() { }
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the function, change the attribute from inner to outer style
+   |
+LL - #![test]
+LL + #[test]
+   | 
+
+error[E0753]: expected outer doc comment
+  --> $DIR/issue-30318.rs:13:1
+   |
+LL | /*! Misplaced comment... */
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn bat() { }
+   | ------------ the inner doc comment doesn't annotate this function
+   |
+help: to annotate the function, change the doc comment from inner to outer style
+   |
+LL | /** Misplaced comment... */
+   |   ~
+
+error[E0753]: expected outer doc comment
+  --> $DIR/issue-30318.rs:19:1
    |
 LL | //! Misplaced comment...
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
+help: you might have meant to write a regular comment
+   |
+LL - //! Misplaced comment...
+LL + // Misplaced comment...
+   | 
 
-error: aborting due to previous error
+error[E0753]: expected outer doc comment
+  --> $DIR/issue-30318.rs:23:1
+   |
+LL | /*! Misplaced comment... */
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
+help: you might have meant to write a regular comment
+   |
+LL - /*! Misplaced comment... */
+LL + /* Misplaced comment... */
+   | 
+
+error: expected item after doc comment
+  --> $DIR/issue-30318.rs:23:1
+   |
+LL | //! Misplaced comment...
+   | ------------------------ other attributes here
+...
+LL | /*! Misplaced comment... */
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ this doc comment doesn't document anything
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0753`.

--- a/src/test/ui/parser/issue-45296.rs
+++ b/src/test/ui/parser/issue-45296.rs
@@ -2,4 +2,5 @@ fn main() {
     let unused = ();
 
     #![allow(unused_variables)] //~ ERROR not permitted in this context
+    fn foo() {}
 }

--- a/src/test/ui/parser/issue-45296.stderr
+++ b/src/test/ui/parser/issue-45296.stderr
@@ -3,8 +3,15 @@ error: an inner attribute is not permitted in this context
    |
 LL |     #![allow(unused_variables)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn foo() {}
+   |     ----------- the inner attribute doesn't annotate this function
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+help: to annotate the function, change the attribute from inner to outer style
+   |
+LL -     #![allow(unused_variables)]
+LL +     #[allow(unused_variables)]
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/stmt_expr_attrs_placement.stderr
+++ b/src/test/ui/parser/stmt_expr_attrs_placement.stderr
@@ -4,7 +4,8 @@ error: an inner attribute is not permitted in this context
 LL |     let a = #![allow(warnings)] (1, 2);
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:10:14
@@ -12,7 +13,8 @@ error: an inner attribute is not permitted in this context
 LL |     let b = (#![allow(warnings)] 1, 2);
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:15:10
@@ -20,7 +22,8 @@ error: an inner attribute is not permitted in this context
 LL |         (#![allow(warnings)] 1, 2)
    |          ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:21:18
@@ -28,7 +31,8 @@ error: an inner attribute is not permitted in this context
 LL |         let e = (#![allow(warnings)] 1, 2);
    |                  ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:26:14
@@ -36,7 +40,8 @@ error: an inner attribute is not permitted in this context
 LL |     let e = [#![allow(warnings)] 1, 2];
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:29:14
@@ -44,7 +49,8 @@ error: an inner attribute is not permitted in this context
 LL |     let f = [#![allow(warnings)] 1; 0];
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:36:24
@@ -52,7 +58,8 @@ error: an inner attribute is not permitted in this context
 LL |     let h = MyStruct { #![allow(warnings)] field: 0 };
    |                        ^^^^^^^^^^^^^^^^^^^
    |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/proc-macro/issue-86781-bad-inner-doc.fixed
+++ b/src/test/ui/proc-macro/issue-86781-bad-inner-doc.fixed
@@ -4,7 +4,7 @@
 #[macro_use]
 extern crate test_macros;
 
-//! Inner doc comment
+/// Inner doc comment
 //~^ ERROR expected outer doc comment
 #[derive(Empty)]
 pub struct Foo; //~ NOTE the inner doc comment doesn't annotate this struct

--- a/src/test/ui/proc-macro/issue-86781-bad-inner-doc.stderr
+++ b/src/test/ui/proc-macro/issue-86781-bad-inner-doc.stderr
@@ -1,10 +1,16 @@
 error[E0753]: expected outer doc comment
-  --> $DIR/issue-86781-bad-inner-doc.rs:6:1
+  --> $DIR/issue-86781-bad-inner-doc.rs:7:1
    |
 LL | //! Inner doc comment
    | ^^^^^^^^^^^^^^^^^^^^^
+...
+LL | pub struct Foo;
+   | --------------- the inner doc comment doesn't annotate this struct
    |
-   = note: inner doc comments like this (starting with `//!` or `/*!`) can only appear before items
+help: to annotate the struct, change the doc comment from inner to outer style
+   |
+LL | /// Inner doc comment
+   |   ~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #88257 (Provide more context on incorrect inner attribute)
 - #88432 (Fix a typo in raw_vec)
 - #88511 (x.py clippy: don't run with --all-targets by default)
 - #88657 (Fix 2021 `dyn` suggestion that used code as label)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88257,88432,88511,88657)
<!-- homu-ignore:end -->