### PR TITLE
Fix typos in rustdoc/lints

### DIFF
--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -70,7 +70,7 @@ This lint **warns by default**. This lint detects when [intra-doc links] from pu
 For example:
 
 ```rust
-#![warn(rustdoc::private_intra_doc_links)] // note: unecessary - warns by default.
+#![warn(rustdoc::private_intra_doc_links)] // note: unnecessary - warns by default.
 
 /// [private]
 pub fn public() {}
@@ -229,7 +229,7 @@ This lint **warns by default**. It detects code block attributes in
 documentation examples that have potentially mis-typed values. For example:
 
 ```rust
-#![warn(rustdoc::invalid_codeblock_attributes)]  // note: unecessary - warns by default.
+#![warn(rustdoc::invalid_codeblock_attributes)]  // note: unnecessary - warns by default.
 
 /// Example.
 ///
@@ -348,7 +348,7 @@ This lint is **warn-by-default**. It detects URLs which are not links.
 For example:
 
 ```rust
-#![warn(rustdoc::bare_urls)] // note: unecessary - warns by default.
+#![warn(rustdoc::bare_urls)] // note: unnecessary - warns by default.
 
 /// http://example.org
 /// [http://example.net]


### PR DESCRIPTION
This PR merely fixes a few typos in a recently introduced change :)

Refs: https://github.com/rust-lang/rust/pull/85223