### PR TITLE
Include copies of rust-lld for `-Z gcc-ld=lld` only in nightly builds.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1133,17 +1133,20 @@ impl Step for Assemble {
             let src_exe = exe("lld", target_compiler.host);
             let dst_exe = exe("rust-lld", target_compiler.host);
             builder.copy(&lld_install.join("bin").join(&src_exe), &libdir_bin.join(&dst_exe));
-            // for `-Z gcc-ld=lld`
-            let gcc_ld_dir = libdir_bin.join("gcc-ld");
-            t!(fs::create_dir(&gcc_ld_dir));
-            builder.copy(
-                &lld_install.join("bin").join(&src_exe),
-                &gcc_ld_dir.join(exe("ld", target_compiler.host)),
-            );
-            builder.copy(
-                &lld_install.join("bin").join(&src_exe),
-                &gcc_ld_dir.join(exe("ld64", target_compiler.host)),
-            );
+
+            if builder.build.unstable_features() {
+                // for `-Z gcc-ld=lld`
+                let gcc_ld_dir = libdir_bin.join("gcc-ld");
+                t!(fs::create_dir(&gcc_ld_dir));
+                builder.copy(
+                    &lld_install.join("bin").join(&src_exe),
+                    &gcc_ld_dir.join(exe("ld", target_compiler.host)),
+                );
+                builder.copy(
+                    &lld_install.join("bin").join(&src_exe),
+                    &gcc_ld_dir.join(exe("ld64", target_compiler.host)),
+                );
+            }
         }
 
         // Similarly, copy `llvm-dwp` into libdir for Split DWARF. Only copy it when the LLVM


### PR DESCRIPTION
Takes care of #88869 for beta/future stable.