### PR TITLE
bootstrap: add config option for nix patching

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -313,6 +313,12 @@ changelog-seen = 2
 # this setting's very existence, are all subject to change.)
 #print-step-rusage = false
 
+# Always patch binaries for usage with Nix toolchains. If `true` then binaries
+# will be patched unconditionally. If `false` or unset, binaries will be patched
+# only if the current distribution is NixOS. This option is useful when using
+# a Nix toolchain on non-NixOS distributions.
+#patch-binaries-for-nix = false
+
 # =============================================================================
 # General install configuration options
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -397,6 +397,7 @@ struct Build {
     install_stage: Option<u32>,
     dist_stage: Option<u32>,
     bench_stage: Option<u32>,
+    patch_binaries_for_nix: Option<bool>,
 }
 
 /// TOML representation of various global install decisions.


### PR DESCRIPTION
On NixOS systems, bootstrap will patch rustc used in bootstrapping after checking `/etc/os-release` (to confirm the current distribution is NixOS). However, when using Nix on a non-NixOS system, it can be desirable for bootstrap to patch rustc. In this commit, a `patch-binaries-for-nix` option is added to `config.toml`, which allows for user opt-in to bootstrap's Nix patching.

r? @Mark-Simulacrum 