### PR TITLE
fix non_blanket_impls iteration order 

### DIFF
--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -3,7 +3,7 @@ use crate::middle::cstore::CrateStore;
 use crate::ty::{fast_reject, TyCtxt};
 
 use rustc_ast as ast;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
 use rustc_hir as hir;
@@ -15,7 +15,7 @@ use rustc_span::symbol::Symbol;
 use rustc_span::{BytePos, CachingSourceMapView, SourceFile, SpanData};
 
 use smallvec::SmallVec;
-use std::cmp::Ord;
+use std::collections::BTreeMap;
 
 fn compute_ignored_attr_names() -> FxHashSet<Symbol> {
     debug_assert!(!ich::IGNORED_ATTRIBUTES.is_empty());
@@ -243,7 +243,7 @@ pub fn hash_stable_trait_impls<'a>(
     hcx: &mut StableHashingContext<'a>,
     hasher: &mut StableHasher,
     blanket_impls: &[DefId],
-    non_blanket_impls: &FxHashMap<fast_reject::SimplifiedType, Vec<DefId>>,
+    non_blanket_impls: &BTreeMap<fast_reject::StableSimplifiedType, Vec<DefId>>,
 ) {
     {
         let mut blanket_impls: SmallVec<[_; 8]> =
@@ -257,14 +257,11 @@ pub fn hash_stable_trait_impls<'a>(
     }
 
     {
-        let mut keys: SmallVec<[_; 8]> =
-            non_blanket_impls.keys().map(|k| (k, k.map_def(|d| hcx.def_path_hash(d)))).collect();
-        keys.sort_unstable_by(|&(_, ref k1), &(_, ref k2)| k1.cmp(k2));
-        keys.len().hash_stable(hcx, hasher);
-        for (key, ref stable_key) in keys {
-            stable_key.hash_stable(hcx, hasher);
+        non_blanket_impls.len().hash_stable(hcx, hasher);
+        for (key, impls) in non_blanket_impls.iter() {
+            key.hash_stable(hcx, hasher);
             let mut impls: SmallVec<[_; 8]> =
-                non_blanket_impls[key].iter().map(|&impl_id| hcx.def_path_hash(impl_id)).collect();
+                impls.iter().map(|&impl_id| hcx.def_path_hash(impl_id)).collect();
 
             if impls.len() > 1 {
                 impls.sort_unstable();

--- a/compiler/rustc_middle/src/traits/specialization_graph.rs
+++ b/compiler/rustc_middle/src/traits/specialization_graph.rs
@@ -1,12 +1,12 @@
 use crate::ich::{self, StableHashingContext};
-use crate::ty::fast_reject::SimplifiedType;
+use crate::ty::fast_reject::StableSimplifiedType;
 use crate::ty::fold::TypeFoldable;
 use crate::ty::{self, TyCtxt};
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_errors::ErrorReported;
 use rustc_hir::def_id::{DefId, DefIdMap};
 use rustc_span::symbol::Ident;
+use std::collections::BTreeMap;
 
 /// A per-trait graph of impls in specialization order. At the moment, this
 /// graph forms a tree rooted with the trait itself, with all other nodes
@@ -62,7 +62,7 @@ pub struct Children {
     // together *all* the impls for a trait, and are populated prior to building
     // the specialization graph.
     /// Impls of the trait.
-    pub nonblanket_impls: FxHashMap<SimplifiedType, Vec<DefId>>,
+    pub nonblanket_impls: BTreeMap<StableSimplifiedType, Vec<DefId>>,
 
     /// Blanket impls associated with the trait.
     pub blanket_impls: Vec<DefId>,

--- a/compiler/rustc_middle/src/traits/specialization_graph.rs
+++ b/compiler/rustc_middle/src/traits/specialization_graph.rs
@@ -55,14 +55,14 @@ pub struct Children {
     // Impls of a trait (or specializations of a given impl). To allow for
     // quicker lookup, the impls are indexed by a simplified version of their
     // `Self` type: impls with a simplifiable `Self` are stored in
-    // `nonblanket_impls` keyed by it, while all other impls are stored in
+    // `non_blanket_impls` keyed by it, while all other impls are stored in
     // `blanket_impls`.
     //
     // A similar division is used within `TraitDef`, but the lists there collect
     // together *all* the impls for a trait, and are populated prior to building
     // the specialization graph.
     /// Impls of the trait.
-    pub nonblanket_impls: BTreeMap<StableSimplifiedType, Vec<DefId>>,
+    pub non_blanket_impls: BTreeMap<StableSimplifiedType, Vec<DefId>>,
 
     /// Blanket impls associated with the trait.
     pub blanket_impls: Vec<DefId>,
@@ -238,8 +238,8 @@ pub fn ancestors(
 
 impl<'a> HashStable<StableHashingContext<'a>> for Children {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        let Children { ref nonblanket_impls, ref blanket_impls } = *self;
+        let Children { ref non_blanket_impls, ref blanket_impls } = *self;
 
-        ich::hash_stable_trait_impls(hcx, hasher, blanket_impls, nonblanket_impls);
+        ich::hash_stable_trait_impls(hcx, hasher, blanket_impls, non_blanket_impls);
     }
 }

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -1,7 +1,7 @@
 use crate::ich::StableHashingContext;
 use crate::ty::{self, Ty, TyCtxt};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, DefPathHash};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
@@ -9,6 +9,7 @@ use std::mem;
 use self::SimplifiedTypeGen::*;
 
 pub type SimplifiedType = SimplifiedTypeGen<DefId>;
+pub type StableSimplifiedType = SimplifiedTypeGen<DefPathHash>;
 
 /// See `simplify_type`
 ///
@@ -104,6 +105,12 @@ pub fn simplify_type(
         ty::Opaque(def_id, _) => Some(OpaqueSimplifiedType(def_id)),
         ty::Foreign(def_id) => Some(ForeignSimplifiedType(def_id)),
         ty::Placeholder(..) | ty::Bound(..) | ty::Infer(_) | ty::Error(_) => None,
+    }
+}
+
+impl SimplifiedType {
+    pub fn to_stable(self, tcx: TyCtxt<'tcx>) -> StableSimplifiedType {
+        self.map_def(|def_id| tcx.def_path_hash(def_id))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -50,7 +50,7 @@ impl ChildrenExt for Children {
         let trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap();
         if let Some(st) = fast_reject::simplify_type(tcx, trait_ref.self_ty(), false) {
             debug!("insert_blindly: impl_def_id={:?} st={:?}", impl_def_id, st);
-            self.nonblanket_impls.entry(st.to_stable(tcx)).or_default().push(impl_def_id)
+            self.non_blanket_impls.entry(st.to_stable(tcx)).or_default().push(impl_def_id)
         } else {
             debug!("insert_blindly: impl_def_id={:?} st=None", impl_def_id);
             self.blanket_impls.push(impl_def_id)
@@ -65,7 +65,7 @@ impl ChildrenExt for Children {
         let vec: &mut Vec<DefId>;
         if let Some(st) = fast_reject::simplify_type(tcx, trait_ref.self_ty(), false) {
             debug!("remove_existing: impl_def_id={:?} st={:?}", impl_def_id, st);
-            vec = self.nonblanket_impls.get_mut(&st.to_stable(tcx)).unwrap();
+            vec = self.non_blanket_impls.get_mut(&st.to_stable(tcx)).unwrap();
         } else {
             debug!("remove_existing: impl_def_id={:?} st=None", impl_def_id);
             vec = &mut self.blanket_impls;
@@ -216,7 +216,7 @@ impl ChildrenExt for Children {
 }
 
 fn iter_children(children: &mut Children) -> impl Iterator<Item = DefId> + '_ {
-    let nonblanket = children.nonblanket_impls.iter_mut().flat_map(|(_, v)| v.iter());
+    let nonblanket = children.non_blanket_impls.iter_mut().flat_map(|(_, v)| v.iter());
     children.blanket_impls.iter().chain(nonblanket).cloned()
 }
 
@@ -224,7 +224,7 @@ fn filtered_children(
     children: &mut Children,
     st: StableSimplifiedType,
 ) -> impl Iterator<Item = DefId> + '_ {
-    let nonblanket = children.nonblanket_impls.entry(st).or_default().iter();
+    let nonblanket = children.non_blanket_impls.entry(st).or_default().iter();
     children.blanket_impls.iter().chain(nonblanket).cloned()
 }
 


### PR DESCRIPTION
We sometimes iterate over all non_blanket_impls, not sure if this is observable outside
of error messages (i.e. as incremental bugs), but it hopefully fixes the underlying issue of #86986.

It does not fix the issue of #86986, as the iteration order still isn't stable between different targets

r? @nikomatsakis @Aaron1011
