### PR TITLE
Don't serialize empty predicates to metadata

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -919,7 +919,12 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         item_id: DefIndex,
         tcx: TyCtxt<'tcx>,
     ) -> ty::GenericPredicates<'tcx> {
-        self.root.tables.explicit_predicates.get(self, item_id).unwrap().decode((self, tcx))
+        self.root
+            .tables
+            .explicit_predicates
+            .get(self, item_id)
+            .map(|e| e.decode((self, tcx)))
+            .unwrap_or_default()
     }
 
     fn get_inferred_outlives(

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -992,7 +992,12 @@ impl EncodeContext<'a, 'tcx> {
             if should_encode_generics(def_kind) {
                 let g = tcx.generics_of(def_id);
                 record!(self.tables.generics[def_id] <- g);
-                record!(self.tables.explicit_predicates[def_id] <- self.tcx.explicit_predicates_of(def_id));
+                let predicates = self.tcx.explicit_predicates_of(def_id);
+                if let ty::GenericPredicates { parent: None, predicates: &[] } = predicates {
+                    // do nothing -- missing entry indicates empty predicates
+                } else {
+                    record!(self.tables.explicit_predicates[def_id] <- predicates);
+                }
                 let inferred_outlives = self.tcx.inferred_outlives_of(def_id);
                 if !inferred_outlives.is_empty() {
                     record!(self.tables.inferred_outlives[def_id] <- inferred_outlives);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -301,6 +301,7 @@ define_tables! {
     inherent_impls: Table<DefIndex, Lazy<[DefIndex]>>,
     variances: Table<DefIndex, Lazy<[ty::Variance]>>,
     generics: Table<DefIndex, Lazy<ty::Generics>>,
+    // Empty entry indicates default predicates -- quite common in practice.
     explicit_predicates: Table<DefIndex, Lazy!(ty::GenericPredicates<'tcx>)>,
     expn_that_defined: Table<DefIndex, Lazy<ExpnId>>,
     // As an optimization, a missing entry indicates an empty `&[]`.


### PR DESCRIPTION
This keeps empty predicates out of the metadata. In practice, it seems like it
is quite common to have a default predicate set, so this should be a win.
Diesel, for example, has 40% of decoded predicates being default/empty.

I believe this is an attempt to implement [this suggestion](https://github.com/rust-lang/rust/pull/87815#issuecomment-901974003), and hopefully will help with that regression.