### PR TITLE
suggestion for typoed crate or module

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2555,7 +2555,22 @@ impl<'a> Resolver<'a> {
 
                             (format!("use of undeclared type `{}`", ident), suggestion)
                         } else {
-                            (format!("use of undeclared crate or module `{}`", ident), None)
+                            (
+                                format!("use of undeclared crate or module `{}`", ident),
+                                self.find_similarly_named_module_or_crate(
+                                    ident.name,
+                                    &parent_scope.module,
+                                )
+                                .map(|sugg| {
+                                    (
+                                        vec![(ident.span, sugg.to_string())],
+                                        String::from(
+                                            "there is a crate or module with a similar name",
+                                        ),
+                                        Applicability::MaybeIncorrect,
+                                    )
+                                }),
+                            )
                         }
                     } else {
                         let parent = path[i - 1].ident.name;

--- a/src/test/ui/macros/macro-inner-attributes.stderr
+++ b/src/test/ui/macros/macro-inner-attributes.stderr
@@ -3,6 +3,11 @@ error[E0433]: failed to resolve: use of undeclared crate or module `a`
    |
 LL |     a::bar();
    |     ^ use of undeclared crate or module `a`
+   |
+help: there is a crate or module with a similar name
+   |
+LL |     b::bar();
+   |     ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/crate-or-module-typo.rs
+++ b/src/test/ui/suggestions/crate-or-module-typo.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+use st::cell::Cell; //~ ERROR failed to resolve: use of undeclared crate or module `st`
+
+mod bar {
+    pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `bar`
+
+    fn baz() {}
+}
+
+use bas::bar; //~ ERROR unresolved import `bas`
+
+struct Foo {
+    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of undeclared crate or module `st`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/crate-or-module-typo.stderr
+++ b/src/test/ui/suggestions/crate-or-module-typo.stderr
@@ -1,0 +1,43 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `st`
+  --> $DIR/crate-or-module-typo.rs:3:5
+   |
+LL | use st::cell::Cell;
+   |     ^^ use of undeclared crate or module `st`
+   |
+help: there is a crate or module with a similar name
+   |
+LL | use std::cell::Cell;
+   |     ~~~
+
+error[E0432]: unresolved import `bas`
+  --> $DIR/crate-or-module-typo.rs:11:5
+   |
+LL | use bas::bar;
+   |     ^^^ use of undeclared crate or module `bas`
+   |
+help: there is a crate or module with a similar name
+   |
+LL | use bar::bar;
+   |     ~~~
+
+error[E0433]: failed to resolve: use of undeclared crate or module `bar`
+  --> $DIR/crate-or-module-typo.rs:6:20
+   |
+LL |     pub fn bar() { bar::baz(); }
+   |                    ^^^ use of undeclared crate or module `bar`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `st`
+  --> $DIR/crate-or-module-typo.rs:14:10
+   |
+LL |     bar: st::cell::Cell<bool>
+   |          ^^ use of undeclared crate or module `st`
+   |
+help: there is a crate or module with a similar name
+   |
+LL |     bar: std::cell::Cell<bool>
+   |          ~~~
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0432, E0433.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
Previously, the compiler didn't suggest similarly named crates or modules. This pull request adds a suggestion for typoed crates or modules.

#76208

before:

```
error[E0433]: failed to resolve: use of undeclared type or module `chono`
 --> src/main.rs:2:5
  |
2 | use chono::prelude::*;
  |     ^^^^^ use of undeclared type or module `chono`
```

after:

```
error[E0433]: failed to resolve: use of undeclared type or module `chono`
 --> src/main.rs:2:5
  |
2 | use chono::prelude::*;
  |     ^^^^^ 
  |     |
  |     use of undeclared crate or module `chono`
  |     help: a similar crate or module exists: `chrono`
```