### PR TITLE
Ensure source file present when calculating max line number

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1131,16 +1131,23 @@ impl EmitterWriter {
             None => return 0,
         };
 
+        let will_be_emitted = |span: &Span| {
+            !span.is_dummy() && {
+                let file = sm.lookup_source_file(span.hi());
+                sm.ensure_source_file_source_present(file)
+            }
+        };
+
         let mut max = 0;
         for primary_span in msp.primary_spans() {
-            if !primary_span.is_dummy() {
+            if will_be_emitted(primary_span) {
                 let hi = sm.lookup_char_pos(primary_span.hi());
                 max = (hi.line).max(max);
             }
         }
         if !self.short_message {
             for span_label in msp.span_labels() {
-                if !span_label.span.is_dummy() {
+                if will_be_emitted(&span_label.span) {
                     let hi = sm.lookup_char_pos(span_label.span.hi());
                     max = (hi.line).max(max);
                 }

--- a/src/test/ui/issues/issue-71363.rs
+++ b/src/test/ui/issues/issue-71363.rs
@@ -1,0 +1,9 @@
+// check-fail
+// compile-flags: -Z simulate-remapped-rust-src-base=/rustc/xyz -Z ui-testing=no
+
+#[derive(Debug)]
+struct Test;
+impl std::error::Error for Test {}
+//~^ ERROR `Test` doesn't implement `std::fmt::Display`
+
+fn main() {}

--- a/src/test/ui/issues/issue-71363.stderr
+++ b/src/test/ui/issues/issue-71363.stderr
@@ -1,0 +1,13 @@
+error[E0277]: `Test` doesn't implement `std::fmt::Display`
+ --> $DIR/issue-71363.rs:6:6
+  |
+6 | impl std::error::Error for Test {}
+  |      ^^^^^^^^^^^^^^^^^ `Test` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `Test`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `std::error::Error`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
In the case where there was a non-dummy span but there was no local file present we would include the line number in the max line number calculation but the sub diagnostic would not be emitted.

Fixes #71363