### PR TITLE
Various fixes for const_trait_impl

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -1004,11 +1004,12 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                 }
 
                 let mut err_span = self.span;
+                let ty_of_dropped_place = dropped_place.ty(self.body, self.tcx).ty;
 
-                let ty_needs_non_const_drop = qualifs::NeedsNonConstDrop::in_any_value_of_ty(
-                    self.ccx,
-                    dropped_place.ty(self.body, self.tcx).ty,
-                );
+                let ty_needs_non_const_drop =
+                    qualifs::NeedsNonConstDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place);
+
+                debug!(?ty_of_dropped_place, ?ty_needs_non_const_drop);
 
                 if !ty_needs_non_const_drop {
                     return;

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -173,6 +173,12 @@ impl<'tcx> CheckConstVisitor<'tcx> {
                 None => return true,
             };
 
+            // If the function belongs to a trait, then it must enable the const_trait_impl
+            // feature to use that trait function (with a const default body).
+            if tcx.trait_of_item(def_id).is_some() {
+                return true;
+            }
+
             // If this crate is not using stability attributes, or this function is not claiming to be a
             // stable `const fn`, that is all that is required.
             if !tcx.features().staged_api || tcx.has_attr(def_id, sym::rustc_const_unstable) {

--- a/src/test/ui/rfc-2632-const-trait-impl/const-drop-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-drop-bound.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+#![feature(const_precise_live_drops)]
+
+const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Drop {
+    match res {
+        Ok(t) => Some(t),
+        Err(_e) => None,
+    }
+}
+
+pub struct Foo<T>(T);
+
+const fn baz<T: ~const Drop, E: ~const Drop>(res: Result<Foo<T>, Foo<E>>) -> Option<Foo<T>> {
+    foo(res)
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-default-body-stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-default-body-stability.rs
@@ -1,0 +1,51 @@
+// check-pass
+
+#![feature(staged_api)]
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+#![feature(const_t_try)]
+#![feature(const_try)]
+#![feature(try_trait_v2)]
+
+#![stable(feature = "foo", since = "1.0")]
+
+use std::ops::{ControlFlow, FromResidual, Try};
+
+#[stable(feature = "foo", since = "1.0")]
+pub struct T;
+
+#[stable(feature = "foo", since = "1.0")]
+#[rustc_const_unstable(feature = "const_t_try", issue = "none")]
+impl const Try for T {
+    type Output = T;
+    type Residual = T;
+
+    fn from_output(t: T) -> T {
+        t
+    }
+
+    fn branch(self) -> ControlFlow<T, T> {
+        ControlFlow::Continue(self)
+    }
+}
+
+#[stable(feature = "foo", since = "1.0")]
+#[rustc_const_unstable(feature = "const_t_try", issue = "none")]
+impl const FromResidual for T {
+    fn from_residual(t: T) -> T {
+        t
+    }
+}
+
+#[stable(feature = "foo", since = "1.0")]
+pub trait Tr {
+    #[default_method_body_is_const]
+    #[stable(feature = "foo", since = "1.0")]
+    fn bar() -> T {
+        T?
+        // Should be allowed.
+        // Must enable unstable features to call this trait fn in const contexts.
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
A few problems I found while making `Iterator` easier to const-implement.

1. More generous `~const Drop` check.

We check for nested fields with caller bounds.

For example, an ADT type with fields of types `A`, `B`, `C`, check if all of them are either:
 - Bounded (`A: ~const Drop`, `B: Copy`)
 - Known to be able to destruct at compile time (`C = i32`, `struct C(i32)`, `C = some_fn`)

2. Don't treat trait functions marked with `#[default_method_body_is_const]` as stable const fns when checking `const_for` and `const_try` feature gates.

I think anyone can review this, so no r? this time.