### PR TITLE
Turn `TrapUnreachable` off by default

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1421,7 +1421,7 @@ impl Default for TargetOptions {
             stack_probes: StackProbeType::None,
             min_global_align: None,
             default_codegen_units: None,
-            trap_unreachable: true,
+            trap_unreachable: false,
             requires_lto: false,
             singlethread: false,
             no_builtins: false,

--- a/src/test/codegen/alloc-optimisation.rs
+++ b/src/test/codegen/alloc-optimisation.rs
@@ -1,5 +1,5 @@
-//
-// min-llvm-version: 10.0.1
+// This requires Rust-specific LLVM patches to recognize our allocation functions.
+// no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]
 


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/issues/28728 is fixed, there's no longer a risk of programs executing past the end of a function, so we don't have to put a trap instruction there anymore.

This should ever so slightly shrink the average Rust program.

(the second commit is a drive-by-fix that reverts an incorrect part of https://github.com/rust-lang/rust/commit/62e7331bd2bd592e30acf63467f140084684bc8f, which made the `alloc-optimisation.rs` test fail with my system's LLVM)