### PR TITLE
Use Ancestory to check default fn in const impl instead of comparing idents

### DIFF
--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
 
 trait Tr {
     fn req(&self);
@@ -17,11 +18,6 @@ struct S;
 impl const Tr for S {
     fn req(&self) {}
 } //~^^ ERROR const trait implementations may not use non-const default functions
-
-impl const Tr for u8 {
-    fn req(&self) {}
-    fn prov(&self) {}
-}
 
 impl const Tr for u16 {
     fn prov(&self) {}

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
@@ -1,5 +1,5 @@
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:17:1
+  --> $DIR/impl-with-default-fn-fail.rs:18:1
    |
 LL | / impl const Tr for S {
 LL | |     fn req(&self) {}
@@ -9,7 +9,7 @@ LL | | }
    = note: `prov` not implemented
 
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:32:1
+  --> $DIR/impl-with-default-fn-fail.rs:28:1
    |
 LL | / impl const Tr for u32 {
 LL | |     fn req(&self) {}
@@ -20,7 +20,7 @@ LL | | }
    = note: `prov` not implemented
 
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn.rs:26:1
+  --> $DIR/impl-with-default-fn-fail.rs:22:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
@@ -1,0 +1,34 @@
+// check-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+
+trait Tr {
+    fn req(&self);
+
+    fn prov(&self) {
+        println!("lul");
+        self.req();
+    }
+
+    #[default_method_body_is_const]
+    fn default() {}
+}
+
+impl const Tr for u8 {
+    fn req(&self) {}
+    fn prov(&self) {}
+}
+
+macro_rules! impl_tr {
+    ($ty: ty) => {
+        impl const Tr for $ty {
+            fn req(&self) {}
+            fn prov(&self) {}
+        }
+    }
+}
+
+impl_tr!(u64);
+
+fn main() {}


### PR DESCRIPTION
Fixes https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/Const.20trait.20impl.20inside.20macro