### PR TITLE
make junit output more consistent with default format

### DIFF
--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -29,7 +29,7 @@ impl<T: Write> JunitFormatter<T> {
 impl<T: Write> OutputFormatter for JunitFormatter<T> {
     fn write_run_start(&mut self, _test_count: usize) -> io::Result<()> {
         // We write xml header on run start
-        self.out.write_all("\n".as_bytes())?;
+        self.out.write_all(b"\n")?;
         self.write_message("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     }
 
@@ -134,7 +134,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         self.write_message("</testsuite>")?;
         self.write_message("</testsuites>")?;
 
-        self.out.write_all("\n\n".as_bytes())?;
+        self.out.write_all(b"\n\n")?;
 
         Ok(state.failed == 0)
     }

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -29,7 +29,8 @@ impl<T: Write> JunitFormatter<T> {
 impl<T: Write> OutputFormatter for JunitFormatter<T> {
     fn write_run_start(&mut self, _test_count: usize) -> io::Result<()> {
         // We write xml header on run start
-        self.write_message(&"<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        self.out.write_all("\n".as_bytes())?;
+        self.write_message("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     }
 
     fn write_test_start(&mut self, _desc: &TestDesc) -> io::Result<()> {
@@ -132,6 +133,8 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         self.write_message("<system-err/>")?;
         self.write_message("</testsuite>")?;
         self.write_message("</testsuites>")?;
+
+        self.out.write_all("\n\n".as_bytes())?;
 
         Ok(state.failed == 0)
     }


### PR DESCRIPTION
The default format of libtest includes new-lines between each section to ensure the label output from cargo is on it's own line

<pre><font color="#A1B56C"><b>❯</b></font> <font color="#A1B56C">cargo</font><font color="#D8D8D8"> </font><font color="#A1B56C">test</font>
<font color="#A1B56C"><b>   Compiling</b></font> test-test v0.1.0 (/home/jlusby/tmp/test-test)
<font color="#A1B56C"><b>    Finished</b></font> test [unoptimized + debuginfo] target(s) in 0.59s
<font color="#A1B56C"><b>     Running</b></font> unittests (target/debug/deps/test_test-639f369234319c09)

running 1 test
test tests::it_works ... <font color="#A1B56C">ok</font>

test result: <font color="#A1B56C">ok</font>. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

<font color="#A1B56C"><b>   Doc-tests</b></font> test-test

running 0 tests

test result: <font color="#A1B56C">ok</font>. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


</pre>

But when the junit outputter was added to libtest these newlines were omitted, resulting in some "fun" output when run via cargo.

Note the `Doc-tests` text at the end of the first line of xml.

<pre><font color="#A1B56C"><b>❯</b></font> <font color="#A1B56C">cargo</font><font color="#D8D8D8"> </font><font color="#A1B56C">test</font><font color="#D8D8D8"> </font><font color="#A1B56C">--</font><font color="#D8D8D8"> </font><font color="#A1B56C">-Zunstable-options</font><font color="#D8D8D8"> </font><font color="#A1B56C">--format</font><font color="#D8D8D8"> </font><font color="#A1B56C">junit</font>
<font color="#A1B56C"><b>    Finished</b></font> test [unoptimized + debuginfo] target(s) in 0.00s
<font color="#A1B56C"><b>     Running</b></font> unittests (target/debug/deps/test_test-639f369234319c09)
&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;testsuites&gt;&lt;testsuite name=&quot;test&quot; package=&quot;test&quot; id=&quot;0&quot; errors=&quot;0&quot; failures=&quot;0&quot; tests=&quot;1&quot; skipped=&quot;0&quot; &gt;&lt;testcase classname=&quot;tests&quot; name=&quot;it_works&quot; time=&quot;0&quot;/&gt;&lt;system-out/&gt;&lt;system-err/&gt;&lt;/testsuite&gt;&lt;/testsuites&gt;<font color="#A1B56C"><b>   Doc-tests</b></font> test-test
&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;testsuites&gt;&lt;testsuite name=&quot;test&quot; package=&quot;test&quot; id=&quot;0&quot; errors=&quot;0&quot; failures=&quot;0&quot; tests=&quot;0&quot; skipped=&quot;0&quot; &gt;&lt;system-out/&gt;&lt;system-err/&gt;&lt;/testsuite&gt;&lt;/testsuites&gt;

</pre>

After this PR the junit output includes the same style of newlines as the pretty format

<pre><font color="#A1B56C"><b>❯</b></font> <font color="#A1B56C">cargo</font><font color="#D8D8D8"> </font><font color="#A1B56C">test</font><font color="#D8D8D8"> </font><font color="#A1B56C">--</font><font color="#D8D8D8"> </font><font color="#A1B56C">-Zunstable-options</font><font color="#D8D8D8"> </font><font color="#A1B56C">--format</font><font color="#D8D8D8"> </font><font color="#A1B56C">junit</font>
<font color="#A1B56C"><b>   Compiling</b></font> test-test v0.1.0 (/home/jlusby/tmp/test-test)
<font color="#A1B56C"><b>    Finished</b></font> test [unoptimized + debuginfo] target(s) in 0.39s
<font color="#A1B56C"><b>     Running</b></font> unittests (target/debug/deps/test_test-42c2320bb9450c69)

&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;testsuites&gt;&lt;testsuite name=&quot;test&quot; package=&quot;test&quot; id=&quot;0&quot; errors=&quot;0&quot; failures=&quot;0&quot; tests=&quot;1&quot; skipped=&quot;0&quot; &gt;&lt;testcase classname=&quot;tests&quot; name=&quot;it_works&quot; time=&quot;0&quot;/&gt;&lt;system-out/&gt;&lt;system-err/&gt;&lt;/testsuite&gt;&lt;/testsuites&gt;

<font color="#A1B56C"><b>   Doc-tests</b></font> test-test

&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;testsuites&gt;&lt;testsuite name=&quot;test&quot; package=&quot;test&quot; id=&quot;0&quot; errors=&quot;0&quot; failures=&quot;0&quot; tests=&quot;0&quot; skipped=&quot;0&quot; &gt;&lt;system-out/&gt;&lt;system-err/&gt;&lt;/testsuite&gt;&lt;/testsuites&gt;


</pre>