### PR TITLE
Disable projection sub-obligation optimization in intercrate mode

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -315,6 +315,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx.tcx
     }
 
+    pub fn is_intercrate(&self) -> bool {
+        self.intercrate
+    }
+
     /// Returns `true` if the trait predicate is considerd `const` to this selection context.
     pub fn is_trait_predicate_const(&self, pred: ty::TraitPredicate<'_>) -> bool {
         match pred.constness {


### PR DESCRIPTION
The meaning of an 'evaluation' in intercrate mode is more complicated
than with an normal `SelectionContext`. To avoid potential issues,
we now always preserve all projection sub-obligations when in
intercrate mode. This avoids needing to answer whether or not
`EvaluatedToOk` always means the same thing in intercrate mode
as it does normally.