### PR TITLE
Fix incorrect disambiguation suggestion for associated items

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -178,6 +178,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 sugg_span,
                                 idx,
                                 self.tcx.sess.source_map(),
+                                item.fn_has_self_parameter,
                             );
                         }
                     }
@@ -220,6 +221,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             sugg_span,
                             idx,
                             self.tcx.sess.source_map(),
+                            item.fn_has_self_parameter,
                         );
                     }
                 }
@@ -1738,6 +1740,7 @@ fn print_disambiguation_help(
     span: Span,
     candidate: Option<usize>,
     source_map: &source_map::SourceMap,
+    fn_has_self_parameter: bool,
 ) {
     let mut applicability = Applicability::MachineApplicable;
     let (span, sugg) = if let (ty::AssocKind::Fn, Some(args)) = (kind, args) {
@@ -1756,9 +1759,14 @@ fn print_disambiguation_help(
                 .collect::<Vec<_>>()
                 .join(", "),
         );
+        let trait_name = if !fn_has_self_parameter {
+            format!("<{} as {}>", rcvr_ty, trait_name)
+        } else {
+            trait_name
+        };
         (span, format!("{}::{}{}", trait_name, item_name, args))
     } else {
-        (span.with_hi(item_name.span.lo()), format!("{}::", trait_name))
+        (span.with_hi(item_name.span.lo()), format!("<{} as {}>::", rcvr_ty, trait_name))
     };
     err.span_suggestion_verbose(
         span,

--- a/src/test/ui/associated-consts/associated-const-ambiguity-report.stderr
+++ b/src/test/ui/associated-consts/associated-const-ambiguity-report.stderr
@@ -16,12 +16,12 @@ LL |     const ID: i32 = 3;
    |     ^^^^^^^^^^^^^^^^^^
 help: disambiguate the associated constant for candidate #1
    |
-LL | const X: i32 = Foo::ID;
-   |                ~~~~~
+LL | const X: i32 = <i32 as Foo>::ID;
+   |                ~~~~~~~~~~~~~~
 help: disambiguate the associated constant for candidate #2
    |
-LL | const X: i32 = Bar::ID;
-   |                ~~~~~
+LL | const X: i32 = <i32 as Bar>::ID;
+   |                ~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0034.stderr
+++ b/src/test/ui/error-codes/E0034.stderr
@@ -16,12 +16,12 @@ LL |     fn foo() {}
    |     ^^^^^^^^
 help: disambiguate the associated function for candidate #1
    |
-LL |     Trait1::foo()
-   |     ~~~~~~~~
+LL |     <Test as Trait1>::foo()
+   |     ~~~~~~~~~~~~~~~~~~
 help: disambiguate the associated function for candidate #2
    |
-LL |     Trait2::foo()
-   |     ~~~~~~~~
+LL |     <Test as Trait2>::foo()
+   |     ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
+++ b/src/test/ui/methods/method-ambig-two-traits-from-impls2.stderr
@@ -16,12 +16,12 @@ LL |     fn foo() {}
    |     ^^^^^^^^
 help: disambiguate the associated function for candidate #1
    |
-LL |     A::foo();
-   |     ~~~
+LL |     <AB as A>::foo();
+   |     ~~~~~~~~~~~
 help: disambiguate the associated function for candidate #2
    |
-LL |     B::foo();
-   |     ~~~
+LL |     <AB as B>::foo();
+   |     ~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -27,16 +27,16 @@ LL |     fn f9(_: usize) -> usize;
            candidate #3: `UnusedTrait`
 help: disambiguate the associated function for candidate #1
    |
-LL |     u.f8(42) + CtxtFn::f9(u, 342) + m.fff(42)
-   |                ~~~~~~~~~~~~~~~~~~
+LL |     u.f8(42) + <usize as CtxtFn>::f9(u, 342) + m.fff(42)
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 help: disambiguate the associated function for candidate #2
    |
-LL |     u.f8(42) + OtherTrait::f9(u, 342) + m.fff(42)
-   |                ~~~~~~~~~~~~~~~~~~~~~~
+LL |     u.f8(42) + <usize as OtherTrait>::f9(u, 342) + m.fff(42)
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 help: disambiguate the associated function for candidate #3
    |
-LL |     u.f8(42) + UnusedTrait::f9(u, 342) + m.fff(42)
-   |                ~~~~~~~~~~~~~~~~~~~~~~~
+LL |     u.f8(42) + <usize as UnusedTrait>::f9(u, 342) + m.fff(42)
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0599]: no method named `fff` found for struct `Myisize` in the current scope
   --> $DIR/issue-7575.rs:62:30
@@ -72,7 +72,7 @@ LL |     fn is_str() -> bool {
    = help: items from traits can only be used if the type parameter is bounded by the trait
 help: disambiguate the associated function for the candidate
    |
-LL |     ManyImplTrait::is_str(t)
+LL |     <T as ManyImplTrait>::is_str(t)
    |
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
Fixes #88806. I have not added a new test case, because the erroneous behavior is already present in existing test cases.