### PR TITLE
Resolve infered types when complaining about unexpected call type 

### DIFF
--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -350,6 +350,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
 
+                let callee_ty = self.resolve_vars_if_possible(callee_ty);
                 let mut err = type_error_struct!(
                     self.tcx.sess,
                     callee_expr.span,

--- a/src/test/ui/typeck/call-block.rs
+++ b/src/test/ui/typeck/call-block.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = {42}(); //~ ERROR expected function, found `_`
+}

--- a/src/test/ui/typeck/call-block.rs
+++ b/src/test/ui/typeck/call-block.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = {42}(); //~ ERROR expected function, found `_`
+    let _ = {42}(); //~ ERROR expected function, found `{integer}`
 }

--- a/src/test/ui/typeck/call-block.stderr
+++ b/src/test/ui/typeck/call-block.stderr
@@ -1,0 +1,11 @@
+error[E0618]: expected function, found `_`
+  --> $DIR/call-block.rs:2:13
+   |
+LL |     let _ = {42}();
+   |             ^^^^--
+   |             |
+   |             call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/typeck/call-block.stderr
+++ b/src/test/ui/typeck/call-block.stderr
@@ -1,4 +1,4 @@
-error[E0618]: expected function, found `_`
+error[E0618]: expected function, found `{integer}`
   --> $DIR/call-block.rs:2:13
    |
 LL |     let _ = {42}();


### PR DESCRIPTION
```
error[E0618]: expected function, found `{integer}`
  --> $DIR/call-block.rs:2:13
   |
LL |     let _ = {42}();
   |             ^^^^--
   |             |
   |             call expression requires function
```
instead of
```
error[E0618]: expected function, found `_`
  --> $DIR/call-block.rs:2:13
   |
LL |     let _ = {42}();
   |             ^^^^--
   |             |
   |             call expression requires function
```