### PR TITLE
Don't lint about missing code examples in derived traits

### DIFF
--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -96,6 +96,7 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
 
     if cx.tcx.hir().attrs(hir_id).lists(sym::doc).has_word(sym::hidden)
         || inherits_doc_hidden(cx.tcx, hir_id)
+        || cx.tcx.hir().span(hir_id).in_derive_expansion()
     {
         return false;
     }

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
@@ -78,6 +78,15 @@ impl Clone for Struct {
 }
 
 
+
+/// doc
+///
+/// ```
+/// println!("hello");
+/// ```
+#[derive(Clone)]
+pub struct NiceStruct;
+
 #[doc(hidden)]
 pub mod foo {
     pub fn bar() {}


### PR DESCRIPTION
When the `missing_doc_code_examples` lint is performed it also requires that derived Trait implementations have a code example for each member etc., which causes undesirable behavior.

# Examples

With `missing_doc_code_examples` enable we are not able to use the `Clone` derive macro due to the generated code not being documented:
```rust
#[deny(rustdoc::missing_doc_code_examples)]

/// docs
/// ```
/// let s = SomeStruct;
/// ```
#[derive(Clone)]
pub struct SomeStruct;
```
yields:
```
 Documenting testt v0.1.0 (<redacted>)
error: missing code example in this documentation
 --> src/lib.rs:7:10
  |
7 | #[derive(Clone)]
  |          ^^^^^
  |
note: the lint level is defined here
 --> src/lib.rs:1:8
  |
1 | #[deny(rustdoc::missing_doc_code_examples)]
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing code example in this documentation
 --> src/lib.rs:7:10
  |
7 | #[derive(Clone)]
  |          ^^^^^

error: could not document `testt`

Caused by:
  process didn't exit successfully: `rustdoc ...
```

closes #81775