### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.45+curl-7.78.0"
+version = "0.4.48+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
+checksum = "a6a77a741f832116da66aeb126b4f19190ecf46144a74a9bde43c2086f38da0e"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
7 commits in 9a28ac83c9eb73e42ffafac552c0a55f00dbf40c..0121d66aa2ef5ffa9735f86c2b56f5fdc5a837a6
2021-09-18 15:42:28 -0500 to 2021-09-22 16:08:27 +0000
- Implement example completion for zsh (rust-lang/cargo#9939)
- Bump curl-sys dependency (rust-lang/cargo#9937)
- Add fetch smoke test. (rust-lang/cargo#9921)
- Differentiate tests in progress bar. (rust-lang/cargo#9934)
- Remove TOML incompatibility hacks (rust-lang/cargo#9932)
- Change diesel compatibility messages (rust-lang/cargo#9927)
- Remove broken link in contrib docs. (rust-lang/cargo#9928)