### PR TITLE
rustdoc-json: Always encode with UTF-8 when opening json files

### DIFF
--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -9,7 +9,7 @@
 import sys
 import json
 
-crate = json.load(open(sys.argv[1]))
+crate = json.load(open(sys.argv[1], encoding="utf-8"))
 
 
 def get_local_item(item_id):

--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -9,7 +9,7 @@
 import sys
 import json
 
-crate = json.load(open(sys.argv[1], encoding="utf-8"))
+crate = json.load(open(sys.argv[1]))
 
 
 def get_local_item(item_id):

--- a/src/test/rustdoc-json/emoji.rs
+++ b/src/test/rustdoc-json/emoji.rs
@@ -1,0 +1,6 @@
+//! 🦀
+
+// edition:2018
+// compile-flags: --crate-version 1.0.0
+
+// @is emoji.json "$.crate_version" '"1.0.0"'


### PR DESCRIPTION
Noticed by https://github.com/rust-lang/rust/pull/88234#issuecomment-927304228

I doubt `check_missing_items.py` malfunctions when the index contains some letters like emojis. This PR is to check that.