### PR TITLE
Do not suggest importing inaccessible items

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2966,7 +2966,15 @@ impl<'a> Resolver<'a> {
                 (None, false)
             };
             if !candidates.is_empty() {
-                diagnostics::show_candidates(&mut err, span, &candidates, instead, found_use);
+                diagnostics::show_candidates(
+                    &self.definitions,
+                    self.session,
+                    &mut err,
+                    span,
+                    &candidates,
+                    instead,
+                    found_use,
+                );
             } else if let Some((span, msg, sugg, appl)) = suggestion {
                 err.span_suggestion(span, msg, sugg, appl);
             }

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `f` in this scope
 LL |         f();
    |         ^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing this function
    |
 LL | use foo::f;
    |
@@ -37,7 +37,7 @@ LL | n!(f);
 LL |         n!(f);
    |            ^ not found in this scope
    |
-   = note: consider importing one of these items:
+   = note: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ LL | n!(f);
 LL |                 f
    |                 ^ not found in this scope
    |
-   = note: consider importing one of these items:
+   = note: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -4,10 +4,8 @@ error[E0425]: cannot find function `fpriv` in this scope
 LL |     fpriv();
    |     ^^^^^ not found in this scope
    |
-help: consider importing this function
-   |
-LL | use bar::fpriv;
-   |
+   = note: this function exists but is inaccessible:
+           bar::fpriv
 
 error[E0425]: cannot find function `epriv` in this scope
   --> $DIR/glob-resolve1.rs:27:5
@@ -15,10 +13,8 @@ error[E0425]: cannot find function `epriv` in this scope
 LL |     epriv();
    |     ^^^^^ not found in this scope
    |
-help: consider importing this function
-   |
-LL | use bar::epriv;
-   |
+   = note: this function exists but is inaccessible:
+           bar::epriv
 
 error[E0423]: expected value, found enum `B`
   --> $DIR/glob-resolve1.rs:28:5
@@ -44,10 +40,8 @@ error[E0425]: cannot find value `C` in this scope
 LL |     C;
    |     ^ not found in this scope
    |
-help: consider importing this unit struct
-   |
-LL | use bar::C;
-   |
+   = note: this unit struct exists but is inaccessible:
+           bar::C
 
 error[E0425]: cannot find function `import` in this scope
   --> $DIR/glob-resolve1.rs:30:5
@@ -67,16 +61,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<A>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this enum
-   |
-LL | use bar::A;
-   |
+   = note: this enum exists but is inaccessible:
+           bar::A
 
 error[E0412]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:33:11
@@ -85,16 +73,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<C>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this struct
-   |
-LL | use bar::C;
-   |
+   = note: this struct exists but is inaccessible:
+           bar::C
 
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:34:11
@@ -103,16 +85,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<D>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this type alias
-   |
-LL | use bar::D;
-   |
+   = note: this type alias exists but is inaccessible:
+           bar::D
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -4,8 +4,11 @@ error[E0425]: cannot find function `fpriv` in this scope
 LL |     fpriv();
    |     ^^^^^ not found in this scope
    |
-   = note: this function exists but is inaccessible:
-           bar::fpriv
+note: function `bar::fpriv` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:7:5
+   |
+LL |     fn fpriv() {}
+   |     ^^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `epriv` in this scope
   --> $DIR/glob-resolve1.rs:27:5
@@ -13,8 +16,11 @@ error[E0425]: cannot find function `epriv` in this scope
 LL |     epriv();
    |     ^^^^^ not found in this scope
    |
-   = note: this function exists but is inaccessible:
-           bar::epriv
+note: function `bar::epriv` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:9:9
+   |
+LL |         fn epriv();
+   |         ^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found enum `B`
   --> $DIR/glob-resolve1.rs:28:5
@@ -40,8 +46,11 @@ error[E0425]: cannot find value `C` in this scope
 LL |     C;
    |     ^ not found in this scope
    |
-   = note: this unit struct exists but is inaccessible:
-           bar::C
+note: unit struct `bar::C` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:18:5
+   |
+LL |     struct C;
+   |     ^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `import` in this scope
   --> $DIR/glob-resolve1.rs:30:5
