### PR TITLE
Enable "generate-link-to-definition" option on rust tools docs as well

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -743,6 +743,7 @@ macro_rules! tool_doc {
                 cargo.rustdocflag("--document-private-items");
                 cargo.rustdocflag("--enable-index-page");
                 cargo.rustdocflag("--show-type-layout");
+                cargo.rustdocflag("--generate-link-to-definition");
                 cargo.rustdocflag("-Zunstable-options");
                 builder.run(&mut cargo.into());
             }


### PR DESCRIPTION
Just realized that we enable the option for the compiler crates, but we don't have it for rustdoc and the other tools documentation...

Part of https://github.com/rust-lang/rust/issues/89095.

cc @rust-lang/rustdoc 
r? @Mark-Simulacrum 