### PR TITLE
Fix extra `non_snake_case` warning for shorthand field bindings

### DIFF
--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -437,12 +437,13 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
             if let hir::Node::Pat(parent_pat) = cx.tcx.hir().get(cx.tcx.hir().get_parent_node(hid))
             {
                 if let PatKind::Struct(_, field_pats, _) = &parent_pat.kind {
-                    for field in field_pats.iter() {
-                        if field.ident != ident {
-                            // Only check if a new name has been introduced, to avoid warning
-                            // on both the struct definition and this pattern.
-                            self.check_snake_case(cx, "variable", &ident);
-                        }
+                    if field_pats
+                        .iter()
+                        .any(|field| !field.is_shorthand && field.pat.hir_id == p.hir_id)
+                    {
+                        // Only check if a new name has been introduced, to avoid warning
+                        // on both the struct definition and this pattern.
+                        self.check_snake_case(cx, "variable", &ident);
                     }
                     return;
                 }

--- a/src/test/ui/lint/issue-89469.rs
+++ b/src/test/ui/lint/issue-89469.rs
@@ -1,0 +1,20 @@
+// Regression test for #89469, where an extra non_snake_case warning was
+// reported for a shorthand field binding.
+
+// check-pass
+#![deny(non_snake_case)]
+
+#[allow(non_snake_case)]
+struct Entry {
+    A: u16,
+    a: u16
+}
+
+fn foo() -> Entry {todo!()}
+
+pub fn f() {
+    let Entry { A, a } = foo();
+    let _ = (A, a);
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #89469. The problem is the innermost `if` condition here:
https://github.com/rust-lang/rust/blob/d14731cb3ced8318d7fc83cbe838f0e7f2fb3b40/compiler/rustc_lint/src/nonstandard_style.rs#L435-L452

This code runs for every `PatKind::Binding`, so if a struct has multiple fields, say A and B, and both are bound in a pattern using shorthands, the call to `self.check_snake_case()` will indeed be skipped in the `check_pat()` call for `A`; but when `check_pat()` is called for `B`, the loop will still iterate over `A`, and `field.ident (= A) != ident (= B)` will be true. I have fixed this by only looking at non-shorthand bindings, and only the binding that `check_pat()` was actually called for.