### PR TITLE
fix(lint): don't suggest refutable patterns to "fix" irrefutable bind

### DIFF
--- a/src/test/ui/suggestions/issue-88730.rs
+++ b/src/test/ui/suggestions/issue-88730.rs
@@ -1,0 +1,16 @@
+#![allow(unused, nonstandard_style)]
+#![deny(bindings_with_variant_name)]
+
+// If an enum has two different variants,
+// then it cannot be matched upon in a function argument.
+// It still gets a warning, but no suggestions.
+enum Foo {
+    C,
+    D,
+}
+
+fn foo(C: Foo) {} //~ERROR
+
+fn main() {
+    let C = Foo::D; //~ERROR
+}

--- a/src/test/ui/suggestions/issue-88730.stderr
+++ b/src/test/ui/suggestions/issue-88730.stderr
@@ -1,0 +1,21 @@
+error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-88730.rs:12:8
+   |
+LL | fn foo(C: Foo) {}
+   |        ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-88730.rs:2:9
+   |
+LL | #![deny(bindings_with_variant_name)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-88730.rs:15:9
+   |
+LL |     let C = Foo::D;
+   |         ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0170`.


### PR DESCRIPTION
In function arguments and let bindings, do not suggest changing `C` to `Foo::C` unless `C` is the only variant of `Foo`, because it won't work.

The general warning is still kept, because code like this is confusing.

Fixes #88730

p.s. `src/test/ui/lint/lint-uppercase-variables.rs` already tests the one-variant case.