### PR TITLE
Suggest using the path separator for tuple struct

### DIFF
--- a/src/test/ui/resolve/suggest-path-for-tuple-struct.rs
+++ b/src/test/ui/resolve/suggest-path-for-tuple-struct.rs
@@ -1,0 +1,26 @@
+mod module {
+    pub struct SomeTupleStruct(u8);
+    pub struct SomeRegularStruct {
+        foo: u8
+    }
+
+    impl SomeTupleStruct {
+        pub fn new() -> Self {
+            Self(0)
+        }
+    }
+    impl SomeRegularStruct {
+        pub fn new() -> Self {
+            Self { foo: 0 }
+        }
+    }
+}
+
+use module::{SomeTupleStruct, SomeRegularStruct};
+
+fn main() {
+    let _ = SomeTupleStruct.new();
+    //~^ ERROR expected value, found struct `SomeTupleStruct`
+    let _ = SomeRegularStruct.new();
+    //~^ ERROR expected value, found struct `SomeRegularStruct`
+}

--- a/src/test/ui/resolve/suggest-path-for-tuple-struct.stderr
+++ b/src/test/ui/resolve/suggest-path-for-tuple-struct.stderr
@@ -1,0 +1,19 @@
+error[E0423]: expected value, found struct `SomeTupleStruct`
+  --> $DIR/suggest-path-for-tuple-struct.rs:22:13
+   |
+LL |     let _ = SomeTupleStruct.new();
+   |             ^^^^^^^^^^^^^^^----
+   |             |
+   |             help: use the path separator to refer to an item: `SomeTupleStruct::new`
+
+error[E0423]: expected value, found struct `SomeRegularStruct`
+  --> $DIR/suggest-path-for-tuple-struct.rs:24:13
+   |
+LL |     let _ = SomeRegularStruct.new();
+   |             ^^^^^^^^^^^^^^^^^----
+   |             |
+   |             help: use the path separator to refer to an item: `SomeRegularStruct::new`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fix confusing error message `constructor is not visible here due to private fields` for tuple struct

closes #83450