### PR TITLE
Don't rebuild GUI test crates every time you run test src/test/rustdoc-gui

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -905,7 +905,7 @@ impl Step for RustdocGUI {
         let out_dir = builder.test_out(self.target).join("rustdoc-gui");
 
         // We remove existing folder to be sure there won't be artifacts remaining.
-        let _ = fs::remove_dir_all(&out_dir);
+        builder.clear_if_dirty(&out_dir, &builder.rustdoc(self.compiler));
 
         let src_path = builder.build.src.join("src/test/rustdoc-gui/src");
         // We generate docs for the libraries present in the rustdoc-gui's src folder.


### PR DESCRIPTION
This method has multiple advantages:

 * It'll completely remove the rustdoc-GUI test doc folder if rustdoc was updated
 * It'll rebuild GUI test crates only they have been updated

All in all, it's quite convenient! (even more with https://github.com/rust-lang/rust/pull/88816)

r? @Mark-Simulacrum  