### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/13.0-2021-08-08
+	branch = rustc/13.0-2021-09-30
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
@@ -171,9 +171,7 @@ impl OutlivesSuggestionBuilder {
         let outlived_fr_name = self.region_vid_to_name(mbcx, errci.outlived_fr);
 
         if let (Some(fr_name), Some(outlived_fr_name)) = (fr_name, outlived_fr_name) {
-            if let RegionNameSource::Static = outlived_fr_name.source {
-                diag.help(&format!("consider replacing `{}` with `'static`", fr_name));
-            } else {
+            if !matches!(outlived_fr_name.source, RegionNameSource::Static) {
                 diag.help(&format!(
                     "consider adding the following bound: `{}: {}`",
                     fr_name, outlived_fr_name

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -102,7 +102,7 @@ impl NonConstOp for FnCallUnstable {
         );
 
         if ccx.is_const_stable_const_fn() {
-            err.help("Const-stable functions can only call other const-stable functions");
+            err.help("const-stable functions can only call other const-stable functions");
         } else if ccx.tcx.sess.is_nightly_build() {
             if let Some(feature) = feature {
                 err.help(&format!(

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -437,12 +437,13 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
             if let hir::Node::Pat(parent_pat) = cx.tcx.hir().get(cx.tcx.hir().get_parent_node(hid))
             {
                 if let PatKind::Struct(_, field_pats, _) = &parent_pat.kind {
-                    for field in field_pats.iter() {
-                        if field.ident != ident {
-                            // Only check if a new name has been introduced, to avoid warning
-                            // on both the struct definition and this pattern.
-                            self.check_snake_case(cx, "variable", &ident);
-                        }
+                    if field_pats
+                        .iter()
+                        .any(|field| !field.is_shorthand && field.pat.hir_id == p.hir_id)
+                    {
+                        // Only check if a new name has been introduced, to avoid warning
+                        // on both the struct definition and this pattern.
+                        self.check_snake_case(cx, "variable", &ident);
                     }
                     return;
                 }

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -58,7 +58,7 @@ pub(super) fn check_abi(tcx: TyCtxt<'_>, hir_id: hir::HirId, span: Span, abi: Ab
             tcx.sess,
             span,
             E0781,
-            "the `\"C-cmse-nonsecure-call\"` ABI is only allowed on function pointers."
+            "the `\"C-cmse-nonsecure-call\"` ABI is only allowed on function pointers"
         )
         .emit()
     }

--- a/library/alloc/src/collections/vec_deque/pair_slices.rs
+++ b/library/alloc/src/collections/vec_deque/pair_slices.rs
@@ -20,10 +20,10 @@ use super::VecDeque;
 ///
 /// and the uneven remainder of either A or B is skipped.
 pub struct PairSlices<'a, 'b, T> {
-    pub(crate) a0: &'a mut [T],
-    pub(crate) a1: &'a mut [T],
-    pub(crate) b0: &'b [T],
-    pub(crate) b1: &'b [T],
+    a0: &'a mut [T],
+    a1: &'a mut [T],
+    b0: &'b [T],
+    b1: &'b [T],
 }
 
 impl<'a, 'b, T> PairSlices<'a, 'b, T> {

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2244,7 +2244,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!((-100", stringify!($SelfT), ").abs_diff(-120), 20", stringify!($UnsignedT), ");")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.abs_diff(", stringify!($SelfT), "::MAX), ", stringify!($UnsignedT), "::MAX);")]
         /// ```
-        #[unstable(feature = "int_abs_diff", issue = "none")]
+        #[unstable(feature = "int_abs_diff", issue = "89492")]
         #[inline]
         pub const fn abs_diff(self, other: Self) -> $UnsignedT {
             if self < other {

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2227,6 +2227,46 @@ macro_rules! int_impl {
             }
         }
 
+        /// Computes the absolute difference between `self` and `other`.
+        ///
+        /// This function always returns the correct answer without overflow or
+        /// panics by returning an unsigned integer.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(int_abs_diff)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(80), 20", stringify!($UnsignedT), ");")]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($UnsignedT), ");")]
+        #[doc = concat!("assert_eq!((-100", stringify!($SelfT), ").abs_diff(80), 180", stringify!($UnsignedT), ");")]
+        #[doc = concat!("assert_eq!((-100", stringify!($SelfT), ").abs_diff(-120), 20", stringify!($UnsignedT), ");")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.abs_diff(", stringify!($SelfT), "::MAX), ", stringify!($UnsignedT), "::MAX);")]
+        /// ```
+        #[unstable(feature = "int_abs_diff", issue = "none")]
+        #[inline]
+        pub const fn abs_diff(self, other: Self) -> $UnsignedT {
+            if self < other {
+                // Converting a non-negative x from signed to unsigned by using
+                // `x as U` is left unchanged, but a negative x is converted
+                // to value x + 2^N. Thus if `s` and `o` are binary variables
+                // respectively indicating whether `self` and `other` are
+                // negative, we are computing the mathematical value:
+                //
+                //    (other + o*2^N) - (self + s*2^N)    mod  2^N
+                //    other - self + (o-s)*2^N            mod  2^N
+                //    other - self                        mod  2^N
+                //
+                // Finally, taking the mod 2^N of the mathematical value of
+                // `other - self` does not change it as it already is
+                // in the range [0, 2^N).
+                (other as $UnsignedT).wrapping_sub(self as $UnsignedT)
+            } else {
+                (self as $UnsignedT).wrapping_sub(other as $UnsignedT)
+            }
+        }
+
         /// Returns a number representing sign of `self`.
         ///
         ///  - `0` if the number is zero

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1501,7 +1501,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(80), 20", stringify!($SelfT), ");")]
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($SelfT), ");")]
         /// ```
-        #[unstable(feature = "int_abs_diff", issue = "none")]
+        #[unstable(feature = "int_abs_diff", issue = "89492")]
         #[inline]
         pub const fn abs_diff(self, other: Self) -> Self {
             if mem::size_of::<Self>() == 1 {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1490,6 +1490,27 @@ macro_rules! uint_impl {
             (c, b | d)
         }
 
+        /// Computes the absolute difference between `self` and `other`.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(int_abs_diff)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(80), 20", stringify!($SelfT), ");")]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($SelfT), ");")]
+        /// ```
+        #[unstable(feature = "int_abs_diff", issue = "none")]
+        #[inline]
+        pub const fn abs_diff(self, other: Self) -> Self {
+            if self < other {
+                other - self
+            } else {
+                self - other
+            }
+        }
+
         /// Calculates the multiplication of `self` and `rhs`.
         ///
         /// Returns a tuple of the multiplication along with a boolean

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1504,10 +1504,16 @@ macro_rules! uint_impl {
         #[unstable(feature = "int_abs_diff", issue = "none")]
         #[inline]
         pub const fn abs_diff(self, other: Self) -> Self {
-            if self < other {
-                other - self
+            if mem::size_of::<Self>() == 1 {
+                // Trick LLVM into generating the psadbw instruction when SSE2
+                // is available and this function is autovectorized for u8's.
+                (self as i32).wrapping_sub(other as i32).abs() as Self
             } else {
-                self - other
+                if self < other {
+                    other - self
+                } else {
+                    self - other
+                }
             }
         }
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -368,20 +368,24 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
 #[cfg(any(target_os = "solaris", target_os = "illumos"))]
 pub fn current_exe() -> io::Result<PathBuf> {
-    extern "C" {
-        fn getexecname() -> *const c_char;
-    }
-    unsafe {
-        let path = getexecname();
-        if path.is_null() {
-            Err(io::Error::last_os_error())
-        } else {
-            let filename = CStr::from_ptr(path).to_bytes();
-            let path = PathBuf::from(<OsStr as OsStrExt>::from_bytes(filename));
+    if let Ok(path) = crate::fs::read_link("/proc/self/path/a.out") {
+        Ok(path)
+    } else {
+        extern "C" {
+            fn getexecname() -> *const c_char;
+        }
+        unsafe {
+            let path = getexecname();
+            if path.is_null() {
+                Err(io::Error::last_os_error())
+            } else {
+                let filename = CStr::from_ptr(path).to_bytes();
+                let path = PathBuf::from(<OsStr as OsStrExt>::from_bytes(filename));
 
-            // Prepend a current working directory to the path if
-            // it doesn't contain an absolute pathname.
-            if filename[0] == b'/' { Ok(path) } else { getcwd().map(|cwd| cwd.join(path)) }
+                // Prepend a current working directory to the path if
+                // it doesn't contain an absolute pathname.
+                if filename[0] == b'/' { Ok(path) } else { getcwd().map(|cwd| cwd.join(path)) }
+            }
         }
     }
 }

--- a/library/std/src/time/monotonic.rs
+++ b/library/std/src/time/monotonic.rs
@@ -5,7 +5,7 @@ pub(super) fn monotonize(raw: time::Instant) -> time::Instant {
     inner::monotonize(raw)
 }
 
-#[cfg(all(target_has_atomic = "64", not(target_has_atomic = "128")))]
+#[cfg(any(all(target_has_atomic = "64", not(target_has_atomic = "128")), target_arch = "aarch64"))]
 pub mod inner {
     use crate::sync::atomic::AtomicU64;
     use crate::sync::atomic::Ordering::*;
@@ -70,7 +70,7 @@ pub mod inner {
     }
 }
 
-#[cfg(target_has_atomic = "128")]
+#[cfg(all(target_has_atomic = "128", not(target_arch = "aarch64")))]
 pub mod inner {
     use crate::sync::atomic::AtomicU128;
     use crate::sync::atomic::Ordering::*;

--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -9,7 +9,7 @@
 import sys
 import json
 
-crate = json.load(open(sys.argv[1]))
+crate = json.load(open(sys.argv[1], encoding="utf-8"))
 
 
 def get_local_item(item_id):

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -773,22 +773,18 @@ h2.small-section-header > .anchor {
 .block a.current.crate { font-weight: 500; }
 
 .item-table {
-	display: grid;
-	column-gap: 1.2rem;
-	row-gap: 0.0rem;
-	grid-template-columns: auto 1fr;
+	display: table-row;
 	/* align content left */
 	justify-items: start;
 }
-
+.item-row {
+	display: table-row;
+}
 .item-left, .item-right {
-	display: block;
+	display: table-cell;
 }
 .item-left {
-	grid-column: 1;
-}
-.item-right {
-	grid-column: 2;
+	padding-right: 1.2rem;
 }
 
 .search-container {
@@ -1891,6 +1887,9 @@ details.undocumented[open] > summary::before {
 
 	/* Display an alternating layout on tablets and phones */
 	.item-table {
+		display: block;
+	}
+	.item-row {
 		display: flex;
 		flex-flow: column wrap;
 	}

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -218,6 +218,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         ConstantItem(c) => ItemEnum::Constant(c.into_tcx(tcx)),
         MacroItem(m) => ItemEnum::Macro(m.source),
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_tcx(tcx)),
+        PrimitiveItem(p) => ItemEnum::PrimitiveType(p.as_sym().to_string()),
         AssocConstItem(t, s) => ItemEnum::AssocConst { type_: t.into_tcx(tcx), default: s },
         AssocTypeItem(g, t) => ItemEnum::AssocType {
             bounds: g.into_iter().map(|x| x.into_tcx(tcx)).collect(),
@@ -225,7 +226,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         },
         // `convert_item` early returns `None` for striped items
         StrippedItem(_) => unreachable!(),
-        PrimitiveItem(_) | KeywordItem(_) => {
+        KeywordItem(_) => {
             panic!("{:?} is not supported for JSON output", item)
         }
         ExternCrateItem { ref src } => ItemEnum::ExternCrate {

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -69,7 +69,21 @@ impl JsonRenderer<'tcx> {
                     .iter()
                     .filter_map(|i| {
                         let item = &i.impl_item;
-                        if item.def_id.is_local() {
+
+                        // HACK(hkmatsumoto): For impls of primitive types, we index them
+                        // regardless of whether they're local. This is because users can
+                        // document primitive items in an arbitrary crate by using
+                        // `doc(primitive)`.
+                        let mut is_primitive_impl = false;
+                        if let clean::types::ItemKind::ImplItem(ref impl_) = *item.kind {
+                            if impl_.trait_.is_none() {
+                                if let clean::types::Type::Primitive(_) = impl_.for_ {
+                                    is_primitive_impl = true;
+                                }
+                            }
+                        }
+
+                        if item.def_id.is_local() || is_primitive_impl {
                             self.item(item.clone()).unwrap();
                             Some(from_item_id(item.def_id))
                         } else {
@@ -189,6 +203,11 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
 
     fn after_krate(&mut self) -> Result<(), Error> {
         debug!("Done with crate");
+
+        for primitive in Rc::clone(&self.cache).primitive_locations.values() {
+            self.get_impls(primitive.clone());
+        }
+
         let mut index = (*self.index).clone().into_inner();
         index.extend(self.get_trait_items());
         // This needs to be the default HashMap for compatibility with the public interface for
@@ -234,7 +253,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 7,
+            format_version: 8,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -221,6 +221,8 @@ pub enum ItemEnum {
     Macro(String),
     ProcMacro(ProcMacro),
 
+    PrimitiveType(String),
+
     AssocConst {
         #[serde(rename = "type")]
         type_: Type,

--- a/src/test/rustdoc-gui/huge-collection-of-constants.goml
+++ b/src/test/rustdoc-gui/huge-collection-of-constants.goml
@@ -1,0 +1,5 @@
+goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
+
+// Make sure that the last two entries are more than 12 pixels apart and not stacked on each other.
+
+compare-elements-position-near-false: ("//*[@class='item-table']//div[last()-1]", "//*[@class='item-table']//div[last()-3]", {"y": 12})

--- a/src/test/rustdoc-gui/src/test_docs/Cargo.toml
+++ b/src/test/rustdoc-gui/src/test_docs/Cargo.toml
@@ -3,5 +3,7 @@ name = "test_docs"
 version = "0.1.0"
 edition = "2018"
 
+build = "build.rs"
+
 [lib]
 path = "lib.rs"

--- a/src/test/rustdoc-gui/src/test_docs/build.rs
+++ b/src/test/rustdoc-gui/src/test_docs/build.rs
@@ -1,0 +1,15 @@
+//! generate 2000 constants for testing
+
+use std::{fs::write, path::PathBuf};
+
+fn main() -> std::io::Result<()> {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is not defined");
+
+    let mut output = String::new();
+    for i in 0..2000 {
+        let line = format!("/// Some const A{0}\npub const A{0}: isize = 0;\n", i);
+        output.push_str(&*line);
+    };
+
+    write(&[&*out_dir, "huge_amount_of_consts.rs"].iter().collect::<PathBuf>(), output)
+}

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -116,3 +116,7 @@ pub mod keyword {}
 
 /// Just some type alias.
 pub type SomeType = u32;
+
+pub mod huge_amount_of_consts {
+    include!(concat!(env!("OUT_DIR"), "/huge_amount_of_consts.rs"));
+}

--- a/src/test/rustdoc-json/primitive.rs
+++ b/src/test/rustdoc-json/primitive.rs
@@ -1,0 +1,14 @@
+// edition:2018
+
+#![feature(doc_primitive)]
+
+#[doc(primitive = "usize")]
+mod usize {}
+
+// @set local_crate_id = primitive.json "$.index[*][?(@.name=='primitive')].crate_id"
+
+// @has - "$.index[*][?(@.name=='log10')]"
+// @!is - "$.index[*][?(@.name=='log10')].crate_id" $local_crate_id
+// @has - "$.index[*][?(@.name=='checked_add')]"
+// @!is - "$.index[*][?(@.name=='checked_add')]" $local_crate_id
+// @!has - "$.index[*][?(@.name=='is_ascii_uppercase')]"

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
@@ -5,8 +5,6 @@ LL | fn baz<'a,'b>(x: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |    bar(foo, x)
    |    ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
@@ -6,8 +6,6 @@ LL | fn baz<'a, 'b>(x: Type<'a>) -> Type<'static> {
 ...
 LL |     bar(foo, x)
    |     ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/auto-trait-validation.fixed
+++ b/src/test/ui/auto-traits/auto-trait-validation.fixed
@@ -2,12 +2,12 @@
 
 // run-rustfix
 
-auto trait Generic<T> {}
+auto trait Generic {}
 //~^ auto traits cannot have generic parameters [E0567]
-auto trait Bound : Copy {}
+auto trait Bound {}
 //~^ auto traits cannot have super traits or lifetime bounds [E0568]
-auto trait LifetimeBound : 'static {}
+auto trait LifetimeBound {}
 //~^ auto traits cannot have super traits or lifetime bounds [E0568]
-auto trait MyTrait { fn foo() {} }
+auto trait MyTrait {  }
 //~^ auto traits cannot have associated items [E0380]
 fn main() {}

--- a/src/test/ui/auto-traits/auto-trait-validation.stderr
+++ b/src/test/ui/auto-traits/auto-trait-validation.stderr
@@ -1,28 +1,37 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:3:19
+  --> $DIR/auto-trait-validation.rs:5:19
    |
 LL | auto trait Generic<T> {}
    |            -------^^^ help: remove the parameters
    |            |
    |            auto trait cannot have generic parameters
 
-error[E0568]: auto traits cannot have super traits
-  --> $DIR/auto-trait-validation.rs:5:20
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/auto-trait-validation.rs:7:17
    |
 LL | auto trait Bound : Copy {}
-   |            -----   ^^^^ help: remove the super traits
+   |            -----^^^^^^^ help: remove the super traits or lifetime bounds
    |            |
-   |            auto trait cannot have super traits
+   |            auto trait cannot have super traits or lifetime bounds
 
-error[E0380]: auto traits cannot have methods or associated items
-  --> $DIR/auto-trait-validation.rs:7:25
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/auto-trait-validation.rs:9:25
+   |
+LL | auto trait LifetimeBound : 'static {}
+   |            -------------^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            |
+   |            auto trait cannot have super traits or lifetime bounds
+
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:11:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   |            -------      ^^^
-   |            |
-   |            auto trait cannot have items
+   |            -------   ---^^^-----
+   |            |         |
+   |            |         help: remove these associated items
+   |            auto trait cannot have associated items
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0380, E0567, E0568.
 For more information about an error, try `rustc --explain E0380`.

--- a/src/test/ui/auto-traits/issue-23080-2.stderr
+++ b/src/test/ui/auto-traits/issue-23080-2.stderr
@@ -1,10 +1,10 @@
-error[E0380]: auto traits cannot have methods or associated items
+error[E0380]: auto traits cannot have associated items
   --> $DIR/issue-23080-2.rs:5:10
    |
 LL | unsafe auto trait Trait {
-   |                   ----- auto trait cannot have items
+   |                   ----- auto trait cannot have associated items
 LL |     type Output;
-   |          ^^^^^^
+   |     -----^^^^^^- help: remove these associated items
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/issue-23080.stderr
+++ b/src/test/ui/auto-traits/issue-23080.stderr
@@ -1,10 +1,13 @@
-error[E0380]: auto traits cannot have methods or associated items
+error[E0380]: auto traits cannot have associated items
   --> $DIR/issue-23080.rs:5:8
    |
-LL | unsafe auto trait Trait {
-   |                   ----- auto trait cannot have items
-LL |     fn method(&self) {
-   |        ^^^^^^
+LL |   unsafe auto trait Trait {
+   |                     ----- auto trait cannot have associated items
+LL |       fn method(&self) {
+   |  _____-  ^^^^^^
+LL | |         println!("Hello");
+LL | |     }
+   | |_____- help: remove these associated items
 
 error: aborting due to previous error
 

--- a/src/test/ui/auto-traits/issue-84075.rs
+++ b/src/test/ui/auto-traits/issue-84075.rs
@@ -1,9 +1,9 @@
-#![feature(auto_traits)]
-#![feature(negative_impls)]
+// Regression test for issue #84075.
 
-auto trait Magic : Sized where Option<Self> : Magic {} //~ ERROR E0568
-//~^ ERROR E0568
-impl<T:Magic> Magic for T {}
+#![feature(auto_traits)]
+
+auto trait Magic where Self: Copy {} //~ ERROR E0568
+impl<T: Magic> Magic for T {}
 
 fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
 

--- a/src/test/ui/auto-traits/issue-84075.stderr
+++ b/src/test/ui/auto-traits/issue-84075.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/typeck-auto-trait-no-supertraits.rs:28:17
+  --> $DIR/issue-84075.rs:5:18
    |
-LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+LL | auto trait Magic where Self: Copy {}
+   |            ----- ^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
    |            |
    |            auto trait cannot have super traits or lifetime bounds
 

--- a/src/test/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/src/test/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -1,11 +1,19 @@
-error[E0568]: auto traits cannot have super traits
-  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:20
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:17
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----   ^^^^^ help: remove the super traits
+   |            -----^^^^^^^^ help: remove the super traits or lifetime bounds
    |            |
-   |            auto trait cannot have super traits
+   |            auto trait cannot have super traits or lifetime bounds
 
-error: aborting due to previous error
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:26
+   |
+LL | auto trait Magic : Sized where Option<Self> : Magic {}
+   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            |
+   |            auto trait cannot have super traits or lifetime bounds
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0568`.

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -18,8 +18,6 @@ LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
 ...
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |                                                 ^ requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:32:49

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
@@ -17,8 +17,6 @@ LL | fn expect_bound_supply_named<'x>() {
 ...
 LL |     closure_expecting_bound(|x: &'x u32| {
    |                              ^ requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
+++ b/src/test/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
@@ -1,4 +1,4 @@
-error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers.
+error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers
   --> $DIR/wrong-abi-location-1.rs:8:1
    |
 LL | pub extern "C-cmse-nonsecure-call" fn test() {}

--- a/src/test/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
+++ b/src/test/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
@@ -1,4 +1,4 @@
-error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers.
+error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers
   --> $DIR/wrong-abi-location-2.rs:8:1
    |
 LL | / extern "C-cmse-nonsecure-call" {

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -4,7 +4,7 @@ error: `foo` is not yet stable as a const fn
 LL | const fn bar() -> u32 { foo() }
    |                         ^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: `foo2` is not yet stable as a const fn
   --> $DIR/min_const_fn_libstd_stability.rs:24:26
@@ -12,7 +12,7 @@ error: `foo2` is not yet stable as a const fn
 LL | const fn bar2() -> u32 { foo2() }
    |                          ^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
   --> $DIR/min_const_fn_libstd_stability.rs:29:26
@@ -35,7 +35,7 @@ error: `foo2_gated` is not yet stable as a const fn
 LL | const fn bar2_gated() -> u32 { foo2_gated() }
    |                                ^^^^^^^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -4,7 +4,7 @@ error: `foo` is not yet stable as a const fn
 LL | const unsafe fn bar() -> u32 { unsafe { foo() } }
    |                                         ^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: `foo2` is not yet stable as a const fn
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:24:42
@@ -12,7 +12,7 @@ error: `foo2` is not yet stable as a const fn
 LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } }
    |                                          ^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: const-stable function cannot use `#[feature(const_fn_floating_point_arithmetic)]`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:29:33
@@ -35,7 +35,7 @@ error: `foo2_gated` is not yet stable as a const fn
 LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } }
    |                                                ^^^^^^^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -4,7 +4,7 @@ error: `foo` is not yet stable as a const fn
 LL | const unsafe fn bar() -> u32 { foo() }
    |                                ^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: `foo2` is not yet stable as a const fn
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:24:33
@@ -12,7 +12,7 @@ error: `foo2` is not yet stable as a const fn
 LL | const unsafe fn bar2() -> u32 { foo2() }
    |                                 ^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: `foo2_gated` is not yet stable as a const fn
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:33:39
@@ -20,7 +20,7 @@ error: `foo2_gated` is not yet stable as a const fn
 LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() }
    |                                       ^^^^^^^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
@@ -14,8 +14,6 @@ LL | fn give_some<'a>() {
    |              -- lifetime `'a` defined here
 LL |     want_hrtb::<&'a u32>()
    |     ^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: implementation of `Foo` is not general enough
   --> $DIR/hrtb-just-for-static.rs:30:5

--- a/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
@@ -54,8 +54,6 @@ LL | fn foo_hrtb_bar_not<'b, T>(mut t: T)
 ...
 LL |     foo_hrtb_bar_not(&mut t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 error: implementation of `Bar` is not general enough
   --> $DIR/hrtb-perfect-forwarding.rs:43:5

--- a/src/test/ui/impl-header-lifetime-elision/dyn-trait.nll.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/dyn-trait.nll.stderr
@@ -5,8 +5,6 @@ LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
    |                              - `x` is a reference that is only valid in the function body
 LL |     static_val(x);
    |     ^^^^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -19,7 +19,6 @@ LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
    |             |
    |             lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy + 'a { x }
@@ -41,7 +40,6 @@ error: lifetime may not live long enough
 LL | fn explicit2<'a>(x: &'a i32) -> impl Copy + 'static { x }
    |              -- lifetime `'a` defined here            ^ returning this value requires that `'a` must outlive `'static`
    |
-   = help: consider replacing `'a` with `'static`
    = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `x`
@@ -66,7 +64,6 @@ error: lifetime may not live long enough
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
    |
-   = help: consider replacing `'a` with `'static`
    = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
@@ -19,7 +19,6 @@ LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
    |                    |
    |                    lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {

--- a/src/test/ui/issues/issue-10291.nll.stderr
+++ b/src/test/ui/issues/issue-10291.nll.stderr
@@ -6,8 +6,6 @@ LL | fn test<'x>(x: &'x isize) {
 LL |     drop::<Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
 LL |         x
    |         ^ returning this value requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-26217.nll.stderr
+++ b/src/test/ui/issues/issue-26217.nll.stderr
@@ -5,8 +5,6 @@ LL | fn bar<'a>() {
    |        -- lifetime `'a` defined here
 LL |     foo::<&'a i32>();
    |     ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54943.nll.stderr
+++ b/src/test/ui/issues/issue-54943.nll.stderr
@@ -6,8 +6,6 @@ LL | fn boo<'a>() {
 ...
 LL |     let x = foo::<&'a u32>();
    |             ^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-55796.nll.stderr
+++ b/src/test/ui/issues/issue-55796.nll.stderr
@@ -6,8 +6,6 @@ LL | pub trait Graph<'a> {
 ...
 LL |         Box::new(self.out_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55796.rs:23:9
@@ -17,8 +15,6 @@ LL | pub trait Graph<'a> {
 ...
 LL |         Box::new(self.in_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-75777.nll.stderr
+++ b/src/test/ui/issues/issue-75777.nll.stderr
@@ -6,8 +6,6 @@ LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> Bo
 LL |     let fut: BoxFuture<'a, A> = Box::pin(future::ready(v));
 LL |     Box::new(move |_| fut)
    |     ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetimes/lifetime-bound-will-change-warning.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-bound-will-change-warning.nll.stderr
@@ -6,8 +6,6 @@ LL | fn test2<'a>(x: &'a Box<dyn Fn() + 'a>) {
 LL |     // but ref_obj will not, so warn.
 LL |     ref_obj(x)
    |     ^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/lifetime-bound-will-change-warning.rs:39:5
@@ -17,8 +15,6 @@ LL | fn test2cc<'a>(x: &'a Box<dyn Fn() + 'a>) {
 LL |     // same as test2, but cross crate
 LL |     lib::ref_obj(x)
    |     ^^^^^^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/issue-89469.rs
+++ b/src/test/ui/lint/issue-89469.rs
@@ -1,0 +1,20 @@
+// Regression test for #89469, where an extra non_snake_case warning was
+// reported for a shorthand field binding.
+
+// check-pass
+#![deny(non_snake_case)]
+
+#[allow(non_snake_case)]
+struct Entry {
+    A: u16,
+    a: u16
+}
+
+fn foo() -> Entry {todo!()}
+
+pub fn f() {
+    let Entry { A, a } = foo();
+    let _ = (A, a);
+}
+
+fn main() {}

--- a/src/test/ui/lub-if.nll.stderr
+++ b/src/test/ui/lub-if.nll.stderr
@@ -6,8 +6,6 @@ LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |         s
    |         ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/lub-if.rs:35:9
@@ -17,8 +15,6 @@ LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |         s
    |         ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lub-match.nll.stderr
+++ b/src/test/ui/lub-match.nll.stderr
@@ -6,8 +6,6 @@ LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |             s
    |             ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/lub-match.rs:39:13
@@ -17,8 +15,6 @@ LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
 ...
 LL |             s
    |             ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -46,8 +46,6 @@ LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |______^ `cell_a` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -46,8 +46,6 @@ LL | |         // Only works if 'x: 'y:
 LL | |         demand_y(x, y, x.get())
 LL | |     });
    | |______^ `cell_a` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(x: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     &*x
    |     ^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-50716.nll.stderr
+++ b/src/test/ui/nll/issue-50716.nll.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
 ...
 LL |     let _x = *s;
    |              ^^ proving this value is `Sized` requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55401.nll.stderr
+++ b/src/test/ui/nll/issue-55401.nll.stderr
@@ -6,8 +6,6 @@ LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u
 LL |     let (ref y, _z): (&'a u32, u32) = (&22, 44);
 LL |     *y
    |     ^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-58299.stderr
+++ b/src/test/ui/nll/issue-58299.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a>(x: i32) {
 ...
 LL |         A::<'a>::X..=A::<'static>::X => (),
    |         ^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-58299.rs:24:27
@@ -17,8 +15,6 @@ LL | fn bar<'a>(x: i32) {
 ...
 LL |         A::<'static>::X..=A::<'a>::X => (),
    |                           ^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-73159-rpit-static.rs
+++ b/src/test/ui/nll/issue-73159-rpit-static.rs
@@ -1,0 +1,14 @@
+// Regression test for issue #73159
+// Tests thar we don't suggest replacing 'a with 'static'
+
+#![feature(nll)]
+
+struct Foo<'a>(&'a [u8]);
+
+impl<'a> Foo<'a> {
+    fn make_it(&self) -> impl Iterator<Item = u8> { //~ ERROR lifetime may not live
+        self.0.iter().copied()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-73159-rpit-static.stderr
+++ b/src/test/ui/nll/issue-73159-rpit-static.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-73159-rpit-static.rs:9:26
+   |
+LL | impl<'a> Foo<'a> {
+   |      -- lifetime `'a` defined here
+LL |     fn make_it(&self) -> impl Iterator<Item = u8> {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ opaque type requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+

--- a/src/test/ui/nll/mir_check_cast_reify.stderr
+++ b/src/test/ui/nll/mir_check_cast_reify.stderr
@@ -6,8 +6,6 @@ LL | fn bar<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     f(x)
    |     ^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
@@ -6,8 +6,6 @@ LL | fn bar<'a>(input: &'a u32, f: fn(&'a u32) -> &'a u32) -> &'static u32 {
 ...
 LL |     unsafe { g(input) }
    |              ^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -5,8 +5,6 @@ LL | fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
    |        -- lifetime `'a` defined here
 LL |     x
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/outlives-suggestion-more.stderr
+++ b/src/test/ui/nll/outlives-suggestion-more.stderr
@@ -46,8 +46,6 @@ LL | fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usi
    |             -- lifetime `'b` defined here
 LL |     (x, y)
    |     ^^^^^^ returning this value requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 help: the following changes may resolve your lifetime errors
    |
@@ -88,8 +86,6 @@ LL | fn foo3<'a, 'b, 'c, 'd, 'e>(
 ...
 LL |     (x, y, z)
    |     ^^^^^^^^^ returning this value requires that `'c` must outlive `'static`
-   |
-   = help: consider replacing `'c` with `'static`
 
 help: the following changes may resolve your lifetime errors
    |

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -17,8 +17,6 @@ LL | fn foo2<'a>(x: &'a usize) -> &'static usize {
    |         -- lifetime `'a` defined here
 LL |     x
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
@@ -66,8 +64,6 @@ LL |     pub fn foo<'a>(x: &'a usize) -> Self {
    |                -- lifetime `'a` defined here
 LL |         Foo { x }
    |         ^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:41:9

--- a/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
+++ b/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
@@ -6,8 +6,6 @@ LL | fn uninit<'a>() {
 LL |     return;
 LL |     let x: &'static &'a ();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:13:12
@@ -17,8 +15,6 @@ LL | fn var_type<'a>() {
 LL |     return;
 LL |     let x: &'static &'a () = &&();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:17:12
@@ -27,8 +23,6 @@ LL | fn uninit_infer<'a>() {
    |                 -- lifetime `'a` defined here
 LL |     let x: &'static &'a _;
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:23:12
@@ -38,8 +32,6 @@ LL | fn infer<'a>() {
 LL |     return;
 LL |     let x: &'static &'a _ = &&();
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:28:12
@@ -49,8 +41,6 @@ LL | fn uninit_no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a ();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:33:12
@@ -60,8 +50,6 @@ LL | fn no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a () = &&();
    |            ^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:38:12
@@ -71,8 +59,6 @@ LL | fn infer_no_var<'a>() {
 LL |     return;
 LL |     let _: &'static &'a _ = &&();
    |            ^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/wf-unreachable.rs:51:12
@@ -82,8 +68,6 @@ LL | fn required_substs<'a>() {
 LL |     return;
 LL |     let _: C<'static, 'a, _> = C((), &(), &());
    |            ^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/nll/user-annotations/closure-substs.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.stderr
@@ -6,8 +6,6 @@ LL | fn foo<'a>() {
 ...
 LL |         return x;
    |                ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/closure-substs.rs:15:16
@@ -25,8 +23,6 @@ LL | fn bar<'a>() {
 ...
 LL |         b(x);
    |         ^^^^ argument requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of closure
   --> $DIR/closure-substs.rs:29:9

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <Foo<'a>>::C
    |     ^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     <T as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
@@ -5,8 +5,6 @@ LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here
 LL |     T::C
    |     ^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
@@ -5,8 +5,6 @@ LL | fn non_wf_associated_const<'a>(x: i32) {
    |                            -- lifetime `'a` defined here
 LL |     A::<'a>::IC;
    |     ^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/issue-54124.stderr
+++ b/src/test/ui/nll/user-annotations/issue-54124.stderr
@@ -15,8 +15,6 @@ LL | fn test<'a>() {
    |         -- lifetime `'a` defined here
 LL |     let _:fn(&()) = |_:&'a ()| {};
    |                      ^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
@@ -6,8 +6,6 @@ LL | fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:49:5
@@ -17,8 +15,6 @@ LL | fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:62:5
@@ -28,8 +24,6 @@ LL | fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
+++ b/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
@@ -6,8 +6,6 @@ LL | fn coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 LL |     let ((y, _z),) = ((s, _x),): (PairCoupledTypes<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:22:5
@@ -17,8 +15,6 @@ LL | fn coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 LL |     let ((y, _z),) = ((s, _x),): (PairCoupledRegions<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:32:5
@@ -28,8 +24,6 @@ LL | fn cast_coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32
 LL |     let ((y, _z),) = ((s, _x),) as (PairCoupledTypes<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:37:5
@@ -39,8 +33,6 @@ LL | fn cast_coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u
 LL |     let ((y, _z),) = ((s, _x),) as (PairCoupledRegions<_>,);
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -156,8 +156,6 @@ LL | fn static_to_a_to_static_through_variable<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:125:5
@@ -167,8 +165,6 @@ LL | fn static_to_a_to_static_through_tuple<'a>(x: &'a u32) -> &'static u32 {
 ...
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:130:5
@@ -178,8 +174,6 @@ LL | fn static_to_a_to_static_through_struct<'a>(_x: &'a u32) -> &'static u32 {
 LL |     let Single { value: y }: Single<&'a u32> = Single { value: &22 };
 LL |     y
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:134:18
@@ -188,8 +182,6 @@ LL | fn a_to_static_then_static<'a>(x: &'a u32) -> &'static u32 {
    |                            -- lifetime `'a` defined here
 LL |     let (y, _z): (&'static u32, u32) = (x, 44);
    |                  ^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 19 previous errors
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
@@ -5,8 +5,6 @@ LL | fn c<'a>(t: &'a Box<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      -- lifetime `'a` defined here
 LL |     ss.t = t;
    |     ^^^^^^^^ assignment requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
@@ -5,8 +5,6 @@ LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      -- lifetime `'a` defined here
 LL |     ss.t = t;
    |     ^^^^^^^^ assignment requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
@@ -18,8 +18,6 @@ LL | fn load2<'a>(ss: &MyBox<dyn SomeTrait + 'a>) -> MyBox<dyn SomeTrait + 'a> {
    |              -- `ss` is a reference that is only valid in the function body
 LL |     load0(ss)
    |     ^^^^^^^^^ `ss` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/region-invariant-static-error-reporting.nll.stderr
+++ b/src/test/ui/regions/region-invariant-static-error-reporting.nll.stderr
@@ -6,8 +6,6 @@ LL | fn unify<'a>(x: Option<Invariant<'a>>, f: fn(Invariant<'a>)) {
 LL |     let bad = if x.is_some() {
 LL |         x.unwrap()
    |         ^^^^^^^^^^ `x` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
@@ -5,8 +5,6 @@ LL | fn param_not_ok<'a>(x: &'a isize) {
    |                 -- lifetime `'a` defined here
 LL |     assert_send::<&'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:26:5
@@ -15,8 +13,6 @@ LL | fn param_not_ok1<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a str>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:30:5
@@ -25,8 +21,6 @@ LL | fn param_not_ok2<'a>(_: &'a isize) {
    |                  -- lifetime `'a` defined here
 LL |     assert_send::<&'a [isize]>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:44:5
@@ -35,8 +29,6 @@ LL | fn box_with_region_not_ok<'a>() {
    |                           -- lifetime `'a` defined here
 LL |     assert_send::<Box<&'a isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:55:5
@@ -45,8 +37,6 @@ LL | fn unsafe_ok2<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*const &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:59:5
@@ -55,8 +45,6 @@ LL | fn unsafe_ok3<'a>(_: &'a isize) {
    |               -- lifetime `'a` defined here
 LL |     assert_send::<*mut &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
@@ -5,8 +5,6 @@ LL | fn caller<'a>(x: &isize) {
    |           -- lifetime `'a` defined here
 LL |     Foo.some_method::<&'a isize>();
    |         ^^^^^^^^^^^ requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-2.rs:9:5

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -29,8 +29,6 @@ LL | fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
    |      -- lifetime `'a` defined here
 LL |     Box::new(B(&*v)) as Box<dyn X>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0515]: cannot return value referencing local data `*v`
   --> $DIR/regions-close-object-into-object-4.rs:9:5

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
@@ -5,8 +5,6 @@ LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {
    |                       -- lifetime `'r` defined here
 LL |     b_isize
    |     ^^^^^^^ returning this value requires that `'r` must outlive `'static`
-   |
-   = help: consider replacing `'r` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-nested-fns.nll.stderr
+++ b/src/test/ui/regions/regions-nested-fns.nll.stderr
@@ -45,8 +45,6 @@ LL | fn nested<'x>(x: &'x isize) {
 ...
 LL |         if false { return x; }
    |                           ^ returning this value requires that `'x` must outlive `'static`
-   |
-   = help: consider replacing `'x` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
@@ -5,8 +5,6 @@ LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:14:5

--- a/src/test/ui/regions/regions-static-bound.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.nll.stderr
@@ -5,8 +5,6 @@ LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
    |                        -- lifetime `'a` defined here
 LL |     t
    |     ^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0621]: explicit lifetime required in the type of `u`
   --> $DIR/regions-static-bound.rs:14:5

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
@@ -6,8 +6,6 @@ LL | fn use_<'b>(c: Invariant<'b>) {
 ...
 LL |     let _: Invariant<'static> = c;
    |            ^^^^^^^^^^^^^^^^^^ type annotation requires that `'b` must outlive `'static`
-   |
-   = help: consider replacing `'b` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
@@ -13,7 +13,7 @@ error: `<Int as Add>::add` is not yet stable as a const fn
 LL |     Int(1i32) + Int(2i32)
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Const-stable functions can only call other const-stable functions
+   = help: const-stable functions can only call other const-stable functions
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.nll.stderr
+++ b/src/test/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.nll.stderr
@@ -5,8 +5,6 @@ LL |     fn use_it<'a, T>(val: &'a dyn ObjectTrait<T>) -> impl OtherTrait<'a> + 
    |                      --- `val` is a reference that is only valid in the function body
 LL |         val.use_self::<T>()
    |         ^^^^^^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:69:9
@@ -15,8 +13,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         val.use_self()
    |         ^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:88:9
@@ -25,8 +21,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         val.use_self()
    |         ^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:108:9
@@ -35,8 +29,6 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |                   --- `val` is a reference that is only valid in the function body
 LL |         MyTrait::use_self(val)
    |         ^^^^^^^^^^^^^^^^^^^^^^ `val` escapes the function body here
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
@@ -32,8 +32,6 @@ LL | |             current: None,
 LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:60:30
@@ -43,7 +41,6 @@ LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> {
    |             |
    |             lifetime `'a` defined here
    |
-   = help: consider replacing `'a` with `'static`
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a bound
    |
 LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> + 'a {

--- a/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -1,10 +1,10 @@
-error[E0568]: auto traits cannot have super traits
-  --> $DIR/supertrait-auto-trait.rs:8:19
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/supertrait-auto-trait.rs:8:17
    |
 LL | auto trait Magic: Copy {}
-   |            -----  ^^^^ help: remove the super traits
+   |            -----^^^^^^ help: remove the super traits or lifetime bounds
    |            |
-   |            auto trait cannot have super traits
+   |            auto trait cannot have super traits or lifetime bounds
 
 error[E0277]: the trait bound `NoClone: Copy` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23

--- a/src/test/ui/variance/variance-associated-types2.nll.stderr
+++ b/src/test/ui/variance/variance-associated-types2.nll.stderr
@@ -5,8 +5,6 @@ LL | fn take<'a>(_: &'a u32) {
    |         -- lifetime `'a` defined here
 LL |     let _: Box<dyn Foo<Bar = &'a u32>> = make();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
-   |
-   = help: consider replacing `'a` with `'static`
 
 error: aborting due to previous error
 

--- a/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
@@ -5,8 +5,6 @@ LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &
    |                     ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:7:5
@@ -15,8 +13,6 @@ LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (
    |                     ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:10:5
@@ -25,8 +21,6 @@ LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &
    |                        ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:13:5
@@ -35,8 +29,6 @@ LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (
    |                        ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:17:5
@@ -45,8 +37,6 @@ LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a
    |                      ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:20:5
@@ -55,8 +45,6 @@ LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a
    |                      ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:23:5
@@ -65,8 +53,6 @@ LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a
    |                         ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:26:5
@@ -75,8 +61,6 @@ LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a
    |                         ---- lifetime `'new` defined here
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:31:5
@@ -86,8 +70,6 @@ LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
 LL |                          -> OccupiedEntry<'a, &'new (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:35:5
@@ -97,8 +79,6 @@ LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
 LL |                          -> OccupiedEntry<'a, (), &'new ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:39:5
@@ -108,8 +88,6 @@ LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
 LL |                             -> OccupiedEntry<'a, &'static (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:43:5
@@ -119,8 +97,6 @@ LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
 LL |                             -> OccupiedEntry<'a, (), &'static ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:48:5
@@ -130,8 +106,6 @@ LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
 LL |                          -> VacantEntry<'a, &'new (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:52:5
@@ -141,8 +115,6 @@ LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
 LL |                          -> VacantEntry<'a, (), &'new ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:56:5
@@ -152,8 +124,6 @@ LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
 LL |                             -> VacantEntry<'a, &'static (), ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variance-btree-invariant-types.rs:60:5
@@ -163,8 +133,6 @@ LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
 LL |                             -> VacantEntry<'a, (), &'static ()> {
 LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
-   |
-   = help: consider replacing `'new` with `'static`
 
 error: aborting due to 16 previous errors
 

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -143,56 +143,41 @@ impl Formatter for HTMLFormatter {
             r##"<script>
 function onEach(arr, func) {{
     if (arr && arr.length > 0 && func) {{
-        for (var i = 0; i < arr.length; i++) {{
-            func(arr[i]);
-        }}
-    }}
-}}
-
-function hasClass(elem, className) {{
-    if (elem && className && elem.className) {{
-        var elemClass = elem.className;
-        var start = elemClass.indexOf(className);
-        if (start === -1) {{
-            return false;
-        }} else if (elemClass.length === className.length) {{
-            return true;
-        }} else {{
-            if (start > 0 && elemClass[start - 1] !== ' ') {{
-                return false;
+        var length = arr.length;
+        var i;
+        for (i = 0; i < length; ++i) {{
+            if (func(arr[i])) {{
+                return true;
             }}
-            var end = start + className.length;
-            if (end < elemClass.length && elemClass[end] !== ' ') {{
-                return false;
-            }}
-            return true;
         }}
-        if (start > 0 && elemClass[start - 1] !== ' ') {{
-            return false;
-        }}
-        var end = start + className.length;
-        if (end < elemClass.length && elemClass[end] !== ' ') {{
-            return false;
-        }}
-        return true;
     }}
     return false;
 }}
 
-onEach(document.getElementsByClassName('rust-example-rendered'), function(e) {{
+function onEachLazy(lazyArray, func) {{
+    return onEach(
+        Array.prototype.slice.call(lazyArray),
+        func);
+}}
+
+function hasClass(elem, className) {{
+    return elem && elem.classList && elem.classList.contains(className);
+}}
+
+onEachLazy(document.getElementsByClassName('rust-example-rendered'), function(e) {{
     if (hasClass(e, 'compile_fail')) {{
         e.addEventListener("mouseover", function(event) {{
-            e.previousElementSibling.childNodes[0].style.color = '#f00';
+            e.parentElement.previousElementSibling.childNodes[0].style.color = '#f00';
         }});
         e.addEventListener("mouseout", function(event) {{
-            e.previousElementSibling.childNodes[0].style.color = '';
+            e.parentElement.previousElementSibling.childNodes[0].style.color = '';
         }});
     }} else if (hasClass(e, 'ignore')) {{
         e.addEventListener("mouseover", function(event) {{
-            e.previousElementSibling.childNodes[0].style.color = '#ff9200';
+            e.parentElement.previousElementSibling.childNodes[0].style.color = '#ff9200';
         }});
         e.addEventListener("mouseout", function(event) {{
-            e.previousElementSibling.childNodes[0].style.color = '';
+            e.parentElement.previousElementSibling.childNodes[0].style.color = '';
         }});
     }}
 }});

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -172,7 +172,7 @@ async function main(argv) {
     }
     files.sort();
 
-    console.log(`Running ${files.length} rustdoc-gui tests...`);
+    console.log(`Running ${files.length} rustdoc-gui (${opts["jobs"]} concurrently) ...`);
 
     if (opts["jobs"] < 1) {
         process.setMaxListeners(files.length + 1);


### PR DESCRIPTION
Successful merges:

 - #87631 (os current_exe using same approach as linux to get always the full ab…)
 - #88234 (rustdoc-json: Don't ignore impls for primitive types)
 - #88651 (Use the 64b inner:monotonize() implementation not the 128b one for aarch64)
 - #88780 (Added abs_diff for integer types.)
 - #88816 (Rustdoc migrate to table so the gui can handle >2k constants)
 - #89244 (refactor: VecDeques PairSlices fields to private)
 - #89364 (rustdoc-json: Encode json files with UTF-8)
 - #89456 (Update to the final LLVM 13.0.0 release)
 - #89462 (haiku thread affinity build fix)
 - #89473 (Fix extra `non_snake_case` warning for shorthand field bindings)
 - #89482 (Follow the diagnostic output style guide)
 - #89494 (Deny `where` clauses on `auto` traits)
 - #89504 (Don't suggest replacing region with 'static in NLL)
 - #89535 (fix busted JavaScript in error index generator)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87631,88234,88651,88780,88816,89244,89364,89456,89462,89473,89482,89494,89504,89535)
<!-- homu-ignore:end -->