### PR TITLE
[rfc 2229] Drop fully captured upvars in the same order as the regular drop code

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -94,5 +94,5 @@ fn test_three() {
 fn main() {
     test_one();
     test_two();
-    test_three(); 
+    test_three();
 }

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -3,6 +3,9 @@
 // Tests that in cases where we individually capture all the fields of a type,
 // we still drop them in the order they would have been dropped in the 2018 edition.
 
+// NOTE: It is *critical* that the order of the min capture NOTES in the stderr output
+//       does *not* change!
+
 #![feature(rustc_attrs)]
 
 #[derive(Debug)]
@@ -21,21 +24,21 @@ fn test_one() {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     || {
-        //~^ ERROR: First Pass analysis includes:
-        //~| ERROR: Min Capture analysis includes:
+        //~^ ERROR: Min Capture analysis includes:
+        //~| ERROR
         println!("{:?}", a.0);
-        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", a.1);
-        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~| NOTE
 
         println!("{:?}", b.0);
-        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", b.1);
-        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~| NOTE
     };
 }
 
@@ -47,21 +50,21 @@ fn test_two() {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     || {
-        //~^ ERROR: First Pass analysis includes:
-        //~| ERROR: Min Capture analysis includes:
+        //~^ ERROR: Min Capture analysis includes:
+        //~| ERROR
         println!("{:?}", a.1);
-        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", a.0);
-        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~| NOTE
 
         println!("{:?}", b.1);
-        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", b.0);
-        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~| NOTE
     };
 }
 
@@ -73,21 +76,21 @@ fn test_three() {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     || {
-        //~^ ERROR: First Pass analysis includes:
-        //~| ERROR: Min Capture analysis includes:
+        //~^ ERROR: Min Capture analysis includes:
+        //~| ERROR
         println!("{:?}", b.1);
-        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", a.1);
-        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~| NOTE
         println!("{:?}", a.0);
-        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~| NOTE
 
         println!("{:?}", b.0);
-        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~| NOTE
     };
 }
 

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -1,0 +1,98 @@
+// edition:2021
+
+// Tests that in cases where we individually capture all the fields of a type,
+// we still drop them in the order they would have been dropped in the 2018 edition.
+
+#![feature(rustc_attrs)]
+
+#[derive(Debug)]
+struct HasDrop;
+impl Drop for HasDrop {
+    fn drop(&mut self) {
+        println!("dropped");
+    }
+}
+
+fn test_one() {
+    let a = (HasDrop, HasDrop);
+    let b = (HasDrop, HasDrop);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+        //~^ ERROR: First Pass analysis includes:
+        //~| ERROR: Min Capture analysis includes:
+        println!("{:?}", a.0);
+        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        println!("{:?}", a.1);
+        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+
+        println!("{:?}", b.0);
+        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        println!("{:?}", b.1);
+        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+    };
+}
+
+fn test_two() {
+    let a = (HasDrop, HasDrop);
+    let b = (HasDrop, HasDrop);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+        //~^ ERROR: First Pass analysis includes:
+        //~| ERROR: Min Capture analysis includes:
+        println!("{:?}", a.1);
+        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        println!("{:?}", a.0);
+        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+
+        println!("{:?}", b.1);
+        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        println!("{:?}", b.0);
+        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+    };
+}
+
+fn test_three() {
+    let a = (HasDrop, HasDrop);
+    let b = (HasDrop, HasDrop);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+        //~^ ERROR: First Pass analysis includes:
+        //~| ERROR: Min Capture analysis includes:
+        println!("{:?}", b.1);
+        //~^ NOTE: Capturing b[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        println!("{:?}", a.1);
+        //~^ NOTE: Capturing a[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        println!("{:?}", a.0);
+        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+
+        println!("{:?}", b.0);
+        //~^ NOTE: Capturing b[(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+    };
+}
+
+fn main() {
+    test_one();
+    test_two();
+    test_three(); 
+}

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -136,25 +136,25 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:52:26
-   |
-LL |         println!("{:?}", a.1);
-   |                          ^^^
 note: Min Capture a[(0, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:55:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:59:26
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:52:26
    |
-LL |         println!("{:?}", b.1);
+LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:62:26
    |
 LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:59:26
+   |
+LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
@@ -202,25 +202,25 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:78:26
-   |
-LL |         println!("{:?}", b.1);
-   |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:88:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
-note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:81:26
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:78:26
    |
-LL |         println!("{:?}", a.1);
+LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Min Capture a[(0, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:81:26
+   |
+LL |         println!("{:?}", a.1);
    |                          ^^^
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:20:13
+  --> $DIR/preserve_field_drop_order.rs:23:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let c = #[rustc_capture_analysis]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:46:13
+  --> $DIR/preserve_field_drop_order.rs:49:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     let c = #[rustc_capture_analysis]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:72:13
+  --> $DIR/preserve_field_drop_order.rs:75:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     let c = #[rustc_capture_analysis]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:23:5
+  --> $DIR/preserve_field_drop_order.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -38,28 +38,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:26:26
+  --> $DIR/preserve_field_drop_order.rs:29:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:29:26
+  --> $DIR/preserve_field_drop_order.rs:32:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:33:26
+  --> $DIR/preserve_field_drop_order.rs:36:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:36:26
+  --> $DIR/preserve_field_drop_order.rs:39:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:23:5
+  --> $DIR/preserve_field_drop_order.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -71,28 +71,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:26:26
-   |
-LL |         println!("{:?}", a.0);
-   |                          ^^^
-note: Min Capture a[(1, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:29:26
    |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:32:26
+   |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:33:26
-   |
-LL |         println!("{:?}", b.0);
-   |                          ^^^
-note: Min Capture b[(1, 0)] -> ImmBorrow
   --> $DIR/preserve_field_drop_order.rs:36:26
    |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:39:26
+   |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:49:5
+  --> $DIR/preserve_field_drop_order.rs:52:5
    |
 LL | /     || {
 LL | |
@@ -104,28 +104,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:52:26
+  --> $DIR/preserve_field_drop_order.rs:55:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:55:26
+  --> $DIR/preserve_field_drop_order.rs:58:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:59:26
+  --> $DIR/preserve_field_drop_order.rs:62:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:62:26
+  --> $DIR/preserve_field_drop_order.rs:65:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:49:5
+  --> $DIR/preserve_field_drop_order.rs:52:5
    |
 LL | /     || {
 LL | |
@@ -137,28 +137,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:55:26
+  --> $DIR/preserve_field_drop_order.rs:58:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:52:26
+  --> $DIR/preserve_field_drop_order.rs:55:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:62:26
+  --> $DIR/preserve_field_drop_order.rs:65:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:59:26
+  --> $DIR/preserve_field_drop_order.rs:62:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:75:5
+  --> $DIR/preserve_field_drop_order.rs:78:5
    |
 LL | /     || {
 LL | |
@@ -170,28 +170,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:78:26
+  --> $DIR/preserve_field_drop_order.rs:81:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:81:26
+  --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:88:26
+  --> $DIR/preserve_field_drop_order.rs:91:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:75:5
+  --> $DIR/preserve_field_drop_order.rs:78:5
    |
 LL | /     || {
 LL | |
@@ -203,22 +203,22 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:88:26
+  --> $DIR/preserve_field_drop_order.rs:91:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:78:26
+  --> $DIR/preserve_field_drop_order.rs:81:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:81:26
+  --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -1,0 +1,228 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/preserve_field_drop_order.rs:20:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/preserve_field_drop_order.rs:46:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/preserve_field_drop_order.rs:72:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error: First Pass analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:23:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", a.0);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:26:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Capturing a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:29:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Capturing b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:33:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Capturing b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:36:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:23:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", a.0);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:26:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:29:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Min Capture b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:33:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:36:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+
+error: First Pass analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:49:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", a.1);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:52:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Capturing a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:55:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Capturing b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:59:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+note: Capturing b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:62:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:49:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", a.1);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:52:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Min Capture a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:55:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:59:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+note: Min Capture b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:62:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+
+error: First Pass analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:75:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", b.1);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:78:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+note: Capturing a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:81:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Capturing a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:84:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Capturing b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:88:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/preserve_field_drop_order.rs:75:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         println!("{:?}", b.1);
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture b[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:78:26
+   |
+LL |         println!("{:?}", b.1);
+   |                          ^^^
+note: Min Capture b[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:88:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Min Capture a[(1, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:81:26
+   |
+LL |         println!("{:?}", a.1);
+   |                          ^^^
+note: Min Capture a[(0, 0)] -> ImmBorrow
+  --> $DIR/preserve_field_drop_order.rs:84:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
@@ -1,0 +1,28 @@
+// run-pass
+// check-run-results
+// revisions: twenty_eighteen twenty_twentyone
+// [twenty_eighteen]compile-flags: --edition 2018
+// [twenty_twentyone]compile-flags: --edition 2021
+
+#[derive(Debug)]
+struct Dropable(String);
+
+impl Drop for Dropable {
+    fn drop(&mut self) {
+        println!("Dropping {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+struct A {
+    x: Dropable,
+    y: Dropable,
+}
+
+fn main() {
+    let a = A { x: Dropable(format!("x")), y: Dropable(format!("y")) };
+
+    let c = move || println!("{:?} {:?}", a.y, a.x);
+    
+    c();
+}

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
@@ -5,7 +5,7 @@
 // [twenty_twentyone]compile-flags: --edition 2021
 
 #[derive(Debug)]
-struct Dropable(String);
+struct Dropable(&'static str);
 
 impl Drop for Dropable {
     fn drop(&mut self) {
@@ -19,10 +19,40 @@ struct A {
     y: Dropable,
 }
 
+#[derive(Debug)]
+struct B {
+    c: A,
+    d: A,
+}
+
+#[derive(Debug)]
+struct R<'a> {
+    c: &'a A,
+    d: &'a A,
+}
+
 fn main() {
-    let a = A { x: Dropable(format!("x")), y: Dropable(format!("y")) };
+    let a = A { x: Dropable("x"), y: Dropable("y") };
 
     let c = move || println!("{:?} {:?}", a.y, a.x);
 
     c();
+
+    let b = B {
+        c: A { x: Dropable("b.c.x"), y: Dropable("b.c.y") },
+        d: A { x: Dropable("b.d.x"), y: Dropable("b.d.y") },
+    };
+
+    let d = move || println!("{:?} {:?} {:?} {:?}", b.d.y, b.d.x, b.c.y, b.c.x);
+
+    d();
+
+        let r = R {
+        c: &A { x: Dropable("r.c.x"), y: Dropable("r.c.y") },
+        d: &A { x: Dropable("r.d.x"), y: Dropable("r.d.y") },
+    };
+
+    let e = move || println!("{:?} {:?} {:?} {:?}", r.d.y, r.d.x, r.c.y, r.c.x);
+
+    e();
 }

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
@@ -23,6 +23,6 @@ fn main() {
     let a = A { x: Dropable(format!("x")), y: Dropable(format!("y")) };
 
     let c = move || println!("{:?} {:?}", a.y, a.x);
-    
+
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_eighteen.run.stdout
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_eighteen.run.stdout
@@ -1,0 +1,3 @@
+Dropable("y") Dropable("x")
+Dropping x
+Dropping y

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_eighteen.run.stdout
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_eighteen.run.stdout
@@ -1,3 +1,13 @@
 Dropable("y") Dropable("x")
+Dropable("b.d.y") Dropable("b.d.x") Dropable("b.c.y") Dropable("b.c.x")
+Dropable("r.d.y") Dropable("r.d.x") Dropable("r.c.y") Dropable("r.c.x")
+Dropping r.d.x
+Dropping r.d.y
+Dropping r.c.x
+Dropping r.c.y
+Dropping b.c.x
+Dropping b.c.y
+Dropping b.d.x
+Dropping b.d.y
 Dropping x
 Dropping y

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
@@ -1,3 +1,13 @@
 Dropable("y") Dropable("x")
+Dropable("b.d.y") Dropable("b.d.x") Dropable("b.c.y") Dropable("b.c.x")
+Dropable("r.d.y") Dropable("r.d.x") Dropable("r.c.y") Dropable("r.c.x")
+Dropping r.d.x
+Dropping r.d.y
+Dropping r.c.x
+Dropping r.c.y
+Dropping b.c.x
+Dropping b.c.y
+Dropping b.d.x
+Dropping b.d.y
 Dropping x
 Dropping y

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
@@ -1,0 +1,3 @@
+Dropable("y") Dropable("x")
+Dropping y
+Dropping x

--- a/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
+++ b/src/test/ui/closures/2229_closure_analysis/preserve_field_drop_order2.twenty_twentyone.run.stdout
@@ -1,3 +1,3 @@
 Dropable("y") Dropable("x")
-Dropping y
 Dropping x
+Dropping y


### PR DESCRIPTION
Currently, with the new 2021 edition, if a closure captures all of the
fields of an upvar, we'll drop those fields in the order they are used
within the closure instead of the normal drop order (the definition
order of the fields in the type).

This changes that so we sort the captured fields by the definition order
which causes them to drop in that same order as well.

Fixes rust-lang/project-rfc-2229#42

r? @nikomatsakis