### PR TITLE
Clarification of default socket flags

### DIFF
--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -15,7 +15,7 @@
 //!   with networking objects like [`TcpListener`], [`TcpStream`] or [`UdpSocket`]
 //! * Other types are return or parameter types for various methods in this module
 //!
-//! Rust disables inheritance of socket objects to child processes by default when possible.  For 
+//! Rust disables inheritance of socket objects to child processes by default when possible.  For
 //! example, through the use of the `CLOEXEC` flag in UNIX systems or the `HANDLE_FLAG_INHERIT`
 //! flag on Windows.
 

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -14,6 +14,10 @@
 //! * [`ToSocketAddrs`] is a trait that used for generic address resolution when interacting
 //!   with networking objects like [`TcpListener`], [`TcpStream`] or [`UdpSocket`]
 //! * Other types are return or parameter types for various methods in this module
+//!
+//! Rust disables inheritance of socket objects to child processes by default when possible.  For 
+//! example, through the use of the `CLOEXEC` flag in UNIX systems or the `HANDLE_FLAG_INHERIT`
+//! flag on Windows.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
This PR outlines the decision to disable inheritance of socket objects when possible to child processes in the documentation.