### PR TITLE
Add Clone-less converter from Arc to Vec

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -136,6 +136,7 @@
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(unsized_fn_params)]
+#![cfg_attr(not(no_global_oom_handling), feature(unwrap_rc_as_box))]
 #![feature(allocator_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(maybe_uninit_extra, maybe_uninit_slice, maybe_uninit_uninit_array)]


### PR DESCRIPTION
Adds a new converter to `Arc<T: ?Sized>`: `try_unwrap_as_box(self) -> Result<Box<T>, Self>`
and its counterpart `Rc<T: ?Sized>`: `try_unwrap_as_box(self) -> Result<Box<T>, Self>`

This method is a safe encapsulation when one wants to extract the (unsized) items behind an `Arc` into an owned allocation. For example, after a computation phase where a slice of items had been shared with workers. None of the existing methods allow _taking_ ownership of an unsized pointee. The only current alternatives are downcasting to a concrete sized types, or in that specific case of a slice a more expensive _cloning_ of the entire slice which requires an additional bound and might invoke arbitrary code.

Alternatives:
* The implementation detail `leak_as_owning_weak` is the 'necessary' operation for performing this in 'userspace'. Concretely, it contains the minimal code around the `CAS(1, 0)` that moves ownership of the strong count to the caller. It's been factored out as a shared pattern between `try_unwrap` and the new interface. It _could_ in theory be used by non-std code to perform the same operations or even different ones if it were made `pub`. 
  For example user code might provide `Deref<T>` and `DerefMut<T>` in-place by keeping the `Weak`. This requires a proper newtype that also _could_ be added to std but is another non-trivial addition, I suppose. That pattern alone does not solve moving the pointee to a properly owned `Box` though.
