### PR TITLE
In suggest_missing_return_type, erase late bound regions after normalizing

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -484,8 +484,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!("suggest_missing_return_type: return type {:?}", ty);
                 debug!("suggest_missing_return_type: expected type {:?}", ty);
                 let bound_vars = self.tcx.late_bound_vars(fn_id);
-                let ty = self.tcx.erase_late_bound_regions(Binder::bind_with_vars(ty, bound_vars));
+                let ty = Binder::bind_with_vars(ty, bound_vars);
                 let ty = self.normalize_associated_types_in(sp, ty);
+                let ty = self.tcx.erase_late_bound_regions(ty);
                 if self.can_coerce(expected, ty) {
                     err.span_label(sp, format!("expected `{}` because of return type", expected));
                     return true;

--- a/src/test/ui/generic-associated-types/issue-88360.rs
+++ b/src/test/ui/generic-associated-types/issue-88360.rs
@@ -1,0 +1,19 @@
+#![feature(generic_associated_types)]
+
+trait GatTrait {
+    type Gat<'a>;
+
+    fn test(&self) -> Self::Gat<'_>;
+}
+
+trait SuperTrait<T>
+where
+    for<'a> Self: GatTrait<Gat<'a> = &'a T>,
+{
+    fn copy(&self) -> Self::Gat<'_> where T: Copy {
+        *self.test()
+        //~^ mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-88360.stderr
+++ b/src/test/ui/generic-associated-types/issue-88360.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-88360.rs:14:9
+   |
+LL | trait SuperTrait<T>
+   |                  - this type parameter
+...
+LL |     fn copy(&self) -> Self::Gat<'_> where T: Copy {
+   |                       ------------- expected `&T` because of return type
+LL |         *self.test()
+   |         ^^^^^^^^^^^^
+   |         |
+   |         expected `&T`, found type parameter `T`
+   |         help: consider borrowing here: `&*self.test()`
+   |
+   = note:   expected reference `&T`
+           found type parameter `T`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #88360

There might be some hardening that could be done to not error or avoid erroring with LUBing `ReErased` with `ReEmpty`, but this was the most simple fix for this particular case.

r? @nikomatsakis 