### PR TITLE
perf: only check for `rustc_trivial_field_reads` attribute on traits, not items, impls, etc.

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -254,30 +254,10 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
         let has_attr = |def_id| self.tcx.has_attr(def_id, sym::rustc_trivial_field_reads);
 
-        if has_attr(def_id) {
-            return true;
-        }
-
         if let Some(impl_of) = self.tcx.impl_of_method(def_id) {
-            if has_attr(impl_of) {
-                return true;
-            }
-
             if let Some(trait_of) = self.tcx.trait_id_of_impl(impl_of) {
                 if has_attr(trait_of) {
                     return true;
-                }
-
-                if let Some(method_ident) = self.tcx.opt_item_name(def_id) {
-                    if let Some(trait_method) = self
-                        .tcx
-                        .associated_items(trait_of)
-                        .find_by_name_and_kind(self.tcx, method_ident, ty::AssocKind::Fn, trait_of)
-                    {
-                        if has_attr(trait_method.def_id) {
-                            return true;
-                        }
-                    }
                 }
             }
         } else if let Some(trait_of) = self.tcx.trait_of_item(def_id) {
@@ -291,9 +271,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
     fn visit_node(&mut self, node: Node<'tcx>) {
         if let Some(item_def_id) = match node {
-            Node::Item(hir::Item { def_id, .. })
-            | Node::ForeignItem(hir::ForeignItem { def_id, .. })
-            | Node::TraitItem(hir::TraitItem { def_id, .. })
+            Node::TraitItem(hir::TraitItem { def_id, .. })
             | Node::ImplItem(hir::ImplItem { def_id, .. }) => Some(def_id.to_def_id()),
             _ => None,
         } {


### PR DESCRIPTION
The checks that are removed in this PR (originally added in #85200) caused a small perf regression: https://github.com/rust-lang/rust/pull/88824#issuecomment-932664761

Since the attribute is currently only applied to traits, I don't think it's worth keeping the additional checks for now.
If/when we decide to apply the attribute somewhere else, we can (partially) revert this and reevaluate the perf impact.

r? @nikomatsakis cc @FabianWolff