### PR TITLE
Add unit assignment to MIR for `asm!()`

### DIFF
--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -449,8 +449,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     })
                     .collect();
 
-                let destination = this.cfg.start_new_block();
+                if !options.contains(InlineAsmOptions::NORETURN) {
+                    this.cfg.push_assign_unit(block, source_info, destination, this.tcx);
+                }
 
+                let destination_block = this.cfg.start_new_block();
                 this.cfg.terminate(
                     block,
                     source_info,
@@ -462,11 +465,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         destination: if options.contains(InlineAsmOptions::NORETURN) {
                             None
                         } else {
-                            Some(destination)
+                            Some(destination_block)
                         },
                     },
                 );
-                destination.unit()
+                destination_block.unit()
             }
 
             // These cases don't actually need a destination

--- a/src/test/ui/asm/issue-89305.rs
+++ b/src/test/ui/asm/issue-89305.rs
@@ -1,0 +1,14 @@
+// Regression test for #89305, where a variable was erroneously reported
+// as both unused and possibly-uninitialized.
+
+// check-pass
+
+#![feature(asm)]
+#![warn(unused)]
+
+fn main() {
+    unsafe {
+        let x: () = asm!("nop");
+        //~^ WARNING: unused variable: `x`
+    }
+}

--- a/src/test/ui/asm/issue-89305.stderr
+++ b/src/test/ui/asm/issue-89305.stderr
@@ -1,0 +1,15 @@
+warning: unused variable: `x`
+  --> $DIR/issue-89305.rs:11:13
+   |
+LL |         let x: () = asm!("nop");
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-89305.rs:7:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #89305. `ExprKind::LlvmInlineAsm` gets a `push_assign_unit()` here:
https://github.com/rust-lang/rust/blob/2b6ed3b675475abc01ce7e68bb75b457f0c85684/compiler/rustc_mir_build/src/build/expr/into.rs#L475-L479

The same should probably happen for `ExprKind::InlineAsm`, which fixes the "use of possibly-uninitialized variable" error described in #89305.
