### PR TITLE
Make crate_dependencies_in_postorder public

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -175,7 +175,7 @@ impl CStore {
         }
     }
 
-    crate fn crate_dependencies_in_postorder(&self, cnum: CrateNum) -> Vec<CrateNum> {
+    pub fn crate_dependencies_in_postorder(&self, cnum: CrateNum) -> Vec<CrateNum> {
         let mut deps = Vec::new();
         if cnum == LOCAL_CRATE {
             self.iter_crate_data(|cnum, _| self.push_dependencies_in_postorder(&mut deps, cnum));
@@ -185,7 +185,7 @@ impl CStore {
         deps
     }
 
-    fn crate_dependencies_in_reverse_postorder(&self, cnum: CrateNum) -> Vec<CrateNum> {
+    pub fn crate_dependencies_in_reverse_postorder(&self, cnum: CrateNum) -> Vec<CrateNum> {
         let mut deps = self.crate_dependencies_in_postorder(cnum);
         deps.reverse();
         deps


### PR DESCRIPTION
Small PR, i need these functions for a custom codegen i am working on, for lazily loading modules (only loading symbols that previous modules need)