### PR TITLE
[beta] bootstrap bump and backports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,7 @@ jobs:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=aarch64-pc-windows-msvc --enable-full-tools --enable-profiler"
               SCRIPT: python x.py dist
               DIST_REQUIRE_ALL_TOOLS: 0
+              WINDOWS_SDK_20348_HACK: 1
             os: windows-latest-xl
           - name: dist-i686-mingw
             env:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,8 +10,7 @@ Language
 
 Compiler
 --------
-- [Added tier 3\* support for `powerpc-unknown-freebsd`.][87370]
-- [Added tier 3 support for `powerpc64le-unknown-freebsd`.][83572]
+- [Added tier 3\* support for `powerpc64le-unknown-freebsd`.][83572]
 
 \* Refer to Rust's [platform support page][platform-support-doc] for more
    information on Rust's tiered platform support.
@@ -24,17 +23,6 @@ Libraries
   no longer reject certain valid floating point values, and reduce
   the produced code size for non-stripped artifacts.
 - [`string::Drain` now implements `AsRef<str>` and `AsRef<[u8]>`.][86858]
-- [`collections::{BinaryHeap, BTreeSet, HashSet, LinkedList, VecDeque}` now
-  implement `From<[T; N]>`.][84111]
-- [`collections::{BTreeMap, HashMap}` now implement `From<[(K, V); N]>`.][84111]
-  This allows you to write the following;
-  ```rust
-  let highscores = std::collections::HashMap::from([
-      ("Alice", 9000u32),
-      ("Bob", 7250),
-      ("Charlie", 5500),
-  ]);
-  ```
 
 Stabilised APIs
 ---------------
@@ -60,7 +48,6 @@ Stabilised APIs
 The following previously stable functions are now `const`.
 
 - [`str::from_utf8_unchecked`]
-- [`mem::transmute`]
 
 
 Cargo
@@ -131,7 +118,6 @@ Compatibility Notes
 [`MaybeUninit::assume_init_ref`]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_ref
 [`MaybeUninit::write`]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.write
 [`Seek::rewind`]: https://doc.rust-lang.org/stable/std/io/trait.Seek.html#method.rewind
-[`mem::transmute`]: https://doc.rust-lang.org/stable/std/mem/fn.transmute.html
 [`ops::ControlFlow`]: https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html
 [`str::from_utf8_unchecked`]: https://doc.rust-lang.org/stable/std/str/fn.from_utf8_unchecked.html
 [`x86::_bittest`]: https://doc.rust-lang.org/stable/core/arch/x86/fn._bittest.html

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -635,6 +635,9 @@ jobs:
               SCRIPT: python x.py dist
               # RLS does not build for aarch64-pc-windows-msvc. See rust-lang/rls#1693
               DIST_REQUIRE_ALL_TOOLS: 0
+              # Hack around this SDK version, because it doesn't work with clang.
+              # See https://github.com/rust-lang/rust/issues/88796
+              WINDOWS_SDK_20348_HACK: 1
             <<: *job-windows-xl
 
           - name: dist-i686-mingw

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -37,6 +37,12 @@ if isMacOS; then
     # `clang-ar` by accident.
     ciCommandSetEnv AR "ar"
 elif isWindows && [[ ${CUSTOM_MINGW-0} -ne 1 ]]; then
+
+    if [[ ${WINDOWS_SDK_20348_HACK-0} -eq 1 ]]; then
+        rm -rf '/c/Program Files (x86)/Windows Kits/10/include/10.0.20348.0'
+        mv '/c/Program Files (x86)/Windows Kits/10/include/'10.0.{19041,20348}.0
+    fi
+
     # If we're compiling for MSVC then we, like most other distribution builders,
     # switch to clang as the compiler. This'll allow us eventually to enable LTO
     # amongst LLVM and rustc. Note that we only do this on MSVC as I don't think

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,8 +12,8 @@
 # stable release's version number. `date` is the date where the release we're
 # bootstrapping off was released.
 
-date: 2021-07-29
-rustc: beta
+date: 2021-09-09
+rustc: 1.55.0
 
 # We use a nightly rustfmt to format the source because it solves some
 # bootstrapping issues with use of new syntax in this repo. If you're looking at

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -9,6 +9,10 @@
 // This fails on lldb 6.0.1 on x86-64 Fedora 28; so ignore Linux for now.
 // ignore-linux
 
+// This started failing in windows too. See https://github.com/rust-lang/rust/issues/88796
+// FIXME: fix and unignore this on windows
+// ignore-windows
+
 // compile-flags:-g
 
 // === GDB TESTS ===================================================================================

--- a/src/test/debuginfo/msvc-pretty-enums.rs
+++ b/src/test/debuginfo/msvc-pretty-enums.rs
@@ -2,6 +2,10 @@
 // ignore-tidy-linelength
 // compile-flags:-g
 
+// This started failing recently. See https://github.com/rust-lang/rust/issues/88796
+// FIXME: fix and unignore this
+// ignore-windows
+
 // cdb-command: g
 
 // Note: The natvis used to visualize niche-layout enums don't work correctly in cdb

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -6,6 +6,10 @@
 // min-lldb-version: 310
 // min-cdb-version: 10.0.18317.1001
 
