### PR TITLE
Use the correct edition for syntax highlighting doctests

### DIFF
--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -61,8 +61,8 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
         };
 
         let hir_id = self.cx.tcx.hir().local_def_id_to_hir_id(local_id);
-        let empty_block = code_block.syntax.is_none() && code_block.is_fenced;
-        let is_ignore = code_block.is_ignore;
+        let empty_block = code_block.lang_string == Default::default() && code_block.is_fenced;
+        let is_ignore = code_block.lang_string.ignore != markdown::Ignore::None;
 
         // The span and whether it is precise or not.
         let (sp, precise_span) = match super::source_span_for_markdown_range(

--- a/src/test/rustdoc-ui/doctest-edition.rs
+++ b/src/test/rustdoc-ui/doctest-edition.rs
@@ -1,0 +1,16 @@
+// edition:2021
+
+#![deny(rustdoc::invalid_rust_codeblocks)]
+//~^ NOTE lint level is defined here
+
+// By default, rustdoc should use the edition of the crate.
+//! ```
+//! foo'b'
+//! ```
+//~^^^ ERROR could not parse
+//~| NOTE prefix `foo` is unknown
+
+// Rustdoc should respect `edition2018` when highlighting syntax.
+//! ```edition2018
+//! foo'b'
+//! ```

--- a/src/test/rustdoc-ui/doctest-edition.stderr
+++ b/src/test/rustdoc-ui/doctest-edition.stderr
@@ -1,0 +1,22 @@
+error: could not parse code block as Rust code
+  --> $DIR/doctest-edition.rs:7:5
+   |
+LL |   //! ```
+   |  _____^
+LL | | //! foo'b'
+LL | | //! ```
+   | |_______^
+   |
+note: the lint level is defined here
+  --> $DIR/doctest-edition.rs:3:9
+   |
+LL | #![deny(rustdoc::invalid_rust_codeblocks)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: error from rustc: prefix `foo` is unknown
+help: mark blocks that do not contain Rust code as text
+   |
+LL | //! ```text
+   |        ++++
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Previously it would unconditionally use edition 2015, which was incorrect.

Helps with https://github.com/rust-lang/rust/issues/89135 in that you can now override the doctest to be 2018 edition instead of being forced to fix the error. This doesn't resolve any of the deeper problems that rustdoc disagrees with most rust users on what a code block is.

cc @Mark-Simulacrum