### PR TITLE
Disallow non-c-like but "fieldless" ADTs from being casted to integer if they use arbitrary enum discriminant

### DIFF
--- a/src/test/ui/cast/issue-88621.rs
+++ b/src/test/ui/cast/issue-88621.rs
@@ -1,0 +1,13 @@
+#![feature(arbitrary_enum_discriminant)]
+
+#[repr(u8)]
+enum Kind2 {
+    Foo() = 1,
+    Bar{} = 2,
+    Baz = 3,
+}
+
+fn main() {
+    let _ = Kind2::Foo() as u8;
+    //~^ ERROR non-primitive cast
+}

--- a/src/test/ui/cast/issue-88621.stderr
+++ b/src/test/ui/cast/issue-88621.stderr
@@ -1,0 +1,9 @@
+error[E0605]: non-primitive cast: `Kind2` as `u8`
+  --> $DIR/issue-88621.rs:11:13
+   |
+LL |     let _ = Kind2::Foo() as u8;
+   |             ^^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0605`.

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant.rs
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant.rs
@@ -22,14 +22,6 @@ impl Enum {
     }
 }
 
-#[allow(dead_code)]
-#[repr(u8)]
-enum FieldlessEnum {
-    Unit = 3,
-    Tuple() = 2,
-    Struct {} = 1,
-}
-
 fn main() {
     const UNIT: Enum = Enum::Unit;
     const TUPLE: Enum = Enum::Tuple(5);
@@ -48,9 +40,4 @@ fn main() {
     assert_eq!(3, UNIT_TAG);
     assert_eq!(2, TUPLE_TAG);
     assert_eq!(1, STRUCT_TAG);
-
-    // Ensure `as` conversions are correct
-    assert_eq!(3, FieldlessEnum::Unit as u8);
-    assert_eq!(2, FieldlessEnum::Tuple() as u8);
-    assert_eq!(1, FieldlessEnum::Struct{} as u8);
 }


### PR DESCRIPTION
Code like

```rust
#[repr(u8)]
enum Enum {
    Foo /* = 0 */,
    Bar(),
    Baz{}
}

let x = Enum::Bar() as u8;
```

seems to be unintentionally allowed so we couldn't disallow them now ~~, but we could disallow them if arbitrary enum discriminant is used before 1.56 hits stable~~ (stabilization was reverted).

Related: #88621

@rustbot label +T-lang