### PR TITLE
docs: `std::hash::Hash` should ensure prefix-free data

### DIFF
--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -156,8 +156,10 @@ mod sip;
 /// ## Prefix collisions
 ///
 /// Implementations of `hash` should ensure that the data they
-/// pass to the `Hasher` are prefix-free. That is, different concatenations
-/// of the same data should not produce the same output.
+/// pass to the `Hasher` are prefix-free. That is,
+/// unequal values should cause two different byte sequences to be written,
+/// and neither of the two sequences should be a prefix of the other.
+///
 /// For example, the standard implementation of [`Hash` for `&str`][impl] passes an extra
 /// `0xFF` byte to the `Hasher` so that the values `("ab", "c")` and `("a",
 /// "bc")` hash differently.

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -153,9 +153,19 @@ mod sip;
 /// Thankfully, you won't need to worry about upholding this property when
 /// deriving both [`Eq`] and `Hash` with `#[derive(PartialEq, Eq, Hash)]`.
 ///
+/// ## Prefix collisions
+///
+/// Implementations of `hash` should ensure that the data they
+/// pass to the `Hasher` are prefix-free. That is, different concatenations
+/// of the same data should not produce the same output.
+/// For example, the standard implementation of [`Hash` for `&str`][impl] passes an extra
+/// `0xFF` byte to the `Hasher` so that the values `("ab", "c")` and `("a",
+/// "bc")` hash differently.
+///
 /// [`HashMap`]: ../../std/collections/struct.HashMap.html
 /// [`HashSet`]: ../../std/collections/struct.HashSet.html
 /// [`hash`]: Hash::hash
+/// [impl]: ../../std/primitive.str.html#impl-Hash
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Hash"]
 pub trait Hash {

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -157,7 +157,7 @@ mod sip;
 ///
 /// Implementations of `hash` should ensure that the data they
 /// pass to the `Hasher` are prefix-free. That is,
-/// unequal values should cause two different byte sequences to be written,
+/// unequal values should cause two different sequences of values to be written,
 /// and neither of the two sequences should be a prefix of the other.
 ///
 /// For example, the standard implementation of [`Hash` for `&str`][impl] passes an extra


### PR DESCRIPTION
Attempt to synthesize the discussion in #89429 into a suggestion regarding `Hash` implementations (not a hard requirement).

Closes #89429.