### PR TITLE
Add `impl From<Ordering> for i32`

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -568,6 +568,18 @@ impl Ordering {
     }
 }
 
+#[stable(feature = "convert_ordering_into_i32", since = "1.57.0")]
+impl From<Ordering> for i32 {
+    /// Convert an [`Ordering`] into a signed 32-bit integer.
+    ///
+    /// This function converts an `Ordering` into an integer compatible with C
+    /// FFI. This `i32` value is compatible with the return value of C library
+    /// functions such as `strncmp`.
+    fn from(ordering: Ordering) -> Self {
+        ordering as i32
+    }
+}
+
 /// A helper struct for reverse ordering.
 ///
 /// This struct is a helper to be used with functions like [`Vec::sort_by_key`] and


### PR DESCRIPTION
This commit adds a first-class `From` conversion of `Ordering` into `i32`.

`Ordering` is defined to be compatible with the return types of the various `...cmp...` routines in the C standard library, but the only way to convert an `Ordering` to an `i32` is with a non-obvious `as` cast.

This commit adds a proper API for doing this and hides a "scary" `as` cast inside the `core` library.