### PR TITLE
2229: Consume IfLet expr

### DIFF
--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -619,6 +619,8 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
 
         if let Some(hir::Guard::If(ref e)) = arm.guard {
             self.consume_expr(e)
+        } else if let Some(hir::Guard::IfLet(_, ref e)) = arm.guard {
+            self.consume_expr(e)
         }
 
         self.consume_expr(&arm.body);

--- a/src/test/ui/closures/2229_closure_analysis/issue-88118-2.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88118-2.rs
@@ -1,0 +1,21 @@
+// edition:2021
+#![feature(if_let_guard)]
+
+fn print_error_count(registry: &Registry) {
+    |x: &Registry| {
+        match &x {
+            Registry if let _ = registry.try_find_description() => { }
+            //~^ WARNING: irrefutable `if let` guard pattern
+            _ => {}
+        }
+    };
+}
+
+struct Registry;
+impl Registry {
+    pub fn try_find_description(&self) {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/closures/2229_closure_analysis/issue-88118-2.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88118-2.rs
@@ -1,5 +1,8 @@
 // edition:2021
+// run-pass
 #![feature(if_let_guard)]
+#[allow(unused_must_use)]
+#[allow(dead_code)]
 
 fn print_error_count(registry: &Registry) {
     |x: &Registry| {

--- a/src/test/ui/closures/2229_closure_analysis/issue-88118-2.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88118-2.stderr
@@ -1,0 +1,19 @@
+warning: irrefutable `if let` guard pattern
+  --> $DIR/issue-88118-2.rs:7:29
+   |
+LL |             Registry if let _ = registry.try_find_description() => { }
+   |                             ^
+   |
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+   = note: this pattern will always match, so the guard is useless
+   = help: consider removing the guard and adding a `let` inside the match arm
+
+error[E0507]: cannot move out of `*registry` which is behind a shared reference
+  --> $DIR/issue-88118-2.rs:7:33
+   |
+LL |             Registry if let _ = registry.try_find_description() => { }
+   |                                 ^^^^^^^^ move occurs because `*registry` has type `Registry`, which does not implement the `Copy` trait
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/closures/2229_closure_analysis/issue-88118-2.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-88118-2.stderr
@@ -1,5 +1,5 @@
 warning: irrefutable `if let` guard pattern
-  --> $DIR/issue-88118-2.rs:7:29
+  --> $DIR/issue-88118-2.rs:10:29
    |
 LL |             Registry if let _ = registry.try_find_description() => { }
    |                             ^
@@ -8,12 +8,5 @@ LL |             Registry if let _ = registry.try_find_description() => { }
    = note: this pattern will always match, so the guard is useless
    = help: consider removing the guard and adding a `let` inside the match arm
 
-error[E0507]: cannot move out of `*registry` which is behind a shared reference
-  --> $DIR/issue-88118-2.rs:7:33
-   |
-LL |             Registry if let _ = registry.try_find_description() => { }
-   |                                 ^^^^^^^^ move occurs because `*registry` has type `Registry`, which does not implement the `Copy` trait
+warning: 1 warning emitted
 
-error: aborting due to previous error; 1 warning emitted
-
-For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
When using the IfLet guard feature, we can ICE when attempting to resolve PlaceBuilders.
For pattern matching, we currently don't consume the IfLet expression when "visiting" the arms leading us to not "read" all variables and hence not being able to resolve them.

r? @nikomatsakis 
Closes https://github.com/rust-lang/rust/issues/88118