### PR TITLE
Mark `String::clone` as inline-able

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1834,10 +1834,14 @@ impl fmt::Display for FromUtf16Error {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Clone for String {
+    // Not marking it inline causes worse assembly to be generated.
+    // https://github.com/rust-lang/rust/issues/88905
+    #[inline]
     fn clone(&self) -> Self {
         String { vec: self.vec.clone() }
     }
 
+    #[inline]
     fn clone_from(&mut self, source: &Self) {
         self.vec.clone_from(&source.vec);
     }

--- a/src/test/codegen/issue-88905.rs
+++ b/src/test/codegen/issue-88905.rs
@@ -1,0 +1,13 @@
+//
+// min-llvm-version: 10.0.1
+// compile-flags: -C opt-level=3
+#![crate_type="lib"]
+
+#[no_mangle]
+pub fn alloc_test(a: &String) {
+    // CHECK-LABEL: @alloc_test
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret void
+    let x = String::clone(a);
+    drop(x);
+}


### PR DESCRIPTION
It calls `Vec::clone` and performs a newtype-wrap around it, so it should be trivial enough that it doesn't cause major size regressions. It also fixes #88905
