### PR TITLE
enable `PathBuf` usage in proc_macro bridge, `tracked::path`

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -21,6 +21,7 @@ use rustc_span::{BytePos, FileName, MultiSpan, Pos, RealFileName, SourceFile, Sp
 use pm::bridge::{server, TokenTree};
 use pm::{Delimiter, Level, LineColumn, Spacing};
 use std::ops::Bound;
+use std::path;
 use std::{ascii, panic};
 
 trait FromInternal<T> {
@@ -406,7 +407,7 @@ impl server::FreeFunctions for Rustc<'_> {
     }
 
     fn track_path(&mut self, path: &str) {
-        self.sess.file_depinfo.borrow_mut().insert(Symbol::intern(path));
+        self.sess.file_depinfo.borrow_mut().insert(path::PathBuf::from(path));
     }
 }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -599,9 +599,8 @@ fn write_out_deps(
         // Account for explicitly marked-to-track files
         // (e.g. accessed in proc macros).
         let file_depinfo = sess.parse_sess.file_depinfo.borrow();
-        let extra_tracked_files = file_depinfo.iter().map(|path_sym| {
-            let path = PathBuf::from(&*path_sym.as_str());
-            let file = FileName::from(path);
+        let extra_tracked_files = file_depinfo.iter().map(|path| {
+            let file = FileName::from(path.clone());
             escape_dep_filename(&file.prefer_local().to_string())
         });
         files.extend(extra_tracked_files);

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -13,6 +13,7 @@ use rustc_span::hygiene::ExpnId;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{MultiSpan, Span, Symbol};
 
+use std::path;
 use std::str;
 
 /// The set of keys (and, optionally, values) that define the compilation
@@ -134,7 +135,7 @@ pub struct ParseSess {
     /// Environment variables accessed during the build and their values when they exist.
     pub env_depinfo: Lock<FxHashSet<(Symbol, Option<Symbol>)>>,
     /// File paths accessed during the build.
-    pub file_depinfo: Lock<FxHashSet<Symbol>>,
+    pub file_depinfo: Lock<FxHashSet<path::PathBuf>>,
     /// All the type ascriptions expressions that have had a suggestion for likely path typo.
     pub type_ascription_path_suggestions: Lock<FxHashSet<Span>>,
     /// Whether cfg(version) should treat the current release as incomplete

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -15,6 +15,7 @@ use std::marker;
 use std::mem;
 use std::ops::Bound;
 use std::panic;
+use std::path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Once;
 use std::thread;
@@ -361,6 +362,7 @@ mark_noop! {
     LineColumn,
     Spacing,
     Bound<usize>,
+    path::PathBuf,
 }
 
 rpc_encode_decode!(

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -5,6 +5,7 @@ use std::char;
 use std::io::Write;
 use std::num::NonZeroU32;
 use std::ops::Bound;
+use std::path;
 use std::str;
 
 pub(super) type Writer = super::buffer::Buffer<u8>;
@@ -243,6 +244,18 @@ impl<S> Encode<S> for String {
 impl<S> DecodeMut<'_, '_, S> for String {
     fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
+    }
+}
+
+impl<S> Encode<S> for path::PathBuf {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.to_str().expect("`PathBuf`s must be valid UTF-8 for now!").encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for path::PathBuf {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        path::PathBuf::from(<&str>::decode(r, s))
     }
 }
 

--- a/src/test/run-make/track-path-dep-info/macro_def.rs
+++ b/src/test/run-make/track-path-dep-info/macro_def.rs
@@ -1,11 +1,21 @@
-#![feature(track_path)]
+#![feature(proc_macro_tracked_env,proc_macro_tracked_path)]
 #![crate_type = "proc-macro"]
 
 extern crate proc_macro;
 use proc_macro::*;
 
+use std::str;
+
 #[proc_macro]
 pub fn access_tracked_paths(_: TokenStream) -> TokenStream {
     tracked_path::path("emojis.txt");
+
+    // currently only valid utf-8 paths are supported
+    let invalid = [1_u8, 2,123, 254, 0, 0, 1, 1];
+    let invalid: &str = unsafe {
+        str::from_utf8_unchecked(&invalid[..])
+    };
+    tracked_path::path(invalid);
+
     TokenStream::new()
 }


### PR DESCRIPTION
Extracted from #87173 

Adds limited `PathBuf` support for convenience to the `proc_macro`-bridge code. Currently does _not_ handle invalid utf-t cases gracefully.

@rustbot assign @petrochenkov 