+// This started failing recently. See https://github.com/rust-lang/rust/issues/88796
+// FIXME: fix and unignore this
+// ignore-windows
+
 // === GDB TESTS ===================================================================================
 
 // gdb-command: run

--- a/src/test/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -1,0 +1,62 @@
+// edition:2021
+
+#![feature(rustc_attrs)]
+
+// Test that we can't move out of struct that impls `Drop`.
+
+
+use std::rc::Rc;
+
+// Test that we restrict precision when moving not-`Copy` types, if any of the parent paths
+// implement `Drop`. This is to ensure that we don't move out of a type that implements Drop.
+pub fn test1() {
+    struct Foo(Rc<i32>);
+
+    impl Drop for Foo {
+        fn drop(self: &mut Foo) {}
+    }
+
+    let f = Foo(Rc::new(1));
+    let x = #[rustc_capture_analysis] move || {
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        println!("{:?}", f.0);
+        //~^ NOTE: Capturing f[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture f[] -> ByValue
+    };
+
+    x();
+}
+
+// Test that we don't restrict precision when moving `Copy` types(i.e. when copying),
+// even if any of the parent paths implement `Drop`.
+fn test2() {
+    struct Character {
+        hp: u32,
+        name: String,
+    }
+
+    impl Drop for Character {
+        fn drop(&mut self) {}
+    }
+
+    let character = Character { hp: 100, name: format!("A") };
+
+    let c = #[rustc_capture_analysis] move || {
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        println!("{}", character.hp)
+        //~^ NOTE: Capturing character[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture character[(0, 0)] -> ByValue
+    };
+
+    c();
+
+    println!("{}", character.name);
+}
+
+fn main() {}

--- a/src/test/ui/closures/2229_closure_analysis/issue-88476.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88476.stderr
@@ -1,0 +1,97 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/issue-88476.rs:20:13
+   |
+LL |     let x = #[rustc_capture_analysis] move || {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/issue-88476.rs:47:13
+   |
+LL |     let c = #[rustc_capture_analysis] move || {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error: First Pass analysis includes:
+  --> $DIR/issue-88476.rs:20:39
+   |
+LL |       let x = #[rustc_capture_analysis] move || {
+   |  _______________________________________^
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing f[(0, 0)] -> ImmBorrow
+  --> $DIR/issue-88476.rs:25:26
+   |
+LL |         println!("{:?}", f.0);
+   |                          ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/issue-88476.rs:20:39
+   |
+LL |       let x = #[rustc_capture_analysis] move || {
+   |  _______________________________________^
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture f[] -> ByValue
+  --> $DIR/issue-88476.rs:25:26
+   |
+LL |         println!("{:?}", f.0);
+   |                          ^^^
+
+error: First Pass analysis includes:
+  --> $DIR/issue-88476.rs:47:39
+   |
+LL |       let c = #[rustc_capture_analysis] move || {
+   |  _______________________________________^
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing character[(0, 0)] -> ImmBorrow
+  --> $DIR/issue-88476.rs:52:24
+   |
+LL |         println!("{}", character.hp)
+   |                        ^^^^^^^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/issue-88476.rs:47:39
+   |
+LL |       let c = #[rustc_capture_analysis] move || {
+   |  _______________________________________^
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture character[(0, 0)] -> ByValue
+  --> $DIR/issue-88476.rs:52:24
+   |
+LL |         println!("{}", character.hp)
+   |                        ^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
@@ -1,0 +1,47 @@
+// check-pass
+// edition:2021
+
+use std::rc::Rc;
+
+// Test that we restrict precision when moving not-`Copy` types, if any of the parent paths
+// implement `Drop`. This is to ensure that we don't move out of a type that implements Drop.
+pub fn test1() {
+    struct Foo(Rc<i32>);
+
+    impl Drop for Foo {
+        fn drop(self: &mut Foo) {}
+    }
+
+    let f = Foo(Rc::new(1));
+    let x = move || {
+        println!("{:?}", f.0);
+    };
+
+    x();
+}
+
+
+// Test that we don't restrict precision when moving `Copy` types(i.e. when copying),
+// even if any of the parent paths implement `Drop`.
+pub fn test2() {
+    struct Character {
+        hp: u32,
+        name: String,
+    }
+
+    impl Drop for Character {
+        fn drop(&mut self) {}
+    }
+
+    let character = Character { hp: 100, name: format!("A") };
+
+    let c = move || {
+        println!("{}", character.hp)
+    };
+
+    c();
+
+    println!("{}", character.name);
+}
+
+fn main() {}


### PR DESCRIPTION
This bumps the beta bootstrap compiler to the released 1.55.0, and backports the following PRs:

* Drop 1.56 stabilizations from 1.55 release notes #88694 
* 2229: Don't move out of drop type #88477 
* Work around CI issue with windows sdk 10.0.20348.0. #88797 

Cargo update:

1 commits in 18751dd3f238d94d384a7fe967abfac06cbfe0b9..d199d817e4bb70facc710716e73b5dddf80bc055
2021-09-01 14:26:00 +0000 to 2021-09-09 14:08:56 +0000
- [beta] Fix `cargo fix --edition` on stable. (rust-lang/cargo#9891)

r? @Mark-Simulacrum 