### PR TITLE
Support incremental in compiletest for non-incremental modes.

### DIFF
--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -1,9 +1,10 @@
 //
 
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
 // We specify opt-level=0 because `drop_in_place` is `Internal` when optimizing
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/extern-drop-glue
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus -Copt-level=0
 
 #![allow(dead_code)]

--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -1,7 +1,8 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=eager -Cincremental=tmp/partitioning-tests/extern-generic -Zshare-generics=y
+// incremental
+// compile-flags:-Zprint-mono-items=eager -Zshare-generics=y
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/incremental-merging.rs
+++ b/src/test/codegen-units/partitioning/incremental-merging.rs
@@ -1,6 +1,7 @@
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/incremental-merging
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Ccodegen-units=3
 
 #![crate_type = "rlib"]

--- a/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
+++ b/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
@@ -1,7 +1,8 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/inlining-from-extern-crate
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus
 
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -1,8 +1,9 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
 // We specify opt-level=0 because `drop_in_place` is `Internal` when optimizing
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/local-drop-glue
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus -Copt-level=0
 
 #![allow(dead_code)]

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -1,6 +1,7 @@
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=eager -Cincremental=tmp/partitioning-tests/local-generic
+// incremental
+// compile-flags:-Zprint-mono-items=eager
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-inlining-but-not-all.rs
+++ b/src/test/codegen-units/partitioning/local-inlining-but-not-all.rs
@@ -1,7 +1,8 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/local-inlining-but-not-all
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus=no
 
 #![allow(dead_code)]

--- a/src/test/codegen-units/partitioning/local-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-inlining.rs
@@ -1,7 +1,8 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/local-inlining
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus
 
 #![allow(dead_code)]

--- a/src/test/codegen-units/partitioning/local-transitive-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-transitive-inlining.rs
@@ -1,7 +1,8 @@
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/local-transitive-inlining
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus
 
 #![allow(dead_code)]

--- a/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
+++ b/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
@@ -4,9 +4,10 @@
 // ignore-test
 
 //
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/methods-are-with-self-type
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 
 #![allow(dead_code)]
 #![feature(start)]

--- a/src/test/codegen-units/partitioning/regular-modules.rs
+++ b/src/test/codegen-units/partitioning/regular-modules.rs
@@ -1,6 +1,7 @@
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=eager -Cincremental=tmp/partitioning-tests/regular-modules
+// incremental
+// compile-flags:-Zprint-mono-items=eager
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/shared-generics.rs
+++ b/src/test/codegen-units/partitioning/shared-generics.rs
@@ -2,7 +2,8 @@
 // no-prefer-dynamic
 // NOTE: We always compile this test with -Copt-level=0 because higher opt-levels
 //       prevent drop-glue from participating in share-generics.
-// compile-flags:-Zprint-mono-items=eager -Zshare-generics=yes -Cincremental=tmp/partitioning-tests/shared-generics-exe -Copt-level=0
+// incremental
+// compile-flags:-Zprint-mono-items=eager -Zshare-generics=yes -Copt-level=0
 
 #![crate_type="rlib"]
 

--- a/src/test/codegen-units/partitioning/statics.rs
+++ b/src/test/codegen-units/partitioning/statics.rs
@@ -1,6 +1,7 @@
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/statics
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 
 #![crate_type="rlib"]
 

--- a/src/test/codegen-units/partitioning/vtable-through-const.rs
+++ b/src/test/codegen-units/partitioning/vtable-through-const.rs
@@ -1,8 +1,9 @@
 //
 
-// We specify -C incremental here because we want to test the partitioning for
+// We specify incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-mono-items=lazy -Cincremental=tmp/partitioning-tests/vtable-through-const
+// incremental
+// compile-flags:-Zprint-mono-items=lazy
 // compile-flags:-Zinline-in-all-cgus
 
 // This test case makes sure, that references made through constants are

--- a/src/test/ui/associated-type-bounds/traits-assoc-type-macros.rs
+++ b/src/test/ui/associated-type-bounds/traits-assoc-type-macros.rs
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags:-Cincremental=tmp/traits-assoc-type-macros
+// incremental
 
 // This test case makes sure that we can compile with incremental compilation
 // enabled when there are macros, traits, inheritance and associated types involved.

