### PR TITLE
Point at argument instead of call for their obligations

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1998,7 +1998,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                     &obligation,
                                     &traits::SelectionError::Unimplemented,
                                     false,
-                                    false,
                                 );
                             }
                         }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mismatched_static_lifetime.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mismatched_static_lifetime.rs
@@ -29,7 +29,13 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             SubregionOrigin::Subtype(box TypeTrace { ref cause, .. }) => cause,
             _ => return None,
         };
-        let (parent, impl_def_id) = match &cause.code {
+        // If we added a "points at argument expression" obligation, we remove it here, we care
+        // about the original obligation only.
+        let code = match &cause.code {
+            ObligationCauseCode::FunctionArgumentObligation { parent_code, .. } => &*parent_code,
+            _ => &cause.code,
+        };
+        let (parent, impl_def_id) = match code {
             ObligationCauseCode::MatchImpl(parent, impl_def_id) => (parent, impl_def_id),
             _ => return None,
         };

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -66,10 +66,6 @@ pub type Selection<'tcx> = ImplSource<'tcx, PredicateObligation<'tcx>>;
 pub struct FulfillmentError<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
     pub code: FulfillmentErrorCode<'tcx>,
-    /// Diagnostics only: we opportunistically change the `code.span` when we encounter an
-    /// obligation error caused by a call argument. When this is the case, we also signal that in
-    /// this field to ensure accuracy of suggestions.
-    pub points_at_arg_span: bool,
     /// Diagnostics only: the 'root' obligation which resulted in
     /// the failure to process `obligation`. This is the obligation
     /// that was initially passed to `register_predicate_obligation`
@@ -128,7 +124,7 @@ impl<'tcx> FulfillmentError<'tcx> {
         code: FulfillmentErrorCode<'tcx>,
         root_obligation: PredicateObligation<'tcx>,
     ) -> FulfillmentError<'tcx> {
-        FulfillmentError { obligation, code, points_at_arg_span: false, root_obligation }
+        FulfillmentError { obligation, code, root_obligation }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/chalk_fulfill.rs
@@ -57,7 +57,6 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                 .map(|obligation| FulfillmentError {
                     obligation: obligation.clone(),
                     code: FulfillmentErrorCode::CodeAmbiguity,
-                    points_at_arg_span: false,
                     // FIXME - does Chalk have a notation of 'root obligation'?
                     // This is just for diagnostics, so it's okay if this is wrong
                     root_obligation: obligation.clone(),
@@ -112,7 +111,6 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                                     code: FulfillmentErrorCode::CodeSelectionError(
                                         SelectionError::Unimplemented,
                                     ),
-                                    points_at_arg_span: false,
                                     // FIXME - does Chalk have a notation of 'root obligation'?
                                     // This is just for diagnostics, so it's okay if this is wrong
                                     root_obligation: obligation,
@@ -129,7 +127,6 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                         code: FulfillmentErrorCode::CodeSelectionError(
                             SelectionError::Unimplemented,
                         ),
-                        points_at_arg_span: false,
                         // FIXME - does Chalk have a notation of 'root obligation'?
                         // This is just for diagnostics, so it's okay if this is wrong
                         root_obligation: obligation,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -54,7 +54,6 @@ pub trait InferCtxtExt<'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'tcx>,
         trait_ref: ty::PolyTraitRef<'tcx>,
-        points_at_arg: bool,
     );
 
     fn get_closure_name(
@@ -69,7 +68,6 @@ pub trait InferCtxtExt<'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
     );
 
     fn suggest_add_reference_to_arg(
@@ -77,7 +75,6 @@ pub trait InferCtxtExt<'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: &ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
         has_custom_message: bool,
     ) -> bool;
 
@@ -93,7 +90,6 @@ pub trait InferCtxtExt<'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
     );
 
     fn suggest_semicolon_removal(
@@ -490,16 +486,19 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'tcx>,
         trait_ref: ty::PolyTraitRef<'tcx>,
-        points_at_arg: bool,
     ) {
         // It only make sense when suggesting dereferences for arguments
-        if !points_at_arg {
+        let code = if let ObligationCauseCode::FunctionArgumentObligation { parent_code, .. } =
+            &obligation.cause.code
+        {
+            std::rc::Rc::clone(parent_code)
+        } else {
             return;
-        }
+        };
         let param_env = obligation.param_env;
         let body_id = obligation.cause.body_id;
         let span = obligation.cause.span;
-        let real_trait_ref = match &obligation.cause.code {
+        let real_trait_ref = match &*code {
             ObligationCauseCode::ImplDerivedObligation(cause)
             | ObligationCauseCode::DerivedObligation(cause)
             | ObligationCauseCode::BuiltinDerivedObligation(cause) => cause.parent_trait_ref,
@@ -584,7 +583,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
     ) {
         let self_ty = match trait_ref.self_ty().no_bound_vars() {
             None => return,
@@ -656,11 +654,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
             _ => return,
         };
-        if points_at_arg {
+        if matches!(obligation.cause.code, ObligationCauseCode::FunctionArgumentObligation { .. }) {
             // When the obligation error has been ensured to have been caused by
             // an argument, the `obligation.cause.span` points at the expression
-            // of the argument, so we can provide a suggestion. This is signaled
-            // by `points_at_arg`. Otherwise, we give a more general note.
+            // of the argument, so we can provide a suggestion. Otherwise, we give
+            // a more general note.
             err.span_suggestion_verbose(
                 obligation.cause.span.shrink_to_hi(),
                 &msg,
@@ -677,7 +675,6 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: &ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
         has_custom_message: bool,
     ) -> bool {
         let span = obligation.cause.span;
@@ -686,9 +683,14 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ExpnKind::Desugaring(DesugaringKind::ForLoop(ForLoopLoc::IntoIter))
         );
 
-        if !points_at_arg && !points_at_for_iter {
-            return false;
-        }
+        let code =
+            if let (ObligationCauseCode::FunctionArgumentObligation { parent_code, .. }, false) =
+                (&obligation.cause.code, points_at_for_iter)
+            {
+                std::rc::Rc::clone(parent_code)
+            } else {
+                return false;
+            };
 
         // List of traits for which it would be nonsensical to suggest borrowing.
         // For instance, immutable references are always Copy, so suggesting to
@@ -787,7 +789,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             return false;
         };
 
-        if let ObligationCauseCode::ImplDerivedObligation(obligation) = &obligation.cause.code {
+        if let ObligationCauseCode::ImplDerivedObligation(obligation) = &*code {
             let expected_trait_ref = obligation.parent_trait_ref.skip_binder();
             let new_imm_trait_ref =
                 ty::TraitRef::new(obligation.parent_trait_ref.def_id(), imm_substs);
@@ -799,7 +801,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return try_borrowing(new_mut_trait_ref, expected_trait_ref, true, &[]);
             }
         } else if let ObligationCauseCode::BindingObligation(_, _)
-        | ObligationCauseCode::ItemObligation(_) = &obligation.cause.code
+        | ObligationCauseCode::ItemObligation(_) = &*code
         {
             if try_borrowing(
                 ty::TraitRef::new(trait_ref.def_id, imm_substs),
@@ -891,8 +893,12 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
-        points_at_arg: bool,
     ) {
+        let points_at_arg = matches!(
+            obligation.cause.code,
+            ObligationCauseCode::FunctionArgumentObligation { .. },
+        );
+
         let span = obligation.cause.span;
         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
             let refs_number =
@@ -2284,6 +2290,21 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         err,
                         &parent_predicate,
                         &data.parent_code,
+                        obligated_types,
+                        seen_requirements,
+                    )
+                });
+            }
+            ObligationCauseCode::FunctionArgumentObligation {
+                arg_hir_id: _,
+                call_hir_id: _,
+                ref parent_code,
+            } => {
+                ensure_sufficient_stack(|| {
+                    self.note_obligation_cause_code(
+                        err,
+                        predicate,
+                        &parent_code,
                         obligated_types,
                         seen_requirements,
                     )

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -491,7 +491,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let code = if let ObligationCauseCode::FunctionArgumentObligation { parent_code, .. } =
             &obligation.cause.code
         {
-            std::rc::Rc::clone(parent_code)
+            parent_code.clone()
         } else {
             return;
         };
@@ -687,7 +687,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             if let (ObligationCauseCode::FunctionArgumentObligation { parent_code, .. }, false) =
                 (&obligation.cause.code, points_at_for_iter)
             {
-                std::rc::Rc::clone(parent_code)
+                parent_code.clone()
             } else {
                 return false;
             };

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -72,7 +72,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         arg_exprs: &'tcx [hir::Expr<'tcx>],
         expected: Expectation<'tcx>,
     ) -> Ty<'tcx> {
-        let original_callee_ty = self.check_expr(callee_expr);
+        let original_callee_ty = match &callee_expr.kind {
+            hir::ExprKind::Path(hir::QPath::Resolved(..) | hir::QPath::TypeRelative(..)) => self
+                .check_expr_with_expectation_and_args(
+                    callee_expr,
+                    Expectation::NoExpectation,
+                    arg_exprs,
+                ),
+            _ => self.check_expr(callee_expr),
+        };
+
         let expr_ty = self.structurally_resolved_type(call_expr.span, original_callee_ty);
 
         let mut autoderef = self.autoderef(callee_expr.span, expr_ty);

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -707,13 +707,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
                 // Object safety violations or miscellaneous.
                 Err(err) => {
-                    self.report_selection_error(
-                        obligation.clone(),
-                        &obligation,
-                        &err,
-                        false,
-                        false,
-                    );
+                    self.report_selection_error(obligation.clone(), &obligation, &err, false);
                     // Treat this like an obligation and follow through
                     // with the unsizing - the lack of a coercion should
                     // be silent, as it causes a type mismatch later.

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -83,7 +83,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// version (resolve_vars_if_possible), this version will
     /// also select obligations if it seems useful, in an effort
     /// to get more type information.
-    pub(in super::super) fn resolve_vars_with_obligations(&self, mut ty: Ty<'tcx>) -> Ty<'tcx> {
+    pub(in super::super) fn resolve_vars_with_obligations(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
+        self.resolve_vars_with_obligations_and_mutate_fulfillment(ty, |_| {})
+    }
+
+    pub(in super::super) fn resolve_vars_with_obligations_and_mutate_fulfillment(
+        &self,
+        mut ty: Ty<'tcx>,
+        mutate_fulfillment_errors: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
+    ) -> Ty<'tcx> {
         debug!("resolve_vars_with_obligations(ty={:?})", ty);
 
         // No Infer()? Nothing needs doing.
@@ -103,7 +111,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // possible. This can help substantially when there are
         // indirect dependencies that don't seem worth tracking
         // precisely.
-        self.select_obligations_where_possible(false, |_| {});
+        self.select_obligations_where_possible(false, mutate_fulfillment_errors);
         ty = self.resolve_vars_if_possible(ty);
 
         debug!("resolve_vars_with_obligations: ty={:?}", ty);

--- a/src/test/ui/associated-types/associated-types-bound-failure.stderr
+++ b/src/test/ui/associated-types/associated-types-bound-failure.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `<G as GetToInt>::R: ToInt` is not satisfied
   --> $DIR/associated-types-bound-failure.rs:19:19
    |
 LL |     ToInt::to_int(&g.get())
-   |                   ^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
+   |     ------------- ^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by `ToInt::to_int`
   --> $DIR/associated-types-bound-failure.rs:6:5

--- a/src/test/ui/associated-types/associated-types-path-2.rs
+++ b/src/test/ui/associated-types/associated-types-path-2.rs
@@ -28,13 +28,11 @@ pub fn f1_int_uint() {
 pub fn f1_uint_uint() {
     f1(2u32, 4u32);
     //~^ ERROR `u32: Foo` is not satisfied
-    //~| ERROR `u32: Foo` is not satisfied
 }
 
 pub fn f1_uint_int() {
     f1(2u32, 4i32);
     //~^ ERROR `u32: Foo` is not satisfied
-    //~| ERROR `u32: Foo` is not satisfied
 }
 
 pub fn f2_int() {

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -10,10 +10,10 @@ LL |     f1(2i32, 4u32);
    |               ~~~
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:29:5
+  --> $DIR/associated-types-path-2.rs:29:14
    |
 LL |     f1(2u32, 4u32);
-   |     ^^ the trait `Foo` is not implemented for `u32`
+   |              ^^^^ the trait `Foo` is not implemented for `u32`
    |
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:13:14
@@ -25,13 +25,13 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
    |
 LL |     f1(2u32, 4u32);
-   |     ^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `u32`
+   |     ^^ the trait `Foo` is not implemented for `u32`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:35:5
+  --> $DIR/associated-types-path-2.rs:35:14
    |
 LL |     f1(2u32, 4i32);
-   |     ^^ the trait `Foo` is not implemented for `u32`
+   |              ^^^^ the trait `Foo` is not implemented for `u32`
    |
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:13:14
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5
    |
 LL |     f1(2u32, 4i32);
-   |     ^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `u32`
+   |     ^^ the trait `Foo` is not implemented for `u32`
 
 error[E0308]: mismatched types
   --> $DIR/associated-types-path-2.rs:41:18

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -24,13 +24,7 @@ LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:29:5
-   |
-LL |     f1(2u32, 4u32);
-   |     ^^ the trait `Foo` is not implemented for `u32`
-
-error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:35:14
+  --> $DIR/associated-types-path-2.rs:34:14
    |
 LL |     f1(2u32, 4i32);
    |     --       ^^^^ the trait `Foo` is not implemented for `u32`
@@ -43,14 +37,8 @@ note: required by a bound in `f1`
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
-error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:35:5
-   |
-LL |     f1(2u32, 4i32);
-   |     ^^ the trait `Foo` is not implemented for `u32`
-
 error[E0308]: mismatched types
-  --> $DIR/associated-types-path-2.rs:41:18
+  --> $DIR/associated-types-path-2.rs:39:18
    |
 LL |     let _: i32 = f2(2i32);
    |            ---   ^^^^^^^^ expected `i32`, found `u32`
@@ -62,7 +50,7 @@ help: you can convert a `u32` to an `i32` and panic if the converted value doesn
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
    |                          ++++++++++++++++++++
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -13,7 +13,9 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:14
    |
 LL |     f1(2u32, 4u32);
-   |              ^^^^ the trait `Foo` is not implemented for `u32`
+   |     --       ^^^^ the trait `Foo` is not implemented for `u32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:13:14
@@ -31,7 +33,9 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:14
    |
 LL |     f1(2u32, 4i32);
-   |              ^^^^ the trait `Foo` is not implemented for `u32`
+   |     --       ^^^^ the trait `Foo` is not implemented for `u32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f1`
   --> $DIR/associated-types-path-2.rs:13:14

--- a/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
+++ b/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-27675-unchecked-bounds.rs:15:31
    |
 LL |     copy::<dyn Setup<From=T>>(t)
-   |                               ^ the trait `Copy` is not implemented for `T`
+   |     ------------------------- ^ the trait `Copy` is not implemented for `T`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `copy`
   --> $DIR/issue-27675-unchecked-bounds.rs:10:12

--- a/src/test/ui/async-await/issue-72442.stderr
+++ b/src/test/ui/async-await/issue-72442.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Option<&str>: AsRef<Path>` is not satisfied
   --> $DIR/issue-72442.rs:12:36
    |
 LL |             let mut f = File::open(path.to_str())?;
-   |                                    ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`
+   |                         ---------- ^^^^^^^^^^^^^ the trait `AsRef<Path>` is not implemented for `Option<&str>`
+   |                         |
+   |                         required by a bound introduced by this call
    |
 note: required by a bound in `File::open`
   --> $SRC_DIR/std/src/fs.rs:LL:COL

--- a/src/test/ui/box/into-boxed-slice-fail.stderr
+++ b/src/test/ui/box/into-boxed-slice-fail.stderr
@@ -2,7 +2,9 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> $DIR/into-boxed-slice-fail.rs:7:35
    |
 LL |     let _ = Box::into_boxed_slice(boxed_slice);
-   |                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             --------------------- ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by `Box::<T, A>::into_boxed_slice`
@@ -24,7 +26,9 @@ error[E0277]: the size for values of type `dyn Debug` cannot be known at compila
   --> $DIR/into-boxed-slice-fail.rs:11:35
    |
 LL |     let _ = Box::into_boxed_slice(boxed_trait);
-   |                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             --------------------- ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
 note: required by `Box::<T, A>::into_boxed_slice`

--- a/src/test/ui/chalkify/type_inference.stderr
+++ b/src/test/ui/chalkify/type_inference.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `{float}: Bar` is not satisfied
   --> $DIR/type_inference.rs:27:14
    |
 LL |     only_bar(x);
-   |              ^ the trait `Bar` is not implemented for `{float}`
+   |     -------- ^ the trait `Bar` is not implemented for `{float}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <i32 as Bar>

--- a/src/test/ui/closure-expected.stderr
+++ b/src/test/ui/closure-expected.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `FnOnce<()>` closure, found `{integer}`
   --> $DIR/closure-expected.rs:3:23
    |
 LL |     let y = x.or_else(4);
-   |                       ^ expected an `FnOnce<()>` closure, found `{integer}`
+   |               ------- ^ expected an `FnOnce<()>` closure, found `{integer}`
+   |               |
+   |               required by a bound introduced by this call
    |
    = help: the trait `FnOnce<()>` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }`

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -2,7 +2,9 @@ error[E0277]: `F` cannot be shared between threads safely
   --> $DIR/closure-bounds-subtype.rs:13:22
    |
 LL |     take_const_owned(f);
-   |                      ^ `F` cannot be shared between threads safely
+   |     ---------------- ^ `F` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `take_const_owned`
   --> $DIR/closure-bounds-subtype.rs:4:50

--- a/src/test/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/src/test/ui/closures/coerce-unsafe-to-closure.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `FnOnce<(&str,)>` closure, found `unsafe extern "rust-i
   --> $DIR/coerce-unsafe-to-closure.rs:2:44
    |
 LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
-   |                                            ^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+   |                                        --- ^^^^^^^^^^^^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+   |                                        |
+   |                                        required by a bound introduced by this call
    |
    = help: the trait `FnOnce<(&str,)>` is not implemented for `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
 

--- a/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
+++ b/src/test/ui/coherence/coherence-unsafe-trait-object-impl.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&dyn Trait: Trait` is not satisfied
   --> $DIR/coherence-unsafe-trait-object-impl.rs:15:13
    |
 LL |     takes_t(t);
-   |             ^ the trait `Trait` is not implemented for `&dyn Trait`
+   |     ------- ^ the trait `Trait` is not implemented for `&dyn Trait`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_t`
   --> $DIR/coherence-unsafe-trait-object-impl.rs:10:15

--- a/src/test/ui/const-generics/issues/issue-86530.stderr
+++ b/src/test/ui/const-generics/issues/issue-86530.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&str: X` is not satisfied
   --> $DIR/issue-86530.rs:16:7
    |
 LL |     z(" ");
-   |       ^^^ the trait `X` is not implemented for `&str`
+   |     - ^^^ the trait `X` is not implemented for `&str`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `z`
   --> $DIR/issue-86530.rs:10:8

--- a/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -5,7 +5,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 ...
 LL |      x: Error
-   |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
+   |      ^^^^^^^^
+   |      |
+   |      the trait `Clone` is not implemented for `Error`
+   |      required by a bound introduced by this call
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -5,10 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 ...
 LL |      x: Error
-   |      ^^^^^^^^
-   |      |
-   |      the trait `Clone` is not implemented for `Error`
-   |      required by a bound introduced by this call
+   |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-enum.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum.stderr
@@ -5,10 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 ...
 LL |      Error
-   |      ^^^^^
-   |      |
-   |      the trait `Clone` is not implemented for `Error`
-   |      required by a bound introduced by this call
+   |      ^^^^^ the trait `Clone` is not implemented for `Error`
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-enum.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum.stderr
@@ -5,7 +5,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 ...
 LL |      Error
-   |      ^^^^^ the trait `Clone` is not implemented for `Error`
+   |      ^^^^^
+   |      |
+   |      the trait `Clone` is not implemented for `Error`
+   |      required by a bound introduced by this call
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-struct.stderr
@@ -5,7 +5,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct Struct {
 LL |     x: Error
-   |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
+   |     ^^^^^^^^
+   |     |
+   |     the trait `Clone` is not implemented for `Error`
+   |     required by a bound introduced by this call
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-struct.stderr
@@ -5,10 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct Struct {
 LL |     x: Error
-   |     ^^^^^^^^
-   |     |
-   |     the trait `Clone` is not implemented for `Error`
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -5,10 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct Struct(
 LL |     Error
-   |     ^^^^^
-   |     |
-   |     the trait `Clone` is not implemented for `Error`
-   |     required by a bound introduced by this call
+   |     ^^^^^ the trait `Clone` is not implemented for `Error`
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -5,7 +5,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct Struct(
 LL |     Error
-   |     ^^^^^ the trait `Clone` is not implemented for `Error`
+   |     ^^^^^
+   |     |
+   |     the trait `Clone` is not implemented for `Error`
+   |     required by a bound introduced by this call
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `C: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
 LL |     is_copy(B { a: 1, b: C });
-   |             ^^^^^^^^^^^^^^^^
-   |             |
-   |             expected an implementor of trait `Copy`
-   |             help: consider borrowing here: `&B { a: 1, b: C }`
+   |     ------- ^^^^^^^^^^^^^^^^
+   |     |       |
+   |     |       expected an implementor of trait `Copy`
+   |     |       help: consider borrowing here: `&B { a: 1, b: C }`
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Copy` for `B<C>`
   --> $DIR/deriving-copyclone.rs:9:10
@@ -23,10 +24,11 @@ error[E0277]: the trait bound `C: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
 LL |     is_clone(B { a: 1, b: C });
-   |              ^^^^^^^^^^^^^^^^
-   |              |
-   |              expected an implementor of trait `Clone`
-   |              help: consider borrowing here: `&B { a: 1, b: C }`
+   |     -------- ^^^^^^^^^^^^^^^^
+   |     |        |
+   |     |        expected an implementor of trait `Clone`
+   |     |        help: consider borrowing here: `&B { a: 1, b: C }`
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Clone` for `B<C>`
   --> $DIR/deriving-copyclone.rs:9:16
@@ -44,10 +46,11 @@ error[E0277]: the trait bound `D: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
 LL |     is_copy(B { a: 1, b: D });
-   |             ^^^^^^^^^^^^^^^^
-   |             |
-   |             expected an implementor of trait `Copy`
-   |             help: consider borrowing here: `&B { a: 1, b: D }`
+   |     ------- ^^^^^^^^^^^^^^^^
+   |     |       |
+   |     |       expected an implementor of trait `Copy`
+   |     |       help: consider borrowing here: `&B { a: 1, b: D }`
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Copy` for `B<D>`
   --> $DIR/deriving-copyclone.rs:9:10

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -29,7 +29,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct C {
 LL |     x: NoCloneOrEq
-   |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     the trait `Clone` is not implemented for `NoCloneOrEq`
+   |     required by a bound introduced by this call
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -29,10 +29,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct C {
 LL |     x: NoCloneOrEq
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     the trait `Clone` is not implemented for `NoCloneOrEq`
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
    |
 note: required by `clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `i8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:24:21
    |
 LL |     Foo::<i32>::bar(&1i8);
-   |                     ^^^^ the trait `Foo<i32>` is not implemented for `i8`
+   |     --------------- ^^^^ the trait `Foo<i32>` is not implemented for `i8`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <i8 as Foo<bool>>
@@ -20,7 +22,9 @@ error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
    |
 LL |     Foo::<i32>::bar(&1u8);
-   |                     ^^^^ the trait `Foo<i32>` is not implemented for `u8`
+   |     --------------- ^^^^ the trait `Foo<i32>` is not implemented for `u8`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <u8 as Foo<bool>>
@@ -37,7 +41,9 @@ error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
    |
 LL |     Foo::<i32>::bar(&true);
-   |                     ^^^^^ the trait `Foo<i32>` is not implemented for `bool`
+   |     --------------- ^^^^^ the trait `Foo<i32>` is not implemented for `bool`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <bool as Foo<bool>>

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -16,7 +16,9 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:15:15
    |
 LL |     some_func(5i32);
-   |               ^^^^ the trait `Foo` is not implemented for `i32`
+   |     --------- ^^^^ the trait `Foo` is not implemented for `i32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `some_func`
   --> $DIR/E0277.rs:7:17

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/error-should-say-copy-not-pod.rs:6:17
    |
 LL |     check_bound("nocopy".to_string());
-   |                 ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |     ----------- ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check_bound`
   --> $DIR/error-should-say-copy-not-pod.rs:3:18

--- a/src/test/ui/expr/malformed_closure/ruby_style_closure.stderr
+++ b/src/test/ui/expr/malformed_closure/ruby_style_closure.stderr
@@ -5,10 +5,19 @@ LL |         Some(x * 2)
    |              ^ not found in this scope
 
 error[E0277]: expected a `FnOnce<({integer},)>` closure, found `Option<_>`
-  --> $DIR/ruby_style_closure.rs:10:22
+  --> $DIR/ruby_style_closure.rs:10:31
    |
-LL |     let p = Some(45).and_then({
-   |                      ^^^^^^^^ expected an `FnOnce<({integer},)>` closure, found `Option<_>`
+LL |       let p = Some(45).and_then({
+   |  ______________________--------_^
+   | |                      |
+   | |                      required by a bound introduced by this call
+LL | |
+LL | |         |x| println!("doubling {}", x);
+LL | |         Some(x * 2)
+   | |         -----------
+LL | |
+LL | |     });
+   | |_____^ expected an `FnOnce<({integer},)>` closure, found `Option<_>`
    |
    = help: the trait `FnOnce<({integer},)>` is not implemented for `Option<_>`
 

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<()>` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL |     is_fn(f);
-   |           ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
+   |     ----- ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Fn<()>` is not implemented for `extern "C" fn() {f}`
    = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }`

--- a/src/test/ui/feature-gates/feature-gate-unsized_fn_params.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unsized_fn_params.stderr
@@ -12,10 +12,10 @@ LL | fn foo(x: &dyn Foo) {
    |           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:24:5
+  --> $DIR/feature-gate-unsized_fn_params.rs:24:9
    |
 LL |     foo(*x);
-   |     ^^^ doesn't have a size known at compile-time
+   |         ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = note: all function arguments must have a statically known size

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -35,7 +35,9 @@ error[E0277]: expected a `Fn<(isize,)>` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:14
    |
 LL |     needs_fn(1);
-   |              ^ expected an `Fn<(isize,)>` closure, found `{integer}`
+   |     -------- ^ expected an `Fn<(isize,)>` closure, found `{integer}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `{integer}`
 note: required by a bound in `needs_fn`

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -2,7 +2,9 @@ error[E0277]: `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6]` cannot b
   --> $DIR/static-not-unpin.rs:14:18
    |
 LL |     assert_unpin(generator);
-   |                  ^^^^^^^^^ the trait `Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6]`
+   |     ------------ ^^^^^^^^^ the trait `Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6]`
+   |     |
+   |     required by a bound introduced by this call
    |
    = note: consider using `Box::pin`
 note: required by a bound in `assert_unpin`

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-62529-1.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-62529-1.stderr
@@ -2,7 +2,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/issue-62529-1.rs:80:10
    |
 LL |       task(annotate(
-   |  __________^
+   |  _____----_^
+   | |     |
+   | |     required by a bound introduced by this call
 LL | |
 LL | |
 LL | |         Annotate::<RefMutFamily<usize>>::new(),
@@ -26,7 +28,9 @@ error[E0277]: the size for values of type `impl Execute` cannot be known at comp
   --> $DIR/issue-62529-1.rs:80:10
    |
 LL |       task(annotate(
-   |  __________^
+   |  _____----_^
+   | |     |
+   | |     required by a bound introduced by this call
 LL | |
 LL | |
 LL | |         Annotate::<RefMutFamily<usize>>::new(),
@@ -50,7 +54,9 @@ error[E0277]: the trait bound `impl Execute: Execute` is not satisfied
   --> $DIR/issue-62529-1.rs:80:10
    |
 LL |       task(annotate(
-   |  __________^
+   |  _____----_^
+   | |     |
+   | |     required by a bound introduced by this call
 LL | |
 LL | |
 LL | |         Annotate::<RefMutFamily<usize>>::new(),

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-62529-1.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-62529-1.stderr
@@ -1,11 +1,17 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/issue-62529-1.rs:80:10
    |
-LL |     task(annotate(
-   |          ^^^^^^^^ expected signature of `for<'r> fn(<RefMutFamily<usize> as FamilyLt<'r>>::Out) -> _`
-...
-LL |         |value: &mut usize| {
-   |         ------------------- found signature of `for<'r> fn(&'r mut usize) -> _`
+LL |       task(annotate(
+   |  __________^
+LL | |
+LL | |
+LL | |         Annotate::<RefMutFamily<usize>>::new(),
+LL | |         |value: &mut usize| {
+   | |         ------------------- found signature of `for<'r> fn(&'r mut usize) -> _`
+LL | |             *value = 2;
+LL | |         }
+LL | |     ));
+   | |_____^ expected signature of `for<'r> fn(<RefMutFamily<usize> as FamilyLt<'r>>::Out) -> _`
    |
 note: required by a bound in `annotate`
   --> $DIR/issue-62529-1.rs:44:8

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:26
    |
 LL |     want_bar_for_any_ccx(b);
-   |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |     -------------------- ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:32:15

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:18:26
    |
 LL |     want_foo_for_any_tcx(f);
-   |                          ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
+   |     -------------------- ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `want_foo_for_any_tcx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:22:15
@@ -20,7 +22,9 @@ error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:26
    |
 LL |     want_bar_for_any_ccx(b);
-   |                          ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |     -------------------- ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `want_bar_for_any_ccx`
   --> $DIR/hrtb-higher-ranker-supertraits.rs:39:15

--- a/src/test/ui/issues/issue-17651.rs
+++ b/src/test/ui/issues/issue-17651.rs
@@ -4,5 +4,4 @@
 fn main() {
     (|| Box::new(*(&[0][..])))();
     //~^ ERROR the size for values of type
-    //~| ERROR the size for values of type
 }

--- a/src/test/ui/issues/issue-17651.stderr
+++ b/src/test/ui/issues/issue-17651.stderr
@@ -2,7 +2,9 @@ error[E0277]: the size for values of type `[{integer}]` cannot be known at compi
   --> $DIR/issue-17651.rs:5:18
    |
 LL |     (|| Box::new(*(&[0][..])))();
-   |                  ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |         -------- ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[{integer}]`
 note: required by `Box::<T>::new`

--- a/src/test/ui/issues/issue-17651.stderr
+++ b/src/test/ui/issues/issue-17651.stderr
@@ -13,16 +13,6 @@ note: required by `Box::<T>::new`
 LL |     pub fn new(x: T) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `[{integer}]` cannot be known at compilation time
-  --> $DIR/issue-17651.rs:5:9
-   |
-LL |     (|| Box::new(*(&[0][..])))();
-   |         ^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[{integer}]`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-23966.stderr
+++ b/src/test/ui/issues/issue-23966.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `FnMut<(_, char)>` closure, found `()`
   --> $DIR/issue-23966.rs:2:32
    |
 LL |     "".chars().fold(|_, _| (), ());
-   |                                ^^ expected an `FnMut<(_, char)>` closure, found `()`
+   |                ----            ^^ expected an `FnMut<(_, char)>` closure, found `()`
+   |                |
+   |                required by a bound introduced by this call
    |
    = help: the trait `FnMut<(_, char)>` is not implemented for `()`
 

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `(): InOut<_>` is not satisfied
   --> $DIR/issue-25076.rs:10:20
    |
 LL |     do_fold(bot(), ());
-   |                    ^^ the trait `InOut<_>` is not implemented for `()`
+   |     -------        ^^ the trait `InOut<_>` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `do_fold`
   --> $DIR/issue-25076.rs:5:18

--- a/src/test/ui/issues/issue-28098.stderr
+++ b/src/test/ui/issues/issue-28098.stderr
@@ -2,7 +2,9 @@ error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:2:28
    |
 LL |     let _ = Iterator::next(&mut ());
-   |                            ^^^^^^^ `()` is not an iterator
+   |             -------------- ^^^^^^^ `()` is not an iterator
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
 note: required by `std::iter::Iterator::next`
@@ -29,7 +31,9 @@ error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:9:28
    |
 LL |     let _ = Iterator::next(&mut ());
-   |                            ^^^^^^^ `()` is not an iterator
+   |             -------------- ^^^^^^^ `()` is not an iterator
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
 note: required by `std::iter::Iterator::next`
@@ -50,7 +54,9 @@ error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:18:28
    |
 LL |     let _ = Iterator::next(&mut ());
-   |                            ^^^^^^^ `()` is not an iterator
+   |             -------------- ^^^^^^^ `()` is not an iterator
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
 note: required by `std::iter::Iterator::next`
@@ -63,7 +69,9 @@ error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:22:28
    |
 LL |     let _ = Iterator::next(&mut ());
-   |                            ^^^^^^^ `()` is not an iterator
+   |             -------------- ^^^^^^^ `()` is not an iterator
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
 note: required by `std::iter::Iterator::next`

--- a/src/test/ui/issues/issue-30355.stderr
+++ b/src/test/ui/issues/issue-30355.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-30355.rs:5:6
+  --> $DIR/issue-30355.rs:5:8
    |
 LL |     &X(*Y)
-   |      ^ doesn't have a size known at compile-time
+   |        ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all function arguments must have a statically known size

--- a/src/test/ui/issues/issue-47706-trait.stderr
+++ b/src/test/ui/issues/issue-47706-trait.stderr
@@ -4,7 +4,9 @@ error[E0593]: function is expected to take a single 0-tuple as argument, but it 
 LL |     fn f(&self, _: ()) {
    |     ------------------ takes 2 distinct arguments
 LL |         None::<()>.map(Self::f);
-   |                        ^^^^^^^ expected function that takes a single 0-tuple as argument
+   |                    --- ^^^^^^^ expected function that takes a single 0-tuple as argument
+   |                    |
+   |                    required by a bound introduced by this call
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -5,7 +5,9 @@ LL |     pub fn new(foo: Option<i32>, _: ()) -> Foo {
    |     ------------------------------------------ takes 2 arguments
 ...
 LL |         self.foo.map(Foo::new)
-   |                      ^^^^^^^^ expected function that takes 1 argument
+   |                  --- ^^^^^^^^ expected function that takes 1 argument
+   |                  |
+   |                  required by a bound introduced by this call
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
   --> $DIR/issue-47706.rs:27:9
@@ -14,7 +16,9 @@ LL |     Bar(i32),
    |     -------- takes 1 argument
 ...
 LL |     foo(Qux::Bar);
-   |         ^^^^^^^^ expected function that takes 0 arguments
+   |     --- ^^^^^^^^ expected function that takes 0 arguments
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/issue-47706.rs:22:8

--- a/src/test/ui/issues/issue-59494.stderr
+++ b/src/test/ui/issues/issue-59494.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<(_,)>` closure, found `impl Fn<(((_, _), _),)>`
   --> $DIR/issue-59494.rs:21:22
    |
 LL |     let t8 = t8n(t7, t7p(f, g));
-   |                      ^^^^^^^^^ expected an `Fn<(_,)>` closure, found `impl Fn<(((_, _), _),)>`
+   |              ---     ^^^^^^^^^ expected an `Fn<(_,)>` closure, found `impl Fn<(((_, _), _),)>`
+   |              |
+   |              required by a bound introduced by this call
    |
    = help: the trait `Fn<(_,)>` is not implemented for `impl Fn<(((_, _), _),)>`
 note: required by a bound in `t8n`

--- a/src/test/ui/issues/issue-60218.stderr
+++ b/src/test/ui/issues/issue-60218.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&u32: Foo` is not satisfied
   --> $DIR/issue-60218.rs:18:27
    |
 LL |     trigger_error(vec![], |x: &u32| x)
-   |                           ^^^^^^^^^^^ the trait `Foo` is not implemented for `&u32`
+   |     -------------         ^^^^^^^^^^^ the trait `Foo` is not implemented for `&u32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `trigger_error`
   --> $DIR/issue-60218.rs:13:72

--- a/src/test/ui/issues/issue-60218.stderr
+++ b/src/test/ui/issues/issue-60218.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `&u32: Foo` is not satisfied
-  --> $DIR/issue-60218.rs:18:5
+  --> $DIR/issue-60218.rs:18:27
    |
 LL |     trigger_error(vec![], |x: &u32| x)
-   |     ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `&u32`
+   |                           ^^^^^^^^^^^ the trait `Foo` is not implemented for `&u32`
    |
 note: required by a bound in `trigger_error`
   --> $DIR/issue-60218.rs:13:72

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -2,10 +2,11 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/issue-60283.rs:17:13
    |
 LL |     foo((), drop)
-   |             ^^^^
-   |             |
-   |             expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
-   |             found signature of `fn(()) -> _`
+   |     ---     ^^^^
+   |     |       |
+   |     |       expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
+   |     |       found signature of `fn(()) -> _`
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/issue-60283.rs:12:16
@@ -20,7 +21,9 @@ error[E0277]: the size for values of type `<() as Trait<'_>>::Item` cannot be kn
   --> $DIR/issue-60283.rs:17:13
    |
 LL |     foo((), drop)
-   |             ^^^^ doesn't have a size known at compile-time
+   |     ---     ^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `<() as Trait<'_>>::Item`
 note: required by a bound in `std::mem::drop`

--- a/src/test/ui/issues/issue-66353.stderr
+++ b/src/test/ui/issues/issue-66353.stderr
@@ -8,7 +8,9 @@ error[E0277]: the trait bound `(): _Func<_>` is not satisfied
   --> $DIR/issue-66353.rs:12:41
    |
 LL |     _Func::< <() as _A>::AssocT >::func(());
-   |                                         ^^ the trait `_Func<_>` is not implemented for `()`
+   |     ----------------------------------- ^^ the trait `_Func<_>` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by `_Func::func`
   --> $DIR/issue-66353.rs:4:5

--- a/src/test/ui/issues/issue-87199.stderr
+++ b/src/test/ui/issues/issue-87199.stderr
@@ -20,7 +20,9 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
   --> $DIR/issue-87199.rs:18:22
    |
 LL |     ref_arg::<[i32]>(&[5]);
-   |                      ^^^^ doesn't have a size known at compile-time
+   |     ---------------- ^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[i32]`
 note: required by a bound in `ref_arg`

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
 LL |     take_param(&x);
-   |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Foo` for `Box<{integer}>`
   --> $DIR/kindck-impl-type-params-2.rs:6:14

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);
-   |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Foo` for `Box<{integer}>`
   --> $DIR/kindck-inherited-copy-bound.rs:14:14

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);
-   |                ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Foo` for `Box<{integer}>`
   --> $DIR/kindck-inherited-copy-bound.rs:14:14

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -33,7 +33,9 @@ LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     foo(f);
-   |         ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected signature of `fn(usize) -> _`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/E0631.rs:3:11
@@ -48,7 +50,9 @@ LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     bar(f);
-   |         ^ expected signature of `fn(usize) -> _`
+   |     --- ^ expected signature of `fn(usize) -> _`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `bar`
   --> $DIR/E0631.rs:4:11

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -119,7 +119,9 @@ error[E0593]: function is expected to take a single 2-tuple as argument, but it 
   --> $DIR/closure-arg-count.rs:24:57
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
-   |                                                         ^^^ expected function that takes a single 2-tuple as argument
+   |                                                     --- ^^^ expected function that takes a single 2-tuple as argument
+   |                                                     |
+   |                                                     required by a bound introduced by this call
 ...
 LL | fn foo() {}
    | -------- takes 0 arguments
@@ -130,13 +132,17 @@ error[E0593]: closure is expected to take a single 2-tuple as argument, but it t
 LL |     let bar = |i, x, y| i;
    |               --------- takes 3 distinct arguments
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(bar);
-   |                                                         ^^^ expected closure that takes a single 2-tuple as argument
+   |                                                     --- ^^^ expected closure that takes a single 2-tuple as argument
+   |                                                     |
+   |                                                     required by a bound introduced by this call
 
 error[E0593]: function is expected to take a single 2-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:29:57
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(qux);
-   |                                                         ^^^ expected function that takes a single 2-tuple as argument
+   |                                                     --- ^^^ expected function that takes a single 2-tuple as argument
+   |                                                     |
+   |                                                     required by a bound introduced by this call
 ...
 LL | fn qux(x: usize, y: usize) {}
    | -------------------------- takes 2 distinct arguments
@@ -145,13 +151,17 @@ error[E0593]: function is expected to take 1 argument, but it takes 2 arguments
   --> $DIR/closure-arg-count.rs:32:45
    |
 LL |     let _it = vec![1, 2, 3].into_iter().map(usize::checked_add);
-   |                                             ^^^^^^^^^^^^^^^^^^ expected function that takes 1 argument
+   |                                         --- ^^^^^^^^^^^^^^^^^^ expected function that takes 1 argument
+   |                                         |
+   |                                         required by a bound introduced by this call
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
   --> $DIR/closure-arg-count.rs:35:10
    |
 LL |     call(Foo);
-   |          ^^^ expected function that takes 0 arguments
+   |     ---- ^^^ expected function that takes 0 arguments
+   |     |
+   |     required by a bound introduced by this call
 ...
 LL | struct Foo(u8);
    | --------------- takes 1 argument

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -5,7 +5,9 @@ LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
 ...
 LL |     apply(&3, takes_mut);
-   |               ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
+   |     -----     ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37
@@ -20,7 +22,9 @@ LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
 LL |     apply(&mut 3, takes_imm);
-   |                   ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |     -----         ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `apply`
   --> $DIR/fn-variance-1.rs:5:37

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -16,5 +16,6 @@ pub fn main() {
     let z = call_it(3, f);
     //~^ ERROR type mismatch
     //~| NOTE expected signature of `fn(isize, isize) -> _`
+    //~| NOTE required by a bound introduced by this call
     println!("{}", z);
 }

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -5,7 +5,9 @@ LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`
 LL |
 LL |     let z = call_it(3, f);
-   |                        ^ expected signature of `fn(isize, isize) -> _`
+   |             -------    ^ expected signature of `fn(isize, isize) -> _`
+   |             |
+   |             required by a bound introduced by this call
    |
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-vtable-mismatch.rs:7:14

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -2,7 +2,9 @@ error[E0277]: `Cell<i32>` cannot be shared between threads safely
   --> $DIR/mutexguard-sync.rs:11:15
    |
 LL |     test_sync(guard);
-   |               ^^^^^ `Cell<i32>` cannot be shared between threads safely
+   |     --------- ^^^^^ `Cell<i32>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `Cell<i32>`
    = note: required because of the requirements on the impl of `Sync` for `MutexGuard<'_, Cell<i32>>`

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -100,7 +100,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:11
    |
 LL |     check(m1::S{});
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -112,7 +114,9 @@ error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:11
    |
 LL |     check(m2::S{});
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -124,7 +128,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:11
    |
 LL |     check(m2::S);
-   |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -136,7 +142,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:39:11
    |
 LL |     check(xm1::S{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -148,7 +156,9 @@ error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:41:11
    |
 LL |     check(xm2::S{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -160,7 +170,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:42:11
    |
 LL |     check(xm2::S);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -172,7 +184,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:11
    |
 LL |     check(m3::TS{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -184,7 +198,9 @@ error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfi
   --> $DIR/namespace-mix.rs:56:11
    |
 LL |     check(m3::TS);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -196,7 +212,9 @@ error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:11
    |
 LL |     check(m4::TS{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -208,7 +226,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:11
    |
 LL |     check(m4::TS);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -220,7 +240,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:61:11
    |
 LL |     check(xm3::TS{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -232,7 +254,9 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::T
   --> $DIR/namespace-mix.rs:62:11
    |
 LL |     check(xm3::TS);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -244,7 +268,9 @@ error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:63:11
    |
 LL |     check(xm4::TS{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -256,7 +282,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:64:11
    |
 LL |     check(xm4::TS);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -268,7 +296,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:11
    |
 LL |     check(m5::US{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -280,7 +310,9 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:11
    |
 LL |     check(m5::US);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -292,7 +324,9 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:11
    |
 LL |     check(m6::US{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -304,7 +338,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:11
    |
 LL |     check(m6::US);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -316,7 +352,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:83:11
    |
 LL |     check(xm5::US{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -328,7 +366,9 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:84:11
    |
 LL |     check(xm5::US);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -340,7 +380,9 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:85:11
    |
 LL |     check(xm6::US{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -352,7 +394,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:86:11
    |
 LL |     check(xm6::US);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -364,7 +408,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:11
    |
 LL |     check(m7::V{});
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -376,7 +422,9 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:11
    |
 LL |     check(m8::V{});
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -388,7 +436,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:11
    |
 LL |     check(m8::V);
-   |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -400,7 +450,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:105:11
    |
 LL |     check(xm7::V{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -412,7 +464,9 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:107:11
    |
 LL |     check(xm8::V{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -424,7 +478,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:108:11
    |
 LL |     check(xm8::V);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -436,7 +492,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:11
    |
 LL |     check(m9::TV{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -448,7 +506,9 @@ error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satis
   --> $DIR/namespace-mix.rs:122:11
    |
 LL |     check(m9::TV);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -460,7 +520,9 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:11
    |
 LL |     check(mA::TV{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -472,7 +534,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:11
    |
 LL |     check(mA::TV);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -484,7 +548,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:127:11
    |
 LL |     check(xm9::TV{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -496,7 +562,9 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::
   --> $DIR/namespace-mix.rs:128:11
    |
 LL |     check(xm9::TV);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -508,7 +576,9 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:129:11
    |
 LL |     check(xmA::TV{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -520,7 +590,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:130:11
    |
 LL |     check(xmA::TV);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -532,7 +604,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:11
    |
 LL |     check(mB::UV{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -544,7 +618,9 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:11
    |
 LL |     check(mB::UV);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -556,7 +632,9 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:11
    |
 LL |     check(mC::UV{});
-   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     ----- ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -568,7 +646,9 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:11
    |
 LL |     check(mC::UV);
-   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -580,7 +660,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:149:11
    |
 LL |     check(xmB::UV{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -592,7 +674,9 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:150:11
    |
 LL |     check(xmB::UV);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -604,7 +688,9 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:151:11
    |
 LL |     check(xmC::UV{});
-   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     ----- ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13
@@ -616,7 +702,9 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:152:11
    |
 LL |     check(xmC::UV);
-   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `check`
   --> $DIR/namespace-mix.rs:21:13

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -2,7 +2,9 @@ error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/no_send-rc.rs:7:9
    |
 LL |     bar(x);
-   |         ^ `Rc<{integer}>` cannot be sent between threads safely
+   |     --- ^ `Rc<{integer}>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
 note: required by a bound in `bar`

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -2,7 +2,9 @@ error[E0277]: `Foo` cannot be sent between threads safely
   --> $DIR/no_send-struct.rs:15:9
    |
 LL |     bar(x);
-   |         ^ `Foo` cannot be sent between threads safely
+   |     --- ^ `Foo` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Foo`
 note: required by a bound in `bar`

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -2,7 +2,9 @@ error[E0277]: `Foo` cannot be shared between threads safely
   --> $DIR/no_share-struct.rs:12:9
    |
 LL |     bar(x);
-   |         ^ `Foo` cannot be shared between threads safely
+   |     --- ^ `Foo` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `Foo`
 note: required by a bound in `bar`

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Box<dyn Foo>: Foo` is not satisfied
   --> $DIR/object-does-not-impl-trait.rs:6:44
    |
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
-   |                                            ^ the trait `Foo` is not implemented for `Box<dyn Foo>`
+   |                                   -------- ^ the trait `Foo` is not implemented for `Box<dyn Foo>`
+   |                                   |
+   |                                   required by a bound introduced by this call
    |
 note: required by a bound in `take_foo`
   --> $DIR/object-does-not-impl-trait.rs:5:15

--- a/src/test/ui/on-unimplemented/enclosing-scope.stderr
+++ b/src/test/ui/on-unimplemented/enclosing-scope.stderr
@@ -4,7 +4,9 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
 LL |       let x = || {
    |  _____________-
 LL | |         f(Foo{});
-   | |           ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |         - ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |         |
+   | |         required by a bound introduced by this call
 LL | |         let y = || {
 LL | |             f(Foo{});
 LL | |         };
@@ -23,7 +25,9 @@ error[E0277]: the trait bound `Foo: Trait` is not satisfied
 LL |           let y = || {
    |  _________________-
 LL | |             f(Foo{});
-   | |               ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |             - ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |             |
+   | |             required by a bound introduced by this call
 LL | |         };
    | |_________- in this scope
    |
@@ -42,7 +46,9 @@ LL | |         f(Foo{});
 LL | |         let y = || {
 ...  |
 LL | |             f(Foo{});
-   | |               ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |             - ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |             |
+   | |             required by a bound introduced by this call
 ...  |
 LL | |     f(Foo{});
 LL | | }
@@ -63,7 +69,9 @@ LL | |         f(Foo{});
 LL | |         let y = || {
 ...  |
 LL | |     f(Foo{});
-   | |       ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |     - ^^^^^ the trait `Trait` is not implemented for `Foo`
+   | |     |
+   | |     required by a bound introduced by this call
 LL | | }
    | |_- in this scope
    |

--- a/src/test/ui/on-unimplemented/multiple-impls.stderr
+++ b/src/test/ui/on-unimplemented/multiple-impls.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:18
    |
 LL |     Index::index(&[] as &[i32], 2u32);
-   |                  ^^^^^^^^^^^^^ trait message
+   |     ------------ ^^^^^^^^^^^^^ trait message
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
 note: required by `Index::index`
@@ -15,7 +17,9 @@ error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:18
    |
 LL |     Index::index(&[] as &[i32], Foo(2u32));
-   |                  ^^^^^^^^^^^^^ on impl for Foo
+   |     ------------ ^^^^^^^^^^^^^ on impl for Foo
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
 note: required by `Index::index`
@@ -28,7 +32,9 @@ error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:18
    |
 LL |     Index::index(&[] as &[i32], Bar(2u32));
-   |                  ^^^^^^^^^^^^^ on impl for Bar
+   |     ------------ ^^^^^^^^^^^^^ on impl for Bar
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
 note: required by `Index::index`

--- a/src/test/ui/on-unimplemented/on-impl.stderr
+++ b/src/test/ui/on-unimplemented/on-impl.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:25
    |
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
-   |                         ^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
+   |     ------------------- ^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
 note: required by `Index::index`

--- a/src/test/ui/phantom-auto-trait.stderr
+++ b/src/test/ui/phantom-auto-trait.stderr
@@ -2,7 +2,9 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-auto-trait.rs:21:12
    |
 LL |     is_zen(x)
-   |            ^ `T` cannot be shared between threads safely
+   |     ------ ^ `T` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Zen` for `&T`
   --> $DIR/phantom-auto-trait.rs:10:24
@@ -29,7 +31,9 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-auto-trait.rs:26:12
    |
 LL |     is_zen(x)
-   |            ^ `T` cannot be shared between threads safely
+   |     ------ ^ `T` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Zen` for `&T`
   --> $DIR/phantom-auto-trait.rs:10:24

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -6,7 +6,10 @@ LL |   #[test]
 LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()
 LL | | }
-   | |_^ `main` can only return types that implement `Termination`
+   | | ^
+   | | |
+   | |_`main` can only return types that implement `Termination`
+   |   required by a bound introduced by this call
    |
    = help: the trait `Termination` is not implemented for `Result<f32, ParseFloatError>`
 note: required by a bound in `assert_test_result`

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -6,10 +6,7 @@ LL |   #[test]
 LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()
 LL | | }
-   | | ^
-   | | |
-   | |_`main` can only return types that implement `Termination`
-   |   required by a bound introduced by this call
+   | |_^ `main` can only return types that implement `Termination`
    |
    = help: the trait `Termination` is not implemented for `Result<f32, ParseFloatError>`
 note: required by a bound in `assert_test_result`

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -2,7 +2,9 @@ error[E0277]: can't compare `S` with `S`
   --> $DIR/call-generic-method-nonconst.rs:19:34
    |
 LL | pub const EQ: bool = equals_self(&S);
-   |                                  ^^ no implementation for `S == S`
+   |                      ----------- ^^ no implementation for `S == S`
+   |                      |
+   |                      required by a bound introduced by this call
    |
    = help: the trait `PartialEq` is not implemented for `S`
 note: required by a bound in `equals_self`

--- a/src/test/ui/rfc-2632-const-trait-impl/const-drop-fail.precise.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-drop-fail.precise.stderr
@@ -9,6 +9,9 @@ LL | struct ConstDropImplWithBounds<T: ~const A>(PhantomData<T>);
 error[E0277]: the trait bound `NonTrivialDrop: Drop` is not satisfied
   --> $DIR/const-drop-fail.rs:45:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^ the trait `Drop` is not implemented for `NonTrivialDrop`
    |
@@ -21,6 +24,9 @@ LL | const fn check<T: ~const Drop>(_: T) {}
 error[E0277]: the trait bound `ConstImplWithDropGlue: Drop` is not satisfied
   --> $DIR/const-drop-fail.rs:47:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Drop` is not implemented for `ConstImplWithDropGlue`
    |
@@ -45,6 +51,9 @@ LL | struct ConstDropImplWithBounds<T: ~const A>(PhantomData<T>);
 error[E0277]: the trait bound `NonTrivialDrop: A` is not satisfied
   --> $DIR/const-drop-fail.rs:49:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     ConstDropImplWithBounds::<NonTrivialDrop>(PhantomData),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `A` is not implemented for `NonTrivialDrop`
    |

--- a/src/test/ui/rfc-2632-const-trait-impl/const-drop-fail.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-drop-fail.stock.stderr
@@ -9,6 +9,9 @@ LL | struct ConstDropImplWithBounds<T: ~const A>(PhantomData<T>);
 error[E0277]: the trait bound `NonTrivialDrop: Drop` is not satisfied
   --> $DIR/const-drop-fail.rs:45:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^ the trait `Drop` is not implemented for `NonTrivialDrop`
    |
@@ -21,6 +24,9 @@ LL | const fn check<T: ~const Drop>(_: T) {}
 error[E0277]: the trait bound `ConstImplWithDropGlue: Drop` is not satisfied
   --> $DIR/const-drop-fail.rs:47:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Drop` is not implemented for `ConstImplWithDropGlue`
    |
@@ -45,6 +51,9 @@ LL | struct ConstDropImplWithBounds<T: ~const A>(PhantomData<T>);
 error[E0277]: the trait bound `NonTrivialDrop: A` is not satisfied
   --> $DIR/const-drop-fail.rs:49:5
    |
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
+...
 LL |     ConstDropImplWithBounds::<NonTrivialDrop>(PhantomData),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `A` is not implemented for `NonTrivialDrop`
    |

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:24:10
    |
 LL |     call(foo);
-   |          ^^^ expected an `Fn<()>` closure, found `fn() {foo}`
+   |     ---- ^^^ expected an `Fn<()>` closure, found `fn() {foo}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Fn<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
@@ -17,7 +19,9 @@ error[E0277]: expected a `FnMut<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:25:14
    |
 LL |     call_mut(foo);
-   |              ^^^ expected an `FnMut<()>` closure, found `fn() {foo}`
+   |     -------- ^^^ expected an `FnMut<()>` closure, found `fn() {foo}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `FnMut<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
@@ -32,7 +36,9 @@ error[E0277]: expected a `FnOnce<()>` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
    |
 LL |     call_once(foo);
-   |               ^^^ expected an `FnOnce<()>` closure, found `fn() {foo}`
+   |     --------- ^^^ expected an `FnOnce<()>` closure, found `fn() {foo}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `FnOnce<()>` is not implemented for `fn() {foo}`
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
@@ -47,7 +53,9 @@ error[E0277]: expected a `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:28:10
    |
 LL |     call(foo_unsafe);
-   |          ^^^^^^^^^^ expected an `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     ---- ^^^^^^^^^^ expected an `Fn<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Fn<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
@@ -62,7 +70,9 @@ error[E0277]: expected a `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo_unsafe);
-   |              ^^^^^^^^^^ expected an `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     -------- ^^^^^^^^^^ expected an `FnMut<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `FnMut<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
@@ -77,7 +87,9 @@ error[E0277]: expected a `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:32:15
    |
 LL |     call_once(foo_unsafe);
-   |               ^^^^^^^^^^ expected an `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     --------- ^^^^^^^^^^ expected an `FnOnce<()>` closure, found `unsafe fn() {foo_unsafe}`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `FnOnce<()>` is not implemented for `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`

--- a/src/test/ui/str/str-idx.stderr
+++ b/src/test/ui/str/str-idx.stderr
@@ -13,7 +13,9 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
   --> $DIR/str-idx.rs:4:19
    |
 LL |     let _ = s.get(4);
-   |                   ^ string indices are ranges of `usize`
+   |               --- ^ string indices are ranges of `usize`
+   |               |
+   |               required by a bound introduced by this call
    |
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
@@ -23,7 +25,9 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
   --> $DIR/str-idx.rs:5:29
    |
 LL |     let _ = s.get_unchecked(4);
-   |                             ^ string indices are ranges of `usize`
+   |               ------------- ^ string indices are ranges of `usize`
+   |               |
+   |               required by a bound introduced by this call
    |
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -37,7 +37,9 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
   --> $DIR/str-mut-idx.rs:9:15
    |
 LL |     s.get_mut(1);
-   |               ^ string indices are ranges of `usize`
+   |       ------- ^ string indices are ranges of `usize`
+   |       |
+   |       required by a bound introduced by this call
    |
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
@@ -47,7 +49,9 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
   --> $DIR/str-mut-idx.rs:11:25
    |
 LL |     s.get_unchecked_mut(1);
-   |                         ^ string indices are ranges of `usize`
+   |       ----------------- ^ string indices are ranges of `usize`
+   |       |
+   |       required by a bound introduced by this call
    |
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,7 +5,9 @@ LL | async fn foo() {}
    |          --- consider calling this function
 ...
 LL |     bar(foo);
-   |         ^^^ `fn() -> impl Future {foo}` is not a future
+   |     --- ^^^ `fn() -> impl Future {foo}` is not a future
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Future` is not implemented for `fn() -> impl Future {foo}`
 note: required by a bound in `bar`
@@ -24,7 +26,9 @@ error[E0277]: `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-be
 LL |     let async_closure = async || ();
    |                         -------- consider calling this closure
 LL |     bar(async_closure);
-   |         ^^^^^^^^^^^^^ `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]` is not a future
+   |     --- ^^^^^^^^^^^^^ `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]` is not a future
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Future` is not implemented for `[closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:36]`
 note: required by a bound in `bar`

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,7 +5,9 @@ LL | fn foo() -> impl T<O=()> { S }
    |    --- consider calling this function
 ...
 LL |     bar(foo);
-   |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |     --- ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `bar`
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16
@@ -23,7 +25,9 @@ error[E0277]: the trait bound `[closure@$DIR/fn-ctor-passed-as-arg-where-it-shou
 LL |     let closure = || S;
    |                   -- consider calling this closure
 LL |     bar(closure);
-   |         ^^^^^^^ the trait `T` is not implemented for `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]`
+   |     --- ^^^^^^^ the trait `T` is not implemented for `[closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:23]`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `bar`
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16

--- a/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/src/test/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:12:7
    |
 LL |   foo(&s);
-   |       ^^ the trait `Trait` is not implemented for `&S`
+   |   --- ^^ the trait `Trait` is not implemented for `&S`
+   |   |
+   |   required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <&'a mut S as Trait>
@@ -20,10 +22,11 @@ error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7
    |
 LL |   foo(s);
-   |       ^
-   |       |
-   |       expected an implementor of trait `Trait`
-   |       help: consider mutably borrowing here: `&mut s`
+   |   --- ^
+   |   |   |
+   |   |   expected an implementor of trait `Trait`
+   |   |   help: consider mutably borrowing here: `&mut s`
+   |   required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal.rs:7:11

--- a/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-bounds.stderr
@@ -2,7 +2,9 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
   --> $DIR/impl-trait-with-missing-bounds.rs:14:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
 note: required by a bound in `qux`
@@ -19,7 +21,9 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
   --> $DIR/impl-trait-with-missing-bounds.rs:22:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
 note: required by a bound in `qux`
@@ -36,7 +40,9 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
   --> $DIR/impl-trait-with-missing-bounds.rs:30:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
 note: required by a bound in `qux`
@@ -53,7 +59,9 @@ error[E0277]: `<impl Iterator + std::fmt::Debug as Iterator>::Item` doesn't impl
   --> $DIR/impl-trait-with-missing-bounds.rs:37:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator + std::fmt::Debug as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator + std::fmt::Debug as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator + std::fmt::Debug as Iterator>::Item`
 note: required by a bound in `qux`
@@ -70,7 +78,9 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
   --> $DIR/impl-trait-with-missing-bounds.rs:6:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
 note: required by a bound in `qux`
@@ -87,7 +97,9 @@ error[E0277]: `<impl Iterator as Iterator>::Item` doesn't implement `Debug`
   --> $DIR/impl-trait-with-missing-bounds.rs:45:13
    |
 LL |         qux(constraint);
-   |             ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         --- ^^^^^^^^^^ `<impl Iterator as Iterator>::Item` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the trait `Debug` is not implemented for `<impl Iterator as Iterator>::Item`
 note: required by a bound in `qux`

--- a/src/test/ui/suggestions/issue-62843.stderr
+++ b/src/test/ui/suggestions/issue-62843.stderr
@@ -2,10 +2,11 @@ error[E0277]: expected a `FnMut<(char,)>` closure, found `String`
   --> $DIR/issue-62843.rs:4:32
    |
 LL |     println!("{:?}", line.find(pattern));
-   |                                ^^^^^^^
-   |                                |
-   |                                expected an implementor of trait `Pattern<'_>`
-   |                                help: consider borrowing here: `&pattern`
+   |                           ---- ^^^^^^^
+   |                           |    |
+   |                           |    expected an implementor of trait `Pattern<'_>`
+   |                           |    help: consider borrowing here: `&pattern`
+   |                           required by a bound introduced by this call
    |
    = note: the trait bound `String: Pattern<'_>` is not satisfied
    = note: required because of the requirements on the impl of `Pattern<'_>` for `String`

--- a/src/test/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
+++ b/src/test/ui/suggestions/issue-79843-impl-trait-with-missing-bounds-on-async-fn.stderr
@@ -2,7 +2,9 @@ error[E0277]: `<impl Foo as Foo>::Bar` cannot be sent between threads safely
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:14:20
    |
 LL |     assert_is_send(&bar);
-   |                    ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
+   |     -------------- ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
 note: required by a bound in `assert_is_send`
@@ -19,7 +21,9 @@ error[E0277]: `<impl Foo as Foo>::Bar` cannot be sent between threads safely
   --> $DIR/issue-79843-impl-trait-with-missing-bounds-on-async-fn.rs:24:20
    |
 LL |     assert_is_send(&bar);
-   |                    ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
+   |     -------------- ^^^^ `<impl Foo as Foo>::Bar` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `<impl Foo as Foo>::Bar`
 note: required by a bound in `assert_is_send`

--- a/src/test/ui/suggestions/issue-84973-2.stderr
+++ b/src/test/ui/suggestions/issue-84973-2.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `i32: Tr` is not satisfied
   --> $DIR/issue-84973-2.rs:11:9
    |
 LL |     foo(a);
-   |         ^
-   |         |
-   |         expected an implementor of trait `Tr`
-   |         help: consider mutably borrowing here: `&mut a`
+   |     --- ^
+   |     |   |
+   |     |   expected an implementor of trait `Tr`
+   |     |   help: consider mutably borrowing here: `&mut a`
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/issue-84973-2.rs:7:11

--- a/src/test/ui/suggestions/issue-84973-blacklist.rs
+++ b/src/test/ui/suggestions/issue-84973-blacklist.rs
@@ -21,7 +21,6 @@ fn main() {
     let ref_cl: &dyn Fn() -> () = &cl;
     f_sized(*ref_cl);
     //~^ ERROR: the size for values of type `dyn Fn()` cannot be known at compilation time [E0277]
-    //~| ERROR: the size for values of type `dyn Fn()` cannot be known at compilation time [E0277]
 
     use std::rc::Rc;
     let rc = Rc::new(0);

--- a/src/test/ui/suggestions/issue-84973-blacklist.stderr
+++ b/src/test/ui/suggestions/issue-84973-blacklist.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/issue-84973-blacklist.rs:15:12
    |
 LL |     f_copy("".to_string());
-   |            ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |     ------ ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f_copy`
   --> $DIR/issue-84973-blacklist.rs:6:14
@@ -14,7 +16,9 @@ error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-84973-blacklist.rs:16:13
    |
 LL |     f_clone(S);
-   |             ^ the trait `Clone` is not implemented for `S`
+   |     ------- ^ the trait `Clone` is not implemented for `S`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f_clone`
   --> $DIR/issue-84973-blacklist.rs:7:15
@@ -39,7 +43,9 @@ error[E0277]: the size for values of type `dyn Fn()` cannot be known at compilat
   --> $DIR/issue-84973-blacklist.rs:22:13
    |
 LL |     f_sized(*ref_cl);
-   |             ^^^^^^^ doesn't have a size known at compile-time
+   |     ------- ^^^^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn Fn()`
 note: required by a bound in `f_sized`
@@ -52,7 +58,9 @@ error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/issue-84973-blacklist.rs:28:12
    |
 LL |     f_send(rc);
-   |            ^^ `Rc<{integer}>` cannot be sent between threads safely
+   |     ------ ^^ `Rc<{integer}>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
 note: required by a bound in `f_send`

--- a/src/test/ui/suggestions/issue-84973-blacklist.stderr
+++ b/src/test/ui/suggestions/issue-84973-blacklist.stderr
@@ -55,7 +55,7 @@ LL | fn f_sized<T: Sized>(t: T) {}
    |            ^ required by this bound in `f_sized`
 
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
-  --> $DIR/issue-84973-blacklist.rs:28:12
+  --> $DIR/issue-84973-blacklist.rs:27:12
    |
 LL |     f_send(rc);
    |     ------ ^^ `Rc<{integer}>` cannot be sent between threads safely
@@ -69,16 +69,6 @@ note: required by a bound in `f_send`
 LL | fn f_send<T: Send>(t: T) {}
    |              ^^^^ required by this bound in `f_send`
 
-error[E0277]: the size for values of type `dyn Fn()` cannot be known at compilation time
-  --> $DIR/issue-84973-blacklist.rs:22:5
-   |
-LL |     f_sized(*ref_cl);
-   |     ^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `dyn Fn()`
-   = note: all function arguments must have a statically known size
-   = help: unsized fn params are gated as an unstable feature
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/issue-84973-negative.stderr
+++ b/src/test/ui/suggestions/issue-84973-negative.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `i32: Tr` is not satisfied
   --> $DIR/issue-84973-negative.rs:10:9
    |
 LL |     bar(a);
-   |         ^ the trait `Tr` is not implemented for `i32`
+   |     --- ^ the trait `Tr` is not implemented for `i32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `bar`
   --> $DIR/issue-84973-negative.rs:5:11
@@ -14,10 +16,11 @@ error[E0277]: the trait bound `f32: Tr` is not satisfied
   --> $DIR/issue-84973-negative.rs:11:9
    |
 LL |     bar(b);
-   |         ^
-   |         |
-   |         expected an implementor of trait `Tr`
-   |         help: consider borrowing here: `&b`
+   |     --- ^
+   |     |   |
+   |     |   expected an implementor of trait `Tr`
+   |     |   help: consider borrowing here: `&b`
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `bar`
   --> $DIR/issue-84973-negative.rs:5:11

--- a/src/test/ui/suggestions/issue-84973.stderr
+++ b/src/test/ui/suggestions/issue-84973.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `Fancy: SomeTrait` is not satisfied
   --> $DIR/issue-84973.rs:6:24
    |
 LL |     let o = Other::new(f);
-   |                        ^
-   |                        |
-   |                        expected an implementor of trait `SomeTrait`
-   |                        help: consider borrowing here: `&f`
+   |             ---------- ^
+   |             |          |
+   |             |          expected an implementor of trait `SomeTrait`
+   |             |          help: consider borrowing here: `&f`
+   |             required by a bound introduced by this call
    |
 note: required by `Other::<'a, G>::new`
   --> $DIR/issue-84973.rs:27:5

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
   --> $DIR/mut-borrow-needed-by-trait.rs:17:29
    |
 LL |     let fp = BufWriter::new(fp);
-   |                             ^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   |              -------------- ^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   |              |
+   |              required by a bound introduced by this call
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
 note: required by `BufWriter::<W>::new`

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -2,7 +2,9 @@ error[E0277]: `impl Sync` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:4:13
    |
 LL |     is_send(val);
-   |             ^^^ `impl Sync` cannot be sent between threads safely
+   |     ------- ^^^ `impl Sync` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
@@ -18,7 +20,9 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
    |
 LL |     is_send(val);
-   |             ^^^ `S` cannot be sent between threads safely
+   |     ------- ^^^ `S` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
@@ -34,7 +38,9 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
    |
 LL |     is_send(val);
-   |             ^^^ `S` cannot be sent between threads safely
+   |     ------- ^^^ `S` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
@@ -50,7 +56,9 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
    |
 LL |     is_send(val);
-   |             ^^^ `S` cannot be sent between threads safely
+   |     ------- ^^^ `S` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
@@ -66,7 +74,9 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
    |
 LL |     is_send(val);
-   |             ^^^ `S` cannot be sent between threads safely
+   |     ------- ^^^ `S` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15
@@ -82,7 +92,9 @@ error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
    |
 LL |     is_send(val);
-   |             ^^^ `S` cannot be sent between threads safely
+   |     ------- ^^^ `S` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `is_send`
   --> $DIR/restrict-type-argument.rs:1:15

--- a/src/test/ui/suggestions/suggest-change-mut.stderr
+++ b/src/test/ui/suggestions/suggest-change-mut.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&T: std::io::Read` is not satisfied
   --> $DIR/suggest-change-mut.rs:12:48
    |
 LL |         let mut stream_reader = BufReader::new(&stream);
-   |                                                ^^^^^^^ the trait `std::io::Read` is not implemented for `&T`
+   |                                 -------------- ^^^^^^^ the trait `std::io::Read` is not implemented for `&T`
+   |                                 |
+   |                                 required by a bound introduced by this call
    |
 note: required by `BufReader::<R>::new`
   --> $SRC_DIR/std/src/io/buffered/bufreader.rs:LL:COL

--- a/src/test/ui/traits/bound/same-crate-name.stderr
+++ b/src/test/ui/traits/bound/same-crate-name.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Foo: main::a::Bar` is not satisfied
   --> $DIR/same-crate-name.rs:31:20
    |
 LL |         a::try_foo(foo);
-   |                    ^^^ the trait `main::a::Bar` is not implemented for `Foo`
+   |         ---------- ^^^ the trait `main::a::Bar` is not implemented for `Foo`
+   |         |
+   |         required by a bound introduced by this call
    |
 help: trait impl with same name found
   --> $DIR/auxiliary/crate_a2.rs:5:1
@@ -20,7 +22,9 @@ error[E0277]: the trait bound `DoesNotImplementTrait: main::a::Bar` is not satis
   --> $DIR/same-crate-name.rs:38:20
    |
 LL |         a::try_foo(implements_no_traits);
-   |                    ^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `DoesNotImplementTrait`
+   |         ---------- ^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `DoesNotImplementTrait`
+   |         |
+   |         required by a bound introduced by this call
    |
 note: required by a bound in `try_foo`
   --> $DIR/auxiliary/crate_a1.rs:3:24
@@ -32,7 +36,9 @@ error[E0277]: the trait bound `ImplementsWrongTraitConditionally<isize>: main::a
   --> $DIR/same-crate-name.rs:45:20
    |
 LL |         a::try_foo(other_variant_implements_mismatched_trait);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsWrongTraitConditionally<isize>`
+   |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsWrongTraitConditionally<isize>`
+   |         |
+   |         required by a bound introduced by this call
    |
 help: trait impl with same name found
   --> $DIR/auxiliary/crate_a2.rs:13:1
@@ -50,7 +56,9 @@ error[E0277]: the trait bound `ImplementsTraitForUsize<isize>: main::a::Bar` is 
   --> $DIR/same-crate-name.rs:51:20
    |
 LL |         a::try_foo(other_variant_implements_correct_trait);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsTraitForUsize<isize>`
+   |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsTraitForUsize<isize>`
+   |         |
+   |         required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <ImplementsTraitForUsize<usize> as main::a::Bar>

--- a/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -10,7 +10,9 @@ error[E0277]: the trait bound `NoClone: Copy` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23
    |
 LL |     let (a, b) = copy(NoClone);
-   |                       ^^^^^^^ the trait `Copy` is not implemented for `NoClone`
+   |                  ---- ^^^^^^^ the trait `Copy` is not implemented for `NoClone`
+   |                  |
+   |                  required by a bound introduced by this call
    |
    = note: required because of the requirements on the impl of `Magic` for `NoClone`
 note: required by a bound in `copy`

--- a/src/test/ui/traits/issue-71136.stderr
+++ b/src/test/ui/traits/issue-71136.stderr
@@ -5,10 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct FooHolster {
 LL |     the_foos: Vec<Foo>,
-   |     ^^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected an implementor of trait `Clone`
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
 note: required by `clone`

--- a/src/test/ui/traits/issue-71136.stderr
+++ b/src/test/ui/traits/issue-71136.stderr
@@ -5,7 +5,10 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct FooHolster {
 LL |     the_foos: Vec<Foo>,
-   |     ^^^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
+   |     ^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected an implementor of trait `Clone`
+   |     required by a bound introduced by this call
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
 note: required by `clone`

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -43,7 +43,7 @@ error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
 LL |     is_send((8, TestType));
    |             ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
    |
-   = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
+   = help: the trait `Send` is not implemented for `dummy1c::TestType`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -75,7 +75,7 @@ error[E0277]: `dummy3::TestType` cannot be sent between threads safely
 LL |     is_send(Box::new(Outer2(TestType)));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
    |
-   = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
+   = help: the trait `Send` is not implemented for `dummy3::TestType`
 note: required because it appears within the type `Outer2<dummy3::TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -2,7 +2,9 @@ error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:23:11
    |
 LL |     Outer(TestType);
-   |           ^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
+   |     ----- ^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy::TestType`
 note: required by `Outer`
@@ -28,7 +30,9 @@ error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:32:13
    |
 LL |     is_send(TestType);
-   |             ^^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
+   |     ------- ^^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy1b::TestType`
 note: required by a bound in `is_send`
@@ -41,7 +45,9 @@ error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:40:13
    |
 LL |     is_send((8, TestType));
-   |             ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
+   |     ------- ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy1c::TestType`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
@@ -55,10 +61,11 @@ error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:48:13
    |
 LL |     is_send(Box::new(TestType));
-   |             ^^^^^^^^^^^^^^^^^^
-   |             |
-   |             expected an implementor of trait `Send`
-   |             help: consider borrowing here: `&Box::new(TestType)`
+   |     ------- ^^^^^^^^^^^^^^^^^^
+   |     |       |
+   |     |       expected an implementor of trait `Send`
+   |     |       help: consider borrowing here: `&Box::new(TestType)`
+   |     required by a bound introduced by this call
    |
    = note: the trait bound `dummy2::TestType: Send` is not satisfied
    = note: required because of the requirements on the impl of `Send` for `Unique<dummy2::TestType>`
@@ -73,7 +80,9 @@ error[E0277]: `dummy3::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:56:13
    |
 LL |     is_send(Box::new(Outer2(TestType)));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
+   |     ------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Send` is not implemented for `dummy3::TestType`
 note: required because it appears within the type `Outer2<dummy3::TestType>`
@@ -93,10 +102,11 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
 LL |     is_sync(Outer2(TestType));
-   |             ^^^^^^^^^^^^^^^^
-   |             |
-   |             expected an implementor of trait `Sync`
-   |             help: consider borrowing here: `&Outer2(TestType)`
+   |     ------- ^^^^^^^^^^^^^^^^
+   |     |       |
+   |     |       expected an implementor of trait `Sync`
+   |     |       help: consider borrowing here: `&Outer2(TestType)`
+   |     required by a bound introduced by this call
    |
    = note: the trait bound `main::TestType: Sync` is not satisfied
 note: required because of the requirements on the impl of `Sync` for `Outer2<main::TestType>`

--- a/src/test/ui/traits/reservation-impl/no-use.stderr
+++ b/src/test/ui/traits/reservation-impl/no-use.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `(): MyTrait` is not satisfied
   --> $DIR/no-use.rs:10:26
    |
 LL |     <() as MyTrait>::foo(&());
-   |                          ^^^ the trait `MyTrait` is not implemented for `()`
+   |     -------------------- ^^^ the trait `MyTrait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the following implementations were found:
              <() as MyTrait>

--- a/src/test/ui/traits/suggest-deferences/issue-39029.stderr
+++ b/src/test/ui/traits/suggest-deferences/issue-39029.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `NoToSocketAddrs: ToSocketAddrs` is not satisfied
   --> $DIR/issue-39029.rs:16:37
    |
 LL |     let _errors = TcpListener::bind(&bad);
-   |                                     ^^^^
-   |                                     |
-   |                                     the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
-   |                                     help: consider adding dereference here: `&*bad`
+   |                   ----------------- ^^^^
+   |                   |                 |
+   |                   |                 the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
+   |                   |                 help: consider adding dereference here: `&*bad`
+   |                   required by a bound introduced by this call
    |
    = note: required because of the requirements on the impl of `ToSocketAddrs` for `&NoToSocketAddrs`
 note: required by a bound in `TcpListener::bind`

--- a/src/test/ui/traits/suggest-deferences/issue-62530.stderr
+++ b/src/test/ui/traits/suggest-deferences/issue-62530.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `&String: SomeTrait` is not satisfied
   --> $DIR/issue-62530.rs:13:26
    |
 LL |     takes_type_parameter(&string);  // Error
-   |                          ^^^^^^^
-   |                          |
-   |                          the trait `SomeTrait` is not implemented for `&String`
-   |                          help: consider adding dereference here: `&*string`
+   |     -------------------- ^^^^^^^
+   |     |                    |
+   |     |                    the trait `SomeTrait` is not implemented for `&String`
+   |     |                    help: consider adding dereference here: `&*string`
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_type_parameter`
   --> $DIR/issue-62530.rs:4:44

--- a/src/test/ui/traits/suggest-deferences/multiple-0.stderr
+++ b/src/test/ui/traits/suggest-deferences/multiple-0.stderr
@@ -2,10 +2,11 @@ error[E0277]: the trait bound `&Baz: Happy` is not satisfied
   --> $DIR/multiple-0.rs:34:9
    |
 LL |     foo(&baz);
-   |         ^^^^
-   |         |
-   |         the trait `Happy` is not implemented for `&Baz`
-   |         help: consider adding dereference here: `&***baz`
+   |     --- ^^^^
+   |     |   |
+   |     |   the trait `Happy` is not implemented for `&Baz`
+   |     |   help: consider adding dereference here: `&***baz`
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/multiple-0.rs:30:26

--- a/src/test/ui/traits/suggest-deferences/multiple-1.stderr
+++ b/src/test/ui/traits/suggest-deferences/multiple-1.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `&mut Baz: Happy` is not satisfied
   --> $DIR/multiple-1.rs:52:9
    |
 LL |     foo(&mut baz);
-   |         ^^^^^^^^ the trait `Happy` is not implemented for `&mut Baz`
+   |     --- ^^^^^^^^ the trait `Happy` is not implemented for `&mut Baz`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `foo`
   --> $DIR/multiple-1.rs:45:26

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -24,7 +24,9 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:25:15
    |
 LL |     Foo::test(&4i32);
-   |               ^^^^^ the trait `Foo` is not implemented for `i32`
+   |     --------- ^^^^^ the trait `Foo` is not implemented for `i32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by `Foo::test`
   --> $DIR/trivial-bounds-leak.rs:5:5
@@ -36,7 +38,9 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:26:22
    |
 LL |     generic_function(5i32);
-   |                      ^^^^ the trait `Foo` is not implemented for `i32`
+   |     ---------------- ^^^^ the trait `Foo` is not implemented for `i32`
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `generic_function`
   --> $DIR/trivial-bounds-leak.rs:29:24

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -2,7 +2,9 @@ error[E0277]: `UnsafeCell<MySync<{integer}>>` cannot be shared between threads s
   --> $DIR/typeck-unsafe-always-share.rs:19:10
    |
 LL |     test(us);
-   |          ^^ `UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
+   |     ---- ^^ `UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<MySync<{integer}>>`
 note: required by a bound in `test`
@@ -15,7 +17,9 @@ error[E0277]: `UnsafeCell<NoSync>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:23:10
    |
 LL |     test(uns);
-   |          ^^^ `UnsafeCell<NoSync>` cannot be shared between threads safely
+   |     ---- ^^^ `UnsafeCell<NoSync>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
 note: required by a bound in `test`
@@ -46,7 +50,9 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:30:10
    |
 LL |     test(NoSync);
-   |          ^^^^^^ `NoSync` cannot be shared between threads safely
+   |     ---- ^^^^^^ `NoSync` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sync` is not implemented for `NoSync`
 note: required by a bound in `test`

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<(isize,)>` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
    |
 LL |     let x = call_it(&S, 22);
-   |                     ^^ expected an `Fn<(isize,)>` closure, found `S`
+   |             ------- ^^ expected an `Fn<(isize,)>` closure, found `S`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `S`
 note: required by a bound in `call_it`

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r i
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
-   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it`
@@ -15,7 +17,9 @@ error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it_mut`
@@ -28,7 +32,9 @@ error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
-   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it_once`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
-   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it`
@@ -15,7 +17,9 @@ error[E0277]: expected a `FnMut<(&isize,)>` closure, found `for<'r> extern "C" f
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it_mut`
@@ -28,7 +32,9 @@ error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" 
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
-   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 note: required by a bound in `call_it_once`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -2,7 +2,9 @@ error[E0277]: expected a `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isi
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
 LL |     let x = call_it(&square, 22);
-   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> Fn<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 note: required by a bound in `call_it`
@@ -15,7 +17,9 @@ error[E0277]: expected a `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> 
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnMut<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 note: required by a bound in `call_it_mut`
@@ -28,7 +32,9 @@ error[E0277]: expected a `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) ->
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
 LL |     let z = call_it_once(square, 22);
-   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |             |
+   |             required by a bound introduced by this call
    |
    = help: the trait `for<'r> FnOnce<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 note: required by a bound in `call_it_once`

--- a/src/test/ui/unsized-locals/unsized-exprs.stderr
+++ b/src/test/ui/unsized-locals/unsized-exprs.stderr
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     udrop::<A<[u8]>>(A { 0: *foo() });
    |                      ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`
+   = help: the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `A<[u8]>`
   --> $DIR/unsized-exprs.rs:3:8
    |

--- a/src/test/ui/unsized-locals/unsized-exprs.stderr
+++ b/src/test/ui/unsized-locals/unsized-exprs.stderr
@@ -12,7 +12,9 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> $DIR/unsized-exprs.rs:24:22
    |
 LL |     udrop::<A<[u8]>>(A { 0: *foo() });
-   |                      ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ---------------- ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `A<[u8]>`

--- a/src/test/ui/unsized/unsized3.rs
+++ b/src/test/ui/unsized/unsized3.rs
@@ -44,8 +44,6 @@ fn f9<X: ?Sized>(x1: Box<S<X>>) {
 fn f10<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(32, *x1));
     //~^ ERROR the size for values of type
-    //~| ERROR the size for values of type
 }
 
-pub fn main() {
-}
+pub fn main() {}

--- a/src/test/ui/unsized/unsized3.stderr
+++ b/src/test/ui/unsized/unsized3.stderr
@@ -93,12 +93,12 @@ LL + fn f9<X>(x1: Box<S<X>>) {
    | 
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:45:9
+  --> $DIR/unsized3.rs:45:8
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
-   |         ^^^^^^^^^ doesn't have a size known at compile-time
+   |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `S<X>`
   --> $DIR/unsized3.rs:28:8
@@ -113,35 +113,6 @@ LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {
 LL + fn f10<X>(x1: Box<S<X>>) {
    | 
 
-error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:45:8
-   |
-LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `std::marker::Sized`
-LL |     f5(&(32, *x1));
-   |        ^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-note: required because it appears within the type `S<X>`
-  --> $DIR/unsized3.rs:28:8
-   |
-LL | struct S<X: ?Sized> {
-   |        ^
-   = note: required because it appears within the type `({integer}, S<X>)`
-note: required by a bound in `f5`
-  --> $DIR/unsized3.rs:24:7
-   |
-LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by this bound in `f5`
-help: consider removing the `?Sized` bound to make the type parameter `Sized`
-   |
-LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {
-LL + fn f10<X>(x1: Box<S<X>>) {
-   | 
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | fn f5<Y: ?Sized>(x: &Y) {}
-   |        ++++++++
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/unsized/unsized3.stderr
+++ b/src/test/ui/unsized/unsized3.stderr
@@ -4,7 +4,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn f1<X: ?Sized>(x: &X) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f2::<X>(x);
-   |             ^ doesn't have a size known at compile-time
+   |     ------- ^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f2`
   --> $DIR/unsized3.rs:10:7
@@ -27,7 +29,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn f3<X: ?Sized + T>(x: &X) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f4::<X>(x);
-   |             ^ doesn't have a size known at compile-time
+   |     ------- ^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required by a bound in `f4`
   --> $DIR/unsized3.rs:21:7
@@ -50,7 +54,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(x1);
-   |        ^^ doesn't have a size known at compile-time
+   |     -- ^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because it appears within the type `S<X>`
   --> $DIR/unsized3.rs:28:8
@@ -78,7 +84,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
    |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(*x1, 34));
-   |        ^^^^^^^^^^ doesn't have a size known at compile-time
+   |     -- ^^^^^^^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because it appears within the type `S<X>`
   --> $DIR/unsized3.rs:28:8
@@ -98,7 +106,9 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
-   |        ^^^^^^^^^^ doesn't have a size known at compile-time
+   |     -- ^^^^^^^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because it appears within the type `S<X>`
   --> $DIR/unsized3.rs:28:8

--- a/src/test/ui/vtable-res-trait-param.stderr
+++ b/src/test/ui/vtable-res-trait-param.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `{integer}: TraitA` is not satisfied
   --> $DIR/vtable-res-trait-param.rs:17:18
    |
 LL |     b.gimme_an_a(y)
-   |                  ^ the trait `TraitA` is not implemented for `{integer}`
+   |       ---------- ^ the trait `TraitA` is not implemented for `{integer}`
+   |       |
+   |       required by a bound introduced by this call
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:22
    |
 LL |         require_copy(self.x);
-   |                      ^^^^^^ the trait `Copy` is not implemented for `T`
+   |         ------------ ^^^^^^ the trait `Copy` is not implemented for `T`
+   |         |
+   |         required by a bound introduced by this call
    |
 note: required by a bound in `require_copy`
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:1:20

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:22
    |
 LL |         require_copy(self.x);
-   |                      ^^^^^^ the trait `Copy` is not implemented for `T`
+   |         ------------ ^^^^^^ the trait `Copy` is not implemented for `T`
+   |         |
+   |         required by a bound introduced by this call
    |
 note: required by a bound in `require_copy`
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:1:20

--- a/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
@@ -2,7 +2,9 @@ error[E0277]: the trait bound `Bar: Eq` is not satisfied
   --> $DIR/where-clauses-method-unsatisfied.rs:18:14
    |
 LL |     x.equals(&x);
-   |              ^^ the trait `Eq` is not implemented for `Bar`
+   |       ------ ^^ the trait `Eq` is not implemented for `Bar`
+   |       |
+   |       required by a bound introduced by this call
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When an obligation is introduced by a specific `fn` argument, point at
the argument instead of the `fn` call if the obligation fails to be
fulfilled.

Move the information about pointing at the call argument expression in
an unmet obligation span from the `FulfillmentError` to a new
`ObligationCauseCode`.

When giving an error about an obligation introduced by a function call
that an argument doesn't fulfill, and that argument is a block, add a
span_label pointing at the innermost tail expression.

Current output:

```
error[E0425]: cannot find value `x` in this scope
 --> f10.rs:4:14
  |
4 |         Some(x * 2)
  |              ^ not found in this scope

error[E0277]: expected a `FnOnce<({integer},)>` closure, found `Option<_>`
 --> f10.rs:2:31
  |
2 |       let p = Some(45).and_then({
  |  ______________________--------_^
  | |                      |
  | |                      required by a bound introduced by this call
3 | |         |x| println!("doubling {}", x);
4 | |         Some(x * 2)
  | |         -----------
5 | |     });
  | |_____^ expected an `FnOnce<({integer},)>` closure, found `Option<_>`
  |
  = help: the trait `FnOnce<({integer},)>` is not implemented for `Option<_>`
```

Previous output:

```
error[E0425]: cannot find value `x` in this scope
 --> f10.rs:4:14
  |
4 |         Some(x * 2)
  |              ^ not found in this scope

error[E0277]: expected a `FnOnce<({integer},)>` closure, found `Option<_>`
 --> f10.rs:2:22
  |
2 |     let p = Some(45).and_then({
  |                      ^^^^^^^^ expected an `FnOnce<({integer},)>` closure, found `Option<_>`
  |
  = help: the trait `FnOnce<({integer},)>` is not implemented for `Option<_>`
```

Partially address #27300. Will require rebasing on top of #88546.