### PR TITLE
Improve `size_hint` bounds for `DecodeUtf16` iterator

### DIFF
--- a/library/core/src/char/decode.rs
+++ b/library/core/src/char/decode.rs
@@ -122,7 +122,12 @@ impl<I: Iterator<Item = u16>> Iterator for DecodeUtf16<I> {
         let (low, high) = self.iter.size_hint();
         // we could be entirely valid surrogates (2 elements per
         // char), or entirely non-surrogates (1 element per char)
-        (low.div_ceil(2), high)
+        //
+        // In addition to `self.iter`, there's potentially one
+        // additional number in `self.buf`.
+        // On odd lower bound, at least one element must stay unpaired
+        // (with other elements from `self.iter`).
+        (low.div_ceil(2), try { high?.checked_add(1)? })
     }
 }
 

--- a/library/core/src/char/decode.rs
+++ b/library/core/src/char/decode.rs
@@ -122,7 +122,7 @@ impl<I: Iterator<Item = u16>> Iterator for DecodeUtf16<I> {
         let (low, high) = self.iter.size_hint();
         // we could be entirely valid surrogates (2 elements per
         // char), or entirely non-surrogates (1 element per char)
-        (low / 2, high)
+        (low.div_ceil(2), high)
     }
 }
 


### PR DESCRIPTION
If at most 2 `u16`s make up one item in the iterator, then there has to be a minimum of `len + 1 / 2` elements for an odd-numbered iterator. In other words, the best lower bound would be determined by rounding up.

Edit: I noticed #88762 while creating a PR including just bea5cd1d213d25fc812793d09a5fcab7dcf56353. So now, I’ve added a commit that fixes #88762 as-well.