### PR TITLE
Fix ICE with inferred type in `const` or `static` item

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -830,19 +830,20 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                 hir::ItemKind::Fn(..) => tcx.ensure().fn_sig(def_id),
                 hir::ItemKind::OpaqueTy(..) => tcx.ensure().item_bounds(def_id),
                 hir::ItemKind::Const(ty, ..) | hir::ItemKind::Static(ty, ..) => {
-                    // (#75889): Account for `const C: dyn Fn() -> _ = "";`
-                    if let hir::TyKind::TraitObject(..) = ty.kind {
+                    if !is_suggestable_infer_ty(ty) {
                         let mut visitor = PlaceholderHirTyCollector::default();
                         visitor.visit_item(it);
-                        placeholder_type_error(
-                            tcx,
-                            None,
-                            &[],
-                            visitor.0,
-                            false,
-                            None,
-                            it.kind.descr(),
-                        );
+                        if !visitor.0.is_empty() {
+                            placeholder_type_error(
+                                tcx,
+                                None,
+                                &[],
+                                visitor.0,
+                                false,
+                                None,
+                                it.kind.descr(),
+                            );
+                        }
                     }
                 }
                 _ => (),

--- a/src/test/ui/typeck/issue-74086.rs
+++ b/src/test/ui/typeck/issue-74086.rs
@@ -1,4 +1,5 @@
 fn main() {
     static BUG: fn(_) -> u8 = |_| 8;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions [E0121]
+    //~| ERROR the type placeholder `_` is not allowed within types on item signatures for static items [E0121]
 }

--- a/src/test/ui/typeck/issue-74086.stderr
+++ b/src/test/ui/typeck/issue-74086.stderr
@@ -4,6 +4,12 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
 LL |     static BUG: fn(_) -> u8 = |_| 8;
    |                    ^ not allowed in type signatures
 
-error: aborting due to previous error
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static items
+  --> $DIR/issue-74086.rs:2:20
+   |
+LL |     static BUG: fn(_) -> u8 = |_| 8;
+   |                    ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/typeck/issue-81885.rs
+++ b/src/test/ui/typeck/issue-81885.rs
@@ -1,8 +1,9 @@
 const TEST4: fn() -> _ = 42;
                   //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
+                  //~| ERROR the type placeholder `_` is not allowed within types on item signatures for constant items
 
 fn main() {
     const TEST5: fn() -> _ = 42;
                       //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
-
+                      //~| ERROR the type placeholder `_` is not allowed within types on item signatures for constant items
 }

--- a/src/test/ui/typeck/issue-81885.stderr
+++ b/src/test/ui/typeck/issue-81885.stderr
@@ -4,12 +4,24 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constant items
+  --> $DIR/issue-81885.rs:1:22
+   |
+LL | const TEST4: fn() -> _ = 42;
+   |                      ^ not allowed in type signatures
+
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-81885.rs:5:26
+  --> $DIR/issue-81885.rs:6:26
    |
 LL |     const TEST5: fn() -> _ = 42;
    |                          ^ not allowed in type signatures
 
-error: aborting due to 2 previous errors
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constant items
+  --> $DIR/issue-81885.rs:6:26
+   |
+LL |     const TEST5: fn() -> _ = 42;
+   |                          ^ not allowed in type signatures
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/typeck/issue-88643.rs
+++ b/src/test/ui/typeck/issue-88643.rs
@@ -1,0 +1,19 @@
+// Regression test for the ICE described in #88643. Specifically:
+// https://github.com/rust-lang/rust/issues/88643#issuecomment-913128893
+// and https://github.com/rust-lang/rust/issues/88643#issuecomment-913171935
+// and https://github.com/rust-lang/rust/issues/88643#issuecomment-913765984
+
+use std::collections::HashMap;
+
+pub trait T {}
+
+static CALLBACKS: HashMap<*const dyn T, dyn FnMut(&mut _) + 'static> = HashMap::new();
+//~^ the type placeholder `_` is not allowed within types on item signatures for static items [E0121]
+
+static CALLBACKS2: Vec<dyn Fn(& _)> = Vec::new();
+//~^ the type placeholder `_` is not allowed within types on item signatures for static items [E0121]
+
+static CALLBACKS3: Option<dyn Fn(& _)> = None;
+//~^ the type placeholder `_` is not allowed within types on item signatures for static items [E0121]
+
+pub fn main() {}

--- a/src/test/ui/typeck/issue-88643.stderr
+++ b/src/test/ui/typeck/issue-88643.stderr
@@ -1,0 +1,21 @@
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static items
+  --> $DIR/issue-88643.rs:10:56
+   |
+LL | static CALLBACKS: HashMap<*const dyn T, dyn FnMut(&mut _) + 'static> = HashMap::new();
+   |                                                        ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static items
+  --> $DIR/issue-88643.rs:13:33
+   |
+LL | static CALLBACKS2: Vec<dyn Fn(& _)> = Vec::new();
+   |                                 ^ not allowed in type signatures
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for static items
+  --> $DIR/issue-88643.rs:16:36
+   |
+LL | static CALLBACKS3: Option<dyn Fn(& _)> = None;
+   |                                    ^ not allowed in type signatures
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -12,6 +12,7 @@ const TEST3: _ = Some(42);
 
 const TEST4: fn() -> _ = 42;
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the type placeholder `_` is not allowed within types on item signatures for constant items
 
 trait Test5 {
     const TEST5: _ = 42;

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -31,8 +31,14 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constant items
+  --> $DIR/typeck_type_placeholder_item_help.rs:13:22
+   |
+LL | const TEST4: fn() -> _ = 42;
+   |                      ^ not allowed in type signatures
+
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:17:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:18:18
    |
 LL |     const TEST5: _ = 42;
    |                  ^
@@ -41,7 +47,7 @@ LL |     const TEST5: _ = 42;
    |                  help: replace with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:24:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:25:18
    |
 LL |     const TEST6: _ = 13;
    |                  ^
@@ -49,6 +55,6 @@ LL |     const TEST6: _ = 13;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Fixes #88643. Currently, there is a check in the compiler that handles the special case of a constant/static variable having a trait object type:
https://github.com/rust-lang/rust/blob/840acd378a273dab6798352d3d6a087fa09e4806/compiler/rustc_typeck/src/collect.rs#L837-L838

But this fails to account for the possibility that the `dyn` type could be nested (as in `Vec<dyn Fn(& _)>`), which causes the ICE described in #88643.