### PR TITLE
Temporarily rename int_roundings functions to avoid conflicts

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1849,17 +1849,17 @@ macro_rules! int_impl {
         #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
         /// let b = 3;
         ///
-        /// assert_eq!(a.div_floor(b), 2);
-        /// assert_eq!(a.div_floor(-b), -3);
-        /// assert_eq!((-a).div_floor(b), -3);
-        /// assert_eq!((-a).div_floor(-b), 2);
+        /// assert_eq!(a.unstable_div_floor(b), 2);
+        /// assert_eq!(a.unstable_div_floor(-b), -3);
+        /// assert_eq!((-a).unstable_div_floor(b), -3);
+        /// assert_eq!((-a).unstable_div_floor(-b), 2);
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_floor(self, rhs: Self) -> Self {
+        pub const fn unstable_div_floor(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if (r > 0 && rhs < 0) || (r < 0 && rhs > 0) {
@@ -1884,17 +1884,17 @@ macro_rules! int_impl {
         #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
         /// let b = 3;
         ///
-        /// assert_eq!(a.div_ceil(b), 3);
-        /// assert_eq!(a.div_ceil(-b), -2);
-        /// assert_eq!((-a).div_ceil(b), -2);
-        /// assert_eq!((-a).div_ceil(-b), 3);
+        /// assert_eq!(a.unstable_div_ceil(b), 3);
+        /// assert_eq!(a.unstable_div_ceil(-b), -2);
+        /// assert_eq!((-a).unstable_div_ceil(b), -2);
+        /// assert_eq!((-a).unstable_div_ceil(-b), 3);
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_ceil(self, rhs: Self) -> Self {
+        pub const fn unstable_div_ceil(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if (r > 0 && rhs > 0) || (r < 0 && rhs < 0) {
@@ -1919,21 +1919,21 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(8), 24);")]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(-8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(-8), 16);")]
-        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").next_multiple_of(8), -16);")]
-        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").next_multiple_of(8), -16);")]
-        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").next_multiple_of(-8), -16);")]
-        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").next_multiple_of(-8), -24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(8), 24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(-8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(-8), 16);")]
+        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").unstable_next_multiple_of(8), -16);")]
+        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").unstable_next_multiple_of(8), -16);")]
+        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").unstable_next_multiple_of(-8), -16);")]
+        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").unstable_next_multiple_of(-8), -24);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn next_multiple_of(self, rhs: Self) -> Self {
+        pub const fn unstable_next_multiple_of(self, rhs: Self) -> Self {
             // This would otherwise fail when calculating `r` when self == T::MIN.
             if rhs == -1 {
                 return self;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1859,12 +1859,12 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".div_floor(4), 1);")]
+        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".unstable_div_floor(4), 1);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[inline(always)]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_floor(self, rhs: Self) -> Self {
+        pub const fn unstable_div_floor(self, rhs: Self) -> Self {
             self / rhs
         }
 
@@ -1880,12 +1880,12 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".div_ceil(4), 2);")]
+        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".unstable_div_ceil(4), 2);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_ceil(self, rhs: Self) -> Self {
+        pub const fn unstable_div_ceil(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if r > 0 && rhs > 0 {
@@ -1908,15 +1908,15 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(8), 24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(8), 24);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn next_multiple_of(self, rhs: Self) -> Self {
+        pub const fn unstable_next_multiple_of(self, rhs: Self) -> Self {
             match self % rhs {
                 0 => self,
                 r => self + (rhs - r)

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -294,33 +294,33 @@ macro_rules! int_module {
             fn test_div_floor() {
                 let a: $T = 8;
                 let b = 3;
-                assert_eq!(a.div_floor(b), 2);
-                assert_eq!(a.div_floor(-b), -3);
-                assert_eq!((-a).div_floor(b), -3);
-                assert_eq!((-a).div_floor(-b), 2);
+                assert_eq!(a.unstable_div_floor(b), 2);
+                assert_eq!(a.unstable_div_floor(-b), -3);
+                assert_eq!((-a).unstable_div_floor(b), -3);
+                assert_eq!((-a).unstable_div_floor(-b), 2);
             }
 
             #[test]
             fn test_div_ceil() {
                 let a: $T = 8;
                 let b = 3;
-                assert_eq!(a.div_ceil(b), 3);
-                assert_eq!(a.div_ceil(-b), -2);
-                assert_eq!((-a).div_ceil(b), -2);
-                assert_eq!((-a).div_ceil(-b), 3);
+                assert_eq!(a.unstable_div_ceil(b), 3);
+                assert_eq!(a.unstable_div_ceil(-b), -2);
+                assert_eq!((-a).unstable_div_ceil(b), -2);
+                assert_eq!((-a).unstable_div_ceil(-b), 3);
             }
 
             #[test]
             fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!((16 as $T).next_multiple_of(-8), 16);
-                assert_eq!((23 as $T).next_multiple_of(-8), 16);
-                assert_eq!((-16 as $T).next_multiple_of(8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(8), -16);
-                assert_eq!((-16 as $T).next_multiple_of(-8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(-8), -24);
-                assert_eq!(MIN.next_multiple_of(-1), MIN);
+                assert_eq!((16 as $T).unstable_next_multiple_of(8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(8), 24);
+                assert_eq!((16 as $T).unstable_next_multiple_of(-8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(-8), 16);
+                assert_eq!((-16 as $T).unstable_next_multiple_of(8), -16);
+                assert_eq!((-23 as $T).unstable_next_multiple_of(8), -16);
+                assert_eq!((-16 as $T).unstable_next_multiple_of(-8), -16);
+                assert_eq!((-23 as $T).unstable_next_multiple_of(-8), -24);
+                assert_eq!(MIN.unstable_next_multiple_of(-1), MIN);
             }
 
             #[test]

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -208,19 +208,19 @@ macro_rules! uint_module {
 
             #[test]
             fn test_div_floor() {
-                assert_eq!((8 as $T).div_floor(3), 2);
+                assert_eq!((8 as $T).unstable_div_floor(3), 2);
             }
 
             #[test]
             fn test_div_ceil() {
-                assert_eq!((8 as $T).div_ceil(3), 3);
+                assert_eq!((8 as $T).unstable_div_ceil(3), 3);
             }
 
             #[test]
             fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!(MAX.next_multiple_of(1), MAX);
+                assert_eq!((16 as $T).unstable_next_multiple_of(8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(8), 24);
+                assert_eq!(MAX.unstable_next_multiple_of(1), MAX);
             }
 
             #[test]


### PR DESCRIPTION
These functions are unstable, but because they're inherent they still
introduce conflicts with stable trait functions in crates. Temporarily
rename them to fix these conflicts, until we can resolve those conflicts
in a better way.