### PR TITLE
Slightly optimize hash map stable hashing

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -552,7 +552,8 @@ pub fn hash_stable_hashmap<HCX, K, V, R, SK, F>(
     SK: HashStable<HCX> + Ord,
     F: Fn(&K, &HCX) -> SK,
 {
-    let mut entries: Vec<_> = map.iter().map(|(k, v)| (to_stable_hash_key(k, hcx), v)).collect();
+    let mut entries: SmallVec<[_; 3]> =
+        map.iter().map(|(k, v)| (to_stable_hash_key(k, hcx), v)).collect();
     entries.sort_unstable_by(|&(ref sk1, _), &(ref sk2, _)| sk1.cmp(sk2));
     entries.hash_stable(hcx, hasher);
 }


### PR DESCRIPTION
I was profiling some of the `rustc-perf` benchmarks locally and noticed that quite some time is spent inside the stable hash of hashmaps. I tried to use a `SmallVec` instead of a `Vec` there, which helped very slightly.

Then I tried to remove the sorting, which was a bottleneck, and replaced it with insertion into a binary heap. Locally, it yielded nice improvements in instruction counts and RSS in several benchmarks for incremental builds. The implementation could probably be much nicer and possibly extended to other stable hashes, but first I wanted to test the perf impact properly.

Can I ask someone to do a perf run? Thank you!