### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -7,7 +7,7 @@
 //! inference graph arose so that we can explain to the user what gave
 //! rise to a particular error.
 //!
-//! The bases of the system are the "origin" types. An "origin" is the
+//! The system is based around a set of "origin" types. An "origin" is the
 //! reason that a constraint or inference variable arose. There are
 //! different "origin" enums for different kinds of constraints/variables
 //! (e.g., `TypeOrigin`, `RegionVariableOrigin`). An origin always has

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -7,7 +7,7 @@
 //! inference graph arose so that we can explain to the user what gave
 //! rise to a particular error.
 //!
-//! The basis of the system are the "origin" types. An "origin" is the
+//! The bases of the system are the "origin" types. An "origin" is the
 //! reason that a constraint or inference variable arose. There are
 //! different "origin" enums for different kinds of constraints/variables
 //! (e.g., `TypeOrigin`, `RegionVariableOrigin`). An origin always has

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -599,7 +599,7 @@ rustc_queries! {
         desc { "computing the inferred outlives predicates for items in this crate" }
     }
 
-    /// Maps from an impl/trait `DefId to a list of the `DefId`s of its items.
+    /// Maps from an impl/trait `DefId` to a list of the `DefId`s of its items.
     query associated_item_def_ids(key: DefId) -> &'tcx [DefId] {
         desc { |tcx| "collecting associated items of `{}`", tcx.def_path_str(key) }
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1493,6 +1493,20 @@ impl<'a> Parser<'a> {
 
     pub(super) fn parse_lit(&mut self) -> PResult<'a, Lit> {
         self.parse_opt_lit().ok_or_else(|| {
+            if let token::Interpolated(inner) = &self.token.kind {
+                let expr = match inner.as_ref() {
+                    token::NtExpr(expr) => Some(expr),
+                    token::NtLiteral(expr) => Some(expr),
+                    _ => None,
+                };
+                if let Some(expr) = expr {
+                    if matches!(expr.kind, ExprKind::Err) {
+                        self.diagnostic()
+                            .delay_span_bug(self.token.span, &"invalid interpolated expression");
+                        return self.diagnostic().struct_dummy();
+                    }
+                }
+            }
             let msg = format!("unexpected token: {}", super::token_descr(&self.token));
             self.struct_span_err(self.token.span, &msg)
         })

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1849,17 +1849,17 @@ macro_rules! int_impl {
         #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
         /// let b = 3;
         ///
-        /// assert_eq!(a.div_floor(b), 2);
-        /// assert_eq!(a.div_floor(-b), -3);
-        /// assert_eq!((-a).div_floor(b), -3);
-        /// assert_eq!((-a).div_floor(-b), 2);
+        /// assert_eq!(a.unstable_div_floor(b), 2);
+        /// assert_eq!(a.unstable_div_floor(-b), -3);
+        /// assert_eq!((-a).unstable_div_floor(b), -3);
+        /// assert_eq!((-a).unstable_div_floor(-b), 2);
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_floor(self, rhs: Self) -> Self {
+        pub const fn unstable_div_floor(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if (r > 0 && rhs < 0) || (r < 0 && rhs > 0) {
@@ -1884,17 +1884,17 @@ macro_rules! int_impl {
         #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
         /// let b = 3;
         ///
-        /// assert_eq!(a.div_ceil(b), 3);
-        /// assert_eq!(a.div_ceil(-b), -2);
-        /// assert_eq!((-a).div_ceil(b), -2);
-        /// assert_eq!((-a).div_ceil(-b), 3);
+        /// assert_eq!(a.unstable_div_ceil(b), 3);
+        /// assert_eq!(a.unstable_div_ceil(-b), -2);
+        /// assert_eq!((-a).unstable_div_ceil(b), -2);
+        /// assert_eq!((-a).unstable_div_ceil(-b), 3);
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_ceil(self, rhs: Self) -> Self {
+        pub const fn unstable_div_ceil(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if (r > 0 && rhs > 0) || (r < 0 && rhs < 0) {
@@ -1919,21 +1919,21 @@ macro_rules! int_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(8), 24);")]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(-8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(-8), 16);")]
-        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").next_multiple_of(8), -16);")]
-        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").next_multiple_of(8), -16);")]
-        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").next_multiple_of(-8), -16);")]
-        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").next_multiple_of(-8), -24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(8), 24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(-8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(-8), 16);")]
+        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").unstable_next_multiple_of(8), -16);")]
+        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").unstable_next_multiple_of(8), -16);")]
+        #[doc = concat!("assert_eq!((-16_", stringify!($SelfT), ").unstable_next_multiple_of(-8), -16);")]
+        #[doc = concat!("assert_eq!((-23_", stringify!($SelfT), ").unstable_next_multiple_of(-8), -24);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn next_multiple_of(self, rhs: Self) -> Self {
+        pub const fn unstable_next_multiple_of(self, rhs: Self) -> Self {
             // This would otherwise fail when calculating `r` when self == T::MIN.
             if rhs == -1 {
                 return self;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1859,12 +1859,12 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".div_floor(4), 1);")]
