### PR TITLE
Add riscv64gc-unknown-hermit Tier 3 target 

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -960,6 +960,7 @@ supported_targets! {
     ("msp430-none-elf", msp430_none_elf),
 
     ("aarch64-unknown-hermit", aarch64_unknown_hermit),
+    ("riscv64gc-unknown-hermit", riscv64gc_unknown_hermit),
     ("x86_64-unknown-hermit", x86_64_unknown_hermit),
 
     ("x86_64-unknown-none-hermitkernel", x86_64_unknown_none_hermitkernel),

--- a/compiler/rustc_target/src/spec/riscv64gc_unknown_hermit.rs
+++ b/compiler/rustc_target/src/spec/riscv64gc_unknown_hermit.rs
@@ -1,0 +1,20 @@
+use crate::spec::Target;
+use crate::spec::{CodeModel, TlsModel};
+
+pub fn target() -> Target {
+    let mut base = super::hermit_base::opts();
+    base.cpu = "generic-rv64".to_string();
+    base.max_atomic_width = Some(64);
+    base.features = "+m,+a,+f,+d,+c".to_string();
+    base.code_model = Some(CodeModel::Medium);
+    base.tls_model = TlsModel::LocalExec;
+    base.llvm_abiname = "lp64d".to_string();
+
+    Target {
+        llvm_target: "riscv64-unknown-hermit".to_string(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".to_string(),
+        arch: "riscv64".to_string(),
+        options: base,
+    }
+}

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -41,7 +41,7 @@ dlmalloc = { version = "0.2.3", features = ['rustc-dep-of-std'] }
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
-[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
+[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64"), target_os = "hermit"))'.dependencies]
 hermit-abi = { version = "0.1.19", features = ['rustc-dep-of-std'] }
 
 [target.wasm32-wasi.dependencies]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -268,6 +268,7 @@ target | std | host | notes
 `riscv32gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 5.4, musl + RISCV32 support patches)
 `riscv32imc-esp-espidf` | ✓ |  | RISC-V ESP-IDF
 `riscv64gc-unknown-freebsd` |   |   | RISC-V FreeBSD
+`riscv64gc-unknown-hermit` | ? |  |
 `riscv64gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 4.20, musl 1.2.0)
 `s390x-unknown-linux-musl` |  |  | S390x Linux (kernel 2.6.32, MUSL)
 `sparc-unknown-linux-gnu` | ✓ |  | 32-bit SPARC Linux


### PR DESCRIPTION
This pull request adds the riscv64gc-unknown-hermit target and is based on existing targets (hermit, riscv64gc).

I understand that Tier 3 targets must meet certain requirements. Adding this target introduces no new dependencies
or changes affecting other targets.