### PR TITLE
rustdoc-json: Encode json files with UTF-8

### DIFF
--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -9,7 +9,7 @@
 import sys
 import json
 
-crate = json.load(open(sys.argv[1]))
+crate = json.load(open(sys.argv[1], encoding="utf-8"))
 
 
 def get_local_item(item_id):


### PR DESCRIPTION
Currently, `check_missing_items.py` malfunctions when the index contains some letters like emojis.

Related to #89360.