### PR TITLE
build abstract consts without typeck for fully qualified associated consts

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3253,6 +3253,13 @@ impl<'hir> Node<'hir> {
             _ => None,
         }
     }
+
+    pub fn is_anon_const(&self) -> Option<&'hir AnonConst> {
+        match self {
+            Self::AnonConst(ct) => Some(ct),
+            _ => None,
+        }
+    }
 }
 
 // Some nodes are used a lot. Make sure they don't unintentionally get bigger.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1792,4 +1792,14 @@ rustc_queries! {
         no_hash
         desc { "performing HIR wf-checking for predicate {:?} at item {:?}", key.0, key.1 }
     }
+
+    /// Builds an abstract const, do not use this directly, but use `AbstractConst::new` instead.
+    query abstract_const_from_fully_qualif_assoc(
+        key: ty::WithOptConstParam<LocalDefId>
+    ) -> Option<Option<&'tcx [thir::abstract_const::Node<'tcx>]>> {
+        desc {
+            "building an abstract representation for the const argument {}",
+            tcx.def_path_str(key.did.to_def_id()),
+        }
+    }
 }

--- a/compiler/rustc_typeck/src/abstract_const_build.rs
+++ b/compiler/rustc_typeck/src/abstract_const_build.rs
@@ -1,0 +1,49 @@
+use rustc_middle::thir::abstract_const::Node as ACNode;
+use rustc_middle::ty::{self, DefIdTree, TyCtxt, TypeFoldable};
+use rustc_span::def_id::LocalDefId;
+
+/// Builds an abstract const, do not use this directly, but use `AbstractConst::new` instead.
+pub(super) fn abstract_const_from_fully_qualif_assoc<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def: ty::WithOptConstParam<LocalDefId>,
+) -> Option<Option<&'tcx [ACNode<'tcx>]>> {
+    let anon_ct_hir_id = tcx.hir().local_def_id_to_hir_id(def.did);
+    tcx.hir()
+        .get(anon_ct_hir_id)
+        .is_anon_const()
+        .and_then(|ct| tcx.hir().is_fully_qualif_assoc_const_proj(ct.body))
+        .map(|(this, path)| {
+            let trait_did = tcx.parent(path.res.def_id()).unwrap();
+            debug!("trait_did: {:?}", trait_did);
+            let item_ctxt: &dyn crate::astconv::AstConv<'_> =
+                &crate::collect::ItemCtxt::new(tcx, trait_did);
+            let self_ty = item_ctxt.ast_ty_to_ty(this);
+            let trait_ref_substs = <dyn crate::astconv::AstConv<'_>>::ast_path_to_mono_trait_ref(
+                item_ctxt,
+                path.span,
+                trait_did,
+                self_ty,
+                &path.segments[0],
+            )
+            .substs;
+            debug!("trait_ref_substs: {:?}", trait_ref_substs);
+
+            // there is no such thing as `feature(generic_associated_consts)` yet so we dont need
+            // to handle substs for the const on the trait i.e. `N` in `<T as Trait<U>>::ASSOC::<N>`
+            assert!(path.segments[1].args.is_none());
+
+            trait_ref_substs.definitely_has_param_types_or_consts(tcx).then(|| {
+                let ct = tcx.mk_const(ty::Const {
+                    val: ty::ConstKind::Unevaluated(ty::Unevaluated::new(
+                        ty::WithOptConstParam {
+                            did: path.res.def_id(),
+                            const_param_did: def.const_param_did,
+                        },
+                        trait_ref_substs,
+                    )),
+                    ty: tcx.type_of(path.res.def_id()),
+                });
+                &*tcx.arena.alloc_from_iter([ACNode::Leaf(ct)])
+            })
+        })
+}

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -837,7 +837,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         );
     }
 
-    fn ast_path_to_mono_trait_ref(
+    pub(crate) fn ast_path_to_mono_trait_ref(
         &self,
         span: Span,
         trait_def_id: DefId,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -91,6 +91,9 @@ pub fn provide(providers: &mut Providers) {
         codegen_fn_attrs,
         collect_mod_item_types,
         should_inherit_track_caller,
+        // TODO: find a proper place for this
+        abstract_const_from_fully_qualif_assoc:
+            crate::abstract_const_build::abstract_const_from_fully_qualif_assoc,
         ..*providers
     };
 }

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -80,6 +80,7 @@ extern crate rustc_middle;
 pub mod check;
 pub mod expr_use_visitor;
 
+mod abstract_const_build;
 mod astconv;
 mod bounds;
 mod check_unused;

--- a/src/test/ui/const-generics/generic_const_exprs/assoc_const_no_typeck.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/assoc_const_no_typeck.rs
@@ -1,0 +1,41 @@
+// check-pass
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+trait Trait<const N: usize> {
+    const ASSOC: usize;
+    type Foo;
+}
+
+fn no_cycle<const N: usize>()
+where
+    u8: Trait<N>,
+    (): Trait<{ <u8 as Trait<N>>::ASSOC }>,
+    [(); <() as Trait<{ <u8 as Trait<N>>::ASSOC }>>::ASSOC]: ,
+{
+}
+
+fn foo<const N: usize>(_: [(); <<() as Trait<N>>::Foo as Trait<N>>::ASSOC])
+where
+    (): Trait<N>,
+    <() as Trait<N>>::Foo: Trait<N>,
+{
+}
+
+trait Trait2<T> {
+    type Foo;
+}
+
+struct Inherent;
+impl Inherent {
+    const ASSOC: usize = 10;
+}
+
+fn bar<T>()
+where
+    (): Trait2<T, Foo = Inherent>,
+    [(); <() as Trait2<T>>::Foo::ASSOC]: ,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
When we build an abstract const for the const arg in `foo::<{ <T as Trait>::ASSOC }>()` we currently typeck the anon constant and then build an abstract const by walking thir. this PR adds a special case for when the anon const is a fully qualified assoc const, instead of typeck'ing and using thir we will just lower it to to defid + substs pair where the defid is the associated item on the trait (the same result using thir would give us but without the cycles :P).

r? @lcnr