### PR TITLE
Add `ConstraintCategory::Usage` for handling aggregate construction

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -40,6 +40,7 @@ impl ConstraintDescription for ConstraintCategory {
             ConstraintCategory::CopyBound => "copying this value ",
             ConstraintCategory::OpaqueType => "opaque type ",
             ConstraintCategory::ClosureUpvar(_) => "closure capture ",
+            ConstraintCategory::Usage => "this usage ",
             ConstraintCategory::Boring
             | ConstraintCategory::BoringNoLocation
             | ConstraintCategory::Internal => "",

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1388,11 +1388,24 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                             ConstraintCategory::Return(ReturnConstraint::Normal)
                         }
                     }
+                    Some(l)
+                        if matches!(
+                            body.local_decls[l].local_info,
+                            Some(box LocalInfo::AggregateTemp)
+                        ) =>
+                    {
+                        ConstraintCategory::Usage
+                    }
                     Some(l) if !body.local_decls[l].is_user_variable() => {
                         ConstraintCategory::Boring
                     }
                     _ => ConstraintCategory::Assignment,
                 };
+                debug!(
+                    "assignment category: {:?} {:?}",
+                    category,
+                    place.as_local().map(|l| &body.local_decls[l])
+                );
 
                 let place_ty = place.ty(body, tcx).ty;
                 let place_ty = self.normalize(place_ty, location);

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -992,6 +992,9 @@ pub enum LocalInfo<'tcx> {
     StaticRef { def_id: DefId, is_thread_local: bool },
     /// A temporary created that references the const with the given `DefId`
     ConstRef { def_id: DefId },
