### PR TITLE
Change scope of temporaries in match guards

### DIFF
--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                     let then_blk = unpack!(this.then_else_break(
                                         block,
                                         &this.thir[cond],
-                                        condition_scope,
+                                        Some(condition_scope),
                                         condition_scope,
                                         then_expr.span,
                                     ));

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -93,7 +93,7 @@
 +     bb6: {
           _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         goto -> bb23;                    // scope 0 at no-location
 +         goto -> bb20;                    // scope 0 at no-location
       }
@@ -108,6 +108,7 @@
 -     bb11: {
 +     bb8: {
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -123,7 +124,7 @@
 -     bb12: {
 +     bb9: {
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         falseEdge -> [real: bb2, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
@@ -149,7 +150,7 @@
 +     bb11: {
           _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         goto -> bb23;                    // scope 0 at no-location
 +         goto -> bb20;                    // scope 0 at no-location
       }
@@ -164,6 +165,7 @@
 -     bb16: {
 +     bb13: {
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -179,7 +181,7 @@
 -     bb17: {
 +     bb14: {
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
+          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         falseEdge -> [real: bb4, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
@@ -190,7 +192,6 @@
 +     bb15: {
           StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
-          StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -72,6 +72,7 @@ fn full_tested_match() -> () {
     }
 
     bb7: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
@@ -81,13 +82,12 @@ fn full_tested_match() -> () {
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:16:31: 16:37
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -70,6 +70,7 @@ fn full_tested_match2() -> () {
     }
 
     bb7: {
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         StorageLive(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
@@ -79,13 +80,12 @@ fn full_tested_match2() -> () {
         _1 = (const 1_i32, move _8);     // scope 2 at $DIR/match_false_edges.rs:27:31: 27:37
         StorageDead(_8);                 // scope 2 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_5);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
     }
 
     bb8: {
-        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
+        StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         falseEdge -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -78,19 +78,19 @@ fn main() -> () {
     }
 
     bb7: {
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _6 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _1 = const 1_i32;                // scope 2 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
     }
 
     bb8: {
-        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
+        StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         falseEdge -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
@@ -122,20 +122,20 @@ fn main() -> () {
 
     bb12: {
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForGuardBinding, _11);  // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageLive(_10);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _10 = ((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _1 = const 3_i32;                // scope 4 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_10);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
     }
 
     bb13: {
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
-        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
+        StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -75,14 +75,14 @@ fn main() -> () {
     }
 
     bb10: {
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:13:23: 13:24
     }
 
     bb11: {
-        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:23: 13:24
+        StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
         falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
     }
 

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -66,7 +66,7 @@
 +         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
 -         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
 -     bb8: {

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -66,7 +66,7 @@
 +         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
 -         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
 -     bb8: {

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -47,6 +47,7 @@
       }
   
       bb5: {
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _6);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
@@ -56,12 +57,11 @@
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
           _0 = const 0_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
           goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
       }
   
       bb6: {
-          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
+          StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
           goto -> bb1;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
       }
   


### PR DESCRIPTION
Each pattern in a match arm has its own copy of the match guard in MIR, with its own temporary, so it has to be dropped before the the guards are joined to the single copy of the arm. This PR changes `then_else_break` to allow it to put the temporary in the innermost scope possible. This change isn't done for `if` expressions because that affects a large number of mir-opt tests and could more significantly affect performance.

closes #88649

r? @oli-obk 