### PR TITLE
add case for checking const refs in check_const_value_eq

### DIFF
--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -639,6 +639,15 @@ fn check_const_value_eq<R: TypeRelation<'tcx>>(
             get_slice_bytes(&tcx, a_val) == get_slice_bytes(&tcx, b_val)
         }
 
+        (ConstValue::ByRef { alloc: alloc_a, .. }, ConstValue::ByRef { alloc: alloc_b, .. })
+            if a.ty.is_ref() || b.ty.is_ref() =>
+        {
+            if a.ty.is_ref() && b.ty.is_ref() {
+                alloc_a == alloc_b
+            } else {
+                false
+            }
+        }
         (ConstValue::ByRef { .. }, ConstValue::ByRef { .. }) => {
             let a_destructured = tcx.destructure_const(relation.param_env().and(a));
             let b_destructured = tcx.destructure_const(relation.param_env().and(b));

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.rs
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+#![feature(fn_traits)]
+#![feature(adt_const_params)]
+//~^ WARNING the feature `adt_const_params` is incomplete
+
+#[derive(PartialEq, Eq)]
+struct CompileTimeSettings{
+    hooks: &'static[fn()],
+}
+
+struct Foo<const T: CompileTimeSettings>;
+
+impl<const T: CompileTimeSettings> Foo<T> {
+    fn call_hooks(){
+    }
+}
+
+fn main(){
+    const SETTINGS: CompileTimeSettings = CompileTimeSettings{
+        hooks: &[],
+    };
+
+    Foo::<SETTINGS>::call_hooks();
+}

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
@@ -1,0 +1,11 @@
+warning: the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/refs_check_const_eq-issue-88384.rs:4:12
+   |
+LL | #![feature(adt_const_params)]
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/refs_check_const_value_eq-issue-88876.rs
+++ b/src/test/ui/consts/refs_check_const_value_eq-issue-88876.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
+
+struct FooConst<const ARRAY: &'static [&'static str]> {}
+
+const FOO_ARR: &[&'static str; 2] = &["Hello", "Friend"];
+
+fn main() {
+    let _ = FooConst::<FOO_ARR> {};
+}


### PR DESCRIPTION
Previously in `check_const_value_eq` we destructured `ConstValue::ByRef` instances, this didn't account for `ty::Ref`s however, which led to an ICE.

Fixes https://github.com/rust-lang/rust/issues/88876
Fixes https://github.com/rust-lang/rust/issues/88384

r? @oli-obk 