--- a/src/test/ui/async-await/issue-72442.rs
+++ b/src/test/ui/async-await/issue-72442.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-flags:-Cincremental=tmp/issue-72442
+// incremental
 
 use std::fs::File;
 use std::future::Future;

--- a/src/test/ui/async-await/issues/issue-64964.rs
+++ b/src/test/ui/async-await/issues/issue-64964.rs
@@ -1,5 +1,6 @@
 // check-pass
-// compile-flags: -Z query-dep-graph -C incremental=tmp/issue-64964
+// incremental
+// compile-flags: -Z query-dep-graph
 // edition:2018
 
 // Regression test for ICE related to `await`ing in a method + incr. comp. (#64964)

--- a/src/test/ui/dep-graph/dep-graph-assoc-type-codegen.rs
+++ b/src/test/ui/dep-graph/dep-graph-assoc-type-codegen.rs
@@ -1,7 +1,8 @@
 // Test that when a trait impl changes, fns whose body uses that trait
 // must also be recompiled.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-assoc-type-codegen
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(warnings)]

--- a/src/test/ui/dep-graph/dep-graph-assoc-type-codegen.stderr
+++ b/src/test/ui/dep-graph/dep-graph-assoc-type-codegen.stderr
@@ -1,5 +1,5 @@
 error: OK
-  --> $DIR/dep-graph-assoc-type-codegen.rs:28:5
+  --> $DIR/dep-graph-assoc-type-codegen.rs:29:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-caller-callee.rs
+++ b/src/test/ui/dep-graph/dep-graph-caller-callee.rs
@@ -1,7 +1,8 @@
 // Test that immediate callers have to change when callee changes, but
 // not callers' callers.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-caller-callee
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/dep-graph/dep-graph-caller-callee.stderr
+++ b/src/test/ui/dep-graph/dep-graph-caller-callee.stderr
@@ -1,11 +1,11 @@
 error: OK
-  --> $DIR/dep-graph-caller-callee.rs:20:5
+  --> $DIR/dep-graph-caller-callee.rs:21:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `x` to `typeck`
-  --> $DIR/dep-graph-caller-callee.rs:31:5
+  --> $DIR/dep-graph-caller-callee.rs:32:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-struct-signature.rs
+++ b/src/test/ui/dep-graph/dep-graph-struct-signature.rs
@@ -1,7 +1,8 @@
 // Test cases where a changing struct appears in the signature of fns
 // and methods.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-struct-signature
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/dep-graph/dep-graph-struct-signature.stderr
+++ b/src/test/ui/dep-graph/dep-graph-struct-signature.stderr
@@ -1,131 +1,131 @@
 error: no path from `WillChange` to `type_of`
-  --> $DIR/dep-graph-struct-signature.rs:27:5
+  --> $DIR/dep-graph-struct-signature.rs:28:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `associated_item`
-  --> $DIR/dep-graph-struct-signature.rs:28:5
+  --> $DIR/dep-graph-struct-signature.rs:29:5
    |
 LL |     #[rustc_then_this_would_need(associated_item)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `trait_def`
-  --> $DIR/dep-graph-struct-signature.rs:29:5
+  --> $DIR/dep-graph-struct-signature.rs:30:5
    |
 LL |     #[rustc_then_this_would_need(trait_def)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:31:9
+  --> $DIR/dep-graph-struct-signature.rs:32:9
    |
 LL |         #[rustc_then_this_would_need(fn_sig)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:35:5
-   |
-LL |     #[rustc_then_this_would_need(fn_sig)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: OK
   --> $DIR/dep-graph-struct-signature.rs:36:5
    |
-LL |     #[rustc_then_this_would_need(typeck)]
+LL |     #[rustc_then_this_would_need(fn_sig)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:39:5
+  --> $DIR/dep-graph-struct-signature.rs:37:5
    |
-LL |     #[rustc_then_this_would_need(fn_sig)]
+LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:40:5
    |
