### PR TITLE
Smarter default implementation of Extend::extend_reserve

### DIFF
--- a/library/core/tests/iter/traits/collect.rs
+++ b/library/core/tests/iter/traits/collect.rs
@@ -1,0 +1,27 @@
+#[test]
+fn test_extend_reserve() {
+    struct Collection {
+        len: usize,
+        capacity: usize,
+    }
+
+    impl Extend<i32> for Collection {
+        fn extend<I: IntoIterator<Item = i32>>(&mut self, elements: I) {
+            let iter = elements.into_iter();
+            let (lower_bound, _) = iter.size_hint();
+            let expected_len = self.len.saturating_add(lower_bound);
+            if self.capacity < expected_len {
+                // do the reserve
+                self.capacity = expected_len;
+            }
+            // do the extend
+            iter.into_iter().for_each(drop);
+        }
+
+        // no custom implementation of extend_reserve
+    }
+
+    let mut collection = Collection { len: 0, capacity: 0 };
+    collection.extend_reserve(5);
+    assert_eq!(collection.capacity, 5);
+}

--- a/library/core/tests/iter/traits/mod.rs
+++ b/library/core/tests/iter/traits/mod.rs
@@ -1,4 +1,5 @@
 mod accum;
+mod collect;
 mod double_ended;
 mod iterator;
 mod step;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(duration_consts_2)]
 #![feature(duration_constants)]
 #![feature(exact_size_is_empty)]
+#![feature(extend_one)]
 #![feature(extern_types)]
 #![feature(flt2dec)]
 #![feature(fmt_internals)]


### PR DESCRIPTION
Following up on https://github.com/rust-lang/rust/issues/72631#issuecomment-915534130: there is a way for `extend_reserve` to perform a sensible reserve by default, without always needing to be overridden by every `Extend` impl, as long as `extend` checks its argument's size_hint as many already do. For example the following code in `String`'s Extend impl:

https://github.com/rust-lang/rust/blob/c9db3e0fbc84d8409285698486375f080d361ef3/library/alloc/src/string.rs#L1927-L1933

In a future PR we can clean up handwritten implementations of `extend_reserve` which are no longer providing value over this default implementation.