### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/thin_vec.rs
+++ b/compiler/rustc_data_structures/src/thin_vec.rs
@@ -2,7 +2,7 @@ use crate::stable_hasher::{HashStable, StableHasher};
 
 use std::iter::FromIterator;
 
-/// A vector type optimized for cases where this size is usually 0 (cf. `SmallVector`).
+/// A vector type optimized for cases where this size is usually 0 (cf. `SmallVec`).
 /// The `Option<Box<..>>` wrapping allows us to represent a zero sized vector with `None`,
 /// which uses only a single (null) pointer.
 #[derive(Clone, Encodable, Decodable, Debug)]

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -1663,7 +1663,7 @@ pub mod marker {
         const PERMITS_TRAVERSAL: bool = true;
     }
     impl BorrowType for Owned {
-        // Traversal isn't needede, it happens using the result of `borrow_mut`.
+        // Traversal isn't needed, it happens using the result of `borrow_mut`.
         // By disabling traversal, and only creating new references to roots,
         // we know that every reference of the `Owned` type is to a root node.
         const PERMITS_TRAVERSAL: bool = false;

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -517,10 +517,19 @@ impl FileTypeExt for fs::FileType {
     }
 }
 
-/// Creates a new file symbolic link on the filesystem.
+/// Creates a new symlink to a non-directory file on the filesystem.
 ///
 /// The `link` path will be a file symbolic link pointing to the `original`
 /// path.
+///
+/// The `original` path should not be a directory or a symlink to a directory,
+/// otherwise the symlink will be broken. Use [`symlink_dir`] for directories.
+///
+/// This function currently corresponds to [`CreateSymbolicLinkW`][CreateSymbolicLinkW].
+/// Note that this [may change in the future][changes].
+///
+/// [CreateSymbolicLinkW]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
+/// [changes]: io#platform-specific-behavior
 ///
 /// # Examples
 ///
@@ -537,10 +546,19 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io:
     sys::fs::symlink_inner(original.as_ref(), link.as_ref(), false)
 }
 
-/// Creates a new directory symlink on the filesystem.
+/// Creates a new symlink to a directory on the filesystem.
 ///
 /// The `link` path will be a directory symbolic link pointing to the `original`
 /// path.
+///
+/// The `original` path must be a directory or a symlink to a directory,
+/// otherwise the symlink will be broken. Use [`symlink_file`] for other files.
+///
+/// This function currently corresponds to [`CreateSymbolicLinkW`][CreateSymbolicLinkW].
+/// Note that this [may change in the future][changes].
+///
+/// [CreateSymbolicLinkW]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
+/// [changes]: io#platform-specific-behavior
 ///
 /// # Examples
 ///

