### PR TITLE
Introduce `Rvalue::ShallowInitBox`

### DIFF
--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -316,7 +316,8 @@ impl<'cx, 'tcx> InvalidationGenerator<'cx, 'tcx> {
             Rvalue::Use(ref operand)
             | Rvalue::Repeat(ref operand, _)
             | Rvalue::UnaryOp(_ /*un_op*/, ref operand)
-            | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/) => {
+            | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/)
+            | Rvalue::ShallowInitBox(ref operand, _ /*ty*/) => {
                 self.consume_operand(location, operand)
             }
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1361,7 +1361,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             Rvalue::Use(ref operand)
             | Rvalue::Repeat(ref operand, _)
             | Rvalue::UnaryOp(_ /*un_op*/, ref operand)
-            | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/) => {
+            | Rvalue::Cast(_ /*cast_kind*/, ref operand, _ /*ty*/)
+            | Rvalue::ShallowInitBox(ref operand, _ /*ty*/) => {
                 self.consume_operand(location, (operand, span), flow_state)
             }
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2018,13 +2018,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 }
             }
 
-            Rvalue::NullaryOp(_, ty) => {
-                // Even with unsized locals cannot box an unsized value.
-                if self.unsized_feature_enabled() {
-                    let span = body.source_info(location).span;
-                    self.ensure_place_sized(ty, span);
-                }
-
+            Rvalue::NullaryOp(_, ty) | Rvalue::ShallowInitBox(_, ty) => {
                 let trait_ref = ty::TraitRef {
                     def_id: tcx.require_lang_item(LangItem::Sized, Some(self.last_span)),
                     substs: tcx.mk_substs_trait(ty, &[]),
@@ -2357,6 +2351,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             | Rvalue::AddressOf(..)
             | Rvalue::Len(..)
             | Rvalue::Cast(..)
+            | Rvalue::ShallowInitBox(..)
             | Rvalue::BinaryOp(..)
             | Rvalue::CheckedBinaryOp(..)
             | Rvalue::NullaryOp(..)

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -701,6 +701,13 @@ fn codegen_stmt<'tcx>(
                     let len = codegen_array_len(fx, place);
                     lval.write_cvalue(fx, CValue::by_val(len, usize_layout));
                 }
+                Rvalue::ShallowInitBox(ref operand, content_ty) => {
+                    let content_ty = fx.monomorphize(content_ty);
+                    let box_layout = fx.layout_of(fx.tcx.mk_box(content_ty));
+                    let operand = codegen_operand(fx, operand);
+                    let operand = operand.load_scalar(fx);
+                    lval.write_cvalue(fx, CValue::by_val(operand, box_layout));
+                }
                 Rvalue::NullaryOp(NullOp::Box, content_ty) => {
                     let usize_type = fx.clif_type(fx.tcx.types.usize).unwrap();
                     let content_ty = fx.monomorphize(content_ty);

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -289,6 +289,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_scalar(Scalar::from_machine_usize(val, self), &dest)?;
             }
 
+            ShallowInitBox(ref operand, _) => {
+                let src = self.eval_operand(operand, None)?;
+                let v = self.read_immediate(&src)?;
+                self.write_immediate(*v, &dest)?;
+            }
+
             Cast(cast_kind, ref operand, cast_ty) => {
                 let src = self.eval_operand(operand, None)?;
                 let cast_ty = self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty);

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -650,6 +650,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
 
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => {}
             Rvalue::NullaryOp(NullOp::Box, _) => self.check_op(ops::HeapAllocation),
+            Rvalue::ShallowInitBox(_, _) => {}
 
             Rvalue::UnaryOp(_, ref operand) => {
                 let ty = operand.ty(self.body, self.tcx);

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -913,6 +913,11 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                     return;
                 }
 
+                if Some(callee) == tcx.lang_items().exchange_malloc_fn() {
+                    self.check_op(ops::HeapAllocation);
+                    return;
+                }
+
                 // `async` blocks get lowered to `std::future::from_generator(/* a closure */)`.
                 let is_async_block = Some(callee) == tcx.lang_items().from_generator_fn();
                 if is_async_block {

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -206,7 +206,8 @@ where
         Rvalue::Use(operand)
         | Rvalue::Repeat(operand, _)
         | Rvalue::UnaryOp(_, operand)
-        | Rvalue::Cast(_, operand, _) => in_operand::<Q, _>(cx, in_local, operand),
+        | Rvalue::Cast(_, operand, _)
+        | Rvalue::ShallowInitBox(operand, _) => in_operand::<Q, _>(cx, in_local, operand),
 
         Rvalue::BinaryOp(_, box (lhs, rhs)) | Rvalue::CheckedBinaryOp(_, box (lhs, rhs)) => {
             in_operand::<Q, _>(cx, in_local, lhs) || in_operand::<Q, _>(cx, in_local, rhs)

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -523,6 +523,8 @@ impl<'tcx> Validator<'_, 'tcx> {
                 NullOp::AlignOf => {}
             },
 
+            Rvalue::ShallowInitBox(_, _) => return Err(Unpromotable),
+
             Rvalue::UnaryOp(op, operand) => {
                 match op {
                     // These operations can never fail.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2200,6 +2200,12 @@ pub enum Rvalue<'tcx> {
     /// that `Foo` has a destructor. These rvalues can be optimized
     /// away after type-checking and before lowering.
     Aggregate(Box<AggregateKind<'tcx>>, Vec<Operand<'tcx>>),
+
+    /// Transmutes a `*mut u8` into shallow-initialized `Box<T>`.
+    ///
+    /// This is different a normal transmute because dataflow analysis will treat the box
+    /// as initialized but its content as uninitialized.
+    ShallowInitBox(Operand<'tcx>, Ty<'tcx>),
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
@@ -2449,6 +2455,10 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         }
                     }),
                 }
+            }
+
+            ShallowInitBox(ref place, ref ty) => {
+                write!(fmt, "ShallowInitBox({:?}, {:?})", place, ty)
             }
         }
     }

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -206,6 +206,7 @@ impl<'tcx> Rvalue<'tcx> {
                     tcx.mk_generator(did, substs, movability)
                 }
             },