+    /// A temporary created during the creation of an aggregate
+    /// (e.g. a temporary for `foo` in `MyStruct { my_field: foo }`)
+    AggregateTemp,
 }
 
 impl<'tcx> LocalDecl<'tcx> {

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -332,17 +332,15 @@ pub enum ConstraintCategory {
     CopyBound,
     SizedBound,
     Assignment,
+    /// A constraint that came from a usage of a variable (e.g. in an ADT expression
+    /// like `Foo { field: my_val }`)
+    Usage,
     OpaqueType,
     ClosureUpvar(hir::HirId),
 
     /// A "boring" constraint (caused by the given location) is one that
     /// the user probably doesn't want to see described in diagnostics,
     /// because it is kind of an artifact of the type system setup.
-    /// Example: `x = Foo { field: y }` technically creates
-    /// intermediate regions representing the "type of `Foo { field: y
-    /// }`", and data flows from `y` into those variables, but they
-    /// are not very interesting. The assignment into `x` on the other
-    /// hand might be.
     Boring,
     // Boring and applicable everywhere.
     BoringNoLocation,

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -326,10 +326,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let fields_map: FxHashMap<_, _> = fields
                     .into_iter()
                     .map(|f| {
+                        let local_info = Box::new(LocalInfo::AggregateTemp);
                         (
                             f.name,
                             unpack!(
-                                block = this.as_operand(block, Some(scope), &this.thir[f.expr])
+                                block = this.as_operand(
+                                    block,
+                                    Some(scope),
+                                    &this.thir[f.expr],
+                                    Some(local_info)
+                                )
                             ),
                         )
                     })
@@ -508,7 +514,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             ExprKind::Yield { value } => {
                 let scope = this.local_scope();
-                let value = unpack!(block = this.as_operand(block, Some(scope), &this.thir[value]));
+                let value =
+                    unpack!(block = this.as_operand(block, Some(scope), &this.thir[value], None));
                 let resume = this.cfg.start_new_block();
                 this.cfg.terminate(
                     block,

--- a/src/test/ui/async-await/issue-76547.nll.stderr
+++ b/src/test/ui/async-await/issue-76547.nll.stderr
@@ -1,20 +1,22 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-76547.rs:19:14
+  --> $DIR/issue-76547.rs:20:13
    |
 LL | async fn fut(bufs: &mut [&mut [u8]]) {
-   |              ^^^^  -     - let's call the lifetime of this reference `'2`
-   |              |     |
-   |              |     let's call the lifetime of this reference `'1`
-   |              assignment requires that `'1` must outlive `'2`
+   |                    -     - let's call the lifetime of this reference `'2`
+   |                    |
+   |                    let's call the lifetime of this reference `'1`
+LL |     ListFut(bufs).await
+   |             ^^^^ this usage requires that `'1` must outlive `'2`
 
 error: lifetime may not live long enough
-  --> $DIR/issue-76547.rs:33:15
+  --> $DIR/issue-76547.rs:34:14
    |
 LL | async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
-   |               ^^^^  -     - let's call the lifetime of this reference `'2`
-   |               |     |
-   |               |     let's call the lifetime of this reference `'1`
-   |               assignment requires that `'1` must outlive `'2`
+   |                     -     - let's call the lifetime of this reference `'2`
+   |                     |
+   |                     let's call the lifetime of this reference `'1`
+LL |     ListFut2(bufs).await
+   |              ^^^^ this usage requires that `'1` must outlive `'2`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-61882-2.stderr
+++ b/src/test/ui/issues/issue-61882-2.stderr
@@ -5,7 +5,7 @@ LL |         Self(&x);
    |              ^^
    |              |
    |              borrowed value does not live long enough
-   |              requires that `x` is borrowed for `'static`
+   |              this usage requires that `x` is borrowed for `'static`
 LL |
 LL |     }
    |     - `x` dropped here while still borrowed

--- a/src/test/ui/nll/issue-46036.stderr
+++ b/src/test/ui/nll/issue-46036.stderr
@@ -5,7 +5,7 @@ LL |     let foo = Foo { x: &a };
    |                        ^^
    |                        |
    |                        borrowed value does not live long enough
-   |                        requires that `a` is borrowed for `'static`
+   |                        this usage requires that `a` is borrowed for `'static`
 LL |     loop { }
 LL | }
    | - `a` dropped here while still borrowed

--- a/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -5,7 +5,7 @@ LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
    |                                                ^^
    |                                                |
    |                                                borrowed value does not live long enough
-   |                                                requires that `c` is borrowed for `'static`
+   |                                                this usage requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -19,7 +19,7 @@ LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                                           ^^
    |                                           |
    |                                           borrowed value does not live long enough
-   |                                           requires that `c` is borrowed for `'a`
+   |                                           this usage requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,7 +33,7 @@ LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                                               ^^
    |                                               |
    |                                               borrowed value does not live long enough
-   |                                               requires that `c` is borrowed for `'a`
+   |                                               this usage requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/src/test/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -5,7 +5,7 @@ LL |     SomeStruct::<&'static u32> { t: &c };
    |                                     ^^
    |                                     |
    |                                     borrowed value does not live long enough
-   |                                     requires that `c` is borrowed for `'static`
+   |                                     this usage requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -19,7 +19,7 @@ LL |     SomeStruct::<&'a u32> { t: &c };
    |                                ^^
    |                                |
    |                                borrowed value does not live long enough
-   |                                requires that `c` is borrowed for `'a`
+   |                                this usage requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,7 +33,7 @@ LL |         SomeStruct::<&'a u32> { t: &c };
    |                                    ^^
    |                                    |
    |                                    borrowed value does not live long enough
-   |                                    requires that `c` is borrowed for `'a`
+   |                                    this usage requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -5,7 +5,7 @@ LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
    |                                           ^^
    |                                           |
    |                                           borrowed value does not live long enough
-   |                                           requires that `c` is borrowed for `'static`
+   |                                           this usage requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -19,7 +19,7 @@ LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
    |                                      ^^
    |                                      |
    |                                      borrowed value does not live long enough
-   |                                      requires that `c` is borrowed for `'a`
+   |                                      this usage requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,7 +33,7 @@ LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
    |                                          ^^
    |                                          |
    |                                          borrowed value does not live long enough
-   |                                          requires that `c` is borrowed for `'a`
+   |                                          this usage requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     SomeStruct::<&'static u32>(&c);
    |                                ^^
    |                                |
    |                                borrowed value does not live long enough
-   |                                requires that `c` is borrowed for `'static`
+   |                                this usage requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -19,7 +19,7 @@ LL |     SomeStruct::<&'a u32>(&c);
    |                           ^^
    |                           |
    |                           borrowed value does not live long enough
-   |                           requires that `c` is borrowed for `'a`
+   |                           this usage requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -33,7 +33,7 @@ LL |         SomeStruct::<&'a u32>(&c);
    |                               ^^
    |                               |
    |                               borrowed value does not live long enough
-   |                               requires that `c` is borrowed for `'a`
+   |                               this usage requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/src/test/ui/nll/where_clauses_in_structs.stderr
+++ b/src/test/ui/nll/where_clauses_in_structs.stderr
@@ -6,7 +6,7 @@ LL | fn bar<'a, 'b>(x: Cell<&'a u32>, y: Cell<&'b u32>) {
    |        |
    |        lifetime `'a` defined here
 LL |     Foo { x, y };
-   |           ^ requires that `'a` must outlive `'b`
+   |           ^ this usage requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
 


### PR DESCRIPTION
In some cases, we emit borrowcheck diagnostics pointing
at a particular field expression in a struct expression
(e.g. `MyStruct { field: my_expr }`). However, this
behavior currently relies on us choosing the
`ConstraintCategory::Boring` with the 'correct' span.
When adding additional variants to `ConstraintCategory`,
(or changing existing usages away from `ConstraintCategory::Boring`),
the current behavior can easily get broken, since a non-boring
constraint will get chosen over a boring one.

To make the diagnostic output less fragile, this commit
adds a `ConstraintCategory::Usage` variant. We use this variant
for the temporary assignments created for each field of
an aggregate we are constructing.

Using this new variant, we can emit a message mentioning
"this usage", emphasizing the fact that the error message
is related to the specific use site (in the struct expression).

This is preparation for additional work on improving NLL error messages
(see #57374)