### PR TITLE
Introduce `tcx.get_diagnostic_name`

### DIFF
--- a/compiler/rustc_hir/src/diagnostic_items.rs
+++ b/compiler/rustc_hir/src/diagnostic_items.rs
@@ -1,0 +1,17 @@
+use crate::def_id::DefId;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_span::Symbol;
+
+#[derive(Debug, Default)]
+pub struct DiagnosticItems {
+    pub id_to_name: FxHashMap<DefId, Symbol>,
+    pub name_to_id: FxHashMap<Symbol, DefId>,
+}
+
+impl<CTX: crate::HashStableContext> HashStable<CTX> for DiagnosticItems {
+    #[inline]
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+        self.name_to_id.hash_stable(ctx, hasher);
+    }
+}

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -18,6 +18,7 @@ mod arena;
 pub mod def;
 pub mod def_path_hash_map;
 pub mod definitions;
+pub mod diagnostic_items;
 pub use rustc_span::def_id;
 mod hir;
 pub mod hir_id;

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -54,9 +54,10 @@ impl<'tcx> LateLintPass<'tcx> for NonPanicFmt {
                     || Some(def_id) == cx.tcx.lang_items().panic_str()
                 {
                     if let Some(id) = f.span.ctxt().outer_expn_data().macro_def_id {
-                        if cx.tcx.is_diagnostic_item(sym::std_panic_2015_macro, id)
-                            || cx.tcx.is_diagnostic_item(sym::core_panic_2015_macro, id)
-                        {
+                        if matches!(
+                            cx.tcx.get_diagnostic_name(id),
+                            Some(sym::core_panic_2015_macro | sym::std_panic_2015_macro)
+                        ) {
                             check_panic(cx, f, arg);
                         }
                     }

--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -51,9 +51,10 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
             Some((DefKind::AssocFn, did)) => match cx.tcx.trait_of_item(did) {
                 // Check that we're dealing with a trait method for one of the traits we care about.
                 Some(trait_id)
-                    if [sym::Clone, sym::Deref, sym::Borrow]
-                        .iter()
-                        .any(|s| cx.tcx.is_diagnostic_item(*s, trait_id)) =>
+                    if matches!(
+                        cx.tcx.get_diagnostic_name(trait_id),
+                        Some(sym::Borrow | sym::Clone | sym::Deref)
+                    ) =>
                 {
                     (trait_id, did)
                 }

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1541,8 +1541,7 @@ impl InvalidAtomicOrdering {
             if let ExprKind::Call(ref func, ref args) = expr.kind;
             if let ExprKind::Path(ref func_qpath) = func.kind;
             if let Some(def_id) = cx.qpath_res(func_qpath, func.hir_id).opt_def_id();
-            if cx.tcx.is_diagnostic_item(sym::fence, def_id) ||
-                cx.tcx.is_diagnostic_item(sym::compiler_fence, def_id);
+            if matches!(cx.tcx.get_diagnostic_name(def_id), Some(sym::fence | sym::compiler_fence));
             if let ExprKind::Path(ref ordering_qpath) = &args[0].kind;
             if let Some(ordering_def_id) = cx.qpath_res(ordering_qpath, args[0].hir_id).opt_def_id();
             if Self::matches_ordering(cx, ordering_def_id, &[sym::Relaxed]);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1750,7 +1750,7 @@ impl EncodeContext<'a, 'tcx> {
     fn encode_diagnostic_items(&mut self) -> Lazy<[(Symbol, DefIndex)]> {
         empty_proc_macro!(self);
         let tcx = self.tcx;
-        let diagnostic_items = tcx.diagnostic_items(LOCAL_CRATE);
+        let diagnostic_items = &tcx.diagnostic_items(LOCAL_CRATE).name_to_id;
         self.lazy(diagnostic_items.iter().map(|(&name, def_id)| (name, def_id.index)))
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1442,7 +1442,7 @@ rustc_queries! {
     }
 
     /// Returns all diagnostic items defined in all crates.
-    query all_diagnostic_items(_: ()) -> FxHashMap<Symbol, DefId> {
+    query all_diagnostic_items(_: ()) -> rustc_hir::diagnostic_items::DiagnosticItems {
         storage(ArenaCacheSelector<'tcx>)
         eval_always
         desc { "calculating the diagnostic items map" }
@@ -1454,7 +1454,7 @@ rustc_queries! {
     }
 
     /// Returns the diagnostic items defined in a crate.
-    query diagnostic_items(_: CrateNum) -> FxHashMap<Symbol, DefId> {
+    query diagnostic_items(_: CrateNum) -> rustc_hir::diagnostic_items::DiagnosticItems {
         storage(ArenaCacheSelector<'tcx>)
         desc { "calculating the diagnostic items map in a crate" }
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1232,12 +1232,17 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Obtain the given diagnostic item's `DefId`. Use `is_diagnostic_item` if you just want to
     /// compare against another `DefId`, since `is_diagnostic_item` is cheaper.
     pub fn get_diagnostic_item(self, name: Symbol) -> Option<DefId> {
-        self.all_diagnostic_items(()).get(&name).copied()
+        self.all_diagnostic_items(()).name_to_id.get(&name).copied()
+    }
+
+    /// Obtain the diagnostic item's name
+    pub fn get_diagnostic_name(self, id: DefId) -> Option<Symbol> {
+        self.diagnostic_items(id.krate).id_to_name.get(&id).copied()
     }
 
     /// Check whether the diagnostic item with the given `name` has the given `DefId`.
     pub fn is_diagnostic_item(self, name: Symbol, did: DefId) -> bool {
-        self.diagnostic_items(did.krate).get(&name) == Some(&did)
+        self.diagnostic_items(did.krate).name_to_id.get(&name) == Some(&did)
     }
 
     pub fn stability(self) -> &'tcx stability::Index<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1636,12 +1636,12 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         // Special case the primary error message when send or sync is the trait that was
         // not implemented.
-        let is_send = self.tcx.is_diagnostic_item(sym::Send, trait_ref.def_id);
-        let is_sync = self.tcx.is_diagnostic_item(sym::Sync, trait_ref.def_id);
         let hir = self.tcx.hir();
-        let trait_explanation = if is_send || is_sync {
+        let trait_explanation = if let Some(name @ (sym::Send | sym::Sync)) =
+            self.tcx.get_diagnostic_name(trait_ref.def_id)
+        {
             let (trait_name, trait_verb) =
-                if is_send { ("`Send`", "sent") } else { ("`Sync`", "shared") };
+                if name == sym::Send { ("`Send`", "sent") } else { ("`Sync`", "shared") };
 
             err.clear_code();
             err.set_primary_message(format!(

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1047,51 +1047,41 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         unsatisfied_predicates: &Vec<(ty::Predicate<'tcx>, Option<ty::Predicate<'tcx>>)>,
     ) {
-        let derivables = [
-            sym::Eq,
-            sym::PartialEq,
-            sym::Ord,
-            sym::PartialOrd,
-            sym::Clone,
-            sym::Copy,
-            sym::Hash,
-            sym::Default,
-            sym::Debug,
-        ];
-        let mut derives = unsatisfied_predicates
-            .iter()
-            .filter_map(|(pred, _)| {
-                let trait_pred =
-                    if let ty::PredicateKind::Trait(trait_pred) = pred.kind().skip_binder() {
-                        trait_pred
-                    } else {
-                        return None;
-                    };
-                let trait_ref = trait_pred.trait_ref;
-                let adt_def = if let ty::Adt(adt_def, _) = trait_ref.self_ty().kind() {
-                    adt_def
-                } else {
-                    return None;
-                };
-                if adt_def.did.is_local() {
-                    let diagnostic_items = self.tcx.diagnostic_items(trait_ref.def_id.krate);
-                    return derivables.iter().find_map(|trait_derivable| {
-                        let item_def_id = diagnostic_items.name_to_id.get(trait_derivable)?;
-                        if item_def_id == &trait_pred.trait_ref.def_id
-                            && !(adt_def.is_enum() && *trait_derivable == sym::Default)
-                        {
-                            return Some((
-                                format!("{}", trait_ref.self_ty()),
-                                self.tcx.def_span(adt_def.did),
-                                format!("{}", trait_ref.print_only_trait_name()),
-                            ));
-                        }
-                        None
-                    });
-                }
-                None
-            })
-            .collect::<Vec<(String, Span, String)>>();
+        let mut derives = Vec::<(String, Span, String)>::new();
+        let mut traits = Vec::<Span>::new();
+        for (pred, _) in unsatisfied_predicates {
+            let trait_pred = match pred.kind().skip_binder() {
+                ty::PredicateKind::Trait(trait_pred) => trait_pred,
+                _ => continue,
+            };
+            let adt = match trait_pred.self_ty().ty_adt_def() {
+                Some(adt) if adt.did.is_local() => adt,
+                _ => continue,
+            };
+            let can_derive = match self.tcx.get_diagnostic_name(trait_pred.def_id()) {
+                Some(sym::Default) => !adt.is_enum(),
+                Some(
+                    sym::Eq
+                    | sym::PartialEq
+                    | sym::Ord
+                    | sym::PartialOrd
+                    | sym::Clone
+                    | sym::Copy
+                    | sym::Hash
+                    | sym::Debug,
+                ) => true,
+                _ => false,
+            };
+            if can_derive {
+                derives.push((
+                    format!("{}", trait_pred.self_ty()),
+                    self.tcx.def_span(adt.did),
+                    format!("{}", trait_pred.trait_ref.print_only_trait_name()),
+                ));
+            } else {
+                traits.push(self.tcx.def_span(trait_pred.def_id()));
+            }
+        }
         derives.sort();
         let derives_grouped = derives.into_iter().fold(
             Vec::<(String, Span, String)>::new(),
@@ -1106,36 +1096,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 acc
             },
         );
-        let mut traits: Vec<_> = unsatisfied_predicates
-            .iter()
-            .filter_map(|(pred, _)| {
-                let trait_pred =
-                    if let ty::PredicateKind::Trait(trait_pred) = pred.kind().skip_binder() {
-                        trait_pred
-                    } else {
-                        return None;
-                    };
-                if let ty::Adt(adt_def, _) = trait_pred.trait_ref.self_ty().kind() {
-                    if !adt_def.did.is_local() {
-                        return None;
-                    }
-                } else {
-                    return None;
-                };
-
-                let did = trait_pred.def_id();
-                let diagnostic_items = self.tcx.diagnostic_items(did.krate);
-
-                if !derivables
-                    .iter()
-                    .any(|trait_derivable| diagnostic_items.get(trait_derivable) == Some(&did))
-                {
-                    Some(self.tcx.def_span(did))
-                } else {
-                    None
-                }
-            })
-            .collect();
         traits.sort();
         traits.dedup();
 

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1076,7 +1076,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if adt_def.did.is_local() {
                     let diagnostic_items = self.tcx.diagnostic_items(trait_ref.def_id.krate);
                     return derivables.iter().find_map(|trait_derivable| {
-                        let item_def_id = diagnostic_items.get(trait_derivable)?;
+                        let item_def_id = diagnostic_items.name_to_id.get(trait_derivable)?;
                         if item_def_id == &trait_pred.trait_ref.def_id
                             && !(adt_def.is_enum() && *trait_derivable == sym::Default)
                         {

--- a/src/test/ui/suggestions/derive-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/derive-trait-for-method-call.stderr
@@ -20,6 +20,17 @@ LL |     let y = x.test();
            `Enum: Clone`
            `Enum: Default`
            `CloneEnum: Default`
+note: the following trait must be implemented
+  --> $SRC_DIR/core/src/default.rs:LL:COL
+   |
+LL | / pub trait Default: Sized {
+LL | |     /// Returns the "default value" for a type.
+LL | |     ///
+LL | |     /// Default values are often some kind of initial value, identity value, or anything else that
+...  |
+LL | |     fn default() -> Self;
+LL | | }
+   | |_^
 help: consider annotating `Enum` with `#[derive(Clone)]`
    |
 LL | #[derive(Clone)]


### PR DESCRIPTION
Introduces a "reverse lookup" for diagnostic items. This is mainly intended for @rust-lang/clippy which often does a long series of `is_diagnostic_item` calls for the same `DefId`. 

r? @oli-obk