### PR TITLE
Consider unfulfilled obligations in binop errors

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2171,9 +2171,25 @@ impl fmt::Debug for TraitRefPrintOnlyTraitPath<'tcx> {
     }
 }
 
+/// Wrapper type for `ty::TraitRef` which opts-in to pretty printing only
+/// the trait name. That is, it will print `Trait` instead of
+/// `<T as Trait<U>>`.
+#[derive(Copy, Clone, TypeFoldable, Lift)]
+pub struct TraitRefPrintOnlyTraitName<'tcx>(ty::TraitRef<'tcx>);
+
+impl fmt::Debug for TraitRefPrintOnlyTraitName<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
 impl ty::TraitRef<'tcx> {
     pub fn print_only_trait_path(self) -> TraitRefPrintOnlyTraitPath<'tcx> {
         TraitRefPrintOnlyTraitPath(self)
+    }
+
+    pub fn print_only_trait_name(self) -> TraitRefPrintOnlyTraitName<'tcx> {
+        TraitRefPrintOnlyTraitName(self)
     }
 }
 
@@ -2193,6 +2209,7 @@ forward_display_to_print! {
     ty::Binder<'tcx, ty::ExistentialPredicate<'tcx>>,
     ty::Binder<'tcx, ty::TraitRef<'tcx>>,
     ty::Binder<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
+    ty::Binder<'tcx, TraitRefPrintOnlyTraitName<'tcx>>,
     ty::Binder<'tcx, ty::FnSig<'tcx>>,
     ty::Binder<'tcx, ty::TraitPredicate<'tcx>>,
     ty::Binder<'tcx, ty::SubtypePredicate<'tcx>>,
@@ -2253,6 +2270,10 @@ define_print_and_forward_display! {
 
     TraitRefPrintOnlyTraitPath<'tcx> {
         p!(print_def_path(self.0.def_id, self.0.substs));
+    }
+
+    TraitRefPrintOnlyTraitName<'tcx> {
+        p!(print_def_path(self.0.def_id, &[]));
     }
 
     ty::ParamTy {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -521,7 +521,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                     "this error might have been caused by changes to \
                                     Rust's type-inference algorithm (see issue #48950 \
                                     <https://github.com/rust-lang/rust/issues/48950> \
-                                    for more information).",
+                                    for more information)",
                                 );
                                 err.help("did you intend to use the type `()` here instead?");
                             }

--- a/src/test/ui/assignment-operator-unimplemented.stderr
+++ b/src/test/ui/assignment-operator-unimplemented.stderr
@@ -6,7 +6,22 @@ LL |   a += *b;
    |   |
    |   cannot use `+=` on type `Foo`
    |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `Foo`
