### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.45+curl-7.78.0"
+version = "0.4.47+curl-7.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
+checksum = "1ab94a47d9b61f2d905beb7a3d46aba7704c9f1dfcf84e7d178998d9e95f7989"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
13 commits in e515c3277bf0681bfc79a9e763861bfe26bb05db..33ee5f82edb50af87b952c5b28de0f5fb41ebf18
2021-09-08 14:32:15 +0000 to 2021-09-17 13:51:54 +0000
- Update curl-sys (rust-lang/cargo#9917)
- Bump Cargo's curl requirement to 7.79.0 (rust-lang/cargo#9914)
- Revert "When a dependency does not have a version, git or path, fails directly" (rust-lang/cargo#9911)
- Add some contributor docs for debugging testsuite tests. (rust-lang/cargo#9904)
- Fix warnings when documenting with `--document-private-items` (rust-lang/cargo#9903)
- Improve "wrong output" error. (rust-lang/cargo#9905)
- Fix warnings from better precision of `dead_code` lint (rust-lang/cargo#9906)
- Bump to 0.58.0, update changelog (rust-lang/cargo#9900)
- Fix rustc --profile=dev unstable check. (rust-lang/cargo#9898)
- config.md: fix typo (rust-lang/cargo#9896)
- Enable some tests on windows. (rust-lang/cargo#9893)
- Enable strip test on macos. (rust-lang/cargo#9889)
- Fix `cargo fix --edition` on stable. (rust-lang/cargo#9890)