### PR TITLE
No --as-needed for -fuse-ld=lld

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2426,7 +2426,14 @@ fn add_upstream_native_libraries(
                 NativeLibKind::Dylib { as_needed } => {
                     cmd.link_dylib(name, verbatim, as_needed.unwrap_or(true))
                 }
-                NativeLibKind::Unspecified => cmd.link_dylib(name, verbatim, true),
+                NativeLibKind::Unspecified => {
+                    cmd.link_dylib(
+                        name,
+                        verbatim,
+                        // FIXME: lld doesn't include some needed shared libraries without this, but includes some unneeded ones with this
+                        sess.opts.cg.link_args.iter().all(|arg| arg != "-fuse-ld=lld"),
+                    )
+                }
                 NativeLibKind::Framework { as_needed } => {
                     cmd.link_framework(name, as_needed.unwrap_or(true))
                 }


### PR DESCRIPTION
I have a crate that uses https://github.com/Andlon/mkl-sys as a dependency, which does not work when the rustflag `-C link-arg=-fuse-ld=lld` is used, but works when the flag is not used. It seems like this is because using --as-needed with lld makes lld not pick up some libraries which are actually needed.

This is the binary compiled using  `-C link-arg=-fuse-ld=lld` without my PR:
```
$ readelf -d target/debug/deps/spam_csr-f895edd13d6929fd | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_intel_ilp64.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```

This is the binary compiled without:
```
$ readelf -d target/debug/deps/spam_csr-f895edd13d6929fd | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_intel_ilp64.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_intel_thread.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_core.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libiomp5.so]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```

This is the binary compiled using  `-C link-arg=-fuse-ld=lld` with my PR:
```
$ readelf -d target/debug/deps/spam_csr-740b6e93024ccac3 | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_intel_ilp64.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_intel_thread.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libmkl_core.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libiomp5.so]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libutil.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```