### PR TITLE
Add vectored positioned I/O on Unix

### DIFF
--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -60,11 +60,7 @@ pub trait FileExt {
     /// written to possibly being only partially filled. This method must behave
     /// equivalently to a single call to read with concatenated buffers.
     #[unstable(feature = "unix_file_vectored_at", issue = "89517")]
-    fn read_vectored_at(
-        &mut self,
-        bufs: &mut [io::IoSliceMut<'_>],
-        offset: u64,
-    ) -> io::Result<usize> {
+    fn read_vectored_at(&self, bufs: &mut [io::IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         io::default_read_vectored(|b| self.read_at(b, offset), bufs)
     }
 
@@ -175,7 +171,7 @@ pub trait FileExt {
     /// from possibly being only partially consumed. This method must behave as
     /// a call to `write_at` with the buffers concatenated would.
     #[unstable(feature = "unix_file_vectored_at", issue = "89517")]
-    fn write_vectored_at(&mut self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
+    fn write_vectored_at(&self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
         io::default_write_vectored(|b| self.write_at(b, offset), bufs)
     }
 
@@ -242,17 +238,13 @@ impl FileExt for fs::File {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.as_inner().read_at(buf, offset)
     }
-    fn read_vectored_at(
-        &mut self,
-        bufs: &mut [io::IoSliceMut<'_>],
-        offset: u64,
-    ) -> io::Result<usize> {
+    fn read_vectored_at(&self, bufs: &mut [io::IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         self.as_inner().read_vectored_at(bufs, offset)
     }
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         self.as_inner().write_at(buf, offset)
     }
-    fn write_vectored_at(&mut self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
+    fn write_vectored_at(&self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
         self.as_inner().write_vectored_at(bufs, offset)
     }
 }

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -54,6 +54,20 @@ pub trait FileExt {
     #[stable(feature = "file_offset", since = "1.15.0")]
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
 
+    /// Like `read_at`, except that it reads into a slice of buffers.
+    ///
+    /// Data is copied to fill each buffer in order, with the final buffer
+    /// written to possibly being only partially filled. This method must behave
+    /// equivalently to a single call to read with concatenated buffers.
+    #[unstable(feature = "unix_file_vectored_at", issue = "89517")]
+    fn read_vectored_at(
+        &mut self,
+        bufs: &mut [io::IoSliceMut<'_>],
+        offset: u64,
+    ) -> io::Result<usize> {
+        io::default_read_vectored(|b| self.read_at(b, offset), bufs)
+    }
+
     /// Reads the exact number of byte required to fill `buf` from the given offset.
     ///
     /// The offset is relative to the start of the file and thus independent
@@ -155,6 +169,16 @@ pub trait FileExt {
     #[stable(feature = "file_offset", since = "1.15.0")]
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
 
+    /// Like `write_at`, except that it writes from a slice of buffers.
+    ///
+    /// Data is copied from each buffer in order, with the final buffer read
+    /// from possibly being only partially consumed. This method must behave as
+    /// a call to `write_at` with the buffers concatenated would.
+    #[unstable(feature = "unix_file_vectored_at", issue = "89517")]
+    fn write_vectored_at(&mut self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
+        io::default_write_vectored(|b| self.write_at(b, offset), bufs)
+    }
+
     /// Attempts to write an entire buffer starting from a given offset.
     ///
     /// The offset is relative to the start of the file and thus independent
@@ -218,8 +242,18 @@ impl FileExt for fs::File {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         self.as_inner().read_at(buf, offset)
     }
+    fn read_vectored_at(
+        &mut self,
+        bufs: &mut [io::IoSliceMut<'_>],
+        offset: u64,
+    ) -> io::Result<usize> {
+        self.as_inner().read_vectored_at(bufs, offset)
+    }
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         self.as_inner().write_at(buf, offset)
+    }
+    fn write_vectored_at(&mut self, bufs: &[io::IoSlice<'_>], offset: u64) -> io::Result<usize> {
+        self.as_inner().write_vectored_at(bufs, offset)
     }
 }
 

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -17,6 +17,10 @@ use crate::sealed::Sealed;
 #[allow(unused_imports)]
 use io::{Read, Write};
 
+// Tests for this module
+#[cfg(test)]
+mod tests;
+
 /// Unix-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
 pub trait FileExt {

--- a/library/std/src/os/unix/fs/tests.rs
+++ b/library/std/src/os/unix/fs/tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[test]
+fn read_vectored_at() {
+    let msg = b"preadv is working!";
+    let dir = crate::sys_common::io::test::tmpdir();
+
+    let filename = dir.join("preadv.txt");
+    {
+        let mut file = fs::File::create(&filename).unwrap();
+        file.write_all(msg).unwrap();
+    }
+    {
+        let file = fs::File::open(&filename).unwrap();
+        let mut buf0 = [0; 4];
+        let mut buf1 = [0; 3];
+
+        let mut iovec = [io::IoSliceMut::new(&mut buf0), io::IoSliceMut::new(&mut buf1)];
+
+        let n = file.read_vectored_at(&mut iovec, 4).unwrap();
+
+        assert!(n == 4 || n == 7);
+        assert_eq!(&buf0, b"dv i");
+
+        if n == 7 {
+            assert_eq!(&buf1, b"s w");
+        }
+    }
+}
+
+#[test]
+fn write_vectored_at() {
+    let msg = b"pwritev is not working!";
+    let dir = crate::sys_common::io::test::tmpdir();
+
+    let filename = dir.join("preadv.txt");
+    {
+        let mut file = fs::File::create(&filename).unwrap();
+        file.write_all(msg).unwrap();
+    }
+    let expected = {
+        let file = fs::File::options().write(true).open(&filename).unwrap();
+        let buf0 = b"    ";
+        let buf1 = b"great  ";
+
+        let iovec = [io::IoSlice::new(buf0), io::IoSlice::new(buf1)];
+
+        let n = file.write_vectored_at(&iovec, 11).unwrap();
+
+        assert!(n == 4 || n == 11);
+
+        if n == 4 { b"pwritev is     working!" } else { b"pwritev is     great  !" }
+    };
+
+    let content = fs::read(&filename).unwrap();
+    assert_eq!(&content, expected);
+}

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1098,6 +1098,10 @@ impl File {
         self.0.read_buf(cursor)
     }
 
+    pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
+        self.0.read_vectored_at(bufs, offset)
+    }
+
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }
@@ -1113,6 +1117,10 @@ impl File {
 
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         self.0.write_at(buf, offset)
+    }
+
+    pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
+        self.0.write_vectored_at(bufs, offset)
     }
 
     pub fn flush(&self) -> io::Result<()> {


### PR DESCRIPTION
Add methods for vectored I/O with an offset on `File` for `unix` under `#![feature(unix_file_vectored_at)]`.

The new methods are wrappers around `preadv` and `pwritev`.

Tracking issue: #89517