### PR TITLE
print-type-sizes: skip field printing for primitives

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1805,8 +1805,11 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
         match layout.variants {
             Variants::Single { index } => {
-                debug!("print-type-size `{:#?}` variant {}", layout, adt_def.variants[index].ident);
-                if !adt_def.variants.is_empty() {
+                if !adt_def.variants.is_empty() && layout.fields != FieldsShape::Primitive {
+                    debug!(
+                        "print-type-size `{:#?}` variant {}",
+                        layout, adt_def.variants[index].ident
+                    );
                     let variant_def = &adt_def.variants[index];
                     let fields: Vec<_> = variant_def.fields.iter().map(|f| f.ident.name).collect();
                     record(

--- a/src/test/ui/print_type_sizes/uninhabited.rs
+++ b/src/test/ui/print_type_sizes/uninhabited.rs
@@ -11,5 +11,5 @@
 fn start(_: isize, _: *const *const u8) -> isize {
     let _x: Option<!> = None;
     let _y: Result<u32, !> = Ok(42);
-    0
+    let _z: Result<!, !> = loop {};
 }

--- a/src/test/ui/print_type_sizes/uninhabited.stdout
+++ b/src/test/ui/print_type_sizes/uninhabited.stdout
@@ -3,3 +3,4 @@ print-type-size     variant `Ok`: 4 bytes
 print-type-size         field `.0`: 4 bytes
 print-type-size type: `std::option::Option<!>`: 0 bytes, alignment: 1 bytes
 print-type-size     variant `None`: 0 bytes
+print-type-size type: `std::result::Result<!, !>`: 0 bytes, alignment: 1 bytes


### PR DESCRIPTION
Fixes #86528.