+LL |     #[rustc_then_this_would_need(fn_sig)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: OK
+  --> $DIR/dep-graph-struct-signature.rs:41:5
+   |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:45:5
+  --> $DIR/dep-graph-struct-signature.rs:46:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: OK
-  --> $DIR/dep-graph-struct-signature.rs:47:9
-   |
-LL |         #[rustc_then_this_would_need(fn_sig)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:48:9
    |
+LL |         #[rustc_then_this_would_need(fn_sig)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: OK
+  --> $DIR/dep-graph-struct-signature.rs:49:9
+   |
 LL |         #[rustc_then_this_would_need(typeck)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:52:5
+  --> $DIR/dep-graph-struct-signature.rs:53:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: OK
-  --> $DIR/dep-graph-struct-signature.rs:54:9
-   |
-LL |         #[rustc_then_this_would_need(fn_sig)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:55:9
    |
+LL |         #[rustc_then_this_would_need(fn_sig)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: OK
+  --> $DIR/dep-graph-struct-signature.rs:56:9
+   |
 LL |         #[rustc_then_this_would_need(typeck)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:60:9
+  --> $DIR/dep-graph-struct-signature.rs:61:9
    |
 LL |         #[rustc_then_this_would_need(type_of)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-struct-signature.rs:62:9
+  --> $DIR/dep-graph-struct-signature.rs:63:9
    |
 LL |         #[rustc_then_this_would_need(type_of)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `type_of`
-  --> $DIR/dep-graph-struct-signature.rs:67:5
+  --> $DIR/dep-graph-struct-signature.rs:68:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `type_of`
-  --> $DIR/dep-graph-struct-signature.rs:74:5
+  --> $DIR/dep-graph-struct-signature.rs:75:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `fn_sig`
-  --> $DIR/dep-graph-struct-signature.rs:76:9
+  --> $DIR/dep-graph-struct-signature.rs:77:9
    |
 LL |         #[rustc_then_this_would_need(fn_sig)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `fn_sig`
-  --> $DIR/dep-graph-struct-signature.rs:80:5
+  --> $DIR/dep-graph-struct-signature.rs:81:5
    |
 LL |     #[rustc_then_this_would_need(fn_sig)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `fn_sig`
-  --> $DIR/dep-graph-struct-signature.rs:83:5
+  --> $DIR/dep-graph-struct-signature.rs:84:5
    |
 LL |     #[rustc_then_this_would_need(fn_sig)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `WillChange` to `typeck`
-  --> $DIR/dep-graph-struct-signature.rs:84:5
+  --> $DIR/dep-graph-struct-signature.rs:85:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
@@ -1,7 +1,8 @@
 // Test that adding an impl to a trait `Foo` DOES affect functions
 // that only use `Bar` if they have methods in common.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-trait-impl-two-traits-same-method
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.stderr
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.stderr
@@ -1,11 +1,11 @@
 error: OK
-  --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:32:5
+  --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:33:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `x::<impl Foo for u32>` to `typeck`
-  --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:41:5
+  --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:42:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
@@ -1,7 +1,8 @@
 // Test that adding an impl to a trait `Foo` does not affect functions
 // that only use `Bar`, so long as they do not have methods in common.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-trait-impl-two-traits
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(warnings)]

--- a/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits.stderr
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl-two-traits.stderr
@@ -1,11 +1,11 @@
 error: no path from `x::<impl Foo for char>` to `typeck`
-  --> $DIR/dep-graph-trait-impl-two-traits.rs:31:5
+  --> $DIR/dep-graph-trait-impl-two-traits.rs:32:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `x::<impl Foo for char>` to `typeck`
-  --> $DIR/dep-graph-trait-impl-two-traits.rs:40:5
+  --> $DIR/dep-graph-trait-impl-two-traits.rs:41:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-trait-impl.rs
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl.rs
@@ -1,7 +1,8 @@
 // Test that when a trait impl changes, fns whose body uses that trait
 // must also be recompiled.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-trait-impl
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(warnings)]

