### PR TITLE
Introduce NullOp::AlignOf

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -823,7 +823,7 @@ pub(crate) fn codegen_intrinsic_call<'tcx>(
             dest.write_cvalue(fx, val);
         };
 
-        pref_align_of | min_align_of | needs_drop | type_id | type_name | variant_count, () {
+        pref_align_of | needs_drop | type_id | type_name | variant_count, () {
             let const_val =
                 fx.tcx.const_eval_instance(ParamEnv::reveal_all(), instance, None).unwrap();
             let val = crate::constant::codegen_const_value(

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -104,7 +104,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 }
             }
             sym::pref_align_of
-            | sym::min_align_of
             | sym::needs_drop
             | sym::type_id
             | sym::type_name

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -487,20 +487,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 )
             }
 
-            mir::Rvalue::NullaryOp(mir::NullOp::SizeOf, ty) => {
-                let ty = self.monomorphize(ty);
-                assert!(bx.cx().type_is_sized(ty));
-                let val = bx.cx().const_usize(bx.cx().layout_of(ty).size.bytes());
-                let tcx = self.cx.tcx();
-                (
-                    bx,
-                    OperandRef {
-                        val: OperandValue::Immediate(val),
-                        layout: self.cx.layout_of(tcx.types.usize),
-                    },
-                )
-            }
-
             mir::Rvalue::NullaryOp(mir::NullOp::Box, content_ty) => {
                 let content_ty = self.monomorphize(content_ty);
                 let content_layout = bx.cx().layout_of(content_ty);
@@ -525,6 +511,27 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let operand = OperandRef { val: OperandValue::Immediate(val), layout: box_layout };
                 (bx, operand)
             }
+
+            mir::Rvalue::NullaryOp(null_op, ty) => {
+                let ty = self.monomorphize(ty);
+                assert!(bx.cx().type_is_sized(ty));
+                let layout = bx.cx().layout_of(ty);
+                let val = match null_op {
+                    mir::NullOp::SizeOf => layout.size.bytes(),
+                    mir::NullOp::AlignOf => layout.align.abi.bytes(),
+                    mir::NullOp::Box => unreachable!(),
+                };
+                let val = bx.cx().const_usize(val);
+                let tcx = self.cx.tcx();
+                (
+                    bx,
+                    OperandRef {
+                        val: OperandValue::Immediate(val),
+                        layout: self.cx.layout_of(tcx.types.usize),
+                    },
+                )
+            }
+
             mir::Rvalue::ThreadLocalRef(def_id) => {
                 assert!(bx.cx().tcx().is_static(def_id));
                 let static_ = bx.get_static(def_id);

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -160,17 +160,14 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(Scalar::from_machine_usize(result, self), dest)?;
             }
 
-            sym::min_align_of
-            | sym::pref_align_of
+            sym::pref_align_of
             | sym::needs_drop
             | sym::type_id
             | sym::type_name
             | sym::variant_count => {
                 let gid = GlobalId { instance, promoted: None };
                 let ty = match intrinsic_name {
-                    sym::min_align_of | sym::pref_align_of | sym::variant_count => {
-                        self.tcx.types.usize
-                    }
+                    sym::pref_align_of | sym::variant_count => self.tcx.types.usize,
                     sym::needs_drop => self.tcx.types.bool,
                     sym::type_id => self.tcx.types.u64,
                     sym::type_name => self.tcx.mk_static_str(),

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -648,7 +648,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                 }
             }
 
