### PR TITLE
Fix Windows LLVM issue.

### DIFF
--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -61,3 +61,9 @@ elif isWindows && [[ ${CUSTOM_MINGW-0} -ne 1 ]]; then
     ciCommandSetEnv RUST_CONFIGURE_ARGS \
         "${RUST_CONFIGURE_ARGS} --set llvm.clang-cl=$(pwd)/clang-rust/bin/clang-cl.exe"
 fi
+
+if isWindows; then
+    # GitHub image 20210928.2 added LLVM, but it is broken (and we don't want
+    # to use it anyways).
+    rm -rf /c/Program\ Files/LLVM
+fi


### PR DESCRIPTION
GitHub image 20210928.2 added LLVM 12.0.1 to the stock image.  However, the `lldb` executable doesn't work, it fails with:

> C:/Program Files/LLVM/bin/lldb.exe: error while loading shared libraries: ?: cannot open shared object file: No such file or directory

We probably don't want to start testing LLDB on windows anyways (at least not without intent).

The hacky solution for now is to just delete the system LLVM.
