### PR TITLE
Add `is_absent` and `is_unicode_error` to VarError

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -274,11 +274,13 @@ pub enum VarError {
 
 impl VarError {
     /// Checks if the error was caused by the environment variable being absent
+    #[unstable(feature = "varerror_methods", issue = "89302")]
     pub const fn is_absent(&self) -> bool {
         matches!(self, VarError::NotPresent)
     }
     /// Checks if the error was caused by the environment variable failing to be valid
     /// Unicode
+    #[unstable(feature = "varerror_methods", issue = "89302")]
     pub const fn is_unicode_error(&self) -> bool {
         matches!(self, VarError::NotUnicode(_))
     }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -275,13 +275,13 @@ pub enum VarError {
 impl VarError {
     /// Checks if the error was caused by the environment variable being absent
     #[unstable(feature = "varerror_methods", issue = "89302")]
-    pub const fn is_absent(&self) -> bool {
+    pub const fn is_not_present(&self) -> bool {
         matches!(self, VarError::NotPresent)
     }
     /// Checks if the error was caused by the environment variable failing to be valid
     /// Unicode
     #[unstable(feature = "varerror_methods", issue = "89302")]
-    pub const fn is_unicode_error(&self) -> bool {
+    pub const fn is_not_unicode(&self) -> bool {
         matches!(self, VarError::NotUnicode(_))
     }
 }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -272,6 +272,18 @@ pub enum VarError {
     NotUnicode(#[stable(feature = "env", since = "1.0.0")] OsString),
 }
 
+impl VarError {
+    /// Checks if the error was caused by the environment variable being absent
+    pub const fn is_absent(&self) -> bool {
+        matches!(self, VarError::NotPresent)
+    }
+    /// Checks if the error was caused by the environment variable failing to be valid
+    /// Unicode
+    pub const fn is_unicode_error(&self) -> bool {
+        matches!(self, VarError::NotUnicode(_))
+    }
+}
+
 #[stable(feature = "env", since = "1.0.0")]
 impl fmt::Display for VarError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Added the following functions to VarError:
- `is_absent`: Check if the error was caused by a missing env var
- `is_unicode_error`: Check if the error was caused by unicode parsing
failure

The addition of these methods generally simplifies some cases
where you'd just want to check if the variable is missing or if
an error has occurred while parsing it.

Signed-off-by: Sayan Nandan <nandansayan@outlook.com>

---
This closes #89302 