### PR TITLE
Implemented MIN and MAX constants for the non-zero integer types.#89065

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -897,7 +897,7 @@ macro_rules! nonzero_unsigned_is_power_of_two {
 nonzero_unsigned_is_power_of_two! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize }
 
 macro_rules! nonzero_min_max {
-    ( $( $min:expr , $Ty: ident($Int: ty); )+ ) => {
+    ( $( $MinVal:expr , $Ty: ident($Int: ty); )+ ) => {
         $(
             impl $Ty {
                 #[unstable(feature = "nonzero_max", issue = "89065")]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -896,35 +896,63 @@ macro_rules! nonzero_unsigned_is_power_of_two {
 
 nonzero_unsigned_is_power_of_two! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize }
 
-macro_rules! nonzero_min_max {
-    ( $( $MinVal:expr , $Ty: ident($Int: ty); )+ ) => {
+macro_rules! nonzero_constants_signed {
+    ( $( $Ty: ident($Int: ty); )+ ) => {
         $(
             impl $Ty {
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
+                /// # Examples
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
                 pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($MinVal), ";")]
-                pub const MIN : $Ty = $Ty::new($MinVal).unwrap();
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                pub const MIN : $Ty = $Ty::new(<$Int>::MIN).unwrap();
                 }
         )+
     }
 }
 
-nonzero_min_max! {
-    1 , NonZeroU8(u8);
-    1 , NonZeroU16(u16);
-    1 , NonZeroU32(u32);
-    1 , NonZeroU64(u64);
-    1 , NonZeroU128(u128);
-    1 , NonZeroUsize(usize);
-    i8::MIN , NonZeroI8(i8);
-    i16::MIN , NonZeroI16(i16);
-    i32::MIN  , NonZeroI32(i32);
-    i64::MIN , NonZeroI64(i64);
-    i128::MIN  , NonZeroI128(i128);
-    isize::MIN  , NonZeroIsize(isize);
+nonzero_constants_signed! {
+    NonZeroI8(i8);
+    NonZeroI16(i16);
+    NonZeroI32(i32);
+    NonZeroI64(i64);
+    NonZeroI128(i128);
+    NonZeroIsize(isize);
+}
+
+macro_rules! nonzero_constants_unsigned{
+    ( $( $Ty: ident($Int: ty); )+ ) => {
+        $(
+            impl $Ty {
+                #[unstable(feature = "nonzero_min_max", issue = "89065")]
+                #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
+                /// Note, while most integer types are defined for every whole number between MIN and
+                /// MAX, signed non-zero integers are a special case. They have a 'gap' at 0.
+                /// # Examples  
+                pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
+                #[unstable(feature = "nonzero_min_max", issue = "89065")]
+                #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
+                /// Note, while most integer types are defined for every whole number between MIN and
+                /// MAX, signed non-zero integers are a special case. They have a 'gap' at 0.
+                /// # Examples
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                pub const MIN : $Ty = $Ty::new(1).unwrap();
+                }
+        )+
+    }
+}
+
+
+nonzero_constants_unsigned! {
+   NonZeroU8(u8);
+    NonZeroU16(u16);
+    NonZeroU32(u32);
+    NonZeroU64(u64);
+    NonZeroU128(u128);
+    NonZeroUsize(usize);
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -895,3 +895,23 @@ macro_rules! nonzero_unsigned_is_power_of_two {
 }
 
 nonzero_unsigned_is_power_of_two! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize }
+
+macro_rules! nonzero_max {
+    ( $( $Ty: ident($Int: ty) )+ ) => {
+        $(
+
+            impl $Ty {
+	        #[unstable(feature = "nonzero_max", issue = "89065")]
+                #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), ">::MAX);")]
+                //SAFETY: Since the MAX value, for any supported integer type, is greater than 0,
+                // the MAX will always be non-zero.
+                pub const MAX : $Ty = unsafe { $Ty::new_unchecked(<$Int>::MAX) };
+            }
+        )+
+    }
+}
+
+nonzero_max! { NonZeroU8(u8) NonZeroI8(i8) NonZeroU16(u16) NonZeroI16(i16) NonZeroU32(u32) NonZeroI32(i32)
+     NonZeroU64(u64) NonZeroI64(i64) NonZeroUsize(usize) NonZeroIsize(isize)
+}

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -901,16 +901,22 @@ macro_rules! nonzero_constants_signed {
         $(
             impl $Ty {
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
-                #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
+                #[doc = concat!("The maximum value for a `", stringify!($Ty), "` is the same as `", stringify!($Int), "`.")]
                 /// # Examples
+                ///
+                /// ```
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
+                /// ```
                 pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap();
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
-                #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
+                #[doc = concat!("The minimum value for a `", stringify!($Ty), " `.")]
                 /// # Examples
+                ///
+                /// ```
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                /// ```
                 pub const MIN : $Ty = $Ty::new(<$Int>::MIN).unwrap();
-                }
+            }
         )+
     }
 }
@@ -929,20 +935,26 @@ macro_rules! nonzero_constants_unsigned{
         $(
             impl $Ty {
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
-                #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
-                /// Note, while most integer types are defined for every whole number between MIN and
+                #[doc = concat!("The maximum value for a `", stringify!($Ty), "` is the same as `", stringify!($Int), "`.")]
+                /// Note: While most integer types are defined for every whole number between MIN and
                 /// MAX, signed non-zero integers are a special case. They have a 'gap' at 0.
                 /// # Examples
+                ///
+                /// ```
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
+                /// ```
                 pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
-                #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
-                /// Note, while most integer types are defined for every whole number between MIN and
+                #[doc = concat!("The minimum value for a `", stringify!($Ty), "`.")]
+                /// Note: While most integer types are defined for every whole number between MIN and
                 /// MAX, signed non-zero integers are a special case. They have a 'gap' at 0.
                 /// # Examples
+                ///
+                /// ```
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                /// ```
                 pub const MIN : $Ty = $Ty::new(1).unwrap();
-                }
+            }
         )+
     }
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -908,10 +908,10 @@ macro_rules! nonzero_min_max {
                 #[unstable(feature = "nonzero_min", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($min), ";")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Min), ";")]
                 // SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
                 // SAFETY:  In the unsignedd case, we use one, which is non-zero.
-                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($min)};
+                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($Min)};
                 }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -896,22 +896,41 @@ macro_rules! nonzero_unsigned_is_power_of_two {
 
 nonzero_unsigned_is_power_of_two! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 NonZeroU128 NonZeroUsize }
 
