### PR TITLE
Stabilize `unreachable_unchecked` as `const fn`

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -44,7 +44,7 @@ use crate::intrinsics;
 /// ```
 #[inline]
 #[stable(feature = "unreachable", since = "1.27.0")]
-#[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
+#[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]
 pub const unsafe fn unreachable_unchecked() -> ! {
     // SAFETY: the safety contract for `intrinsics::unreachable` must
     // be upheld by the caller.

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -735,7 +735,7 @@ extern "rust-intrinsic" {
     /// reach code marked with this function.
     ///
     /// The stabilized version of this intrinsic is [`core::hint::unreachable_unchecked`].
-    #[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
+    #[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]
     pub fn unreachable() -> !;
 
     /// Informs the optimizer that a condition is always true.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -103,7 +103,6 @@
 #![feature(const_trait_impl)]
 #![feature(const_type_id)]
 #![feature(const_type_name)]
-#![feature(const_unreachable_unchecked)]
 #![feature(const_default_impls)]
 #![feature(duration_consts_2)]
 #![feature(ptr_metadata)]

--- a/src/test/ui/consts/const_unsafe_unreachable.rs
+++ b/src/test/ui/consts/const_unsafe_unreachable.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(const_unreachable_unchecked)]
-
 const unsafe fn foo(x: bool) -> bool {
     match x {
         true => true,
@@ -12,5 +10,5 @@ const unsafe fn foo(x: bool) -> bool {
 const BAR: bool = unsafe { foo(true) };
 
 fn main() {
-  assert_eq!(BAR, true);
+    assert_eq!(BAR, true);
 }

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.rs
@@ -1,5 +1,4 @@
 // error-pattern: evaluation of constant value failed
-#![feature(const_unreachable_unchecked)]
 
 const unsafe fn foo(x: bool) -> bool {
     match x {
@@ -11,5 +10,5 @@ const unsafe fn foo(x: bool) -> bool {
 const BAR: bool = unsafe { foo(false) };
 
 fn main() {
-  assert_eq!(BAR, true);
+    assert_eq!(BAR, true);
 }

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -7,13 +7,13 @@ LL |     unsafe { intrinsics::unreachable() }
    |              entering unreachable code
    |              inside `unreachable_unchecked` at $SRC_DIR/core/src/hint.rs:LL:COL
    |
-  ::: $DIR/const_unsafe_unreachable_ub.rs:7:18
+  ::: $DIR/const_unsafe_unreachable_ub.rs:6:18
    |
 LL |         false => std::hint::unreachable_unchecked(),
-   |                  ---------------------------------- inside `foo` at $DIR/const_unsafe_unreachable_ub.rs:7:18
+   |                  ---------------------------------- inside `foo` at $DIR/const_unsafe_unreachable_ub.rs:6:18
 ...
 LL | const BAR: bool = unsafe { foo(false) };
-   |                            ---------- inside `BAR` at $DIR/const_unsafe_unreachable_ub.rs:11:28
+   |                            ---------- inside `BAR` at $DIR/const_unsafe_unreachable_ub.rs:10:28
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Closes #53188

This PR stabilizes `core::hint::unreachable_unchecked` as `const fn`. MIRI is able to detect when this method is called. Stabilization was delayed until `const_panic` was stabilized so as to avoid users calling this method in its place (thus resulting in runtime UB). With #89508, that is no longer an issue.

@rustbot label +A-const-eval +A-const-fn +T-lang +S-blocked

(not sure why it's T-lang, but that's what the tracking issue is)