### PR TITLE
rustdoc: Improve doctest pass's name and module's name

### DIFF
--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -2,7 +2,7 @@ use crate::clean;
 use crate::core::DocContext;
 use crate::fold::{self, DocFolder};
 use crate::html::markdown::{find_testable_code, ErrorCodes};
-use crate::passes::doc_test_lints::{should_have_doc_example, Tests};
+use crate::passes::check_doc_test_visibility::{should_have_doc_example, Tests};
 use crate::passes::Pass;
 use rustc_hir as hir;
 use rustc_lint::builtin::MISSING_DOCS;

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -1,6 +1,6 @@
 //! This pass is overloaded and runs two different lints.
 //!
-//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doctests
+//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doctests.
 //! - PRIVATE_DOC_TESTS: this lint is **STABLE** and looks for private items with doctests.
 
 use super::Pass;
@@ -15,23 +15,23 @@ use rustc_middle::lint::LintLevelSource;
 use rustc_session::lint;
 use rustc_span::symbol::sym;
 
-crate const CHECK_PRIVATE_ITEMS_DOC_TESTS: Pass = Pass {
-    name: "check-private-items-doc-tests",
-    run: check_private_items_doc_tests,
-    description: "check private items doc tests",
+crate const CHECK_DOC_TEST_VISIBILITY: Pass = Pass {
+    name: "check_doc_test_visibility",
+    run: check_doc_test_visibility,
+    description: "run various visibility-related lints on doctests",
 };
 
-struct PrivateItemDocTestLinter<'a, 'tcx> {
+struct DocTestVisibilityLinter<'a, 'tcx> {
     cx: &'a mut DocContext<'tcx>,
 }
 
-crate fn check_private_items_doc_tests(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
-    let mut coll = PrivateItemDocTestLinter { cx };
+crate fn check_doc_test_visibility(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
+    let mut coll = DocTestVisibilityLinter { cx };
 
     coll.fold_crate(krate)
 }
 
-impl<'a, 'tcx> DocFolder for PrivateItemDocTestLinter<'a, 'tcx> {
+impl<'a, 'tcx> DocFolder for DocTestVisibilityLinter<'a, 'tcx> {
     fn fold_item(&mut self, item: Item) -> Option<Item> {
         let dox = item.attrs.collapsed_doc_value().unwrap_or_else(String::new);
 

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -33,8 +33,8 @@ crate use self::propagate_doc_cfg::PROPAGATE_DOC_CFG;
 crate mod collect_intra_doc_links;
 crate use self::collect_intra_doc_links::COLLECT_INTRA_DOC_LINKS;
 
-mod doc_test_lints;
-crate use self::doc_test_lints::CHECK_PRIVATE_ITEMS_DOC_TESTS;
+mod check_doc_test_visibility;
+crate use self::check_doc_test_visibility::CHECK_DOC_TEST_VISIBILITY;
 
 mod collect_trait_impls;
 crate use self::collect_trait_impls::COLLECT_TRAIT_IMPLS;
@@ -79,7 +79,7 @@ crate enum Condition {
 
 /// The full list of passes.
 crate const PASSES: &[Pass] = &[
-    CHECK_PRIVATE_ITEMS_DOC_TESTS,
+    CHECK_DOC_TEST_VISIBILITY,
     STRIP_HIDDEN,
     UNINDENT_COMMENTS,
     STRIP_PRIVATE,
@@ -97,7 +97,7 @@ crate const PASSES: &[Pass] = &[
 crate const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::always(COLLECT_TRAIT_IMPLS),
     ConditionalPass::always(UNINDENT_COMMENTS),
-    ConditionalPass::always(CHECK_PRIVATE_ITEMS_DOC_TESTS),
+    ConditionalPass::always(CHECK_DOC_TEST_VISIBILITY),
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),


### PR DESCRIPTION
As the docs at the top of the file say, it is an overloaded pass and
actually runs two lints.
