### PR TITLE
Try to recover from a `=>` -> `=` or `->` typo in a match arm

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -295,6 +295,7 @@ impl TokenKind {
         match *self {
             Comma => Some(vec![Dot, Lt, Semi]),
             Semi => Some(vec![Colon, Comma]),
+            FatArrow => Some(vec![Eq, RArrow]),
             _ => None,
         }
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2322,7 +2322,21 @@ impl<'a> Parser<'a> {
                 None
             };
             let arrow_span = this.token.span;
-            this.expect(&token::FatArrow)?;
+            if let Err(mut err) = this.expect(&token::FatArrow) {
+                // We might have a `=>` -> `=` or `->` typo (issue #89396).
+                if let token::Eq | token::RArrow = this.token.kind {
+                    err.span_suggestion(
+                        this.token.span,
+                        "try using a fat arrow here",
+                        "=>".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
+                    err.emit();
+                    this.bump();
+                } else {
+                    return Err(err);
+                }
+            }
             let arm_start_span = this.token.span;
 
             let expr = this.parse_expr_res(Restrictions::STMT_EXPR, None).map_err(|mut err| {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2324,7 +2324,10 @@ impl<'a> Parser<'a> {
             let arrow_span = this.token.span;
             if let Err(mut err) = this.expect(&token::FatArrow) {
                 // We might have a `=>` -> `=` or `->` typo (issue #89396).
-                if let token::Eq | token::RArrow = this.token.kind {
+                if TokenKind::FatArrow
+                    .similar_tokens()
+                    .map_or(false, |similar_tokens| similar_tokens.contains(&this.token.kind))
+                {
                     err.span_suggestion(
                         this.token.span,
                         "try using a fat arrow here",

--- a/src/test/ui/parser/issue-89396.fixed
+++ b/src/test/ui/parser/issue-89396.fixed
@@ -1,0 +1,16 @@
+// Regression test for issue #89396: Try to recover from a
+// `=>` -> `=` or `->` typo in a match arm.
+
+// run-rustfix
+
+fn main() {
+    let opt = Some(42);
+    let _ = match opt {
+        Some(_) => true,
+        //~^ ERROR: expected one of
+        //~| HELP: try using a fat arrow here
+        None => false,
+        //~^ ERROR: expected one of
+        //~| HELP: try using a fat arrow here
+    };
+}

--- a/src/test/ui/parser/issue-89396.rs
+++ b/src/test/ui/parser/issue-89396.rs
@@ -1,0 +1,16 @@
+// Regression test for issue #89396: Try to recover from a
+// `=>` -> `=` or `->` typo in a match arm.
+
+// run-rustfix
+
+fn main() {
+    let opt = Some(42);
+    let _ = match opt {
+        Some(_) = true,
+        //~^ ERROR: expected one of
+        //~| HELP: try using a fat arrow here
+        None -> false,
+        //~^ ERROR: expected one of
+        //~| HELP: try using a fat arrow here
+    };
+}

--- a/src/test/ui/parser/issue-89396.stderr
+++ b/src/test/ui/parser/issue-89396.stderr
@@ -1,0 +1,20 @@
+error: expected one of `=>`, `if`, or `|`, found `=`
+  --> $DIR/issue-89396.rs:9:17
+   |
+LL |         Some(_) = true,
+   |                 ^
+   |                 |
+   |                 expected one of `=>`, `if`, or `|`
+   |                 help: try using a fat arrow here: `=>`
+
+error: expected one of `=>`, `@`, `if`, or `|`, found `->`
+  --> $DIR/issue-89396.rs:12:14
+   |
+LL |         None -> false,
+   |              ^^
+   |              |
+   |              expected one of `=>`, `@`, `if`, or `|`
+   |              help: try using a fat arrow here: `=>`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #89396.