### PR TITLE
Allow marker traits as additional traits on trait objects.

### DIFF
--- a/src/test/ui/associated-types/issue-22560.stderr
+++ b/src/test/ui/associated-types/issue-22560.stderr
@@ -24,13 +24,13 @@ LL |   type Test = dyn Add + Sub;
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/issue-22560.rs:9:23
    |
 LL | type Test = dyn Add + Sub;
-   |                 ---   ^^^ additional non-auto trait
+   |                 ---   ^^^ additional non-auto or marker trait
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<[type error]> + Sub<[type error]> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>

--- a/src/test/ui/associated-types/missing-associated-types.rs
+++ b/src/test/ui/associated-types/missing-associated-types.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 trait X<Rhs>: Mul<Rhs> + Div<Rhs> {}
 trait Y<Rhs>: Div<Rhs, Output = Rhs> {
     type A;
@@ -10,16 +10,16 @@ trait Z<Rhs>: Div<Rhs> {
 trait Fine<Rhs>: Div<Rhs, Output = Rhs> {}
 
 type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 //~| ERROR the value of the associated types
 type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 //~| ERROR the value of the associated types
 type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 //~| ERROR the value of the associated types
 type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 //~| ERROR the value of the associated types
 type Bal<Rhs> = dyn X<Rhs>;
 //~^ ERROR the value of the associated types

--- a/src/test/ui/associated-types/missing-associated-types.stderr
+++ b/src/test/ui/associated-types/missing-associated-types.stderr
@@ -1,10 +1,10 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/missing-associated-types.rs:12:32
    |
 LL | type Foo<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs>;
-   |                     --------   ^^^^^^^^ additional non-auto trait
+   |                     --------   ^^^^^^^^ additional non-auto or marker trait
    |                     |
-   |                     first non-auto trait
+   |                     first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
@@ -27,13 +27,13 @@ help: specify the associated types
 LL | type Foo<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + X<Rhs, Output = Type> + Y<Rhs, A = Type>;
    |                     ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/missing-associated-types.rs:15:32
    |
 LL | type Bar<Rhs> = dyn Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs>;
-   |                     --------   ^^^^^^^^ additional non-auto trait
+   |                     --------   ^^^^^^^^ additional non-auto or marker trait
    |                     |
-   |                     first non-auto trait
+   |                     first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + X<Rhs> + Z<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
@@ -63,13 +63,13 @@ help: specify the associated types
 LL | type Bar<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + X<Rhs> + Z<Rhs, A = Type, B = Type, Output = Type>;
    |                     ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/missing-associated-types.rs:18:32
    |
 LL | type Baz<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Y<Rhs>;
-   |                     --------   ^^^^^^^^ additional non-auto trait
+   |                     --------   ^^^^^^^^ additional non-auto or marker trait
    |                     |
-   |                     first non-auto trait
+   |                     first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Y<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
@@ -91,13 +91,13 @@ help: specify the associated types
 LL | type Baz<Rhs> = dyn Add<Rhs, Output = Type> + Sub<Rhs, Output = Type> + Y<Rhs, A = Type>;
    |                     ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/missing-associated-types.rs:21:32
    |
 LL | type Bat<Rhs> = dyn Add<Rhs> + Sub<Rhs> + Fine<Rhs>;
-   |                     --------   ^^^^^^^^ additional non-auto trait
+   |                     --------   ^^^^^^^^ additional non-auto or marker trait
    |                     |
-   |                     first non-auto trait
+   |                     first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Add<Rhs> + Sub<Rhs> + Fine<Rhs> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>

--- a/src/test/ui/error-codes/E0225.rs
+++ b/src/test/ui/error-codes/E0225.rs
@@ -4,7 +4,7 @@ trait Foo = std::io::Read + std::io::Write;
 
 fn main() {
     let _: Box<dyn std::io::Read + std::io::Write>;
-    //~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+    //~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
     let _: Box<dyn Foo>;
-    //~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+    //~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 }

--- a/src/test/ui/error-codes/E0225.stderr
+++ b/src/test/ui/error-codes/E0225.stderr
@@ -1,21 +1,21 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/E0225.rs:6:36
    |
 LL |     let _: Box<dyn std::io::Read + std::io::Write>;
-   |                    -------------   ^^^^^^^^^^^^^^ additional non-auto trait
+   |                    -------------   ^^^^^^^^^^^^^^ additional non-auto or marker trait
    |                    |
-   |                    first non-auto trait
+   |                    first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: std::io::Read + std::io::Write {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/E0225.rs:8:20
    |
 LL | trait Foo = std::io::Read + std::io::Write;
-   |             -------------   -------------- additional non-auto trait
+   |             -------------   -------------- additional non-auto or marker trait
    |             |
-   |             first non-auto trait
+   |             first non-auto or marker trait
 ...
 LL |     let _: Box<dyn Foo>;
    |                    ^^^

--- a/src/test/ui/issues/issue-32963.rs
+++ b/src/test/ui/issues/issue-32963.rs
@@ -2,11 +2,13 @@ use std::mem;
 
 trait Misc {}
 
-fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
+fn size_of_copy<T: Copy + ?Sized>() -> usize {
+    mem::size_of::<T>()
+}
 
 fn main() {
     size_of_copy::<dyn Misc + Copy>();
-    //~^ ERROR only auto traits can be used as additional traits in a trait object
-    //~| ERROR only auto traits can be used as additional traits in a trait object
+    //~^ ERROR only auto and marker traits can be used as additional traits in a trait object
+    //~| ERROR only auto and marker traits can be used as additional traits in a trait object
     //~| ERROR the trait bound `dyn Misc: Copy` is not satisfied
 }

--- a/src/test/ui/issues/issue-32963.stderr
+++ b/src/test/ui/issues/issue-32963.stderr
@@ -1,27 +1,27 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
-  --> $DIR/issue-32963.rs:8:31
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
+  --> $DIR/issue-32963.rs:10:31
    |
 LL |     size_of_copy::<dyn Misc + Copy>();
-   |                        ----   ^^^^ additional non-auto trait
+   |                        ----   ^^^^ additional non-auto or marker trait
    |                        |
-   |                        first non-auto trait
+   |                        first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Misc + Copy {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
-  --> $DIR/issue-32963.rs:8:31
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
+  --> $DIR/issue-32963.rs:10:31
    |
 LL |     size_of_copy::<dyn Misc + Copy>();
-   |                        ----   ^^^^ additional non-auto trait
+   |                        ----   ^^^^ additional non-auto or marker trait
    |                        |
-   |                        first non-auto trait
+   |                        first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Misc + Copy {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
 error[E0277]: the trait bound `dyn Misc: Copy` is not satisfied
-  --> $DIR/issue-32963.rs:8:5
+  --> $DIR/issue-32963.rs:10:5
    |
 LL |     size_of_copy::<dyn Misc + Copy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `dyn Misc`
@@ -29,7 +29,7 @@ LL |     size_of_copy::<dyn Misc + Copy>();
 note: required by a bound in `size_of_copy`
   --> $DIR/issue-32963.rs:5:20
    |
-LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
+LL | fn size_of_copy<T: Copy + ?Sized>() -> usize {
    |                    ^^^^ required by this bound in `size_of_copy`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/marker_trait_attr/marker-trait-on-trait-object.rs
+++ b/src/test/ui/marker_trait_attr/marker-trait-on-trait-object.rs
@@ -1,0 +1,11 @@
+// check-pass
+
+#![feature(marker_trait_attr)]
+
+trait NonMarker {}
+#[marker]
+trait Marker {}
+
+fn main() {
+    let _: &(dyn NonMarker + Marker);
+}

--- a/src/test/ui/parser/trait-object-delimiters.rs
+++ b/src/test/ui/parser/trait-object-delimiters.rs
@@ -1,7 +1,7 @@
 // edition:2018
 
 fn foo1(_: &dyn Drop + AsRef<str>) {} //~ ERROR ambiguous `+` in a type
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 
 fn foo2(_: &dyn (Drop + AsRef<str>)) {} //~ ERROR incorrect braces around trait bounds
 
@@ -12,6 +12,6 @@ fn foo3(_: &dyn {Drop + AsRef<str>}) {} //~ ERROR expected parameter name, found
 fn foo4(_: &dyn <Drop + AsRef<str>>) {} //~ ERROR expected identifier, found `<`
 
 fn foo5(_: &(dyn Drop + dyn AsRef<str>)) {} //~ ERROR invalid `dyn` keyword
-//~^ ERROR only auto traits can be used as additional traits in a trait object
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object
 
 fn main() {}

--- a/src/test/ui/parser/trait-object-delimiters.stderr
+++ b/src/test/ui/parser/trait-object-delimiters.stderr
@@ -44,13 +44,13 @@ LL | fn foo5(_: &(dyn Drop + dyn AsRef<str>)) {}
    |
    = help: `dyn` is only needed at the start of a trait `+`-separated list
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/trait-object-delimiters.rs:3:24
    |
 LL | fn foo1(_: &dyn Drop + AsRef<str>) {}
-   |                 ----   ^^^^^^^^^^ additional non-auto trait
+   |                 ----   ^^^^^^^^^^ additional non-auto or marker trait
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Drop + AsRef<str> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
@@ -61,13 +61,13 @@ error[E0224]: at least one trait is required for an object type
 LL | fn foo3(_: &dyn {Drop + AsRef<str>}) {}
    |             ^^^
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/trait-object-delimiters.rs:14:29
    |
 LL | fn foo5(_: &(dyn Drop + dyn AsRef<str>)) {}
-   |                  ----       ^^^^^^^^^^ additional non-auto trait
+   |                  ----       ^^^^^^^^^^ additional non-auto or marker trait
    |                  |
-   |                  first non-auto trait
+   |                  first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Drop + AsRef<str> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>

--- a/src/test/ui/parser/trait-object-trait-parens.rs
+++ b/src/test/ui/parser/trait-object-trait-parens.rs
@@ -7,17 +7,17 @@ fn f<T: (Copy) + (?Sized) + (for<'a> Trait<'a>)>() {}
 fn main() {
     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
     //~^ ERROR `?Trait` is not permitted in trait object types
-    //~| ERROR only auto traits can be used as additional traits
+    //~| ERROR only auto and marker traits can be used as additional traits
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
     //~^ ERROR `?Trait` is not permitted in trait object types
-    //~| ERROR only auto traits can be used as additional traits
+    //~| ERROR only auto and marker traits can be used as additional traits
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
     //~^ ERROR `?Trait` is not permitted in trait object types
-    //~| ERROR only auto traits can be used as additional traits
+    //~| ERROR only auto and marker traits can be used as additional traits
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -44,35 +44,35 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35
    |
 LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
-   |                -----              ^^^^^^^^^^^^^^^^^^^ additional non-auto trait
+   |                -----              ^^^^^^^^^^^^^^^^^^^ additional non-auto or marker trait
    |                |
-   |                first non-auto trait
+   |                first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + for<'a> Trait<'a> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:13:47
    |
 LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
-   |                         -------------------   ^^^^^ additional non-auto trait
+   |                         -------------------   ^^^^^ additional non-auto or marker trait
    |                         |
-   |                         first non-auto trait
+   |                         first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: for<'a> Trait<'a> + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:18:36
    |
 LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
-   |                -----------------   ^^^^^ additional non-auto trait
+   |                -----------------   ^^^^^ additional non-auto or marker trait
    |                |
-   |                first non-auto trait
+   |                first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: for<'a> Trait<'a> + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>

--- a/src/test/ui/traits/alias/no-duplicates.rs
+++ b/src/test/ui/traits/alias/no-duplicates.rs
@@ -1,5 +1,5 @@
 // The purpose of this test is to demonstrate that duplicating object safe traits
-// that are not auto traits is rejected with trait aliases even though one could
+// that are not auto or marker traits is rejected with trait aliases even though one could
 // reasonably accept this.
 
 #![feature(trait_alias)]
@@ -14,19 +14,19 @@ trait _0 = Obj;
 trait _1 = _0;
 
 type _T00 = dyn _0 + _0;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T01 = dyn _1 + _0;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T02 = dyn _1 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T03 = dyn Obj + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T04 = dyn _1 + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Nest some more and in weird ways:
 
@@ -35,57 +35,57 @@ trait _3 = Obj;
 trait _4 = _3;
 
 type _T10 = dyn _2 + _3;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T11 = dyn _3 + _2;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T12 = dyn Obj + _2;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T13 = dyn _2 + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T14 = dyn _1 + _3;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T15 = dyn _3 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T16 = dyn _1 + _4;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T17 = dyn _4 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Include auto traits:
 
 trait _5 = Obj + Send;
 
 type _T20 = dyn _5 + _5;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T21 = dyn Obj + _5;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T22 = dyn _5 + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T23 = dyn _5 + Send + Sync + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Also nest:
 
 trait _6 = _5 + _5; // ==> Obj + Send + Obj + Send
 
 type _T30 = dyn _6;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T31 = dyn _6 + Send;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T32 = dyn Send + _6;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Nest some more:
 
@@ -93,19 +93,19 @@ trait _7 = _5 + Sync;
 trait _8 = Unpin + _7;
 
 type _T40 = dyn _8 + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T41 = dyn Obj + _8;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T42 = dyn _8 + _4;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T43 = dyn _4 + _8;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T44 = dyn _4 + Send + Sync + _8;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Take higher ranked types into account.
 
@@ -115,12 +115,12 @@ trait ObjL<'l> {}
 trait _9 = for<'a> ObjL<'a>;
 trait _10 = for<'b> ObjL<'b>;
 type _T50 = dyn _9 + _10;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 trait ObjT<T> {}
 trait _11 = ObjT<for<'a> fn(&'a u8)>;
 trait _12 = ObjT<for<'b> fn(&'b u8)>;
 type _T60 = dyn _11 + _12;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 fn main() {}

--- a/src/test/ui/traits/alias/no-duplicates.stderr
+++ b/src/test/ui/traits/alias/no-duplicates.stderr
@@ -1,11 +1,11 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:16:22
    |
 LL | trait _0 = Obj;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 ...
 LL | type _T00 = dyn _0 + _0;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -15,14 +15,14 @@ LL | type _T00 = dyn _0 + _0;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:19:22
    |
 LL | trait _0 = Obj;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
@@ -34,14 +34,14 @@ LL | type _T01 = dyn _1 + _0;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:22:22
    |
 LL | trait _0 = Obj;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _1 = _0;
    |            --
    |            |
@@ -56,46 +56,46 @@ LL | type _T02 = dyn _1 + _1;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:25:23
    |
 LL | trait _0 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | type _T03 = dyn Obj + _1;
    |                 ---   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:28:22
    |
 LL | trait _0 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | type _T04 = dyn _1 + Obj;
-   |                 --   ^^^ additional non-auto trait
+   |                 --   ^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:37:17
    |
 LL | trait _0 = Obj;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
@@ -113,16 +113,16 @@ LL | type _T10 = dyn _2 + _3;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:40:22
    |
 LL | trait _0 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | trait _2 = _0 + _1;
    |            -- referenced here (additional use)
 LL | trait _3 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | type _T11 = dyn _3 + _2;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -132,11 +132,11 @@ LL | type _T11 = dyn _3 + _2;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:43:23
    |
 LL | trait _0 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | trait _2 = _0 + _1;
    |            -- referenced here (additional use)
@@ -144,19 +144,19 @@ LL | trait _2 = _0 + _1;
 LL | type _T12 = dyn Obj + _2;
    |                 ---   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:46:17
    |
 LL | trait _0 = Obj;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
@@ -174,16 +174,16 @@ LL | type _T13 = dyn _2 + Obj;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:49:22
    |
 LL | trait _0 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _3 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | type _T14 = dyn _1 + _3;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -193,16 +193,16 @@ LL | type _T14 = dyn _1 + _3;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:52:22
    |
 LL | trait _0 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _3 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | type _T15 = dyn _3 + _1;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -212,16 +212,16 @@ LL | type _T15 = dyn _3 + _1;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:55:22
    |
 LL | trait _0 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _3 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 LL | trait _4 = _3;
    |            -- referenced here (additional use)
 ...
@@ -233,16 +233,16 @@ LL | type _T16 = dyn _1 + _4;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:58:22
    |
 LL | trait _0 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _3 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _4 = _3;
    |            -- referenced here (first use)
 ...
@@ -254,14 +254,14 @@ LL | type _T17 = dyn _4 + _1;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:65:22
    |
 LL | trait _5 = Obj + Send;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | 
 LL | type _T20 = dyn _5 + _5;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -271,56 +271,56 @@ LL | type _T20 = dyn _5 + _5;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:68:23
    |
 LL | trait _5 = Obj + Send;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | type _T21 = dyn Obj + _5;
    |                 ---   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:71:22
    |
 LL | trait _5 = Obj + Send;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | type _T22 = dyn _5 + Obj;
-   |                 --   ^^^ additional non-auto trait
+   |                 --   ^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:74:36
    |
 LL | trait _5 = Obj + Send;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | type _T23 = dyn _5 + Send + Sync + Obj;
-   |                 --                 ^^^ additional non-auto trait
+   |                 --                 ^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:81:17
    |
 LL | trait _5 = Obj + Send;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 ...
 LL | trait _6 = _5 + _5; // ==> Obj + Send + Obj + Send
    |            --   -- referenced here (additional use)
@@ -336,14 +336,14 @@ LL | type _T30 = dyn _6;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:84:17
    |
 LL | trait _5 = Obj + Send;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 ...
 LL | trait _6 = _5 + _5; // ==> Obj + Send + Obj + Send
    |            --   -- referenced here (additional use)
@@ -359,14 +359,14 @@ LL | type _T31 = dyn _6 + Send;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:87:24
    |
 LL | trait _5 = Obj + Send;
    |            ---
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 ...
 LL | trait _6 = _5 + _5; // ==> Obj + Send + Obj + Send
    |            --   -- referenced here (additional use)
@@ -382,11 +382,11 @@ LL | type _T32 = dyn Send + _6;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:95:22
    |
 LL | trait _5 = Obj + Send;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | trait _7 = _5 + Sync;
    |            -- referenced here (first use)
@@ -394,18 +394,18 @@ LL | trait _8 = Unpin + _7;
    |                    -- referenced here (first use)
 LL | 
 LL | type _T40 = dyn _8 + Obj;
-   |                 --   ^^^ additional non-auto trait
+   |                 --   ^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:98:23
    |
 LL | trait _5 = Obj + Send;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | trait _7 = _5 + Sync;
    |            -- referenced here (additional use)
@@ -415,21 +415,21 @@ LL | trait _8 = Unpin + _7;
 LL | type _T41 = dyn Obj + _8;
    |                 ---   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:101:22
    |
 LL | trait _3 = Obj;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 LL | trait _4 = _3;
    |            -- referenced here (additional use)
 ...
 LL | trait _5 = Obj + Send;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 ...
 LL | trait _7 = _5 + Sync;
    |            -- referenced here (first use)
@@ -444,16 +444,16 @@ LL | type _T42 = dyn _8 + _4;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:104:22
    |
 LL | trait _3 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _4 = _3;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Obj + Send;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | trait _7 = _5 + Sync;
    |            -- referenced here (additional use)
@@ -468,16 +468,16 @@ LL | type _T43 = dyn _4 + _8;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:107:36
    |
 LL | trait _3 = Obj;
-   |            --- first non-auto trait
+   |            --- first non-auto or marker trait
 LL | trait _4 = _3;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Obj + Send;
-   |            --- additional non-auto trait
+   |            --- additional non-auto or marker trait
 ...
 LL | trait _7 = _5 + Sync;
    |            -- referenced here (additional use)
@@ -492,13 +492,13 @@ LL | type _T44 = dyn _4 + Send + Sync + _8;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:117:22
    |
 LL | trait _9 = for<'a> ObjL<'a>;
-   |            ---------------- first non-auto trait
+   |            ---------------- first non-auto or marker trait
 LL | trait _10 = for<'b> ObjL<'b>;
-   |             ---------------- additional non-auto trait
+   |             ---------------- additional non-auto or marker trait
 LL | type _T50 = dyn _9 + _10;
    |                 --   ^^^ trait alias used in trait object type (additional use)
    |                 |
@@ -507,13 +507,13 @@ LL | type _T50 = dyn _9 + _10;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: for<'a> ObjL<'a> + for<'b> ObjL<'b> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:123:23
    |
 LL | trait _11 = ObjT<for<'a> fn(&'a u8)>;
-   |             ------------------------ first non-auto trait
+   |             ------------------------ first non-auto or marker trait
 LL | trait _12 = ObjT<for<'b> fn(&'b u8)>;
-   |             ------------------------ additional non-auto trait
+   |             ------------------------ additional non-auto or marker trait
 LL | type _T60 = dyn _11 + _12;
    |                 ---   ^^^ trait alias used in trait object type (additional use)
    |                 |

--- a/src/test/ui/traits/alias/no-extra-traits.rs
+++ b/src/test/ui/traits/alias/no-extra-traits.rs
@@ -1,5 +1,5 @@
 // The purpose of this test is to demonstrate that trait alias expansion
-// preserves the rule that `dyn Trait` may only reference one non-auto trait.
+// preserves the rule that `dyn Trait` may only reference one non-auto or marker trait.
 
 #![feature(trait_alias)]
 
@@ -14,16 +14,16 @@ trait _0 = ObjA;
 trait _1 = _0;
 
 type _T00 = dyn _0 + ObjB;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T01 = dyn ObjB + _0;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T02 = dyn ObjB + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T03 = dyn _1 + ObjB;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Nest some more and in weird ways:
 
@@ -32,44 +32,44 @@ trait _3 = _2;
 trait _4 = _3;
 
 type _T10 = dyn _2 + _3;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T11 = dyn _3 + _2;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T12 = dyn _2 + _4;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T13 = dyn _4 + _2;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Include auto traits:
 
 trait _5 = Sync + ObjB + Send;
 
 type _T20 = dyn _5 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T21 = dyn _1 + _5;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T22 = dyn _5 + ObjA;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T23 = dyn ObjA + _5;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T24 = dyn Send + _5 + _1 + Sync;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T25 = dyn _1 + Sync + _5 + Send;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T26 = dyn Sync + Send + _5 + ObjA;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T27 = dyn Send + Sync + ObjA + _5;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Also nest:
 
@@ -78,22 +78,22 @@ trait _7 = _6;
 trait _8 = _7;
 
 type _T30 = dyn _6;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T31 = dyn _6 + Send;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T32 = dyn Send + _6;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T33 = dyn _8;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T34 = dyn _8 + Send;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T35 = dyn Send + _8;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Nest some more:
 
@@ -101,21 +101,21 @@ trait _9 = _5 + Sync;
 trait _10 = Unpin + _9;
 
 type _T40 = dyn _10 + ObjA;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T41 = dyn ObjA + _10;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T42 = dyn _10 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T43 = dyn Send + _10 + Sync + ObjA;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T44 = dyn ObjA + _10 + Send + Sync;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _T45 = dyn Sync + Send + _10 + _1;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 fn main() {}

--- a/src/test/ui/traits/alias/no-extra-traits.stderr
+++ b/src/test/ui/traits/alias/no-extra-traits.stderr
@@ -1,71 +1,71 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:16:22
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 ...
 LL | type _T00 = dyn _0 + ObjB;
-   |                 --   ^^^^ additional non-auto trait
+   |                 --   ^^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:19:24
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 ...
 LL | type _T01 = dyn ObjB + _0;
    |                 ----   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:22:24
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | type _T02 = dyn ObjB + _1;
    |                 ----   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:25:22
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | type _T03 = dyn _1 + ObjB;
-   |                 --   ^^^^ additional non-auto trait
+   |                 --   ^^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:34:22
    |
 LL | trait _2 = ObjB;
    |            ----
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _3 = _2;
    |            -- referenced here (additional use)
 ...
@@ -77,14 +77,14 @@ LL | type _T10 = dyn _2 + _3;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:37:22
    |
 LL | trait _2 = ObjB;
    |            ----
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _3 = _2;
    |            -- referenced here (first use)
 ...
@@ -96,14 +96,14 @@ LL | type _T11 = dyn _3 + _2;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:40:22
    |
 LL | trait _2 = ObjB;
    |            ----
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _3 = _2;
    |            -- referenced here (additional use)
 LL | trait _4 = _3;
@@ -117,14 +117,14 @@ LL | type _T12 = dyn _2 + _4;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:43:22
    |
 LL | trait _2 = ObjB;
    |            ----
    |            |
-   |            additional non-auto trait
-   |            first non-auto trait
+   |            additional non-auto or marker trait
+   |            first non-auto or marker trait
 LL | trait _3 = _2;
    |            -- referenced here (first use)
 LL | trait _4 = _3;
@@ -138,16 +138,16 @@ LL | type _T13 = dyn _4 + _2;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:50:22
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 LL | 
 LL | type _T20 = dyn _5 + _1;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -157,16 +157,16 @@ LL | type _T20 = dyn _5 + _1;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:53:22
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | type _T21 = dyn _1 + _5;
    |                 --   ^^ trait alias used in trait object type (additional use)
@@ -176,44 +176,44 @@ LL | type _T21 = dyn _1 + _5;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:56:22
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | type _T22 = dyn _5 + ObjA;
-   |                 --   ^^^^ additional non-auto trait
+   |                 --   ^^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:59:24
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | type _T23 = dyn ObjA + _5;
    |                 ----   ^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:62:29
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | type _T24 = dyn Send + _5 + _1 + Sync;
    |                        --   ^^ trait alias used in trait object type (additional use)
@@ -223,16 +223,16 @@ LL | type _T24 = dyn Send + _5 + _1 + Sync;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:65:29
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | type _T25 = dyn _1 + Sync + _5 + Send;
    |                 --          ^^ trait alias used in trait object type (additional use)
@@ -242,44 +242,44 @@ LL | type _T25 = dyn _1 + Sync + _5 + Send;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:68:36
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | type _T26 = dyn Sync + Send + _5 + ObjA;
-   |                               --   ^^^^ additional non-auto trait
+   |                               --   ^^^^ additional non-auto or marker trait
    |                               |
    |                               trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:71:38
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | type _T27 = dyn Send + Sync + ObjA + _5;
    |                               ----   ^^ trait alias used in trait object type (additional use)
    |                               |
-   |                               first non-auto trait
+   |                               first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:80:17
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -295,16 +295,16 @@ LL | type _T30 = dyn _6;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:83:17
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -320,16 +320,16 @@ LL | type _T31 = dyn _6 + Send;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:86:24
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -345,16 +345,16 @@ LL | type _T32 = dyn Send + _6;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:89:17
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -380,16 +380,16 @@ LL | type _T33 = dyn _8;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:92:17
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -415,16 +415,16 @@ LL | type _T34 = dyn _8 + Send;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:95:24
    |
 LL | trait _0 = ObjA;
-   |            ---- first non-auto trait
+   |            ---- first non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (first use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _6 = _1 + _5;
    |            --   -- referenced here (additional use)
@@ -450,11 +450,11 @@ LL | type _T35 = dyn Send + _8;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:103:23
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (first use)
@@ -462,18 +462,18 @@ LL | trait _10 = Unpin + _9;
    |                     -- referenced here (first use)
 LL | 
 LL | type _T40 = dyn _10 + ObjA;
-   |                 ---   ^^^^ additional non-auto trait
+   |                 ---   ^^^^ additional non-auto or marker trait
    |                 |
    |                 trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:106:24
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (additional use)
@@ -483,21 +483,21 @@ LL | trait _10 = Unpin + _9;
 LL | type _T41 = dyn ObjA + _10;
    |                 ----   ^^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:109:23
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (first use)
@@ -512,11 +512,11 @@ LL | type _T42 = dyn _10 + _1;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:112:37
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (first use)
@@ -524,18 +524,18 @@ LL | trait _10 = Unpin + _9;
    |                     -- referenced here (first use)
 ...
 LL | type _T43 = dyn Send + _10 + Sync + ObjA;
-   |                        ---          ^^^^ additional non-auto trait
+   |                        ---          ^^^^ additional non-auto or marker trait
    |                        |
    |                        trait alias used in trait object type (first use)
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjB + ObjA {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:115:24
    |
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- additional non-auto trait
+   |                   ---- additional non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (additional use)
@@ -545,21 +545,21 @@ LL | trait _10 = Unpin + _9;
 LL | type _T44 = dyn ObjA + _10 + Send + Sync;
    |                 ----   ^^^ trait alias used in trait object type (additional use)
    |                 |
-   |                 first non-auto trait
+   |                 first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjA + ObjB {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-extra-traits.rs:118:37
    |
 LL | trait _0 = ObjA;
-   |            ---- additional non-auto trait
+   |            ---- additional non-auto or marker trait
 LL | trait _1 = _0;
    |            -- referenced here (additional use)
 ...
 LL | trait _5 = Sync + ObjB + Send;
-   |                   ---- first non-auto trait
+   |                   ---- first non-auto or marker trait
 ...
 LL | trait _9 = _5 + Sync;
    |            -- referenced here (first use)

--- a/src/test/ui/traits/bad-sized.rs
+++ b/src/test/ui/traits/bad-sized.rs
@@ -2,7 +2,7 @@ trait Trait {}
 
 pub fn main() {
     let x: Vec<dyn Trait + Sized> = Vec::new();
-    //~^ ERROR only auto traits can be used as additional traits in a trait object
+    //~^ ERROR only auto and marker traits can be used as additional traits in a trait object
     //~| ERROR the size for values of type
     //~| ERROR the size for values of type
     //~| ERROR the size for values of type

--- a/src/test/ui/traits/bad-sized.stderr
+++ b/src/test/ui/traits/bad-sized.stderr
@@ -1,10 +1,10 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/bad-sized.rs:4:28
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
-   |                    -----   ^^^^^ additional non-auto trait
+   |                    -----   ^^^^^ additional non-auto or marker trait
    |                    |
-   |                    first non-auto trait
+   |                    first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Trait + Sized {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>

--- a/src/test/ui/traits/wf-object/no-duplicates.rs
+++ b/src/test/ui/traits/wf-object/no-duplicates.rs
@@ -1,20 +1,20 @@
 // The purpose of this test is to demonstrate that duplicating object safe traits
-// that are not auto-traits is rejected even though one could reasonably accept this.
+// that are not auto or marker traits is rejected even though one could reasonably accept this.
 
 // Some arbitrary object-safe trait:
 trait Obj {}
 
 // Demonstrate that recursive expansion of trait aliases doesn't affect stable behavior:
 type _0 = dyn Obj + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 // Some variations:
 
 type _1 = dyn Send + Obj + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _2 = dyn Obj + Send + Obj;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 type _3 = dyn Obj + Send + Send; // But it is OK to duplicate auto traits.
 
@@ -24,10 +24,10 @@ type _3 = dyn Obj + Send + Send; // But it is OK to duplicate auto traits.
 // them semantically the same.
 trait ObjL<'l> {}
 type _4 = dyn for<'a> ObjL<'a> + for<'b> ObjL<'b>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 trait ObjT<T> {}
 type _5 = dyn ObjT<for<'a> fn(&'a u8)> + ObjT<for<'b> fn(&'b u8)>;
-//~^ ERROR only auto traits can be used as additional traits in a trait object [E0225]
+//~^ ERROR only auto and marker traits can be used as additional traits in a trait object [E0225]
 
 fn main() {}

--- a/src/test/ui/traits/wf-object/no-duplicates.stderr
+++ b/src/test/ui/traits/wf-object/no-duplicates.stderr
@@ -1,54 +1,54 @@
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:8:21
    |
 LL | type _0 = dyn Obj + Obj;
-   |               ---   ^^^ additional non-auto trait
+   |               ---   ^^^ additional non-auto or marker trait
    |               |
-   |               first non-auto trait
+   |               first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:13:28
    |
 LL | type _1 = dyn Send + Obj + Obj;
-   |                      ---   ^^^ additional non-auto trait
+   |                      ---   ^^^ additional non-auto or marker trait
    |                      |
-   |                      first non-auto trait
+   |                      first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:16:28
    |
 LL | type _2 = dyn Obj + Send + Obj;
-   |               ---          ^^^ additional non-auto trait
+   |               ---          ^^^ additional non-auto or marker trait
    |               |
-   |               first non-auto trait
+   |               first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:26:34
    |
 LL | type _4 = dyn for<'a> ObjL<'a> + for<'b> ObjL<'b>;
-   |               ----------------   ^^^^^^^^^^^^^^^^ additional non-auto trait
+   |               ----------------   ^^^^^^^^^^^^^^^^ additional non-auto or marker trait
    |               |
-   |               first non-auto trait
+   |               first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: for<'a> ObjL<'a> + for<'b> ObjL<'b> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
-error[E0225]: only auto traits can be used as additional traits in a trait object
+error[E0225]: only auto and marker traits can be used as additional traits in a trait object
   --> $DIR/no-duplicates.rs:30:42
    |
 LL | type _5 = dyn ObjT<for<'a> fn(&'a u8)> + ObjT<for<'b> fn(&'b u8)>;
-   |               ------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^ additional non-auto trait
+   |               ------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^ additional non-auto or marker trait
    |               |
-   |               first non-auto trait
+   |               first non-auto or marker trait
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: ObjT<for<'a> fn(&'a u8)> + ObjT<for<'b> fn(&'b u8)> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>


### PR DESCRIPTION
Currently, only auto traits are allowed to be extra traits on trait objects because they are guaranteed to have no functions. However, there is another type of trait that has this property: marker traits. It seems like an oversight that this is not allowed.

This PR fixes this.

Work left to do:
- [x]  See if this change is enough to make it work
- [x]  Change error message