### PR TITLE
Allow missing code examples in trait impls.

### DIFF
--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.rs
@@ -70,6 +70,13 @@ pub union Union {
     b: f32,
 }
 
+// no code example and it's fine!
+impl Clone for Struct {
+    fn clone(&self) -> Self {
+        Self { field: self.field }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod foo {


### PR DESCRIPTION
Excludes Trait implementations from the items that need to have doc code examples when using the `rustdoc::missing_doc_code_examples` lint.

For details see #88741

fixes #88741

r? @jyn514 