### PR TITLE
test - simulate default discriminant start at 1

### DIFF
--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -27,7 +27,7 @@ pub enum IntPredicate {
 }
 
 pub enum RealPredicate {
-    RealPredicateFalse,
+    RealPredicateFalse = 0, // FIXME(bonega)
     RealOEQ,
     RealOGT,
     RealOGE,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2631,7 +2631,7 @@ impl Item<'_> {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[derive(Encodable, Decodable, HashStable_Generic)]
 pub enum Unsafety {
-    Unsafe,
+    Unsafe = 0, //FIXME(bonega)
     Normal,
 }
 

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -20,7 +20,7 @@ use rustc_span::Span;
 use std::lazy::SyncLazy;
 
 pub enum LangItemGroup {
-    Op,
+    Op = 0, //FIXME(bonega)
 }
 
 const NUM_GROUPS: usize = 1;
@@ -44,6 +44,7 @@ macro_rules! language_item_table {
         enum_from_u32! {
             /// A representation of all the valid language items in Rust.
             #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Encodable, Decodable)]
+            #[repr(u32)]
             pub enum LangItem {
                 $(
                     #[doc = concat!("The `", stringify!($name), "` lang item.")]

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -125,7 +125,7 @@ pub enum Alignment {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Flag {
     /// A `+` will be used to denote positive numbers.
-    FlagSignPlus,
+    FlagSignPlus = 0, //FIXME(bonega)
     /// A `-` will be used to denote negative numbers. This is the default.
     FlagSignMinus,
     /// An alternate form will be used for the value. In the case of numbers,

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -240,7 +240,7 @@ impl DebruijnIndex {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[derive(Encodable, Decodable)]
 pub enum IntTy {
-    Isize,
+    Isize = 0, //FIXME(bonega)
     I8,
     I16,
     I32,
@@ -287,7 +287,7 @@ impl IntTy {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Debug)]
 #[derive(Encodable, Decodable)]
 pub enum UintTy {
-    Usize,
+    Usize = 0, //FIXME(bonega)
     U8,
     U16,
     U32,
@@ -334,7 +334,7 @@ impl UintTy {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[derive(Encodable, Decodable)]
 pub enum FloatTy {
-    F32,
+    F32 = 0, //FIXME(bonega)
     F64,
 }
 

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -343,7 +343,7 @@ impl<'a> ArgumentV1<'a> {
 // flags available in the v1 format of format_args
 #[derive(Copy, Clone)]
 enum FlagV1 {
-    SignPlus,
+    SignPlus = 0, //FIXME(bonega)
     SignMinus,
     Alternate,
     SignAwareZeroPad,

--- a/library/std/src/sync/mpsc/oneshot.rs
+++ b/library/std/src/sync/mpsc/oneshot.rs
@@ -52,20 +52,23 @@ pub struct Packet<T> {
     upgrade: UnsafeCell<MyUpgrade<T>>,
 }
 
+#[repr(usize)]
 pub enum Failure<T> {
-    Empty,
+    Empty = 0, //FIXME(bonega) repr
     Disconnected,
     Upgraded(Receiver<T>),
 }
 
+#[repr(usize)]
 pub enum UpgradeResult {
-    UpSuccess,
+    UpSuccess = 0, //FIXME(bonega) repr
     UpDisconnected,
     UpWoke(SignalToken),
 }
 
+#[repr(usize)]
 enum MyUpgrade<T> {
-    NothingSent,
+    NothingSent = 0, //FIXME(bonega) repr
     SendUsed,
     GoUp(Receiver<T>),
 }

--- a/src/test/codegen/enum-bounds-check.rs
+++ b/src/test/codegen/enum-bounds-check.rs
@@ -3,7 +3,8 @@
 #![crate_type = "lib"]
 
 pub enum Foo {
-    A, B
+    A = 0,
+    B,
 }
 
 // CHECK-LABEL: @lookup
@@ -15,7 +16,7 @@ pub fn lookup(buf: &[u8; 2], f: Foo) -> u8 {
 
 pub enum Bar {
     A = 2,
-    B = 3
+    B = 3,
 }
 
 // CHECK-LABEL: @lookup_unmodified

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:11:11: 11:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:11:5: 11:12
+          switchInt(move _2) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:11:5: 11:12
       }
   
       bb1: {

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -11,9 +11,9 @@
       bb0: {
 -         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
--         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         switchInt(move _3) -> [2_isize: bb2, 3_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
-+         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         switchInt(move _2) -> [2_isize: bb2, 3_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
       bb1: {

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -106,10 +106,10 @@
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
                                            // ty::Const
                                            // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + val: Value(Scalar(0x01))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x01)) }
       }
   
       bb2: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -119,10 +119,10 @@
           _22 = const core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + val: Value(Scalar(0x01))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x01)) }
           StorageLive(_23);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_24);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _24 = _13;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -139,10 +139,10 @@
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
                                            // ty::Const
                                            // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + val: Value(Scalar(0x01))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x01)) }
       }
   
       bb4: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
+          switchInt(move _2) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
       }
   
       bb1: {

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
-          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
+          switchInt(move _2) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
       }
   
       bb1: {

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -17,18 +17,18 @@
 -         (_2.1: E) = const E::A;          // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
 -                                          // ty::Const
 -                                          // + ty: E
--                                          // + val: Value(Scalar(0x00))
+-                                          // + val: Value(Scalar(0x01))
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals.rs:28:6: 28:16
--                                          // + literal: Const { ty: E, val: Value(Scalar(0x00)) }
+-                                          // + literal: Const { ty: E, val: Value(Scalar(0x01)) }
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:15: 28:16
 -         (_2.1: E) = const E::B;          // scope 0 at $DIR/simplify-locals.rs:28:5: 28:26
 -                                          // ty::Const
 -                                          // + ty: E
--                                          // + val: Value(Scalar(0x01))
+-                                          // + val: Value(Scalar(0x02))
 -                                          // mir::Constant
 -                                          // + span: $DIR/simplify-locals.rs:28:5: 28:26
--                                          // + literal: Const { ty: E, val: Value(Scalar(0x01)) }
+-                                          // + literal: Const { ty: E, val: Value(Scalar(0x02)) }
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:25: 28:26
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:26: 28:27
           return;                          // scope 0 at $DIR/simplify-locals.rs:29:2: 29:2

--- a/src/test/ui/consts/const-enum-cast.rs
+++ b/src/test/ui/consts/const-enum-cast.rs
@@ -1,10 +1,16 @@
 // run-pass
 #![allow(non_upper_case_globals)]
 
-enum A { A1, A2 }
-enum B { B1=4, B2=2 }
+enum A {
+    A1,
+    A2,
+}
+enum B {
+    B1 = 4,
+    B2 = 2,
+}
 
-pub fn main () {
+pub fn main() {
     static c1: isize = A::A2 as isize;
     static c2: isize = B::B2 as isize;
     let a1 = A::A2 as isize;
@@ -15,12 +21,24 @@ pub fn main () {
     assert_eq!(a2, 2);
 
     // Turns out that adding a let-binding generates totally different MIR.
-    static c1_2: isize = { let v = A::A1; v as isize };
-    static c2_2: isize = { let v = B::B1; v as isize };
-    let a1_2 = { let v = A::A1; v as isize };
-    let a2_2 = { let v = B::B1; v as isize };
-    assert_eq!(c1_2, 0);
+    static c1_2: isize = {
+        let v = A::A1;
+        v as isize
+    };
+    static c2_2: isize = {
+        let v = B::B1;
+        v as isize
+    };
+    let a1_2 = {
+        let v = A::A1;
+        v as isize
+    };
+    let a2_2 = {
+        let v = B::B1;
+        v as isize
+    };
+    assert_eq!(c1_2, 1);
     assert_eq!(c2_2, 4);
-    assert_eq!(a1_2, 0);
+    assert_eq!(a1_2, 1);
     assert_eq!(a2_2, 4);
 }

--- a/src/test/ui/enum-discriminant/discriminant_size.rs
+++ b/src/test/ui/enum-discriminant/discriminant_size.rs
@@ -30,9 +30,9 @@ enum E4 {
 fn main() {
     let mut target: [isize; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E1::A);
-    assert_eq!(target, [0, 0, 0]);
-    target[1] = discriminant_value(&E1::B);
     assert_eq!(target, [0, 1, 0]);
+    target[1] = discriminant_value(&E1::B);
+    assert_eq!(target, [0, 2, 0]);
 
     let mut target: [i8; 3] = [0, 0, 0];
     target[1] = discriminant_value(&E2::A);

--- a/src/test/ui/enum-discriminant/discriminant_value.rs
+++ b/src/test/ui/enum-discriminant/discriminant_value.rs
@@ -9,14 +9,14 @@ enum CLike1 {
     A,
     B,
     C,
-    D
+    D,
 }
 
 enum CLike2 {
     A = 5,
     B = 2,
     C = 19,
-    D
+    D,
 }
 
 #[repr(i8)]
@@ -24,37 +24,34 @@ enum CLike3 {
     A = 5,
     B,
     C = -1,
-    D
+    D,
 }
 
 enum ADT {
     First(u32, u32),
-    Second(u64)
+    Second(u64),
 }
 
 enum NullablePointer {
     Something(&'static u32),
-    Nothing
+    Nothing,
 }
 
-static CONST : u32 = 0xBEEF;
+static CONST: u32 = 0xBEEF;
 
 #[allow(dead_code)]
 #[repr(isize)]
 enum Mixed {
     Unit = 3,
     Tuple(u16) = 2,
-    Struct {
-        a: u8,
-        b: u16,
-    } = 1,
+    Struct { a: u8, b: u16 } = 1,
 }
 
 pub fn main() {
-    assert_eq!(discriminant_value(&CLike1::A), 0isize);
-    assert_eq!(discriminant_value(&CLike1::B), 1);
-    assert_eq!(discriminant_value(&CLike1::C), 2);
-    assert_eq!(discriminant_value(&CLike1::D), 3);
+    assert_eq!(discriminant_value(&CLike1::A), 1isize);
+    assert_eq!(discriminant_value(&CLike1::B), 2);
+    assert_eq!(discriminant_value(&CLike1::C), 3);
+    assert_eq!(discriminant_value(&CLike1::D), 4);
 
     assert_eq!(discriminant_value(&CLike2::A), 5isize);
     assert_eq!(discriminant_value(&CLike2::B), 2);
@@ -66,7 +63,7 @@ pub fn main() {
     assert_eq!(discriminant_value(&CLike3::C), -1);
     assert_eq!(discriminant_value(&CLike3::D), 0);
 
-    assert_eq!(discriminant_value(&ADT::First(0,0)), 0isize);
+    assert_eq!(discriminant_value(&ADT::First(0, 0)), 0isize);
     assert_eq!(discriminant_value(&ADT::Second(5)), 1);
 
     assert_eq!(discriminant_value(&NullablePointer::Nothing), 1isize);
@@ -77,5 +74,5 @@ pub fn main() {
 
     assert_eq!(discriminant_value(&Mixed::Unit), 3isize);
     assert_eq!(discriminant_value(&Mixed::Tuple(5)), 2);
-    assert_eq!(discriminant_value(&Mixed::Struct{a: 7, b: 11}), 1);
+    assert_eq!(discriminant_value(&Mixed::Struct { a: 7, b: 11 }), 1);
 }


### PR DESCRIPTION
*WIP/TEST*
Trying to gauge the general performance impact of enums not starting with zero.
This is only for `repr(rust)`

Please sate my curiosity with a perf-run

Edit: sorry - didn't mean to set of all the sirens...