### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.47+curl-7.79.0"
+version = "0.4.45+curl-7.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab94a47d9b61f2d905beb7a3d46aba7704c9f1dfcf84e7d178998d9e95f7989"
+checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
1 commits in 33ee5f82edb50af87b952c5b28de0f5fb41ebf18..9a28ac83c9eb73e42ffafac552c0a55f00dbf40c
2021-09-17 13:51:54 +0000 to 2021-09-18 15:42:28 -0500
- Temporarily revert curl-sys update. (rust-lang/cargo#9920)