### PR TITLE
Fix Lower/UpperExp formatting for integers and precision zero

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -305,7 +305,6 @@ macro_rules! impl_Exp {
                     n /= 10;
                     exponent += 1;
                 }
-                let trailing_zeros = exponent;
 
                 let (added_precision, subtracted_precision) = match f.precision() {
                     Some(fmt_prec) => {
@@ -333,7 +332,7 @@ macro_rules! impl_Exp {
                         n += 1;
                     }
                 }
-                (n, exponent, trailing_zeros, added_precision)
+                (n, exponent, exponent, added_precision)
             };
 
             // 39 digits (worst case u128) + . = 40

--- a/library/core/tests/fmt/num.rs
+++ b/library/core/tests/fmt/num.rs
@@ -146,7 +146,7 @@ fn test_format_int_exp_precision() {
     assert_eq!(format!("{:.1000e}", 1), format!("1.{}e0", "0".repeat(1000)));
     //test zero precision
     assert_eq!(format!("{:.0e}", 1), format!("1e0",));
-    assert_eq!(format!("{:.0e}", 25), format!("3e1",));
+    assert_eq!(format!("{:.0e}", 35), format!("4e1",));
 
     //test padding with precision (and sign)
     assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");

--- a/library/core/tests/fmt/num.rs
+++ b/library/core/tests/fmt/num.rs
@@ -146,6 +146,7 @@ fn test_format_int_exp_precision() {
     assert_eq!(format!("{:.1000e}", 1), format!("1.{}e0", "0".repeat(1000)));
     //test zero precision
     assert_eq!(format!("{:.0e}", 1), format!("1e0",));
+    assert_eq!(format!("{:.0e}", 25), format!("3e1",));
 
     //test padding with precision (and sign)
     assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");


### PR DESCRIPTION
Fixes the integer part of #89493 (I daren't touch the floating-point formatting code). The issue is that the "subtracted" precision essentially behaves like extra trailing zeros, but this is not currently reflected in the code properly.