+            Rvalue::ShallowInitBox(_, ty) => tcx.mk_box(ty),
         }
     }
 
@@ -214,7 +215,9 @@ impl<'tcx> Rvalue<'tcx> {
     /// whether its only shallowly initialized (`Rvalue::Box`).
     pub fn initialization_state(&self) -> RvalueInitializationState {
         match *self {
-            Rvalue::NullaryOp(NullOp::Box, _) => RvalueInitializationState::Shallow,
+            Rvalue::NullaryOp(NullOp::Box, _) | Rvalue::ShallowInitBox(_, _) => {
+                RvalueInitializationState::Shallow
+            }
             _ => RvalueInitializationState::Deep,
         }
     }

--- a/compiler/rustc_middle/src/mir/type_foldable.rs
+++ b/compiler/rustc_middle/src/mir/type_foldable.rs
@@ -210,6 +210,7 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
                 });
                 Aggregate(kind, fields.fold_with(folder))
             }
+            ShallowInitBox(op, ty) => ShallowInitBox(op.fold_with(folder), ty.fold_with(folder)),
         }
     }
 
@@ -254,6 +255,10 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
                     }
                 }
                 fields.visit_with(visitor)
+            }
+            ShallowInitBox(ref op, ty) => {
+                op.visit_with(visitor)?;
+                ty.visit_with(visitor)
             }
         }
     }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -753,6 +753,11 @@ macro_rules! make_mir_visitor {
                             self.visit_operand(operand, location);
                         }
                     }
+
+                    Rvalue::ShallowInitBox(operand, ty) => {
+                        self.visit_operand(operand, location);
+                        self.visit_ty(ty, TyContext::Location(location));
+                    }
                 }
             }
 

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -169,6 +169,7 @@ where
             }
 
             mir::Rvalue::Cast(..)
