### PR TITLE
Allow use of AddressSanitizer on Windows by linking to existing libraries

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1397,7 +1397,10 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot enable crt-static with sanitizers on Linux
-    if sess.crt_static(None) && !sess.opts.debugging_opts.sanitizer.is_empty() {
+    if sess.crt_static(None)
+        && !sess.opts.debugging_opts.sanitizer.is_empty()
+        && !sess.target.is_like_windows
+    {
         sess.err(
             "Sanitizer is incompatible with statically linked libc, \
                                 disable it using `-C target-feature=-crt-static`",

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
@@ -1,10 +1,11 @@
-use crate::spec::Target;
+use crate::spec::{SanitizerSet, Target};
 
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
     base.has_elf_tls = true;
+    base.supported_sanitizers = SanitizerSet::ADDRESS;
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".to_string(),


### PR DESCRIPTION
This change makes it possible to use address sanitizer on Windows by determining the right library name to use based on the way that the crt is being linked.

Currently, this change does not build the address sanitizer libraries (as we do for other platforms) so it is necessary to provide the libraries either from building those libraries from llvm or using other libraries from your C++ toolchain.

The current support for AddressSanitizer outside of windows involves renaming things compiled out of the llvm fork. I don't quite follow how this will work when sanitizing hybrid C/C++/Rust programs, and the approach causes additional problems on Windows because the renamed import library still references the dll with the original name.

I expect some of these questions will need to be resolved as part of stabilization (see #47174) but I wanted to make some progress on the Windows support as mentioned there and in other issues like #89339 so that we can see how this will all fit together.