### PR TITLE
Fix the population of the `union.impls` field

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -169,6 +169,8 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                 s.impls = self.get_impls(id.expect_def_id())
             } else if let types::ItemEnum::Enum(ref mut e) = new_item.inner {
                 e.impls = self.get_impls(id.expect_def_id())
+            } else if let types::ItemEnum::Union(ref mut u) = new_item.inner {
+                u.impls = self.get_impls(id.expect_def_id())
             }
             let removed = self.index.borrow_mut().insert(from_item_id(id), new_item.clone());
 

--- a/src/test/rustdoc-json/unions/impl.rs
+++ b/src/test/rustdoc-json/unions/impl.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+// @has impl.json "$.index[*][?(@.name=='Ux')].visibility" \"public\"
+// @has - "$.index[*][?(@.name=='Ux')].kind" \"union\"
+pub union Ux {
+    a: u32,
+    b: u64
+}
+
+// @has - "$.index[*][?(@.name=='Num')].visibility" \"public\"
+// @has - "$.index[*][?(@.name=='Num')].kind" \"trait\"
+pub trait Num {}
+
+// @count - "$.index[*][?(@.name=='Ux')].inner.impls" 1
+impl Num for Ux {}


### PR DESCRIPTION
This pull-request fix the population of the `union.impls` field that was forgot when the `Union` type was introduce as a split from the `Struct` type https://github.com/rust-lang/rust/pull/81500.

@rustbot label +T-rustdoc +A-rustdoc-json