--- a/src/test/ui/dep-graph/dep-graph-trait-impl.stderr
+++ b/src/test/ui/dep-graph/dep-graph-trait-impl.stderr
@@ -1,29 +1,29 @@
 error: OK
-  --> $DIR/dep-graph-trait-impl.rs:27:5
+  --> $DIR/dep-graph-trait-impl.rs:28:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-trait-impl.rs:32:5
+  --> $DIR/dep-graph-trait-impl.rs:33:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-trait-impl.rs:37:5
+  --> $DIR/dep-graph-trait-impl.rs:38:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-trait-impl.rs:42:5
+  --> $DIR/dep-graph-trait-impl.rs:43:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `x::<impl Foo for char>` to `typeck`
-  --> $DIR/dep-graph-trait-impl.rs:55:5
+  --> $DIR/dep-graph-trait-impl.rs:56:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-type-alias.rs
+++ b/src/test/ui/dep-graph/dep-graph-type-alias.rs
@@ -1,6 +1,7 @@
 // Test that changing what a `type` points to does not go unnoticed.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-type-alias
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/dep-graph/dep-graph-type-alias.stderr
+++ b/src/test/ui/dep-graph/dep-graph-type-alias.stderr
@@ -1,71 +1,71 @@
 error: no path from `TypeAlias` to `type_of`
-  --> $DIR/dep-graph-type-alias.rs:17:1
+  --> $DIR/dep-graph-type-alias.rs:18:1
    |
 LL | #[rustc_then_this_would_need(type_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:19:5
+  --> $DIR/dep-graph-type-alias.rs:20:5
    |
 LL |     #[rustc_then_this_would_need(type_of)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `TypeAlias` to `type_of`
-  --> $DIR/dep-graph-type-alias.rs:24:1
+  --> $DIR/dep-graph-type-alias.rs:25:1
    |
 LL | #[rustc_then_this_would_need(type_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:27:9
+  --> $DIR/dep-graph-type-alias.rs:28:9
    |
 LL |         #[rustc_then_this_would_need(type_of)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `TypeAlias` to `type_of`
-  --> $DIR/dep-graph-type-alias.rs:33:1
+  --> $DIR/dep-graph-type-alias.rs:34:1
    |
 LL | #[rustc_then_this_would_need(type_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:35:5
+  --> $DIR/dep-graph-type-alias.rs:36:5
    |
 LL |     #[rustc_then_this_would_need(fn_sig)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no path from `TypeAlias` to `type_of`
-  --> $DIR/dep-graph-type-alias.rs:41:1
+  --> $DIR/dep-graph-type-alias.rs:42:1
    |
 LL | #[rustc_then_this_would_need(type_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:43:5
+  --> $DIR/dep-graph-type-alias.rs:44:5
    |
 LL |     #[rustc_then_this_would_need(fn_sig)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:44:5
+  --> $DIR/dep-graph-type-alias.rs:45:5
    |
 LL |     #[rustc_then_this_would_need(typeck)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:48:1
+  --> $DIR/dep-graph-type-alias.rs:49:1
    |
 LL | #[rustc_then_this_would_need(type_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:51:1
+  --> $DIR/dep-graph-type-alias.rs:52:1
    |
 LL | #[rustc_then_this_would_need(fn_sig)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: OK
-  --> $DIR/dep-graph-type-alias.rs:52:1
+  --> $DIR/dep-graph-type-alias.rs:53:1
    |
 LL | #[rustc_then_this_would_need(typeck)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dep-graph/dep-graph-variance-alias.rs
+++ b/src/test/ui/dep-graph/dep-graph-variance-alias.rs
@@ -1,7 +1,8 @@
 // Test that changing what a `type` points to does not go unnoticed
 // by the variance analysis.
 
-// compile-flags: -Z query-dep-graph -C incremental=tmp/dep-graph-variance-alias
+// incremental
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/dep-graph/dep-graph-variance-alias.stderr
+++ b/src/test/ui/dep-graph/dep-graph-variance-alias.stderr
@@ -1,5 +1,5 @@
 error: OK
