### PR TITLE
Fix ICE with buffered lint referring to AST node deleted by everybody_loops

### DIFF
--- a/src/test/ui/lint/issue-87308.rs
+++ b/src/test/ui/lint/issue-87308.rs
@@ -1,0 +1,12 @@
+// Regression test for issue #87308.
+
+// compile-flags: -Zunpretty=everybody_loops
+// check-pass
+
+macro_rules! foo {
+    () => { break 'x; }
+}
+
+pub fn main() {
+    'x: loop { foo!() }
+}

--- a/src/test/ui/lint/issue-87308.stdout
+++ b/src/test/ui/lint/issue-87308.stdout
@@ -1,0 +1,14 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// Regression test for issue #87308.
+
+// compile-flags: -Zunpretty=everybody_loops
+// check-pass
+
+macro_rules! foo { () => { break 'x ; } }
+
+pub fn main() { loop { } }


### PR DESCRIPTION
Fixes #87308. Note the following comment:
https://github.com/rust-lang/rust/blob/08759c691e2e9799a3c6780ffdf910240ebd4a6b/compiler/rustc_lint/src/early.rs#L415-L417

As it turns out, this is not _always_ a bug, because `-Zunpretty=everybody_loops` causes a lot of AST nodes to be deleted, and thus some buffered lints will refer to non-existent node ids. To fix this, my changes simply ignore buffered lints if `-Zunpretty=everybody_loops` is enabled, which, from my understanding, shouldn't be a big issue because it only affects pretty-printing. Of course, a more elegant solution would only ignore buffered lints that actually point at deleted node ids, but I haven't figured out an easy way of achieving this.

For the concrete example in #87308, the buffered lint is created [here](https://github.com/rust-lang/rust/blob/08759c691e2e9799a3c6780ffdf910240ebd4a6b/compiler/rustc_expand/src/mbe/macro_rules.rs#L145-L151) with the `lint_node_id` from [here](https://github.com/rust-lang/rust/blob/08759c691e2e9799a3c6780ffdf910240ebd4a6b/compiler/rustc_expand/src/mbe/macro_rules.rs#L319), i.e. it points at the macro _expansion_, which then gets deleted by `ReplaceBodyWithLoop` [here](https://github.com/rust-lang/rust/blob/08759c691e2e9799a3c6780ffdf910240ebd4a6b/compiler/rustc_interface/src/passes.rs#L377).