### PR TITLE
Restrict parsing of bare union/struct to field types

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -765,57 +765,23 @@ impl<'a> Parser<'a> {
             if self.eat(&token::Colon) { self.parse_generic_bounds(None)? } else { Vec::new() };
         generics.where_clause = self.parse_where_clause()?;
 
-        let default = if self.eat(&token::Eq) {
-            Some(self.parse_ty_recover_anon_adt(|this| this.expect_semi())?.0)
-        } else {
-            self.expect_semi()?;
-            None
-        };
+        let default =
+            if self.eat(&token::Eq) { Some(self.parse_ty_recover_anon_adt()?) } else { None };
+        self.expect_semi()?;
 
         Ok((ident, ItemKind::TyAlias(Box::new(TyAliasKind(def, generics, bounds, default)))))
     }
 
-    /// Parses a type. If a misparse happens, we attempt to parse the type again, allowing
-    /// anonymous `union`s and `struct`s in its place. If successful, we return this. The
-    /// anonymous ADTs will be disallowed elsewhere.
-    fn parse_ty_recover_anon_adt<F, R>(&mut self, after: F) -> PResult<'a, (P<Ty>, R)>
-    where
-        F: Fn(&mut Self) -> PResult<'a, R>,
-    {
+    /// Parses a type. If we encounter an anonymous `union` or `struct`, we parse it, but still
+    /// allow `static C: union = union::val;` to be parsed correctly. The anonymous ADTs will be
+    /// disallowed elsewhere.
+    fn parse_ty_recover_anon_adt(&mut self) -> PResult<'a, P<Ty>> {
         if (self.token.is_keyword(kw::Union) | self.token.is_keyword(kw::Struct))
             && self.look_ahead(1, |t| t == &token::OpenDelim(token::Brace))
         {
-            let mut snapshot = self.clone();
-            let mut err;
-            match self.parse_ty() {
-                Ok(ty) => match after(self) {
-                    Ok(r) => return Ok((ty, r)),
-                    Err(orig_err) => {
-                        err = orig_err;
-                    }
-                },
-                Err(orig_err) => {
-                    err = orig_err;
-                }
-            }
-            match snapshot.parse_ty_allow_anon_adt() {
-                Ok(ty) => match after(&mut snapshot) {
-                    Ok(r) => {
-                        err.delay_as_bug();
-                        *self = snapshot;
-                        return Ok((ty, r));
-                    }
-                    Err(mut snapshot_err) => snapshot_err.cancel(),
-                },
-                Err(mut snapshot_err) => {
-                    snapshot_err.cancel();
-                }
-            }
-            Err(err)
+            self.parse_ty_allow_anon_adt()
         } else {
-            let ty = self.parse_ty()?;
-            let r = after(self)?;
-            Ok((ty, r))
+            self.parse_ty()
         }
     }
 
@@ -1107,18 +1073,14 @@ impl<'a> Parser<'a> {
 
         // Parse the type of a `const` or `static mut?` item.
         // That is, the `":" $ty` fragment.
-        let (ty, expr) = if self.eat(&token::Colon) {
-            self.parse_ty_recover_anon_adt(|this| {
-                let expr = if this.eat(&token::Eq) { Some(this.parse_expr()?) } else { None };
-                this.expect_semi()?;
-                Ok(expr)
-            })?
+        let ty = if self.eat(&token::Colon) {
+            self.parse_ty_recover_anon_adt()?
         } else {
-            let ty = self.recover_missing_const_type(id, m);
-            let expr = if self.eat(&token::Eq) { Some(self.parse_expr()?) } else { None };
-            self.expect_semi()?;
-            (ty, expr)
+            self.recover_missing_const_type(id, m)
         };
+
+        let expr = if self.eat(&token::Eq) { Some(self.parse_expr()?) } else { None };
+        self.expect_semi()?;
 
         Ok((id, ty, expr))
     }

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -316,7 +316,7 @@ impl<'a> Parser<'a> {
             |(fields, recovered)| {
                 let span = lo.to(self.prev_token.span);
                 self.sess.gated_spans.gate(sym::unnamed_fields, span);
-                // These will be rejected during AST validation in `deny_anonymous_struct`.
+                // These can be rejected during AST validation in `deny_anonymous_struct`.
                 return if is_union {
                     TyKind::AnonymousUnion(fields, recovered)
                 } else {

--- a/src/test/pretty/anonymous-types.rs
+++ b/src/test/pretty/anonymous-types.rs
@@ -16,9 +16,4 @@ struct Foo {
     e: f32,
 }
 
-type A =
- struct {
-     field: u8,
- };
-
 fn main() { }

--- a/src/test/ui/parser/issue-88583-union-as-ident.rs
+++ b/src/test/ui/parser/issue-88583-union-as-ident.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+#![allow(non_camel_case_types)]
+
+struct union;
+
+impl union {
+    pub fn new() -> Self {
+        union { }
+    }
+}
+
+fn main() {
+    let _u = union::new();
+}


### PR DESCRIPTION
Do not unconditionally parse bare types everywhere, only parse them if
they are in a field type, and try them when recovering a misparse
everywhere else, using them only if they are successfuly fully parsed.

Fix #88583.

r? @pnkfelix 