### PR TITLE
Document behavior of  `MaybeLiveLocals` regarding enums and field-senstivity

### DIFF
--- a/src/test/ui/mir-dataflow/liveness-enum.rs
+++ b/src/test/ui/mir-dataflow/liveness-enum.rs
@@ -1,0 +1,22 @@
+#![feature(core_intrinsics, rustc_attrs)]
+
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_liveness, stop_after_dataflow)]
+fn foo() -> Option<i32> {
+    let mut x = None;
+
+    // `x` is live here since it is used in the next statement...
+    rustc_peek(x);
+
+    dbg!(x);
+
+    // But not here, since it is overwritten below
+    rustc_peek(x); //~ ERROR rustc_peek: bit not set
+
+    x = Some(4);
+
+    x
+}
+
+fn main() {}

--- a/src/test/ui/mir-dataflow/liveness-enum.stderr
+++ b/src/test/ui/mir-dataflow/liveness-enum.stderr
@@ -1,0 +1,10 @@
+error: rustc_peek: bit not set
+  --> $DIR/liveness-enum.rs:15:5
+   |
+LL |     rustc_peek(x);
+   |     ^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This arose from a [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/MaybeLiveLocals.20and.20Discriminants) where a new contributor attempted to implement a dead-store elimination pass using this analysis. They ran into a nasty hack around `SetDiscriminant`, which lets us handle assignments of literals to enum-typed locals (e.g. `x = Some(4)`) correctly. This took me a while to figure out.

Document this oddity, so the next person will have an easier time, and add a test to enshrine the current behavior.

r? @tmiasko