### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign/printf/tests.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign/printf/tests.rs
@@ -3,7 +3,7 @@ use super::{iter_subs, parse_next_substitution as pns, Format as F, Num as N, Su
 macro_rules! assert_eq_pnsat {
     ($lhs:expr, $rhs:expr) => {
         assert_eq!(
-            pns($lhs).and_then(|(s, _)| s.translate()),
+            pns($lhs).and_then(|(s, _)| s.translate().ok()),
             $rhs.map(<String as From<&str>>::from)
         )
     };
@@ -98,7 +98,7 @@ fn test_parse() {
 #[test]
 fn test_iter() {
     let s = "The %d'th word %% is: `%.*s` %!\n";
-    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate()).collect();
+    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate().ok()).collect();
     assert_eq!(
         subs.iter().map(|ms| ms.as_ref().map(|s| &s[..])).collect::<Vec<_>>(),
         vec![Some("{}"), None, Some("{:.*}"), None]

--- a/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
@@ -3,7 +3,7 @@ use super::{parse_next_substitution as pns, Substitution as S};
 macro_rules! assert_eq_pnsat {
     ($lhs:expr, $rhs:expr) => {
         assert_eq!(
-            pns($lhs).and_then(|(f, _)| f.translate()),
+            pns($lhs).and_then(|(f, _)| f.translate().ok()),
             $rhs.map(<String as From<&str>>::from)
         )
     };
@@ -37,7 +37,7 @@ fn test_parse() {
 fn test_iter() {
     use super::iter_subs;
     let s = "The $0'th word $$ is: `$WORD` $!\n";
-    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate()).collect();
+    let subs: Vec<_> = iter_subs(s, 0).map(|sub| sub.translate().ok()).collect();
     assert_eq!(
         subs.iter().map(|ms| ms.as_ref().map(|s| &s[..])).collect::<Vec<_>>(),
         vec![Some("{0}"), None, Some("{WORD}")]

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -253,7 +253,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Len(place) => {
-                // FIXME(CTFE): don't allow computing the length of arrays in const eval
                 let src = self.eval_place(place)?;
                 let mplace = self.force_allocation(&src)?;
                 let len = mplace.len(self)?;

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -197,12 +197,17 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             Aggregate(ref kind, ref operands) => {
+                // active_field_index is for union initialization.
                 let (dest, active_field_index) = match **kind {
                     mir::AggregateKind::Adt(adt_def, variant_index, _, _, active_field_index) => {
                         self.write_discriminant(variant_index, &dest)?;
                         if adt_def.is_enum() {
-                            (self.place_downcast(&dest, variant_index)?, active_field_index)
+                            assert!(active_field_index.is_none());
+                            (self.place_downcast(&dest, variant_index)?, None)
                         } else {
+                            if active_field_index.is_some() {
+                                assert_eq!(operands.len(), 1);
+                            }
                             (dest, active_field_index)
                         }
                     }
@@ -211,12 +216,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
                 for (i, operand) in operands.iter().enumerate() {
                     let op = self.eval_operand(operand, None)?;
-                    // Ignore zero-sized fields.
-                    if !op.layout.is_zst() {
-                        let field_index = active_field_index.unwrap_or(i);
-                        let field_dest = self.place_field(&dest, field_index)?;
-                        self.copy_op(&op, &field_dest)?;
-                    }
+                    let field_index = active_field_index.unwrap_or(i);
+                    let field_dest = self.place_field(&dest, field_index)?;
+                    self.copy_op(&op, &field_dest)?;
                 }
             }
 

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -299,7 +299,7 @@ language_item_table! {
     Oom,                     sym::oom,                 oom,                        Target::Fn,             GenericRequirement::None;
     AllocLayout,             sym::alloc_layout,        alloc_layout,               Target::Struct,         GenericRequirement::None;
 
-    Start,                   sym::start,               start_fn,                   Target::Fn,             GenericRequirement::None;
+    Start,                   sym::start,               start_fn,                   Target::Fn,             GenericRequirement::Exact(1);
 
     EhPersonality,           sym::eh_personality,      eh_personality,             Target::Fn,             GenericRequirement::None;
     EhCatchTypeinfo,         sym::eh_catch_typeinfo,   eh_catch_typeinfo,          Target::Static,         GenericRequirement::None;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -675,7 +675,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         &self,
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'_>,
-        trait_ref: &ty::Binder<'tcx, ty::TraitRef<'tcx>>,
+        poly_trait_ref: &ty::Binder<'tcx, ty::TraitRef<'tcx>>,
         has_custom_message: bool,
     ) -> bool {
         let span = obligation.cause.span;
@@ -704,7 +704,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         never_suggest_borrow.push(self.tcx.get_diagnostic_item(sym::send_trait).unwrap());
 
         let param_env = obligation.param_env;
-        let trait_ref = trait_ref.skip_binder();
+        let trait_ref = poly_trait_ref.skip_binder();
 
         let found_ty = trait_ref.self_ty();
         let found_ty_str = found_ty.to_string();
@@ -714,25 +714,25 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let mut_substs = self.tcx.mk_substs_trait(mut_borrowed_found_ty, &[]);
 
         // Try to apply the original trait binding obligation by borrowing.
-        let mut try_borrowing = |new_imm_trait_ref: ty::TraitRef<'tcx>,
-                                 new_mut_trait_ref: ty::TraitRef<'tcx>,
-                                 expected_trait_ref: ty::TraitRef<'tcx>,
+        let mut try_borrowing = |new_imm_trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
+                                 new_mut_trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
+                                 expected_trait_ref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
                                  blacklist: &[DefId]|
          -> bool {
-            if blacklist.contains(&expected_trait_ref.def_id) {
+            if blacklist.contains(&expected_trait_ref.def_id()) {
                 return false;
             }
 
             let imm_result = self.predicate_must_hold_modulo_regions(&Obligation::new(
                 ObligationCause::dummy(),
                 param_env,
-                ty::Binder::dummy(new_imm_trait_ref).without_const().to_predicate(self.tcx),
+                new_imm_trait_ref.without_const().to_predicate(self.tcx),
             ));
 
             let mut_result = self.predicate_must_hold_modulo_regions(&Obligation::new(
                 ObligationCause::dummy(),
                 param_env,
-                ty::Binder::dummy(new_mut_trait_ref).without_const().to_predicate(self.tcx),
+                new_mut_trait_ref.without_const().to_predicate(self.tcx),
             ));
 
             if imm_result || mut_result {
@@ -805,19 +805,19 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         };
 
         if let ObligationCauseCode::ImplDerivedObligation(obligation) = &*code {
-            let expected_trait_ref = obligation.parent_trait_ref.skip_binder();
-            let new_imm_trait_ref =
-                ty::TraitRef::new(obligation.parent_trait_ref.def_id(), imm_substs);
-            let new_mut_trait_ref =
-                ty::TraitRef::new(obligation.parent_trait_ref.def_id(), mut_substs);
+            let expected_trait_ref = obligation.parent_trait_ref;
+            let new_imm_trait_ref = poly_trait_ref
+                .rebind(ty::TraitRef::new(obligation.parent_trait_ref.def_id(), imm_substs));
+            let new_mut_trait_ref = poly_trait_ref
+                .rebind(ty::TraitRef::new(obligation.parent_trait_ref.def_id(), mut_substs));
             return try_borrowing(new_imm_trait_ref, new_mut_trait_ref, expected_trait_ref, &[]);
         } else if let ObligationCauseCode::BindingObligation(_, _)
         | ObligationCauseCode::ItemObligation(_) = &*code
         {
             return try_borrowing(
-                ty::TraitRef::new(trait_ref.def_id, imm_substs),
-                ty::TraitRef::new(trait_ref.def_id, mut_substs),
-                trait_ref,
+                poly_trait_ref.rebind(ty::TraitRef::new(trait_ref.def_id, imm_substs)),
+                poly_trait_ref.rebind(ty::TraitRef::new(trait_ref.def_id, mut_substs)),
+                *poly_trait_ref,
                 &never_suggest_borrow[..],
             );
         } else {

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -350,6 +350,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
 
+                let callee_ty = self.resolve_vars_if_possible(callee_ty);
                 let mut err = type_error_struct!(
                     self.tcx.sess,
                     callee_expr.span,

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -338,8 +338,17 @@ pub fn available_concurrency() -> io::Result<NonZeroUsize> {
             }
 
             Ok(unsafe { NonZeroUsize::new_unchecked(cpus as usize) })
+        } else if #[cfg(target_os = "haiku")] {
+            let mut sinfo: libc::system_info = crate::mem::zeroed();
+            let res = libc::get_system_info(&mut sinfo);
+
+            if res != libc::B_OK {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(unsafe { NonZeroUsize::new_unchecked(sinfo.cpu_count as usize) })
         } else {
-            // FIXME: implement on vxWorks, Redox, Haiku, l4re
+            // FIXME: implement on vxWorks, Redox, l4re
             Err(io::Error::new_const(io::ErrorKind::Unsupported, &"Getting the number of hardware threads is not supported on the target platform"))
         }
     }

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -10,6 +10,6 @@ bench-stage = 0
 incremental = true
 
 [llvm]
-# Will download LLVM from CI if available on your platform (Linux only for now)
+# Will download LLVM from CI if available on your platform.
 # https://github.com/rust-lang/rust/issues/77084 tracks support for more platforms
 download-ci-llvm = "if-available"

--- a/src/test/run-make-fulldeps/target-specs/foo.rs
+++ b/src/test/run-make-fulldeps/target-specs/foo.rs
@@ -11,7 +11,7 @@ trait Sized {}
 auto trait Freeze {}
 
 #[lang = "start"]
-fn start<T>(_main: *const u8, _argc: isize, _argv: *const *const u8) -> isize {
+fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8) -> isize {
     0
 }
 

--- a/src/test/run-make-fulldeps/target-specs/foo.rs
+++ b/src/test/run-make-fulldeps/target-specs/foo.rs
@@ -11,7 +11,7 @@ trait Sized {}
 auto trait Freeze {}
 
 #[lang = "start"]
-fn start(_main: *const u8, _argc: isize, _argv: *const *const u8) -> isize {
+fn start<T>(_main: *const u8, _argc: isize, _argv: *const *const u8) -> isize {
     0
 }
 

--- a/src/test/ui/fmt/issue-89173.rs
+++ b/src/test/ui/fmt/issue-89173.rs
@@ -1,0 +1,14 @@
+// Regression test for #89173: Make sure a helpful note is issued for
+// printf-style format strings using `*` to specify the width.
+
+fn main() {
+    let num = 0x0abcde;
+    let width = 6;
+    print!("%0*x", width, num);
+    //~^ ERROR: multiple unused formatting arguments
+    //~| NOTE: multiple missing formatting specifiers
+    //~| NOTE: argument never used
+    //~| NOTE: argument never used
+    //~| NOTE: format specifiers use curly braces, and you have to use a positional or named parameter for the width
+    //~| NOTE: printf formatting not supported
+}

--- a/src/test/ui/fmt/issue-89173.stderr
+++ b/src/test/ui/fmt/issue-89173.stderr
@@ -1,0 +1,18 @@
+error: multiple unused formatting arguments
+  --> $DIR/issue-89173.rs:7:20
+   |
+LL |     print!("%0*x", width, num);
+   |            ------  ^^^^^  ^^^ argument never used
+   |            |       |
+   |            |       argument never used
+   |            multiple missing formatting specifiers
+   |
+note: format specifiers use curly braces, and you have to use a positional or named parameter for the width
+  --> $DIR/issue-89173.rs:7:13
+   |
+LL |     print!("%0*x", width, num);
+   |             ^^^^
+   = note: printf formatting not supported; see the documentation for `std::fmt`
+
+error: aborting due to previous error
+

--- a/src/test/ui/lang-items/lang-item-generic-requirements.rs
+++ b/src/test/ui/lang-items/lang-item-generic-requirements.rs
@@ -1,9 +1,8 @@
-// Checks whether declaring a lang item with the wrong number
-// of generic arguments crashes the compiler (issue #83893, #87573, and part of #9307).
+// Checks that declaring a lang item with the wrong number
+// of generic arguments errors rather than crashing (issue #83893, #87573, part of #9307, #79559).
 
 #![feature(lang_items, no_core)]
 #![no_core]
-#![crate_type = "lib"]
 
 #[lang = "sized"]
 trait MySized {}
@@ -26,6 +25,14 @@ struct MyPhantomData<T, U>;
 //~^ ERROR parameter `T` is never used
 //~| ERROR parameter `U` is never used
 
+// When the `start` lang item is missing generics very odd things can happen, especially when
+// it comes to cross-crate monomorphization
+#[lang = "start"]
+//~^ ERROR `start` language item must be applied to a function with 1 generic argument [E0718]
+fn start(_: *const u8, _: isize, _: *const *const u8) -> isize {
+    0
+}
+
 fn ice() {
     // Use add
     let r = 5;
@@ -42,3 +49,6 @@ fn ice() {
     // Use phantomdata
     let _ = MyPhantomData::<(), i32>;
 }
+
+// use `start`
+fn main() {}

--- a/src/test/ui/lang-items/lang-item-generic-requirements.stderr
+++ b/src/test/ui/lang-items/lang-item-generic-requirements.stderr
@@ -1,5 +1,5 @@
 error[E0718]: `add` language item must be applied to a trait with 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:11:1
+  --> $DIR/lang-item-generic-requirements.rs:10:1
    |
 LL | #[lang = "add"]
    | ^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | trait MyAdd<'a, T> {}
    |            ------- this trait has 2 generic arguments
 
 error[E0718]: `drop_in_place` language item must be applied to a function with at least 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:15:1
+  --> $DIR/lang-item-generic-requirements.rs:14:1
    |
 LL | #[lang = "drop_in_place"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL | fn my_ptr_drop() {}
    |               - this function has 0 generic arguments
 
 error[E0718]: `index` language item must be applied to a trait with 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:19:1
+  --> $DIR/lang-item-generic-requirements.rs:18:1
    |
 LL | #[lang = "index"]
    | ^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL | trait MyIndex<'a, T> {}
    |              ------- this trait has 2 generic arguments
 
 error[E0718]: `phantom_data` language item must be applied to a struct with 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:23:1
+  --> $DIR/lang-item-generic-requirements.rs:22:1
    |
 LL | #[lang = "phantom_data"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,8 +32,17 @@ LL |
 LL | struct MyPhantomData<T, U>;
    |                     ------ this struct has 2 generic arguments
 
+error[E0718]: `start` language item must be applied to a function with 1 generic argument
+  --> $DIR/lang-item-generic-requirements.rs:30:1
+   |
+LL | #[lang = "start"]
+   | ^^^^^^^^^^^^^^^^^
+LL |
+LL | fn start(_: *const u8, _: isize, _: *const *const u8) -> isize {
+   |         - this function has 0 generic arguments
+
 error[E0392]: parameter `T` is never used
-  --> $DIR/lang-item-generic-requirements.rs:25:22
+  --> $DIR/lang-item-generic-requirements.rs:24:22
    |
 LL | struct MyPhantomData<T, U>;
    |                      ^ unused parameter
@@ -42,7 +51,7 @@ LL | struct MyPhantomData<T, U>;
    = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
 error[E0392]: parameter `U` is never used
-  --> $DIR/lang-item-generic-requirements.rs:25:25
+  --> $DIR/lang-item-generic-requirements.rs:24:25
    |
 LL | struct MyPhantomData<T, U>;
    |                         ^ unused parameter
@@ -50,7 +59,7 @@ LL | struct MyPhantomData<T, U>;
    = help: consider removing `U` or referring to it in a field
    = help: if you intended `U` to be a const parameter, use `const U: usize` instead
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0392, E0718.
 For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/suggestions/issue-88730.rs
+++ b/src/test/ui/suggestions/issue-88730.rs
@@ -1,0 +1,16 @@
+#![allow(unused, nonstandard_style)]
+#![deny(bindings_with_variant_name)]
+
+// If an enum has two different variants,
+// then it cannot be matched upon in a function argument.
+// It still gets a warning, but no suggestions.
+enum Foo {
+    C,
+    D,
+}
+
+fn foo(C: Foo) {} //~ERROR
+
+fn main() {
+    let C = Foo::D; //~ERROR
+}

--- a/src/test/ui/suggestions/issue-88730.stderr
+++ b/src/test/ui/suggestions/issue-88730.stderr
@@ -1,0 +1,21 @@
+error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-88730.rs:12:8
+   |
+LL | fn foo(C: Foo) {}
+   |        ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-88730.rs:2:9
+   |
+LL | #![deny(bindings_with_variant_name)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0170]: pattern binding `C` is named the same as one of the variants of the type `Foo`
+  --> $DIR/issue-88730.rs:15:9
+   |
+LL |     let C = Foo::D;
+   |         ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0170`.

--- a/src/test/ui/suggestions/issue-89333.rs
+++ b/src/test/ui/suggestions/issue-89333.rs
@@ -1,0 +1,9 @@
+// check-fail
+// Ensure we don't error when emitting trait bound not satisfied when self type
+// has late bound var
+
+fn main() {
+    test(&|| 0); //~ ERROR the trait bound
+}
+
+fn test<T>(arg: &impl Fn() -> T) where for<'a> &'a T: Default {}

--- a/src/test/ui/suggestions/issue-89333.stderr
+++ b/src/test/ui/suggestions/issue-89333.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `for<'a> &'a {integer}: Default` is not satisfied
+  --> $DIR/issue-89333.rs:6:10
+   |
+LL |     test(&|| 0);
+   |     ---- ^^^^^ the trait `for<'a> Default` is not implemented for `&'a {integer}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&CStr as Default>
+             <&OsStr as Default>
+             <&[T] as Default>
+             <&mut [T] as Default>
+           and 217 others
+note: required by a bound in `test`
+  --> $DIR/issue-89333.rs:9:55
+   |
+LL | fn test<T>(arg: &impl Fn() -> T) where for<'a> &'a T: Default {}
+   |                                                       ^^^^^^^ required by this bound in `test`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/typeck/call-block.rs
+++ b/src/test/ui/typeck/call-block.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = {42}(); //~ ERROR expected function, found `_`
+}

--- a/src/test/ui/typeck/call-block.rs
+++ b/src/test/ui/typeck/call-block.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = {42}(); //~ ERROR expected function, found `_`
+    let _ = {42}(); //~ ERROR expected function, found `{integer}`
 }

--- a/src/test/ui/typeck/call-block.stderr
+++ b/src/test/ui/typeck/call-block.stderr
@@ -1,0 +1,11 @@
+error[E0618]: expected function, found `_`
+  --> $DIR/call-block.rs:2:13
+   |
+LL |     let _ = {42}();
+   |             ^^^^--
+   |             |
+   |             call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/typeck/call-block.stderr
+++ b/src/test/ui/typeck/call-block.stderr
@@ -1,4 +1,4 @@
-error[E0618]: expected function, found `_`
+error[E0618]: expected function, found `{integer}`
   --> $DIR/call-block.rs:2:13
    |
 LL |     let _ = {42}();

--- a/src/tools/clippy/tests/ui/def_id_nocore.rs
+++ b/src/tools/clippy/tests/ui/def_id_nocore.rs
@@ -15,10 +15,11 @@ pub trait Copy {}
 pub unsafe trait Freeze {}
 
 #[lang = "start"]
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
+fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8) -> isize {
     0
 }
+
+fn main() {}
 
 struct A;
 

--- a/src/tools/clippy/tests/ui/def_id_nocore.stderr
+++ b/src/tools/clippy/tests/ui/def_id_nocore.stderr
@@ -1,5 +1,5 @@
 error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
-  --> $DIR/def_id_nocore.rs:26:19
+  --> $DIR/def_id_nocore.rs:27:19
    |
 LL |     pub fn as_ref(self) -> &'static str {
    |                   ^^^^


### PR DESCRIPTION
Successful merges:

 - #88782 (Fix ICE when `start` lang item has wrong generics)
 - #89202 (Resolve infered types when complaining about unexpected call type )
 - #89306 (thread: implements available_concurrency on haiku)
 - #89314 (fix(lint): don't suggest refutable patterns to "fix" irrefutable bind)
 - #89340 (Improve error message for `printf`-style format strings)
 - #89345 (Don't lose binders when printing trait bound suggestion)
 - #89370 (CTFE: tweak aggregate rvalue handling)
 - #89392 (bootstrap: Update comment in config.library.toml.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88782,89202,89306,89314,89340,89345,89370,89392)
<!-- homu-ignore:end -->