### PR TITLE
Run `no_core` rustdoc tests only on Linux

### DIFF
--- a/src/test/rustdoc/cross-crate-primitive-doc.rs
+++ b/src/test/rustdoc/cross-crate-primitive-doc.rs
@@ -1,6 +1,6 @@
 // aux-build:primitive-doc.rs
 // compile-flags: --extern-html-root-url=primitive_doc=../ -Z unstable-options
-// ignore-windows
+// only-linux
 
 #![feature(no_core)]
 #![no_core]

--- a/src/test/rustdoc/intra-doc/prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-doc/prim-methods-external-core.rs
@@ -1,7 +1,7 @@
 // aux-build:my-core.rs
 // build-aux-docs
 // ignore-cross-compile
-// ignore-windows
+// only-linux
 
 #![deny(broken_intra_doc_links)]
 #![feature(no_core, lang_items)]


### PR DESCRIPTION
I don't think this is really worth investigating further so I just disabled them.

They currently fail like this:
```
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "-Wl,-exported_symbols_list,/var/folders/pg/gjhzdz7n361f0pv665d0723w0000gn/T/rustcPUsMpx/list" "-arch" "arm64" "/Users/hans/dev/rust/build/aarch64-apple-darwin/test/rustdoc/intra-doc/prim-methods-external-core/auxiliary/my-core.my_core.9f3c60de-cgu.0.rcgu.o" "/Users/hans/dev/rust/build/aarch64-apple-darwin/test/rustdoc/intra-doc/prim-methods-external-core/auxiliary/my-core.50fu2g9urkmisdsg.rcgu.o" "-L" "/Users/hans/dev/rust/build/aarch64-apple-darwin/native/rust-test-helpers" "-L" "/Users/hans/dev/rust/build/aarch64-apple-darwin/test/rustdoc/intra-doc/prim-methods-external-core/auxiliary" "-L" "/Users/hans/dev/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib" "-L" "/Users/hans/dev/rust/build/aarch64-apple-darwin/stage1/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/Users/hans/dev/rust/build/aarch64-apple-darwin/test/rustdoc/intra-doc/prim-methods-external-core/auxiliary/libmy_core.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-Wl,-install_name" "-Wl,@rpath/libmy_core.dylib" "-nodefaultlibs"
  = note: ld: dynamic main executables must link with libSystem.dylib for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

r? @jyn514