### PR TITLE
bootstrap: Update comment in config.library.toml.

### DIFF
--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -11,5 +11,4 @@ incremental = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.
-# https://github.com/rust-lang/rust/issues/77084 tracks support for more platforms
 download-ci-llvm = "if-available"

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -10,6 +10,6 @@ bench-stage = 0
 incremental = true
 
 [llvm]
-# Will download LLVM from CI if available on your platform (Linux only for now)
+# Will download LLVM from CI if available on your platform.
 # https://github.com/rust-lang/rust/issues/77084 tracks support for more platforms
 download-ci-llvm = "if-available"


### PR DESCRIPTION
Downloading LLVM from CI works for all platforms now.

All other templates in this directory already have the proper comment. Seems this one was neglected.