+note: an implementation of `AddAssign<_>` might be missing for `Foo`
+  --> $DIR/assignment-operator-unimplemented.rs:1:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^^ must implement `AddAssign<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait AddAssign<Rhs = Self> {
+LL | |     /// Performs the `+=` operation.
+LL | |     ///
+LL | |     /// # Example
+...  |
+LL | |     fn add_assign(&mut self, rhs: Rhs);
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/issue-28837.stderr
+++ b/src/test/ui/binop/issue-28837.stderr
@@ -6,7 +6,22 @@ LL |     a + a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Add` might be missing for `A`
+note: an implementation of `Add<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Add<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Add<Rhs = Self> {
+LL | |     /// The resulting type after applying the `+` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn add(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: cannot subtract `A` from `A`
   --> $DIR/issue-28837.rs:8:7
@@ -16,7 +31,22 @@ LL |     a - a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Sub` might be missing for `A`
+note: an implementation of `Sub<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Sub<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Sub<Rhs = Self> {
+LL | |     /// The resulting type after applying the `-` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn sub(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: cannot multiply `A` by `A`
   --> $DIR/issue-28837.rs:10:7
@@ -26,7 +56,22 @@ LL |     a * a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Mul` might be missing for `A`
+note: an implementation of `Mul<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Mul<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Mul<Rhs = Self> {
+LL | |     /// The resulting type after applying the `*` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn mul(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: cannot divide `A` by `A`
   --> $DIR/issue-28837.rs:12:7
@@ -36,7 +81,22 @@ LL |     a / a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Div` might be missing for `A`
+note: an implementation of `Div<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Div<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Div<Rhs = Self> {
+LL | |     /// The resulting type after applying the `/` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn div(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: cannot mod `A` by `A`
   --> $DIR/issue-28837.rs:14:7
@@ -46,7 +106,22 @@ LL |     a % a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Rem` might be missing for `A`
+note: an implementation of `Rem<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Rem<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Rem<Rhs = Self> {
+LL | |     /// The resulting type after applying the `%` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn rem(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: no implementation for `A & A`
   --> $DIR/issue-28837.rs:16:7
@@ -56,7 +131,22 @@ LL |     a & a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::BitAnd` might be missing for `A`
+note: an implementation of `BitAnd<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `BitAnd<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait BitAnd<Rhs = Self> {
+LL | |     /// The resulting type after applying the `&` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn bitand(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: no implementation for `A | A`
   --> $DIR/issue-28837.rs:18:7
@@ -66,7 +156,22 @@ LL |     a | a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::BitOr` might be missing for `A`
+note: an implementation of `BitOr<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `BitOr<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait BitOr<Rhs = Self> {
+LL | |     /// The resulting type after applying the `|` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn bitor(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: no implementation for `A << A`
   --> $DIR/issue-28837.rs:20:7
@@ -76,7 +181,22 @@ LL |     a << a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Shl` might be missing for `A`
+note: an implementation of `Shl<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Shl<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait Shl<Rhs = Self> {
+LL | |     /// The resulting type after applying the `<<` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn shl(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: no implementation for `A >> A`
   --> $DIR/issue-28837.rs:22:7
@@ -86,7 +206,22 @@ LL |     a >> a;
    |     |
    |     A
    |
-   = note: an implementation of `std::ops::Shr` might be missing for `A`
+note: an implementation of `Shr<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `Shr<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait Shr<Rhs = Self> {
+LL | |     /// The resulting type after applying the `>>` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn shr(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: binary operation `==` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:24:7
@@ -96,7 +231,15 @@ LL |     a == a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+note: an implementation of `PartialEq<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialEq<_>`
+help: consider annotating `A` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:26:7
@@ -106,7 +249,15 @@ LL |     a != a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+note: an implementation of `PartialEq<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialEq<_>`
+help: consider annotating `A` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `<` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:28:7
@@ -116,7 +267,15 @@ LL |     a < a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+note: an implementation of `PartialOrd<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialOrd<_>`
+help: consider annotating `A` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error[E0369]: binary operation `<=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:30:7
@@ -126,7 +285,15 @@ LL |     a <= a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+note: an implementation of `PartialOrd<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialOrd<_>`
+help: consider annotating `A` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error[E0369]: binary operation `>` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:32:7
@@ -136,7 +303,15 @@ LL |     a > a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+note: an implementation of `PartialOrd<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialOrd<_>`
+help: consider annotating `A` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error[E0369]: binary operation `>=` cannot be applied to type `A`
   --> $DIR/issue-28837.rs:34:7
@@ -146,7 +321,15 @@ LL |     a >= a;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialOrd` might be missing for `A`
+note: an implementation of `PartialOrd<_>` might be missing for `A`
+  --> $DIR/issue-28837.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^ must implement `PartialOrd<_>`
+help: consider annotating `A` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error: aborting due to 15 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -7,8 +7,16 @@ LL | #[derive(PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:9:6
@@ -19,8 +27,16 @@ LL | #[derive(PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -7,8 +7,16 @@ LL | #[derive(PartialEq)]
 LL |      Error
    |      ^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-enum.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum.rs:9:6
@@ -19,8 +27,16 @@ LL | #[derive(PartialEq)]
 LL |      Error
    |      ^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-enum.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -7,8 +7,16 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-struct.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-struct.rs:8:5
@@ -19,8 +27,16 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-struct.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -7,8 +7,16 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-tuple-struct.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-tuple-struct.rs:8:5
@@ -19,8 +27,16 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
+note: an implementation of `PartialEq<_>` might be missing for `Error`
+  --> $DIR/derives-span-PartialEq-tuple-struct.rs:4:1
+   |
+LL | struct Error;
+   | ^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -7,8 +7,16 @@ LL | struct E {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
+note: an implementation of `PartialEq<_>` might be missing for `NoCloneOrEq`
+  --> $DIR/deriving-no-inner-impl-error-message.rs:1:1
+   |
+LL | struct NoCloneOrEq;
+   | ^^^^^^^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NoCloneOrEq` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
   --> $DIR/deriving-no-inner-impl-error-message.rs:5:5
@@ -19,8 +27,16 @@ LL | struct E {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
+note: an implementation of `PartialEq<_>` might be missing for `NoCloneOrEq`
+  --> $DIR/deriving-no-inner-impl-error-message.rs:1:1
+   |
+LL | struct NoCloneOrEq;
+   | ^^^^^^^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NoCloneOrEq` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error[E0277]: the trait bound `NoCloneOrEq: Clone` is not satisfied
   --> $DIR/deriving-no-inner-impl-error-message.rs:10:5

--- a/src/test/ui/destructuring-assignment/note-unsupported.stderr
+++ b/src/test/ui/destructuring-assignment/note-unsupported.stderr
@@ -99,7 +99,22 @@ LL |     S { x: a, y: b } += s;
    |     |
    |     cannot use `+=` on type `S`
    |
-   = note: an implementation of `std::ops::AddAssign` might be missing for `S`
+note: an implementation of `AddAssign<_>` might be missing for `S`
+  --> $DIR/note-unsupported.rs:1:1
+   |
+LL | struct S { x: u8, y: u8 }
+   | ^^^^^^^^ must implement `AddAssign<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait AddAssign<Rhs = Self> {
+LL | |     /// Performs the `+=` operation.
+LL | |     ///
+LL | |     /// # Example
+...  |
+LL | |     fn add_assign(&mut self, rhs: Rhs);
+LL | | }
+   | |_^
 
 error[E0067]: invalid left-hand side of assignment
   --> $DIR/note-unsupported.rs:17:22

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -36,7 +36,22 @@ error[E0600]: cannot apply unary operator `!` to type `Question`
 LL |     !Question::Yes;
    |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
-   = note: an implementation of `std::ops::Not` might be missing for `Question`
+note: an implementation of `Not` might be missing for `Question`
+  --> $DIR/error-festival.rs:1:1
+   |
+LL | enum Question {
+   | ^^^^^^^^^^^^^ must implement `Not`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait Not {
+LL | |     /// The resulting type after applying the `!` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn not(self) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/error-festival.rs:25:5

--- a/src/test/ui/issues/issue-14091-2.stderr
+++ b/src/test/ui/issues/issue-14091-2.stderr
@@ -4,7 +4,22 @@ error[E0600]: cannot apply unary operator `!` to type `BytePos`
 LL |     assert!(x, x);
    |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
-   = note: an implementation of `std::ops::Not` might be missing for `BytePos`
+note: an implementation of `Not` might be missing for `BytePos`
+  --> $DIR/issue-14091-2.rs:6:1
+   |
+LL | pub struct BytePos(pub u32);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `Not`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait Not {
+LL | |     /// The resulting type after applying the `!` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn not(self) -> Self::Output;
+LL | | }
+   | |_^
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-31076.rs
+++ b/src/test/ui/issues/issue-31076.rs
@@ -11,7 +11,7 @@ impl Add<i32> for i32 {}
 
 fn main() {
     let x = 5 + 6;
-    //~^ ERROR cannot add `{integer}` to `{integer}`
+    //~^ ERROR cannot add `i32` to `{integer}`
     let y = 5i32 + 6i32;
     //~^ ERROR cannot add `i32` to `i32`
 }

--- a/src/test/ui/issues/issue-31076.stderr
+++ b/src/test/ui/issues/issue-31076.stderr
@@ -1,8 +1,8 @@
-error[E0369]: cannot add `{integer}` to `{integer}`
+error[E0369]: cannot add `i32` to `{integer}`
   --> $DIR/issue-31076.rs:13:15
    |
 LL |     let x = 5 + 6;
-   |             - ^ - {integer}
+   |             - ^ - i32
    |             |
    |             {integer}
 

--- a/src/test/ui/issues/issue-3820.stderr
+++ b/src/test/ui/issues/issue-3820.stderr
@@ -6,7 +6,22 @@ LL |     let w = u * 3;
    |             |
    |             Thing
    |
-   = note: an implementation of `std::ops::Mul` might be missing for `Thing`
+note: an implementation of `Mul<_>` might be missing for `Thing`
+  --> $DIR/issue-3820.rs:1:1
+   |
+LL | struct Thing {
+   | ^^^^^^^^^^^^ must implement `Mul<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Mul<Rhs = Self> {
+LL | |     /// The resulting type after applying the `*` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn mul(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-62375.stderr
+++ b/src/test/ui/issues/issue-62375.stderr
@@ -6,7 +6,15 @@ LL |     a == A::Value;
    |     |
    |     A
    |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `A`
+note: an implementation of `PartialEq<_>` might be missing for `A`
+  --> $DIR/issue-62375.rs:1:1
+   |
+LL | enum A {
+   | ^^^^^^ must implement `PartialEq<_>`
+help: consider annotating `A` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -55,6 +55,17 @@ LL |      .take()
    = note: the following trait bounds were not satisfied:
            `Foo: Iterator`
            which is required by `&mut Foo: Iterator`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL | / pub trait Iterator {
+LL | |     /// The type of the elements being iterated over.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Item;
+...  |
+LL | |     }
+LL | | }
+   | |_^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `take`, perhaps you need to implement it:
            candidate #1: `Iterator`

--- a/src/test/ui/never_type/defaulted-never-note.fallback.stderr
+++ b/src/test/ui/never_type/defaulted-never-note.fallback.stderr
@@ -5,7 +5,7 @@ LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
    |
    = note: this trait is implemented for `()`
-   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information).
+   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: did you intend to use the type `()` here instead?
 note: required by a bound in `foo`
   --> $DIR/defaulted-never-note.rs:25:11

--- a/src/test/ui/never_type/diverging-fallback-no-leak.fallback.stderr
+++ b/src/test/ui/never_type/diverging-fallback-no-leak.fallback.stderr
@@ -5,7 +5,7 @@ LL |     unconstrained_arg(return);
    |     ^^^^^^^^^^^^^^^^^ the trait `Test` is not implemented for `!`
    |
    = note: this trait is implemented for `()`
-   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information).
+   = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: did you intend to use the type `()` here instead?
 note: required by a bound in `unconstrained_arg`
   --> $DIR/diverging-fallback-no-leak.rs:12:25

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -30,7 +30,22 @@ LL |     let _ = |A | B: E| ();
    |                  |
    |                  E
    |
-   = note: an implementation of `std::ops::BitOr` might be missing for `E`
+note: an implementation of `BitOr<_>` might be missing for `E`
+  --> $DIR/or-patterns-syntactic-fail.rs:6:1
+   |
+LL | enum E { A, B }
+   | ^^^^^^ must implement `BitOr<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
+   |
+LL | / pub trait BitOr<Rhs = Self> {
+LL | |     /// The resulting type after applying the `|` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn bitor(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -20,7 +20,22 @@ LL |     let y = World::Hello + World::Goodbye;
    |             |
    |             World
    |
-   = note: an implementation of `std::ops::Add` might be missing for `World`
+note: an implementation of `Add<_>` might be missing for `World`
+  --> $DIR/issue-39018.rs:15:1
+   |
+LL | enum World {
+   | ^^^^^^^^^^ must implement `Add<_>`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Add<Rhs = Self> {
+LL | |     /// The resulting type after applying the `+` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn add(self, rhs: Rhs) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0369]: cannot add `String` to `&str`
   --> $DIR/issue-39018.rs:11:22

--- a/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
@@ -22,6 +22,14 @@ LL |     println!("{}", MyStruct.foo_one());
    |
    = note: the following trait bounds were not satisfied:
            `MyStruct: Foo`
+note: the following trait must be implemented
+  --> $DIR/specialization-trait-not-implemented.rs:7:1
+   |
+LL | / trait Foo {
+LL | |     fn foo_one(&self) -> &'static str;
+LL | |     fn foo_two(&self) -> &'static str;
+LL | | }
+   | |_^
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Foo` defines an item `foo_one`, perhaps you need to implement it
   --> $DIR/specialization-trait-not-implemented.rs:7:1

--- a/src/test/ui/suggestions/invalid-bin-op.stderr
+++ b/src/test/ui/suggestions/invalid-bin-op.stderr
@@ -6,7 +6,16 @@ LL |     let _ = s == t;
    |             |
    |             S<T>
    |
+note: an implementation of `PartialEq<_>` might be missing for `S<T>`
+  --> $DIR/invalid-bin-op.rs:5:1
+   |
+LL | struct S<T>(T);
+   | ^^^^^^^^^^^^^^^ must implement `PartialEq<_>`
    = note: the trait `std::cmp::PartialEq` is not implemented for `S<T>`
+help: consider annotating `S<T>` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-ascription-precedence.stderr
+++ b/src/test/ui/type/type-ascription-precedence.stderr
@@ -28,7 +28,22 @@ error[E0600]: cannot apply unary operator `-` to type `Z`
 LL |     -(S: Z);
    |     ^^^^^^^ cannot apply unary operator `-`
    |
-   = note: an implementation of `std::ops::Neg` might be missing for `Z`
+note: an implementation of `std::ops::Neg` might be missing for `Z`
+  --> $DIR/type-ascription-precedence.rs:9:1
+   |
+LL | struct Z;
+   | ^^^^^^^^^ must implement `std::ops::Neg`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |
+LL | / pub trait Neg {
+LL | |     /// The resulting type after applying the `-` operator.
+LL | |     #[stable(feature = "rust1", since = "1.0.0")]
+LL | |     type Output;
+...  |
+LL | |     fn neg(self) -> Self::Output;
+LL | | }
+   | |_^
 
 error[E0308]: mismatched types
   --> $DIR/type-ascription-precedence.rs:45:5


### PR DESCRIPTION
When encountering a binop where the types would have been accepted, if
all the predicates had been fulfilled, include information about the
predicates and suggest appropriate `#[derive]`s if possible.

Fix #84515.