### PR TITLE
[experiment] Make `Cell<T>::update` work for `T: Default | Copy`.

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -441,8 +441,8 @@ impl<T> Cell<T> {
     /// Updates the contained value using a function.
     ///
     /// If `T` implements [`Copy`], the function is called on a copy of the
-    /// contain value. Otherwise, if `T` implements [`Default`], the value
-    /// contained in the cell is temporarily replaced by [`Default::default()]`
+    /// contained value. Otherwise, if `T` implements [`Default`], the value
+    /// contained in the cell is temporarily replaced by [`Default::default()`]
     /// while the function runs.
     ///
     /// # Examples

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -140,6 +140,7 @@
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(llvm_asm)]
+#![feature(marker_trait_attr)]
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -52,11 +52,16 @@ fn smoketest_cell() {
 fn cell_update() {
     let x = Cell::new(10);
 
-    assert_eq!(x.update(|x| x + 5), 15);
+    x.update(|x| x + 5);
     assert_eq!(x.get(), 15);
 
-    assert_eq!(x.update(|x| x / 3), 5);
+    x.update(|x| x / 3);
     assert_eq!(x.get(), 5);
+
+    let x = Cell::new("abc".to_string());
+
+    x.update(|x| x + "123");
+    assert_eq!(x.take(), "abc123");
 }
 
 #[test]


### PR DESCRIPTION
This uses some unstable trickery to implement `Cell::update` for types that are either Copy or Default or both, and use the `.get() + .set()` behaviour if possible (if it is Copy), or use `.take() + .set()` otherwise (if it is Default and not Copy).

See https://github.com/rust-lang/rust/issues/50186#issuecomment-930127090

![image](https://user-images.githubusercontent.com/783247/135280616-b222a1d4-bc54-4a1e-9acb-0079edab9090.png)