+            | mir::Rvalue::ShallowInitBox(..)
             | mir::Rvalue::Use(..)
             | mir::Rvalue::ThreadLocalRef(..)
             | mir::Rvalue::Repeat(..)

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -327,6 +327,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             Rvalue::Use(ref operand)
             | Rvalue::Repeat(ref operand, _)
             | Rvalue::Cast(_, ref operand, _)
+            | Rvalue::ShallowInitBox(ref operand, _)
             | Rvalue::UnaryOp(_, ref operand) => self.gather_operand(operand),
             Rvalue::BinaryOp(ref _binop, box (ref lhs, ref rhs))
             | Rvalue::CheckedBinaryOp(ref _binop, box (ref lhs, ref rhs)) => {

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -723,6 +723,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             | Rvalue::Repeat(..)
             | Rvalue::Len(..)
             | Rvalue::Cast(..)
+            | Rvalue::ShallowInitBox(..)
             | Rvalue::Discriminant(..)
             | Rvalue::NullaryOp(..) => {}
         }

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -967,6 +967,7 @@ impl<'tcx> Visitor<'tcx> for BorrowCollector {
             }
 
             Rvalue::Cast(..)
+            | Rvalue::ShallowInitBox(..)
             | Rvalue::Use(..)
             | Rvalue::Repeat(..)
             | Rvalue::Len(..)

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -204,6 +204,7 @@ fn is_likely_const<'tcx>(mut tracked_place: Place<'tcx>, block: &BasicBlockData<
                         | Rvalue::AddressOf(_, _)
                         | Rvalue::Cast(_, Operand::Constant(_), _)
                         | Rvalue::NullaryOp(_, _)
+                        | Rvalue::ShallowInitBox(_, _)
                         | Rvalue::UnaryOp(_, Operand::Constant(_)) => return true,
 
                         // These rvalues make things ambiguous
@@ -301,6 +302,7 @@ fn find_determining_place<'tcx>(
                     | Rvalue::ThreadLocalRef(_)
                     | Rvalue::AddressOf(_, _)
                     | Rvalue::NullaryOp(_, _)
+                    | Rvalue::ShallowInitBox(_, _)
                     | Rvalue::UnaryOp(_, Operand::Constant(_))
                     | Rvalue::Cast(_, Operand::Constant(_), _)
                     => return None,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -307,7 +307,6 @@ unsafe impl Allocator for Global {
 }
 
 /// The allocator for unique pointers.
-// This function must not unwind. If it does, MIR codegen will fail.
 #[cfg(all(not(no_global_oom_handling), not(test)))]
 #[lang = "exchange_malloc"]
 #[inline]

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -3,64 +3,78 @@
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/box_expr.rs:6:11: 6:11
     let _1: std::boxed::Box<S>;          // in scope 0 at $DIR/box_expr.rs:7:9: 7:10
