### PR TITLE
Give sidebar a z-index

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -290,6 +290,12 @@ nav.sub {
 	overflow: auto;
 }
 
+.rustdoc:not(.source) .sidebar {
+	/* Ensure that sidebar does not overlap with content when horizontal
+	 * scrollbar is present */
+	z-index: 1;
+}
+
 /* Improve the scrollbar display on firefox */
 * {
 	scrollbar-width: initial;


### PR DESCRIPTION
This ensures that sidebar does not overlap with content when horizontal scrollbar is present.

The overlap is visible in https://docs.rs/ndarray/0.15.3/ndarray/struct.ArrayBase.html.

Discovered by @m13253.
