### PR TITLE
Lint bare traits in AstConv.

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -47,7 +47,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{struct_span_err, Applicability};
+use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{DefId, DefPathHash, LocalDefId, CRATE_DEF_ID};
@@ -56,11 +56,9 @@ use rustc_hir::intravisit;
 use rustc_hir::{ConstArg, GenericArg, InferKind, ParamName};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_query_system::ich::StableHashingContext;
-use rustc_session::lint::builtin::BARE_TRAIT_OBJECTS;
-use rustc_session::lint::{BuiltinLintDiagnostics, LintBuffer};
+use rustc_session::lint::LintBuffer;
 use rustc_session::utils::{FlattenNonterminals, NtToTokenstream};
 use rustc_session::Session;
-use rustc_span::edition::Edition;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::source_map::{respan, DesugaringKind};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
@@ -1190,11 +1188,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> hir::Ty<'hir> {
         let id = self.lower_node_id(t.id);
         let qpath = self.lower_qpath(t.id, qself, path, param_mode, itctx);
-        let ty = self.ty_path(id, t.span, qpath);
-        if let hir::TyKind::TraitObject(..) = ty.kind {
-            self.maybe_lint_bare_trait(t.span, t.id, qself.is_none() && path.is_global());
-        }
-        ty
+        self.ty_path(id, t.span, qpath)
     }
 
     fn ty(&mut self, span: Span, kind: hir::TyKind<'hir>) -> hir::Ty<'hir> {
@@ -1291,9 +1285,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         lifetime_bound.unwrap_or_else(|| this.elided_dyn_bound(t.span));
                     (bounds, lifetime_bound)
                 });
-                if kind != TraitObjectSyntax::Dyn {
-                    self.maybe_lint_bare_trait(t.span, t.id, false);
-                }
                 hir::TyKind::TraitObject(bounds, lifetime_bound, kind)
             }
             TyKind::ImplTrait(def_node_id, ref bounds) => {
@@ -2393,39 +2384,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             hir_id: self.next_id(),
             span: self.lower_span(span),
             name: hir::LifetimeName::Implicit(missing),
-        }
-    }
-
-    fn maybe_lint_bare_trait(&mut self, span: Span, id: NodeId, is_global: bool) {
-        // FIXME(davidtwco): This is a hack to detect macros which produce spans of the
-        // call site which do not have a macro backtrace. See #61963.
-        let is_macro_callsite = self
-            .sess
-            .source_map()
-            .span_to_snippet(span)
-            .map(|snippet| snippet.starts_with("#["))
-            .unwrap_or(true);
-        if !is_macro_callsite {
-            if span.edition() < Edition::Edition2021 {
-                self.resolver.lint_buffer().buffer_lint_with_diagnostic(
-                    BARE_TRAIT_OBJECTS,
-                    id,
-                    span,
-                    "trait objects without an explicit `dyn` are deprecated",
-                    BuiltinLintDiagnostics::BareTraitObject(span, is_global),
-                )
-            } else {
-                let msg = "trait objects must include the `dyn` keyword";
-                let label = "add `dyn` keyword before this trait";
-                let mut err = struct_span_err!(self.sess, span, E0782, "{}", msg,);
-                err.span_suggestion_verbose(
-                    span.shrink_to_lo(),
-                    label,
-                    String::from("dyn "),
-                    Applicability::MachineApplicable,
-                );
-                err.emit();
-            }
         }
     }
 }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -635,16 +635,6 @@ pub trait LintContext: Sized {
                     }
                 },
                 BuiltinLintDiagnostics::Normal => (),
