### PR TITLE
Highlight the `const fn` if error happened because of a bound on the impl block

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -599,12 +599,21 @@ pub mod ty {
         }
 
         fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
-            feature_err(
+            let mut builder = feature_err(
                 &ccx.tcx.sess.parse_sess,
                 sym::const_fn_trait_bound,
                 span,
                 "trait bounds other than `Sized` on const fn parameters are unstable",
-            )
+            );
+
+            match ccx.fn_sig() {
+                Some(fn_sig) if !fn_sig.span.contains(span) => {
+                    builder.span_label(fn_sig.span, "function declared as const here");
+                }
+                _ => {}
+            }
+
+            builder
         }
     }
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -214,6 +214,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
+LL |
+LL |     const fn foo(&self) {}
+   |     ------------------- function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
@@ -223,6 +226,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
+LL |
+LL |     const fn foo2(&self) {}
+   |     -------------------- function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
@@ -232,6 +238,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
+LL |
+LL |     const fn foo3(&self) {}
+   |     -------------------- function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
@@ -292,7 +301,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
   --> $DIR/min_const_fn.rs:139:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1 }
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
@@ -301,7 +312,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
   --> $DIR/min_const_fn.rs:139:42
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1 }
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
@@ -310,7 +323,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
   --> $DIR/min_const_fn.rs:139:42
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1 }
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -1,6 +1,8 @@
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
+LL | const fn no_inner_dyn_trait2(x: Hide) {
+   | ------------------------------------- function declared as const here
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
@@ -11,7 +13,9 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
-   |                                                                  ^^
+   | -----------------------------------------                        ^^
+   | |
+   | function declared as const here
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable


### PR DESCRIPTION
Currently, for the following code, the compiler produces the errors like the
following:
```rust
struct Type<T>(T);

impl<T: Clone> Type<T> {
    const fn f() {}
}
```
```text
error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
 --> ./test.rs:3:6
  |
3 | impl<T: Clone> Type<T> {
  |      ^
  |
  = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
  = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
```

This can be confusing (especially to newcomers) since the error mentions "const fn parameters", but highlights only the impl.

This PR adds function highlighting, changing the error to the following:

```text
error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
 --> ./test.rs:3:6
  |
3 | impl<T: Clone> Type<T> {
  |      ^
4 |     pub const fn f() {}
  |     ---------------- function declared as const here
  |
  = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
  = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
```

---

I've originally wanted to point directly to `const` token, but couldn't find a way to get it's span. It seems like this span is lost during the AST -> HIR lowering.

Also, since the errors for object casts in `const fn`s (`&T` -> `&dyn Trait`) seem to trigger the same error, this PR accidentally changes these errors too. Not sure if it's desired or how to fix this.

P.S. it's my first time contributing to diagnostics, so feedback is very appreciated! 

---

r? @estebank 

@rustbot label: +A-diagnostics 