### PR TITLE
Add trait object safety information on trait documentation page

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -497,6 +497,13 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
 
     // Output the trait definition
     wrap_into_docblock(w, |w| {
+        if let Some(def_id) = it.def_id.as_def_id() {
+            write!(
+                w,
+                "<div class=\"obj-info\">This trait is <b>{}object safe</b>.</div>",
+                if cx.tcx().is_object_safe(def_id) { "" } else { "not " }
+            );
+        }
         wrap_item(w, "trait", |w| {
             render_attributes_in_pre(w, it, "");
             write!(

--- a/src/test/rustdoc/trait-object-safe.rs
+++ b/src/test/rustdoc/trait-object-safe.rs
@@ -1,0 +1,23 @@
+#![crate_name = "foo"]
+
+// @has 'foo/trait.Safe.html'
+// @has - '//*[@class="obj-info"]' 'This trait is object safe.'
+pub trait Safe {
+    fn foo(&self);
+}
+
+// @has 'foo/trait.Unsafe.html'
+// @has - '//*[@class="obj-info"]' 'This trait is not object safe.'
+pub trait Unsafe {
+    fn foo() -> Self;
+}
+
+// @has 'foo/trait.Unsafe2.html'
+// @has - '//*[@class="obj-info"]' 'This trait is not object safe.'
+pub trait Unsafe2<T> {
+    fn foo(i: T);
+}
+
+// @has 'foo/struct.Foo.html'
+// @!has - '//*[@class="obj-info"]'
+pub struct Foo;


### PR DESCRIPTION
Fixes #85138.

It looks like this:

![Screenshot from 2021-10-05 12-42-18](https://user-images.githubusercontent.com/3050060/136008430-e8bb45aa-57e1-4e91-bc7b-b778861520d9.png)

So now, what remains to be done is debating over the appearance of the information.

r? @jsha 