-    let mut _2: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
-    let _3: ();                          // in scope 0 at $DIR/box_expr.rs:8:5: 8:12
-    let mut _4: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:8:10: 8:11
+    let mut _2: usize;                   // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
+    let mut _3: usize;                   // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
+    let mut _4: *mut u8;                 // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
+    let mut _5: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:7:13: 7:25
+    let _6: ();                          // in scope 0 at $DIR/box_expr.rs:8:5: 8:12
+    let mut _7: std::boxed::Box<S>;      // in scope 0 at $DIR/box_expr.rs:8:10: 8:11
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/box_expr.rs:7:9: 7:10
+    }
+    scope 2 {
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:7:9: 7:10
-        StorageLive(_2);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        _2 = Box(S);                     // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        (*_2) = S::new() -> [return: bb1, unwind: bb7]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
+        _2 = SizeOf(S);                  // scope 2 at $DIR/box_expr.rs:7:13: 7:25
+        _3 = AlignOf(S);                 // scope 2 at $DIR/box_expr.rs:7:13: 7:25
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/box_expr.rs:7:13: 7:25
+                                         // mir::Constant
+                                         // + span: $DIR/box_expr.rs:7:13: 7:25
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+    }
+
+    bb1: {
+        StorageLive(_5);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
+        _5 = ShallowInitBox(move _4, S); // scope 0 at $DIR/box_expr.rs:7:13: 7:25
+        (*_5) = S::new() -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:7:17: 7:23
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
-        _1 = move _2;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
-        drop(_2) -> bb2;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+    bb2: {
+        _1 = move _5;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
+        drop(_5) -> bb3;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
     }
 
-    bb2: {
-        StorageDead(_2);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
-        StorageLive(_3);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
-        StorageLive(_4);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _4 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
-        _3 = std::mem::drop::<Box<S>>(move _4) -> [return: bb3, unwind: bb5]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
+    bb3: {
+        StorageDead(_5);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+        StorageLive(_6);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
+        StorageLive(_7);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
+        _7 = move _1;                    // scope 1 at $DIR/box_expr.rs:8:10: 8:11
+        _6 = std::mem::drop::<Box<S>>(move _7) -> [return: bb4, unwind: bb6]; // scope 1 at $DIR/box_expr.rs:8:5: 8:12
                                          // mir::Constant
                                          // + span: $DIR/box_expr.rs:8:5: 8:9
                                          // + literal: Const { ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
-        StorageDead(_3);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
+    bb4: {
+        StorageDead(_7);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
+        StorageDead(_6);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
         _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
-        drop(_1) -> bb4;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        drop(_1) -> bb5;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
-    bb4: {
+    bb5: {
         StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
         return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
     }
 
-    bb5 (cleanup): {
-        drop(_4) -> bb6;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
-    }
-
     bb6 (cleanup): {
-        drop(_1) -> bb8;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
+        drop(_7) -> bb7;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
     }
 
     bb7 (cleanup): {
-        drop(_2) -> bb8;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+        drop(_1) -> bb9;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
     bb8 (cleanup): {
+        drop(_5) -> bb9;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
+    }
+
+    bb9 (cleanup): {
         resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
     }
 }

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -6,34 +6,51 @@
       let _1: i32;                         // in scope 0 at $DIR/boxes.rs:12:9: 12:10
       let mut _2: i32;                     // in scope 0 at $DIR/boxes.rs:12:13: 12:22
       let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:12:14: 12:22
-      let mut _4: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:12:14: 12:22
+      let mut _4: usize;                   // in scope 0 at $DIR/boxes.rs:12:14: 12:22
+      let mut _5: usize;                   // in scope 0 at $DIR/boxes.rs:12:14: 12:22
+      let mut _6: *mut u8;                 // in scope 0 at $DIR/boxes.rs:12:14: 12:22
+      let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/boxes.rs:12:14: 12:22
       scope 1 {
           debug x => _1;                   // in scope 1 at $DIR/boxes.rs:12:9: 12:10
+      }
+      scope 2 {
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/boxes.rs:12:9: 12:10
           StorageLive(_2);                 // scope 0 at $DIR/boxes.rs:12:13: 12:22
           StorageLive(_3);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          StorageLive(_4);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          _4 = Box(i32);                   // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          (*_4) = const 42_i32;            // scope 0 at $DIR/boxes.rs:12:19: 12:21
-          _3 = move _4;                    // scope 0 at $DIR/boxes.rs:12:14: 12:22
-          StorageDead(_4);                 // scope 0 at $DIR/boxes.rs:12:21: 12:22
-          _2 = (*_3);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
-          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
-          StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
-          drop(_3) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+-         _4 = SizeOf(i32);                // scope 2 at $DIR/boxes.rs:12:14: 12:22
+-         _5 = AlignOf(i32);               // scope 2 at $DIR/boxes.rs:12:14: 12:22
+-         _6 = alloc::alloc::exchange_malloc(move _4, move _5) -> bb1; // scope 2 at $DIR/boxes.rs:12:14: 12:22
++         _4 = const 4_usize;              // scope 2 at $DIR/boxes.rs:12:14: 12:22
++         _5 = const 4_usize;              // scope 2 at $DIR/boxes.rs:12:14: 12:22
++         _6 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> bb1; // scope 2 at $DIR/boxes.rs:12:14: 12:22
+                                           // mir::Constant
+                                           // + span: $DIR/boxes.rs:12:14: 12:22
+                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
+          StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
+          _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:12:14: 12:22
+          (*_7) = const 42_i32;            // scope 0 at $DIR/boxes.rs:12:19: 12:21
+          _3 = move _7;                    // scope 0 at $DIR/boxes.rs:12:14: 12:22
+          StorageDead(_7);                 // scope 0 at $DIR/boxes.rs:12:21: 12:22
+          _2 = (*_3);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
+          _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
+          StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
+          drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+      }
+  
+      bb2: {
           StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
           nop;                             // scope 0 at $DIR/boxes.rs:11:11: 13:2
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
       }
   
-      bb2 (cleanup): {
+      bb3 (cleanup): {
           resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
       }
   }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -4,23 +4,37 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:7:11: 7:11
       let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-      let mut _2: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _3: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-+     let mut _4: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++     let mut _7: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
       scope 1 {
           debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:8:9: 8:11
       }
-+     scope 2 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
+      scope 2 {
+      }
++     scope 3 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
 +     }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-          StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageLive(_4);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+                                           // mir::Constant
+                                           // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
+                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+-         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
@@ -30,32 +44,32 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb2: {
 +                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0_usize; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageDead(_4);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++         ((*_7).1: usize) = const 0_usize; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
           _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb2: {
-+     bb1: {
+-     bb3: {
++     bb2: {
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
--     bb3 (cleanup): {
-+     bb2 (cleanup): {
+-     bb4 (cleanup): {
++     bb3 (cleanup): {
           resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
--     bb4 (cleanup): {
--         _3 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_2.1: std::alloc::Global)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-     bb5 (cleanup): {
+-         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<std::vec::Vec<u32>, std::alloc::Global>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -4,23 +4,37 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-into-box-place.rs:7:11: 7:11
       let _1: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-      let mut _2: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-      let mut _3: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
-+     let mut _4: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+      let mut _2: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _3: usize;                   // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _4: *mut u8;                 // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _5: std::boxed::Box<std::vec::Vec<u32>>; // in scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+      let mut _6: ();                      // in scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++     let mut _7: &mut std::vec::Vec<u32>; // in scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
       scope 1 {
           debug _x => _1;                  // in scope 1 at $DIR/inline-into-box-place.rs:8:9: 8:11
       }
-+     scope 2 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
+      scope 2 {
+      }
++     scope 3 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
 +     }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
-          StorageLive(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          _2 = Box(std::vec::Vec<u32>);    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
--         (*_2) = Vec::<u32>::new() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageLive(_4);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         _4 = &mut (*_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_4).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
+                                           // mir::Constant
+                                           // + span: $DIR/inline-into-box-place.rs:8:29: 8:43
+                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+-         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // ty::Const
 +                                          // + ty: alloc::raw_vec::RawVec<u32>
 +                                          // + val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } })
@@ -30,32 +44,32 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb2: {
 +                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_4).1: usize) = const 0_usize; // scope 2 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         StorageDead(_4);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-          _1 = move _2;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
-          StorageDead(_2);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
++         ((*_7).1: usize) = const 0_usize; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
+          _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
+          StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
           _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb2: {
-+     bb1: {
+-     bb3: {
++     bb2: {
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
--     bb3 (cleanup): {
-+     bb2 (cleanup): {
+-     bb4 (cleanup): {
++     bb3 (cleanup): {
           resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
--     bb4 (cleanup): {
--         _3 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_2.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_2.1: std::alloc::Global)) -> bb3; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
+-     bb5 (cleanup): {
+-         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // + literal: Const { ty: unsafe fn(std::ptr::Unique<std::vec::Vec<u32>>, std::alloc::Global) {alloc::alloc::box_free::<std::vec::Vec<u32>, std::alloc::Global>}, val: Value(Scalar(<ZST>)) }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -3,106 +3,120 @@
 fn test() -> Option<Box<u32>> {
     let mut _0: std::option::Option<std::boxed::Box<u32>>; // return place in scope 0 at $DIR/issue-62289.rs:8:14: 8:30
     let mut _1: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _2: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-    let mut _3: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-    let mut _4: std::option::Option<u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-    let mut _5: isize;                   // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let _6: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let mut _7: !;                       // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let mut _8: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-    let _9: u32;                         // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+    let mut _2: usize;                   // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+    let mut _3: usize;                   // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+    let mut _4: *mut u8;                 // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+    let mut _5: std::boxed::Box<u32>;    // in scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+    let mut _6: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+    let mut _7: std::option::Option<u32>; // in scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+    let mut _8: isize;                   // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+    let _9: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+    let mut _10: !;                      // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+    let mut _11: std::option::Option<std::convert::Infallible>; // in scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+    let _12: u32;                        // in scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     scope 1 {
-        debug residual => _6;            // in scope 1 at $DIR/issue-62289.rs:9:19: 9:20
-        scope 2 {
+    }
+    scope 2 {
+        debug residual => _9;            // in scope 2 at $DIR/issue-62289.rs:9:19: 9:20
+        scope 3 {
         }
     }
-    scope 3 {
-        debug val => _9;                 // in scope 3 at $DIR/issue-62289.rs:9:15: 9:20
-        scope 4 {
+    scope 4 {
+        debug val => _12;                // in scope 4 at $DIR/issue-62289.rs:9:15: 9:20
+        scope 5 {
         }
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        StorageLive(_2);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        _2 = Box(u32);                   // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        StorageLive(_3);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        StorageLive(_4);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _4 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _3 = <Option<u32> as Try>::branch(move _4) -> [return: bb1, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        _2 = SizeOf(u32);                // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
+        _3 = AlignOf(u32);               // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
+        _4 = alloc::alloc::exchange_malloc(move _2, move _3) -> bb1; // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
+                                         // mir::Constant
+                                         // + span: $DIR/issue-62289.rs:9:10: 9:21
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+    }
+
+    bb1: {
+        StorageLive(_5);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+        _5 = ShallowInitBox(move _4, u32); // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+        StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageLive(_7);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+        _7 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+        _6 = <Option<u32> as Try>::branch(move _7) -> [return: bb2, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
                                          // + literal: Const { ty: fn(std::option::Option<u32>) -> std::ops::ControlFlow<<std::option::Option<u32> as std::ops::Try>::Residual, <std::option::Option<u32> as std::ops::Try>::Output> {<std::option::Option<u32> as std::ops::Try>::branch}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
-        StorageDead(_4);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _5 = discriminant(_3);           // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        switchInt(move _5) -> [0_isize: bb2, 1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-    }
-
     bb2: {
-        StorageLive(_9);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        _9 = ((_3 as Continue).0: u32);  // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
-        (*_2) = _9;                      // scope 4 at $DIR/issue-62289.rs:9:15: 9:20
-        StorageDead(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _1 = move _2;                    // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
-        drop(_2) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageDead(_7);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _8 = discriminant(_6);           // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
     bb3: {
-        unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageLive(_12);                // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        _12 = ((_6 as Continue).0: u32); // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+        (*_5) = _12;                     // scope 5 at $DIR/issue-62289.rs:9:15: 9:20
+        StorageDead(_12);                // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _1 = move _5;                    // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
+        drop(_5) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
     bb4: {
-        StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        _6 = ((_3 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        StorageLive(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _8 = _6;                         // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _8) -> [return: bb5, unwind: bb11]; // scope 2 at $DIR/issue-62289.rs:9:15: 9:20
+        unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
+    }
+
+    bb5: {
+        StorageLive(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        StorageLive(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
+        _11 = _9;                        // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
+        _0 = <Option<Box<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _11) -> [return: bb6, unwind: bb12]; // scope 3 at $DIR/issue-62289.rs:9:15: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:19: 9:20
                                          // + literal: Const { ty: fn(std::option::Option<std::convert::Infallible>) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
-        StorageDead(_8);                 // scope 2 at $DIR/issue-62289.rs:9:19: 9:20
-        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
-        drop(_2) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-    }
-
     bb6: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
-        drop(_1) -> bb7;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
+        StorageDead(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
+        drop(_5) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
     bb7: {
-        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb9;                     // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
     bb8: {
-        StorageDead(_2);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
         StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-        StorageDead(_3);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
-        goto -> bb9;                     // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
     bb9: {
+        StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
+        StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
+        goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
+    }
+
+    bb10: {
         return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
-    bb10 (cleanup): {
-        drop(_1) -> bb12;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
-    }
-
     bb11 (cleanup): {
-        drop(_2) -> bb12;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+        drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
     bb12 (cleanup): {
+        drop(_5) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
+    }
+
+    bb13 (cleanup): {
         resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -4,80 +4,108 @@ fn move_out_by_subslice() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:10:27: 10:27
     let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
     let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-    let mut _4: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-    let mut _5: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
     scope 1 {
         debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-        let _6: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
-        scope 2 {
-            debug _y => _6;              // in scope 2 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+        let _12: [std::boxed::Box<i32>; 2]; // in scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+        scope 4 {
+            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:12:10: 12:17
         }
+    }
+    scope 2 {
+    }
+    scope 3 {
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        StorageLive(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-        _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
-        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+                                         // mir::Constant
+                                         // + span: $DIR/uniform_array_move_out.rs:11:14: 11:19
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
-        StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-        _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
-        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
+        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
-        _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
-        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
+        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+                                         // mir::Constant
+                                         // + span: $DIR/uniform_array_move_out.rs:11:21: 11:26
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
+        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
     }
 
     bb4: {
-        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
-        StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
-        _6 = move _1[0..2];              // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
-        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:10:27: 13:2
-        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
+        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
+        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
     bb5: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
     bb6: {
+        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
+        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+        _12 = move _1[0..2];             // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
+        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:10:27: 13:2
+        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb7: {
+        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
+    }
+
+    bb8: {
         StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
         return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
     }
 
-    bb7 (cleanup): {
-        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
-    }
-
-    bb8 (cleanup): {
-        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
-    }
-
     bb9 (cleanup): {
-        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
     }
 
     bb10 (cleanup): {
+        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+    }
+
+    bb11 (cleanup): {
+        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
+    }
+
+    bb12 (cleanup): {
         resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -4,80 +4,108 @@ fn move_out_from_end() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/uniform_array_move_out.rs:4:24: 4:24
     let _1: [std::boxed::Box<i32>; 2];   // in scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
     let mut _2: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-    let mut _4: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-    let mut _5: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _3: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+    let mut _4: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+    let mut _5: *mut u8;                 // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+    let mut _6: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+    let mut _7: std::boxed::Box<i32>;    // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _8: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _9: usize;                   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _10: *mut u8;                // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+    let mut _11: std::boxed::Box<i32>;   // in scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
     scope 1 {
         debug a => _1;                   // in scope 1 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-        let _6: std::boxed::Box<i32>;    // in scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
-        scope 2 {
-            debug _y => _6;              // in scope 2 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+        let _12: std::boxed::Box<i32>;   // in scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+        scope 4 {
+            debug _y => _12;             // in scope 4 at $DIR/uniform_array_move_out.rs:6:14: 6:16
         }
+    }
+    scope 2 {
+    }
+    scope 3 {
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        StorageLive(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        _3 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        (*_3) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-        _2 = move _3;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
-        drop(_3) -> [return: bb1, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        _4 = AlignOf(i32);               // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12]; // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+                                         // mir::Constant
+                                         // + span: $DIR/uniform_array_move_out.rs:5:14: 5:19
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
-        StorageLive(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        StorageLive(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        _5 = Box(i32);                   // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        (*_5) = const 2_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-        _4 = move _5;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
-        drop(_5) -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        _2 = move _6;                    // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
+        drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
     }
 
     bb2: {
-        StorageDead(_5);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
-        _1 = [move _2, move _4];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
-        drop(_4) -> [return: bb3, unwind: bb9]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
+        StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        _9 = AlignOf(i32);               // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11]; // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+                                         // mir::Constant
+                                         // + span: $DIR/uniform_array_move_out.rs:5:21: 5:26
+                                         // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        drop(_2) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        _7 = move _11;                   // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
+        drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
     }
 
     bb4: {
-        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
-        StorageLive(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
-        _6 = move _1[1 of 2];            // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
-        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:4:24: 7:2
-        drop(_6) -> [return: bb5, unwind: bb7]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
+        _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
+        drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
     bb5: {
-        StorageDead(_6);                 // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-        drop(_1) -> [return: bb6, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
     bb6: {
+        StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
+        StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+        _12 = move _1[1 of 2];           // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
+        _0 = const ();                   // scope 0 at $DIR/uniform_array_move_out.rs:4:24: 7:2
+        drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb7: {
+        StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+        drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
+    }
+
+    bb8: {
         StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
         return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
     }
 
-    bb7 (cleanup): {
-        drop(_1) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
-    }
-
-    bb8 (cleanup): {
-        drop(_4) -> bb9;                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
-    }
-
     bb9 (cleanup): {
-        drop(_2) -> bb10;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+        drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
     }
 
     bb10 (cleanup): {
+        drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+    }
+
+    bb11 (cleanup): {
+        drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
+    }
+
+    bb12 (cleanup): {
         resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
     }
 }

--- a/src/test/ui/consts/miri_unleashed/box.rs
+++ b/src/test/ui/consts/miri_unleashed/box.rs
@@ -9,5 +9,5 @@ fn main() {}
 static TEST_BAD: &mut i32 = {
     &mut *(box 0)
     //~^ ERROR could not evaluate static initializer
-    //~| NOTE heap allocations
+    //~| NOTE calling non-const function `alloc::alloc::exchange_malloc`
 };

--- a/src/test/ui/consts/miri_unleashed/box.stderr
+++ b/src/test/ui/consts/miri_unleashed/box.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/box.rs:10:11
    |
 LL |     &mut *(box 0)
-   |           ^^^^^^^ "heap allocations via `box` keyword" needs an rfc before being allowed inside constants
+   |           ^^^^^^^ calling non-const function `alloc::alloc::exchange_malloc`
 
 warning: skipping const checks
    |

--- a/src/test/ui/nll/issue-52663-trait-object.stderr
+++ b/src/test/ui/nll/issue-52663-trait-object.stderr
@@ -4,7 +4,7 @@ error[E0597]: `tmp0` does not live long enough
 LL |         let tmp1 = &tmp0;
    |                    ^^^^^ borrowed value does not live long enough
 LL |         box tmp1 as Box<dyn Foo + '_>
-   |         ----------------------------- borrow later captured here by trait object
+   |         ----------------------------- borrow later used here
 LL |     };
    |     - `tmp0` dropped here while still borrowed
 

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -194,6 +194,7 @@ fn check_rvalue(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, def_id: DefId, rvalue: &Rv
         },
         Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => Ok(()),
         Rvalue::NullaryOp(NullOp::Box, _) => Err((span, "heap allocations are not allowed in const fn".into())),
+        Rvalue::ShallowInitBox(_, _) => Ok(()),
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, tcx);
             if ty.is_integral() || ty.is_bool() {


### PR DESCRIPTION
Polished version of #88700.

Implements MCP rust-lang/compiler-team#460, and should allow #43596 to go forward.

In short, creating an empty box is split from a nullary-op `NullOp::Box` into two steps, first a call to `exchange_malloc`, then a `Rvalue::ShallowInitBox` which transmutes `*mut u8` to a shallow-initialized `Box<T>`. This allows the `exchange_malloc` call to unwind. Details can be found in the MCP.

`NullOp::Box` is not yet removed, purely to make reverting easier in case anything goes wrong as the result of this PR. If revert is needed a reversion of "Use Rvalue::ShallowInitBox for box expression" commit followed by a test bless should be sufficient.

Experiments in #88700 showed a very slight compile-time perf regression due to (supposedly) slightly more time spent in LLVM. We could omit unwind edge generation (in non-`oom=panic` case) in box expression MIR construction to restore perf; but I don't think it's necessary since runtime perf isn't affected and perf difference is rather small.