### PR TITLE
feat(rustc_parse): recover from pre-RFC-2000 const generics syntax

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -384,6 +384,16 @@ impl GenericArgs<'_> {
         self.args.iter().any(|arg| matches!(arg, GenericArg::Type(_)))
     }
 
+    pub fn has_err(&self) -> bool {
+        self.args.iter().any(|arg| match arg {
+            GenericArg::Type(ty) => matches!(ty.kind, TyKind::Err),
+            _ => false,
+        }) || self.bindings.iter().any(|arg| match arg.kind {
+            TypeBindingKind::Equality { ty } => matches!(ty.kind, TyKind::Err),
+            _ => false,
+        })
+    }
+
     #[inline]
     pub fn num_type_params(&self) -> usize {
         self.args.iter().filter(|arg| matches!(arg, GenericArg::Type(_))).count()

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -495,25 +495,28 @@ impl<'a> Parser<'a> {
             None => {
                 let after_eq = eq.shrink_to_hi();
                 let before_next = self.token.span.shrink_to_lo();
-                let the_type_placeholder = if matches!(self.token.kind, token::Comma | token::Gt) {
-                    " TheType"
-                } else {
-                    " TheType "
-                };
-                self.struct_span_err(after_eq.to(before_next), "missing type to the right of `=`")
-                    .span_suggestion(
+                let mut err = self
+                    .struct_span_err(after_eq.to(before_next), "missing type to the right of `=`");
+                if matches!(self.token.kind, token::Comma | token::Gt) {
+                    err.span_suggestion(
                         self.sess.source_map().next_point(eq).to(before_next),
                         "to constrain the associated type, add a type after `=`",
-                        the_type_placeholder.to_string(),
+                        " TheType".to_string(),
                         Applicability::HasPlaceholders,
-                    )
-                    .span_suggestion(
+                    );
+                    err.span_suggestion(
                         eq.to(before_next),
                         &format!("remove the `=` if `{}` is a type", ident),
                         String::new(),
                         Applicability::MaybeIncorrect,
                     )
-                    .emit();
+                } else {
+                    err.span_label(
+                        self.token.span,
+                        &format!("expected type, found {}", super::token_descr(&self.token)),
+                    )
+                };
+                return Err(err);
             }
         }
         Ok(self.mk_ty(span, ast::TyKind::Err))
@@ -584,6 +587,12 @@ impl<'a> Parser<'a> {
                 "expected lifetime, type, or constant, found keyword `const`",
             );
             if self.check_const_arg() {
+                err.span_suggestion_verbose(
+                    start.until(self.token.span),
+                    "the `const` keyword is only needed in the definition of the type",
+                    String::new(),
+                    Applicability::MaybeIncorrect,
+                );
                 err.emit();
                 GenericArg::Const(self.parse_const_arg()?)
             } else {

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -495,11 +495,16 @@ impl<'a> Parser<'a> {
             None => {
                 let after_eq = eq.shrink_to_hi();
                 let before_next = self.token.span.shrink_to_lo();
+                let the_type_placeholder = if matches!(self.token.kind, token::Comma | token::Gt) {
+                    " TheType"
+                } else {
+                    " TheType "
+                };
                 self.struct_span_err(after_eq.to(before_next), "missing type to the right of `=`")
                     .span_suggestion(
                         self.sess.source_map().next_point(eq).to(before_next),
                         "to constrain the associated type, add a type after `=`",
-                        " TheType".to_string(),
+                        the_type_placeholder.to_string(),
                         Applicability::HasPlaceholders,
                     )
                     .span_suggestion(
@@ -571,6 +576,19 @@ impl<'a> Parser<'a> {
                     // Try to recover from possible `const` arg without braces.
                     return self.recover_const_arg(start, err).map(Some);
                 }
+            }
+        } else if self.eat_keyword_noexpect(kw::Const) {
+            // Detect and recover from the old, pre-RFC2000 syntax for const generics.
+            let mut err = self.struct_span_err(
+                start,
+                "expected lifetime, type, or constant, found keyword `const`",
+            );
+            if self.check_const_arg() {
+                err.emit();
+                GenericArg::Const(self.parse_const_arg()?)
+            } else {
+                let after_kw_const = self.token.span;
+                return self.recover_const_arg(after_kw_const, err).map(Some);
             }
         } else {
             return Ok(None);

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -601,7 +601,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     def_id,
                 )
                 .diagnostic()
-                .emit();
+                .emit_unless(gen_args.has_err());
 
                 false
             };

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.rs
@@ -1,0 +1,16 @@
+trait Foo<const N: usize> {
+    fn do_x(&self) -> [u8; N];
+}
+
+struct Bar;
+
+const T: usize = 42;
+
+impl Foo<const 3> for Bar {
+//~^ERROR expected lifetime, type, or constant, found keyword `const`
+    fn do_x(&self) -> [u8; 3] {
+        [0u8; 3]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
@@ -1,0 +1,8 @@
+error: expected lifetime, type, or constant, found keyword `const`
+  --> $DIR/issue-89013-no-assoc.rs:9:10
+   |
+LL | impl Foo<const 3> for Bar {
+   |          ^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
@@ -3,6 +3,12 @@ error: expected lifetime, type, or constant, found keyword `const`
    |
 LL | impl Foo<const 3> for Bar {
    |          ^^^^^
+   |
+help: the `const` keyword is only needed in the definition of the type
+   |
+LL - impl Foo<const 3> for Bar {
+LL + impl Foo<3> for Bar {
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
@@ -7,9 +7,8 @@ struct Bar;
 const T: usize = 42;
 
 impl Foo<N = 3> for Bar {
-//~^ERROR cannot constrain an associated constant to a value
-//~^^ERROR this trait takes 1 generic argument but 0 generic arguments
-//~^^^ERROR associated type bindings are not allowed here
+//~^ ERROR cannot constrain an associated constant to a value
+//~| ERROR associated type bindings are not allowed here
     fn do_x(&self) -> [u8; 3] {
         [0u8; 3]
     }

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.rs
@@ -1,0 +1,18 @@
+trait Foo<const N: usize> {
+    fn do_x(&self) -> [u8; N];
+}
+
+struct Bar;
+
+const T: usize = 42;
+
+impl Foo<N = 3> for Bar {
+//~^ERROR cannot constrain an associated constant to a value
+//~^^ERROR this trait takes 1 generic argument but 0 generic arguments
+//~^^^ERROR associated type bindings are not allowed here
+    fn do_x(&self) -> [u8; 3] {
+        [0u8; 3]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -7,29 +7,12 @@ LL | impl Foo<N = 3> for Bar {
    |          |   ...cannot be constrained to this value
    |          this associated constant...
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/issue-89013-no-kw.rs:9:6
-   |
-LL | impl Foo<N = 3> for Bar {
-   |      ^^^ expected 1 generic argument
-   |
-note: trait defined here, with 1 generic parameter: `N`
-  --> $DIR/issue-89013-no-kw.rs:1:7
-   |
-LL | trait Foo<const N: usize> {
-   |       ^^^       -
-help: add missing generic argument
-   |
-LL | impl Foo<N, N = 3> for Bar {
-   |          ++
-
 error[E0229]: associated type bindings are not allowed here
   --> $DIR/issue-89013-no-kw.rs:9:10
    |
 LL | impl Foo<N = 3> for Bar {
    |          ^^^^^ associated type not allowed here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0107, E0229.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0229`.

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -1,0 +1,35 @@
+error: cannot constrain an associated constant to a value
+  --> $DIR/issue-89013-no-kw.rs:9:10
+   |
+LL | impl Foo<N = 3> for Bar {
+   |          -^^^-
+   |          |   |
+   |          |   ...cannot be constrained to this value
+   |          this associated constant...
+
+error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/issue-89013-no-kw.rs:9:6
+   |
+LL | impl Foo<N = 3> for Bar {
+   |      ^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `N`
+  --> $DIR/issue-89013-no-kw.rs:1:7
+   |
+LL | trait Foo<const N: usize> {
+   |       ^^^       -
+help: add missing generic argument
+   |
+LL | impl Foo<N, N = 3> for Bar {
+   |          ++
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-89013-no-kw.rs:9:10
+   |
+LL | impl Foo<N = 3> for Bar {
+   |          ^^^^^ associated type not allowed here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0229.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.rs
@@ -8,7 +8,6 @@ const T: usize = 42;
 
 impl Foo<N = type 3> for Bar {
 //~^ERROR missing type to the right of `=`
-//~^^ERROR found keyword `type`
     fn do_x(&self) -> [u8; 3] {
         [0u8; 3]
     }

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.rs
@@ -1,0 +1,17 @@
+trait Foo<const N: usize> {
+    fn do_x(&self) -> [u8; N];
+}
+
+struct Bar;
+
+const T: usize = 42;
+
+impl Foo<N = type 3> for Bar {
+//~^ERROR missing type to the right of `=`
+//~^^ERROR found keyword `type`
+    fn do_x(&self) -> [u8; 3] {
+        [0u8; 3]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.stderr
@@ -2,23 +2,7 @@ error: missing type to the right of `=`
   --> $DIR/issue-89013-type.rs:9:13
    |
 LL | impl Foo<N = type 3> for Bar {
-   |             ^
-   |
-help: to constrain the associated type, add a type after `=`
-   |
-LL | impl Foo<N = TheType type 3> for Bar {
-   |              +++++++
-help: remove the `=` if `N` is a type
-   |
-LL - impl Foo<N = type 3> for Bar {
-LL + impl Foo<N type 3> for Bar {
-   | 
+   |             ^---- expected type, found keyword `type`
 
-error: expected one of `,`, `>`, a const expression, lifetime, or type, found keyword `type`
-  --> $DIR/issue-89013-type.rs:9:14
-   |
-LL | impl Foo<N = type 3> for Bar {
-   |              ^^^^ expected one of `,`, `>`, a const expression, lifetime, or type
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-type.stderr
@@ -1,0 +1,24 @@
+error: missing type to the right of `=`
+  --> $DIR/issue-89013-type.rs:9:13
+   |
+LL | impl Foo<N = type 3> for Bar {
+   |             ^
+   |
+help: to constrain the associated type, add a type after `=`
+   |
+LL | impl Foo<N = TheType type 3> for Bar {
+   |              +++++++
+help: remove the `=` if `N` is a type
+   |
+LL - impl Foo<N = type 3> for Bar {
+LL + impl Foo<N type 3> for Bar {
+   | 
+
+error: expected one of `,`, `>`, a const expression, lifetime, or type, found keyword `type`
+  --> $DIR/issue-89013-type.rs:9:14
+   |
+LL | impl Foo<N = type 3> for Bar {
+   |              ^^^^ expected one of `,`, `>`, a const expression, lifetime, or type
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
@@ -1,0 +1,19 @@
+trait Foo<const N: usize> {
+    fn do_x(&self) -> [u8; N];
+}
+
+struct Bar;
+
+const T: usize = 42;
+
+impl Foo<N = const 3> for Bar {
+//~^ERROR expected lifetime, type, or constant, found keyword `const`
+//~^^ERROR cannot constrain an associated constant to a value
+//~^^^ERROR this trait takes 1 generic argument but 0 generic arguments
+//~^^^^ERROR associated type bindings are not allowed here
+    fn do_x(&self) -> [u8; 3] {
+        [0u8; 3]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
@@ -7,10 +7,10 @@ struct Bar;
 const T: usize = 42;
 
 impl Foo<N = const 3> for Bar {
-//~^ERROR expected lifetime, type, or constant, found keyword `const`
-//~^^ERROR cannot constrain an associated constant to a value
-//~^^^ERROR this trait takes 1 generic argument but 0 generic arguments
-//~^^^^ERROR associated type bindings are not allowed here
+//~^ ERROR expected lifetime, type, or constant, found keyword `const`
+//~| ERROR cannot constrain an associated constant to a value
+//~| ERROR this trait takes 1 generic argument but 0 generic arguments
+//~| ERROR associated type bindings are not allowed here
     fn do_x(&self) -> [u8; 3] {
         [0u8; 3]
     }

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.rs
@@ -9,7 +9,6 @@ const T: usize = 42;
 impl Foo<N = const 3> for Bar {
 //~^ ERROR expected lifetime, type, or constant, found keyword `const`
 //~| ERROR cannot constrain an associated constant to a value
-//~| ERROR this trait takes 1 generic argument but 0 generic arguments
 //~| ERROR associated type bindings are not allowed here
     fn do_x(&self) -> [u8; 3] {
         [0u8; 3]

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -19,29 +19,12 @@ LL | impl Foo<N = const 3> for Bar {
    |          |         ...cannot be constrained to this value
    |          this associated constant...
 
-error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/issue-89013.rs:9:6
-   |
-LL | impl Foo<N = const 3> for Bar {
-   |      ^^^ expected 1 generic argument
-   |
-note: trait defined here, with 1 generic parameter: `N`
-  --> $DIR/issue-89013.rs:1:7
-   |
-LL | trait Foo<const N: usize> {
-   |       ^^^       -
-help: add missing generic argument
-   |
-LL | impl Foo<N, N = const 3> for Bar {
-   |          ++
-
 error[E0229]: associated type bindings are not allowed here
   --> $DIR/issue-89013.rs:9:10
    |
 LL | impl Foo<N = const 3> for Bar {
    |          ^^^^^^^^^^^ associated type not allowed here
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0107, E0229.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0229`.

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -1,0 +1,41 @@
+error: expected lifetime, type, or constant, found keyword `const`
+  --> $DIR/issue-89013.rs:9:14
+   |
+LL | impl Foo<N = const 3> for Bar {
+   |              ^^^^^
+
+error: cannot constrain an associated constant to a value
+  --> $DIR/issue-89013.rs:9:10
+   |
+LL | impl Foo<N = const 3> for Bar {
+   |          -^^^^^^^^^-
+   |          |         |
+   |          |         ...cannot be constrained to this value
+   |          this associated constant...
+
+error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/issue-89013.rs:9:6
+   |
+LL | impl Foo<N = const 3> for Bar {
+   |      ^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `N`
+  --> $DIR/issue-89013.rs:1:7
+   |
+LL | trait Foo<const N: usize> {
+   |       ^^^       -
+help: add missing generic argument
+   |
+LL | impl Foo<N, N = const 3> for Bar {
+   |          ++
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-89013.rs:9:10
+   |
+LL | impl Foo<N = const 3> for Bar {
+   |          ^^^^^^^^^^^ associated type not allowed here
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0229.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -3,6 +3,12 @@ error: expected lifetime, type, or constant, found keyword `const`
    |
 LL | impl Foo<N = const 3> for Bar {
    |              ^^^^^
+   |
+help: the `const` keyword is only needed in the definition of the type
+   |
+LL - impl Foo<N = const 3> for Bar {
+LL + impl Foo<N = 3> for Bar {
+   | 
 
 error: cannot constrain an associated constant to a value
   --> $DIR/issue-89013.rs:9:10


### PR DESCRIPTION
Fixes #89013