### PR TITLE
pre-pre-pre-rfc: return tracing for `core::result::Result`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1052,6 +1052,7 @@ symbols! {
         repr_transparent,
         residual,
         result,
+        return_tracing,
         rhs,
         rintf32,
         rintf64,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1888,6 +1888,10 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
     }
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// Try
+/////////////////////////////////////////////////////////////////////////////
+
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T, E> ops::Try for Result<T, E> {
     type Output = T;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -64,6 +64,7 @@
 #![feature(const_option)]
 #![feature(integer_atomics)]
 #![feature(int_roundings)]
+#![feature(return_tracing)]
 #![feature(slice_group_by)]
 #![feature(trusted_random_access)]
 #![feature(unsize)]


### PR DESCRIPTION
it's so pre you can't even see it