-macro_rules! nonzero_max {
-    ( $( $Ty: ident($Int: ty) )+ ) => {
+macro_rules! nonzero_min_max {
+    ( $( $min:expr , $Ty: ident($Int: ty); )+ ) => {
         $(
 
             impl $Ty {
 	        #[unstable(feature = "nonzero_max", issue = "89065")]
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), ">::MAX);")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
                 //SAFETY: Since the MAX value, for any supported integer type, is greater than 0,
                 // the MAX will always be non-zero.
                 pub const MAX : $Ty = unsafe { $Ty::new_unchecked(<$Int>::MAX) };
-            }
+                #[unstable(feature = "nonzero_min", issue = "89065")]
+                #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
+		/// # Examples
+		///
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($min), ";")]
+		//SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
+		//        In the unsignedd case, we use one, which is non-zero.
+                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($min)};
+                 }
         )+
     }
 }
 
-nonzero_max! { NonZeroU8(u8) NonZeroI8(i8) NonZeroU16(u16) NonZeroI16(i16) NonZeroU32(u32) NonZeroI32(i32)
-     NonZeroU64(u64) NonZeroI64(i64) NonZeroUsize(usize) NonZeroIsize(isize)
+nonzero_min_max! {
+    1 , NonZeroU8(u8);
+    1 , NonZeroU16(u16);
+    1 , NonZeroU32(u32);
+    1 , NonZeroU64(u64);
+    1 , NonZeroU128(u128);
+    1 , NonZeroUsize(usize);
+    i8::MIN , NonZeroI8(i8);
+    i16::MIN , NonZeroI16(i16);
+    i32::MIN  , NonZeroI32(i32);
+    i64::MIN , NonZeroI64(i64);
+    i128::MIN  , NonZeroI128(i128);
+    isize::MIN  , NonZeroIsize(isize);
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -913,7 +913,7 @@ macro_rules! nonzero_constants_signed {
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN);")]
                 /// ```
                 pub const MIN : $Ty = $Ty::new(<$Int>::MIN).unwrap();
             }
@@ -951,7 +951,7 @@ macro_rules! nonzero_constants_unsigned{
                 /// # Examples
                 ///
                 /// ```
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN;")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Int), "::MIN);")]
                 /// ```
                 pub const MIN : $Ty = $Ty::new(1).unwrap();
             }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -903,15 +903,12 @@ macro_rules! nonzero_min_max {
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
-                // SAFETY: Since the MAX value, for any supported integer type, is greater than 0, the MAX will always be non-zero.
-                pub const MAX : $Ty = unsafe { $Ty::new_unchecked(<$Int>::MAX) };
+                pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($MinVal), ";")]
-                // SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
-                // SAFETY:  In the unsignedd case, we use one, which is non-zero.
-                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($MinVal)};
+                pub const MIN : $Ty = $Ty::new($MinVal).unwrap();
                 }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -947,7 +947,6 @@ macro_rules! nonzero_constants_unsigned{
     }
 }
 
