### PR TITLE
Add regression test for issues #88969 and #89119 

### DIFF
--- a/src/test/ui/traits/auxiliary/issue_89119_intercrate_caching.rs
+++ b/src/test/ui/traits/auxiliary/issue_89119_intercrate_caching.rs
@@ -1,0 +1,60 @@
+// This is the auxiliary crate for the regression test for issue #89119, minimized
+// from `zvariant-2.8.0`.
+
+use std::convert::TryFrom;
+use std::borrow::Cow;
+
+pub struct Str<'a>(Cow<'a, str>);
+impl<'a> Str<'a> {
+    pub fn to_owned(&self) -> Str<'static> {
+        todo!()
+    }
+}
+
+pub enum Value<'a> {
+    Str(Str<'a>),
+    Value(Box<Value<'a>>),
+}
+impl<'a> Value<'a> {
+    pub fn to_owned(&self) -> Value<'static> {
+        match self {
+            Value::Str(v) => Value::Str(v.to_owned()),
+            Value::Value(v) => {
+                let o = OwnedValue::from(&**v);
+                Value::Value(Box::new(o.into_inner()))
+            }
+        }
+    }
+}
+
+struct OwnedValue(Value<'static>);
+impl OwnedValue {
+    pub(crate) fn into_inner(self) -> Value<'static> {
+        todo!()
+    }
+}
+impl<'a, T> TryFrom<OwnedValue> for Vec<T>
+where
+    T: TryFrom<Value<'a>, Error = ()>,
+{
+    type Error = ();
+    fn try_from(_: OwnedValue) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+impl TryFrom<OwnedValue> for Vec<OwnedValue> {
+    type Error = ();
+    fn try_from(_: OwnedValue) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+impl<'a> From<Value<'a>> for OwnedValue {
+    fn from(_: Value<'a>) -> Self {
+        todo!()
+    }
+}
+impl<'a> From<&Value<'a>> for OwnedValue {
+    fn from(_: &Value<'a>) -> Self {
+        todo!()
+    }
+}

--- a/src/test/ui/traits/issue-89119.rs
+++ b/src/test/ui/traits/issue-89119.rs
@@ -1,0 +1,11 @@
+// This is a regression test for issue #89119: an issue in intercrate mode caching.
+//
+// It requires multiple crates, of course, but the bug is triggered by the code in the dependency,
+// not the main crate. This is why this file is empty.
+//
+// The auxiliary crate used in the test contains the code minimized from `zvariant-2.8.0`.
+
+// check-pass
+// aux-build: issue_89119_intercrate_caching.rs
+
+fn main() {}


### PR DESCRIPTION
This adds a regression test to complete https://github.com/rust-lang/rust/pull/89125, and thus for issues #88969 and #89119, which needed a test.

Used with multiple crates, [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=f665e7e882059157e0f86cfb09c47187) minimized from `zvariant-2.8.0` reproduces the error on `nightly-2021-09-19`.

The test in this PR fails on master if the commit 6dbb9d4eee0a2789a74bb2d4b8228626f7cd741c from #89125 is reverted, and passes otherwise since it's now fixed.

r? @Aaron1011 