-  --> $DIR/dep-graph-variance-alias.rs:18:1
+  --> $DIR/dep-graph-variance-alias.rs:19:1
    |
 LL | #[rustc_then_this_would_need(variances_of)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/suggestions/issue-72766.rs
+++ b/src/test/ui/suggestions/issue-72766.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-flags: -Cincremental=tmp/issue-72766
+// incremental
 
 pub struct SadGirl;
 

--- a/src/test/ui/wf/hir-wf-check-erase-regions.rs
+++ b/src/test/ui/wf/hir-wf-check-erase-regions.rs
@@ -1,5 +1,5 @@
 // Regression test for #87549.
-// compile-flags: -C incremental=tmp/wf/hir-wf-check-erase-regions
+// incremental
 
 pub struct Table<T, const N: usize>([Option<T>; N]);
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -459,3 +459,9 @@ pub fn output_base_dir(config: &Config, testpaths: &TestPaths, revision: Option<
 pub fn output_base_name(config: &Config, testpaths: &TestPaths, revision: Option<&str>) -> PathBuf {
     output_base_dir(config, testpaths, revision).join(testpaths.file.file_stem().unwrap())
 }
+
+/// Absolute path to the directory to use for incremental compilation. Example:
+///   /path/to/build/host-triple/test/ui/relative/testname.mode/testname.inc
+pub fn incremental_dir(config: &Config, testpaths: &TestPaths) -> PathBuf {
+    output_base_name(config, testpaths, None).with_extension("inc")
+}

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -113,6 +113,21 @@ pub struct TestProps {
     // testing harness and used when generating compilation
     // arguments. (In particular, it propagates to the aux-builds.)
     pub incremental_dir: Option<PathBuf>,
+    // If `true`, this test will use incremental compilation.
+    //
+    // This can be set manually with the `incremental` header, or implicitly
+    // by being a part of an incremental mode test. Using the `incremental`
+    // header should be avoided if possible; using an incremental mode test is
+    // preferred. Incremental mode tests support multiple passes, which can
+    // verify that the incremental cache can be loaded properly after being
+    // created. Just setting the header will only verify the behavior with
+    // creating an incremental cache, but doesn't check that it is created
+    // correctly.
+    //
+    // Compiletest will create the incremental directory, and ensure it is
+    // empty before the test starts. Incremental mode tests will reuse the
+    // incremental directory between passes in the same test.
+    pub incremental: bool,
     // How far should the test proceed while still passing.
     pass_mode: Option<PassMode>,
     // Ignore `--pass` overrides from the command line for this test.
@@ -163,6 +178,7 @@ impl TestProps {
             pretty_compare_only: false,
             forbid_output: vec![],
             incremental_dir: None,
+            incremental: false,
             pass_mode: None,
             fail_mode: None,
             ignore_pass: false,
@@ -350,6 +366,10 @@ impl TestProps {
                 if !self.stderr_per_bitwidth {
                     self.stderr_per_bitwidth = config.parse_stderr_per_bitwidth(ln);
                 }
+
+                if !self.incremental {
+                    self.incremental = config.parse_incremental(ln);
+                }
             });
         }
 
@@ -358,6 +378,10 @@ impl TestProps {
         }
         if self.should_ice {
             self.failure_status = 101;
+        }
+
+        if config.mode == Mode::Incremental {
+            self.incremental = true;
         }
 
         for key in &["RUST_TEST_NOCAPTURE", "RUST_TEST_THREADS"] {
@@ -730,6 +754,10 @@ impl Config {
 
     fn parse_edition(&self, line: &str) -> Option<String> {
         self.parse_name_value_directive(line, "edition")
+    }
+
+    fn parse_incremental(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "incremental")
     }
 }
 


### PR DESCRIPTION
This adds first-class support for using incremental builds in non-incremental-mode tests.  These tests previously manually passed `-C incremental=tmp/foo` which resulted in reusing the same tmp folder between runs.  This means that these tests could fail whenever the on-disk incremental format changed (such as when updating one's local source tree).  This changes it so that these tests can pass a `// incremental-build` header which instructs compiletest to create a set aside a dedicated incremental directory which will be cleared before the test starts to ensure it has a clean slate.
