### PR TITLE
Rustdoc migrate to table so the gui can handle >2k constants

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -773,22 +773,18 @@ h2.small-section-header > .anchor {
 .block a.current.crate { font-weight: 500; }
 
 .item-table {
-	display: grid;
-	column-gap: 1.2rem;
-	row-gap: 0.0rem;
-	grid-template-columns: auto 1fr;
+	display: table-row;
 	/* align content left */
 	justify-items: start;
 }
-
+.item-row {
+	display: table-row;
+}
 .item-left, .item-right {
-	display: block;
+	display: table-cell;
 }
 .item-left {
-	grid-column: 1;
-}
-.item-right {
-	grid-column: 2;
+	padding-right: 1.2rem;
 }
 
 .search-container {
@@ -1891,6 +1887,9 @@ details.undocumented[open] > summary::before {
 
 	/* Display an alternating layout on tablets and phones */
 	.item-table {
+		display: block;
+	}
+	.item-row {
 		display: flex;
 		flex-flow: column wrap;
 	}

--- a/src/test/rustdoc-gui/huge-collection-of-constants.goml
+++ b/src/test/rustdoc-gui/huge-collection-of-constants.goml
@@ -1,0 +1,5 @@
+goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
+
+// Make sure that the last two entries are more than 12 pixels apart and not stacked on each other.
+
+compare-elements-position-near-false: ("//*[@class='item-table']//div[last()-1]", "//*[@class='item-table']//div[last()-3]", {"y": 12})

--- a/src/test/rustdoc-gui/src/test_docs/Cargo.toml
+++ b/src/test/rustdoc-gui/src/test_docs/Cargo.toml
@@ -3,5 +3,7 @@ name = "test_docs"
 version = "0.1.0"
 edition = "2018"
 
+build = "build.rs"
+
 [lib]
 path = "lib.rs"

--- a/src/test/rustdoc-gui/src/test_docs/build.rs
+++ b/src/test/rustdoc-gui/src/test_docs/build.rs
@@ -1,0 +1,15 @@
+//! generate 2000 constants for testing
+
+use std::{fs::write, path::PathBuf};
+
+fn main() -> std::io::Result<()> {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is not defined");
+
+    let mut output = String::new();
+    for i in 0..2000 {
+        let line = format!("/// Some const A{0}\npub const A{0}: isize = 0;\n", i);
+        output.push_str(&*line);
+    };
+
+    write(&[&*out_dir, "huge_amount_of_consts.rs"].iter().collect::<PathBuf>(), output)
+}

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -116,3 +116,7 @@ pub mod keyword {}
 
 /// Just some type alias.
 pub type SomeType = u32;
+
+pub mod huge_amount_of_consts {
+    include!(concat!(env!("OUT_DIR"), "/huge_amount_of_consts.rs"));
+}

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -172,7 +172,7 @@ async function main(argv) {
     }
     files.sort();
 
-    console.log(`Running ${files.length} rustdoc-gui tests...`);
+    console.log(`Running ${files.length} rustdoc-gui (${opts["jobs"]} concurrently) ...`);
 
     if (opts["jobs"] < 1) {
         process.setMaxListeners(files.length + 1);


### PR DESCRIPTION
Closes #88545.

This PR adds a test for overlapping entries in the `item-table` https://github.com/rust-lang/rust/issues/88545
It currently includes the commit with the workaround from https://github.com/rust-lang/rust/pull/88776