### PR TITLE
Fix: non_exhaustive_omitted_patterns by filtering unstable and doc hidden variants

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -38,7 +38,7 @@ use rustc_macros::HashStable;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::cstore::CrateStoreDyn;
 use rustc_span::symbol::{kw, Ident, Symbol};
-use rustc_span::Span;
+use rustc_span::{sym, Span};
 use rustc_target::abi::Align;
 
 use std::cmp::Ordering;
@@ -1898,6 +1898,14 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Determines whether an item is annotated with an attribute.
     pub fn has_attr(self, did: DefId, attr: Symbol) -> bool {
         self.sess.contains_name(&self.get_attrs(did), attr)
+    }
+
+    /// Determines whether an item is annotated with `doc(hidden)`.
+    pub fn is_doc_hidden(self, did: DefId) -> bool {
+        self.get_attrs(did)
+            .iter()
+            .filter_map(|attr| if attr.has_name(sym::doc) { attr.meta_item_list() } else { None })
+            .any(|items| items.iter().any(|item| item.has_name(sym::hidden)))
     }
 
     /// Returns `true` if this is an `auto trait`.

--- a/src/test/ui/pattern/usefulness/auxiliary/hidden.rs
+++ b/src/test/ui/pattern/usefulness/auxiliary/hidden.rs
@@ -1,0 +1,6 @@
+pub enum Foo {
+    A,
+    B,
+    #[doc(hidden)]
+    C,
+}

--- a/src/test/ui/pattern/usefulness/auxiliary/unstable.rs
+++ b/src/test/ui/pattern/usefulness/auxiliary/unstable.rs
@@ -1,0 +1,12 @@
+#![feature(staged_api)]
+#![stable(feature = "stable_test_feature", since = "1.0.0")]
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub enum Foo {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    Stable,
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    Stable2,
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Unstable,
+}

--- a/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
+++ b/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
@@ -1,0 +1,30 @@
+// aux-build:hidden.rs
+
+extern crate hidden;
+
+use hidden::Foo;
+
+fn main() {
+    match Foo::A {
+        Foo::A => {}
+        Foo::B => {}
+    }
+    //~^^^^ non-exhaustive patterns: `_` not covered
+
+    match Foo::A {
+        Foo::A => {}
+        Foo::C => {}
+    }
+    //~^^^^ non-exhaustive patterns: `B` not covered
+
+    match Foo::A {
+        Foo::A => {}
+    }
+    //~^^^ non-exhaustive patterns: `B` and `_` not covered
+
+    match None {
+        None => {}
+        Some(Foo::A) => {}
+    }
+    //~^^^^ non-exhaustive patterns: `Some(B)` and `Some(_)` not covered
+}

