### PR TITLE
Add rustdoc version into the help popup

### DIFF
--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -268,10 +268,18 @@ pub(super) fn write_shared(
     // Maybe we can change the representation to move this out of main.js?
     write_minify(
         "main.js",
-        static_files::MAIN_JS.replace(
-            "/* INSERT THEMES HERE */",
-            &format!(" = {}", serde_json::to_string(&themes).unwrap()),
-        ),
+        static_files::MAIN_JS
+            .replace(
+                "/* INSERT THEMES HERE */",
+                &format!(" = {}", serde_json::to_string(&themes).unwrap()),
+            )
+            .replace(
+                "/* INSERT RUSTDOC_VERSION HERE */",
+                &format!(
+                    "rustdoc {}",
+                    rustc_interface::util::version_str().unwrap_or("unknown version")
+                ),
+            ),
         cx,
         options,
     )?;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -928,14 +928,23 @@ body.blur > :not(#help) {
 	display: block;
 	margin-right: 0.5rem;
 }
-#help > div > span {
+#help span.top, #help span.bottom {
+	text-align: center;
+	display: block;
+	font-size: 18px;
+
+}
+#help span.top {
 	text-align: center;
 	display: block;
 	margin: 10px 0;
-	font-size: 18px;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid;
 	padding-bottom: 4px;
 	margin-bottom: 6px;
+}
+#help span.bottom {
+	clear: both;
+	border-top: 1px solid;
 }
 #help dd { margin: 5px 35px; }
 #help .infos { padding-left: 0; }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -286,8 +286,8 @@ details.undocumented > summary::before {
 	border-radius: 4px;
 }
 
-#help > div > span {
-	border-bottom-color: #5c6773;
+#help span.bottom, #help span.top {
+	border-color: #5c6773;
 }
 
 .since {

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -242,8 +242,8 @@ details.undocumented > summary::before {
 	border-color: #bfbfbf;
 }
 
-#help > div > span {
-	border-bottom-color: #bfbfbf;
+#help span.bottom, #help span.top {
+	border-color: #bfbfbf;
 }
 
 #help dt {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -232,8 +232,8 @@ details.undocumented > summary::before {
 	border-color: #bfbfbf;
 }
 
-#help > div > span {
-	border-bottom-color: #bfbfbf;
+#help span.bottom, #help span.top {
+	border-color: #bfbfbf;
 }
 
 .since {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -911,6 +911,7 @@ function hideThemeButtonState() {
         });
 
         var book_info = document.createElement("span");
+        book_info.className = "top";
         book_info.innerHTML = "You can find more information in \
             <a href=\"https://doc.rust-lang.org/rustdoc/\">the rustdoc book</a>.";
 
@@ -960,6 +961,14 @@ function hideThemeButtonState() {
         container.appendChild(book_info);
         container.appendChild(div_shortcuts);
         container.appendChild(div_infos);
+
+        var rustdoc_version = document.createElement("span");
+        rustdoc_version.className = "bottom";
+        var rustdoc_version_code = document.createElement("code");
+        rustdoc_version_code.innerText = "/* INSERT RUSTDOC_VERSION HERE */";
+        rustdoc_version.appendChild(rustdoc_version_code);
+
+        container.appendChild(rustdoc_version);
 
         popup.appendChild(container);
         insertAfter(popup, searchState.outputElement());


### PR DESCRIPTION
After a discussion with a rustdoc user about a specific behaviour, we realized we were not talking about the same version. To add on top of it, it was actually not that simple to find out the version since it was hosted documentation.

So to simplify things, I added the version into the help popup:

![Screenshot from 2021-09-16 10-45-52](https://user-images.githubusercontent.com/3050060/133581128-b93b460a-e1cb-4a31-9f2f-97c7a916cfcc.png)

Does the version format looks or would you prefer that I add more information? We can also add the commit hash, commit date, host and release.

cc @rust-lang/rustdoc 
r? @jyn514 