### PR TITLE
[perf experiment] Use `intern` instead of `intern_ref` in `direct_interners!`.

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2101,7 +2101,7 @@ macro_rules! direct_interners {
 
         impl<'tcx> TyCtxt<'tcx> {
             pub fn $method(self, v: $ty) -> &'tcx $ty {
-                self.interners.$name.intern_ref(&v, || {
+                self.interners.$name.intern(v, |v| {
                     Interned(self.interners.arena.alloc(v))
                 }).0
             }


### PR DESCRIPTION
*Opening as draft as it's not intended to be merged, it's only for perf testing*

This is me testing the theory that the regressions measured in https://github.com/rust-lang/rust/pull/88575#issuecomment-914537788 cannot come from the main changes of that PR, but rather from the switch of `ty::Region` and `ty::Const` interning, since `-check` benchmarks are affected, while the PR mostly changes `FnAbi` (used only by codegen).

r? @ghost