### PR TITLE
Use missing_docs lint on tuple fields as well

### DIFF
--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -161,13 +161,13 @@ pub trait Pattern<'a>: Sized {
 pub enum SearchStep {
     /// Expresses that a match of the pattern has been found at
     /// `haystack[a..b]`.
-    Match(usize, usize),
+    Match(#[allow(missing_docs)] usize, #[allow(missing_docs)] usize),
     /// Expresses that `haystack[a..b]` has been rejected as a possible match
     /// of the pattern.
     ///
     /// Note that there might be more than one `Reject` between two `Match`es,
     /// there is no requirement for them to be combined into one.
-    Reject(usize, usize),
+    Reject(#[allow(missing_docs)] usize, #[allow(missing_docs)] usize),
     /// Expresses that every byte of the haystack has been visited, ending
     /// the iteration.
     Done,

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -147,8 +147,12 @@ pub enum Prefix<'a> {
     /// server's hostname and a share name.
     #[stable(feature = "rust1", since = "1.0.0")]
     VerbatimUNC(
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        &'a OsStr,
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        &'a OsStr,
     ),
 
     /// Verbatim disk prefix, e.g., `\\?\C:`.
@@ -171,8 +175,12 @@ pub enum Prefix<'a> {
     /// UNC prefixes consist of the server's hostname and a share name.
     #[stable(feature = "rust1", since = "1.0.0")]
     UNC(
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
-        #[stable(feature = "rust1", since = "1.0.0")] &'a OsStr,
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        &'a OsStr,
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        &'a OsStr,
     ),
 
     /// Prefix `C:` for the given disk drive.

--- a/src/test/rustdoc-ui/missing-doc-tuple-variant.rs
+++ b/src/test/rustdoc-ui/missing-doc-tuple-variant.rs
@@ -1,0 +1,15 @@
+// compile-flags: -Z unstable-options --check
+
+#![deny(missing_docs)]
+
+//! crate level doc
+
+/// Enum doc.
+pub enum Foo {
+    /// Variant doc.
+    Foo(String),
+    /// Variant Doc.
+    Bar(String, u32),
+    //~^ ERROR
+    //~^^ ERROR
+}

--- a/src/test/rustdoc-ui/missing-doc-tuple-variant.stderr
+++ b/src/test/rustdoc-ui/missing-doc-tuple-variant.stderr
@@ -1,0 +1,20 @@
+error: missing documentation for a struct field
+  --> $DIR/missing-doc-tuple-variant.rs:12:9
+   |
+LL |     Bar(String, u32),
+   |         ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/missing-doc-tuple-variant.rs:3:9
+   |
+LL | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
+
+error: missing documentation for a struct field
+  --> $DIR/missing-doc-tuple-variant.rs:12:17
+   |
+LL |     Bar(String, u32),
+   |                 ^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Since we count them in the rustdoc `show-coverage` option, I thought it would be logical to throw the error here as well.

What do you think @rust-lang/rustdoc ?

r? @Manishearth 