### PR TITLE
Change return type for T::{log,log2,log10} to u32.

### DIFF
--- a/library/core/src/num/int_log10.rs
+++ b/library/core/src/num/int_log10.rs
@@ -116,8 +116,8 @@ mod unchecked {
 
 macro_rules! impl_checked {
     ($T:ident) => {
-        pub const fn $T(val: $T) -> Option<$T> {
-            if val > 0 { Some(unchecked::$T(val) as $T) } else { None }
+        pub const fn $T(val: $T) -> Option<u32> {
+            if val > 0 { Some(unchecked::$T(val)) } else { None }
         }
     };
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2026,7 +2026,7 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log(self, base: Self) -> Self {
+        pub const fn log(self, base: Self) -> u32 {
             match self.checked_log(base) {
                 Some(n) => n,
                 None => {
@@ -2060,7 +2060,7 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log2(self) -> Self {
+        pub const fn log2(self) -> u32 {
             match self.checked_log2() {
                 Some(n) => n,
                 None => {
@@ -2094,7 +2094,7 @@ macro_rules! int_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log10(self) -> Self {
+        pub const fn log10(self) -> u32 {
             match self.checked_log10() {
                 Some(n) => n,
                 None => {
@@ -2125,7 +2125,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log(self, base: Self) -> Option<Self> {
+        pub const fn checked_log(self, base: Self) -> Option<u32> {
             if self <= 0 || base <= 1 {
                 None
             } else {
@@ -2161,12 +2161,12 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log2(self) -> Option<Self> {
+        pub const fn checked_log2(self) -> Option<u32> {
             if self <= 0 {
                 None
             } else {
                 // SAFETY: We just checked that this number is positive
-                let log = (Self::BITS - 1) as Self - unsafe { intrinsics::ctlz_nonzero(self) };
+                let log = (Self::BITS - 1) - unsafe { intrinsics::ctlz_nonzero(self) as u32 };
                 Some(log)
             }
         }
@@ -2185,11 +2185,8 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log10(self) -> Option<Self> {
-            match int_log10::$ActualT(self as $ActualT) {
-                Some(s) => Some(s as Self),
-                None => None,
-            }
+        pub const fn checked_log10(self) -> Option<u32> {
+            int_log10::$ActualT(self as $ActualT)
         }
 
         /// Computes the absolute value of `self`.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -660,7 +660,7 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log(self, base: Self) -> Self {
+        pub const fn log(self, base: Self) -> u32 {
             match self.checked_log(base) {
                 Some(n) => n,
                 None => {
@@ -694,7 +694,7 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log2(self) -> Self {
+        pub const fn log2(self) -> u32 {
             match self.checked_log2() {
                 Some(n) => n,
                 None => {
@@ -728,7 +728,7 @@ macro_rules! uint_impl {
         #[track_caller]
         #[rustc_inherit_overflow_checks]
         #[allow(arithmetic_overflow)]
-        pub const fn log10(self) -> Self {
+        pub const fn log10(self) -> u32 {
             match self.checked_log10() {
                 Some(n) => n,
                 None => {
@@ -759,7 +759,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log(self, base: Self) -> Option<Self> {
+        pub const fn checked_log(self, base: Self) -> Option<u32> {
             if self <= 0 || base <= 1 {
                 None
             } else {
@@ -795,12 +795,12 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log2(self) -> Option<Self> {
+        pub const fn checked_log2(self) -> Option<u32> {
             if self <= 0 {
                 None
             } else {
                 // SAFETY: We just checked that this number is positive
-                let log = (Self::BITS - 1) as Self - unsafe { intrinsics::ctlz_nonzero(self) };
+                let log = (Self::BITS - 1) - unsafe { intrinsics::ctlz_nonzero(self) as u32 };
                 Some(log)
             }
         }
@@ -819,11 +819,8 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                         without modifying the original"]
         #[inline]
-        pub const fn checked_log10(self) -> Option<Self> {
-            match int_log10::$ActualT(self as $ActualT) {
-                Some(s) => Some(s as Self),
-                None => None,
-            }
+        pub const fn checked_log10(self) -> Option<u32> {
+            int_log10::$ActualT(self as $ActualT)
         }
 
         /// Checked negation. Computes `-self`, returning `None` unless `self ==

--- a/library/core/tests/num/int_log.rs
+++ b/library/core/tests/num/int_log.rs
@@ -26,10 +26,10 @@ fn checked_log() {
         assert_eq!(i.checked_log(4), None);
     }
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as i16));
+        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
     }
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u16));
+        assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
     }
 }
 
@@ -46,19 +46,19 @@ fn checked_log2() {
     assert_eq!(0i16.checked_log2(), None);
 
     for i in 1..=u8::MAX {
-        assert_eq!(i.checked_log2(), Some((i as f32).log2() as u8));
+        assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
     }
     for i in 1..=u16::MAX {
         // Guard against Android's imprecise f32::log2 implementation.
         if i != 8192 && i != 32768 {
-            assert_eq!(i.checked_log2(), Some((i as f32).log2() as u16));
+            assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
         }
     }
     for i in i8::MIN..=0 {
         assert_eq!(i.checked_log2(), None);
     }
     for i in 1..=i8::MAX {
-        assert_eq!(i.checked_log2(), Some((i as f32).log2() as i8));
+        assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
     }
     for i in i16::MIN..=0 {
         assert_eq!(i.checked_log2(), None);
@@ -66,7 +66,7 @@ fn checked_log2() {
     for i in 1..=i16::MAX {
         // Guard against Android's imprecise f32::log2 implementation.
         if i != 8192 {
-            assert_eq!(i.checked_log2(), Some((i as f32).log2() as i16));
+            assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
         }
     }
 }
@@ -75,9 +75,9 @@ fn checked_log2() {
 #[test]
 #[cfg(not(target_os = "android"))]
 fn checked_log2_not_android() {
-    assert_eq!(8192u16.checked_log2(), Some((8192f32).log2() as u16));
-    assert_eq!(32768u16.checked_log2(), Some((32768f32).log2() as u16));
-    assert_eq!(8192i16.checked_log2(), Some((8192f32).log2() as i16));
+    assert_eq!(8192u16.checked_log2(), Some((8192f32).log2() as u32));
+    assert_eq!(32768u16.checked_log2(), Some((32768f32).log2() as u32));
+    assert_eq!(8192i16.checked_log2(), Some((8192f32).log2() as u32));
 }
 
 #[test]
@@ -91,10 +91,10 @@ fn checked_log10() {
         assert_eq!(i.checked_log10(), None);
     }
     for i in 1..=i16::MAX {
-        assert_eq!(i.checked_log10(), Some((i as f32).log10() as i16));
+        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
     }
     for i in 1..=u16::MAX {
-        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u16));
+        assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
     }
 }
 


### PR DESCRIPTION
The value is at most 128, and this is consistent with using u32 for small values elsewhere (e.g. BITS, count_ones, leading_zeros).