### PR TITLE
[bootstrap] Improve the error message when `ninja` is not found to link to installation instructions

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1494,8 +1494,12 @@ impl Build {
             {
                 eprintln!(
                     "
-Couldn't find required command: ninja
-You should install ninja, or set `ninja=false` in config.toml in the `[llvm]` section.
+Couldn't find required command: ninja (or ninja-build)
+
+You should install ninja as described at
+<https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages>,
+or set `download-ci-llvm = true` in the `[llvm]` section of `config.toml`
+to download LLVM rather than building it.
 "
                 );
                 std::process::exit(1);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1498,7 +1498,8 @@ Couldn't find required command: ninja (or ninja-build)
 
 You should install ninja as described at
 <https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages>,
-or set `download-ci-llvm = true` in the `[llvm]` section of `config.toml`
+or set `ninja = false` in the `[llvm]` section of `config.toml`.
+Alternatively, set `download-ci-llvm = true` in that `[llvm]` section
 to download LLVM rather than building it.
 "
                 );


### PR DESCRIPTION
fixes #89091

Signed-off-by: Daira Hopwood <daira@jacaranda.org>