-            Rvalue::NullaryOp(NullOp::SizeOf, _) => {}
+            Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => {}
             Rvalue::NullaryOp(NullOp::Box, _) => self.check_op(ops::HeapAllocation),
 
             Rvalue::UnaryOp(_, ref operand) => {

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -520,6 +520,7 @@ impl<'tcx> Validator<'_, 'tcx> {
             Rvalue::NullaryOp(op, _) => match op {
                 NullOp::Box => return Err(Unpromotable),
                 NullOp::SizeOf => {}
+                NullOp::AlignOf => {}
             },
 
             Rvalue::UnaryOp(op, operand) => {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2278,6 +2278,8 @@ impl BinOp {
 pub enum NullOp {
     /// Returns the size of a value of that type
     SizeOf,
+    /// Returns the minimum alignment of a type
+    AlignOf,
     /// Creates a new uninitialized box for a value of that type
     Box,
 }

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -196,7 +196,7 @@ impl<'tcx> Rvalue<'tcx> {
             Rvalue::UnaryOp(UnOp::Not | UnOp::Neg, ref operand) => operand.ty(local_decls, tcx),
             Rvalue::Discriminant(ref place) => place.ty(local_decls, tcx).ty.discriminant_ty(tcx),
             Rvalue::NullaryOp(NullOp::Box, t) => tcx.mk_box(t),
-            Rvalue::NullaryOp(NullOp::SizeOf, _) => tcx.types.usize,
+            Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => tcx.types.usize,
             Rvalue::Aggregate(ref ak, ref ops) => match **ak {
                 AggregateKind::Array(ty) => tcx.mk_array(ty, ops.len() as u64),
                 AggregateKind::Tuple => tcx.mk_tup(ops.iter().map(|op| op.ty(local_decls, tcx))),

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -342,7 +342,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             | Rvalue::AddressOf(..)
             | Rvalue::Discriminant(..)
             | Rvalue::Len(..)
-            | Rvalue::NullaryOp(NullOp::SizeOf, _)
+            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _)
             | Rvalue::NullaryOp(NullOp::Box, _) => {
                 // This returns an rvalue with uninitialized contents. We can't
                 // move out of it here because it is an rvalue - assignments always

--- a/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
@@ -1,0 +1,24 @@
+- // MIR for `align_of` before LowerIntrinsics
++ // MIR for `align_of` after LowerIntrinsics
+  
+  fn align_of() -> usize {
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:18:25: 18:30
+  
+      bb0: {
+-         _0 = std::intrinsics::min_align_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
+-                                          // mir::Constant
+-                                          // + span: $DIR/lower_intrinsics.rs:19:5: 19:40
+-                                          // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::min_align_of::<T>}, val: Value(Scalar(<ZST>)) }
++         _0 = AlignOf(T);                 // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
+      }
+  
+      bb1: {
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:20:2: 20:2
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:18:1: 20:2
+      }
+  }
+  

--- a/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -2,127 +2,127 @@
 + // MIR for `discriminant` after LowerIntrinsics
   
   fn discriminant(_1: T) -> () {
-      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:68:24: 68:25
-      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:68:30: 68:30
-      let _2: <T as std::marker::DiscriminantKind>::Discriminant; // in scope 0 at $DIR/lower_intrinsics.rs:69:5: 69:45
-      let mut _3: &T;                      // in scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
-      let _4: &T;                          // in scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
-      let _5: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:70:5: 70:45
-      let mut _6: &i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
-      let _7: &i32;                        // in scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
-      let _8: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:70:43: 70:44
-      let _9: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:71:5: 71:46
-      let mut _10: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-      let _11: &();                        // in scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-      let _12: ();                         // in scope 0 at $DIR/lower_intrinsics.rs:71:43: 71:45
-      let _13: isize;                      // in scope 0 at $DIR/lower_intrinsics.rs:72:5: 72:48
-      let mut _14: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-      let _15: &E;                         // in scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-      let _16: E;                          // in scope 0 at $DIR/lower_intrinsics.rs:72:43: 72:47
-      let mut _17: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-      let mut _18: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-      let mut _19: &i32;                   // in scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
+      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:73:24: 73:25
+      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:73:30: 73:30
+      let _2: <T as std::marker::DiscriminantKind>::Discriminant; // in scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
+      let mut _3: &T;                      // in scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+      let _4: &T;                          // in scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+      let _5: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
+      let mut _6: &i32;                    // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+      let _7: &i32;                        // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+      let _8: i32;                         // in scope 0 at $DIR/lower_intrinsics.rs:75:43: 75:44
+      let _9: u8;                          // in scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
+      let mut _10: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+      let _11: &();                        // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+      let _12: ();                         // in scope 0 at $DIR/lower_intrinsics.rs:76:43: 76:45
+      let _13: isize;                      // in scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
+      let mut _14: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+      let _15: &E;                         // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+      let _16: E;                          // in scope 0 at $DIR/lower_intrinsics.rs:77:43: 77:47
+      let mut _17: &E;                     // in scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+      let mut _18: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+      let mut _19: &i32;                   // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:69:5: 69:45
-          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
-          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
-          _4 = &_1;                        // scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
-          _3 = &(*_4);                     // scope 0 at $DIR/lower_intrinsics.rs:69:42: 69:44
--         _2 = discriminant_value::<T>(move _3) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:69:5: 69:45
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
+          StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+          StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+          _4 = &_1;                        // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+          _3 = &(*_4);                     // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
+-         _2 = discriminant_value::<T>(move _3) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:69:5: 69:41
+-                                          // + span: $DIR/lower_intrinsics.rs:74:5: 74:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r T) -> <T as std::marker::DiscriminantKind>::Discriminant {std::intrinsics::discriminant_value::<T>}, val: Value(Scalar(<ZST>)) }
-+         _2 = discriminant((*_3));        // scope 0 at $DIR/lower_intrinsics.rs:69:5: 69:45
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:69:5: 69:45
++         _2 = discriminant((*_3));        // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
       }
   
       bb1: {
-          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:69:44: 69:45
-          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:69:45: 69:46
-          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:69:45: 69:46
-          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:70:5: 70:45
-          StorageLive(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
-          StorageLive(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
-          _19 = const discriminant::<T>::promoted[2]; // scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
+          StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:44: 74:45
+          StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
+          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
+          StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
+          StorageLive(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+          StorageLive(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+          _19 = const discriminant::<T>::promoted[2]; // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
                                            // ty::Const
                                            // + ty: &i32
                                            // + val: Unevaluated(discriminant, [T], Some(promoted[2]))
                                            // mir::Constant
-                                           // + span: $DIR/lower_intrinsics.rs:70:42: 70:44
-                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:27 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[2]) }) }
-          _7 = &(*_19);                    // scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
-          _6 = &(*_7);                     // scope 0 at $DIR/lower_intrinsics.rs:70:42: 70:44
--         _5 = discriminant_value::<i32>(move _6) -> bb2; // scope 0 at $DIR/lower_intrinsics.rs:70:5: 70:45
+                                           // + span: $DIR/lower_intrinsics.rs:75:42: 75:44
+                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:29 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[2]) }) }
+          _7 = &(*_19);                    // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+          _6 = &(*_7);                     // scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
+-         _5 = discriminant_value::<i32>(move _6) -> bb2; // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:70:5: 70:41
+-                                          // + span: $DIR/lower_intrinsics.rs:75:5: 75:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r i32) -> <i32 as std::marker::DiscriminantKind>::Discriminant {std::intrinsics::discriminant_value::<i32>}, val: Value(Scalar(<ZST>)) }
-+         _5 = discriminant((*_6));        // scope 0 at $DIR/lower_intrinsics.rs:70:5: 70:45
-+         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:70:5: 70:45
++         _5 = discriminant((*_6));        // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
++         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
       }
   
       bb2: {
-          StorageDead(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:70:44: 70:45
-          StorageDead(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:70:45: 70:46
-          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:70:45: 70:46
-          StorageLive(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:71:5: 71:46
-          StorageLive(_10);                // scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-          StorageLive(_11);                // scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-          _18 = const discriminant::<T>::promoted[1]; // scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
+          StorageDead(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:75:44: 75:45
+          StorageDead(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
+          StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
+          StorageLive(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
+          StorageLive(_10);                // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+          StorageLive(_11);                // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+          _18 = const discriminant::<T>::promoted[1]; // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
                                            // ty::Const
                                            // + ty: &()
                                            // + val: Unevaluated(discriminant, [T], Some(promoted[1]))
                                            // mir::Constant
-                                           // + span: $DIR/lower_intrinsics.rs:71:42: 71:45
-                                           // + literal: Const { ty: &(), val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:27 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[1]) }) }
-          _11 = &(*_18);                   // scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
-          _10 = &(*_11);                   // scope 0 at $DIR/lower_intrinsics.rs:71:42: 71:45
--         _9 = discriminant_value::<()>(move _10) -> bb3; // scope 0 at $DIR/lower_intrinsics.rs:71:5: 71:46
+                                           // + span: $DIR/lower_intrinsics.rs:76:42: 76:45
+                                           // + literal: Const { ty: &(), val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:29 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[1]) }) }
+          _11 = &(*_18);                   // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+          _10 = &(*_11);                   // scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
+-         _9 = discriminant_value::<()>(move _10) -> bb3; // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:71:5: 71:41
+-                                          // + span: $DIR/lower_intrinsics.rs:76:5: 76:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r ()) -> <() as std::marker::DiscriminantKind>::Discriminant {std::intrinsics::discriminant_value::<()>}, val: Value(Scalar(<ZST>)) }
-+         _9 = discriminant((*_10));       // scope 0 at $DIR/lower_intrinsics.rs:71:5: 71:46
-+         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:71:5: 71:46
++         _9 = discriminant((*_10));       // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
++         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
       }
   
       bb3: {
-          StorageDead(_10);                // scope 0 at $DIR/lower_intrinsics.rs:71:45: 71:46
-          StorageDead(_11);                // scope 0 at $DIR/lower_intrinsics.rs:71:46: 71:47
-          StorageDead(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:71:46: 71:47
-          StorageLive(_13);                // scope 0 at $DIR/lower_intrinsics.rs:72:5: 72:48
-          StorageLive(_14);                // scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-          StorageLive(_15);                // scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-          _17 = const discriminant::<T>::promoted[0]; // scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
+          StorageDead(_10);                // scope 0 at $DIR/lower_intrinsics.rs:76:45: 76:46
+          StorageDead(_11);                // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
+          StorageDead(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
+          StorageLive(_13);                // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
+          StorageLive(_14);                // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+          StorageLive(_15);                // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+          _17 = const discriminant::<T>::promoted[0]; // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
                                            // ty::Const
                                            // + ty: &E
                                            // + val: Unevaluated(discriminant, [T], Some(promoted[0]))
                                            // mir::Constant
-                                           // + span: $DIR/lower_intrinsics.rs:72:42: 72:47
-                                           // + literal: Const { ty: &E, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:27 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[0]) }) }
-          _15 = &(*_17);                   // scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
-          _14 = &(*_15);                   // scope 0 at $DIR/lower_intrinsics.rs:72:42: 72:47
--         _13 = discriminant_value::<E>(move _14) -> bb4; // scope 0 at $DIR/lower_intrinsics.rs:72:5: 72:48
+                                           // + span: $DIR/lower_intrinsics.rs:77:42: 77:47
+                                           // + literal: Const { ty: &E, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:29 ~ lower_intrinsics[2872]::discriminant), const_param_did: None }, substs_: Some([T]), promoted: Some(promoted[0]) }) }
+          _15 = &(*_17);                   // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+          _14 = &(*_15);                   // scope 0 at $DIR/lower_intrinsics.rs:77:42: 77:47
+-         _13 = discriminant_value::<E>(move _14) -> bb4; // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:72:5: 72:41
+-                                          // + span: $DIR/lower_intrinsics.rs:77:5: 77:41
 -                                          // + literal: Const { ty: for<'r> extern "rust-intrinsic" fn(&'r E) -> <E as std::marker::DiscriminantKind>::Discriminant {std::intrinsics::discriminant_value::<E>}, val: Value(Scalar(<ZST>)) }
-+         _13 = discriminant((*_14));      // scope 0 at $DIR/lower_intrinsics.rs:72:5: 72:48
-+         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:72:5: 72:48
++         _13 = discriminant((*_14));      // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
++         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
       }
   
       bb4: {
-          StorageDead(_14);                // scope 0 at $DIR/lower_intrinsics.rs:72:47: 72:48
-          StorageDead(_15);                // scope 0 at $DIR/lower_intrinsics.rs:72:48: 72:49
-          StorageDead(_13);                // scope 0 at $DIR/lower_intrinsics.rs:72:48: 72:49
-          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:68:30: 73:2
-          drop(_1) -> bb5;                 // scope 0 at $DIR/lower_intrinsics.rs:73:1: 73:2
+          StorageDead(_14);                // scope 0 at $DIR/lower_intrinsics.rs:77:47: 77:48
+          StorageDead(_15);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
+          StorageDead(_13);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
+          _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:73:30: 78:2
+          drop(_1) -> bb5;                 // scope 0 at $DIR/lower_intrinsics.rs:78:1: 78:2
       }
   
       bb5: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:73:2: 73:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:78:2: 78:2
       }
   
       bb6 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:68:1: 73:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:73:1: 78:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -1,32 +1,32 @@
 // MIR for `f_u64` before PreCodegen
 
 fn f_u64() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:16
-    let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:35:5: 35:21
-    scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics.rs:35:5: 35:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:35:5: 35:21
+    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:39:16: 39:16
+    let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
+    scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
+        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
                                          // mir::Constant
-                                         // + span: $DIR/lower_intrinsics.rs:35:5: 35:21
+                                         // + span: $DIR/lower_intrinsics.rs:40:5: 40:21
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:35:5: 35:21
-        return;                          // scope 0 at $DIR/lower_intrinsics.rs:36:2: 36:2
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        return;                          // scope 0 at $DIR/lower_intrinsics.rs:41:2: 41:2
     }
 }

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -1,27 +1,27 @@
 // MIR for `f_unit` before PreCodegen
 
 fn f_unit() -> () {
-    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:28:17: 28:17
-    let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:29:16: 29:18
-    scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics.rs:29:5: 29:19
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:29:5: 29:19
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:29:5: 29:19
-        scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:29:5: 29:19
+    let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:33:17: 33:17
+    let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
+    scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
         }
     }
 
     bb0: {
-        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:29:16: 29:18
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:29:5: 29:19
-        _2 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:29:5: 29:19
+        StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        _2 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
                                          // mir::Constant
-                                         // + span: $DIR/lower_intrinsics.rs:29:5: 29:19
+                                         // + span: $DIR/lower_intrinsics.rs:34:5: 34:19
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:29:5: 29:19
-        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:29:18: 29:19
-        return;                          // scope 0 at $DIR/lower_intrinsics.rs:30:2: 30:2
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:18: 34:19
+        return;                          // scope 0 at $DIR/lower_intrinsics.rs:35:2: 35:2
     }
 }

--- a/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
@@ -2,32 +2,32 @@
 + // MIR for `forget` after LowerIntrinsics
   
   fn forget(_1: T) -> () {
-      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:18:18: 18:19
-      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:18:24: 18:24
-      let mut _2: T;                       // in scope 0 at $DIR/lower_intrinsics.rs:19:30: 19:31
+      debug t => _1;                       // in scope 0 at $DIR/lower_intrinsics.rs:23:18: 23:19
+      let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:23:24: 23:24
+      let mut _2: T;                       // in scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:19:30: 19:31
-          _2 = move _1;                    // scope 0 at $DIR/lower_intrinsics.rs:19:30: 19:31
--         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:32
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
+          _2 = move _1;                    // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
+-         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:19:5: 19:29
+-                                          // + span: $DIR/lower_intrinsics.rs:24:5: 24:29
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(T) {std::intrinsics::forget::<T>}, val: Value(Scalar(<ZST>)) }
-+         _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:32
-+         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:32
++         _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
++         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:19:31: 19:32
-          goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:20:1: 20:2
+          StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:31: 24:32
+          goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:25:1: 25:2
       }
   
       bb2: {
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:20:2: 20:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:25:2: 25:2
       }
   
       bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:18:1: 20:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:23:1: 25:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
@@ -2,34 +2,34 @@
 + // MIR for `non_const` after LowerIntrinsics
   
   fn non_const() -> usize {
-      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:55:26: 55:31
-      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:57:9: 57:18
-      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:58:5: 58:14
+      let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:60:26: 60:31
+      let _1: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:62:9: 62:18
+      let mut _2: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}; // in scope 0 at $DIR/lower_intrinsics.rs:63:5: 63:14
       scope 1 {
-          debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:57:9: 57:18
+          debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:62:9: 62:18
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:57:9: 57:18
-          _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:57:21: 57:51
+          StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:62:9: 62:18
+          _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:62:21: 62:51
                                            // mir::Constant
-                                           // + span: $DIR/lower_intrinsics.rs:57:21: 57:51
+                                           // + span: $DIR/lower_intrinsics.rs:62:21: 62:51
                                            // + literal: Const { ty: extern "rust-intrinsic" fn() -> usize {std::intrinsics::size_of::<T>}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:58:5: 58:14
-          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:58:5: 58:14
--         _0 = move _2() -> bb1;           // scope 1 at $DIR/lower_intrinsics.rs:58:5: 58:16
-+         _0 = SizeOf(T);                  // scope 1 at $DIR/lower_intrinsics.rs:58:5: 58:16
-+         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:58:5: 58:16
+          StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:14
+          _2 = _1;                         // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:14
+-         _0 = move _2() -> bb1;           // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
++         _0 = SizeOf(T);                  // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
++         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
       }
   
       bb1: {
-          StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:58:15: 58:16
-          StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:59:1: 59:2
-          return;                          // scope 0 at $DIR/lower_intrinsics.rs:59:2: 59:2
+          StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:63:15: 63:16
+          StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:64:1: 64:2
+          return;                          // scope 0 at $DIR/lower_intrinsics.rs:64:2: 64:2
       }
   
       bb2 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:55:1: 59:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:60:1: 64:2
       }
   }
   

--- a/src/test/mir-opt/lower_intrinsics.rs
+++ b/src/test/mir-opt/lower_intrinsics.rs
@@ -14,6 +14,11 @@ pub fn size_of<T>() -> usize {
     core::intrinsics::size_of::<T>()
 }
 
+// EMIT_MIR lower_intrinsics.align_of.LowerIntrinsics.diff
+pub fn align_of<T>() -> usize {
+    core::intrinsics::min_align_of::<T>()
+}
+
 // EMIT_MIR lower_intrinsics.forget.LowerIntrinsics.diff
 pub fn forget<T>(t: T) {
     core::intrinsics::forget(t)

--- a/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
@@ -2,25 +2,25 @@
 + // MIR for `unreachable` after LowerIntrinsics
   
   fn unreachable() -> ! {
-      let mut _0: !;                       // return place in scope 0 at $DIR/lower_intrinsics.rs:23:25: 23:26
-      let mut _1: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:23:27: 25:2
-      let _2: ();                          // in scope 0 at $DIR/lower_intrinsics.rs:24:14: 24:45
-      let mut _3: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:24:14: 24:45
+      let mut _0: !;                       // return place in scope 0 at $DIR/lower_intrinsics.rs:28:25: 28:26
+      let mut _1: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:28:27: 30:2
+      let _2: ();                          // in scope 0 at $DIR/lower_intrinsics.rs:29:14: 29:45
+      let mut _3: !;                       // in scope 0 at $DIR/lower_intrinsics.rs:29:14: 29:45
       scope 1 {
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:47
-          StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:24:14: 24:45
--         std::intrinsics::unreachable();  // scope 1 at $DIR/lower_intrinsics.rs:24:14: 24:45
+          StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:29:5: 29:47
+          StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
+-         std::intrinsics::unreachable();  // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
 -                                          // mir::Constant
--                                          // + span: $DIR/lower_intrinsics.rs:24:14: 24:43
+-                                          // + span: $DIR/lower_intrinsics.rs:29:14: 29:43
 -                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn() -> ! {std::intrinsics::unreachable}, val: Value(Scalar(<ZST>)) }
-+         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:24:14: 24:45
++         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
       }
   
       bb1 (cleanup): {
-          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:23:1: 25:2
+          resume;                          // scope 0 at $DIR/lower_intrinsics.rs:28:1: 30:2
       }
   }
   

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -192,7 +192,7 @@ fn check_rvalue(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: DefId, rvalue: &Rv
                 ))
             }
         },
-        Rvalue::NullaryOp(NullOp::SizeOf, _) => Ok(()),
+        Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => Ok(()),
         Rvalue::NullaryOp(NullOp::Box, _) => Err((span, "heap allocations are not allowed in const fn".into())),
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, tcx);


### PR DESCRIPTION
This PR introduces `Rvalue::NullaryOp(NullOp::AlignOf, ty)`, which will be lowered from `align_of`, similar to `size_of` lowering to `Rvalue::NullaryOp(NullOp::SizeOf, ty)`.

The changes are originally part of #88700 but since it's not dependent on other changes and could have performance impact on its own, it's separated into its own PR.