### PR TITLE
refactor: VecDeques PairSlices fields to private

### DIFF
--- a/library/alloc/src/collections/vec_deque/pair_slices.rs
+++ b/library/alloc/src/collections/vec_deque/pair_slices.rs
@@ -20,10 +20,10 @@ use super::VecDeque;
 ///
 /// and the uneven remainder of either A or B is skipped.
 pub struct PairSlices<'a, 'b, T> {
-    pub(crate) a0: &'a mut [T],
-    pub(crate) a1: &'a mut [T],
-    pub(crate) b0: &'b [T],
-    pub(crate) b1: &'b [T],
+    a0: &'a mut [T],
+    a1: &'a mut [T],
+    b0: &'b [T],
+    b1: &'b [T],
 }
 
 impl<'a, 'b, T> PairSlices<'a, 'b, T> {


### PR DESCRIPTION
Reducing VecDeque's PairSlices fields to private, a `from(...)` method is already used to create PairSlices.