### PR TITLE
Avoid allocations and copying in Vec::leak

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1952,10 +1952,11 @@ impl<T, A: Allocator> Vec<T, A> {
     /// `'a`. If the type has only static references, or none at all, then this
     /// may be chosen to be `'static`.
     ///
-    /// This method does not reallocate or shrink the `Vec`, so the leaked
-    /// allocation may include unused capacity that is not part of the returned
-    /// slice.  Unsafe code that later reconstructs or deallocates the `Vec`
-    /// (for example, by calling [`Vec::from_raw_parts`]) must keep track of the
+    /// As of Rust 1.57, this method does not reallocate or shrink the `Vec`,
+    /// so the leaked allocation may include unused capacity that is not part
+    /// of the returned slice.
+    /// Unsafe code that later reconstructs or deallocates the `Vec` (for
+    /// example, by calling [`Vec::from_raw_parts`]) must keep track of the
     /// original capacity.
     ///
     /// This function is mainly useful for data that lives for the remainder of

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1952,8 +1952,11 @@ impl<T, A: Allocator> Vec<T, A> {
     /// `'a`. If the type has only static references, or none at all, then this
     /// may be chosen to be `'static`.
     ///
-    /// This function is similar to the [`leak`][Box::leak] function on [`Box`]
-    /// except that there is no way to recover the leaked memory.
+    /// This method does not reallocate or shrink the `Vec`, so the leaked
+    /// allocation may include unused capacity that is not part of the returned
+    /// slice.  Unsafe code that later reconstructs or deallocates the `Vec`
+    /// (for example, by calling [`Vec::from_raw_parts`]) must keep track of the
+    /// original capacity.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1955,9 +1955,6 @@ impl<T, A: Allocator> Vec<T, A> {
     /// As of Rust 1.57, this method does not reallocate or shrink the `Vec`,
     /// so the leaked allocation may include unused capacity that is not part
     /// of the returned slice.
-    /// Unsafe code that later reconstructs or deallocates the `Vec` (for
-    /// example, by calling [`Vec::from_raw_parts`]) must keep track of the
-    /// original capacity.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1976,7 +1976,8 @@ impl<T, A: Allocator> Vec<T, A> {
     where
         A: 'a,
     {
-        Box::leak(self.into_boxed_slice())
+        let mut me = ManuallyDrop::new(self);
+        unsafe { slice::from_raw_parts_mut(me.as_mut_ptr(), me.len) }
     }
 
     /// Returns the remaining spare capacity of the vector as a slice of


### PR DESCRIPTION
The [`Vec::leak`] method (#62195) is currently implemented by calling `Vec::into_boxed_slice` and `Box::leak`.  This shrinks the vector before leaking it, which potentially causes a reallocation and copies the vector's contents.

By avoiding the conversion to `Box`, we can instead leak the vector without any expensive operations, just by returning a slice reference and forgetting the `Vec`.  Users who *want* to shrink the vector first can still do so by calling `shrink_to_fit` explicitly.

**Note:**  This could break code that uses `Box::from_raw` to “un-leak” the slice returned by `Vec::leak`.  However, the `Vec::leak` docs explicitly forbid this, so such code is already incorrect.

[`Vec::leak`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.leak