### PR TITLE
rustdoc: Remove lazy_static dependency

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -25,6 +25,7 @@ use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 use std::cell::RefCell;
+use std::lazy::SyncLazy;
 use std::mem;
 use std::rc::Rc;
 
@@ -271,9 +272,8 @@ crate fn create_config(
             providers.typeck_item_bodies = |_, _| {};
             // hack so that `used_trait_imports` won't try to call typeck
             providers.used_trait_imports = |_, _| {
-                lazy_static! {
-                    static ref EMPTY_SET: FxHashSet<LocalDefId> = FxHashSet::default();
-                }
+                static EMPTY_SET: SyncLazy<FxHashSet<LocalDefId>> =
+                    SyncLazy::new(FxHashSet::default);
                 &EMPTY_SET
             };
             // In case typeck does end up being called, don't ICE in case there were name resolution errors

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -19,8 +19,6 @@
 #![warn(rustc::internal)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate tracing;
 
 // N.B. these need `extern crate` even in 2018 edition


### PR DESCRIPTION
The macro was used in only one place and there are equivalents in the std, so it seemed weird to keep it around...

I think running a perf check would be a good idea though, just in case.

r? @jyn514 