### PR TITLE
use CLOCK_BOOTTIME in Instant::now

### DIFF
--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -291,8 +291,13 @@ mod inner {
         pub fn now() -> Instant {
             #[cfg(target_os = "macos")]
             const clock_id: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
-            #[cfg(not(target_os = "macos"))]
+
+            #[cfg(target_os = "linux")]
+            const clock_id: libc::clockid_t = libc::CLOCK_BOOTTIME;
+
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
             const clock_id: libc::clockid_t = libc::CLOCK_MONOTONIC;
+
             Instant { t: Timespec::now(clock_id) }
         }
 

--- a/src/tools/miri/src/shims/time.rs
+++ b/src/tools/miri/src/shims/time.rs
@@ -45,6 +45,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 relative_clocks = vec![
                     this.eval_libc_i32("CLOCK_MONOTONIC")?,
                     this.eval_libc_i32("CLOCK_MONOTONIC_COARSE")?,
+                    // This is the equivalent to `CLOCK_UPTIME_RAW` in the macos section
+                    // We support it, because std relies on it
+                    this.eval_libc_i32("CLOCK_BOOTTIME")?,
                 ];
             }
             "macos" => {


### PR DESCRIPTION
There was a discussion on rust-lang/rust#87907 that all platforms expect
linux advance its monotonic timer if the system goes into a sleep state
(e.g. suspend or hibernate).
It was decided that CLOCK_BOOTTIME should be used on inux targets, but
because that constant would break older systems (e.g. linux kernels
<2.6.39) there should be a fallback to CLOCK_MONOTONIC.

Related to #87907
Closes #87906

cc @joshtriplett @cuviper 