### PR TITLE
Remove whitespaces in doctests' name

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -853,6 +853,7 @@ impl Collector {
 
     fn generate_name(&self, line: usize, filename: &FileName) -> String {
         let mut item_path = self.names.join("::");
+        item_path.retain(|c| c != ' ');
         if !item_path.is_empty() {
             item_path.push(' ');
         }


### PR DESCRIPTION
Fixes #88263.

Instead of handling white spaces when we filter tests (which would be quite complicated since we split on them!), I propose to instead replace them with dashes.

So for example, this:

```console
test foo.rs - Iter2<T, P>::len (line 13) ... ok
test foo.rs - Iter<T, P>::len (line 4) ... ok
```

becomes:

```console
test foo.rs - Iter<T,-P>::len (line 4) ... ok
test foo.rs - Iter2<T,-P>::len (line 13) ... ok
```

r? @jyn514 