### PR TITLE
Fixed numerus of error message

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -10,7 +10,9 @@ use crate::traits::normalize_projection_type;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{error_code, struct_span_err, Applicability, DiagnosticBuilder, Style};
+use rustc_errors::{
+    error_code, pluralize, struct_span_err, Applicability, DiagnosticBuilder, Style,
+};
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
@@ -2273,7 +2275,11 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     parent_trait_ref = child_trait_ref;
                 }
                 if count > 0 {
-                    err.note(&format!("{} redundant requirements hidden", count));
+                    err.note(&format!(
+                        "{} redundant requirement{} hidden",
+                        count,
+                        pluralize!(count)
+                    ));
                     err.note(&format!(
                         "required because of the requirements on the impl of `{}` for `{}`",
                         parent_trait_ref.print_only_trait_path(),

--- a/src/test/ui/associated-types/impl-wf-cycle-1.stderr
+++ b/src/test/ui/associated-types/impl-wf-cycle-1.stderr
@@ -15,7 +15,7 @@ note: required because of the requirements on the impl of `Grault` for `(T,)`
    |
 LL | impl<T: Grault> Grault for (T,)
    |                 ^^^^^^     ^^^^
-   = note: 1 redundant requirements hidden
+   = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Grault` for `(T,)`
 
 error[E0275]: overflow evaluating the requirement `<(T,) as Grault>::A == _`
@@ -29,7 +29,7 @@ note: required because of the requirements on the impl of `Grault` for `(T,)`
    |
 LL | impl<T: Grault> Grault for (T,)
    |                 ^^^^^^     ^^^^
-   = note: 1 redundant requirements hidden
+   = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Grault` for `(T,)`
 
 error[E0275]: overflow evaluating the requirement `<(T,) as Grault>::A == _`
@@ -43,7 +43,7 @@ note: required because of the requirements on the impl of `Grault` for `(T,)`
    |
 LL | impl<T: Grault> Grault for (T,)
    |                 ^^^^^^     ^^^^
-   = note: 1 redundant requirements hidden
+   = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Grault` for `(T,)`
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
When there are redundant trait requirements and these are hidden, a message is generated by the following code snippet:
`format!("{} redundant requirements hidden", count)`
But if there is only a single hidden requirement, it will still print this message in plural instead of singular.