### PR TITLE
Use the `matches` macro in `Option::contains`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -589,10 +589,7 @@ impl<T> Option<T> {
     where
         U: PartialEq<T>,
     {
-        match self {
-            Some(y) => x == y,
-            None => false,
-        }
+        matches!(self, Some(y) if x == y)
     }
 
     /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a simple code-style PR that makes `Option::contains` use the `matches` macro, as per Clippy's [match_like_matches_macro](https://rust-lang.github.io/rust-clippy/master/#match_like_matches_macro)