### PR TITLE
Add bpf(el|eb)-unknown-none targets to dist-various-2

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -100,6 +100,8 @@ ENV CARGO_TARGET_AARCH64_FUCHSIA_RUSTFLAGS \
 
 ENV TARGETS=x86_64-fuchsia
 ENV TARGETS=$TARGETS,aarch64-fuchsia
+ENV TARGETS=$TARGETS,bpfel-unknown-none
+ENV TARGETS=$TARGETS,bpfeb-unknown-none
 ENV TARGETS=$TARGETS,wasm32-unknown-unknown
 ENV TARGETS=$TARGETS,wasm32-wasi
 ENV TARGETS=$TARGETS,sparcv9-sun-solaris


### PR DESCRIPTION
This commit adds the bpfel-unknown-none and bpfeb-unknown-none targets
to the dist-various-2. The motivation for this is to allow for libcore
to be added to a nightly toolchain using `rustup target add`. This will
allow us to perform testing of the bpf-linker against rust nightly.

See: https://github.com/aya-rs/bpf-linker/pull/4, which currently requires building a nightly toolchain from source for these tests, which takes ~50 minutes (x3 for testing against various LLVMs)