### PR TITLE
Feat: added caching schema for debuginfo type names

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -375,7 +375,12 @@ macro_rules! return_if_metadata_created_in_meantime {
 }
 
 fn check_type_name_cache(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, qualified: bool) -> String {
-    compute_debuginfo_type_name(cx.tcx, ty, qualified, &debug_context(cx).type_name_cache)
+    compute_debuginfo_type_name(
+        cx.tcx,
+        ty,
+        qualified,
+        &mut debug_context(cx).type_name_cache.borrow_mut(),
+    )
 }
 
 fn fixed_vec_metadata(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -208,7 +208,7 @@ impl TypeMap<'ll, 'tcx> {
     fn register_unique_id_with_type_name(
         &mut self,
         unique_type_id: UniqueTypeId,
-        type_name: String
+        type_name: String,
     ) {
         if self.unique_id_to_type_name.insert(unique_type_id, type_name).is_some() {
             bug!(
@@ -395,23 +395,16 @@ macro_rules! return_if_metadata_created_in_meantime {
     };
 }
 
-fn check_type_name_cache(
-    cx: &CodegenCx<'ll, 'tcx>,
-    ty: Ty<'tcx>,
-    qualified: bool,
-) -> String {
+fn check_type_name_cache(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, qualified: bool) -> String {
     let mut type_map = debug_context(cx).type_map.borrow_mut();
     let unique_type_id = type_map.get_unique_type_id_of_type(cx, ty);
     match type_map.find_type_name_for_unique_id(unique_type_id) {
-        Some(type_name) => { type_name },
+        Some(type_name) => type_name,
         None => {
             let type_name = compute_debuginfo_type_name(cx.tcx, ty, qualified);
-            type_map.register_unique_id_with_type_name(
-                unique_type_id,
-                type_name.clone(),
-            );
+            type_map.register_unique_id_with_type_name(unique_type_id, type_name.clone());
             type_name
-        },
+        }
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -375,8 +375,7 @@ macro_rules! return_if_metadata_created_in_meantime {
 }
 
 fn check_type_name_cache(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, qualified: bool) -> String {
-    let type_name_cache = &mut *debug_context(cx).type_name_cache.borrow_mut();
-    compute_debuginfo_type_name(cx.tcx, ty, qualified, type_name_cache)
+    compute_debuginfo_type_name(cx.tcx, ty, qualified, &debug_context(cx).type_name_cache)
 }
 
 fn fixed_vec_metadata(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -10,12 +10,12 @@ use self::utils::{create_DIArray, is_node_local_to_unit, DIB};
 use crate::abi::FnAbi;
 use crate::builder::Builder;
 use crate::common::CodegenCx;
+use crate::debuginfo::utils::debug_context;
 use crate::llvm;
 use crate::llvm::debuginfo::{
     DIArray, DIBuilder, DIFile, DIFlags, DILexicalBlock, DILocation, DISPFlags, DIScope, DIType,
     DIVariable,
 };
-use crate::debuginfo::utils::debug_context;
 use crate::value::Value;
 
 use rustc_codegen_ssa::debuginfo::type_names;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -438,12 +438,11 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             substs: SubstsRef<'tcx>,
             name_to_append_suffix_to: &mut String,
         ) -> &'ll DIArray {
-            let type_name_cache = &mut *debug_context(cx).type_name_cache.borrow_mut();
             type_names::push_generic_params(
                 cx.tcx,
                 cx.tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), substs),
                 name_to_append_suffix_to,
-                type_name_cache,
+                &debug_context(cx).type_name_cache,
             );
 
             if substs.types().next().is_none() {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -38,8 +38,8 @@ use rustc_target::abi::{Primitive, Size};
 use libc::c_uint;
 use smallvec::SmallVec;
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::iter;
+use std::rc::Rc;
 use tracing::debug;
 
 mod create_scope_map;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -38,6 +38,7 @@ use rustc_target::abi::{Primitive, Size};
 use libc::c_uint;
 use smallvec::SmallVec;
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::iter;
 use tracing::debug;
 
@@ -63,7 +64,7 @@ pub struct CrateDebugContext<'a, 'tcx> {
     builder: &'a mut DIBuilder<'a>,
     created_files: RefCell<FxHashMap<(Option<String>, Option<String>), &'a DIFile>>,
     created_enum_disr_types: RefCell<FxHashMap<(DefId, Primitive), &'a DIType>>,
-    type_name_cache: RefCell<FxHashMap<(Ty<'tcx>, bool), String>>,
+    type_name_cache: RefCell<FxHashMap<(Ty<'tcx>, bool), Rc<str>>>,
 
     type_map: RefCell<TypeMap<'a, 'tcx>>,
     namespace_map: RefCell<DefIdMap<&'a DIScope>>,

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -442,7 +442,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 cx.tcx,
                 cx.tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), substs),
                 name_to_append_suffix_to,
-                &debug_context(cx).type_name_cache,
+                &mut debug_context(cx).type_name_cache.borrow_mut(),
             );
 
             if substs.types().next().is_none() {

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -23,8 +23,8 @@ use rustc_middle::ty::{self, AdtDef, ExistentialProjection, Ty, TyCtxt};
 use rustc_target::abi::{Integer, TagEncoding, Variants};
 use smallvec::SmallVec;
 
-use std::fmt::Write;
 use std::cell::RefCell;
+use std::fmt::Write;
 
 // Compute the name of the type as it should be stored in debuginfo. Does not do
 // any caching, i.e., calling the function twice with the same type will also do
@@ -52,7 +52,7 @@ fn push_debuginfo_type_name<'tcx>(
     qualified: bool,
     output: &mut String,
     visited: &mut FxHashSet<Ty<'tcx>>,
-    type_name_cache:  &RefCell<FxHashMap<(Ty<'tcx>, bool), String>>,
+    type_name_cache: &RefCell<FxHashMap<(Ty<'tcx>, bool), String>>,
 ) {
     // Check if we have seen this type and qualifier before.
     if let Some(type_name) = type_name_cache.borrow().get(&(&t, qualified)) {
@@ -439,7 +439,7 @@ fn push_debuginfo_type_name<'tcx>(
         substs: SubstsRef<'tcx>,
         output: &mut String,
         visited: &mut FxHashSet<Ty<'tcx>>,
-        type_name_cache:  &RefCell<FxHashMap<(Ty<'tcx>, bool), String>>,
+        type_name_cache: &RefCell<FxHashMap<(Ty<'tcx>, bool), String>>,
     ) {
         let layout = tcx.layout_of(tcx.param_env(def.did).and(ty)).expect("layout error");
 

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -37,11 +37,6 @@ pub fn compute_debuginfo_type_name<'tcx>(
 ) -> String {
     let _prof = tcx.prof.generic_activity("compute_debuginfo_type_name");
 
-    // Check if we have seen this type and qualifier before.
-    if let Some(type_name) = type_name_cache.get(&(&t, qualified)) {
-        return type_name.clone();
-    }
-
     let mut result = String::with_capacity(64);
     let mut visited = FxHashSet::default();
     push_debuginfo_type_name(tcx, t, qualified, &mut result, &mut visited, type_name_cache);
@@ -58,6 +53,12 @@ fn push_debuginfo_type_name<'tcx>(
     visited: &mut FxHashSet<Ty<'tcx>>,
     type_name_cache: &mut FxHashMap<(Ty<'tcx>, bool), String>,
 ) {
+    // Check if we have seen this type and qualifier before.
+    if let Some(type_name) = type_name_cache.get(&(&t, qualified)) {
+        output.push_str(&type_name.clone());
+        return;
+    }
+
     // When targeting MSVC, emit C++ style type names for compatibility with
     // .natvis visualizers (and perhaps other existing native debuggers?)
     let cpp_like_names = cpp_like_names(tcx);


### PR DESCRIPTION
This is a WIP addressing #86431. This PR aims to accomplish two things:

- [x] Implements a caching schema to avoid redundant calls to `compute_debuginfo_type_name()`.
- [ ] Add profiling support for determining the amount of redundant computations that _would_ be performed, if the caching schema were not implemented. 
    - As for how: I plan to just use counters to track how many times we call `compute_debuginfo_type_name()` and how many times we return a name for the cache. @rylev also suggested that determining how many individual memory allocations occur each time redundant work is performed, but I am unsure of how to go about this.
      