### PR TITLE
Add missing impls field to typedef

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -627,7 +627,11 @@ crate fn from_macro_kind(kind: rustc_span::hygiene::MacroKind) -> MacroKind {
 impl FromWithTcx<clean::Typedef> for Typedef {
     fn from_tcx(typedef: clean::Typedef, tcx: TyCtxt<'_>) -> Self {
         let clean::Typedef { type_, generics, item_type: _ } = typedef;
-        Typedef { type_: type_.into_tcx(tcx), generics: generics.into_tcx(tcx) }
+        Typedef {
+            type_: type_.into_tcx(tcx),
+            generics: generics.into_tcx(tcx),
+            impls: Vec::new(), // Added in JsonRenderer::item
+        }
     }
 }
 

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -171,6 +171,8 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                 e.impls = self.get_impls(id.expect_def_id())
             } else if let types::ItemEnum::Union(ref mut u) = new_item.inner {
                 u.impls = self.get_impls(id.expect_def_id())
+            } else if let types::ItemEnum::Typedef(ref mut t) = new_item.inner {
+                t.impls = self.get_impls(id.expect_def_id())
             }
             let removed = self.index.borrow_mut().insert(from_item_id(id), new_item.clone());
 
@@ -236,7 +238,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 7,
+            format_version: 8,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -494,6 +494,7 @@ pub struct Typedef {
     #[serde(rename = "type")]
     pub type_: Type,
     pub generics: Generics,
+    pub impls: Vec<Id>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/test/rustdoc-json/typedefs/type_impl.rs
+++ b/src/test/rustdoc-json/typedefs/type_impl.rs
@@ -1,0 +1,12 @@
+#![no_std]
+
+// @has type_impl.json "$.index[*][?(@.name=='Ix')].visibility" \"public\"
+// @has - "$.index[*][?(@.name=='Ix')].kind" \"typedef\"
+pub type Ix = usize;
+
+// @has - "$.index[*][?(@.name=='IxTrait')].visibility" \"public\"
+// @has - "$.index[*][?(@.name=='IxTrait')].kind" \"trait\"
+pub trait IxTrait {}
+
+// @count - "$.index[*][?(@.name=='Ix')].inner.impls" 1
+impl IxTrait for Ix {}


### PR DESCRIPTION
This pull-request add a `impls` field to the `Typedef` definition of `rustdoc-json-types` and populates it in the same way it's done for `struct`, `enum` and `union`.

@rustbot label +T-rustdoc +A-rustdoc-json 