--- a/src/test/ui/const-generics/issues/issue-82956.rs
+++ b/src/test/ui/const-generics/issues/issue-82956.rs
@@ -1,0 +1,33 @@
+#![feature(generic_const_exprs, array_map)]
+#![allow(incomplete_features)]
+
+pub struct ConstCheck<const CHECK: bool>;
+
+pub trait True {}
+impl True for ConstCheck<true> {}
+
+pub trait OrdesDec {
+    type Newlen;
+    type Output;
+
+    fn pop(self) -> (Self::Newlen, Self::Output);
+}
+
+impl<T, const N: usize> OrdesDec for [T; N]
+where
+    ConstCheck<{N > 1}>: True,
+    [T; N - 1]: Sized,
+{
+    type Newlen = [T; N - 1];
+    type Output = T;
+
+    fn pop(self) -> (Self::Newlen, Self::Output) {
+        let mut iter = IntoIter::new(self);
+        //~^ ERROR: failed to resolve: use of undeclared type `IntoIter`
+        let end = iter.next_back().unwrap();
+        let new = [(); N - 1].map(move |()| iter.next().unwrap());
+        (new, end)
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-82956.stderr
+++ b/src/test/ui/const-generics/issues/issue-82956.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared type `IntoIter`
+  --> $DIR/issue-82956.rs:25:24
+   |
+LL |         let mut iter = IntoIter::new(self);
+   |                        ^^^^^^^^ not found in this scope
+   |
+help: consider importing one of these items
+   |
+LL | use std::array::IntoIter;
+   |
+LL | use std::collections::binary_heap::IntoIter;
+   |
+LL | use std::collections::btree_map::IntoIter;
+   |
+LL | use std::collections::btree_set::IntoIter;
+   |
+     and 8 other candidates
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/const-generics/issues/issue-84659.rs
+++ b/src/test/ui/const-generics/issues/issue-84659.rs
@@ -1,0 +1,12 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+trait Bar<const N: usize> {}
+
+trait Foo<'a> {
+    const N: usize;
+    type Baz: Bar<{ Self::N }>;
+    //~^ ERROR: unconstrained generic constant
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-84659.stderr
+++ b/src/test/ui/const-generics/issues/issue-84659.stderr
@@ -1,0 +1,10 @@
+error: unconstrained generic constant
+  --> $DIR/issue-84659.rs:8:15
+   |
+LL |     type Baz: Bar<{ Self::N }>;
+   |               ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { Self::N }]:`
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-86530.rs
+++ b/src/test/ui/const-generics/issues/issue-86530.rs
@@ -1,5 +1,5 @@
 #![feature(generic_const_exprs)]
-#![allow(incomplete_features)]                                                                                                                                                                                                                
+#![allow(incomplete_features)]
 
 pub trait X {
     const Y: usize;

--- a/src/test/ui/const-generics/issues/issue-86530.rs
+++ b/src/test/ui/const-generics/issues/issue-86530.rs
@@ -1,0 +1,20 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]                                                                                                                                                                                                                
+
+pub trait X {
+    const Y: usize;
+}
+
+fn z<T>(t: T)
+where
+    T: X,
+    [(); T::Y]: ,
+{
+}
+
+fn unit_literals() {
+    z(" ");
+    //~^ ERROR: the trait bound `&str: X` is not satisfied
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-86530.stderr
+++ b/src/test/ui/const-generics/issues/issue-86530.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `&str: X` is not satisfied
+  --> $DIR/issue-86530.rs:16:7
+   |
+LL |     z(" ");
+   |       ^^^ the trait `X` is not implemented for `&str`
+   |
+note: required by a bound in `z`
+  --> $DIR/issue-86530.rs:10:8
+   |
+LL | fn z<T>(t: T)
+   |    - required by a bound in this
+LL | where
+LL |     T: X,
+   |        ^ required by this bound in `z`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/issues/issue-86535-2.rs
+++ b/src/test/ui/const-generics/issues/issue-86535-2.rs
@@ -1,0 +1,19 @@
+// run-pass
+#![feature(adt_const_params, generic_const_exprs)]
+#![allow(incomplete_features)]                                                                                                                                                                                                                
+
+pub trait Foo {
+    const ASSOC_C: usize;
+    fn foo() where [(); Self::ASSOC_C]:;
+}
+
+struct Bar<const N: &'static ()>;
+impl<const N: &'static ()> Foo for Bar<N> {
+    const ASSOC_C: usize = 3;
+
+    fn foo() where [u8; Self::ASSOC_C]: {
+        let _: [u8; Self::ASSOC_C] = loop {};
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-86535-2.rs
+++ b/src/test/ui/const-generics/issues/issue-86535-2.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![feature(adt_const_params, generic_const_exprs)]
-#![allow(incomplete_features)]                                                                                                                                                                                                                
+#![allow(incomplete_features)]
 
 pub trait Foo {
     const ASSOC_C: usize;

--- a/src/test/ui/const-generics/issues/issue-86535.rs
+++ b/src/test/ui/const-generics/issues/issue-86535.rs
@@ -1,0 +1,20 @@
+// run-pass
+#![feature(adt_const_params, generic_const_exprs)]
+#![allow(incomplete_features, unused_variables)]
+
+struct F<const S: &'static str>;
+impl<const S: &'static str> X for F<{ S }> {
+    const W: usize = 3;
+
+    fn d(r: &[u8; Self::W]) -> F<{ S }> {
+        let x: [u8; Self::W] = [0; Self::W];
+        F
+    }
+}
+
+pub trait X {
+    const W: usize;
+    fn d(r: &[u8; Self::W]) -> Self;
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/sneaky-array-repeat-expr.rs
+++ b/src/test/ui/const-generics/sneaky-array-repeat-expr.rs
@@ -1,0 +1,32 @@
+trait Trait<const N: usize> {
+    const Assoc: usize;
+}
+
+impl<const N: usize> Trait<N> for () {
+    const Assoc: usize = 1;
+}
+
+
+pub const fn foo<const N: usize>() where (): Trait<N> {
+    let bar = [(); <()>::Assoc];
+    //~^ error: constant expression depends on a generic parameter
+}
+
+trait Trait2<const N: usize> {
+    const Assoc2: usize;
+}
+
+impl<const N: usize> Trait2<N> for () {
+    const Assoc2: usize = N - 1;
+}
+
+
+pub const fn foo2<const N: usize>() where (): Trait2<N> {
+    let bar2 = [(); <()>::Assoc2];
+    //~^ error: constant expression depends on a generic parameter
+}
+
+fn main() {
+    foo::<0>();
+    foo2::<0>();
+}

--- a/src/test/ui/const-generics/sneaky-array-repeat-expr.stderr
+++ b/src/test/ui/const-generics/sneaky-array-repeat-expr.stderr
@@ -1,0 +1,18 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/sneaky-array-repeat-expr.rs:11:20
+   |
+LL |     let bar = [(); <()>::Assoc];
+   |                    ^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/sneaky-array-repeat-expr.rs:25:21
+   |
+LL |     let bar2 = [(); <()>::Assoc2];
+   |                     ^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/moves/move-guard-same-consts.rs
+++ b/src/test/ui/moves/move-guard-same-consts.rs
@@ -2,7 +2,7 @@
 // arms whose patterns were composed solely of constants to not have
 // them linked in the cfg.
 //
-// THis was broken for various reasons. In particular, that hack was
+// This was broken for various reasons. In particular, that hack was
 // originally authored under the assunption that other checks
 // elsewhere would ensure that the two patterns did not overlap.  But
 // that assumption did not hold, at least not in the long run (namely,


### PR DESCRIPTION
Successful merges:

 - #88602 (Add tests for some const generics issues)
 - #88647 (Document when to use Windows' `symlink_dir` vs. `symlink_file`)
 - #88659 (Remove SmallVector mention)
 - #88661 (Correct typo)
 - #88673 (Fix typo: needede -> needed)
 - #88685 (:arrow_up: rust-analyzer)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88602,88647,88659,88661,88673,88685)
<!-- homu-ignore:end -->