### PR TITLE
remove unnecessary bound on Zip specialization impl

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -429,13 +429,9 @@ where
     }
 }
 
+// Since SourceIter forwards the left hand side we do the same here
 #[unstable(issue = "none", feature = "inplace_iteration")]
-// Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
-// and Drop implementation of the source is unclear.
-//
-// An additional method returning the number of times the source has been logically advanced
-// (without calling next()) would be needed to properly drop the remainder of the source.
-unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where A::Item: Copy {}
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Debug, B: Debug> Debug for Zip<A, B> {


### PR DESCRIPTION
I originally added this bound in an attempt to make the specialization
sound for owning iterators but it was never correct here and the correct
and [already implemented](https://github.com/rust-lang/rust/blob/497ee321af3b8496eaccd7af7b437f18bab81abf/library/alloc/src/vec/into_iter.rs#L220-L232) solution is is to place it on the IntoIter
implementation.