### PR TITLE
Specialize `Vec::extend` and `Vec::from_iter` for arrays

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -110,6 +110,9 @@ mod is_zero;
 #[cfg(not(no_global_oom_handling))]
 mod source_iter_marker;
 
+#[cfg(not(no_global_oom_handling))]
+use source_iter_marker::SpecFromIterWithSource;
+
 mod partial_eq;
 
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/source_iter_marker.rs
+++ b/library/alloc/src/vec/source_iter_marker.rs
@@ -2,7 +2,20 @@ use core::iter::{InPlaceIterable, SourceIter, TrustedRandomAccessNoCoerce};
 use core::mem::{self, ManuallyDrop};
 use core::ptr::{self};
 
-use super::{AsIntoIter, InPlaceDrop, SpecFromIter, SpecFromIterNested, Vec};
+use super::{AsIntoIter, InPlaceDrop, SpecFromIterNested, Vec};
+
+pub(super) trait SpecFromIterWithSource<T, I> {
+    fn from_iter(iter: I) -> Self;
+}
+
+impl<T, I> SpecFromIterWithSource<T, I> for Vec<T>
+where
+    I: Iterator<Item = T>,
+{
+    default fn from_iter(iterator: I) -> Self {
+        SpecFromIterNested::from_iter(iterator)
+    }
+}
 
 /// Specialization marker for collecting an iterator pipeline into a Vec while reusing the
 /// source allocation, i.e. executing the pipeline in place.
@@ -21,7 +34,7 @@ pub(super) trait SourceIterMarker: SourceIter<Source: AsIntoIter> {}
 // several other specializations already depend on.
 impl<T> SourceIterMarker for T where T: SourceIter<Source: AsIntoIter> + InPlaceIterable {}
 
-impl<T, I> SpecFromIter<T, I> for Vec<T>
+impl<T, I> SpecFromIterWithSource<T, I> for Vec<T>
 where
     I: Iterator<Item = T> + SourceIterMarker,
 {

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -1,7 +1,6 @@
 use crate::alloc::Allocator;
 use core::iter::TrustedLen;
-use core::ptr::{self};
-use core::slice::{self};
+use core::{array, mem, ptr, slice};
 
 use super::{IntoIter, SetLenOnDrop, Vec};
 
@@ -63,6 +62,15 @@ impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
             self.append_elements(iterator.as_slice() as _);
         }
         iterator.ptr = iterator.end;
+    }
+}
+
+impl<T, A: Allocator, const N: usize> SpecExtend<T, array::IntoIter<T, N>> for Vec<T, A> {
+    fn spec_extend(&mut self, iterator: array::IntoIter<T, N>) {
+        unsafe {
+            self.append_elements(iterator.as_slice());
+        }
+        mem::forget(iterator);
     }
 }
 


### PR DESCRIPTION
This brings performance and code size improvements.

Drawback: this adds one layer one specialization for `SpecExtend`.