### PR TITLE
Don't suggest replacing region with 'static in NLL

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
@@ -171,9 +171,7 @@ impl OutlivesSuggestionBuilder {
         let outlived_fr_name = self.region_vid_to_name(mbcx, errci.outlived_fr);
 
         if let (Some(fr_name), Some(outlived_fr_name)) = (fr_name, outlived_fr_name) {
-            if let RegionNameSource::Static = outlived_fr_name.source {
-                diag.help(&format!("consider replacing `{}` with `'static`", fr_name));
-            } else {
+            if !matches!(outlived_fr_name.source, RegionNameSource::Static) {
                 diag.help(&format!(
                     "consider adding the following bound: `{}: {}`",
                     fr_name, outlived_fr_name

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
@@ -5,8 +5,6 @@ LL | fn baz<'a,'b>(x: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |    bar(foo, x)
    |    ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
@@ -6,8 +6,6 @@ LL | fn baz<'a, 'b>(x: Type<'a>) -> Type<'static> {
 ...
 LL |     bar(foo, x)
    |     ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -18,8 +18,6 @@ LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
 ...
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |                                                 ^ requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:32:49

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
@@ -17,8 +17,6 @@ LL | fn expect_bound_supply_named<'x>() {
 ...
 LL |     closure_expecting_bound(|x: &'x u32| {
    |                              ^ requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
@@ -14,8 +14,6 @@ LL | fn give_some<'a>() {
    |              -- lifetime `'a` defined here
 LL |     want_hrtb::<&'a u32>()
    |     ^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: implementation of `Foo` is not general enough
   --> $DIR/hrtb-just-for-static.rs:30:5

--- a/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
@@ -54,8 +54,6 @@ LL | fn foo_hrtb_bar_not<'b, T>(mut t: T)
 ...
 LL |     foo_hrtb_bar_not(&mut t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 error: implementation of `Bar` is not general enough
   --> $DIR/hrtb-perfect-forwarding.rs:43:5

--- a/src/test/ui/impl-header-lifetime-elision/dyn-trait.nll.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/dyn-trait.nll.stderr
@@ -5,8 +5,6 @@ LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
    |                              - `x` is a reference that is only valid in the function body
 LL |     static_val(x);
    |     ^^^^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -19,7 +19,6 @@ LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
    |             |
    |             lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy + 'a { x }
@@ -41,7 +40,6 @@ error: lifetime may not live long enough
 LL | fn explicit2<'a>(x: &'a i32) -> impl Copy + 'static { x }
    |              -- lifetime `'a` defined here            ^ returning this value requires that `'a` must outlive `'static`
    |
-   = help: consider replacing `'a` with `'static`
    = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `x`
@@ -66,7 +64,6 @@ error: lifetime may not live long enough
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
    |
-   = help: consider replacing `'a` with `'static`
    = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
@@ -19,7 +19,6 @@ LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
    |                    |
    |                    lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {

--- a/src/test/ui/issues/issue-10291.nll.stderr
+++ b/src/test/ui/issues/issue-10291.nll.stderr
@@ -6,8 +6,6 @@ LL | fn test<'x>(x: &'x isize) {
 LL |     drop::<Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
 LL |         x
    |         ^ returning this value requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-26217.nll.stderr
+++ b/src/test/ui/issues/issue-26217.nll.stderr
@@ -5,8 +5,6 @@ LL | fn bar<'a>() {
    |        -- lifetime `'a` defined here
 LL |     foo::<&'a i32>();
    |     ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54943.nll.stderr
+++ b/src/test/ui/issues/issue-54943.nll.stderr
@@ -6,8 +6,6 @@ LL | fn boo<'a>() {
 ...
 LL |     let x = foo::<&'a u32>();
    |             ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-55796.nll.stderr
+++ b/src/test/ui/issues/issue-55796.nll.stderr
@@ -6,8 +6,6 @@ LL | pub trait Graph<'a> {
 ...
 LL |         Box::new(self.out_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55796.rs:23:9
@@ -17,8 +15,6 @@ LL | pub trait Graph<'a> {
 ...
 LL |         Box::new(self.in_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-75777.nll.stderr
+++ b/src/test/ui/issues/issue-75777.nll.stderr
@@ -6,8 +6,6 @@ LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> Bo
 LL |     let fut: BoxFuture<'a, A> = Box::pin(future::ready(v));
 LL |     Box::new(move |_| fut)
    |     ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-bound-will-change-warning.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-bound-will-change-warning.nll.stderr
@@ -6,8 +6,6 @@ LL | fn test2<'a>(x: &'a Box<dyn Fn() + 'a>) {
 LL |     // but ref_obj will not, so warn.
 LL |     ref_obj(x)
    |     ^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/lifetime-bound-will-change-warning.rs:39:5
@@ -17,8 +15,6 @@ LL | fn test2cc<'a>(x: &'a Box<dyn Fn() + 'a>) {
 LL |     // same as test2, but cross crate
 LL |     lib::ref_obj(x)
    |     ^^^^^^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lub-if.nll.stderr
+++ b/src/test/ui/lub-if.nll.stderr
@@ -6,8 +6,6 @@ LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |         s
    |         ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/lub-if.rs:35:9
@@ -17,8 +15,6 @@ LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |         s
    |         ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lub-match.nll.stderr
+++ b/src/test/ui/lub-match.nll.stderr
@@ -6,8 +6,6 @@ LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |             s
    |             ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/lub-match.rs:39:13
@@ -17,8 +15,6 @@ LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |             s
    |             ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -46,8 +46,6 @@ LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |______^ `cell_a` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -46,8 +46,6 @@ LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |______^ `cell_a` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(x: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     &*x
    |     ^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-50716.nll.stderr
+++ b/src/test/ui/nll/issue-50716.nll.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
 ...
 LL |     let _x = *s;
    |              ^^ proving this value is `Sized` requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55401.nll.stderr
+++ b/src/test/ui/nll/issue-55401.nll.stderr
@@ -6,8 +6,6 @@ LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u
 LL |     let (ref y, _z): (&'a u32, u32) = (&22, 44);
 LL |     *y
    |     ^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-58299.stderr
+++ b/src/test/ui/nll/issue-58299.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a>(x: i32) {
 ...
 LL |         A::<'a>::X..=A::<'static>::X => (),
    |         ^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-58299.rs:24:27
@@ -17,8 +15,6 @@ LL | fn bar<'a>(x: i32) {
 ...
 LL |         A::<'static>::X..=A::<'a>::X => (),
    |                           ^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-73159-rpit-static.rs
+++ b/src/test/ui/nll/issue-73159-rpit-static.rs
@@ -1,0 +1,14 @@
+// Regression test for issue #73159
+// Tests thar we don't suggest replacing 'a with 'static'
+
+#![feature(nll)]
+
+struct Foo<'a>(&'a [u8]);
+
+impl<'a> Foo<'a> {
+    fn make_it(&self) -> impl Iterator<Item = u8> { //~ ERROR lifetime may not live
+        self.0.iter().copied()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-73159-rpit-static.stderr
+++ b/src/test/ui/nll/issue-73159-rpit-static.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-73159-rpit-static.rs:9:26
+   |
+LL | impl<'a> Foo<'a> {
+   |      -- lifetime `'a` defined here
+LL |     fn make_it(&self) -> impl Iterator<Item = u8> {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ opaque type requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+

--- a/src/test/ui/nll/mir_check_cast_reify.stderr
+++ b/src/test/ui/nll/mir_check_cast_reify.stderr
@@ -6,8 +6,6 @@ LL | fn bar<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     f(x)
    |     ^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
@@ -6,8 +6,6 @@ LL | fn bar<'a>(input: &'a u32, f: fn(&'a u32) -> &'a u32) -> &'static u32 {
 ...
 LL |     unsafe { g(input) }
    |              ^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -5,8 +5,6 @@ LL | fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
    |        -- lifetime `'a` defined here
 LL |     x
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/outlives-suggestion-more.stderr
+++ b/src/test/ui/nll/outlives-suggestion-more.stderr
@@ -46,8 +46,6 @@ LL | fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usi
    |             -- lifetime `'b` defined here
 LL |     (x, y)
    |     ^^^^^^ returning this value requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 help: the following changes may resolve your lifetime errors
    |
@@ -88,8 +86,6 @@ LL | fn foo3<'a, 'b, 'c, 'd, 'e>(
 ...
 LL |     (x, y, z)
    |     ^^^^^^^^^ returning this value requires that `'c` must outlive `'static`
-   |
-   = help: consider replacing `'c` with `'static`
 
 help: the following changes may resolve your lifetime errors
    |

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -17,8 +17,6 @@ LL | fn foo2<'a>(x: &'a usize) -> &'static usize {
    |         -- lifetime `'a` defined here
 LL |     x
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
@@ -66,8 +64,6 @@ LL |     pub fn foo<'a>(x: &'a usize) -> Self {
    |                -- lifetime `'a` defined here
 LL |         Foo { x }
    |         ^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:41:9

--- a/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
+++ b/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
@@ -6,8 +6,6 @@ LL | fn uninit<'a>() {
 LL |     return;
 LL |     let x: &'static &'a ();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:13:12
@@ -17,8 +15,6 @@ LL | fn var_type<'a>() {
 LL |     return;
 LL |     let x: &'static &'a () = &&();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:17:12
@@ -27,8 +23,6 @@ LL | fn uninit_infer<'a>() {
    |                 -- lifetime `'a` defined here
 LL |     let x: &'static &'a _;
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:23:12
@@ -38,8 +32,6 @@ LL | fn infer<'a>() {
 LL |     return;
 LL |     let x: &'static &'a _ = &&();
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:28:12
@@ -49,8 +41,6 @@ LL | fn uninit_no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a ();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:33:12
@@ -60,8 +50,6 @@ LL | fn no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a () = &&();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:38:12
@@ -71,8 +59,6 @@ LL | fn infer_no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a _ = &&();
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:51:12
@@ -82,8 +68,6 @@ LL | fn required_substs<'a>() {
 LL |     return;
 LL |     let _: C<'static, 'a, _> = C((), &(), &());
    |            ^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/nll/user-annotations/closure-substs.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a>() {
 ...
 LL |         return x;
    |                ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/closure-substs.rs:15:16
@@ -25,8 +23,6 @@ LL | fn bar<'a>() {
 ...
 LL |         b(x);
    |         ^^^^ argument requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of closure
   --> $DIR/closure-substs.rs:29:9

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <Foo<'a>>::C
    |     ^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <T as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     T::C
    |     ^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
@@ -5,8 +5,6 @@ LL | fn non_wf_associated_const<'a>(x: i32) {
    |                            -- lifetime `'a` defined here
 LL |     A::<'a>::IC;
    |     ^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/issue-54124.stderr
+++ b/src/test/ui/nll/user-annotations/issue-54124.stderr
@@ -15,8 +15,6 @@ LL | fn test<'a>() {
    |         -- lifetime `'a` defined here
 LL |     let _:fn(&()) = |_:&'a ()| {};
    |                      ^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
@@ -6,8 +6,6 @@ LL | fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:49:5
@@ -17,8 +15,6 @@ LL | fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:62:5
@@ -28,8 +24,6 @@ LL | fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
+++ b/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
@@ -6,8 +6,6 @@ LL | fn coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 LL |     let ((y, _z),) = ((s, _x),): (PairCoupledTypes<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:22:5
@@ -17,8 +15,6 @@ LL | fn coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 LL |     let ((y, _z),) = ((s, _x),): (PairCoupledRegions<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:32:5
@@ -28,8 +24,6 @@ LL | fn cast_coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32
 LL |     let ((y, _z),) = ((s, _x),) as (PairCoupledTypes<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:37:5
@@ -39,8 +33,6 @@ LL | fn cast_coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u
 LL |     let ((y, _z),) = ((s, _x),) as (PairCoupledRegions<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -156,8 +156,6 @@ LL | fn static_to_a_to_static_through_variable<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:125:5
@@ -167,8 +165,6 @@ LL | fn static_to_a_to_static_through_tuple<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:130:5
@@ -178,8 +174,6 @@ LL | fn static_to_a_to_static_through_struct<'a>(_x: &'a u32) -> &'static u32 {
 LL |     let Single { value: y }: Single<&'a u32> = Single { value: &22 };
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:134:18
@@ -188,8 +182,6 @@ LL | fn a_to_static_then_static<'a>(x: &'a u32) -> &'static u32 {
    |                            -- lifetime `'a` defined here
 LL |     let (y, _z): (&'static u32, u32) = (x, 44);
    |                  ^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
@@ -5,8 +5,6 @@ LL | fn c<'a>(t: &'a Box<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      -- lifetime `'a` defined here
 LL |     ss.t = t;
    |     ^^^^^^^^ assignment requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
@@ -5,8 +5,6 @@ LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      -- lifetime `'a` defined here
 LL |     ss.t = t;
    |     ^^^^^^^^ assignment requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
@@ -18,8 +18,6 @@ LL | fn load2<'a>(ss: &MyBox<dyn SomeTrait + 'a>) -> MyBox<dyn SomeTrait + 'a> {
    |              -- `ss` is a reference that is only valid in the function body
 LL |     load0(ss)
    |     ^^^^^^^^^ `ss` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/region-invariant-static-error-reporting.nll.stderr
+++ b/src/test/ui/regions/region-invariant-static-error-reporting.nll.stderr
@@ -6,8 +6,6 @@ LL | fn unify<'a>(x: Option<Invariant<'a>>, f: fn(Invariant<'a>)) {
 LL |     let bad = if x.is_some() {
 LL |         x.unwrap()
    |         ^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
@@ -5,8 +5,6 @@ LL | fn param_not_ok<'a>(x: &'a isize) {
    |                 -- lifetime `'a` defined here
 LL |     assert_send::<&'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:26:5
@@ -15,8 +13,6 @@ LL | fn param_not_ok1<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a str>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:30:5
@@ -25,8 +21,6 @@ LL | fn param_not_ok2<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a [isize]>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:44:5
@@ -35,8 +29,6 @@ LL | fn box_with_region_not_ok<'a>() {
    |                           -- lifetime `'a` defined here
 LL |     assert_send::<Box<&'a isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:55:5
@@ -45,8 +37,6 @@ LL | fn unsafe_ok2<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*const &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:59:5
@@ -55,8 +45,6 @@ LL | fn unsafe_ok3<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*mut &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
@@ -5,8 +5,6 @@ LL | fn caller<'a>(x: &isize) {
    |           -- lifetime `'a` defined here
 LL |     Foo.some_method::<&'a isize>();
    |         ^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-2.rs:9:5

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -29,8 +29,6 @@ LL | fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-4.rs:9:5

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-nested-fns.nll.stderr
+++ b/src/test/ui/regions/regions-nested-fns.nll.stderr
@@ -45,8 +45,6 @@ LL | fn nested<'x>(x: &'x isize) {
 ...
 LL |         if false { return x; }
    |                           ^ returning this value requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
@@ -5,8 +5,6 @@ LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:14:5

--- a/src/test/ui/regions/regions-static-bound.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.nll.stderr
@@ -5,8 +5,6 @@ LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:14:5

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
@@ -6,8 +6,6 @@ LL | fn use_<'b>(c: Invariant<'b>) {
 ...
 LL |     let _: Invariant<'static> = c;
    |            ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.nll.stderr
+++ b/src/test/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.nll.stderr
@@ -5,8 +5,6 @@ LL |     fn use_it<'a, T>(val: &'a dyn ObjectTrait<T>) -> impl OtherTrait<'a> + 
    |                      --- `val` is a reference that is only valid in the function body
 LL |         val.use_self::<T>()
    |         ^^^^^^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:69:9
@@ -15,8 +13,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         val.use_self()
    |         ^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:88:9
@@ -25,8 +21,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         val.use_self()
    |         ^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:108:9
@@ -35,8 +29,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         MyTrait::use_self(val)
    |         ^^^^^^^^^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
@@ -32,8 +32,6 @@ LL | |             current: None,
 LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:60:30
@@ -43,7 +41,6 @@ LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> {
    |             |
    |             lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> + 'a {

--- a/src/test/ui/variance/variance-associated-types2.nll.stderr
+++ b/src/test/ui/variance/variance-associated-types2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn take<'a>(_: &'a u32) {
    |         -- lifetime `'a` defined here
 LL |     let _: Box<dyn Foo<Bar = &'a u32>> = make();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
@@ -5,8 +5,6 @@ LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &
    |                     ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:7:5
@@ -15,8 +13,6 @@ LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (
    |                     ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:10:5
@@ -25,8 +21,6 @@ LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &
    |                        ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:13:5
@@ -35,8 +29,6 @@ LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (
    |                        ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:17:5
@@ -45,8 +37,6 @@ LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a
    |                      ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:20:5
@@ -55,8 +45,6 @@ LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a
    |                      ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:23:5
@@ -65,8 +53,6 @@ LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a
    |                         ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:26:5
@@ -75,8 +61,6 @@ LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a
    |                         ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:31:5
@@ -86,8 +70,6 @@ LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
 LL |                          -> OccupiedEntry<'a, &'new (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:35:5
@@ -97,8 +79,6 @@ LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
 LL |                          -> OccupiedEntry<'a, (), &'new ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:39:5
@@ -108,8 +88,6 @@ LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
 LL |                             -> OccupiedEntry<'a, &'static (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:43:5
@@ -119,8 +97,6 @@ LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
 LL |                             -> OccupiedEntry<'a, (), &'static ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:48:5
@@ -130,8 +106,6 @@ LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
 LL |                          -> VacantEntry<'a, &'new (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:52:5
@@ -141,8 +115,6 @@ LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
 LL |                          -> VacantEntry<'a, (), &'new ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:56:5
@@ -152,8 +124,6 @@ LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
 LL |                             -> VacantEntry<'a, &'static (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:60:5
@@ -163,8 +133,6 @@ LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
 LL |                             -> VacantEntry<'a, (), &'static ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #73159

This is similar to #69350 - if the user didn't initially
write out a 'static lifetime, adding 'static in response to
a lifetime error is usually the wrong thing to do.