-                BuiltinLintDiagnostics::BareTraitObject(span, is_global) => {
-                    let (sugg, app) = match sess.source_map().span_to_snippet(span) {
-                        Ok(s) if is_global => {
-                            (format!("dyn ({})", s), Applicability::MachineApplicable)
-                        }
-                        Ok(s) => (format!("dyn {}", s), Applicability::MachineApplicable),
-                        Err(_) => ("dyn <type>".to_string(), Applicability::HasPlaceholders),
-                    };
-                    db.span_suggestion(span, "use `dyn`", sugg, app);
-                }
                 BuiltinLintDiagnostics::AbsPathWithModule(span) => {
                     let (sugg, app) = match sess.source_map().span_to_snippet(span) {
                         Ok(ref s) => {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -285,7 +285,6 @@ pub enum ExternDepSpec {
 #[derive(PartialEq, Debug)]
 pub enum BuiltinLintDiagnostics {
     Normal,
-    BareTraitObject(Span, /* is_global */ bool),
     AbsPathWithModule(Span),
     ProcMacroDeriveResolutionFallback(Span),
     MacroExpandedMacroExportsAccessedByAbsolutePaths(Span),

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -13,6 +13,7 @@ use crate::errors::{
 };
 use crate::middle::resolve_lifetime as rl;
 use crate::require_c_abi_if_c_variadic;
+use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{struct_span_err, Applicability, ErrorReported, FatalError};
 use rustc_hir as hir;
@@ -24,7 +25,8 @@ use rustc_hir::{GenericArg, GenericArgs};
 use rustc_middle::ty::subst::{self, GenericArgKind, InternalSubsts, Subst, SubstsRef};
 use rustc_middle::ty::GenericParamDefKind;
 use rustc_middle::ty::{self, Const, DefIdTree, Ty, TyCtxt, TypeFoldable};
-use rustc_session::lint::builtin::AMBIGUOUS_ASSOCIATED_ITEMS;
+use rustc_session::lint::builtin::{AMBIGUOUS_ASSOCIATED_ITEMS, BARE_TRAIT_OBJECTS};
+use rustc_span::edition::Edition;
 use rustc_span::lev_distance::find_best_match_for_name;
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
@@ -2289,13 +2291,19 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     /// Parses the programmer's textual representation of a type into our
     /// internal notion of a type.
     pub fn ast_ty_to_ty(&self, ast_ty: &hir::Ty<'_>) -> Ty<'tcx> {
-        self.ast_ty_to_ty_inner(ast_ty, false)
+        self.ast_ty_to_ty_inner(ast_ty, false, false)
+    }
+
+    /// Parses the programmer's textual representation of a type into our
+    /// internal notion of a type.  This is meant to be used within a path.
+    pub fn ast_ty_to_ty_in_path(&self, ast_ty: &hir::Ty<'_>) -> Ty<'tcx> {
+        self.ast_ty_to_ty_inner(ast_ty, false, true)
     }
 
     /// Turns a `hir::Ty` into a `Ty`. For diagnostics' purposes we keep track of whether trait
     /// objects are borrowed like `&dyn Trait` to avoid emitting redundant errors.
     #[tracing::instrument(level = "debug", skip(self))]
-    fn ast_ty_to_ty_inner(&self, ast_ty: &hir::Ty<'_>, borrowed: bool) -> Ty<'tcx> {
+    fn ast_ty_to_ty_inner(&self, ast_ty: &hir::Ty<'_>, borrowed: bool, in_path: bool) -> Ty<'tcx> {
         let tcx = self.tcx();
 
         let result_ty = match ast_ty.kind {
@@ -2306,7 +2314,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             hir::TyKind::Rptr(ref region, ref mt) => {
                 let r = self.ast_region_to_region(region, None);
                 debug!(?r);
-                let t = self.ast_ty_to_ty_inner(mt.ty, true);
+                let t = self.ast_ty_to_ty_inner(mt.ty, true, false);
                 tcx.mk_ref(r, ty::TypeAndMut { ty: t, mutbl: mt.mutbl })
             }
             hir::TyKind::Never => tcx.types.never,
@@ -2325,6 +2333,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ))
             }
             hir::TyKind::TraitObject(bounds, ref lifetime, _) => {
+                self.maybe_lint_bare_trait(ast_ty, in_path);
                 self.conv_object_ty_poly_trait_ref(ast_ty.span, bounds, lifetime, borrowed)
             }
             hir::TyKind::Path(hir::QPath::Resolved(ref maybe_qself, ref path)) => {
@@ -2345,7 +2354,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             hir::TyKind::Path(hir::QPath::TypeRelative(ref qself, ref segment)) => {
                 debug!(?qself, ?segment);
-                let ty = self.ast_ty_to_ty(qself);
+                let ty = self.ast_ty_to_ty_inner(qself, false, true);
 
                 let res = if let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = qself.kind {
                     path.res
@@ -2601,5 +2610,50 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             tcx.sess.emit_err(AmbiguousLifetimeBound { span });
         }
         Some(r)
+    }
+
+    fn maybe_lint_bare_trait(&self, self_ty: &hir::Ty<'_>, in_path: bool) {
+        let tcx = self.tcx();
+        if let hir::TyKind::TraitObject([poly_trait_ref, ..], _, TraitObjectSyntax::None) =
+            self_ty.kind
+        {
+            let (mut sugg, app) = match tcx.sess.source_map().span_to_snippet(self_ty.span) {
+                Ok(s) if poly_trait_ref.trait_ref.path.is_global() => {
+                    (format!("dyn ({})", s), Applicability::MachineApplicable)
+                }
+                Ok(s) => (format!("dyn {}", s), Applicability::MachineApplicable),
+                Err(_) => ("dyn <type>".to_string(), Applicability::HasPlaceholders),
+            };
+            if in_path {
+                let has_bracket = tcx
+                    .sess
+                    .source_map()
+                    .span_to_prev_source(self_ty.span)
+                    .ok()
+                    .map_or(false, |s| s.trim_end().ends_with('<'));
+                if !has_bracket {
+                    sugg = format!("<{}>", sugg);
+                }
+            }
+            if tcx.sess.edition() >= Edition::Edition2021 {
+                let msg = "trait objects must include the `dyn` keyword";
+                let label = "add `dyn` keyword before this trait";
+                let mut err =
+                    rustc_errors::struct_span_err!(tcx.sess, self_ty.span, E0782, "{}", msg);
+                err.span_suggestion_verbose(self_ty.span, label, sugg, app).emit();
+            } else {
+                let msg = "trait objects without an explicit `dyn` are deprecated";
+                tcx.struct_span_lint_hir(
+                    BARE_TRAIT_OBJECTS,
+                    self_ty.hir_id,
+                    self_ty.span,
+                    |lint| {
+                        let mut db = lint.build(msg);
+                        db.span_suggestion(self_ty.span, "use `dyn`", sugg, app);
+                        db.emit()
+                    },
+                );
+            }
+        }
     }
 }

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2635,7 +2635,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     sugg = format!("<{}>", sugg);
                 }
             }
-            if tcx.sess.edition() >= Edition::Edition2021 {
+            if self_ty.span.edition() >= Edition::Edition2021 {
                 let msg = "trait objects must include the `dyn` keyword";
                 let label = "add `dyn` keyword before this trait";
                 let mut err =

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -6,7 +6,6 @@ use crate::check::callee::{self, DeferredCallResolution};
 use crate::check::method::{self, MethodCallee, SelfSource};
 use crate::check::{BreakableCtxt, Diverges, Expectation, FnCtxt, LocalTy};
 
-use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, DiagnosticBuilder, ErrorReported};
@@ -14,7 +13,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::{ExprKind, GenericArg, Node, QPath, TyKind};
+use rustc_hir::{ExprKind, GenericArg, Node, QPath};
 use rustc_infer::infer::canonical::{Canonical, OriginalQueryValues, QueryResponse};
 use rustc_infer::infer::error_reporting::TypeAnnotationNeeded::E0282;
 use rustc_infer::infer::{InferOk, InferResult};
@@ -28,8 +27,6 @@ use rustc_middle::ty::{
     Ty, UserType,
 };
 use rustc_session::lint;
-use rustc_session::lint::builtin::BARE_TRAIT_OBJECTS;
-use rustc_span::edition::Edition;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::source_map::{original_sp, DUMMY_SP};
 use rustc_span::symbol::{kw, sym, Ident};
@@ -844,7 +841,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // to be object-safe.
                 // We manually call `register_wf_obligation` in the success path
                 // below.
-                (<dyn AstConv<'_>>::ast_ty_to_ty(self, qself), qself, segment)
+                (<dyn AstConv<'_>>::ast_ty_to_ty_in_path(self, qself), qself, segment)
             }
             QPath::LangItem(..) => {
                 bug!("`resolve_ty_and_res_fully_qualified_call` called on `LangItem`")
@@ -890,7 +887,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
 
         if result.is_ok() {
-            self.maybe_lint_bare_trait(qpath, hir_id, span);
             self.register_wf_obligation(ty.into(), qself.span, traits::WellFormed(None));
         }
 
@@ -901,56 +897,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Some(ty),
             slice::from_ref(&**item_segment),
         )
-    }
-
-    fn maybe_lint_bare_trait(&self, qpath: &QPath<'_>, hir_id: hir::HirId, span: Span) {
-        if let QPath::TypeRelative(self_ty, _) = qpath {
-            if let TyKind::TraitObject([poly_trait_ref, ..], _, TraitObjectSyntax::None) =
-                self_ty.kind
-            {
-                let msg = "trait objects without an explicit `dyn` are deprecated";
-                let (sugg, app) = match self.tcx.sess.source_map().span_to_snippet(self_ty.span) {
-                    Ok(s) if poly_trait_ref.trait_ref.path.is_global() => {
-                        (format!("dyn ({})", s), Applicability::MachineApplicable)
-                    }
-                    Ok(s) => (format!("dyn {}", s), Applicability::MachineApplicable),
-                    Err(_) => ("dyn <type>".to_string(), Applicability::HasPlaceholders),
-                };
-                // Wrap in `<..>` if it isn't already.
-                let sugg = match self.tcx.sess.source_map().span_to_snippet(span) {
-                    Ok(s) if s.starts_with('<') => sugg,
-                    _ => format!("<{}>", sugg),
-                };
-                let sugg_label = "use `dyn`";
-                if self.sess().edition() >= Edition::Edition2021 {
-                    let mut err = rustc_errors::struct_span_err!(
-                        self.sess(),
-                        self_ty.span,
-                        E0782,
-                        "{}",
-                        msg,
-                    );
-                    err.span_suggestion(
-                        self_ty.span,
-                        sugg_label,
-                        sugg,
-                        Applicability::MachineApplicable,
-                    )
-                    .emit();
-                } else {
-                    self.tcx.struct_span_lint_hir(
-                        BARE_TRAIT_OBJECTS,
-                        hir_id,
-                        self_ty.span,
-                        |lint| {
-                            let mut db = lint.build(msg);
-                            db.span_suggestion(self_ty.span, sugg_label, sugg, app);
-                            db.emit()
-                        },
-                    );
-                }
-            }
-        }
     }
 
     /// Given a function `Node`, return its `FnDecl` if it exists, or `None` otherwise.

--- a/src/test/rustdoc-ui/display-output.rs
+++ b/src/test/rustdoc-ui/display-output.rs
@@ -10,6 +10,6 @@
 /// #![warn(unused)]
 /// let x = 12;
 ///
-/// fn foo(x: &std::fmt::Display) {}
+/// fn foo(x: &dyn std::fmt::Display) {}
 /// ```
 pub fn foo() {}

--- a/src/test/rustdoc-ui/display-output.stdout
+++ b/src/test/rustdoc-ui/display-output.stdout
@@ -5,16 +5,6 @@ test $DIR/display-output.rs - foo (line 9) ... ok
 successes:
 
 ---- $DIR/display-output.rs - foo (line 9) stdout ----
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/display-output.rs:13:12
-   |
-LL | fn foo(x: &std::fmt::Display) {}
-   |            ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn std::fmt::Display`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 warning: unused variable: `x`
   --> $DIR/display-output.rs:11:5
    |
@@ -31,13 +21,13 @@ LL | #![warn(unused)]
 warning: unused variable: `x`
   --> $DIR/display-output.rs:13:8
    |
-LL | fn foo(x: &std::fmt::Display) {}
+LL | fn foo(x: &dyn std::fmt::Display) {}
    |        ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 warning: function is never used: `foo`
   --> $DIR/display-output.rs:13:4
    |
-LL | fn foo(x: &std::fmt::Display) {}
+LL | fn foo(x: &dyn std::fmt::Display) {}
    |    ^^^
    |
 note: the lint level is defined here
@@ -47,7 +37,7 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
 
-warning: 4 warnings emitted
+warning: 3 warnings emitted
 
 
 

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
@@ -12,8 +12,6 @@ fn b() {
     //~^ ERROR expected trait, found constant `BAR`
     //~| ERROR expected trait, found constant `BAR`
     //~| ERROR type provided when a constant was expected
-    //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
 }
 fn c() {
     foo::<3 + 3>(); //~ ERROR expressions must be enclosed in braces

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -10,7 +10,7 @@ LL |     foo::<{ BAR + 3 }>();
    |           +         +
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:19:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:17:11
    |
 LL |     foo::<3 + 3>();
    |           ^^^^^
@@ -21,7 +21,7 @@ LL |     foo::<{ 3 + 3 }>();
    |           +       +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:22:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:20:15
    |
 LL |     foo::<BAR - 3>();
    |               ^ expected one of `,` or `>`
@@ -32,7 +32,7 @@ LL |     foo::<{ BAR - 3 }>();
    |           +         +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:25:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:23:15
    |
 LL |     foo::<BAR - BAR>();
    |               ^ expected one of `,` or `>`
@@ -43,7 +43,7 @@ LL |     foo::<{ BAR - BAR }>();
    |           +           +
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:28:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:26:11
    |
 LL |     foo::<100 - BAR>();
    |           ^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     foo::<{ 100 - BAR }>();
    |           +           +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:31:19
+  --> $DIR/const-expression-suggest-missing-braces.rs:29:19
    |
 LL |     foo::<bar<i32>()>();
    |                   ^ expected one of `,` or `>`
@@ -65,7 +65,7 @@ LL |     foo::<{ bar<i32>() }>();
    |           +            +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:34:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:32:21
    |
 LL |     foo::<bar::<i32>()>();
    |                     ^ expected one of `,` or `>`
@@ -76,7 +76,7 @@ LL |     foo::<{ bar::<i32>() }>();
    |           +              +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:37:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:35:21
    |
 LL |     foo::<bar::<i32>() + BAR>();
    |                     ^ expected one of `,` or `>`
@@ -87,7 +87,7 @@ LL |     foo::<{ bar::<i32>() + BAR }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:40:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:38:21
    |
 LL |     foo::<bar::<i32>() - BAR>();
    |                     ^ expected one of `,` or `>`
@@ -98,7 +98,7 @@ LL |     foo::<{ bar::<i32>() - BAR }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:43:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:41:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -109,7 +109,7 @@ LL |     foo::<{ BAR - bar::<i32>() }>();
    |           +                    +
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:46:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:44:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -131,23 +131,13 @@ error[E0404]: expected trait, found constant `BAR`
 LL |     foo::<BAR + BAR>();
    |                 ^^^ not a trait
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/const-expression-suggest-missing-braces.rs:11:11
-   |
-LL |     foo::<BAR + BAR>();
-   |           ^^^^^^^^^ help: use `dyn`: `dyn BAR + BAR`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 error[E0747]: type provided when a constant was expected
   --> $DIR/const-expression-suggest-missing-braces.rs:11:11
    |
 LL |     foo::<BAR + BAR>();
    |           ^^^^^^^^^
 
-error: aborting due to 14 previous errors; 1 warning emitted
+error: aborting due to 14 previous errors
 
 Some errors have detailed explanations: E0404, E0747.
 For more information about an error, try `rustc --explain E0404`.

--- a/src/test/ui/did_you_mean/bad-assoc-ty.rs
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.rs
@@ -32,6 +32,8 @@ type G = dyn 'static + (Send)::AssocTy;
 // Recovery should not apply in this context.
 type H = Fn(u8) -> (u8)::Output;
 //~^ ERROR ambiguous associated type
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 macro_rules! ty {
     ($ty: ty) => ($ty::AssocTy);

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -103,11 +103,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bad-assoc-ty.rs:33:10
    |
 LL | type H = Fn(u8) -> (u8)::Output;
-   |          ^^^^^^^^^^^^^^ help: use `dyn`: `<dyn Fn(u8) -> (u8)>`
+   |          ^^^^^^^^^^^^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL | type H = <dyn Fn(u8) -> (u8)>::Output;
+   |          ++++               +
 
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:33:10

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -41,13 +41,13 @@ LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<dyn 'static + (Send)>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:44:10
+  --> $DIR/bad-assoc-ty.rs:46:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^ help: try: `<ty!()>::AssocTy`
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:37:19
+  --> $DIR/bad-assoc-ty.rs:39:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^^^^^^^^^^ help: try: `<$ty>::AssocTy`
@@ -99,6 +99,16 @@ error[E0223]: ambiguous associated type
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<(dyn Send + 'static) as Trait>::AssocTy`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/bad-assoc-ty.rs:33:10
+   |
+LL | type H = Fn(u8) -> (u8)::Output;
+   |          ^^^^^^ help: use `dyn`: `<dyn Fn(u8)>`
+   |
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:33:10
    |
@@ -106,7 +116,7 @@ LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<(dyn Fn(u8) -> u8 + 'static) as Trait>::Output`
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:37:19
+  --> $DIR/bad-assoc-ty.rs:39:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
@@ -117,13 +127,13 @@ LL | type J = ty!(u8);
    = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:44:10
+  --> $DIR/bad-assoc-ty.rs:46:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<u8 as Trait>::AssocTy`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:49:13
+  --> $DIR/bad-assoc-ty.rs:51:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
    |             ^  ^ not allowed in type signatures
@@ -136,7 +146,7 @@ LL | fn foo<X: K<T, T>, T>(x: X) {}
    |             ~  ~ +++
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:52:34
+  --> $DIR/bad-assoc-ty.rs:54:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
@@ -147,7 +157,7 @@ LL | fn bar<F, T>(_: F) where F: Fn() -> T {}
    |         +++                         ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:55:19
+  --> $DIR/bad-assoc-ty.rs:57:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
@@ -158,7 +168,7 @@ LL | fn baz<F: Fn() -> T, T>(_: F) {}
    |                   ~+++
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:58:33
+  --> $DIR/bad-assoc-ty.rs:60:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
@@ -169,7 +179,7 @@ LL | struct L<F, T>(F) where F: Fn() -> T;
    |           +++                      ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:60:30
+  --> $DIR/bad-assoc-ty.rs:62:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
@@ -180,7 +190,7 @@ LL | struct M<F, T> where F: Fn() -> T {
    |           +++                   ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:64:28
+  --> $DIR/bad-assoc-ty.rs:66:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
@@ -191,7 +201,7 @@ LL | enum N<F, T> where F: Fn() -> T {
    |         +++                   ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:69:29
+  --> $DIR/bad-assoc-ty.rs:71:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -202,7 +212,7 @@ LL | union O<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:74:29
+  --> $DIR/bad-assoc-ty.rs:76:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -213,7 +223,7 @@ LL | trait P<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:79:38
+  --> $DIR/bad-assoc-ty.rs:81:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
    |                                      ^ not allowed in type signatures
@@ -223,7 +233,7 @@ help: use type parameters instead
 LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
    |             +++                         ~
 
-error: aborting due to 28 previous errors
+error: aborting due to 28 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0121, E0223.
 For more information about an error, try `rustc --explain E0121`.

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -103,7 +103,7 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bad-assoc-ty.rs:33:10
    |
 LL | type H = Fn(u8) -> (u8)::Output;
-   |          ^^^^^^ help: use `dyn`: `<dyn Fn(u8)>`
+   |          ^^^^^^^^^^^^^^ help: use `dyn`: `<dyn Fn(u8) -> (u8)>`
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.rs
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.rs
@@ -7,8 +7,6 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~| ERROR trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     let _x: &SomeTrait = todo!();
-    //~^ ERROR trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
 }
 
 trait SomeTrait {}

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.rs
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.rs
@@ -6,7 +6,17 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~| WARN this is accepted in the current edition
     //~| ERROR trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
     let _x: &SomeTrait = todo!();
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 }
 
 trait SomeTrait {}

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -21,14 +21,5 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-2018-edition-lint.rs:9:14
-   |
-LL |     let _x: &SomeTrait = todo!();
-   |              ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -31,5 +31,75 @@ LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    | 
 
-error: aborting due to 2 previous errors
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2018-edition-lint.rs:17:14
+   |
+LL |     let _x: &SomeTrait = todo!();
+   |              ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     let _x: &SomeTrait = todo!();
+LL +     let _x: &dyn SomeTrait = todo!();
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2018-edition-lint.rs:4:17
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                 ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2018-edition-lint.rs:4:17
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                 ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2018-edition-lint.rs:4:35
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                                   ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2018-edition-lint.rs:4:35
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                                   ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   | 
+
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -2,7 +2,7 @@ error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:17
    |
 LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                 ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                 ^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/dyn-2018-edition-lint.rs:2:8
@@ -11,15 +11,25 @@ LL | #[deny(bare_trait_objects)]
    |        ^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   | 
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
    |
 LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
-   |                                   ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                                   ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   | 
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -4,7 +4,6 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
     let _x: &SomeTrait = todo!();
-    //~^ ERROR trait objects must include the `dyn` keyword
 }
 
 trait SomeTrait {}

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -1,15 +1,4 @@
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/dyn-2021-edition-error.rs:6:14
-   |
-LL |     let _x: &SomeTrait = todo!();
-   |              ^^^^^^^^^
-   |
-help: add `dyn` keyword before this trait
-   |
-LL |     let _x: &dyn SomeTrait = todo!();
-   |              +++
-
-error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-2021-edition-error.rs:3:17
    |
 LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
@@ -18,7 +7,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 help: add `dyn` keyword before this trait
    |
 LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |                 +++
+   |                 ~~~~~~~~~~~~~
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-2021-edition-error.rs:3:35
@@ -29,8 +18,8 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 help: add `dyn` keyword before this trait
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |                                   +++
+   |                                   ~~~~~~~~~~~~~
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -6,8 +6,9 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
 help: add `dyn` keyword before this trait
    |
-LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   |                 ~~~~~~~~~~~~~
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
+   | 
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-2021-edition-error.rs:3:35
@@ -17,8 +18,9 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
 help: add `dyn` keyword before this trait
    |
-LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   |                                   ~~~~~~~~~~~~~
+LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
+   | 
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.fixed
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.fixed
@@ -15,8 +15,6 @@ impl fmt::Display for Foo {
         <dyn fmt::Debug>::fmt(self, f)
         //~^ ERROR trait objects without an explicit `dyn` are deprecated
         //~| WARNING this is accepted in the current edition
-        //~| ERROR trait objects without an explicit `dyn` are deprecated
-        //~| WARNING this is accepted in the current edition
     }
 }
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.rs
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.rs
@@ -15,8 +15,6 @@ impl fmt::Display for Foo {
         <fmt::Debug>::fmt(self, f)
         //~^ ERROR trait objects without an explicit `dyn` are deprecated
         //~| WARNING this is accepted in the current edition
-        //~| ERROR trait objects without an explicit `dyn` are deprecated
-        //~| WARNING this is accepted in the current edition
     }
 }
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -12,14 +12,5 @@ LL | #![deny(bare_trait_objects)]
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dyn-angle-brackets.rs:15:10
-   |
-LL |         <fmt::Debug>::fmt(self, f)
-   |          ^^^^^^^^^^ help: use `dyn`: `dyn fmt::Debug`
-   |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -2,7 +2,7 @@ error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-angle-brackets.rs:15:10
    |
 LL |         <fmt::Debug>::fmt(self, f)
-   |          ^^^^^^^^^^ help: use `dyn`: `dyn fmt::Debug`
+   |          ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/dyn-angle-brackets.rs:4:9
@@ -11,6 +11,11 @@ LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -         <fmt::Debug>::fmt(self, f)
+LL +         <dyn fmt::Debug>::fmt(self, f)
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/dyn-trait-sugg-2021.rs
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.rs
@@ -3,10 +3,10 @@
 trait Foo<T> {}
 
 impl<T> dyn Foo<T> {
-    fn hi(_x: T)  {}
+    fn hi(_x: T) {}
 }
 
 fn main() {
     Foo::hi(123);
-    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+    //~^ ERROR trait objects must include the `dyn` keyword
 }

--- a/src/test/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.stderr
@@ -1,8 +1,13 @@
-error[E0782]: trait objects without an explicit `dyn` are deprecated
+error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-trait-sugg-2021.rs:10:5
    |
 LL |     Foo::hi(123);
-   |     ^^^ help: use `dyn`: `<dyn Foo>`
+   |     ^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL |     <dyn Foo>::hi(123);
+   |     ~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.stderr
@@ -7,7 +7,7 @@ LL |     Foo::hi(123);
 help: add `dyn` keyword before this trait
    |
 LL |     <dyn Foo>::hi(123);
-   |     ~~~~~~~~~
+   |     ++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -9,7 +9,5 @@ fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~| ERROR: parenthesized generic arguments cannot be used
   //~| ERROR this associated type takes 0 generic arguments but 1 generic argument
   //~| ERROR this associated type takes 1 lifetime argument but 0 lifetime arguments
-  //~| WARNING: trait objects without an explicit `dyn` are deprecated
-  //~| WARNING: this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/src/test/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -10,16 +10,6 @@ error: parenthesized generic arguments cannot be used in associated type constra
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
    |                           ^^^^^
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/gat-trait-path-parenthesised-args.rs:7:29
-   |
-LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                             ^^ help: use `dyn`: `dyn 'a`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 error[E0107]: this associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:7:27
    |
@@ -50,6 +40,6 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/issues/issue-28344.rs
+++ b/src/test/ui/issues/issue-28344.rs
@@ -4,8 +4,12 @@ fn main() {
     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
     //~^ ERROR must be specified
     //~| no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 
     let g = BitXor::bitor;
     //~^ ERROR must be specified
     //~| no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -2,11 +2,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-28344.rs:4:17
    |
 LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
-   |                 ^^^^^^ help: use `dyn`: `<dyn BitXor>`
+   |                 ^^^^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let x: u8 = <dyn BitXor>::bitor(0 as u8, 0 as u8);
+   |                 ++++       +
 
 error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
   --> $DIR/issue-28344.rs:4:17
@@ -27,10 +31,14 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-28344.rs:10:13
    |
 LL |     let g = BitXor::bitor;
-   |             ^^^^^^ help: use `dyn`: `<dyn BitXor>`
+   |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let g = <dyn BitXor>::bitor;
+   |             ++++       +
 
 error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
   --> $DIR/issue-28344.rs:10:13

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -1,3 +1,13 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-28344.rs:4:17
+   |
+LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
+   |                 ^^^^^^ help: use `dyn`: `<dyn BitXor>`
+   |
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
   --> $DIR/issue-28344.rs:4:17
    |
@@ -13,14 +23,23 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         function or associated item not found in `dyn BitXor<_>`
    |                         help: there is an associated function with a similar name: `bitxor`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-28344.rs:10:13
+   |
+LL |     let g = BitXor::bitor;
+   |             ^^^^^^ help: use `dyn`: `<dyn BitXor>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
-  --> $DIR/issue-28344.rs:8:13
+  --> $DIR/issue-28344.rs:10:13
    |
 LL |     let g = BitXor::bitor;
    |             ^^^^^^ help: specify the associated type: `BitXor<Output = Type>`
 
 error[E0599]: no function or associated item named `bitor` found for trait object `dyn BitXor<_>` in the current scope
-  --> $DIR/issue-28344.rs:8:21
+  --> $DIR/issue-28344.rs:10:21
    |
 LL |     let g = BitXor::bitor;
    |                     ^^^^^
@@ -28,7 +47,7 @@ LL |     let g = BitXor::bitor;
    |                     function or associated item not found in `dyn BitXor<_>`
    |                     help: there is an associated function with a similar name: `bitxor`
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 2 warnings emitted
 
 Some errors have detailed explanations: E0191, E0599.
 For more information about an error, try `rustc --explain E0191`.

--- a/src/test/ui/issues/issue-58734.rs
+++ b/src/test/ui/issues/issue-58734.rs
@@ -19,4 +19,6 @@ fn main() {
     // no object safety error
     Trait::nonexistent(());
     //~^ ERROR no function or associated item named `nonexistent` found
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/issues/issue-58734.stderr
+++ b/src/test/ui/issues/issue-58734.stderr
@@ -1,9 +1,19 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-58734.rs:20:5
+   |
+LL |     Trait::nonexistent(());
+   |     ^^^^^ help: use `dyn`: `<dyn Trait>`
+   |
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0599]: no function or associated item named `nonexistent` found for trait object `dyn Trait` in the current scope
   --> $DIR/issue-58734.rs:20:12
    |
 LL |     Trait::nonexistent(());
    |            ^^^^^^^^^^^ function or associated item not found in `dyn Trait`
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/issues/issue-58734.stderr
+++ b/src/test/ui/issues/issue-58734.stderr
@@ -2,11 +2,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-58734.rs:20:5
    |
 LL |     Trait::nonexistent(());
-   |     ^^^^^ help: use `dyn`: `<dyn Trait>`
+   |     ^^^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     <dyn Trait>::nonexistent(());
+   |     ++++      +
 
 error[E0599]: no function or associated item named `nonexistent` found for trait object `dyn Trait` in the current scope
   --> $DIR/issue-58734.rs:20:12

--- a/src/test/ui/issues/issue-86756.stderr
+++ b/src/test/ui/issues/issue-86756.stderr
@@ -18,11 +18,16 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-86756.rs:5:15
    |
 LL |     eq::<dyn, Foo>
-   |               ^^^ help: use `dyn`: `dyn Foo`
+   |               ^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     eq::<dyn, Foo>
+LL +     eq::<dyn, dyn Foo>
+   | 
 
 error[E0107]: missing generics for trait `Foo`
   --> $DIR/issue-86756.rs:5:15

--- a/src/test/ui/lint/bare-trait-objects-path.rs
+++ b/src/test/ui/lint/bare-trait-objects-path.rs
@@ -21,4 +21,6 @@ fn main() {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     let _: Dyn::Ty; //~ ERROR ambiguous associated type
+    //~^ WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/lint/bare-trait-objects-path.stderr
+++ b/src/test/ui/lint/bare-trait-objects-path.stderr
@@ -1,3 +1,13 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/bare-trait-objects-path.rs:23:12
+   |
+LL |     let _: Dyn::Ty;
+   |            ^^^ help: use `dyn`: `<dyn Dyn>`
+   |
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0223]: ambiguous associated type
   --> $DIR/bare-trait-objects-path.rs:23:12
    |
@@ -10,7 +20,6 @@ warning: trait objects without an explicit `dyn` are deprecated
 LL |     Dyn::func();
    |     ^^^ help: use `dyn`: `<dyn Dyn>`
    |
-   = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
@@ -32,6 +41,6 @@ LL |     Dyn::CONST;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-error: aborting due to previous error; 3 warnings emitted
+error: aborting due to previous error; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0223`.

--- a/src/test/ui/lint/bare-trait-objects-path.stderr
+++ b/src/test/ui/lint/bare-trait-objects-path.stderr
@@ -2,11 +2,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:23:12
    |
 LL |     let _: Dyn::Ty;
-   |            ^^^ help: use `dyn`: `<dyn Dyn>`
+   |            ^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let _: <dyn Dyn>::Ty;
+   |            ++++    +
 
 error[E0223]: ambiguous associated type
   --> $DIR/bare-trait-objects-path.rs:23:12
@@ -18,28 +22,40 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:14:5
    |
 LL |     Dyn::func();
-   |     ^^^ help: use `dyn`: `<dyn Dyn>`
+   |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     <dyn Dyn>::func();
+   |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:17:5
    |
 LL |     ::Dyn::func();
-   |     ^^^^^ help: use `dyn`: `<dyn (::Dyn)>`
+   |     ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     <dyn (::Dyn)>::func();
+   |     ++++++     ++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/bare-trait-objects-path.rs:20:5
    |
 LL |     Dyn::CONST;
-   |     ^^^ help: use `dyn`: `<dyn Dyn>`
+   |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     <dyn Dyn>::CONST;
+   |     ++++    +
 
 error: aborting due to previous error; 4 warnings emitted
 

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.rs
@@ -10,5 +10,9 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -2,29 +2,44 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = note: requested on the command line with `--force-warn bare-trait-objects`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -8,5 +8,23 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/cap-lints-allow.rs
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.rs
@@ -8,5 +8,9 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.stderr
@@ -2,29 +2,44 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = note: requested on the command line with `--force-warn bare-trait-objects`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.stderr
@@ -8,5 +8,23 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/cap-lints-allow.rs:8:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/cap-lints-allow.rs:8:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.rs
@@ -8,5 +8,9 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -2,29 +2,44 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -8,5 +8,23 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.rs
@@ -10,5 +10,9 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -8,5 +8,23 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-lint-group.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-lint-group.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -2,29 +2,44 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.rs
@@ -10,5 +10,9 @@ pub trait SomeTrait {}
 pub fn function(_x: Box<SomeTrait>) {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
 
 fn main() {}

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -8,5 +8,23 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
+   |
+LL | pub fn function(_x: Box<SomeTrait>) {}
+   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -2,29 +2,44 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
    |
 LL | pub fn function(_x: Box<SomeTrait>) {}
-   |                         ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub fn function(_x: Box<SomeTrait>) {}
+LL + pub fn function(_x: Box<dyn SomeTrait>) {}
+   | 
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/parser/issues/issue-68890-2.rs
+++ b/src/test/ui/parser/issues/issue-68890-2.rs
@@ -3,5 +3,3 @@ fn main() {}
 type X<'a> = (?'a) +;
 //~^ ERROR `?` may only modify trait bounds, not lifetime bounds
 //~| ERROR at least one trait is required for an object type
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition

--- a/src/test/ui/parser/issues/issue-68890-2.stderr
+++ b/src/test/ui/parser/issues/issue-68890-2.stderr
@@ -4,22 +4,12 @@ error: `?` may only modify trait bounds, not lifetime bounds
 LL | type X<'a> = (?'a) +;
    |               ^
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-68890-2.rs:3:14
-   |
-LL | type X<'a> = (?'a) +;
-   |              ^^^^^^^ help: use `dyn`: `dyn (?'a) +`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 error[E0224]: at least one trait is required for an object type
   --> $DIR/issue-68890-2.rs:3:14
    |
 LL | type X<'a> = (?'a) +;
    |              ^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/parser/issues/issue-73568-lifetime-after-mut.rs
+++ b/src/test/ui/parser/issues/issue-73568-lifetime-after-mut.rs
@@ -13,11 +13,7 @@ mac!('a);
 // avoid false positives
 fn y<'a>(y: &mut 'a + Send) {
     //~^ ERROR expected a path on the left-hand side of `+`, not `&mut 'a`
-    //~| WARNING trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
     //~| ERROR at least one trait is required for an object type
     let z = y as &mut 'a + Send;
     //~^ ERROR expected value, found trait `Send`
-    //~| WARNING trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/src/test/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -22,29 +22,10 @@ LL | mac!('a);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0423]: expected value, found trait `Send`
-  --> $DIR/issue-73568-lifetime-after-mut.rs:19:28
+  --> $DIR/issue-73568-lifetime-after-mut.rs:17:28
    |
 LL |     let z = y as &mut 'a + Send;
    |                            ^^^^ not a value
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-73568-lifetime-after-mut.rs:14:18
-   |
-LL | fn y<'a>(y: &mut 'a + Send) {
-   |                  ^^ help: use `dyn`: `dyn 'a`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-73568-lifetime-after-mut.rs:19:23
-   |
-LL |     let z = y as &mut 'a + Send;
-   |                       ^^ help: use `dyn`: `dyn 'a`
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/issue-73568-lifetime-after-mut.rs:14:18
@@ -52,7 +33,7 @@ error[E0224]: at least one trait is required for an object type
 LL | fn y<'a>(y: &mut 'a + Send) {
    |                  ^^
 
-error: aborting due to 5 previous errors; 2 warnings emitted
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0178, E0224, E0423.
 For more information about an error, try `rustc --explain E0178`.

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.rs
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.rs
@@ -11,6 +11,4 @@ fn main() {
     m!('static);
     //~^ ERROR lifetime in trait object type must be followed by `+`
     //~| ERROR at least one trait is required for an object type
-    //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
@@ -4,22 +4,12 @@ error: lifetime in trait object type must be followed by `+`
 LL |     m!('static);
    |        ^^^^^^^
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/trait-object-macro-matcher.rs:11:8
-   |
-LL |     m!('static);
-   |        ^^^^^^^ help: use `dyn`: `dyn 'static`
-   |
-   = note: `#[warn(bare_trait_objects)]` on by default
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 error[E0224]: at least one trait is required for an object type
   --> $DIR/trait-object-macro-matcher.rs:11:8
    |
 LL |     m!('static);
    |        ^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0224`.

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -20,11 +20,16 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/trait-object-trait-parens.rs:8:16
    |
 LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
+LL +     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;
+   | 
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35
@@ -41,10 +46,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/trait-object-trait-parens.rs:13:16
    |
 LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn ?Sized + (for<'a> Trait<'a>) + (Obj)`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
+LL +     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
+   | 
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:13:47
@@ -61,10 +71,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/trait-object-trait-parens.rs:18:16
    |
 LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn for<'a> Trait<'a> + (Obj) + (?Sized)`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
+LL +     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;
+   | 
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:18:36

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -26,24 +26,6 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/trait-object-trait-parens.rs:13:16
-   |
-LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn ?Sized + (for<'a> Trait<'a>) + (Obj)`
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/trait-object-trait-parens.rs:18:16
-   |
-LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn for<'a> Trait<'a> + (Obj) + (?Sized)`
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35
    |
@@ -55,6 +37,15 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: Obj + for<'a> Trait<'a> {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/trait-object-trait-parens.rs:13:16
+   |
+LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn ?Sized + (for<'a> Trait<'a>) + (Obj)`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:13:47
    |
@@ -65,6 +56,15 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |
    = help: consider creating a new trait with all of these as supertraits and using that trait here instead: `trait NewTrait: for<'a> Trait<'a> + Obj {}`
    = note: auto-traits like `Send` and `Sync` are traits that have special properties; for more information on them, visit <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/trait-object-trait-parens.rs:18:16
+   |
+LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn for<'a> Trait<'a> + (Obj) + (?Sized)`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:18:36

--- a/src/test/ui/suggestions/issue-61963.rs
+++ b/src/test/ui/suggestions/issue-61963.rs
@@ -18,9 +18,19 @@ pub struct Qux<T>(T);
 pub struct Foo {
     //~^ ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition
     qux: Qux<Qux<Baz>>,
     bar: Box<Bar>,
     //~^ ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
+    //~| WARN this is accepted in the current edition
+    //~| ERROR trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARN this is accepted in the current edition
 }
 

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -1,5 +1,5 @@
 error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-61963.rs:22:14
+  --> $DIR/issue-61963.rs:28:14
    |
 LL |     bar: Box<Bar>,
    |              ^^^
@@ -31,5 +31,75 @@ LL - pub struct Foo {
 LL + dyn pub struct Foo {
    | 
 
-error: aborting due to 2 previous errors
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-61963.rs:28:14
+   |
+LL |     bar: Box<Bar>,
+   |              ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     bar: Box<Bar>,
+LL +     bar: Box<dyn Bar>,
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-61963.rs:28:14
+   |
+LL |     bar: Box<Bar>,
+   |              ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     bar: Box<Bar>,
+LL +     bar: Box<dyn Bar>,
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-61963.rs:18:1
+   |
+LL | pub struct Foo {
+   | ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub struct Foo {
+LL + dyn pub struct Foo {
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-61963.rs:18:1
+   |
+LL | pub struct Foo {
+   | ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub struct Foo {
+LL + dyn pub struct Foo {
+   | 
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/issue-61963.rs:18:1
+   |
+LL | pub struct Foo {
+   | ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub struct Foo {
+LL + dyn pub struct Foo {
+   | 
+
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -2,7 +2,7 @@ error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:22:14
    |
 LL |     bar: Box<Bar>,
-   |              ^^^ help: use `dyn`: `dyn Bar`
+   |              ^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-61963.rs:3:9
@@ -11,15 +11,25 @@ LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL -     bar: Box<Bar>,
+LL +     bar: Box<dyn Bar>,
+   | 
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
    |
 LL | pub struct Foo {
-   | ^^^ help: use `dyn`: `dyn pub`
+   | ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - pub struct Foo {
+LL + dyn pub struct Foo {
+   | 
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/bound/not-on-bare-trait.stderr
+++ b/src/test/ui/traits/bound/not-on-bare-trait.stderr
@@ -2,11 +2,16 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/not-on-bare-trait.rs:7:12
    |
 LL | fn foo(_x: Foo + Send) {
-   |            ^^^^^^^^^^ help: use `dyn`: `dyn Foo + Send`
+   |            ^^^^^^^^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL - fn foo(_x: Foo + Send) {
+LL + fn foo(_x: dyn Foo + Send) {
+   | 
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/src/test/ui/unspecified-self-in-trait-ref.rs
+++ b/src/test/ui/unspecified-self-in-trait-ref.rs
@@ -9,12 +9,22 @@ pub trait Bar<X=usize, A=Self> {
 fn main() {
     let a = Foo::lol();
     //~^ ERROR no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
     let b = Foo::<_>::lol();
     //~^ ERROR no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
     let c = Bar::lol();
     //~^ ERROR no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
     let d = Bar::<usize, _>::lol();
     //~^ ERROR no function or associated item named
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
     let e = Bar::<usize>::lol();
     //~^ ERROR must be explicitly specified
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
 }

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -2,11 +2,15 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/unspecified-self-in-trait-ref.rs:10:13
    |
 LL |     let a = Foo::lol();
-   |             ^^^ help: use `dyn`: `<dyn Foo>`
+   |             ^^^
    |
    = note: `#[warn(bare_trait_objects)]` on by default
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let a = <dyn Foo>::lol();
+   |             ++++    +
 
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Foo<_>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:10:18
@@ -18,10 +22,14 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/unspecified-self-in-trait-ref.rs:14:13
    |
 LL |     let b = Foo::<_>::lol();
-   |             ^^^^^^^^ help: use `dyn`: `<dyn Foo::<_>>`
+   |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let b = <dyn Foo::<_>>::lol();
+   |             ++++         +
 
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Foo<_>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:14:23
@@ -33,10 +41,14 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/unspecified-self-in-trait-ref.rs:18:13
    |
 LL |     let c = Bar::lol();
-   |             ^^^ help: use `dyn`: `<dyn Bar>`
+   |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let c = <dyn Bar>::lol();
+   |             ++++    +
 
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Bar<_, _>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:18:18
@@ -48,10 +60,14 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/unspecified-self-in-trait-ref.rs:22:13
    |
 LL |     let d = Bar::<usize, _>::lol();
-   |             ^^^^^^^^^^^^^^^ help: use `dyn`: `<dyn Bar::<usize, _>>`
+   |             ^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let d = <dyn Bar::<usize, _>>::lol();
+   |             ++++                +
 
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Bar<usize, _>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:22:30
@@ -63,10 +79,14 @@ warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/unspecified-self-in-trait-ref.rs:26:13
    |
 LL |     let e = Bar::<usize>::lol();
-   |             ^^^^^^^^^^^^ help: use `dyn`: `<dyn Bar::<usize>>`
+   |             ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL |     let e = <dyn Bar::<usize>>::lol();
+   |             ++++             +
 
 error[E0393]: the type parameter `A` must be explicitly specified
   --> $DIR/unspecified-self-in-trait-ref.rs:26:13

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -1,29 +1,75 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/unspecified-self-in-trait-ref.rs:10:13
+   |
+LL |     let a = Foo::lol();
+   |             ^^^ help: use `dyn`: `<dyn Foo>`
+   |
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Foo<_>` in the current scope
   --> $DIR/unspecified-self-in-trait-ref.rs:10:18
    |
 LL |     let a = Foo::lol();
    |                  ^^^ function or associated item not found in `dyn Foo<_>`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/unspecified-self-in-trait-ref.rs:14:13
+   |
+LL |     let b = Foo::<_>::lol();
+   |             ^^^^^^^^ help: use `dyn`: `<dyn Foo::<_>>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Foo<_>` in the current scope
-  --> $DIR/unspecified-self-in-trait-ref.rs:12:23
+  --> $DIR/unspecified-self-in-trait-ref.rs:14:23
    |
 LL |     let b = Foo::<_>::lol();
    |                       ^^^ function or associated item not found in `dyn Foo<_>`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/unspecified-self-in-trait-ref.rs:18:13
+   |
+LL |     let c = Bar::lol();
+   |             ^^^ help: use `dyn`: `<dyn Bar>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Bar<_, _>` in the current scope
-  --> $DIR/unspecified-self-in-trait-ref.rs:14:18
+  --> $DIR/unspecified-self-in-trait-ref.rs:18:18
    |
 LL |     let c = Bar::lol();
    |                  ^^^ function or associated item not found in `dyn Bar<_, _>`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/unspecified-self-in-trait-ref.rs:22:13
+   |
+LL |     let d = Bar::<usize, _>::lol();
+   |             ^^^^^^^^^^^^^^^ help: use `dyn`: `<dyn Bar::<usize, _>>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0599]: no function or associated item named `lol` found for trait object `dyn Bar<usize, _>` in the current scope
-  --> $DIR/unspecified-self-in-trait-ref.rs:16:30
+  --> $DIR/unspecified-self-in-trait-ref.rs:22:30
    |
 LL |     let d = Bar::<usize, _>::lol();
    |                              ^^^ function or associated item not found in `dyn Bar<usize, _>`
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/unspecified-self-in-trait-ref.rs:26:13
+   |
+LL |     let e = Bar::<usize>::lol();
+   |             ^^^^^^^^^^^^ help: use `dyn`: `<dyn Bar::<usize>>`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+
 error[E0393]: the type parameter `A` must be explicitly specified
-  --> $DIR/unspecified-self-in-trait-ref.rs:18:13
+  --> $DIR/unspecified-self-in-trait-ref.rs:26:13
    |
 LL | / pub trait Bar<X=usize, A=Self> {
 LL | |     fn foo(&self);
@@ -35,7 +81,7 @@ LL |       let e = Bar::<usize>::lol();
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 5 warnings emitted
 
 Some errors have detailed explanations: E0393, E0599.
 For more information about an error, try `rustc --explain E0393`.


### PR DESCRIPTION
Removing the lint from lowering allows to:
- make lowering querification easier;
- have the lint implementation in only one place.

r? @estebank 