### PR TITLE
Improve error message for `printf`-style format strings

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign/printf/tests.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign/printf/tests.rs
@@ -3,7 +3,7 @@ use super::{iter_subs, parse_next_substitution as pns, Format as F, Num as N, Su
 macro_rules! assert_eq_pnsat {
     ($lhs:expr, $rhs:expr) => {
         assert_eq!(
-            pns($lhs).and_then(|(s, _)| s.translate()),
+            pns($lhs).and_then(|(s, _)| s.translate().ok()),
             $rhs.map(<String as From<&str>>::from)
         )
     };
@@ -98,7 +98,7 @@ fn test_parse() {
 #[test]
 fn test_iter() {
     let s = "The %d'th word %% is: `%.*s` %!\n";
-    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate()).collect();
+    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate().ok()).collect();
     assert_eq!(
         subs.iter().map(|ms| ms.as_ref().map(|s| &s[..])).collect::<Vec<_>>(),
         vec![Some("{}"), None, Some("{:.*}"), None]

--- a/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
@@ -3,7 +3,7 @@ use super::{parse_next_substitution as pns, Substitution as S};
 macro_rules! assert_eq_pnsat {
     ($lhs:expr, $rhs:expr) => {
         assert_eq!(
-            pns($lhs).and_then(|(f, _)| f.translate()),
+            pns($lhs).and_then(|(f, _)| f.translate().ok()),
             $rhs.map(<String as From<&str>>::from)
         )
     };
@@ -37,7 +37,7 @@ fn test_parse() {
 fn test_iter() {
     use super::iter_subs;
     let s = "The $0'th word $$ is: `$WORD` $!\n";
-    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate()).collect();
+    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate().ok()).collect();
     assert_eq!(
         subs.iter().map(|ms| ms.as_ref().map(|s| &s[..])).collect::<Vec<_>>(),
         vec![Some("{0}"), None, Some("{WORD}")]

--- a/src/test/ui/fmt/issue-89173.rs
+++ b/src/test/ui/fmt/issue-89173.rs
@@ -1,0 +1,14 @@
+// Regression test for #89173: Make sure a helpful note is issued for
+// printf-style format strings using `*` to specify the width.
+
+fn main() {
+    let num = 0x0abcde;
+    let width = 6;
+    print!("%0*x", width, num);
+    //~^ ERROR: multiple unused formatting arguments
+    //~| NOTE: multiple missing formatting specifiers
+    //~| NOTE: argument never used
+    //~| NOTE: argument never used
+    //~| NOTE: format specifiers use curly braces, and you have to use a positional or named parameter for the width
+    //~| NOTE: printf formatting not supported
+}

--- a/src/test/ui/fmt/issue-89173.stderr
+++ b/src/test/ui/fmt/issue-89173.stderr
@@ -1,0 +1,18 @@
+error: multiple unused formatting arguments
+  --> $DIR/issue-89173.rs:7:20
+   |
+LL |     print!("%0*x", width, num);
+   |            ------  ^^^^^  ^^^ argument never used
+   |            |       |
+   |            |       argument never used
+   |            multiple missing formatting specifiers
+   |
+note: format specifiers use curly braces, and you have to use a positional or named parameter for the width
+  --> $DIR/issue-89173.rs:7:13
+   |
+LL |     print!("%0*x", width, num);
+   |             ^^^^
+   = note: printf formatting not supported; see the documentation for `std::fmt`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #89173. The following is actually supported today:
```rust
fn main() {
    let num = 5;
    let width = 20;
    print!("%*2$x", num, width);
}
```
```
error: multiple unused formatting arguments
 --> src/main.rs:4:21
  |
4 |     print!("%*2$x", num, width);
  |            -------  ^^^  ^^^^^ argument never used
  |            ||       |
  |            ||       argument never used
  |            |help: format specifiers use curly braces: `{:1$x}`
  |            multiple missing formatting specifiers
  |
  = note: printf formatting not supported; see the documentation for `std::fmt`
```
However, as noted in #89173, something like
```rust
    print!("%0*x", width, num);
```
does not give a helpful suggestion. I think this is partly intended, because there actually _is_ no Rust equivalent to this; you always have to use a positional or named argument to specify the width (instead of just using the "next" argument, as `printf` or even `.*` as a precision specifier in Rust would). Therefore, I have added a note:
```
[...]
note: format specifiers use curly braces, and you have to use a positional or named parameter for the width
 --> t2.rs:4:13
  |
4 |     print!("%0*x", width, num);
  |             ^^^^
  = note: printf formatting not supported; see the documentation for `std::fmt`
```
This is not perfect, but it should at least point the user in the right direction, instead of issuing no explanation at all.

cc @lcnr