### PR TITLE
Introduce linter for diagnostic messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ name = "compiletest"
 version = "0.0.0"
 dependencies = [
  "colored",
+ "diaglint",
  "diff",
  "getopts",
  "glob",
@@ -945,6 +946,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "diaglint"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3730e1cddacaff508f3dfc1cc050e27e2823a55c44664e0b3a64cbc1008b37f8"
+dependencies = [
+ "annotate-snippets",
+ "nom",
+ "nom_locate",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2253,6 +2267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2330,28 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nom"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
 
 [[package]]
 name = "ntapi"

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 colored = "2"
 diff = "0.1.10"
+diaglint = "0.1.8"
 unified-diff = "0.2.1"
 getopts = "0.2"
 tracing = "0.1"

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -145,6 +145,8 @@ pub struct TestProps {
     pub run_rustfix: bool,
     // If true, `rustfix` will only apply `MachineApplicable` suggestions.
     pub rustfix_only_machine_applicable: bool,
+    // Lints to ignore when checking diagnostics.
+    pub ignored_diaglints: Vec<String>,
     pub assembly_output: Option<String>,
     // If true, the test is expected to ICE
     pub should_ice: bool,
@@ -188,6 +190,7 @@ impl TestProps {
             failure_status: -1,
             run_rustfix: false,
             rustfix_only_machine_applicable: false,
+            ignored_diaglints: vec![],
             assembly_output: None,
             should_ice: false,
             stderr_per_bitwidth: false,
@@ -356,6 +359,10 @@ impl TestProps {
                 if !self.rustfix_only_machine_applicable {
                     self.rustfix_only_machine_applicable =
                         config.parse_rustfix_only_machine_applicable(ln);
+                }
+
+                if let Some(ignored_diaglint) = config.parse_ignored_diaglints(ln) {
+                    self.ignored_diaglints.push(ignored_diaglint);
                 }
 
                 if self.assembly_output.is_none() {
@@ -616,6 +623,10 @@ impl Config {
 
     fn parse_stderr_per_bitwidth(&self, line: &str) -> bool {
         self.parse_name_directive(line, "stderr-per-bitwidth")
+    }
+
+    fn parse_ignored_diaglints(&self, line: &str) -> Option<String> {
+        self.parse_name_value_directive(line, "ignored-diaglints").map(|r| r.trim().to_string())
     }
 
     fn parse_assembly_output(&self, line: &str) -> Option<String> {

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -83,6 +83,16 @@ pub fn rustfix_diagnostics_only(output: &str) -> String {
         .collect()
 }
 
+/// Tries to return a line that would successfully parsed into `Diagnostic`.
+/// Returns `None` if `output` does not contain diagnostics.
+pub fn diaglint_diagnostics_only(output: &str) -> Option<String> {
+    output
+        .lines()
+        .filter(|line| line.starts_with('{'))
+        .find(|line| serde_json::from_str::<Diagnostic>(line).is_ok())
+        .map(|line| line.to_owned())
+}
+
 pub fn extract_rendered(output: &str) -> String {
     output
         .lines()


### PR DESCRIPTION
Sometimes, contributors add diagnostics not practicing [the diagnostic message convention](https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-output-style-guide) and overlooked by reviewers. This PR adds a linter for diagnostic messages to preemptively warn such diagnostics and lighten the burden of reviewers.