### PR TITLE
Add two inline annotations for hot functions

### DIFF
--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -400,6 +400,7 @@ pub(crate) struct TyVidEqKey<'tcx> {
 }
 
 impl<'tcx> From<ty::TyVid> for TyVidEqKey<'tcx> {
+    #[inline] // make this function eligible for inlining - it is quite hot.
     fn from(vid: ty::TyVid) -> Self {
         TyVidEqKey { vid, phantom: PhantomData }
     }

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -437,6 +437,7 @@ impl EqUnifyValue for IntVarValue {}
 
 impl UnifyKey for IntVid {
     type Value = Option<IntVarValue>;
+    #[inline] // make this function eligible for inlining - it is quite hot.
     fn index(&self) -> u32 {
         self.index
     }


### PR DESCRIPTION
These two functions are essentially no-ops (and compile to just a load and
return), but show up in process_obligations profiles with a high call count --
so worthwhile to try and inline them. This is not normally possible as they're
non-generic, so they don't get offered for inlining by our current algorithm.