### PR TITLE
[WIP] cstore: Add a new caching layer for data decoded from resolver

### DIFF
--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -179,6 +179,7 @@ impl<'tcx> Queries<'tcx> {
                 self.codegen_backend().metadata_loader(),
                 &krate,
                 &crate_name,
+                &self.arena as *const _ as usize,
             );
             let krate = resolver.access(|resolver| {
                 passes::configure_and_expand(&sess, &lint_store, krate, &crate_name, resolver)

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -205,7 +205,7 @@ fn get_or_insert_with<K: Idx, V>(
     k: K,
     v: impl FnOnce() -> V,
 ) -> &V {
-    // cache.ensure_contains_elem(k, || None);
+    cache.ensure_contains_elem(k, || None);
     match &mut cache[k] {
         entry @ None => {
             *entry = Some(v());
@@ -2049,8 +2049,8 @@ impl CrateMetadata {
         // Pre-decode the DefPathHash->DefIndex table. This is a cheap operation
         // that does not copy any data. It just does some data verification.
         let def_path_hash_map = root.def_path_hash_map.decode(&blob);
-        let num_def_ids = root.tables.def_keys.size();
-        let num_quoted_spans = root.tables.proc_macro_quoted_spans.size();
+        // let num_def_ids = root.tables.def_keys.size();
+        // let num_quoted_spans = root.tables.proc_macro_quoted_spans.size();
 
         CrateMetadata {
             blob,
@@ -2072,30 +2072,30 @@ impl CrateMetadata {
             hygiene_context: Default::default(),
             def_key_cache: Default::default(),
             def_path_hash_cache: Default::default(),
-            // struct_field_names: Default::default(),
-            // struct_field_visibilities: Default::default(),
-            // ctor_def_ids_and_kinds: Default::default(),
-            // visibilities: Default::default(),
-            // item_children: Default::default(),
-            // associated_items: Default::default(),
-            // spans: Default::default(),
-            // def_kinds: Default::default(),
-            // generics: Default::default(),
-            // module_expansions: Default::default(),
-            // proc_macro_quoted_spans: Default::default(),
-            // item_attrs: Default::default(),
-            struct_field_names: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            struct_field_visibilities: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            ctor_def_ids_and_kinds: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            visibilities: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            item_children: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            associated_items: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            spans: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            def_kinds: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            generics: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            module_expansions: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
-            proc_macro_quoted_spans: Lock::new(IndexVec::from_elem_n(None, num_quoted_spans)),
-            item_attrs: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            struct_field_names: Default::default(),
+            struct_field_visibilities: Default::default(),
+            ctor_def_ids_and_kinds: Default::default(),
+            visibilities: Default::default(),
+            item_children: Default::default(),
+            associated_items: Default::default(),
+            spans: Default::default(),
+            def_kinds: Default::default(),
+            generics: Default::default(),
+            module_expansions: Default::default(),
+            proc_macro_quoted_spans: Default::default(),
+            item_attrs: Default::default(),
+            // struct_field_names: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // struct_field_visibilities: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // ctor_def_ids_and_kinds: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // visibilities: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // item_children: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // associated_items: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // spans: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // def_kinds: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // generics: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // module_expansions: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
+            // proc_macro_quoted_spans: Lock::new(IndexVec::from_elem_n(None, num_quoted_spans)),
+            // item_attrs: Lock::new(IndexVec::from_elem_n(None, num_def_ids)),
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -151,9 +151,9 @@ crate struct CrateMetadata {
     item_attrs: Cache<DefIndex, Vec<ast::Attribute>>,
 }
 
+type Cache<K, V> = Lock<FxHashMap<K, V>>;
 #[allow(dead_code)]
-type CacheOld<K, V> = Lock<FxHashMap<K, V>>;
-type Cache<K, V> = Lock<IndexVec<K, Option<V>>>;
+type CacheIndexVec<K, V> = Lock<IndexVec<K, Option<V>>>;
 
 /// Holds information about a rustc_span::SourceFile imported from another crate.
 /// See `imported_source_files()` for more information.
@@ -182,8 +182,7 @@ pub(super) struct DecodeContext<'a, 'tcx> {
     alloc_decoding_session: Option<AllocDecodingSession<'a>>,
 }
 
-#[allow(dead_code)]
-fn get_or_insert_with_old<K: Eq + Hash, V>(
+fn get_or_insert_with<K: Eq + Hash, V>(
     cache: &mut FxHashMap<K, V>,
     k: K,
     v: impl FnOnce() -> V,
@@ -191,8 +190,7 @@ fn get_or_insert_with_old<K: Eq + Hash, V>(
     cache.entry(k).or_insert_with(v)
 }
 
-#[allow(dead_code)]
-fn steal_or_create_with_old<K: Eq + Hash, V>(
+fn steal_or_create_with<K: Eq + Hash, V>(
     cache: &mut FxHashMap<K, V>,
     k: K,
     v: impl FnOnce() -> V,
@@ -200,7 +198,8 @@ fn steal_or_create_with_old<K: Eq + Hash, V>(
     cache.remove(&k).unwrap_or_else(v)
 }
 
-fn get_or_insert_with<K: Idx, V>(
+#[allow(dead_code)]
+fn get_or_insert_with_index_vec<K: Idx, V>(
     cache: &mut IndexVec<K, Option<V>>,
     k: K,
     v: impl FnOnce() -> V,
@@ -215,7 +214,8 @@ fn get_or_insert_with<K: Idx, V>(
     }
 }
 
-fn steal_or_create_with<K: Idx, V>(
+#[allow(dead_code)]
+fn steal_or_create_with_index_vec<K: Idx, V>(
     cache: &mut IndexVec<K, Option<V>>,
     k: K,
     v: impl FnOnce() -> V,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -978,6 +978,8 @@ impl<'tcx> Deref for TyCtxt<'tcx> {
     }
 }
 
+pub type TcxArena<'tcx> = &'tcx WorkerLocal<Arena<'tcx>>;
+
 pub struct GlobalCtxt<'tcx> {
     pub arena: &'tcx WorkerLocal<Arena<'tcx>>,
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -65,7 +65,7 @@ pub use self::consts::{Const, ConstInt, ConstKind, InferConst, ScalarInt, Uneval
 pub use self::context::{
     tls, CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
     CtxtInterners, DelaySpanBugEmitted, FreeRegionInfo, GeneratorInteriorTypeCause, GlobalCtxt,
-    Lift, OnDiskCache, TyCtxt, TypeckResults, UserType, UserTypeAnnotationIndex,
+    Lift, OnDiskCache, TcxArena, TyCtxt, TypeckResults, UserType, UserTypeAnnotationIndex,
 };
 pub use self::instance::{Instance, InstanceDef};
 pub use self::list::List;

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -3391,12 +3391,12 @@ impl<'a> Resolver<'a> {
                     return None;
                 }
 
+                // The lookup is cached to avoid parsing attributes for an item multiple times.
                 if let Some(v) = self.legacy_const_generic_args.get(&def_id) {
                     return v.clone();
                 }
 
-                let parse_attrs = || {
-                    let attrs = self.cstore().item_attrs_untracked(def_id, self.session);
+                let ret = self.cstore().item_attrs_untracked(def_id, self.session, |attrs| {
                     let attr =
                         attrs.iter().find(|a| a.has_name(sym::rustc_legacy_const_generics))?;
                     let mut ret = vec![];
@@ -3409,11 +3409,7 @@ impl<'a> Resolver<'a> {
                         }
                     }
                     Some(ret)
-                };
-
-                // Cache the lookup to avoid parsing attributes for an iterm
-                // multiple times.
-                let ret = parse_attrs();
+                });
                 self.legacy_const_generic_args.insert(def_id, ret.clone());
                 return ret;
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -3396,7 +3396,7 @@ impl<'a> Resolver<'a> {
                 }
 
                 let parse_attrs = || {
-                    let attrs = self.cstore().item_attrs(def_id, self.session);
+                    let attrs = self.cstore().item_attrs_untracked(def_id, self.session);
                     let attr =
                         attrs.iter().find(|a| a.has_name(sym::rustc_legacy_const_generics))?;
                     let mut ret = vec![];

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -179,7 +179,7 @@ crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) 
     let fqn = if let ItemType::Macro = kind {
         // Check to see if it is a macro 2.0 or built-in macro
         if matches!(
-            CStore::from_tcx(cx.tcx).load_macro_untracked(did, cx.sess()),
+            CStore::from_tcx(cx.tcx).load_macro_untracked(did, cx.sess(), cx.tcx.arena),
             LoadedMacro::MacroDef(def, _)
                 if matches!(&def.kind, ast::ItemKind::MacroDef(ast_def)
                     if !ast_def.macro_rules)
@@ -556,7 +556,7 @@ fn build_macro(
     name: Symbol,
     import_def_id: Option<DefId>,
 ) -> clean::ItemKind {
-    match CStore::from_tcx(cx.tcx).load_macro_untracked(def_id, cx.sess()) {
+    match CStore::from_tcx(cx.tcx).load_macro_untracked(def_id, cx.sess(), cx.tcx.arena) {
         LoadedMacro::MacroDef(item_def, _) => {
             if let ast::ItemKind::MacroDef(ref def) = item_def.kind {
                 clean::MacroItem(clean::Macro {


### PR DESCRIPTION
Implement something to address https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.22Querifying.22.20early.20cstore.20accesses/near/253737343

One obvious further optimization would be to use some kind of arena to avoid cloning heavy decoded data like vectors.