--- a/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
@@ -1,0 +1,54 @@
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> $DIR/doc-hidden-non-exhaustive.rs:8:11
+   |
+LL |     match Foo::A {
+   |           ^^^^^^ pattern `_` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error[E0004]: non-exhaustive patterns: `B` not covered
+  --> $DIR/doc-hidden-non-exhaustive.rs:14:11
+   |
+LL |     match Foo::A {
+   |           ^^^^^^ pattern `B` not covered
+   |
+  ::: $DIR/auxiliary/hidden.rs:3:5
+   |
+LL |     B,
+   |     - not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error[E0004]: non-exhaustive patterns: `B` and `_` not covered
+  --> $DIR/doc-hidden-non-exhaustive.rs:20:11
+   |
+LL |     match Foo::A {
+   |           ^^^^^^ patterns `B` and `_` not covered
+   |
+  ::: $DIR/auxiliary/hidden.rs:3:5
+   |
+LL |     B,
+   |     - not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error[E0004]: non-exhaustive patterns: `Some(B)` and `Some(_)` not covered
+  --> $DIR/doc-hidden-non-exhaustive.rs:25:11
+   |
+LL |     match None {
+   |           ^^^^ patterns `Some(B)` and `Some(_)` not covered
+   |
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ---- not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Option<Foo>`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/stable-gated-patterns.rs
+++ b/src/test/ui/pattern/usefulness/stable-gated-patterns.rs
@@ -1,0 +1,18 @@
+// aux-build:unstable.rs
+
+extern crate unstable;
+
+use unstable::Foo;
+
+fn main() {
+    match Foo::Stable {
+        Foo::Stable => {}
+    }
+    //~^^^ non-exhaustive patterns: `Stable2` and `_` not covered
+
+    match Foo::Stable {
+        Foo::Stable => {}
+        Foo::Stable2 => {}
+    }
+    //~^^^^ non-exhaustive patterns: `_` not covered
+}

--- a/src/test/ui/pattern/usefulness/stable-gated-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/stable-gated-patterns.stderr
@@ -1,0 +1,26 @@
+error[E0004]: non-exhaustive patterns: `Stable2` and `_` not covered
+  --> $DIR/stable-gated-patterns.rs:8:11
+   |
+LL |     match Foo::Stable {
+   |           ^^^^^^^^^^^ patterns `Stable2` and `_` not covered
+   |
+  ::: $DIR/auxiliary/unstable.rs:9:5
+   |
+LL |     Stable2,
+   |     ------- not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> $DIR/stable-gated-patterns.rs:13:11
+   |
+LL |     match Foo::Stable {
+   |           ^^^^^^^^^^^ pattern `_` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/unstable-gated-patterns.rs
+++ b/src/test/ui/pattern/usefulness/unstable-gated-patterns.rs
@@ -1,0 +1,22 @@
+#![feature(unstable_test_feature)]
+
+// aux-build:unstable.rs
+
+extern crate unstable;
+
+use unstable::Foo;
+
+fn main() {
+    match Foo::Stable {
+        Foo::Stable => {}
+        Foo::Stable2 => {}
+    }
+    //~^^^^ non-exhaustive patterns: `Unstable` not covered
+
+    // Ok: all variants are explicitly matched
+    match Foo::Stable {
+        Foo::Stable => {}
+        Foo::Stable2 => {}
+        Foo::Unstable => {}
+    }
+}

--- a/src/test/ui/pattern/usefulness/unstable-gated-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/unstable-gated-patterns.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: `Unstable` not covered
+  --> $DIR/unstable-gated-patterns.rs:10:11
+   |
+LL |     match Foo::Stable {
+   |           ^^^^^^^^^^^ pattern `Unstable` not covered
+   |
+  ::: $DIR/auxiliary/unstable.rs:11:5
+   |
+LL |     Unstable,
+   |     -------- not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `Foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/rfc-2008-non-exhaustive/auxiliary/unstable.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/auxiliary/unstable.rs
@@ -1,0 +1,29 @@
+#![feature(staged_api)]
+#![stable(feature = "stable_test_feature", since = "1.0.0")]
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+#[non_exhaustive]
+pub enum UnstableEnum {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    Stable,
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    Stable2,
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Unstable,
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+#[non_exhaustive]
+pub enum OnlyUnstableEnum {
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Unstable,
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    Unstable2,
+}
+
+impl OnlyUnstableEnum {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub fn new() -> Self {
+        Self::Unstable
+    }
+}

--- a/src/test/ui/rfc-2008-non-exhaustive/omitted-patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/omitted-patterns.stderr
@@ -1,11 +1,11 @@
 warning: some fields are not explicitly listed
-  --> $DIR/reachable-patterns.rs:129:9
+  --> $DIR/omitted-patterns.rs:102:9
    |
 LL |         VariantNonExhaustive::Bar { x, .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `y` not listed
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:126:12
+  --> $DIR/omitted-patterns.rs:99:12
    |
 LL |     #[warn(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,13 +13,13 @@ LL |     #[warn(non_exhaustive_omitted_patterns)]
    = note: the pattern is of type `VariantNonExhaustive` and the `non_exhaustive_omitted_patterns` attribute was found
 
 warning: some fields are not explicitly listed
-  --> $DIR/reachable-patterns.rs:134:9
+  --> $DIR/omitted-patterns.rs:107:9
    |
 LL |     let FunctionalRecord { first_field, second_field, .. } = FunctionalRecord::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `third_field` not listed
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:133:12
+  --> $DIR/omitted-patterns.rs:106:12
    |
 LL |     #[warn(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,13 +27,13 @@ LL |     #[warn(non_exhaustive_omitted_patterns)]
    = note: the pattern is of type `FunctionalRecord` and the `non_exhaustive_omitted_patterns` attribute was found
 
 warning: some fields are not explicitly listed
-  --> $DIR/reachable-patterns.rs:142:29
+  --> $DIR/omitted-patterns.rs:115:29
    |
 LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = NestedStruct::default();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `second_field` not listed
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:141:12
+  --> $DIR/omitted-patterns.rs:114:12
    |
 LL |     #[warn(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     #[warn(non_exhaustive_omitted_patterns)]
    = note: the pattern is of type `NormalStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 warning: some fields are not explicitly listed
-  --> $DIR/reachable-patterns.rs:142:9
+  --> $DIR/omitted-patterns.rs:115:9
    |
 LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = NestedStruct::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `foo` not listed
@@ -50,13 +50,13 @@ LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = Nested
    = note: the pattern is of type `NestedStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:56:9
+  --> $DIR/omitted-patterns.rs:58:9
    |
 LL |         _ => {}
    |         ^ pattern `Struct { .. }` not covered
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:55:16
+  --> $DIR/omitted-patterns.rs:57:16
    |
 LL |         #[deny(non_exhaustive_omitted_patterns)]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,13 +64,13 @@ LL |         #[deny(non_exhaustive_omitted_patterns)]
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:63:9
+  --> $DIR/omitted-patterns.rs:65:9
    |
 LL |         _ => {}
    |         ^ pattern `Tuple(_)` not covered
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:62:16
+  --> $DIR/omitted-patterns.rs:64:16
    |
 LL |         #[deny(non_exhaustive_omitted_patterns)]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,13 +78,13 @@ LL |         #[deny(non_exhaustive_omitted_patterns)]
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:73:9
+  --> $DIR/omitted-patterns.rs:75:9
    |
 LL |         _ => {}
    |         ^ pattern `Unit` not covered
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:72:16
+  --> $DIR/omitted-patterns.rs:74:16
    |
 LL |         #[deny(non_exhaustive_omitted_patterns)]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,13 +92,13 @@ LL |         #[deny(non_exhaustive_omitted_patterns)]
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:90:32
+  --> $DIR/omitted-patterns.rs:92:32
    |
 LL |         NestedNonExhaustive::A(_) => {}
    |                                ^ patterns `Tuple(_)` and `Struct { .. }` not covered
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:87:12
+  --> $DIR/omitted-patterns.rs:89:12
    |
 LL |     #[deny(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ LL |     #[deny(non_exhaustive_omitted_patterns)]
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:92:9
+  --> $DIR/omitted-patterns.rs:94:9
    |
 LL |         _ => {}
    |         ^ pattern `C` not covered
@@ -115,32 +115,46 @@ LL |         _ => {}
    = note: the matched value is of type `NestedNonExhaustive` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:122:9
-   |
-LL |         _ => {}
-   |         ^ patterns `HostUnreachable`, `NetworkUnreachable`, `NetworkDown` and 18 more not covered
-   |
-note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:99:12
-   |
-LL |     #[deny(non_exhaustive_omitted_patterns)]
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: ensure that all variants are matched explicitly by adding the suggested match arms
-   = note: the matched value is of type `ErrorKind` and the `non_exhaustive_omitted_patterns` attribute was found
-
-error: some variants are not matched explicitly
-  --> $DIR/reachable-patterns.rs:159:9
+  --> $DIR/omitted-patterns.rs:132:9
    |
 LL |         _ => {}
    |         ^ pattern `A(_)` not covered
    |
 note: the lint level is defined here
-  --> $DIR/reachable-patterns.rs:157:12
+  --> $DIR/omitted-patterns.rs:130:12
    |
 LL |     #[deny(non_exhaustive_omitted_patterns)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: ensure that all variants are matched explicitly by adding the suggested match arms
    = note: the matched value is of type `NonExhaustiveSingleVariant` and the `non_exhaustive_omitted_patterns` attribute was found
 
-error: aborting due to 7 previous errors; 4 warnings emitted
+error: some variants are not matched explicitly
+  --> $DIR/omitted-patterns.rs:144:9
+   |
+LL |         _ => {}
+   |         ^ pattern `Unstable` not covered
+   |
+note: the lint level is defined here
+  --> $DIR/omitted-patterns.rs:143:16
+   |
+LL |         #[deny(non_exhaustive_omitted_patterns)]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `UnstableEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+
+error: some variants are not matched explicitly
+  --> $DIR/omitted-patterns.rs:167:9
+   |
+LL |         _ => {}
+   |         ^ pattern `Unstable2` not covered
+   |
+note: the lint level is defined here
+  --> $DIR/omitted-patterns.rs:164:12
+   |
+LL |     #[deny(non_exhaustive_omitted_patterns)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `OnlyUnstableEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+
+error: aborting due to 8 previous errors; 4 warnings emitted
 

--- a/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.rs
@@ -1,0 +1,33 @@
+// Test that the `non_exhaustive_omitted_patterns` lint is triggered correctly with variants
+// marked stable and unstable.
+
+#![feature(non_exhaustive_omitted_patterns_lint)]
+
+// aux-build:unstable.rs
+extern crate unstable;
+
+use unstable::{UnstableEnum, OnlyUnstableEnum};
+
+fn main() {
+    // OK: this matches all the stable variants
+    match UnstableEnum::Stable {
+        UnstableEnum::Stable => {}
+        UnstableEnum::Stable2 => {}
+        #[deny(non_exhaustive_omitted_patterns)]
+        _ => {}
+    }
+
+    match UnstableEnum::Stable {
+        UnstableEnum::Stable => {}
+        #[deny(non_exhaustive_omitted_patterns)]
+        _ => {}
+    }
+    //~^^ some variants are not matched explicitly
+
+    // Ok: although this is a bit odd, we don't have anything to report
+    // since there is no stable variants and the feature is off
+    #[deny(non_exhaustive_omitted_patterns)]
+    match OnlyUnstableEnum::new() {
+        _ => {}
+    }
+}

--- a/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/stable-omitted-patterns.stderr
@@ -1,0 +1,16 @@
+error: some variants are not matched explicitly
+  --> $DIR/stable-omitted-patterns.rs:23:9
+   |
+LL |         _ => {}
+   |         ^ pattern `Stable2` not covered
+   |
+note: the lint level is defined here
+  --> $DIR/stable-omitted-patterns.rs:22:16
+   |
+LL |         #[deny(non_exhaustive_omitted_patterns)]
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: ensure that all variants are matched explicitly by adding the suggested match arms
+   = note: the matched value is of type `UnstableEnum` and the `non_exhaustive_omitted_patterns` attribute was found
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes: #89042

Now that #86809 has been merged there are cases (std::io::ErrorKind) where unstable feature gated variants were included in warning/error messages when the feature was not turned on. This filters those variants out of the return of `SplitWildcard::new`.

Variants marked `doc(hidden)` are filtered out of the witnesses list in `Usefulness::apply_constructor`.

Probably worth a perf run :shrug: since this area can be sensitive.