### PR TITLE
feat(rustc_typeck): suggest removing bad parens in `(recv.method)()`

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1842,13 +1842,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             expr_t
         );
         err.span_label(field.span, "method, not a field");
-        let expr_is_call = if let hir::Node::Expr(parent_expr) =
-            self.tcx.hir().get(self.tcx.hir().get_parent_node(expr.hir_id))
-        {
-            matches!(parent_expr.kind, ExprKind::Call(..))
-        } else {
-            false
-        };
+        let expr_is_call =
+            if let hir::Node::Expr(hir::Expr { kind: ExprKind::Call(callee, _args), .. }) =
+                self.tcx.hir().get(self.tcx.hir().get_parent_node(expr.hir_id))
+            {
+                expr.hir_id == callee.hir_id
+            } else {
+                false
+            };
         let expr_snippet =
             self.tcx.sess.source_map().span_to_snippet(expr.span).unwrap_or(String::new());
         if expr_is_call && expr_snippet.starts_with("(") && expr_snippet.ends_with(")") {

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1853,10 +1853,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expr_snippet =
             self.tcx.sess.source_map().span_to_snippet(expr.span).unwrap_or(String::new());
         if expr_is_call && expr_snippet.starts_with("(") && expr_snippet.ends_with(")") {
-            err.span_suggestion_short(
-                expr.span,
+            let after_open = expr.span.lo() + rustc_span::BytePos(1);
+            let before_close = expr.span.hi() - rustc_span::BytePos(1);
+            err.multipart_suggestion(
                 "remove wrapping parentheses to call the method",
-                expr_snippet[1..expr_snippet.len() - 1].to_owned(),
+                vec![
+                    (expr.span.with_hi(after_open), String::new()),
+                    (expr.span.with_lo(before_close), String::new()),
+                ],
                 Applicability::MachineApplicable,
             );
         } else if !self.expr_in_place(expr.hir_id) {

--- a/src/test/ui/typeck/issue-88803-call-expr-method.fixed
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.fixed
@@ -4,6 +4,6 @@ fn main() {
     let a = Some(42);
     println!(
         "The value is {}.",
-        (a.unwrap)() //~ERROR [E0615]
+        a.unwrap() //~ERROR [E0615]
     );
 }

--- a/src/test/ui/typeck/issue-88803-call-expr-method.rs
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let a = Some(42);
+    println!(
+        "The value is {}.",
+        (a.unwrap)() //~ERROR [E0615]
+    );
+}

--- a/src/test/ui/typeck/issue-88803-call-expr-method.stderr
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.stderr
@@ -1,0 +1,12 @@
+error[E0615]: attempted to take value of method `unwrap` on type `Option<{integer}>`
+  --> $DIR/issue-88803-call-expr-method.rs:5:12
+   |
+LL |         (a.unwrap)()
+   |         ---^^^^^^-
+   |         |  |
+   |         |  method, not a field
+   |         help: remove wrapping parentheses to call the method
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0615`.

--- a/src/test/ui/typeck/issue-88803-call-expr-method.stderr
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.stderr
@@ -2,10 +2,13 @@ error[E0615]: attempted to take value of method `unwrap` on type `Option<{intege
   --> $DIR/issue-88803-call-expr-method.rs:7:12
    |
 LL |         (a.unwrap)()
-   |         ---^^^^^^-
-   |         |  |
-   |         |  method, not a field
-   |         help: remove wrapping parentheses to call the method
+   |            ^^^^^^ method, not a field
+   |
+help: remove wrapping parentheses to call the method
+   |
+LL -         (a.unwrap)()
+LL +         a.unwrap()
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/issue-88803-call-expr-method.stderr
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.stderr
@@ -1,5 +1,5 @@
 error[E0615]: attempted to take value of method `unwrap` on type `Option<{integer}>`
-  --> $DIR/issue-88803-call-expr-method.rs:5:12
+  --> $DIR/issue-88803-call-expr-method.rs:7:12
    |
 LL |         (a.unwrap)()
    |         ---^^^^^^-


### PR DESCRIPTION
Fixes #88803