+        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".unstable_div_floor(4), 1);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[inline(always)]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_floor(self, rhs: Self) -> Self {
+        pub const fn unstable_div_floor(self, rhs: Self) -> Self {
             self / rhs
         }
 
@@ -1880,12 +1880,12 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".div_ceil(4), 2);")]
+        #[doc = concat!("assert_eq!(7_", stringify!($SelfT), ".unstable_div_ceil(4), 2);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn div_ceil(self, rhs: Self) -> Self {
+        pub const fn unstable_div_ceil(self, rhs: Self) -> Self {
             let d = self / rhs;
             let r = self % rhs;
             if r > 0 && rhs > 0 {
@@ -1908,15 +1908,15 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(int_roundings)]
-        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".next_multiple_of(8), 16);")]
-        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".next_multiple_of(8), 24);")]
+        #[doc = concat!("assert_eq!(16_", stringify!($SelfT), ".unstable_next_multiple_of(8), 16);")]
+        #[doc = concat!("assert_eq!(23_", stringify!($SelfT), ".unstable_next_multiple_of(8), 24);")]
         /// ```
         #[unstable(feature = "int_roundings", issue = "88581")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
         #[rustc_inherit_overflow_checks]
-        pub const fn next_multiple_of(self, rhs: Self) -> Self {
+        pub const fn unstable_next_multiple_of(self, rhs: Self) -> Self {
             match self % rhs {
                 0 => self,
                 r => self + (rhs - r)

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -294,33 +294,33 @@ macro_rules! int_module {
             fn test_div_floor() {
                 let a: $T = 8;
                 let b = 3;
-                assert_eq!(a.div_floor(b), 2);
-                assert_eq!(a.div_floor(-b), -3);
-                assert_eq!((-a).div_floor(b), -3);
-                assert_eq!((-a).div_floor(-b), 2);
+                assert_eq!(a.unstable_div_floor(b), 2);
+                assert_eq!(a.unstable_div_floor(-b), -3);
+                assert_eq!((-a).unstable_div_floor(b), -3);
+                assert_eq!((-a).unstable_div_floor(-b), 2);
             }
 
             #[test]
             fn test_div_ceil() {
                 let a: $T = 8;
                 let b = 3;
-                assert_eq!(a.div_ceil(b), 3);
-                assert_eq!(a.div_ceil(-b), -2);
-                assert_eq!((-a).div_ceil(b), -2);
-                assert_eq!((-a).div_ceil(-b), 3);
+                assert_eq!(a.unstable_div_ceil(b), 3);
+                assert_eq!(a.unstable_div_ceil(-b), -2);
+                assert_eq!((-a).unstable_div_ceil(b), -2);
+                assert_eq!((-a).unstable_div_ceil(-b), 3);
             }
 
             #[test]
             fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!((16 as $T).next_multiple_of(-8), 16);
-                assert_eq!((23 as $T).next_multiple_of(-8), 16);
-                assert_eq!((-16 as $T).next_multiple_of(8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(8), -16);
-                assert_eq!((-16 as $T).next_multiple_of(-8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(-8), -24);
-                assert_eq!(MIN.next_multiple_of(-1), MIN);
+                assert_eq!((16 as $T).unstable_next_multiple_of(8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(8), 24);
+                assert_eq!((16 as $T).unstable_next_multiple_of(-8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(-8), 16);
+                assert_eq!((-16 as $T).unstable_next_multiple_of(8), -16);
+                assert_eq!((-23 as $T).unstable_next_multiple_of(8), -16);
+                assert_eq!((-16 as $T).unstable_next_multiple_of(-8), -16);
+                assert_eq!((-23 as $T).unstable_next_multiple_of(-8), -24);
+                assert_eq!(MIN.unstable_next_multiple_of(-1), MIN);
             }
 
             #[test]

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -208,19 +208,19 @@ macro_rules! uint_module {
 
             #[test]
             fn test_div_floor() {
-                assert_eq!((8 as $T).div_floor(3), 2);
+                assert_eq!((8 as $T).unstable_div_floor(3), 2);
             }
 
             #[test]
             fn test_div_ceil() {
-                assert_eq!((8 as $T).div_ceil(3), 3);
+                assert_eq!((8 as $T).unstable_div_ceil(3), 3);
             }
 
             #[test]
             fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!(MAX.next_multiple_of(1), MAX);
+                assert_eq!((16 as $T).unstable_next_multiple_of(8), 16);
+                assert_eq!((23 as $T).unstable_next_multiple_of(8), 24);
+                assert_eq!(MAX.unstable_next_multiple_of(1), MAX);
             }
 
             #[test]

--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -248,7 +248,11 @@ impl<T> Packet<T> {
     // Returns true if blocking should proceed.
     fn decrement(&self, token: SignalToken) -> StartResult {
         unsafe {
-            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0, "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364");
+            assert_eq!(
+                self.to_wake.load(Ordering::SeqCst),
+                0,
+                "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364"
+            );
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);
 

--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -248,7 +248,7 @@ impl<T> Packet<T> {
     // Returns true if blocking should proceed.
     fn decrement(&self, token: SignalToken) -> StartResult {
         unsafe {
-            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0);
+            assert_eq!(self.to_wake.load(Ordering::SeqCst), 0, "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364");
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);
 

--- a/library/std/src/sync/mpsc/shared.rs
+++ b/library/std/src/sync/mpsc/shared.rs
@@ -251,7 +251,7 @@ impl<T> Packet<T> {
             assert_eq!(
                 self.to_wake.load(Ordering::SeqCst),
                 0,
-                "This is a known bug in rust. See https://github.com/rust-lang/rust/issues/39364"
+                "This is a known bug in the Rust standard library. See https://github.com/rust-lang/rust/issues/39364"
             );
             let ptr = token.cast_to_usize();
             self.to_wake.store(ptr, Ordering::SeqCst);

--- a/src/test/rustdoc/cross-crate-primitive-doc.rs
+++ b/src/test/rustdoc/cross-crate-primitive-doc.rs
@@ -1,6 +1,6 @@
 // aux-build:primitive-doc.rs
 // compile-flags: --extern-html-root-url=primitive_doc=../ -Z unstable-options
-// ignore-windows
+// only-linux
 
 #![feature(no_core)]
 #![no_core]

--- a/src/test/rustdoc/intra-doc/prim-methods-external-core.rs
+++ b/src/test/rustdoc/intra-doc/prim-methods-external-core.rs
@@ -1,7 +1,7 @@
 // aux-build:my-core.rs
 // build-aux-docs
 // ignore-cross-compile
-// ignore-windows
+// only-linux
 
 #![deny(broken_intra_doc_links)]
 #![feature(no_core, lang_items)]

--- a/src/test/ui/attributes/extented-attribute-macro-error.rs
+++ b/src/test/ui/attributes/extented-attribute-macro-error.rs
@@ -1,0 +1,8 @@
+// normalize-stderr-test: "couldn't read.*" -> "couldn't read the file"
+
+#![feature(extended_key_value_attributes)]
+#![doc = include_str!("../not_existing_file.md")]
+struct Documented {}
+//~^^ ERROR couldn't read
+
+fn main() {}

--- a/src/test/ui/attributes/extented-attribute-macro-error.stderr
+++ b/src/test/ui/attributes/extented-attribute-macro-error.stderr
@@ -1,0 +1,10 @@
+error: couldn't read the file
+  --> $DIR/extented-attribute-macro-error.rs:4:10
+   |
+LL | #![doc = include_str!("../not_existing_file.md")]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/missing-type-param-used-in-param.fixed
+++ b/src/test/ui/suggestions/missing-type-param-used-in-param.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+
+fn two_type_params<A, B>(_: B) {}
+
+fn main() {
+    two_type_params::<String, _>(100); //~ ERROR this function takes 2 generic arguments
+    two_type_params::<String, _>(100);
+}

--- a/src/test/ui/suggestions/missing-type-param-used-in-param.rs
+++ b/src/test/ui/suggestions/missing-type-param-used-in-param.rs
@@ -1,0 +1,8 @@
+// run-rustfix
+
+fn two_type_params<A, B>(_: B) {}
+
+fn main() {
+    two_type_params::<String>(100); //~ ERROR this function takes 2 generic arguments
+    two_type_params::<String, _>(100);
+}

--- a/src/test/ui/suggestions/missing-type-param-used-in-param.stderr
+++ b/src/test/ui/suggestions/missing-type-param-used-in-param.stderr
@@ -1,0 +1,21 @@
+error[E0107]: this function takes 2 generic arguments but 1 generic argument was supplied
+  --> $DIR/missing-type-param-used-in-param.rs:6:5
+   |
+LL |     two_type_params::<String>(100);
+   |     ^^^^^^^^^^^^^^^   ------ supplied 1 generic argument
+   |     |
+   |     expected 2 generic arguments
+   |
+note: function defined here, with 2 generic parameters: `A`, `B`
+  --> $DIR/missing-type-param-used-in-param.rs:3:4
+   |
+LL | fn two_type_params<A, B>(_: B) {}
+   |    ^^^^^^^^^^^^^^^ -  -
+help: add missing generic argument
+   |
+LL |     two_type_params::<String, _>(100);
+   |                             +++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - #88612 (Add a better error message for #39364)
 - #89023 (Resolve issue : Somewhat confusing error with extended_key_value_attributes)
 - #89148 (Suggest `_` in turbofish if param will be inferred from fn argument)
 - #89171 (Run `no_core` rustdoc tests only on Linux)
 - #89176 (Change singular to plural)
 - #89184 (Temporarily rename int_roundings functions to avoid conflicts)
 - #89200 (Fix typo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88612,89023,89148,89171,89176,89184,89200)
<!-- homu-ignore:end -->