### PR TITLE
BTree: refactor clone, mostly for readability

### DIFF
--- a/library/alloc/src/collections/btree/bare_tree.rs
+++ b/library/alloc/src/collections/btree/bare_tree.rs
@@ -1,0 +1,54 @@
+use super::node::{marker, NodeRef};
+
+/// Simple tree around a raw `NodeRef`, that provides a destructor.
+/// Unlike smarter sister `BTreeMap`, it does not keep track of element count,
+/// does not allow replacing the root, therefore can be statically tyoed by the
+/// node type of the root, and cannot represent a tree without root node
+/// (its `Option` exists only to disable the `drop` method when needed).
+pub struct BareTree<K, V, RootType>(Option<NodeRef<marker::Owned, K, V, RootType>>);
+
+impl<K, V, RootType> Drop for BareTree<K, V, RootType> {
+    fn drop(&mut self) {
+        if let Some(root) = self.0.take() {
+            let mut cur_edge = root.forget_type().into_dying().first_leaf_edge();
+            while let Some((next_edge, kv)) = unsafe { cur_edge.deallocating_next() } {
+                unsafe { kv.drop_key_val() };
+                cur_edge = next_edge;
+            }
+        }
+    }
+}
+
+impl<K, V> BareTree<K, V, marker::Leaf> {
+    /// Returns a new tree consisting of a single leaf that is initially empty.
+    pub fn new_leaf() -> Self {
+        Self(Some(NodeRef::new_leaf()))
+    }
+}
+
+impl<K, V> BareTree<K, V, marker::Internal> {
+    /// Returns a new tree with an internal root, that initially has no elements
+    /// and one child.
+    pub fn new_internal(child: NodeRef<marker::Owned, K, V, marker::LeafOrInternal>) -> Self {
+        Self(Some(NodeRef::new_internal(child)))
+    }
+}
+
+impl<K, V, RootType> BareTree<K, V, RootType> {
+    /// Mutably borrows the owned root node.
+    pub fn borrow_mut(&mut self) -> NodeRef<marker::Mut<'_>, K, V, RootType> {
+        self.0.as_mut().unwrap().borrow_mut()
+    }
+
+    /// Removes any static information asserting that the root is a `Leaf` or
+    /// `Internal` node.
+    pub fn forget_root_type(mut self) -> BareTree<K, V, marker::LeafOrInternal> {
+        BareTree(self.0.take().map(NodeRef::forget_type))
+    }
+
+    /// Consumes the tree, returning a `NodeRef` that still enforces ownership
+    /// but lacks a destructor.
+    pub fn into_inner(mut self) -> NodeRef<marker::Owned, K, V, RootType> {
+        self.0.take().unwrap()
+    }
+}

--- a/library/alloc/src/collections/btree/mod.rs
+++ b/library/alloc/src/collections/btree/mod.rs
@@ -1,4 +1,5 @@
 mod append;
+mod bare_tree;
 mod borrow;
 mod dedup_sorted_iter;
 mod fix;

--- a/library/alloc/src/collections/btree/navigate.rs
+++ b/library/alloc/src/collections/btree/navigate.rs
@@ -441,7 +441,7 @@ impl<K, V> Handle<NodeRef<marker::Dying, K, V, marker::Leaf>, marker::Edge> {
     ///   `deallocating_next_back`.
     /// - The returned KV handle is only valid to access the key and value,
     ///   and only valid until the next call to a `deallocating_` method.
-    unsafe fn deallocating_next(
+    pub unsafe fn deallocating_next(
         self,
     ) -> Option<(Self, Handle<NodeRef<marker::Dying, K, V, marker::LeafOrInternal>, marker::KV>)>
     {


### PR DESCRIPTION
Simplifies the `clone` member, in particular its `clone_subtree` function, at the expense of having more code elsewhere, which might be reusable but wasn't reused up to now. The new destructor exploits the fact that the underlying navigation code spots the end of the tree itself, if we destroy the tree in a single direction. In theory, this performs whimsically better than before because it no longer keeps track of the number of elements already cloned, just in case the clone needs to be rolled back after a panic.