### PR TITLE
Only check the compiler and standard library before documenting them

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -55,7 +55,8 @@ fn cargo_subcommand(kind: Kind) -> &'static str {
         Kind::Check => "check",
         Kind::Clippy => "clippy",
         Kind::Fix => "fix",
-        _ => unreachable!(),
+        // Another top-level command is calling check
+        _ => "check",
     }
 }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -665,7 +665,6 @@ macro_rules! tool_doc {
     ($tool: ident, $should_run: literal, $path: literal, [$($krate: literal),+ $(,)?] $(,)?) => {
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct $tool {
-            stage: u32,
             target: TargetSelection,
         }
 
@@ -679,7 +678,7 @@ macro_rules! tool_doc {
             }
 
             fn make_run(run: RunConfig<'_>) {
-                run.builder.ensure($tool { stage: run.builder.top_stage, target: run.target });
+                run.builder.ensure($tool { target: run.target });
             }
 
             /// Generates compiler documentation.
@@ -689,7 +688,7 @@ macro_rules! tool_doc {
             /// we do not merge it with the other documentation from std, test and
             /// proc_macros. This is largely just a wrapper around `cargo doc`.
             fn run(self, builder: &Builder<'_>) {
-                let stage = self.stage;
+                let stage = builder.top_stage;
                 let target = self.target;
                 builder.info(
                     &format!(


### PR DESCRIPTION
Rustdoc doesn't require the build artifacts to generate the docs, and
especially in the case of rustc, it greatly increases the time needed to
run the build.

r? @Mark-Simulacrum cc @steffahn 