### PR TITLE
Use a sharded symbol interner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,6 +4036,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "syn",
  "synstructure",
 ]

--- a/compiler/rustc_macros/Cargo.toml
+++ b/compiler/rustc_macros/Cargo.toml
@@ -10,4 +10,5 @@ proc-macro = true
 synstructure = "0.12.1"
 syn = { version = "1", features = ["full"] }
 proc-macro2 = "1"
+rustc-hash = "1.1.0"
 quote = "1"

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -16,6 +16,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(crate_visibility_modifier)]
+#![feature(hash_raw_entry)]
 #![feature(if_let_guard)]
 #![feature(negative_impls)]
 #![feature(nll)]

--- a/compiler/rustc_span/src/symbol/tests.rs
+++ b/compiler/rustc_span/src/symbol/tests.rs
@@ -4,7 +4,7 @@ use crate::create_default_session_globals_then;
 
 #[test]
 fn interner_tests() {
-    let i = Interner::default();
+    let i = Interner::empty_for_test();
     // first one is zero:
     assert_eq!(i.intern("dog"), Symbol::new(0));
     // re-use gets the same entry:


### PR DESCRIPTION
This should reduce contention when accessing the symbol interner from multiple threads when using parallel rustc.