### PR TITLE
Do not issue E0071 if a type error has already been reported

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0071.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0071.md
@@ -15,13 +15,13 @@ form of initializer was used.
 For example, the code above can be fixed to:
 
 ```
-enum Foo {
-    FirstValue(i32)
-}
+type U32 = u32;
+let t: U32 = 4;
+```
 
-fn main() {
-    let u = Foo::FirstValue(0i32);
+or:
 
-    let t = 4;
-}
+```
+struct U32 { value: u32 }
+let t = U32 { value: 4 };
 ```

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -494,15 +494,25 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             Some((variant, ty))
         } else {
-            struct_span_err!(
-                self.tcx.sess,
-                path_span,
-                E0071,
-                "expected struct, variant or union type, found {}",
-                ty.sort_string(self.tcx)
-            )
-            .span_label(path_span, "not a struct")
-            .emit();
+            match ty.kind() {
+                ty::Error(_) => {
+                    // E0071 might be caused by a spelling error, which will have
+                    // already caused an error message and probably a suggestion
+                    // elsewhere. Refrain from emitting more unhelpful errors here
+                    // (issue #88844).
+                }
+                _ => {
+                    struct_span_err!(
+                        self.tcx.sess,
+                        path_span,
+                        E0071,
+                        "expected struct, variant or union type, found {}",
+                        ty.sort_string(self.tcx)
+                    )
+                    .span_label(path_span, "not a struct")
+                    .emit();
+                }
+            }
             None
         }
     }

--- a/src/test/ui/typeck/issue-88844.rs
+++ b/src/test/ui/typeck/issue-88844.rs
@@ -1,0 +1,14 @@
+// Regression test for #88844.
+
+struct Struct { value: i32 }
+//~^ NOTE: similarly named struct `Struct` defined here
+
+impl Stuct {
+//~^ ERROR: cannot find type `Stuct` in this scope [E0412]
+//~| HELP: a struct with a similar name exists
+    fn new() -> Self {
+        Self { value: 42 }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-88844.stderr
+++ b/src/test/ui/typeck/issue-88844.stderr
@@ -1,0 +1,12 @@
+error[E0412]: cannot find type `Stuct` in this scope
+  --> $DIR/issue-88844.rs:6:6
+   |
+LL | struct Struct { value: i32 }
+   | ------------- similarly named struct `Struct` defined here
+...
+LL | impl Stuct {
+   |      ^^^^^ help: a struct with a similar name exists: `Struct`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #88844. A suggested fix is already included in the error message for E0412, so with my changes, E0071 is simply not emitted anymore if the type in question is a "type error". This makes sense, I think, because we cannot confidently state that something is "not a struct" if we couldn't resolve it properly; and it's unnecessary to pollute the output with this additional error message, as it is a direct consequence of the former error.

I have also addressed the issue mentioned in https://github.com/rust-lang/rust/issues/88844#issuecomment-917324856 by changing the fixed example in the documentation to more closely match the erroneous code example.