### PR TITLE
Move generic error message to separate branches

### DIFF
--- a/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
@@ -10,9 +10,10 @@ error: overly complex generic constant
   --> $DIR/array-size-in-generic-struct-param.rs:19:15
    |
 LL |     arr: [u8; CFG.arr_size],
-   |               ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |               ^^^^^^^^^^^^ field access is not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/closures.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/closures.stderr
@@ -4,9 +4,10 @@ error: overly complex generic constant
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    |                                   ^^^^-------^^
    |                                       |
-   |                                       unsupported operation in generic constant, this may be supported in the future
+   |                                       dereferencing is not supported in generic constants
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/generic_const_exprs/let-bindings.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/let-bindings.stderr
@@ -2,17 +2,19 @@ error: overly complex generic constant
   --> $DIR/let-bindings.rs:6:68
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                                                    ^^^^^^^^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/let-bindings.rs:6:35
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                   ^^^^^^^^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                   ^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/unused_expr.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/unused_expr.stderr
@@ -2,25 +2,28 @@ error: overly complex generic constant
   --> $DIR/unused_expr.rs:4:34
    |
 LL | fn add<const N: usize>() -> [u8; { N + 1; 5 }] {
-   |                                  ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                  ^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/unused_expr.rs:9:34
    |
 LL | fn div<const N: usize>() -> [u8; { N / 1; 5 }] {
-   |                                  ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                  ^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/unused_expr.rs:16:38
    |
 LL | fn fn_call<const N: usize>() -> [u8; { foo(N); 5 }] {
-   |                                      ^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                      ^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-67375.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-67375.full.stderr
@@ -4,7 +4,7 @@ error: overly complex generic constant
 LL |     inner: [(); { [|_: &T| {}; 0].len() }],
    |                 ^^---------------^^^^^^^^
    |                   |
-   |                   unsupported operation in generic constant
+   |                   pointer casts are not allowed in generic constants
    |
    = help: consider moving this anonymous constant into a `const` function
 

--- a/src/test/ui/const-generics/issues/issue-67945-2.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-67945-2.full.stderr
@@ -8,9 +8,10 @@ LL | |         let x: Option<Box<Self>> = None;
 LL | |
 LL | |         0
 LL | |     }],
-   | |_____^ unsupported operation in generic constant, this may be supported in the future
+   | |_____^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This decomposes an error message in generic constants into more specific branches, for better
readability.

r? @lcnr