### PR TITLE
Improve error message for missing trait in trait impl

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -493,7 +493,20 @@ impl<'a> Parser<'a> {
         let ty_first = if self.token.is_keyword(kw::For) && self.look_ahead(1, |t| t != &token::Lt)
         {
             let span = self.prev_token.span.between(self.token.span);
-            self.struct_span_err(span, "missing trait in a trait impl").emit();
+            self.struct_span_err(span, "missing trait in a trait impl")
+                .span_suggestion(
+                    span,
+                    "add a trait here",
+                    " Trait ".into(),
+                    Applicability::HasPlaceholders,
+                )
+                .span_suggestion(
+                    span.to(self.token.span),
+                    "for an inherent impl, drop this `for`",
+                    "".into(),
+                    Applicability::MaybeIncorrect,
+                )
+                .emit();
             P(Ty {
                 kind: TyKind::Path(None, err_path(span)),
                 span,

--- a/src/test/ui/parser/issue-88818.rs
+++ b/src/test/ui/parser/issue-88818.rs
@@ -1,0 +1,10 @@
+// Regression test for #88818 (improve error message for missing trait
+// in `impl for X`).
+
+struct S { }
+impl for S { }
+//~^ ERROR: missing trait in a trait impl
+//~| HELP: add a trait here
+//~| HELP: for an inherent impl, drop this `for`
+
+fn main() {}

--- a/src/test/ui/parser/issue-88818.stderr
+++ b/src/test/ui/parser/issue-88818.stderr
@@ -1,17 +1,17 @@
 error: missing trait in a trait impl
-  --> $DIR/issue-56031.rs:3:5
+  --> $DIR/issue-88818.rs:5:5
    |
-LL | impl for T {}
+LL | impl for S { }
    |     ^
    |
 help: add a trait here
    |
-LL | impl Trait for T {}
+LL | impl Trait for S { }
    |      +++++
 help: for an inherent impl, drop this `for`
    |
-LL - impl for T {}
-LL + impl T {}
+LL - impl for S { }
+LL + impl S { }
    | 
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #88818. For the following example:
```rust
struct S { }
impl for S { }
```
the current output is:
```
error: missing trait in a trait impl
 --> t1.rs:2:5
  |
2 | impl for S { }
  |     ^
```
With my changes, I get:
```
error: missing trait in a trait impl
 --> t1.rs:2:5
  |
2 | impl for S { }
  |     ^
  |
help: add a trait here
  |
2 | impl Trait for S { }
  |      +++++
help: for an inherent impl, drop this `for`
  |
2 - impl for S { }
2 + impl S { }
  | 
```