### PR TITLE
make member constraints pick static if no upper bounds

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -717,11 +717,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // free region that must outlive the member region `R0` (`UB:
         // R0`). Therefore, we need only keep an option `O` if `UB: O`
         // for all UB.
+        let fr_static = self.universal_regions.fr_static;
         let rev_scc_graph = self.reverse_scc_graph();
         let universal_region_relations = &self.universal_region_relations;
-        for ub in rev_scc_graph.upper_bounds(scc) {
+        let mut any_upper_bounds = false;
+        for ub in rev_scc_graph.upper_bounds(scc).filter(|ub| *ub != fr_static) {
             debug!("apply_member_constraint: ub={:?}", ub);
             choice_regions.retain(|&o_r| universal_region_relations.outlives(ub, o_r));
+            any_upper_bounds = true;
         }
         debug!("apply_member_constraint: after ub, choice_regions={:?}", choice_regions);
 
@@ -730,46 +733,50 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             return false;
         }
 
-        // Otherwise, we need to find the minimum remaining choice, if
-        // any, and take that.
-        debug!("apply_member_constraint: choice_regions remaining are {:#?}", choice_regions);
-        let min = |r1: ty::RegionVid, r2: ty::RegionVid| -> Option<ty::RegionVid> {
-            let r1_outlives_r2 = self.universal_region_relations.outlives(r1, r2);
-            let r2_outlives_r1 = self.universal_region_relations.outlives(r2, r1);
-            match (r1_outlives_r2, r2_outlives_r1) {
-                (true, true) => Some(r1.min(r2)),
-                (true, false) => Some(r2),
-                (false, true) => Some(r1),
-                (false, false) => None,
-            }
-        };
-        let mut min_choice = choice_regions[0];
-        for &other_option in &choice_regions[1..] {
-            debug!(
-                "apply_member_constraint: min_choice={:?} other_option={:?}",
-                min_choice, other_option,
-            );
-            match min(min_choice, other_option) {
-                Some(m) => min_choice = m,
-                None => {
-                    debug!(
-                        "apply_member_constraint: {:?} and {:?} are incomparable; no min choice",
-                        min_choice, other_option,
-                    );
-                    return false;
+        // If there WERE no upper bounds (apart from static), and static is one of the options,
+        // then we can just pick that (c.f. #63033).
+        let choice = if !any_upper_bounds && choice_regions.contains(&fr_static) {
+            fr_static
+        } else {
+            // Otherwise, we need to find the minimum remaining choice, if
+            // any, and take that.
+            debug!("apply_member_constraint: choice_regions remaining are {:#?}", choice_regions);
+            let min = |r1: ty::RegionVid, r2: ty::RegionVid| -> Option<ty::RegionVid> {
+                let r1_outlives_r2 = self.universal_region_relations.outlives(r1, r2);
+                let r2_outlives_r1 = self.universal_region_relations.outlives(r2, r1);
+                match (r1_outlives_r2, r2_outlives_r1) {
+                    (true, true) => Some(r1.min(r2)),
+                    (true, false) => Some(r2),
+                    (false, true) => Some(r1),
+                    (false, false) => None,
+                }
+            };
+            let mut min_choice = choice_regions[0];
+            for &other_option in &choice_regions[1..] {
+                debug!(
+                    "apply_member_constraint: min_choice={:?} other_option={:?}",
+                    min_choice, other_option,
+                );
+                match min(min_choice, other_option) {
+                    Some(m) => min_choice = m,
+                    None => {
+                        debug!(
+                            "apply_member_constraint: {:?} and {:?} are incomparable; no min choice",
+                            min_choice, other_option,
+                        );
+                        return false;
+                    }
                 }
             }
-        }
+            min_choice
+        };
 
-        let min_choice_scc = self.constraint_sccs.scc(min_choice);
-        debug!(
-            "apply_member_constraint: min_choice={:?} best_choice_scc={:?}",
-            min_choice, min_choice_scc,
-        );
-        if self.scc_values.add_region(scc, min_choice_scc) {
+        let choice_scc = self.constraint_sccs.scc(choice);
+        debug!("apply_member_constraint: min_choice={:?} best_choice_scc={:?}", choice, choice_scc,);
+        if self.scc_values.add_region(scc, choice_scc) {
             self.member_constraints_applied.push(AppliedMemberConstraint {
                 member_region_scc: scc,
-                min_choice,
+                min_choice: choice,
                 member_constraint_index,
             });
 

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -473,8 +473,9 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         }
 
         let fr_fn_body = self.infcx.next_nll_region_var(FR).to_region_vid();
-        let num_universals = self.infcx.num_region_vars();
+        debug!("build: fr_fn_Body = {:?}", fr_fn_body);
 
+        let num_universals = self.infcx.num_region_vars();
         debug!("build: global regions = {}..{}", FIRST_GLOBAL_INDEX, first_extern_index);
         debug!("build: extern regions = {}..{}", first_extern_index, first_local_index);
         debug!("build: local regions  = {}..{}", first_local_index, num_universals);

--- a/src/test/ui/async-await/multiple-lifetimes/two-refs-and-a-dyn.rs
+++ b/src/test/ui/async-await/multiple-lifetimes/two-refs-and-a-dyn.rs
@@ -1,0 +1,20 @@
+// Regression test for #63033. The scenario here is:
+//
+// - The returned future captures the `Box<dyn T>`, which is shorthand for `Box<dyn T + 'static>`.
+// - The actual value that gets captured is `Box<dyn T + '?0>` where `'static: '?0`
+// - We generate a member constraint `'?0 member ['a, 'b, 'static]`
+// - None of those regions are a "least choice", so we got stuck
+//
+// After the fix, we now select `'static` in cases where there are no upper bounds (apart from
+// 'static).
+//
+// edition:2018
+// check-pass
+
+#![allow(dead_code)]
+trait T {}
+struct S;
+impl S {
+    async fn f<'a, 'b>(_a: &'a S, _b: &'b S, _c: Box<dyn T>) {}
+}
+fn main() {}

--- a/src/test/ui/async-await/multiple-lifetimes/two-refs-and-a-static.rs
+++ b/src/test/ui/async-await/multiple-lifetimes/two-refs-and-a-static.rs
@@ -1,0 +1,16 @@
+// Regression test for #63033. The scenario here is:
+//
+// - The returned future captures the &'static String`
+// - The actual value that gets captured is `&'?0 String` where `'static: '?0`
+// - We generate a member constraint `'?0 member ['a, 'b, 'static]`
+// - None of those regions are a "least choice", so we got stuck
+//
+// After the fix, we now select `'static` in cases where there are no upper bounds (apart from
+// 'static).
+//
+// edition:2018
+// check-pass
+
+async fn test<'a, 'b>(test: &'a String, test2: &'b String, test3: &'static String) {}
+
+fn main() {}

--- a/src/test/ui/upper-bound-from-type-param.rs
+++ b/src/test/ui/upper-bound-from-type-param.rs
@@ -1,0 +1,19 @@
+// Regression test found by crater run. The scenario here is that we have
+// a region variable `?0` from the `impl Future` with no upper bounds
+// and a member constraint of `?0 in ['a, 'static]`. If we pick `'static`,
+// however, we then fail the check that `F: ?0` (since we only know that
+// F: ?a). The problem here is that our upper bound detection
+// doesn't consider "type tests" like `F: 'x`. This was fixed by
+// preferring to pick a least choice and only using static as a last resort.
+//
+// edition:2018
+// check-pass
+
+trait Future {}
+impl Future for () {}
+
+fn sink_error1<'a, F: 'a>(f: F) -> impl Future + 'a {
+    sink_error2(f) // error: `F` may not live long enough
+}
+fn sink_error2<'a, F: 'a>(_: F) -> impl Future + 'a {}
+fn main() {}


### PR DESCRIPTION
The current member constraint algorithm has a failure mode when it encounters a
variable `'0` and the only constraint is that `':static: '0`. In that case,
there are no upper bounds, or at least no non-trivial upper bounds.  As a
result, we are not able to rule out any of the choices, so if you have a
constraint like `'0 member ['a, 'b, 'static]`, where `'a` and `'b` are
unrelated, then the algorithm gets stuck as there is no 'least choice' from
that set.

The tweak in this commit changes the algorithm so that *if* there are no upper
bounds (and hence `'0` can get as large as desired without creating a region
check error), it will just pick `'static`. This should only occur in cases
where the data is flowing out from a `'static` value.

This change is probably *not* right for impl Trait in let bindings, but those
are challenging with member constraints anyway, and not currently supported.
Furthermore, this change is not needed in a polonius-like formulation, which
effectively permits "ad-hoc intersections" of lifetimes as the value for a
region, and hence could give a value like `'a ^ 'b` as the resulting lifetime.
Therefore I think there isn't forwards compat danger here. (famous last words?)

r? @lqd 
cc @tmandry @eholk @jackh726 @pnkfelix 

I was thinking it might be nice to schedule a recorded zoom session to talk over this PR and how this bit of the code works, as I imagine it has a ... low bus factor. =)

Fixes #63033 