### PR TITLE
Update rand to 0.8 in library/ and compiler/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.0.0"
 dependencies = [
  "compiler_builtins",
  "core",
- "rand 0.7.3",
+ "rand 0.8.3",
  "rand_xorshift",
 ]
 
@@ -714,7 +714,7 @@ dependencies = [
 name = "core"
 version = "0.0.0"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.3",
 ]
 
 [[package]]
@@ -2920,11 +2920,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -3886,7 +3886,7 @@ dependencies = [
 name = "rustc_incremental"
 version = "0.0.0"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.3",
  "rustc_ast",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_incremental/Cargo.toml
+++ b/compiler/rustc_incremental/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 [dependencies]
 rustc_graphviz = { path = "../rustc_graphviz" }
 tracing = "0.1"
-rand = "0.7"
+rand = "0.8"
 rustc_middle = { path = "../rustc_middle" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir" }

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -13,8 +13,8 @@ core = { path = "../core" }
 compiler_builtins = { version = "0.1.40", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
-rand = "0.7"
-rand_xorshift = "0.2"
+rand = "0.8"
+rand_xorshift = "0.3"
 
 [[test]]
 name = "collectionstests"

--- a/library/alloc/benches/slice.rs
+++ b/library/alloc/benches/slice.rs
@@ -221,7 +221,7 @@ fn gen_strings(len: usize) -> Vec<String> {
     let mut v = vec![];
     for _ in 0..len {
         let n = rng.gen::<usize>() % 20 + 1;
-        v.push((&mut rng).sample_iter(&Alphanumeric).take(n).collect());
+        v.push((&mut rng).sample_iter(&Alphanumeric).map(char::from).take(n).collect());
     }
     v
 }

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -391,7 +391,7 @@ fn test_reverse() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_sort() {
-    let mut rng = thread_rng();
+    let mut rng = &mut thread_rng();
 
     for len in (2..25).chain(500..510) {
         for &modulus in &[5, 10, 100, 1000] {

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -22,7 +22,7 @@ path = "benches/lib.rs"
 test = true
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 
 [features]
 # Make panics and failed asserts immediately abort without formatting any message


### PR DESCRIPTION
Removes some duplication. According to cargo tree, rand 0.7 is still used in various tools like miri, rls, or mdbook, but it's gone from library or compiler dependencies.