### PR TITLE
Optimize is_sorted for Range and RangeInclusive

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -673,6 +673,11 @@ impl<A: Step> Iterator for ops::Range<A> {
     }
 
     #[inline]
+    fn is_sorted(self) -> bool {
+        true
+    }
+
+    #[inline]
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
@@ -1094,6 +1099,11 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
     #[inline]
     fn max(mut self) -> Option<A> {
         self.next_back()
+    }
+
+    #[inline]
+    fn is_sorted(self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
The [`Step`] trait guarantees that `Range<impl Step>` yields items in sorted order.  We can override `Iterator::is_sorted` based on this guarantee, as we already do for `Iterator::min` and `max`.

Thank you to @fiveseven-lambda who pointed this out [on the Rust Users Forum](https://users.rust-lang.org/t/is-sorted-method-in-impl-iterator-for-range/64717).

[`Step`]: https://doc.rust-lang.org/stable/std/iter/trait.Step.html