### PR TITLE
refactor: VecDeques Drain fields to private

### DIFF
--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -18,10 +18,21 @@ pub struct Drain<
     T: 'a,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
-    pub(crate) after_tail: usize,
-    pub(crate) after_head: usize,
-    pub(crate) iter: Iter<'a, T>,
-    pub(crate) deque: NonNull<VecDeque<T, A>>,
+    after_tail: usize,
+    after_head: usize,
+    iter: Iter<'a, T>,
+    deque: NonNull<VecDeque<T, A>>,
+}
+
+impl<'a, T, A: Allocator> Drain<'a, T, A> {
+    pub(super) unsafe fn new(
+        after_tail: usize,
+        after_head: usize,
+        iter: Iter<'a, T>,
+        deque: NonNull<VecDeque<T, A>>,
+    ) -> Self {
+        Drain { after_tail, after_head, iter, deque }
+    }
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1269,19 +1269,17 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // the drain is complete and the Drain destructor is run.
         self.head = drain_tail;
 
-        Drain {
-            deque: NonNull::from(&mut *self),
-            after_tail: drain_head,
-            after_head: head,
-            iter: Iter {
-                tail: drain_tail,
-                head: drain_head,
-                // Crucially, we only create shared references from `self` here and read from
-                // it.  We do not write to `self` nor reborrow to a mutable reference.
-                // Hence the raw pointer we created above, for `deque`, remains valid.
-                ring: unsafe { self.buffer_as_slice() },
-            },
-        }
+        let deque = NonNull::from(&mut *self);
+        let iter = Iter {
+            tail: drain_tail,
+            head: drain_head,
+            // Crucially, we only create shared references from `self` here and read from
+            // it.  We do not write to `self` nor reborrow to a mutable reference.
+            // Hence the raw pointer we created above, for `deque`, remains valid.
+            ring: unsafe { self.buffer_as_slice() },
+        };
+
+        unsafe { Drain::new(drain_head, head, iter, deque) }
     }
 
     /// Clears the `VecDeque`, removing all values.


### PR DESCRIPTION
Made the fields of VecDeque's Drain private by creating a Drain::new(...) function to create a new instance of Drain and migrating usage to use Drain::new(...).