### PR TITLE
debuginfo: Add script for Rust support in lldb-mi

### DIFF
--- a/src/etc/rust-lldb-mi
+++ b/src/etc/rust-lldb-mi
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Exit if anything fails
+set -e
+
+# Find the host triple so we can find lldb in rustlib.
+host=$(rustc -vV | sed -n -e 's/^host: //p')
+
+# Find out where to look for the pretty printer Python module
+RUSTC_SYSROOT=$(rustc --print sysroot)
+RUST_LLDB_MI="$RUSTC_SYSROOT/lib/rustlib/$host/bin/lldb-mi"
+RUST_LLDB="$RUSTC_SYSROOT/lib/rustlib/$host/bin/lldb"
+
+lldb=lldb
+lldb_mi=lldb-mi
+if [[ -f "$RUST_LLDB_MI" && -f "$RUST_LLDB" ]]; then
+    lldb_mi="$RUST_LLDB_MI"
+    lldb="$RUST_LLDB"
+else
+    if ! command -v "$lldb_mi" > /dev/null; then
+        echo "$lldb_mi not found! Please install it." >&2
+        exit 1
+    else
+        LLDB_VERSION=$("$lldb" --version | cut -d ' ' -f3)
+
+        if [ "$LLDB_VERSION" = "3.5.0" ]; then
+            cat << EOF >&2
+***
+WARNING: This version of LLDB has known issues with Rust and cannot display the contents of local variables!
+***
+EOF
+        fi
+    fi
+fi
+
+script_import="command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_lookup.py\""
+commands_file="$RUSTC_SYSROOT/lib/rustlib/etc/lldb_commands"
+
+# Call LLDB with the commands added to the argument list
+exec "$lldb_mi" --command "$script_import" --source "$commands_file" "$@"


### PR DESCRIPTION
As of the merge of PR lldb-tools/lldb-mi#80 made possible for `lldb-mi` to run a command before execution this PR extends Rust debugging with the tool.

Tested via launching a debugging session with the C/C++ VSCode extension and setting the `miDebuggerPath` field to `/usr/bin/rust-lldb-mi`.
