### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1356,32 +1356,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // keep track of the Span info. Now, `add_implicitly_sized` in `AstConv` checks both param bounds and
         // where clauses for `?Sized`.
         for pred in &generics.where_clause.predicates {
-            if let WherePredicate::BoundPredicate(ref bound_pred) = *pred {
-                'next_bound: for bound in &bound_pred.bounds {
-                    if let GenericBound::Trait(_, TraitBoundModifier::Maybe) = *bound {
-                        // Check if the where clause type is a plain type parameter.
-                        match self
-                            .resolver
-                            .get_partial_res(bound_pred.bounded_ty.id)
-                            .map(|d| (d.base_res(), d.unresolved_segments()))
-                        {
-                            Some((Res::Def(DefKind::TyParam, def_id), 0))
-                                if bound_pred.bound_generic_params.is_empty() =>
-                            {
-                                for param in &generics.params {
-                                    if def_id == self.resolver.local_def_id(param.id).to_def_id() {
-                                        continue 'next_bound;
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
-                        self.diagnostic().span_err(
-                            bound_pred.bounded_ty.span,
-                            "`?Trait` bounds are only permitted at the \
-                                 point where a type parameter is declared",
-                        );
+            let bound_pred = match *pred {
+                WherePredicate::BoundPredicate(ref bound_pred) => bound_pred,
+                _ => continue,
+            };
+            let compute_is_param = || {
+                // Check if the where clause type is a plain type parameter.
+                match self
+                    .resolver
+                    .get_partial_res(bound_pred.bounded_ty.id)
+                    .map(|d| (d.base_res(), d.unresolved_segments()))
+                {
+                    Some((Res::Def(DefKind::TyParam, def_id), 0))
+                        if bound_pred.bound_generic_params.is_empty() =>
+                    {
+                        generics
+                            .params
+                            .iter()
+                            .find(|p| def_id == self.resolver.local_def_id(p.id).to_def_id())
+                            .is_some()
                     }
+                    // Either the `bounded_ty` is not a plain type parameter, or
+                    // it's not found in the generic type parameters list.
+                    _ => false,
+                }
+            };
+            // We only need to compute this once per `WherePredicate`, but don't
+            // need to compute this at all unless there is a Maybe bound.
+            let mut is_param: Option<bool> = None;
+            for bound in &bound_pred.bounds {
+                if !matches!(*bound, GenericBound::Trait(_, TraitBoundModifier::Maybe)) {
+                    continue;
+                }
+                let is_param = *is_param.get_or_insert_with(compute_is_param);
+                if !is_param {
+                    self.diagnostic().span_err(
+                        bound.span(),
+                        "`?Trait` bounds are only permitted at the \
+                        point where a type parameter is declared",
+                    );
                 }
             }
         }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -172,7 +172,7 @@ pub trait ResolverAstLowering {
     fn legacy_const_generic_args(&mut self, expr: &Expr) -> Option<Vec<usize>>;
 
     /// Obtains resolution for a `NodeId` with a single resolution.
-    fn get_partial_res(&mut self, id: NodeId) -> Option<PartialRes>;
+    fn get_partial_res(&self, id: NodeId) -> Option<PartialRes>;
 
     /// Obtains per-namespace resolutions for `use` statement with the given `NodeId`.
     fn get_import_res(&mut self, id: NodeId) -> PerNS<Option<Res<NodeId>>>;

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -342,7 +342,7 @@ impl MutVisitor<'tcx> for TransformVisitor<'tcx> {
             let source_info = data.terminator().source_info;
             // We must assign the value first in case it gets declared dead below
             data.statements.extend(self.make_state(state_idx, v, source_info));
-            let state = if let Some((resume, resume_arg)) = resume {
+            let state = if let Some((resume, mut resume_arg)) = resume {
                 // Yield
                 let state = 3 + self.suspension_points.len();
 
@@ -350,7 +350,8 @@ impl MutVisitor<'tcx> for TransformVisitor<'tcx> {
                 // live across a yield.
                 let resume_arg =
                     if let Some(&(ty, variant, idx)) = self.remap.get(&resume_arg.local) {
-                        self.make_field(variant, idx, ty)
+                        replace_base(&mut resume_arg, self.make_field(variant, idx, ty), self.tcx);
+                        resume_arg
                     } else {
                         resume_arg
                     };

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1132,7 +1132,7 @@ impl ResolverAstLowering for Resolver<'_> {
         self.legacy_const_generic_args(expr)
     }
 
-    fn get_partial_res(&mut self, id: NodeId) -> Option<PartialRes> {
+    fn get_partial_res(&self, id: NodeId) -> Option<PartialRes> {
         self.partial_res_map.get(&id).cloned()
     }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2966,7 +2966,15 @@ impl<'a> Resolver<'a> {
                 (None, false)
             };
             if !candidates.is_empty() {
-                diagnostics::show_candidates(&mut err, span, &candidates, instead, found_use);
+                diagnostics::show_candidates(
+                    &self.definitions,
+                    self.session,
+                    &mut err,
+                    span,
+                    &candidates,
+                    instead,
+                    found_use,
+                );
             } else if let Some((span, msg, sugg, appl)) = suggestion {
                 err.span_suggestion(span, msg, sugg, appl);
             }

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -2136,7 +2136,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             idx_t
         } else {
             let base_t = self.structurally_resolved_type(base.span, base_t);
-            match self.lookup_indexing(expr, base, base_t, idx_t) {
+            match self.lookup_indexing(expr, base, base_t, idx, idx_t) {
                 Some((index_ty, element_ty)) => {
                     // two-phase not needed because index_ty is never mutable
                     self.demand_coerce(idx, idx_t, index_ty, None, AllowTwoPhase::No);

--- a/compiler/rustc_typeck/src/check/place_op.rs
+++ b/compiler/rustc_typeck/src/check/place_op.rs
@@ -49,7 +49,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &hir::Expr<'_>,
         base_expr: &'tcx hir::Expr<'tcx>,
         base_ty: Ty<'tcx>,
-        idx_expr: &'tcx hir::Expr<'tcx>,
+        index_expr: &'tcx hir::Expr<'tcx>,
         idx_ty: Ty<'tcx>,
     ) -> Option<(/*index type*/ Ty<'tcx>, /*element type*/ Ty<'tcx>)> {
         // FIXME(#18741) -- this is almost but not quite the same as the
@@ -59,10 +59,40 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut autoderef = self.autoderef(base_expr.span, base_ty);
         let mut result = None;
         while result.is_none() && autoderef.next().is_some() {
-            result = self.try_index_step(expr, base_expr, &autoderef, idx_ty, idx_expr);
+            result = self.try_index_step(expr, base_expr, &autoderef, idx_ty, index_expr);
         }
         self.register_predicates(autoderef.into_obligations());
         result
+    }
+
+    fn negative_index(
+        &self,
+        ty: Ty<'tcx>,
+        span: Span,
+        base_expr: &hir::Expr<'_>,
+    ) -> Option<(Ty<'tcx>, Ty<'tcx>)> {
+        let ty = self.resolve_vars_if_possible(ty);
+        let mut err = self.tcx.sess.struct_span_err(
+            span,
+            &format!("negative integers cannot be used to index on a `{}`", ty),
+        );
+        err.span_label(span, &format!("cannot use a negative integer for indexing on `{}`", ty));
+        if let (hir::ExprKind::Path(..), Ok(snippet)) =
+            (&base_expr.kind, self.tcx.sess.source_map().span_to_snippet(base_expr.span))
+        {
+            // `foo[-1]` to `foo[foo.len() - 1]`
+            err.span_suggestion_verbose(
+                span.shrink_to_lo(),
+                &format!(
+                    "to access an element starting from the end of the `{}`, compute the index",
+                    ty,
+                ),
+                format!("{}.len() ", snippet),
+                Applicability::MachineApplicable,
+            );
+        }
+        err.emit();
+        Some((self.tcx.ty_error(), self.tcx.ty_error()))
     }
 
     /// To type-check `base_expr[index_expr]`, we progressively autoderef
@@ -76,7 +106,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_expr: &hir::Expr<'_>,
         autoderef: &Autoderef<'a, 'tcx>,
         index_ty: Ty<'tcx>,
-        idx_expr: &hir::Expr<'_>,
+        index_expr: &hir::Expr<'_>,
     ) -> Option<(/*index type*/ Ty<'tcx>, /*element type*/ Ty<'tcx>)> {
         let adjusted_ty =
             self.structurally_resolved_type(autoderef.span(), autoderef.final_ty(false));
@@ -86,49 +116,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             expr, base_expr, adjusted_ty, index_ty
         );
 
-        let negative_index = || {
-            let ty = self.resolve_vars_if_possible(adjusted_ty);
-            let mut err = self.tcx.sess.struct_span_err(
-                idx_expr.span,
-                &format!("negative integers cannot be used to index on a `{}`", ty),
-            );
-            err.span_label(
-                idx_expr.span,
-                &format!("cannot use a negative integer for indexing on `{}`", ty),
-            );
-            if let (hir::ExprKind::Path(..), Ok(snippet)) =
-                (&base_expr.kind, self.tcx.sess.source_map().span_to_snippet(base_expr.span))
-            {
-                // `foo[-1]` to `foo[foo.len() - 1]`
-                err.span_suggestion_verbose(
-                    idx_expr.span.shrink_to_lo(),
-                    &format!(
-                        "if you wanted to access an element starting from the end of the `{}`, you \
-                        must compute it",
-                        ty,
-                    ),
-                    format!("{}.len() ", snippet),
-                    Applicability::MachineApplicable,
-                );
-            }
-            err.emit();
-            Some((self.tcx.ty_error(), self.tcx.ty_error()))
-        };
         if let hir::ExprKind::Unary(
             hir::UnOp::Neg,
             hir::Expr {
                 kind: hir::ExprKind::Lit(hir::Lit { node: ast::LitKind::Int(..), .. }),
                 ..
             },
-        ) = idx_expr.kind
+        ) = index_expr.kind
         {
             match adjusted_ty.kind() {
                 ty::Adt(ty::AdtDef { did, .. }, _)
                     if self.tcx.is_diagnostic_item(sym::vec_type, *did) =>
                 {
-                    return negative_index();
+                    return self.negative_index(adjusted_ty, index_expr.span, base_expr);
                 }
-                ty::Slice(_) | ty::Array(_, _) => return negative_index(),
+                ty::Slice(_) | ty::Array(_, _) => {
+                    return self.negative_index(adjusted_ty, index_expr.span, base_expr);
+                }
                 _ => {}
             }
         }

--- a/src/test/ui/generator/yield-in-box.rs
+++ b/src/test/ui/generator/yield-in-box.rs
@@ -1,8 +1,10 @@
 // run-pass
-
 // Test that box-statements with yields in them work.
 
-#![feature(generators, box_syntax)]
+#![feature(generators, box_syntax, generator_trait)]
+use std::pin::Pin;
+use std::ops::Generator;
+use std::ops::GeneratorState;
 
 fn main() {
     let x = 0i32;
@@ -15,4 +17,8 @@ fn main() {
             _t => {}
         }
     };
+
+    let mut g = |_| box yield;
+    assert_eq!(Pin::new(&mut g).resume(1), GeneratorState::Yielded(()));
+    assert_eq!(Pin::new(&mut g).resume(2), GeneratorState::Complete(box 2));
 }

--- a/src/test/ui/generator/yield-in-box.stderr
+++ b/src/test/ui/generator/yield-in-box.stderr
@@ -1,5 +1,5 @@
 warning: unused generator that must be used
-  --> $DIR/yield-in-box.rs:9:5
+  --> $DIR/yield-in-box.rs:11:5
    |
 LL | /     || {
 LL | |         let y = 2u32;

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find function `f` in this scope
 LL |         f();
    |         ^ not found in this scope
    |
-help: consider importing one of these items
+help: consider importing this function
    |
 LL | use foo::f;
    |
@@ -37,7 +37,7 @@ LL | n!(f);
 LL |         n!(f);
    |            ^ not found in this scope
    |
-   = note: consider importing one of these items:
+   = note: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ LL | n!(f);
 LL |                 f
    |                 ^ not found in this scope
    |
-   = note: consider importing one of these items:
+   = note: consider importing this function:
            foo::f
    = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
@@ -4,7 +4,11 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
    |                                                                          ^^^^^^^^^^^^^^^^^^
    |
-   = note: hidden type `Ordinary<'_>` captures lifetime '_#9r
+note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined on the function body at 16:21
+  --> $DIR/ordinary-bounds-unrelated.rs:16:21
+   |
+LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
+   |                     ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
@@ -4,7 +4,11 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
    |                                                              ^^^^^^^^^^^^^^^^^^
    |
-   = note: hidden type `Ordinary<'_>` captures lifetime '_#6r
+note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined on the function body at 18:21
+  --> $DIR/ordinary-bounds-unsuited.rs:18:21
+   |
+LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
+   |                     ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -4,10 +4,8 @@ error[E0425]: cannot find function `fpriv` in this scope
 LL |     fpriv();
    |     ^^^^^ not found in this scope
    |
-help: consider importing this function
-   |
-LL | use bar::fpriv;
-   |
+   = note: this function exists but is inaccessible:
+           bar::fpriv
 
 error[E0425]: cannot find function `epriv` in this scope
   --> $DIR/glob-resolve1.rs:27:5
@@ -15,10 +13,8 @@ error[E0425]: cannot find function `epriv` in this scope
 LL |     epriv();
    |     ^^^^^ not found in this scope
    |
-help: consider importing this function
-   |
-LL | use bar::epriv;
-   |
+   = note: this function exists but is inaccessible:
+           bar::epriv
 
 error[E0423]: expected value, found enum `B`
   --> $DIR/glob-resolve1.rs:28:5
@@ -44,10 +40,8 @@ error[E0425]: cannot find value `C` in this scope
 LL |     C;
    |     ^ not found in this scope
    |
-help: consider importing this unit struct
-   |
-LL | use bar::C;
-   |
+   = note: this unit struct exists but is inaccessible:
+           bar::C
 
 error[E0425]: cannot find function `import` in this scope
   --> $DIR/glob-resolve1.rs:30:5
@@ -67,16 +61,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<A>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this enum
-   |
-LL | use bar::A;
-   |
+   = note: this enum exists but is inaccessible:
+           bar::A
 
 error[E0412]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:33:11
@@ -85,16 +73,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<C>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this struct
-   |
-LL | use bar::C;
-   |
+   = note: this struct exists but is inaccessible:
+           bar::C
 
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:34:11
@@ -103,16 +85,10 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<D>();
-   |           ^
+   |           ^ help: an enum with a similar name exists: `B`
    |
-help: an enum with a similar name exists
-   |
-LL |     foo::<B>();
-   |           ~
-help: consider importing this type alias
-   |
-LL | use bar::D;
-   |
+   = note: this type alias exists but is inaccessible:
+           bar::D
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -4,8 +4,11 @@ error[E0425]: cannot find function `fpriv` in this scope
 LL |     fpriv();
    |     ^^^^^ not found in this scope
    |
-   = note: this function exists but is inaccessible:
-           bar::fpriv
+note: function `bar::fpriv` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:7:5
+   |
+LL |     fn fpriv() {}
+   |     ^^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `epriv` in this scope
   --> $DIR/glob-resolve1.rs:27:5
@@ -13,8 +16,11 @@ error[E0425]: cannot find function `epriv` in this scope
 LL |     epriv();
    |     ^^^^^ not found in this scope
    |
-   = note: this function exists but is inaccessible:
-           bar::epriv
+note: function `bar::epriv` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:9:9
+   |
+LL |         fn epriv();
+   |         ^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found enum `B`
   --> $DIR/glob-resolve1.rs:28:5
@@ -40,8 +46,11 @@ error[E0425]: cannot find value `C` in this scope
 LL |     C;
    |     ^ not found in this scope
    |
-   = note: this unit struct exists but is inaccessible:
-           bar::C
+note: unit struct `bar::C` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:18:5
+   |
+LL |     struct C;
+   |     ^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `import` in this scope
   --> $DIR/glob-resolve1.rs:30:5
@@ -63,8 +72,11 @@ LL |     pub enum B {
 LL |     foo::<A>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this enum exists but is inaccessible:
-           bar::A
+note: enum `bar::A` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:11:5
+   |
+LL |     enum A {
+   |     ^^^^^^ not accessible
 
 error[E0412]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:33:11
@@ -75,8 +87,11 @@ LL |     pub enum B {
 LL |     foo::<C>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this struct exists but is inaccessible:
-           bar::C
+note: struct `bar::C` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:18:5
+   |
+LL |     struct C;
+   |     ^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:34:11
@@ -87,8 +102,11 @@ LL |     pub enum B {
 LL |     foo::<D>();
    |           ^ help: an enum with a similar name exists: `B`
    |
-   = note: this type alias exists but is inaccessible:
-           bar::D
+note: type alias `bar::D` exists but is inaccessible
+  --> $DIR/glob-resolve1.rs:20:5
+   |
+LL |     type D = isize;
+   |     ^^^^^^^^^^^^^^^ not accessible
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/imports/issue-4366-2.stderr
+++ b/src/test/ui/imports/issue-4366-2.stderr
@@ -4,10 +4,8 @@ error[E0412]: cannot find type `Bar` in this scope
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
    |
-help: consider importing this type alias
-   |
-LL |         use a::b::Bar;
-   |
+   = note: this type alias exists but is inaccessible:
+           a::b::Bar
 
 error[E0423]: expected function, found module `foo`
   --> $DIR/issue-4366-2.rs:25:5

--- a/src/test/ui/imports/issue-4366-2.stderr
+++ b/src/test/ui/imports/issue-4366-2.stderr
@@ -4,8 +4,11 @@ error[E0412]: cannot find type `Bar` in this scope
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
    |
-   = note: this type alias exists but is inaccessible:
-           a::b::Bar
+note: type alias `a::b::Bar` exists but is inaccessible
+  --> $DIR/issue-4366-2.rs:11:9
+   |
+LL |         type Bar = isize;
+   |         ^^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected function, found module `foo`
   --> $DIR/issue-4366-2.rs:25:5

--- a/src/test/ui/maybe-bounds-where.stderr
+++ b/src/test/ui/maybe-bounds-where.stderr
@@ -1,32 +1,32 @@
 error: `?Trait` bounds are only permitted at the point where a type parameter is declared
-  --> $DIR/maybe-bounds-where.rs:1:23
+  --> $DIR/maybe-bounds-where.rs:1:28
    |
 LL | struct S1<T>(T) where (T): ?Sized;
-   |                       ^^^
+   |                            ^^^^^^
 
 error: `?Trait` bounds are only permitted at the point where a type parameter is declared
-  --> $DIR/maybe-bounds-where.rs:4:23
+  --> $DIR/maybe-bounds-where.rs:4:27
    |
 LL | struct S2<T>(T) where u8: ?Sized;
-   |                       ^^
+   |                           ^^^^^^
 
 error: `?Trait` bounds are only permitted at the point where a type parameter is declared
-  --> $DIR/maybe-bounds-where.rs:7:23
+  --> $DIR/maybe-bounds-where.rs:7:35
    |
 LL | struct S3<T>(T) where &'static T: ?Sized;
-   |                       ^^^^^^^^^^
+   |                                   ^^^^^^
 
 error: `?Trait` bounds are only permitted at the point where a type parameter is declared
-  --> $DIR/maybe-bounds-where.rs:12:31
+  --> $DIR/maybe-bounds-where.rs:12:34
    |
 LL | struct S4<T>(T) where for<'a> T: ?Trait<'a>;
-   |                               ^
+   |                                  ^^^^^^^^^^
 
 error: `?Trait` bounds are only permitted at the point where a type parameter is declared
-  --> $DIR/maybe-bounds-where.rs:21:18
+  --> $DIR/maybe-bounds-where.rs:21:21
    |
 LL |     fn f() where T: ?Sized {}
-   |                  ^
+   |                     ^^^^^^
 
 warning: default bound relaxed for a type parameter, but this does nothing because the given bound is not a default; only `?Sized` is supported
   --> $DIR/maybe-bounds-where.rs:12:11

--- a/src/test/ui/resolve/issue-42944.stderr
+++ b/src/test/ui/resolve/issue-42944.stderr
@@ -16,10 +16,8 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this s
 LL |         Bx(());
    |         ^^ not found in this scope
    |
-help: consider importing this tuple struct
-   |
-LL |     use foo::Bx;
-   |
+   = note: this tuple struct exists but is inaccessible:
+           foo::Bx
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-42944.stderr
+++ b/src/test/ui/resolve/issue-42944.stderr
@@ -16,8 +16,11 @@ error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this s
 LL |         Bx(());
    |         ^^ not found in this scope
    |
-   = note: this tuple struct exists but is inaccessible:
-           foo::Bx
+note: tuple struct `foo::Bx` exists but is inaccessible
+  --> $DIR/issue-42944.rs:2:5
+   |
+LL |     pub struct Bx(());
+   |     ^^^^^^^^^^^^^^^^^^ not accessible
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-88472.rs
+++ b/src/test/ui/resolve/issue-88472.rs
@@ -6,6 +6,8 @@
 
 mod a {
     struct Foo;
+    //~^ NOTE: struct `a::Foo` exists but is inaccessible
+    //~| NOTE: not accessible
 }
 
 mod b {
@@ -14,14 +16,16 @@ mod b {
     type Bar = Foo;
     //~^ ERROR: cannot find type `Foo` in this scope [E0412]
     //~| NOTE: not found in this scope
-    //~| NOTE: this struct exists but is inaccessible
 }
 
 mod c {
     enum Eee {}
+    //~^ NOTE: these enums exist but are inaccessible
+    //~| NOTE: `c::Eee`: not accessible
 
     mod d {
         enum Eee {}
+        //~^ NOTE: `c::d::Eee`: not accessible
     }
 }
 
@@ -29,7 +33,6 @@ mod e {
     type Baz = Eee;
     //~^ ERROR: cannot find type `Eee` in this scope [E0412]
     //~| NOTE: not found in this scope
-    //~| NOTE: these items exist but are inaccessible
 }
 
 fn main() {}

--- a/src/test/ui/resolve/issue-88472.rs
+++ b/src/test/ui/resolve/issue-88472.rs
@@ -1,0 +1,35 @@
+// Regression test for #88472, where a suggestion was issued to
+// import an inaccessible struct.
+
+#![warn(unused_imports)]
+//~^ NOTE: the lint level is defined here
+
+mod a {
+    struct Foo;
+}
+
+mod b {
+    use crate::a::*;
+    //~^ WARNING: unused import
+    type Bar = Foo;
+    //~^ ERROR: cannot find type `Foo` in this scope [E0412]
+    //~| NOTE: not found in this scope
+    //~| NOTE: this struct exists but is inaccessible
+}
+
+mod c {
+    enum Eee {}
+
+    mod d {
+        enum Eee {}
+    }
+}
+
+mod e {
+    type Baz = Eee;
+    //~^ ERROR: cannot find type `Eee` in this scope [E0412]
+    //~| NOTE: not found in this scope
+    //~| NOTE: these items exist but are inaccessible
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-88472.stderr
+++ b/src/test/ui/resolve/issue-88472.stderr
@@ -1,0 +1,34 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/issue-88472.rs:14:16
+   |
+LL |     type Bar = Foo;
+   |                ^^^ not found in this scope
+   |
+   = note: this struct exists but is inaccessible:
+           a::Foo
+
+error[E0412]: cannot find type `Eee` in this scope
+  --> $DIR/issue-88472.rs:29:16
+   |
+LL |     type Baz = Eee;
+   |                ^^^ not found in this scope
+   |
+   = note: these items exist but are inaccessible:
+           c::Eee
+           c::d::Eee
+
+warning: unused import: `crate::a::*`
+  --> $DIR/issue-88472.rs:12:9
+   |
+LL |     use crate::a::*;
+   |         ^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-88472.rs:4:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/resolve/issue-88472.stderr
+++ b/src/test/ui/resolve/issue-88472.stderr
@@ -1,24 +1,32 @@
 error[E0412]: cannot find type `Foo` in this scope
-  --> $DIR/issue-88472.rs:14:16
+  --> $DIR/issue-88472.rs:16:16
    |
 LL |     type Bar = Foo;
    |                ^^^ not found in this scope
    |
-   = note: this struct exists but is inaccessible:
-           a::Foo
+note: struct `a::Foo` exists but is inaccessible
+  --> $DIR/issue-88472.rs:8:5
+   |
+LL |     struct Foo;
+   |     ^^^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `Eee` in this scope
-  --> $DIR/issue-88472.rs:29:16
+  --> $DIR/issue-88472.rs:33:16
    |
 LL |     type Baz = Eee;
    |                ^^^ not found in this scope
    |
-   = note: these items exist but are inaccessible:
-           c::Eee
-           c::d::Eee
+note: these enums exist but are inaccessible
+  --> $DIR/issue-88472.rs:22:5
+   |
+LL |     enum Eee {}
+   |     ^^^^^^^^ `c::Eee`: not accessible
+...
+LL |         enum Eee {}
+   |         ^^^^^^^^ `c::d::Eee`: not accessible
 
 warning: unused import: `crate::a::*`
-  --> $DIR/issue-88472.rs:12:9
+  --> $DIR/issue-88472.rs:14:9
    |
 LL |     use crate::a::*;
    |         ^^^^^^^^^^^

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -171,8 +171,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found enum `m::n::Z`
   --> $DIR/privacy-enum-ctor.rs:57:16
@@ -211,8 +214,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Fn;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
@@ -223,8 +229,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Struct;
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0423]: expected value, found struct variant `m::n::Z::Struct`
   --> $DIR/privacy-enum-ctor.rs:64:16
@@ -246,8 +255,11 @@ LL |     pub enum E {
 LL |     let _: Z = m::n::Z::Unit {};
    |            ^ help: an enum with a similar name exists: `E`
    |
-   = note: this enum exists but is inaccessible:
-           m::Z
+note: enum `m::Z` exists but is inaccessible
+  --> $DIR/privacy-enum-ctor.rs:11:9
+   |
+LL |         pub(in m) enum Z {
+   |         ^^^^^^^^^^^^^^^^ not accessible
 
 error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:57:22

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -169,16 +169,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0423]: expected value, found enum `m::n::Z`
   --> $DIR/privacy-enum-ctor.rs:57:16
@@ -215,16 +209,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Fn;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Fn;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
@@ -233,16 +221,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Struct;
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Struct;
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0423]: expected value, found struct variant `m::n::Z::Struct`
   --> $DIR/privacy-enum-ctor.rs:64:16
@@ -262,16 +244,10 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Unit {};
-   |            ^
+   |            ^ help: an enum with a similar name exists: `E`
    |
-help: an enum with a similar name exists
-   |
-LL |     let _: E = m::n::Z::Unit {};
-   |            ~
-help: consider importing this enum
-   |
-LL | use m::Z;
-   |
+   = note: this enum exists but is inaccessible:
+           m::Z
 
 error[E0603]: enum `Z` is private
   --> $DIR/privacy-enum-ctor.rs:57:22

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -33,8 +33,11 @@ error[E0423]: expected value, found struct `xcrate::S`
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
    |
-   = note: this tuple struct exists but is inaccessible:
-           m::S
+note: tuple struct `m::S` exists but is inaccessible
+  --> $DIR/privacy-struct-ctor.rs:6:5
+   |
+LL |     pub struct S(u8);
+   |     ^^^^^^^^^^^^^^^^^ not accessible
 
 error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -33,10 +33,8 @@ error[E0423]: expected value, found struct `xcrate::S`
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
    |
-help: consider importing this tuple struct instead
-   |
-LL | use m::S;
-   |
+   = note: this tuple struct exists but is inaccessible:
+           m::S
 
 error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -66,8 +66,11 @@ error[E0531]: cannot find unit struct, unit variant or constant `Self` in this s
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
    |
-   = note: this unit struct exists but is inaccessible:
-           foo::Self
+note: unit struct `foo::Self` exists but is inaccessible
+  --> $DIR/self_type_keyword.rs:2:3
+   |
+LL |   struct Self;
+   |   ^^^^^^^^^^^^ not accessible
 
 error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:6:12

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -66,10 +66,8 @@ error[E0531]: cannot find unit struct, unit variant or constant `Self` in this s
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
    |
-help: consider importing this unit struct
-   |
-LL | use foo::Self;
-   |
+   = note: this unit struct exists but is inaccessible:
+           foo::Self
 
 error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:6:12

--- a/src/test/ui/suggestions/negative-literal-index.fixed
+++ b/src/test/ui/suggestions/negative-literal-index.fixed
@@ -1,0 +1,22 @@
+// run-rustfix
+
+use std::ops::Index;
+struct X;
+impl Index<i32> for X {
+    type Output = ();
+
+    fn index(&self, _: i32) -> &() {
+        &()
+    }
+}
+
+fn main() {
+    let x = vec![1, 2, 3];
+    x[x.len() -1]; //~ ERROR negative integers cannot be used to index on a
+    let x = [1, 2, 3];
+    x[x.len() -1]; //~ ERROR negative integers cannot be used to index on a
+    let x = &[1, 2, 3];
+    x[x.len() -1]; //~ ERROR negative integers cannot be used to index on a
+    let _ = x;
+    X[-1];
+}

--- a/src/test/ui/suggestions/negative-literal-index.rs
+++ b/src/test/ui/suggestions/negative-literal-index.rs
@@ -1,0 +1,22 @@
+// run-rustfix
+
+use std::ops::Index;
+struct X;
+impl Index<i32> for X {
+    type Output = ();
+
+    fn index(&self, _: i32) -> &() {
+        &()
+    }
+}
+
+fn main() {
+    let x = vec![1, 2, 3];
+    x[-1]; //~ ERROR negative integers cannot be used to index on a
+    let x = [1, 2, 3];
+    x[-1]; //~ ERROR negative integers cannot be used to index on a
+    let x = &[1, 2, 3];
+    x[-1]; //~ ERROR negative integers cannot be used to index on a
+    let _ = x;
+    X[-1];
+}

--- a/src/test/ui/suggestions/negative-literal-index.stderr
+++ b/src/test/ui/suggestions/negative-literal-index.stderr
@@ -4,7 +4,7 @@ error: negative integers cannot be used to index on a `Vec<{integer}>`
 LL |     x[-1];
    |       ^^ cannot use a negative integer for indexing on `Vec<{integer}>`
    |
-help: if you wanted to access an element starting from the end of the `Vec<{integer}>`, you must compute it
+help: to access an element starting from the end of the `Vec<{integer}>`, compute the index
    |
 LL |     x[x.len() -1];
    |       +++++++
@@ -15,7 +15,7 @@ error: negative integers cannot be used to index on a `[{integer}; 3]`
 LL |     x[-1];
    |       ^^ cannot use a negative integer for indexing on `[{integer}; 3]`
    |
-help: if you wanted to access an element starting from the end of the `[{integer}; 3]`, you must compute it
+help: to access an element starting from the end of the `[{integer}; 3]`, compute the index
    |
 LL |     x[x.len() -1];
    |       +++++++
@@ -26,7 +26,7 @@ error: negative integers cannot be used to index on a `[{integer}; 3]`
 LL |     x[-1];
    |       ^^ cannot use a negative integer for indexing on `[{integer}; 3]`
    |
-help: if you wanted to access an element starting from the end of the `[{integer}; 3]`, you must compute it
+help: to access an element starting from the end of the `[{integer}; 3]`, compute the index
    |
 LL |     x[x.len() -1];
    |       +++++++

--- a/src/test/ui/suggestions/negative-literal-index.stderr
+++ b/src/test/ui/suggestions/negative-literal-index.stderr
@@ -1,0 +1,35 @@
+error: negative integers cannot be used to index on a `Vec<{integer}>`
+  --> $DIR/negative-literal-index.rs:15:7
+   |
+LL |     x[-1];
+   |       ^^ cannot use a negative integer for indexing on `Vec<{integer}>`
+   |
+help: if you wanted to access an element starting from the end of the `Vec<{integer}>`, you must compute it
+   |
+LL |     x[x.len() -1];
+   |       +++++++
+
+error: negative integers cannot be used to index on a `[{integer}; 3]`
+  --> $DIR/negative-literal-index.rs:17:7
+   |
+LL |     x[-1];
+   |       ^^ cannot use a negative integer for indexing on `[{integer}; 3]`
+   |
+help: if you wanted to access an element starting from the end of the `[{integer}; 3]`, you must compute it
+   |
+LL |     x[x.len() -1];
+   |       +++++++
+
+error: negative integers cannot be used to index on a `[{integer}; 3]`
+  --> $DIR/negative-literal-index.rs:19:7
+   |
+LL |     x[-1];
+   |       ^^ cannot use a negative integer for indexing on `[{integer}; 3]`
+   |
+help: if you wanted to access an element starting from the end of the `[{integer}; 3]`, you must compute it
+   |
+LL |     x[x.len() -1];
+   |       +++++++
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/traits/auxiliary/issue_89119_intercrate_caching.rs
+++ b/src/test/ui/traits/auxiliary/issue_89119_intercrate_caching.rs
@@ -1,0 +1,60 @@
+// This is the auxiliary crate for the regression test for issue #89119, minimized
+// from `zvariant-2.8.0`.
+
+use std::convert::TryFrom;
+use std::borrow::Cow;
+
+pub struct Str<'a>(Cow<'a, str>);
+impl<'a> Str<'a> {
+    pub fn to_owned(&self) -> Str<'static> {
+        todo!()
+    }
+}
+
+pub enum Value<'a> {
+    Str(Str<'a>),
+    Value(Box<Value<'a>>),
+}
+impl<'a> Value<'a> {
+    pub fn to_owned(&self) -> Value<'static> {
+        match self {
+            Value::Str(v) => Value::Str(v.to_owned()),
+            Value::Value(v) => {
+                let o = OwnedValue::from(&**v);
+                Value::Value(Box::new(o.into_inner()))
+            }
+        }
+    }
+}
+
+struct OwnedValue(Value<'static>);
+impl OwnedValue {
+    pub(crate) fn into_inner(self) -> Value<'static> {
+        todo!()
+    }
+}
+impl<'a, T> TryFrom<OwnedValue> for Vec<T>
+where
+    T: TryFrom<Value<'a>, Error = ()>,
+{
+    type Error = ();
+    fn try_from(_: OwnedValue) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+impl TryFrom<OwnedValue> for Vec<OwnedValue> {
+    type Error = ();
+    fn try_from(_: OwnedValue) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+impl<'a> From<Value<'a>> for OwnedValue {
+    fn from(_: Value<'a>) -> Self {
+        todo!()
+    }
+}
+impl<'a> From<&Value<'a>> for OwnedValue {
+    fn from(_: &Value<'a>) -> Self {
+        todo!()
+    }
+}

--- a/src/test/ui/traits/issue-89119.rs
+++ b/src/test/ui/traits/issue-89119.rs
@@ -1,0 +1,11 @@
+// This is a regression test for issue #89119: an issue in intercrate mode caching.
+//
+// It requires multiple crates, of course, but the bug is triggered by the code in the dependency,
+// not the main crate. This is why this file is empty.
+//
+// The auxiliary crate used in the test contains the code minimized from `zvariant-2.8.0`.
+
+// check-pass
+// aux-build: issue_89119_intercrate_caching.rs
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #88838 (Do not suggest importing inaccessible items)
 - #89251 (Detect when negative literal indices are used and suggest appropriate code)
 - #89321 (Rebase resume argument projections during state transform)
 - #89327 (Pick one possible lifetime in case there are multiple choices)
 - #89344 (Cleanup lower_generics_mut and make span be the bound itself)
 - #89397 (Update `llvm` submodule to fix function name mangling on x86 Windows)
 - #89412 (Add regression test for issues #88969 and #89119 )

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88838,89251,89321,89327,89344,89397,89412)
<!-- homu-ignore:end -->