### PR TITLE
Improve error message for missing angle brackets in `[_]::method`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1211,6 +1211,8 @@ impl Expr {
                 }
             }
 
+            ExprKind::Underscore => TyKind::Infer,
+
             // This expression doesn't look like a type syntactically.
             _ => return None,
         };

--- a/src/test/ui/parser/issue-89388.rs
+++ b/src/test/ui/parser/issue-89388.rs
@@ -1,0 +1,7 @@
+// Regression test for #89388.
+
+fn main() {
+    let option: Option<&[u8]> = Some(b"...");
+    let _ = option.map([_]::to_vec);
+    //~^ ERROR: missing angle brackets in associated item path
+}

--- a/src/test/ui/parser/issue-89388.stderr
+++ b/src/test/ui/parser/issue-89388.stderr
@@ -1,0 +1,8 @@
+error: missing angle brackets in associated item path
+  --> $DIR/issue-89388.rs:5:24
+   |
+LL |     let _ = option.map([_]::to_vec);
+   |                        ^^^^^^^^^^^ help: try: `<[_]>::to_vec`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #89388.