### PR TITLE
platform-support.md: correct ARMv7+MUSL platform triple notes

### DIFF
--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -133,8 +133,8 @@ target | std | notes
 `armv5te-unknown-linux-musleabi` | ✓ | ARMv5TE Linux with MUSL
 `armv7-linux-androideabi` | ✓ | ARMv7a Android
 `armv7-unknown-linux-gnueabi` | ✓ |ARMv7 Linux (kernel 4.15, glibc 2.27)
-`armv7-unknown-linux-musleabi` | ✓ |ARMv7 Linux, MUSL
-`armv7-unknown-linux-musleabihf` | ✓ | ARMv7 Linux with MUSL
+`armv7-unknown-linux-musleabi` | ✓ |ARMv7 Linux with MUSL
+`armv7-unknown-linux-musleabihf` | ✓ | ARMv7 Linux with MUSL, hardfloat
 `armv7a-none-eabi` | * | Bare ARMv7-A
 `armv7r-none-eabi` | * | Bare ARMv7-R
 `armv7r-none-eabihf` | * | Bare ARMv7-R, hardfloat


### PR DESCRIPTION
This PR fixes two minor inconsistencies in the platform support list.

- use "with MUSL" suffix for "armv7-unknown-linux-musleabi"
- add "hardfloat" suffix for "armv7-unknown-linux-musleabihf"

r? @steveklabnik