### PR TITLE
Fix docs for `uX::checked_next_multiple_of`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1927,7 +1927,8 @@ macro_rules! uint_impl {
         }
 
         /// Calculates the smallest value greater than or equal to `self` that
-        /// is a multiple of `rhs`. If `rhs` is negative,
+        /// is a multiple of `rhs`. Returns `None` is `rhs` is zero or the
+        /// operation would result in overflow.
         ///
         /// # Examples
         ///


### PR DESCRIPTION
Thanks to @photino for noticing this [here](https://github.com/rust-lang/rust/issues/88581#issuecomment-913982246).

r? @joshtriplett 

@rustbot label: +A-docs +A-waiting-on-review