-
 nonzero_constants_unsigned! {
    NonZeroU8(u8);
     NonZeroU16(u16);

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -908,10 +908,10 @@ macro_rules! nonzero_min_max {
                 #[unstable(feature = "nonzero_min", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples
-                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($Min), ";")]
+                #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($MinVal), ";")]
                 // SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
                 // SAFETY:  In the unsignedd case, we use one, which is non-zero.
-                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($Min)};
+                pub const MIN : $Ty = unsafe { $Ty::new_unchecked($MinVal)};
                 }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -933,7 +933,7 @@ macro_rules! nonzero_constants_unsigned{
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
                 /// Note, while most integer types are defined for every whole number between MIN and
                 /// MAX, signed non-zero integers are a special case. They have a 'gap' at 0.
-                /// # Examples  
+                /// # Examples
                 pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -904,7 +904,7 @@ macro_rules! nonzero_constants_signed {
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
                 /// # Examples
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
-                pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap() ;
+                pub const MAX : $Ty = $Ty::new(<$Int>::MAX).unwrap();
                 #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -899,23 +899,20 @@ nonzero_unsigned_is_power_of_two! { NonZeroU8 NonZeroU16 NonZeroU32 NonZeroU64 N
 macro_rules! nonzero_min_max {
     ( $( $min:expr , $Ty: ident($Int: ty); )+ ) => {
         $(
-
             impl $Ty {
-	        #[unstable(feature = "nonzero_max", issue = "89065")]
+                #[unstable(feature = "nonzero_max", issue = "89065")]
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
-                //SAFETY: Since the MAX value, for any supported integer type, is greater than 0,
-                // the MAX will always be non-zero.
+                // SAFETY: Since the MAX value, for any supported integer type, is greater than 0, the MAX will always be non-zero.
                 pub const MAX : $Ty = unsafe { $Ty::new_unchecked(<$Int>::MAX) };
                 #[unstable(feature = "nonzero_min", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
-		/// # Examples
-		///
+                /// # Examples
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($min), ";")]
-		//SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
-		//        In the unsignedd case, we use one, which is non-zero.
+                // SAFETY: In the signed case, the minimum integer is negative, and therefore non-zero.
+                // SAFETY:  In the unsignedd case, we use one, which is non-zero.
                 pub const MIN : $Ty = unsafe { $Ty::new_unchecked($min)};
-                 }
+                }
         )+
     }
 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -900,12 +900,12 @@ macro_rules! nonzero_min_max {
     ( $( $MinVal:expr , $Ty: ident($Int: ty); )+ ) => {
         $(
             impl $Ty {
-                #[unstable(feature = "nonzero_max", issue = "89065")]
+                #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The maximum value for a`", stringify!($Ty), "` is the same as `", stringify!($Int), "`")]
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MAX, ", stringify!($Int), "::MAX);")]
                 // SAFETY: Since the MAX value, for any supported integer type, is greater than 0, the MAX will always be non-zero.
                 pub const MAX : $Ty = unsafe { $Ty::new_unchecked(<$Int>::MAX) };
-                #[unstable(feature = "nonzero_min", issue = "89065")]
+                #[unstable(feature = "nonzero_min_max", issue = "89065")]
                 #[doc = concat!("The minimum value for a`", stringify!($Ty), "`.")]
                 /// # Examples
                 #[doc = concat!("assert_eq!(", stringify!($Ty), "::MIN, ", stringify!($MinVal), ";")]


### PR DESCRIPTION
This implements the feature requested in #89065 . I wrote some tests, but it appears that non-stable features aren't supposed to be tested in the normal nonzero.rs test file. Is there a place to add tests for non-stable features?