@@ -63,8 +72,11 @@ LL |     pub enum B {
 LL |     foo::<A>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this enum exists but is inaccessible:
-           bar::A
+note: enum `bar::A` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:11:5
+   |
+LL |     enum A {
+   |     ^^^^^^ not accessible
 
 error[E0412]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:33:11
@@ -75,8 +87,11 @@ LL |     pub enum B {
 LL |     foo::<C>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this struct exists but is inaccessible:
-           bar::C
+note: struct `bar::C` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:18:5
+   |
+LL |     struct C;
+   |     ^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:34:11
@@ -87,8 +102,11 @@ LL |     pub enum B {
 LL |     foo::<D>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this type alias exists but is inaccessible:
-           bar::D
+note: type alias `bar::D` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:20:5
+   |
+LL |     type D = isize;
+   |     ^^^^^^^^^^^^^^^ not accessible
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/imports/issue-4366-2.stderr
+++ b/src/test/ui/imports/issue-4366-2.stderr
@@ -4,10 +4,8 @@ error[E0412]: cannot find type `Bar` in this scope
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
    |
-help: consider importing this type alias
-   |
-LL |         use a::b::Bar;
-   |
+   = note: this type alias exists but is inaccessible:
+           a::b::Bar
 
 error[E0423]: expected function, found module `foo`
   --> $DIR/issue-4366-2.rs:25:5

--- a/src/test/ui/imports/issue-4366-2.stderr
+++ b/src/test/ui/imports/issue-4366-2.stderr
@@ -4,8 +4,11 @@ error[E0412]: cannot find type `Bar` in this scope
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
    |
-   = note: this type alias exists but is inaccessible:
-           a::b::Bar
+note: type alias `a::b::Bar` exists but is inaccessible
+  --> $DIR/issue-4366-2.rs:11:9
+   |
+LL |         type Bar = isize;
+   |         ^^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected function, found module `foo`
   --> $DIR/issue-4366-2.rs:25:5

--- a/src/test/ui/resolve/issue-42944.stderr
+++ b/src/test/ui/resolve/issue-42944.stderr
@@ -16,10 +16,8 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this s
 LL |         Bx(());
    |         ^^ not found in this scope
    |
-help: consider importing this tuple struct
-   |
-LL |     use foo::Bx;
-   |
+   = note: this tuple struct exists but is inaccessible:
+           foo::Bx
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-42944.stderr
+++ b/src/test/ui/resolve/issue-42944.stderr
@@ -16,8 +16,11 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this s
 LL |         Bx(());
    |         ^^ not found in this scope
    |
-   = note: this tuple struct exists but is inaccessible:
-           foo::Bx
+note: tuple struct `foo::Bx` exists but is inaccessible
+  --> $DIR/issue-42944.rs:2:5
+   |
+LL |     pub struct Bx(());
+   |     ^^^^^^^^^^^^^^^^^^ not accessible
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-88472.rs
+++ b/src/test/ui/resolve/issue-88472.rs
@@ -6,6 +6,8 @@
 
 mod a {
     struct Foo;
+    //~^ NOTE: struct `a::Foo` exists but is inaccessible
+    //~| NOTE: not accessible
 }
 
 mod b {
@@ -14,14 +16,16 @@ mod b {
     type Bar = Foo;
     //~^ ERROR: cannot find type `Foo` in this scope [E0412]
     //~| NOTE: not found in this scope
-    //~| NOTE: this struct exists but is inaccessible
 }
 
 mod c {
     enum Eee {}
+    //~^ NOTE: these enums exist but are inaccessible
+    //~| NOTE: `c::Eee`: not accessible
 
     mod d {
         enum Eee {}
+        //~^ NOTE: `c::d::Eee`: not accessible
     }
 }
 
@@ -29,7 +33,6 @@ mod e {
     type Baz = Eee;
     //~^ ERROR: cannot find type `Eee` in this scope [E0412]
     //~| NOTE: not found in this scope
-    //~| NOTE: these items exist but are inaccessible
 }
 
 fn main() {}

--- a/src/test/ui/resolve/issue-88472.rs
+++ b/src/test/ui/resolve/issue-88472.rs
@@ -1,0 +1,35 @@
+// Regression test for #88472, where a suggestion was issued to
+// import an inaccessible struct.
+
+#![warn(unused_imports)]
+//~^ NOTE: the lint level is defined here
+
+mod a {
+    struct Foo;
+}
+
+mod b {
+    use crate::a::*;
+    //~^ WARNING: unused import
+    type Bar = Foo;
+    //~^ ERROR: cannot find type `Foo` in this scope [E0412]
+    //~| NOTE: not found in this scope
+    //~| NOTE: this struct exists but is inaccessible
+}
+
+mod c {
+    enum Eee {}
+
+    mod d {
+        enum Eee {}
+    }
+}
+
+mod e {
+    type Baz = Eee;
+    //~^ ERROR: cannot find type `Eee` in this scope [E0412]
+    //~| NOTE: not found in this scope
+    //~| NOTE: these items exist but are inaccessible
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-88472.stderr
+++ b/src/test/ui/resolve/issue-88472.stderr
@@ -1,0 +1,34 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/issue-88472.rs:14:16
+   |
+LL |     type Bar = Foo;
+   |                ^^^ not found in this scope
+   |
+   = note: this struct exists but is inaccessible:
+           a::Foo
+
+error[E0412]: cannot find type `Eee` in this scope
+  --> $DIR/issue-88472.rs:29:16
+   |
+LL |     type Baz = Eee;
+   |                ^^^ not found in this scope
+   |
+   = note: these items exist but are inaccessible:
+           c::Eee
+           c::d::Eee
+
+warning: unused import: `crate::a::*`
+  --> $DIR/issue-88472.rs:12:9
+   |
+LL |     use crate::a::*;
+   |         ^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-88472.rs:4:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/resolve/issue-88472.stderr
+++ b/src/test/ui/resolve/issue-88472.stderr
@@ -1,24 +1,32 @@
 error[E0412]: cannot find type `Foo` in this scope
-  --> $DIR/issue-88472.rs:14:16
+  --> $DIR/issue-88472.rs:16:16
    |
 LL |     type Bar = Foo;
    |                ^^^ not found in this scope
    |
-   = note: this struct exists but is inaccessible:
-           a::Foo
+note: struct `a::Foo` exists but is inaccessible
+  --> $DIR/issue-88472.rs:8:5
+   |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `Eee` in this scope
-  --> $DIR/issue-88472.rs:29:16
+  --> $DIR/issue-88472.rs:33:16
    |
 LL |     type Baz = Eee;
    |                ^^^ not found in this scope
    |
-   = note: these items exist but are inaccessible:
-           c::Eee
-           c::d::Eee
+note: these enums exist but are inaccessible
+  --> $DIR/issue-88472.rs:22:5
+   |
+LL |     enum Eee {}
+   |     ^^^^^^^^ `c::Eee`: not accessible
+...
+LL |         enum Eee {}
+   |         ^^^^^^^^ `c::d::Eee`: not accessible
 
 warning: unused import: `crate::a::*`
-  --> $DIR/issue-88472.rs:12:9
+  --> $DIR/issue-88472.rs:14:9
    |
 LL |     use crate::a::*;
    |         ^^^^^^^^^^^

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -171,8 +171,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found enum `m::n::Z`
   --> $DIR/privacy-enum-ctor.rs:57:16
@@ -211,8 +214,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Fn;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
@@ -223,8 +229,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Struct;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found struct variant `m::n::Z::Struct`
   --> $DIR/privacy-enum-ctor.rs:64:16
@@ -246,8 +255,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Unit {};
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:57:22

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -169,16 +169,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0423]: expected value, found enum `m::n::Z`
   --> $DIR/privacy-enum-ctor.rs:57:16
@@ -215,16 +209,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Fn;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Fn;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
@@ -233,16 +221,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Struct;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Struct;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0423]: expected value, found struct variant `m::n::Z::Struct`
   --> $DIR/privacy-enum-ctor.rs:64:16
@@ -262,16 +244,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Unit {};
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Unit {};
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:57:22

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -33,8 +33,11 @@ error[E0423]: expected value, found struct `xcrate::S`
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
    |
-   = note: this tuple struct exists but is inaccessible:
-           m::S
+note: tuple struct `m::S` exists but is inaccessible
+  --> $DIR/privacy-struct-ctor.rs:6:5
+   |
+LL |     pub struct S(u8);
+   |     ^^^^^^^^^^^^^^^^^ not accessible
 
 error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -33,10 +33,8 @@ error[E0423]: expected value, found struct `xcrate::S`
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
    |
-help: consider importing this tuple struct instead
-   |
-LL | use m::S;
-   |
+   = note: this tuple struct exists but is inaccessible:
+           m::S
 
 error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -66,8 +66,11 @@ error[E0531]: cannot find unit struct, unit variant or constant `Self` in this s
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
    |
-   = note: this unit struct exists but is inaccessible:
-           foo::Self
+note: unit struct `foo::Self` exists but is inaccessible
+  --> $DIR/self_type_keyword.rs:2:3
+   |
+LL |   struct Self;
+   |   ^^^^^^^^^^^^ not accessible
 
 error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:6:12

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -66,10 +66,8 @@ error[E0531]: cannot find unit struct, unit variant or constant `Self` in this s
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
    |
-help: consider importing this unit struct
-   |
-LL | use foo::Self;
-   |
+   = note: this unit struct exists but is inaccessible:
+           foo::Self
 
 error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:6:12


### PR DESCRIPTION
Fixes #88472. For this example:
```rust
mod a {
    struct Foo;
}

mod b {
    type Bar = Foo;
}
```
rustc currently emits:
```
error[E0412]: cannot find type `Foo` in this scope
 --> test.rs:6:16
  |
6 |     type Bar = Foo;
  |                ^^^ not found in this scope
  |
help: consider importing this struct
  |
6 |     use a::Foo;
  |
```
this is incorrect, as applying this suggestion leads to
```
error[E0603]: struct `Foo` is private
 --> test.rs:6:12
  |
6 |     use a::Foo;
  |            ^^^ private struct
  |
note: the struct `Foo` is defined here
 --> test.rs:2:5
  |
2 |     struct Foo;
  |     ^^^^^^^^^^^
```
With my changes, I get:
```
error[E0412]: cannot find type `Foo` in this scope
 --> test.rs:6:16
  |
6 |     type Bar = Foo;
  |                ^^^ not found in this scope
  |
  = note: this struct exists but is inaccessible:
          a::Foo
```
As for the wildcard mentioned in #88472, I would argue that the warning is actually correct, since the import _is_ unused. I think the real issue is the wrong suggestion, which I have fixed here.