### PR TITLE
Remove textual span from diagnostic string

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2235,8 +2235,7 @@ pub enum TyKind<'hir> {
     ///
     /// Type parameters may be stored in each `PathSegment`.
     Path(QPath<'hir>),
-    /// An opaque type definition itself. This is currently only used for the
-    /// `opaque type Foo: Trait` item that `impl Trait` in desugars to.
+    /// An opaque type definition itself. This is only used for `impl Trait`.
     ///
     /// The generic argument list contains the lifetimes (and in the future
     /// possibly parameters) that are actually bound on the `impl Trait`.

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -267,6 +267,18 @@ pub fn unexpected_hidden_region_diagnostic(
                 hidden_region,
                 "",
             );
+            if let Some(reg_info) = tcx.is_suitable_region(hidden_region) {
+                let fn_returns = tcx.return_type_impl_or_dyn_traits(reg_info.def_id);
+                nice_region_error::suggest_new_region_bound(
+                    tcx,
+                    &mut err,
+                    fn_returns,
+                    hidden_region.to_string(),
+                    None,
+                    format!("captures {}", hidden_region),
+                    None,
+                )
+            }
         }
         _ => {
             // Ugh. This is a painful case: the hidden region is not one

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -116,7 +116,7 @@ pub(super) fn note_and_explain_region(
     emit_msg_span(err, prefix, description, span, suffix);
 }
 
-pub(super) fn note_and_explain_free_region(
+fn explain_free_region(
     tcx: TyCtxt<'tcx>,
     err: &mut DiagnosticBuilder<'_>,
     prefix: &str,
@@ -125,7 +125,7 @@ pub(super) fn note_and_explain_free_region(
 ) {
     let (description, span) = msg_span_from_free_region(tcx, region, None);
 
-    emit_msg_span(err, prefix, description, span, suffix);
+    label_msg_span(err, prefix, description, span, suffix);
 }
 
 fn msg_span_from_free_region(
@@ -210,6 +210,22 @@ fn emit_msg_span(
     }
 }
 
+fn label_msg_span(
+    err: &mut DiagnosticBuilder<'_>,
+    prefix: &str,
+    description: String,
+    span: Option<Span>,
+    suffix: &str,
+) {
+    let message = format!("{}{}{}", prefix, description, suffix);
+
+    if let Some(span) = span {
+        err.span_label(span, &message);
+    } else {
+        err.note(&message);
+    }
+}
+
 pub fn unexpected_hidden_region_diagnostic(
     tcx: TyCtxt<'tcx>,
     span: Span,
@@ -244,7 +260,7 @@ pub fn unexpected_hidden_region_diagnostic(
             //
             // (*) if not, the `tainted_by_errors` field would be set to
             // `Some(ErrorReported)` in any case, so we wouldn't be here at all.
-            note_and_explain_free_region(
+            explain_free_region(
                 tcx,
                 &mut err,
                 &format!("hidden type `{}` captures ", hidden_ty),

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
@@ -14,6 +14,8 @@ mod static_impl_trait;
 mod trait_impl_difference;
 mod util;
 
+pub use static_impl_trait::suggest_new_region_bound;
+
 impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     pub fn try_report_nice_region_error(&self, error: &RegionResolutionError<'tcx>) -> bool {
         NiceRegionError::new(self, error.clone()).try_report().is_some()

--- a/src/test/ui/associated-consts/associated-const-impl-wrong-lifetime.stderr
+++ b/src/test/ui/associated-consts/associated-const-impl-wrong-lifetime.stderr
@@ -6,7 +6,7 @@ LL |     const NAME: &'a str = "unit";
    |
    = note: expected reference `&'static str`
               found reference `&'a str`
-note: the lifetime `'a` as defined on the impl at 6:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/associated-const-impl-wrong-lifetime.rs:6:6
    |
 LL | impl<'a> Foo for &'a () {

--- a/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/src/test/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -24,12 +24,12 @@ LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d
    |
    = note: expected fn pointer `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
               found fn pointer `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
-note: the lifetime `'c` as defined on the method body at 27:24...
+note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
-note: ...does not necessarily outlive the lifetime `'c` as defined on the method body at 27:24
+note: ...does not necessarily outlive the lifetime `'c` as defined here
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
@@ -43,12 +43,12 @@ LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d
    |
    = note: expected fn pointer `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
               found fn pointer `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
-note: the lifetime `'c` as defined on the method body at 27:24...
+note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
-note: ...does not necessarily outlive the lifetime `'c` as defined on the method body at 27:24
+note: ...does not necessarily outlive the lifetime `'c` as defined here
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {

--- a/src/test/ui/c-variadic/issue-86053-1.stderr
+++ b/src/test/ui/c-variadic/issue-86053-1.stderr
@@ -84,12 +84,12 @@ error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the 
 LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 10:16
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/issue-86053-1.rs:10:16
    |
 LL | fn ordering4 < 'a , 'b     > ( a :            ,   self , self ,   self ,
    |                ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 10:21
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/issue-86053-1.rs:10:21
    |
 LL | fn ordering4 < 'a , 'b     > ( a :            ,   self , self ,   self ,

--- a/src/test/ui/c-variadic/issue-86053-2.stderr
+++ b/src/test/ui/c-variadic/issue-86053-2.stderr
@@ -5,7 +5,7 @@ LL | unsafe extern "C" fn ordering4<'a, F: H<&'static &'a ()>>(_: (), ...) {}
    |                                       ^^^^^^^^^^^^^^^^^^
    |
    = note: the pointer is valid for the static lifetime
-note: but the referenced data is only valid for the lifetime `'a` as defined on the function body at 8:32
+note: but the referenced data is only valid for the lifetime `'a` as defined here
   --> $DIR/issue-86053-2.rs:8:32
    |
 LL | unsafe extern "C" fn ordering4<'a, F: H<&'static &'a ()>>(_: (), ...) {}

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -6,12 +6,12 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |
    = note: expected fn pointer `fn(&u32)`
               found fn pointer `fn(&'x u32)`
-note: the anonymous lifetime #1 defined on the body at 16:48...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/expect-fn-supply-fn.rs:16:48
    |
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |                                                ^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime `'x` as defined on the function body at 13:36
+note: ...does not necessarily outlive the lifetime `'x` as defined here
   --> $DIR/expect-fn-supply-fn.rs:13:36
    |
 LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
@@ -25,12 +25,12 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |
    = note: expected fn pointer `fn(&u32)`
               found fn pointer `fn(&'x u32)`
-note: the lifetime `'x` as defined on the function body at 13:36...
+note: the lifetime `'x` as defined here...
   --> $DIR/expect-fn-supply-fn.rs:13:36
    |
 LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
    |                                    ^^
-note: ...does not necessarily outlive the anonymous lifetime #1 defined on the body at 16:48
+note: ...does not necessarily outlive the anonymous lifetime #1 defined here
   --> $DIR/expect-fn-supply-fn.rs:16:48
    |
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.stderr
@@ -6,7 +6,7 @@ LL |     closure_expecting_bound(|x: &'x u32| {
    |
    = note: expected reference `&u32`
               found reference `&'x u32`
-note: the anonymous lifetime #1 defined on the body at 14:29...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/expect-region-supply-region-2.rs:14:29
    |
 LL |       closure_expecting_bound(|x: &'x u32| {
@@ -18,7 +18,7 @@ LL | |
 LL | |         f = Some(x);
 LL | |     });
    | |_____^
-note: ...does not necessarily outlive the lifetime `'x` as defined on the function body at 9:30
+note: ...does not necessarily outlive the lifetime `'x` as defined here
   --> $DIR/expect-region-supply-region-2.rs:9:30
    |
 LL | fn expect_bound_supply_named<'x>() {
@@ -32,12 +32,12 @@ LL |     closure_expecting_bound(|x: &'x u32| {
    |
    = note: expected reference `&u32`
               found reference `&'x u32`
-note: the lifetime `'x` as defined on the function body at 9:30...
+note: the lifetime `'x` as defined here...
   --> $DIR/expect-region-supply-region-2.rs:9:30
    |
 LL | fn expect_bound_supply_named<'x>() {
    |                              ^^
-note: ...does not necessarily outlive the anonymous lifetime #1 defined on the body at 14:29
+note: ...does not necessarily outlive the anonymous lifetime #1 defined here
   --> $DIR/expect-region-supply-region-2.rs:14:29
    |
 LL |       closure_expecting_bound(|x: &'x u32| {

--- a/src/test/ui/dropck/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/dropck/reject-specialized-drops-8142.stderr
@@ -30,7 +30,7 @@ LL | impl                    Drop for N<'static>     { fn drop(&mut self) { } } 
    |
    = note: expected struct `N<'n>`
               found struct `N<'static>`
-note: the lifetime `'n` as defined on the struct at 7:10...
+note: the lifetime `'n` as defined here...
   --> $DIR/reject-specialized-drops-8142.rs:7:10
    |
 LL | struct N<'n> { x: &'n i8 }
@@ -91,12 +91,12 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'lw` 
 LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'l1` as defined on the struct at 16:10...
+note: first, the lifetime cannot outlive the lifetime `'l1` as defined here...
   --> $DIR/reject-specialized-drops-8142.rs:16:10
    |
 LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
    |          ^^^
-note: ...but the lifetime must also be valid for the lifetime `'l2` as defined on the struct at 16:15...
+note: ...but the lifetime must also be valid for the lifetime `'l2` as defined here...
   --> $DIR/reject-specialized-drops-8142.rs:16:15
    |
 LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }

--- a/src/test/ui/error-codes/E0308-2.stderr
+++ b/src/test/ui/error-codes/E0308-2.stderr
@@ -6,7 +6,7 @@ LL | impl Eq for &dyn DynEq {}
    |
    = note: expected trait `<&dyn DynEq as PartialEq>`
               found trait `<&(dyn DynEq + 'static) as PartialEq>`
-note: the lifetime `'_` as defined on the impl at 9:13...
+note: the lifetime `'_` as defined here...
   --> $DIR/E0308-2.rs:9:13
    |
 LL | impl Eq for &dyn DynEq {}

--- a/src/test/ui/error-codes/E0478.stderr
+++ b/src/test/ui/error-codes/E0478.stderr
@@ -4,12 +4,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     child: Box<dyn Wedding<'kiss> + 'SnowWhite>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'SnowWhite` as defined on the struct at 3:22
+note: lifetime parameter instantiated with the lifetime `'SnowWhite` as defined here
   --> $DIR/E0478.rs:3:22
    |
 LL | struct Prince<'kiss, 'SnowWhite> {
    |                      ^^^^^^^^^^
-note: but lifetime parameter must outlive the lifetime `'kiss` as defined on the struct at 3:15
+note: but lifetime parameter must outlive the lifetime `'kiss` as defined here
   --> $DIR/E0478.rs:3:15
    |
 LL | struct Prince<'kiss, 'SnowWhite> {

--- a/src/test/ui/error-codes/E0490.stderr
+++ b/src/test/ui/error-codes/E0490.stderr
@@ -4,12 +4,12 @@ error[E0490]: a value of type `&'b ()` is borrowed for too long
 LL |     let x: &'a _ = &y;
    |                    ^^
    |
-note: the type is valid for the lifetime `'a` as defined on the function body at 1:6
+note: the type is valid for the lifetime `'a` as defined here
   --> $DIR/E0490.rs:1:6
    |
 LL | fn f<'a, 'b>(y: &'b ()) {
    |      ^^
-note: but the borrow lasts for the lifetime `'b` as defined on the function body at 1:10
+note: but the borrow lasts for the lifetime `'b` as defined here
   --> $DIR/E0490.rs:1:10
    |
 LL | fn f<'a, 'b>(y: &'b ()) {
@@ -21,7 +21,7 @@ error[E0495]: cannot infer an appropriate lifetime for borrow expression due to 
 LL |     let x: &'a _ = &y;
    |                    ^^
    |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 1:10...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/E0490.rs:1:10
    |
 LL | fn f<'a, 'b>(y: &'b ()) {
@@ -31,7 +31,7 @@ note: ...so that the type `&'b ()` is not borrowed for too long
    |
 LL |     let x: &'a _ = &y;
    |                    ^^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 1:6...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/E0490.rs:1:6
    |
 LL | fn f<'a, 'b>(y: &'b ()) {
@@ -48,7 +48,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     let x: &'a _ = &y;
    |                    ^^
    |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 1:10...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/E0490.rs:1:10
    |
 LL | fn f<'a, 'b>(y: &'b ()) {
@@ -60,7 +60,7 @@ LL |     let x: &'a _ = &y;
    |                    ^^
    = note: expected `&'a &()`
               found `&'a &'b ()`
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 1:6...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/E0490.rs:1:6
    |
 LL | fn f<'a, 'b>(y: &'b ()) {

--- a/src/test/ui/explicit/explicit-self-lifetime-mismatch.stderr
+++ b/src/test/ui/explicit/explicit-self-lifetime-mismatch.stderr
@@ -6,12 +6,12 @@ LL |            Foo<'b,'a>
    |
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
-note: the lifetime `'b` as defined on the impl at 6:9...
+note: the lifetime `'b` as defined here...
   --> $DIR/explicit-self-lifetime-mismatch.rs:6:9
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |         ^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 6:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/explicit-self-lifetime-mismatch.rs:6:6
    |
 LL | impl<'a,'b> Foo<'a,'b> {
@@ -25,12 +25,12 @@ LL |            Foo<'b,'a>
    |
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
-note: the lifetime `'a` as defined on the impl at 6:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/explicit-self-lifetime-mismatch.rs:6:6
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |      ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the impl at 6:9
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/explicit-self-lifetime-mismatch.rs:6:9
    |
 LL | impl<'a,'b> Foo<'a,'b> {

--- a/src/test/ui/generator/resume-arg-late-bound.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.stderr
@@ -6,7 +6,7 @@ LL |     test(gen);
    |
    = note: expected type `for<'a> Generator<&'a mut bool>`
               found type `Generator<&mut bool>`
-note: the required lifetime does not necessarily outlive the anonymous lifetime #1 defined on the body at 11:15
+note: the required lifetime does not necessarily outlive the anonymous lifetime #1 defined here
   --> $DIR/resume-arg-late-bound.rs:11:15
    |
 LL |       let gen = |arg: &mut bool| {
@@ -29,7 +29,7 @@ LL |     test(gen);
    |
    = note: expected type `for<'a> Generator<&'a mut bool>`
               found type `Generator<&mut bool>`
-note: the anonymous lifetime #1 defined on the body at 11:15 doesn't meet the lifetime requirements
+note: the anonymous lifetime #1 defined here doesn't meet the lifetime requirements
   --> $DIR/resume-arg-late-bound.rs:11:15
    |
 LL |       let gen = |arg: &mut bool| {

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -22,12 +22,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the associated item at 17:12
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/impl_bounds.rs:17:12
    |
 LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());
    |            ^^
-note: but lifetime parameter must outlive the lifetime `'b` as defined on the associated item at 17:16
+note: but lifetime parameter must outlive the lifetime `'b` as defined here
   --> $DIR/impl_bounds.rs:17:16
    |
 LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());

--- a/src/test/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.stderr
+++ b/src/test/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.stderr
@@ -9,7 +9,7 @@ note: because this has an unmet lifetime requirement
    |
 LL |     type T<'a>: A;
    |                 ^ introduces a `'static` lifetime requirement
-note: the lifetime `'a` as defined on the associated item at 17:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:17:12
    |
 LL |     type T<'a> = Box<dyn A + 'a>;
@@ -36,7 +36,7 @@ note: because this has an unmet lifetime requirement
    |
 LL |     type T<'a>: C;
    |                 ^ introduces a `'static` lifetime requirement
-note: the lifetime `'a` as defined on the associated item at 27:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:27:12
    |
 LL |     type T<'a> = Box<dyn A + 'a>;
@@ -58,7 +58,7 @@ note: because this has an unmet lifetime requirement
    |
 LL |     type T<'a>: E;
    |                 ^ introduces a `'static` lifetime requirement
-note: the lifetime `'a` as defined on the associated item at 37:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:37:12
    |
 LL |     type T<'a> = (Box<dyn A + 'a>, Box<dyn A + 'a>);

--- a/src/test/ui/generic-associated-types/unsatified-item-lifetime-bound.stderr
+++ b/src/test/ui/generic-associated-types/unsatified-item-lifetime-bound.stderr
@@ -12,7 +12,7 @@ error[E0478]: lifetime bound not satisfied
 LL |     f: <T as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the struct at 12:10
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatified-item-lifetime-bound.rs:12:10
    |
 LL | struct B<'a, T: for<'r> X<Y<'r> = &'r ()>> {
@@ -25,7 +25,7 @@ error[E0478]: lifetime bound not satisfied
 LL |     f: <T as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the struct at 17:10
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatified-item-lifetime-bound.rs:17:10
    |
 LL | struct C<'a, T: X> {
@@ -38,7 +38,7 @@ error[E0478]: lifetime bound not satisfied
 LL |     f: <() as X>::Y<'a>,
    |        ^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the struct at 22:10
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatified-item-lifetime-bound.rs:22:10
    |
 LL | struct D<'a> {

--- a/src/test/ui/generic-associated-types/unsatisfied-outlives-bound.stderr
+++ b/src/test/ui/generic-associated-types/unsatisfied-outlives-bound.stderr
@@ -4,7 +4,7 @@ error[E0477]: the type `&'b ()` does not fulfill the required lifetime
 LL |     type Item<'a> = &'b ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: type must outlive the lifetime `'a` as defined on the associated item at 8:15 as required by this binding
+note: type must outlive the lifetime `'a` as defined here as required by this binding
   --> $DIR/unsatisfied-outlives-bound.rs:8:15
    |
 LL |     type Item<'a> = &'b ();

--- a/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
@@ -10,7 +10,7 @@ LL | | fn(Inv<'y>)) }
    |
    = note: expected enum `Option<fn(Inv<'y>)>`
               found enum `Option<fn(Inv<'x>)>`
-note: the lifetime `'x` as defined on the function body at 38:20...
+note: the lifetime `'x` as defined here...
   --> $DIR/hr-subtype.rs:38:20
    |
 LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
@@ -19,7 +19,7 @@ LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
-note: ...does not necessarily outlive the lifetime `'y` as defined on the function body at 38:24
+note: ...does not necessarily outlive the lifetime `'y` as defined here
   --> $DIR/hr-subtype.rs:38:24
    |
 LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
@@ -42,7 +42,7 @@ LL | | fn(Inv<'y>)) }
    |
    = note: expected enum `Option<fn(Inv<'x>)>`
               found enum `Option<fn(Inv<'y>)>`
-note: the lifetime `'x` as defined on the function body at 44:22...
+note: the lifetime `'x` as defined here...
   --> $DIR/hr-subtype.rs:44:22
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
@@ -51,7 +51,7 @@ LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
-note: ...does not necessarily outlive the lifetime `'y` as defined on the function body at 44:26
+note: ...does not necessarily outlive the lifetime `'y` as defined here
   --> $DIR/hr-subtype.rs:44:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
@@ -10,7 +10,7 @@ LL | | fn(&'y u32)) }
    |
    = note: expected enum `Option<fn(&'x u32)>`
               found enum `Option<fn(&'y u32)>`
-note: the lifetime `'x` as defined on the function body at 44:22...
+note: the lifetime `'x` as defined here...
   --> $DIR/hr-subtype.rs:44:22
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
@@ -19,7 +19,7 @@ LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_x_vs_free_y: (fn(&'x u32),
 LL | | fn(&'y u32)) }
    | |______________- in this macro invocation
-note: ...does not necessarily outlive the lifetime `'y` as defined on the function body at 44:26
+note: ...does not necessarily outlive the lifetime `'y` as defined here
   --> $DIR/hr-subtype.rs:44:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {

--- a/src/test/ui/impl-trait/hidden-lifetimes.stderr
+++ b/src/test/ui/impl-trait/hidden-lifetimes.stderr
@@ -5,6 +5,11 @@ LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
    |                 --                                   ^^^^^^^^^^^^^^
    |                 |
    |                 hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
+   |
+help: to declare that the `impl Trait` captures 'b, you can add an explicit `'b` lifetime bound
+   |
+LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a + 'b {
+   |                                                                     ++++
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/hidden-lifetimes.rs:45:70
@@ -13,6 +18,11 @@ LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl S
    |                        --                                            ^^^^^^^^^^^^^^
    |                        |
    |                        hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
+   |
+help: to declare that the `impl Trait` captures 'b, you can add an explicit `'b` lifetime bound
+   |
+LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a + 'b {
+   |                                                                                     ++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/hidden-lifetimes.stderr
+++ b/src/test/ui/impl-trait/hidden-lifetimes.stderr
@@ -2,25 +2,17 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
   --> $DIR/hidden-lifetimes.rs:28:54
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
-   |                                                      ^^^^^^^^^^^^^^
-   |
-note: hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
-  --> $DIR/hidden-lifetimes.rs:28:17
-   |
-LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
-   |                 ^^
+   |                 --                                   ^^^^^^^^^^^^^^
+   |                 |
+   |                 hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
 
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> $DIR/hidden-lifetimes.rs:45:70
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
-   |                                                                      ^^^^^^^^^^^^^^
-   |
-note: hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
-  --> $DIR/hidden-lifetimes.rs:45:24
-   |
-LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
-   |                        ^^
+   |                        --                                            ^^^^^^^^^^^^^^
+   |                        |
+   |                        hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/hidden-lifetimes.stderr
+++ b/src/test/ui/impl-trait/hidden-lifetimes.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
    |                                                      ^^^^^^^^^^^^^^
    |
-note: hidden type `&'a mut &'b T` captures the lifetime `'b` as defined on the function body at 28:17
+note: hidden type `&'a mut &'b T` captures the lifetime `'b` as defined here
   --> $DIR/hidden-lifetimes.rs:28:17
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
@@ -16,7 +16,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |                                                                      ^^^^^^^^^^^^^^
    |
-note: hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined on the function body at 45:24
+note: hidden type `Rc<RefCell<&'b T>>` captures the lifetime `'b` as defined here
   --> $DIR/hidden-lifetimes.rs:45:24
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.rs
@@ -1,5 +1,3 @@
-// compile-flags:-Zborrowck=mir
-
 #![feature(type_alias_impl_trait)]
 
 #[derive(Clone)]

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.rs
@@ -1,6 +1,5 @@
 // compile-flags:-Zborrowck=mir
 
-#![feature(member_constraints)]
 #![feature(type_alias_impl_trait)]
 
 #[derive(Clone)]

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |                                                            ^^^^^^^^^
    |
-note: hidden type `*mut &'a i32` captures the lifetime `'a` as defined on the function body at 13:8
+note: hidden type `*mut &'a i32` captures the lifetime `'a` as defined here
   --> $DIR/error-handling-2.rs:13:8
    |
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
@@ -2,13 +2,9 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
   --> $DIR/error-handling-2.rs:13:60
    |
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
-   |                                                            ^^^^^^^^^
-   |
-note: hidden type `*mut &'a i32` captures the lifetime `'a` as defined here
-  --> $DIR/error-handling-2.rs:13:8
-   |
-LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
-   |        ^^
+   |        --                                                  ^^^^^^^^^
+   |        |
+   |        hidden type `*mut &'a i32` captures the lifetime `'a` as defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
-  --> $DIR/error-handling-2.rs:12:60
+  --> $DIR/error-handling-2.rs:10:60
    |
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        --                                                  ^^^^^^^^^

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling-2.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
-  --> $DIR/error-handling-2.rs:13:60
+  --> $DIR/error-handling-2.rs:12:60
    |
 LL | fn foo<'a: 'b, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        --                                                  ^^^^^^^^^

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.rs
@@ -1,5 +1,3 @@
-// compile-flags:-Zborrowck=mir
-
 #![feature(type_alias_impl_trait)]
 
 #[derive(Clone)]

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/error-handling.rs:22:16
+  --> $DIR/error-handling.rs:20:16
    |
 LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        --  -- lifetime `'b` defined here

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
@@ -2,13 +2,14 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
   --> $DIR/ordinary-bounds-unrelated.rs:16:74
    |
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
-   |                                                                          ^^^^^^^^^^^^^^^^^^
+   |                     --                                                   ^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
    |
-note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
-  --> $DIR/ordinary-bounds-unrelated.rs:16:21
+help: to declare that the `impl Trait` captures 'b, you can add an explicit `'b` lifetime bound
    |
-LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
-   |                     ^^
+LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e> + 'b
+   |                                                                                             ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unrelated.nll.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>
    |                                                                          ^^^^^^^^^^^^^^^^^^
    |
-note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined on the function body at 16:21
+note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
   --> $DIR/ordinary-bounds-unrelated.rs:16:21
    |
 LL | fn upper_bounds<'a, 'b, 'c, 'd, 'e>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'d, 'e>

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
@@ -2,13 +2,14 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
   --> $DIR/ordinary-bounds-unsuited.rs:18:62
    |
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
-   |                                                              ^^^^^^^^^^^^^^^^^^
+   |                     --                                       ^^^^^^^^^^^^^^^^^^
+   |                     |
+   |                     hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
    |
-note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
-  --> $DIR/ordinary-bounds-unsuited.rs:18:21
+help: to declare that the `impl Trait` captures 'b, you can add an explicit `'b` lifetime bound
    |
-LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
-   |                     ^^
+LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b> + 'b
+   |                                                                                 ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-unsuited.nll.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>
    |                                                              ^^^^^^^^^^^^^^^^^^
    |
-note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined on the function body at 18:21
+note: hidden type `Ordinary<'b>` captures the lifetime `'b` as defined here
   --> $DIR/ordinary-bounds-unsuited.rs:18:21
    |
 LL | fn upper_bounds<'a, 'b>(a: Ordinary<'a>, b: Ordinary<'b>) -> impl Trait<'a, 'b>

--- a/src/test/ui/impl-trait/region-escape-via-bound.stderr
+++ b/src/test/ui/impl-trait/region-escape-via-bound.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL | fn foo(x: Cell<&'x u32>) -> impl Trait<'y>
    |                             ^^^^^^^^^^^^^^
    |
-note: hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined on the function body at 17:7
+note: hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
   --> $DIR/region-escape-via-bound.rs:17:7
    |
 LL | where 'x: 'y

--- a/src/test/ui/impl-trait/region-escape-via-bound.stderr
+++ b/src/test/ui/impl-trait/region-escape-via-bound.stderr
@@ -6,6 +6,11 @@ LL | fn foo(x: Cell<&'x u32>) -> impl Trait<'y>
 LL |
 LL | where 'x: 'y
    |       -- hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
+   |
+help: to declare that the `impl Trait` captures 'x, you can add an explicit `'x` lifetime bound
+   |
+LL | fn foo(x: Cell<&'x u32>) -> impl Trait<'y> + 'x
+   |                                            ++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/region-escape-via-bound.stderr
+++ b/src/test/ui/impl-trait/region-escape-via-bound.stderr
@@ -3,12 +3,9 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
    |
 LL | fn foo(x: Cell<&'x u32>) -> impl Trait<'y>
    |                             ^^^^^^^^^^^^^^
-   |
-note: hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
-  --> $DIR/region-escape-via-bound.rs:17:7
-   |
+LL |
 LL | where 'x: 'y
-   |       ^^
+   |       -- hidden type `Cell<&'x u32>` captures the lifetime `'x` as defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-10291.stderr
+++ b/src/test/ui/issues/issue-10291.stderr
@@ -4,7 +4,7 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         x
    |         ^
    |
-note: ...the reference is valid for the anonymous lifetime #1 defined on the body at 2:69...
+note: ...the reference is valid for the anonymous lifetime #1 defined here...
   --> $DIR/issue-10291.rs:2:69
    |
 LL |       drop::<Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
@@ -12,7 +12,7 @@ LL |       drop::<Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
 LL | |         x
 LL | |     }));
    | |_____^
-note: ...but the borrowed content is only valid for the lifetime `'x` as defined on the function body at 1:9
+note: ...but the borrowed content is only valid for the lifetime `'x` as defined here
   --> $DIR/issue-10291.rs:1:9
    |
 LL | fn test<'x>(x: &'x isize) {

--- a/src/test/ui/issues/issue-16683.stderr
+++ b/src/test/ui/issues/issue-16683.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |         self.a();
    |              ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 3:10...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/issue-16683.rs:3:10
    |
 LL |     fn b(&self) {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |         self.a();
    |         ^^^^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the trait at 1:9...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/issue-16683.rs:1:9
    |
 LL | trait T<'a> {

--- a/src/test/ui/issues/issue-17740.stderr
+++ b/src/test/ui/issues/issue-17740.stderr
@@ -6,12 +6,12 @@ LL |     fn bar(self: &mut Foo) {
    |
    = note: expected struct `Foo<'a>`
               found struct `Foo<'_>`
-note: the anonymous lifetime defined on the method body at 6:23...
+note: the anonymous lifetime defined here...
   --> $DIR/issue-17740.rs:6:23
    |
 LL |     fn bar(self: &mut Foo) {
    |                       ^^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 5:7
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/issue-17740.rs:5:7
    |
 LL | impl <'a> Foo<'a>{
@@ -25,12 +25,12 @@ LL |     fn bar(self: &mut Foo) {
    |
    = note: expected struct `Foo<'a>`
               found struct `Foo<'_>`
-note: the lifetime `'a` as defined on the impl at 5:7...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-17740.rs:5:7
    |
 LL | impl <'a> Foo<'a>{
    |       ^^
-note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 6:23
+note: ...does not necessarily outlive the anonymous lifetime defined here
   --> $DIR/issue-17740.rs:6:23
    |
 LL |     fn bar(self: &mut Foo) {

--- a/src/test/ui/issues/issue-17758.stderr
+++ b/src/test/ui/issues/issue-17758.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |         self.foo();
    |              ^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 6:12...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/issue-17758.rs:6:12
    |
 LL |     fn bar(&self) {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |         self.foo();
    |         ^^^^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the trait at 4:11...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/issue-17758.rs:4:11
    |
 LL | trait Foo<'a> {

--- a/src/test/ui/issues/issue-17905-2.stderr
+++ b/src/test/ui/issues/issue-17905-2.stderr
@@ -6,12 +6,12 @@ LL |     fn say(self: &Pair<&str, isize>) {
    |
    = note: expected struct `Pair<&str, _>`
               found struct `Pair<&str, _>`
-note: the anonymous lifetime defined on the method body at 8:24...
+note: the anonymous lifetime defined here...
   --> $DIR/issue-17905-2.rs:8:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {
    |                        ^^^^
-note: ...does not necessarily outlive the lifetime `'_` as defined on the impl at 5:5
+note: ...does not necessarily outlive the lifetime `'_` as defined here
   --> $DIR/issue-17905-2.rs:5:5
    |
 LL |     &str,
@@ -25,12 +25,12 @@ LL |     fn say(self: &Pair<&str, isize>) {
    |
    = note: expected struct `Pair<&str, _>`
               found struct `Pair<&str, _>`
-note: the lifetime `'_` as defined on the impl at 5:5...
+note: the lifetime `'_` as defined here...
   --> $DIR/issue-17905-2.rs:5:5
    |
 LL |     &str,
    |     ^
-note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 8:24
+note: ...does not necessarily outlive the anonymous lifetime defined here
   --> $DIR/issue-17905-2.rs:8:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -4,12 +4,12 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
    |        ^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 28:58...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/issue-20831-debruijn.rs:28:58
    |
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the impl at 26:6...
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
   --> $DIR/issue-20831-debruijn.rs:26:6
    |
 LL | impl<'a> Publisher<'a> for MyStruct<'a> {

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -6,12 +6,12 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`
-note: the anonymous lifetime defined on the method body at 5:15...
+note: the anonymous lifetime defined here...
   --> $DIR/issue-27942.rs:5:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |               ^^^^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the trait at 3:18
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/issue-27942.rs:3:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
@@ -25,12 +25,12 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`
-note: the lifetime `'a` as defined on the trait at 3:18...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-27942.rs:3:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
    |                  ^^
-note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 5:15
+note: ...does not necessarily outlive the anonymous lifetime defined here
   --> $DIR/issue-27942.rs:5:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -11,12 +11,12 @@ LL | |     }
    |
    = note: expected fn pointer `fn(&mut RepeatMut<'a, T>) -> Option<_>`
               found fn pointer `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
-note: the anonymous lifetime #1 defined on the method body at 6:5...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/issue-37884.rs:6:5
    |
 LL |     fn next(&'a mut self) -> Option<Self::Item>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 3:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/issue-37884.rs:3:6
    |
 LL | impl<'a, T: 'a> Iterator for RepeatMut<'a, T> {

--- a/src/test/ui/issues/issue-52213.stderr
+++ b/src/test/ui/issues/issue-52213.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     match (&t,) {
    |           ^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 1:23...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/issue-52213.rs:1:23
    |
 LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
@@ -16,7 +16,7 @@ LL |     match (&t,) {
    |           ^^^^^
    = note: expected `(&&(T,),)`
               found `(&&'a (T,),)`
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 1:27...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/issue-52213.rs:1:27
    |
 LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {

--- a/src/test/ui/issues/issue-52533-1.stderr
+++ b/src/test/ui/issues/issue-52533-1.stderr
@@ -6,12 +6,12 @@ LL |     gimme(|x, y| y)
    |
    = note: expected reference `&Foo<'_, '_, u32>`
               found reference `&Foo<'_, '_, u32>`
-note: the anonymous lifetime #3 defined on the body at 9:11...
+note: the anonymous lifetime #3 defined here...
   --> $DIR/issue-52533-1.rs:9:11
    |
 LL |     gimme(|x, y| y)
    |           ^^^^^^^^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the body at 9:11
+note: ...does not necessarily outlive the anonymous lifetime #2 defined here
   --> $DIR/issue-52533-1.rs:9:11
    |
 LL |     gimme(|x, y| y)

--- a/src/test/ui/issues/issue-52533.stderr
+++ b/src/test/ui/issues/issue-52533.stderr
@@ -4,12 +4,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |     foo(|a, b| b)
    |                ^
    |
-note: ...the reference is valid for the anonymous lifetime #1 defined on the body at 5:9...
+note: ...the reference is valid for the anonymous lifetime #1 defined here...
   --> $DIR/issue-52533.rs:5:9
    |
 LL |     foo(|a, b| b)
    |         ^^^^^^^^
-note: ...but the borrowed content is only valid for the anonymous lifetime #2 defined on the body at 5:9
+note: ...but the borrowed content is only valid for the anonymous lifetime #2 defined here
   --> $DIR/issue-52533.rs:5:9
    |
 LL |     foo(|a, b| b)

--- a/src/test/ui/issues/issue-55796.stderr
+++ b/src/test/ui/issues/issue-55796.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |         Box::new(self.out_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the trait at 7:17...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/issue-55796.rs:7:17
    |
 LL | pub trait Graph<'a> {
@@ -29,7 +29,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |         Box::new(self.in_edges(u).map(|e| e.target()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the trait at 7:17...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/issue-55796.rs:7:17
    |
 LL | pub trait Graph<'a> {

--- a/src/test/ui/issues/issue-65230.stderr
+++ b/src/test/ui/issues/issue-65230.stderr
@@ -6,7 +6,7 @@ LL | impl T1 for &dyn T2 {}
    |
    = note: expected trait `<&dyn T2 as T0>`
               found trait `<&(dyn T2 + 'static) as T0>`
-note: the lifetime `'_` as defined on the impl at 8:13...
+note: the lifetime `'_` as defined here...
   --> $DIR/issue-65230.rs:8:13
    |
 LL | impl T1 for &dyn T2 {}

--- a/src/test/ui/issues/issue-75777.stderr
+++ b/src/test/ui/issues/issue-75777.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     Box::new(move |_| fut)
    |              ^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 11:11...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/issue-75777.rs:11:11
    |
 LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> BoxFuture<'a, A>> {

--- a/src/test/ui/lifetimes/issue-79187-2.stderr
+++ b/src/test/ui/lifetimes/issue-79187-2.stderr
@@ -25,7 +25,7 @@ LL |     take_foo(|a: &i32| a);
    |
    = note: expected reference `&i32`
               found reference `&i32`
-note: the anonymous lifetime #1 defined on the body at 9:14 doesn't meet the lifetime requirements
+note: the anonymous lifetime #1 defined here doesn't meet the lifetime requirements
   --> $DIR/issue-79187-2.rs:9:14
    |
 LL |     take_foo(|a: &i32| a);
@@ -44,7 +44,7 @@ LL |     take_foo(|a: &i32| -> &i32 { a });
    |
    = note: expected reference `&i32`
               found reference `&i32`
-note: the anonymous lifetime #1 defined on the body at 10:14 doesn't meet the lifetime requirements
+note: the anonymous lifetime #1 defined here doesn't meet the lifetime requirements
   --> $DIR/issue-79187-2.rs:10:14
    |
 LL |     take_foo(|a: &i32| -> &i32 { a });

--- a/src/test/ui/lifetimes/lifetime-bound-will-change-warning.stderr
+++ b/src/test/ui/lifetimes/lifetime-bound-will-change-warning.stderr
@@ -6,7 +6,7 @@ LL |     ref_obj(x)
    |
    = note: expected reference `&Box<(dyn Fn() + 'static)>`
               found reference `&Box<(dyn Fn() + 'a)>`
-note: the lifetime `'a` as defined on the function body at 32:10...
+note: the lifetime `'a` as defined here...
   --> $DIR/lifetime-bound-will-change-warning.rs:32:10
    |
 LL | fn test2<'a>(x: &'a Box<dyn Fn() + 'a>) {
@@ -21,7 +21,7 @@ LL |     lib::ref_obj(x)
    |
    = note: expected reference `&Box<(dyn Fn() + 'static)>`
               found reference `&Box<(dyn Fn() + 'a)>`
-note: the lifetime `'a` as defined on the function body at 37:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/lifetime-bound-will-change-warning.rs:37:12
    |
 LL | fn test2cc<'a>(x: &'a Box<dyn Fn() + 'a>) {

--- a/src/test/ui/lub-if.stderr
+++ b/src/test/ui/lub-if.stderr
@@ -5,7 +5,7 @@ LL |         s
    |         ^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 23:17
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/lub-if.rs:23:17
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
@@ -18,7 +18,7 @@ LL |         s
    |         ^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 32:17
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/lub-if.rs:32:17
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {

--- a/src/test/ui/lub-match.stderr
+++ b/src/test/ui/lub-match.stderr
@@ -5,7 +5,7 @@ LL |             s
    |             ^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 25:17
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/lub-match.rs:25:17
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
@@ -18,7 +18,7 @@ LL |             s
    |             ^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 35:17
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/lub-match.rs:35:17
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {

--- a/src/test/ui/match/match-ref-mut-invariance.stderr
+++ b/src/test/ui/match/match-ref-mut-invariance.stderr
@@ -6,12 +6,12 @@ LL |         match self.0 { ref mut x => x }
    |
    = note: expected mutable reference `&'a mut &'a i32`
               found mutable reference `&'a mut &'b i32`
-note: the lifetime `'a` as defined on the method body at 9:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/match-ref-mut-invariance.rs:9:12
    |
 LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the impl at 8:6
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/match-ref-mut-invariance.rs:8:6
    |
 LL | impl<'b> S<'b> {

--- a/src/test/ui/match/match-ref-mut-let-invariance.stderr
+++ b/src/test/ui/match/match-ref-mut-let-invariance.stderr
@@ -6,12 +6,12 @@ LL |         x
    |
    = note: expected mutable reference `&'a mut &'a i32`
               found mutable reference `&'a mut &'b i32`
-note: the lifetime `'a` as defined on the method body at 9:12...
+note: the lifetime `'a` as defined here...
   --> $DIR/match-ref-mut-let-invariance.rs:9:12
    |
 LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the impl at 8:6
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/match-ref-mut-let-invariance.rs:8:6
    |
 LL | impl<'b> S<'b> {

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -30,7 +30,7 @@ LL |     baz(f);
    |
    = note: expected type `for<'r> Fn<(*mut &'r u32,)>`
               found type `Fn<(*mut &'a u32,)>`
-note: the required lifetime does not necessarily outlive the lifetime `'a` as defined on the function body at 9:10
+note: the required lifetime does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/closure-arg-type-mismatch.rs:9:10
    |
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
@@ -58,7 +58,7 @@ LL |     baz(f);
    |
    = note: expected type `for<'r> Fn<(*mut &'r u32,)>`
               found type `Fn<(*mut &'a u32,)>`
-note: the lifetime `'a` as defined on the function body at 9:10 doesn't meet the lifetime requirements
+note: the lifetime `'a` as defined here doesn't meet the lifetime requirements
   --> $DIR/closure-arg-type-mismatch.rs:9:10
    |
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {

--- a/src/test/ui/nll/issue-50716.stderr
+++ b/src/test/ui/nll/issue-50716.stderr
@@ -6,7 +6,7 @@ LL |     let _x = *s;
    |
    = note: expected type `<<&'a T as A>::X as Sized>`
               found type `<<&'static T as A>::X as Sized>`
-note: the lifetime `'a` as defined on the function body at 9:8...
+note: the lifetime `'a` as defined here...
   --> $DIR/issue-50716.rs:9:8
    |
 LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)

--- a/src/test/ui/nll/issue-52742.stderr
+++ b/src/test/ui/nll/issue-52742.stderr
@@ -4,12 +4,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         self.y = b.z
    |                  ^^^
    |
-note: ...the reference is valid for the lifetime `'_` as defined on the impl at 12:10...
+note: ...the reference is valid for the lifetime `'_` as defined here...
   --> $DIR/issue-52742.rs:12:10
    |
 LL | impl Foo<'_, '_> {
    |          ^^
-note: ...but the borrowed content is only valid for the anonymous lifetime defined on the method body at 13:31
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
   --> $DIR/issue-52742.rs:13:31
    |
 LL |     fn take_bar(&mut self, b: Bar<'_>) {

--- a/src/test/ui/nll/issue-55394.stderr
+++ b/src/test/ui/nll/issue-55394.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'s` d
 LL |         Foo { bar }
    |         ^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 8:17...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/issue-55394.rs:8:17
    |
 LL |     fn new(bar: &mut Bar) -> Self {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |         Foo { bar }
    |               ^^^
-note: but, the lifetime must be valid for the lifetime `'_` as defined on the impl at 7:10...
+note: but, the lifetime must be valid for the lifetime `'_` as defined here...
   --> $DIR/issue-55394.rs:7:10
    |
 LL | impl Foo<'_> {

--- a/src/test/ui/nll/issue-55401.stderr
+++ b/src/test/ui/nll/issue-55401.stderr
@@ -5,7 +5,7 @@ LL |     *y
    |     ^^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 1:47
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/issue-55401.rs:1:47
    |
 LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/normalization-bounds-error.stderr
+++ b/src/test/ui/nll/normalization-bounds-error.stderr
@@ -4,12 +4,12 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` d
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    |    ^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'d` as defined on the function body at 12:14...
+note: first, the lifetime cannot outlive the lifetime `'d` as defined here...
   --> $DIR/normalization-bounds-error.rs:12:14
    |
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    |              ^^
-note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the function body at 12:18...
+note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
   --> $DIR/normalization-bounds-error.rs:12:18
    |
 LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}

--- a/src/test/ui/nll/trait-associated-constant.stderr
+++ b/src/test/ui/nll/trait-associated-constant.stderr
@@ -6,12 +6,12 @@ LL |     const AC: Option<&'c str> = None;
    |
    = note: expected enum `Option<&'b str>`
               found enum `Option<&'c str>`
-note: the lifetime `'c` as defined on the impl at 20:18...
+note: the lifetime `'c` as defined here...
   --> $DIR/trait-associated-constant.rs:20:18
    |
 LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct {
    |                  ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the impl at 20:14
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/trait-associated-constant.rs:20:14
    |
 LL | impl<'a: 'b, 'b, 'c> Anything<'a, 'b> for FailStruct {

--- a/src/test/ui/nll/type-alias-free-regions.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |         C { f: b }
    |         ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 16:24...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/type-alias-free-regions.rs:16:24
    |
 LL |     fn from_box(b: Box<B>) -> Self {
@@ -16,7 +16,7 @@ LL |         C { f: b }
    |                ^
    = note: expected `Box<Box<&isize>>`
               found `Box<Box<&isize>>`
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 15:6...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/type-alias-free-regions.rs:15:6
    |
 LL | impl<'a> FromBox<'a> for C<'a> {
@@ -35,7 +35,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |         C { f: Box::new(b.0) }
    |                ^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 26:23...
+note: first, the lifetime cannot outlive the anonymous lifetime defined here...
   --> $DIR/type-alias-free-regions.rs:26:23
    |
 LL |     fn from_tuple(b: (B,)) -> Self {
@@ -47,7 +47,7 @@ LL |         C { f: Box::new(b.0) }
    |                         ^^^
    = note: expected `Box<&isize>`
               found `Box<&isize>`
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 25:6...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/type-alias-free-regions.rs:25:6
    |
 LL | impl<'a> FromTuple<'a> for C<'a> {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.stderr
@@ -5,7 +5,7 @@ LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 17:8
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/constant-in-expr-normalize.rs:17:8
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.stderr
@@ -5,7 +5,7 @@ LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 9:8
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/constant-in-expr-trait-item-1.rs:9:8
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.stderr
@@ -5,7 +5,7 @@ LL |     <T as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 9:8
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/constant-in-expr-trait-item-2.rs:9:8
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |     T::C
    |     ^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 9:8...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/constant-in-expr-trait-item-3.rs:9:8
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for automatic coercion due to
 LL |     ss
    |     ^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 54:10...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/object-lifetime-default-elision.rs:54:10
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     ss
    |     ^^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 54:13...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/object-lifetime-default-elision.rs:54:13
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
@@ -33,7 +33,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     ss
    |     ^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 54:10...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/object-lifetime-default-elision.rs:54:10
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
@@ -43,7 +43,7 @@ note: ...so that the declared lifetime parameter bounds are satisfied
    |
 LL |     ss
    |     ^^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 54:13...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/object-lifetime-default-elision.rs:54:13
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.stderr
@@ -6,7 +6,7 @@ LL |     ss.t = t;
    |
    = note: expected reference `&'a Box<(dyn Test + 'static)>`
               found reference `&'a Box<(dyn Test + 'a)>`
-note: the lifetime `'a` as defined on the function body at 14:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/object-lifetime-default-from-rptr-box-error.rs:14:6
    |
 LL | fn c<'a>(t: &'a Box<dyn Test+'a>, mut ss: SomeStruct<'a>) {

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
@@ -6,7 +6,7 @@ LL |     ss.t = t;
    |
    = note: expected reference `&'a MyBox<(dyn Test + 'static)>`
               found reference `&'a MyBox<(dyn Test + 'a)>`
-note: the lifetime `'a` as defined on the function body at 20:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:20:6
    |
 LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.stderr
@@ -18,7 +18,7 @@ LL |     load0(ss)
    |
    = note: expected reference `&MyBox<(dyn SomeTrait + 'static)>`
               found reference `&MyBox<(dyn SomeTrait + 'a)>`
-note: the lifetime `'a` as defined on the function body at 30:10...
+note: the lifetime `'a` as defined here...
   --> $DIR/object-lifetime-default-mybox.rs:30:10
    |
 LL | fn load2<'a>(ss: &MyBox<dyn SomeTrait + 'a>) -> MyBox<dyn SomeTrait + 'a> {

--- a/src/test/ui/regions/issue-28848.stderr
+++ b/src/test/ui/regions/issue-28848.stderr
@@ -4,12 +4,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     Foo::<'a, 'b>::xmute(u)
    |     ^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'b` as defined on the function body at 9:16
+note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/issue-28848.rs:9:16
    |
 LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {
    |                ^^
-note: but lifetime parameter must outlive the lifetime `'a` as defined on the function body at 9:12
+note: but lifetime parameter must outlive the lifetime `'a` as defined here
   --> $DIR/issue-28848.rs:9:12
    |
 LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {

--- a/src/test/ui/regions/issue-78262.default.stderr
+++ b/src/test/ui/regions/issue-78262.default.stderr
@@ -6,7 +6,7 @@ LL |     let f = |x: &dyn TT| x.func();
    |
    = note: expected reference `&(dyn TT + 'static)`
               found reference `&dyn TT`
-note: the anonymous lifetime #1 defined on the body at 14:13...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/issue-78262.rs:14:13
    |
 LL |     let f = |x: &dyn TT| x.func();

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -10,12 +10,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     z: Box<dyn Is<'a>+'b+'c>,
    |        ^^^^^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'b` as defined on the struct at 11:15
+note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:15
    |
 LL | struct Foo<'a,'b,'c> {
    |               ^^
-note: but lifetime parameter must outlive the lifetime `'a` as defined on the struct at 11:12
+note: but lifetime parameter must outlive the lifetime `'a` as defined here
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:12
    |
 LL | struct Foo<'a,'b,'c> {

--- a/src/test/ui/regions/region-invariant-static-error-reporting.stderr
+++ b/src/test/ui/regions/region-invariant-static-error-reporting.stderr
@@ -13,7 +13,7 @@ LL | |     };
    |
    = note: expected struct `Invariant<'a>`
               found struct `Invariant<'static>`
-note: the lifetime `'a` as defined on the function body at 13:10...
+note: the lifetime `'a` as defined here...
   --> $DIR/region-invariant-static-error-reporting.rs:13:10
    |
 LL | fn unify<'a>(x: Option<Invariant<'a>>, f: fn(Invariant<'a>)) {

--- a/src/test/ui/regions/region-object-lifetime-2.stderr
+++ b/src/test/ui/regions/region-object-lifetime-2.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |     x.borrowed()
    |       ^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 9:42...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/region-object-lifetime-2.rs:9:42
    |
 LL | fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a dyn Foo) -> &'b () {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     x.borrowed()
    |     ^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 9:45...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/region-object-lifetime-2.rs:9:45
    |
 LL | fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a dyn Foo) -> &'b () {

--- a/src/test/ui/regions/region-object-lifetime-4.stderr
+++ b/src/test/ui/regions/region-object-lifetime-4.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |     x.borrowed()
    |       ^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 11:41...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/region-object-lifetime-4.rs:11:41
    |
 LL | fn borrowed_receiver_related_lifetimes2<'a,'b>(x: &'a (dyn Foo + 'b)) -> &'b () {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     x.borrowed()
    |     ^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 11:44...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/region-object-lifetime-4.rs:11:44
    |
 LL | fn borrowed_receiver_related_lifetimes2<'a,'b>(x: &'a (dyn Foo + 'b)) -> &'b () {

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.stderr
@@ -52,7 +52,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     Box::new(v)
    |              ^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 22:6...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/region-object-lifetime-in-coercion.rs:22:6
    |
 LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {
@@ -64,7 +64,7 @@ LL |     Box::new(v)
    |              ^
    = note: expected `&[u8]`
               found `&'a [u8]`
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 22:9...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/region-object-lifetime-in-coercion.rs:22:9
    |
 LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {

--- a/src/test/ui/regions/regions-addr-of-upvar-self.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for borrow expression due to 
 LL |             let p: &'static mut usize = &mut self.food;
    |                                         ^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'_` as defined on the body at 7:18...
+note: first, the lifetime cannot outlive the lifetime `'_` as defined here...
   --> $DIR/regions-addr-of-upvar-self.rs:7:18
    |
 LL |         let _f = || {

--- a/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.migrate.stderr
+++ b/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.migrate.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifet
 LL |     let _: &'a WithAssoc<TheType<'b>> = loop { };
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 33:15
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-assoc-type-in-supertrait-outlives-container.rs:33:15
    |
 LL | fn with_assoc<'a,'b>() {
    |               ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 33:18
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-assoc-type-in-supertrait-outlives-container.rs:33:18
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
+++ b/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
@@ -16,7 +16,7 @@ error[E0477]: the type `&'a i32` does not fulfill the required lifetime
 LL |     type Value = &'a i32;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: type must outlive the lifetime `'b` as defined on the impl at 19:10 as required by this binding
+note: type must outlive the lifetime `'b` as defined here as required by this binding
   --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:19:10
    |
 LL | impl<'a, 'b> Foo<'b> for &'a i64 {

--- a/src/test/ui/regions/regions-bounds.stderr
+++ b/src/test/ui/regions/regions-bounds.stderr
@@ -6,12 +6,12 @@ LL |     return e;
    |
    = note: expected struct `TupleStruct<'b>`
               found struct `TupleStruct<'a>`
-note: the lifetime `'a` as defined on the function body at 8:10...
+note: the lifetime `'a` as defined here...
   --> $DIR/regions-bounds.rs:8:10
    |
 LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
    |          ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the function body at 8:13
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/regions-bounds.rs:8:13
    |
 LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
@@ -25,12 +25,12 @@ LL |     return e;
    |
    = note: expected struct `Struct<'b>`
               found struct `Struct<'a>`
-note: the lifetime `'a` as defined on the function body at 12:10...
+note: the lifetime `'a` as defined here...
   --> $DIR/regions-bounds.rs:12:10
    |
 LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {
    |          ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the function body at 12:13
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/regions-bounds.rs:12:13
    |
 LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 18:20...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-close-over-type-parameter-multiple.rs:18:20
    |
 LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'c> {
@@ -14,7 +14,7 @@ note: ...so that the declared lifetime parameter bounds are satisfied
    |
 LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: but, the lifetime must be valid for the lifetime `'c` as defined on the function body at 18:26...
+note: but, the lifetime must be valid for the lifetime `'c` as defined here...
   --> $DIR/regions-close-over-type-parameter-multiple.rs:18:26
    |
 LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'c> {

--- a/src/test/ui/regions/regions-creating-enums4.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |     Ast::Add(x, y)
    |     ^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 6:16...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-creating-enums4.rs:6:16
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
@@ -16,7 +16,7 @@ LL |     Ast::Add(x, y)
    |              ^
    = note: expected `&Ast<'_>`
               found `&Ast<'a>`
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 6:19...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/regions-creating-enums4.rs:6:19
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {

--- a/src/test/ui/regions/regions-early-bound-error-method.stderr
+++ b/src/test/ui/regions/regions-early-bound-error-method.stderr
@@ -4,12 +4,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         g2.get()
    |         ^^^^^^^^
    |
-note: ...the reference is valid for the lifetime `'a` as defined on the impl at 18:6...
+note: ...the reference is valid for the lifetime `'a` as defined here...
   --> $DIR/regions-early-bound-error-method.rs:18:6
    |
 LL | impl<'a> Box<'a> {
    |      ^^
-note: ...but the borrowed content is only valid for the lifetime `'b` as defined on the method body at 19:11
+note: ...but the borrowed content is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-early-bound-error-method.rs:19:11
    |
 LL |     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {

--- a/src/test/ui/regions/regions-early-bound-error.stderr
+++ b/src/test/ui/regions/regions-early-bound-error.stderr
@@ -4,12 +4,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |     g1.get()
    |     ^^^^^^^^
    |
-note: ...the reference is valid for the lifetime `'b` as defined on the function body at 18:11...
+note: ...the reference is valid for the lifetime `'b` as defined here...
   --> $DIR/regions-early-bound-error.rs:18:11
    |
 LL | fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {
    |           ^^
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 18:8
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/regions-early-bound-error.rs:18:8
    |
 LL | fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {

--- a/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee-4.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the 
 LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
    |                                                                    ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 5:14
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-free-region-ordering-callee-4.rs:5:14
    |
 LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
    |              ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 5:18
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-free-region-ordering-callee-4.rs:5:18
    |
 LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {

--- a/src/test/ui/regions/regions-free-region-ordering-caller.migrate.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller.migrate.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'b &'a usize`, reference has a longer lifetime than the 
 LL |     let z: Option<&'b &'a usize> = None;
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'b` as defined on the function body at 10:14
+note: the pointer is valid for the lifetime `'b` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:10:14
    |
 LL | fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
    |              ^^
-note: but the referenced data is only valid for the lifetime `'a` as defined on the function body at 10:10
+note: but the referenced data is only valid for the lifetime `'a` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:10:10
    |
 LL | fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -21,12 +21,12 @@ error[E0491]: in type `&'b Paramd<'a>`, reference has a longer lifetime than the
 LL |     let z: Option<&'b Paramd<'a>> = None;
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'b` as defined on the function body at 15:14
+note: the pointer is valid for the lifetime `'b` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:15:14
    |
 LL | fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
    |              ^^
-note: but the referenced data is only valid for the lifetime `'a` as defined on the function body at 15:10
+note: but the referenced data is only valid for the lifetime `'a` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:15:10
    |
 LL | fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -38,12 +38,12 @@ error[E0491]: in type `&'a &'b usize`, reference has a longer lifetime than the 
 LL |     let z: Option<&'a &'b usize> = None;
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 21:10
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:21:10
    |
 LL | fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {
    |          ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 21:14
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-free-region-ordering-caller.rs:21:14
    |
 LL | fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {

--- a/src/test/ui/regions/regions-free-region-ordering-incorrect.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-incorrect.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime for borrow expression due to 
 LL |             None => &self.val
    |                     ^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the method body at 14:12...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-free-region-ordering-incorrect.rs:14:12
    |
 LL |     fn get<'a>(&'a self) -> &'b T {
@@ -14,7 +14,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |             None => &self.val
    |                     ^^^^^^^^^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the impl at 13:6...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/regions-free-region-ordering-incorrect.rs:13:6
    |
 LL | impl<'b, T> Node<'b, T> {

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.stderr
@@ -6,7 +6,7 @@ LL |     b_isize
    |
    = note: expected struct `Invariant<'static>`
               found struct `Invariant<'r>`
-note: the lifetime `'r` as defined on the function body at 11:23...
+note: the lifetime `'r` as defined here...
   --> $DIR/regions-infer-invariance-due-to-decl.rs:11:23
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.stderr
@@ -6,7 +6,7 @@ LL |     b_isize
    |
    = note: expected struct `Invariant<'static>`
               found struct `Invariant<'r>`
-note: the lifetime `'r` as defined on the function body at 9:23...
+note: the lifetime `'r` as defined here...
   --> $DIR/regions-infer-invariance-due-to-mutability-3.rs:9:23
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.stderr
@@ -6,7 +6,7 @@ LL |     b_isize
    |
    = note: expected struct `Invariant<'static>`
               found struct `Invariant<'r>`
-note: the lifetime `'r` as defined on the function body at 9:23...
+note: the lifetime `'r` as defined here...
   --> $DIR/regions-infer-invariance-due-to-mutability-4.rs:9:23
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-not-param.stderr
+++ b/src/test/ui/regions/regions-infer-not-param.stderr
@@ -6,12 +6,12 @@ LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
    |
    = note: expected struct `Direct<'b>`
               found struct `Direct<'a>`
-note: the lifetime `'a` as defined on the function body at 15:16...
+note: the lifetime `'a` as defined here...
   --> $DIR/regions-infer-not-param.rs:15:16
    |
 LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
    |                ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the function body at 15:19
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/regions-infer-not-param.rs:15:19
    |
 LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
@@ -25,12 +25,12 @@ LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
    |
    = note: expected struct `Indirect2<'b>`
               found struct `Indirect2<'a>`
-note: the lifetime `'a` as defined on the function body at 19:19...
+note: the lifetime `'a` as defined here...
   --> $DIR/regions-infer-not-param.rs:19:19
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
    |                   ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the function body at 19:22
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/regions-infer-not-param.rs:19:22
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
@@ -44,12 +44,12 @@ LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
    |
    = note: expected struct `Indirect2<'b>`
               found struct `Indirect2<'a>`
-note: the lifetime `'b` as defined on the function body at 19:22...
+note: the lifetime `'b` as defined here...
   --> $DIR/regions-infer-not-param.rs:19:22
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
    |                      ^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the function body at 19:19
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/regions-infer-not-param.rs:19:19
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }

--- a/src/test/ui/regions/regions-infer-paramd-indirect.stderr
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.stderr
@@ -6,12 +6,12 @@ LL |         self.f = b;
    |
    = note: expected struct `Box<Box<&'a isize>>`
               found struct `Box<Box<&isize>>`
-note: the anonymous lifetime defined on the method body at 21:36...
+note: the anonymous lifetime defined here...
   --> $DIR/regions-infer-paramd-indirect.rs:21:36
    |
 LL |     fn set_f_bad(&mut self, b: Box<B>) {
    |                                    ^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 16:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/regions-infer-paramd-indirect.rs:16:6
    |
 LL | impl<'a> SetF<'a> for C<'a> {

--- a/src/test/ui/regions/regions-nested-fns.stderr
+++ b/src/test/ui/regions/regions-nested-fns.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     let mut ay = &y;
    |                  ^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 7:58...
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
   --> $DIR/regions-nested-fns.rs:7:58
    |
 LL |       ignore::<Box<dyn for<'z> FnMut(&'z isize)>>(Box::new(|z| {
@@ -19,7 +19,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |         ay = z;
    |              ^
-note: but, the lifetime must be valid for the anonymous lifetime #1 defined on the body at 13:72...
+note: but, the lifetime must be valid for the anonymous lifetime #1 defined here...
   --> $DIR/regions-nested-fns.rs:13:72
    |
 LL |       ignore::< Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
@@ -48,7 +48,7 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         if false { return x; }
    |                           ^
    |
-note: ...the reference is valid for the anonymous lifetime #1 defined on the body at 13:72...
+note: ...the reference is valid for the anonymous lifetime #1 defined here...
   --> $DIR/regions-nested-fns.rs:13:72
    |
 LL |       ignore::< Box<dyn for<'z> FnMut(&'z isize) -> &'z isize>>(Box::new(|z| {
@@ -58,7 +58,7 @@ LL | |         if false { return ay; }
 LL | |         return z;
 LL | |     }));
    | |_____^
-note: ...but the borrowed content is only valid for the lifetime `'x` as defined on the function body at 3:11
+note: ...but the borrowed content is only valid for the lifetime `'x` as defined here
   --> $DIR/regions-nested-fns.rs:3:11
    |
 LL | fn nested<'x>(x: &'x isize) {

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -8,12 +8,12 @@ LL | | where
 LL | |     <() as Project<'a, 'b>>::Item: Eq,
    | |______________________________________^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 24:8...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:8
    |
 LL | fn bar<'a, 'b>()
    |        ^^
-note: ...but the lifetime must also be valid for the lifetime `'b` as defined on the function body at 24:12...
+note: ...but the lifetime must also be valid for the lifetime `'b` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:12
    |
 LL | fn bar<'a, 'b>()
@@ -36,12 +36,12 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL | fn bar<'a, 'b>()
    |    ^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 24:8...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:8
    |
 LL | fn bar<'a, 'b>()
    |        ^^
-note: ...but the lifetime must also be valid for the lifetime `'b` as defined on the function body at 24:12...
+note: ...but the lifetime must also be valid for the lifetime `'b` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:12
    |
 LL | fn bar<'a, 'b>()

--- a/src/test/ui/regions/regions-outlives-projection-container-hrtb.migrate.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-hrtb.migrate.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a WithHrAssoc<TheType<'b>>`, reference has a longer lif
 LL |     let _: &'a WithHrAssoc<TheType<'b>> = loop { };
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 27:15
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container-hrtb.rs:27:15
    |
 LL | fn with_assoc<'a,'b>() {
    |               ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 27:18
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container-hrtb.rs:27:18
    |
 LL | fn with_assoc<'a,'b>() {
@@ -21,12 +21,12 @@ error[E0491]: in type `&'a WithHrAssocSub<TheType<'b>>`, reference has a longer 
 LL |     let _: &'a WithHrAssocSub<TheType<'b>> = loop { };
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 46:19
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container-hrtb.rs:46:19
    |
 LL | fn with_assoc_sub<'a,'b>() {
    |                   ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 46:22
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container-hrtb.rs:46:22
    |
 LL | fn with_assoc_sub<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container-wc.migrate.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-wc.migrate.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifet
 LL |     let _: &'a WithAssoc<TheType<'b>> = loop { };
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 27:15
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container-wc.rs:27:15
    |
 LL | fn with_assoc<'a,'b>() {
    |               ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 27:18
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container-wc.rs:27:18
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifet
 LL |     let _x: &'a WithAssoc<TheType<'b>> = loop { };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 28:15
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container.rs:28:15
    |
 LL | fn with_assoc<'a,'b>() {
    |               ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 28:18
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container.rs:28:18
    |
 LL | fn with_assoc<'a,'b>() {
@@ -21,12 +21,12 @@ error[E0491]: in type `&'a WithoutAssoc<TheType<'b>>`, reference has a longer li
 LL |     let _x: &'a WithoutAssoc<TheType<'b>> = loop { };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 50:18
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container.rs:50:18
    |
 LL | fn without_assoc<'a,'b>() {
    |                  ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 50:21
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container.rs:50:21
    |
 LL | fn without_assoc<'a,'b>() {
@@ -38,12 +38,12 @@ error[E0491]: in type `&'a WithAssoc<TheType<'b>>`, reference has a longer lifet
 LL |     call::<&'a WithAssoc<TheType<'b>>>();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 58:20
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container.rs:58:20
    |
 LL | fn call_with_assoc<'a,'b>() {
    |                    ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 58:23
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container.rs:58:23
    |
 LL | fn call_with_assoc<'a,'b>() {
@@ -55,12 +55,12 @@ error[E0491]: in type `&'a WithoutAssoc<TheType<'b>>`, reference has a longer li
 LL |     call::<&'a WithoutAssoc<TheType<'b>>>();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the function body at 67:23
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-projection-container.rs:67:23
    |
 LL | fn call_without_assoc<'a,'b>() {
    |                       ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the function body at 67:26
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-projection-container.rs:67:26
    |
 LL | fn call_without_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-ret-borrowed-1.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed-1.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     with(|o| o)
    |              ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 10:10...
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
   --> $DIR/regions-ret-borrowed-1.rs:10:10
    |
 LL |     with(|o| o)
@@ -16,7 +16,7 @@ LL |     with(|o| o)
    |              ^
    = note: expected `&isize`
               found `&isize`
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 9:14...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/regions-ret-borrowed-1.rs:9:14
    |
 LL | fn return_it<'a>() -> &'a isize {

--- a/src/test/ui/regions/regions-ret-borrowed.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed.stderr
@@ -4,7 +4,7 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |     with(|o| o)
    |              ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 13:10...
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
   --> $DIR/regions-ret-borrowed.rs:13:10
    |
 LL |     with(|o| o)
@@ -16,7 +16,7 @@ LL |     with(|o| o)
    |              ^
    = note: expected `&isize`
               found `&isize`
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 12:14...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/regions-ret-borrowed.rs:12:14
    |
 LL | fn return_it<'a>() -> &'a isize {

--- a/src/test/ui/regions/regions-static-bound.migrate.stderr
+++ b/src/test/ui/regions/regions-static-bound.migrate.stderr
@@ -5,7 +5,7 @@ LL |     t
    |     ^
    |
    = note: ...the reference is valid for the static lifetime...
-note: ...but the borrowed content is only valid for the lifetime `'a` as defined on the function body at 8:24
+note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
   --> $DIR/regions-static-bound.rs:8:24
    |
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {

--- a/src/test/ui/regions/regions-trait-object-subtyping.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.stderr
@@ -4,12 +4,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     x
    |     ^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the function body at 13:9
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/regions-trait-object-subtyping.rs:13:9
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
    |         ^^
-note: but lifetime parameter must outlive the lifetime `'b` as defined on the function body at 13:12
+note: but lifetime parameter must outlive the lifetime `'b` as defined here
   --> $DIR/regions-trait-object-subtyping.rs:13:12
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
@@ -21,7 +21,7 @@ error[E0495]: cannot infer an appropriate lifetime for automatic coercion due to
 LL |     x
    |     ^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the function body at 13:9...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-trait-object-subtyping.rs:13:9
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
@@ -31,7 +31,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     x
    |     ^
-note: but, the lifetime must be valid for the lifetime `'b` as defined on the function body at 13:12...
+note: but, the lifetime must be valid for the lifetime `'b` as defined here...
   --> $DIR/regions-trait-object-subtyping.rs:13:12
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
@@ -52,12 +52,12 @@ LL |     x
    |
    = note: expected struct `Wrapper<&'b mut (dyn Dummy + 'b)>`
               found struct `Wrapper<&'a mut (dyn Dummy + 'a)>`
-note: the lifetime `'b` as defined on the function body at 20:15...
+note: the lifetime `'b` as defined here...
   --> $DIR/regions-trait-object-subtyping.rs:20:15
    |
 LL | fn foo4<'a:'b,'b>(x: Wrapper<&'a mut dyn Dummy>) -> Wrapper<&'b mut dyn Dummy> {
    |               ^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the function body at 20:9
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/regions-trait-object-subtyping.rs:20:9
    |
 LL | fn foo4<'a:'b,'b>(x: Wrapper<&'a mut dyn Dummy>) -> Wrapper<&'b mut dyn Dummy> {

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.stderr
@@ -6,7 +6,7 @@ LL |     let _: Invariant<'static> = c;
    |
    = note: expected struct `Invariant<'static>`
               found struct `Invariant<'b>`
-note: the lifetime `'b` as defined on the function body at 11:9...
+note: the lifetime `'b` as defined here...
   --> $DIR/regions-variance-invariant-use-covariant.rs:11:9
    |
 LL | fn use_<'b>(c: Invariant<'b>) {

--- a/src/test/ui/regions/regions-wf-trait-object.stderr
+++ b/src/test/ui/regions/regions-wf-trait-object.stderr
@@ -4,12 +4,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     x: Box<dyn TheTrait<'a>+'b>
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'b` as defined on the struct at 6:15
+note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/regions-wf-trait-object.rs:6:15
    |
 LL | struct Foo<'a,'b> {
    |               ^^
-note: but lifetime parameter must outlive the lifetime `'a` as defined on the struct at 6:12
+note: but lifetime parameter must outlive the lifetime `'a` as defined here
   --> $DIR/regions-wf-trait-object.rs:6:12
    |
 LL | struct Foo<'a,'b> {

--- a/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-region-rev.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-region-rev.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a Foo<'b>`, reference has a longer lifetime than the da
 LL |         type Out = &'a Foo<'b>;
    |                    ^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the impl at 16:10
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-region-rev.rs:16:10
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {
    |          ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the impl at 16:14
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-nominal-type-region-rev.rs:16:14
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {

--- a/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-region.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-region.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a Foo<'b>`, reference has a longer lifetime than the da
 LL |         type Out = &'a Foo<'b>;
    |                    ^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the impl at 16:10
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-region.rs:16:10
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {
    |          ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the impl at 16:14
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-nominal-type-region.rs:16:14
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {

--- a/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-type-rev.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-type-rev.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a Foo<&'b i32>`, reference has a longer lifetime than t
 LL |         type Out = &'a Foo<&'b i32>;
    |                    ^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the impl at 16:10
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-type-rev.rs:16:10
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {
    |          ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the impl at 16:14
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-nominal-type-type-rev.rs:16:14
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {

--- a/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-type.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-outlives-nominal-type-type.stderr
@@ -4,12 +4,12 @@ error[E0491]: in type `&'a Foo<&'b i32>`, reference has a longer lifetime than t
 LL |         type Out = &'a Foo<&'b i32>;
    |                    ^^^^^^^^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the impl at 16:10
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-type.rs:16:10
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {
    |          ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the impl at 16:14
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-outlives-nominal-type-type.rs:16:14
    |
 LL |     impl<'a, 'b> Trait<'a, 'b> for usize {

--- a/src/test/ui/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
@@ -26,12 +26,12 @@ error[E0491]: in type `&'a &'b T`, reference has a longer lifetime than the data
 LL |     type Out = &'a &'b T;
    |                ^^^^^^^^^
    |
-note: the pointer is valid for the lifetime `'a` as defined on the impl at 24:6
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-struct-not-wf.rs:24:6
    |
 LL | impl<'a, 'b, T> Trait1<'a, 'b, T> for u32 {
    |      ^^
-note: but the referenced data is only valid for the lifetime `'b` as defined on the impl at 24:10
+note: but the referenced data is only valid for the lifetime `'b` as defined here
   --> $DIR/regions-struct-not-wf.rs:24:10
    |
 LL | impl<'a, 'b, T> Trait1<'a, 'b, T> for u32 {

--- a/src/test/ui/static/static-lifetime.stderr
+++ b/src/test/ui/static/static-lifetime.stderr
@@ -4,7 +4,7 @@ error[E0478]: lifetime bound not satisfied
 LL | impl<'a, A: Clone> Arbitrary for ::std::borrow::Cow<'a, A> {}
    |                    ^^^^^^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'a` as defined on the impl at 3:6
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/static-lifetime.rs:3:6
    |
 LL | impl<'a, A: Clone> Arbitrary for ::std::borrow::Cow<'a, A> {}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
@@ -7,7 +7,7 @@ LL | |         t.test();
 LL | |     });
    | |______^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime defined on the function body at 19:24...
+note: the parameter type `T` must be valid for the anonymous lifetime defined here...
   --> $DIR/missing-lifetimes-in-signature-2.rs:19:24
    |
 LL | fn func<T: Test>(foo: &Foo, t: T) {

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -6,7 +6,7 @@ LL | fn func<T: Test>(foo: &Foo, t: T) {
 LL |     foo.bar(move |_| {
    |         ^^^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime defined on the function body at 19:24...
+note: the parameter type `T` must be valid for the anonymous lifetime defined here...
   --> $DIR/missing-lifetimes-in-signature-2.rs:19:24
    |
 LL | fn func<T: Test>(foo: &Foo, t: T) {

--- a/src/test/ui/traits/impl-of-supertrait-has-wrong-lifetime-parameters.stderr
+++ b/src/test/ui/traits/impl-of-supertrait-has-wrong-lifetime-parameters.stderr
@@ -4,12 +4,12 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` d
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
    |             ^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'a` as defined on the impl at 24:6...
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:6
    |
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
    |      ^^
-note: ...but the lifetime must also be valid for the lifetime `'b` as defined on the impl at 24:9...
+note: ...but the lifetime must also be valid for the lifetime `'b` as defined here...
   --> $DIR/impl-of-supertrait-has-wrong-lifetime-parameters.rs:24:9
    |
 LL | impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {

--- a/src/test/ui/traits/matching-lifetimes.stderr
+++ b/src/test/ui/traits/matching-lifetimes.stderr
@@ -6,12 +6,12 @@ LL |     fn foo(x: Foo<'b,'a>) {
    |
    = note: expected fn pointer `fn(Foo<'a, 'b>)`
               found fn pointer `fn(Foo<'b, 'a>)`
-note: the lifetime `'b` as defined on the impl at 13:9...
+note: the lifetime `'b` as defined here...
   --> $DIR/matching-lifetimes.rs:13:9
    |
 LL | impl<'a,'b> Tr for Foo<'a,'b> {
    |         ^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 13:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/matching-lifetimes.rs:13:6
    |
 LL | impl<'a,'b> Tr for Foo<'a,'b> {
@@ -25,12 +25,12 @@ LL |     fn foo(x: Foo<'b,'a>) {
    |
    = note: expected fn pointer `fn(Foo<'a, 'b>)`
               found fn pointer `fn(Foo<'b, 'a>)`
-note: the lifetime `'a` as defined on the impl at 13:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/matching-lifetimes.rs:13:6
    |
 LL | impl<'a,'b> Tr for Foo<'a,'b> {
    |      ^^
-note: ...does not necessarily outlive the lifetime `'b` as defined on the impl at 13:9
+note: ...does not necessarily outlive the lifetime `'b` as defined here
   --> $DIR/matching-lifetimes.rs:13:9
    |
 LL | impl<'a,'b> Tr for Foo<'a,'b> {

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-3.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-3.stderr
@@ -6,7 +6,7 @@ LL |     let _ = x as &dyn Bar<'a>; // Error
    |
    = note: expected trait object `dyn Bar<'a>`
               found trait object `dyn Bar<'static>`
-note: the lifetime `'a` as defined on the function body at 12:16...
+note: the lifetime `'a` as defined here...
   --> $DIR/type-checking-test-3.rs:12:16
    |
 LL | fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
@@ -21,7 +21,7 @@ LL |     let _ = x as &dyn Bar<'static>; // Error
    |
    = note: expected trait object `dyn Bar<'static>`
               found trait object `dyn Bar<'a>`
-note: the lifetime `'a` as defined on the function body at 17:16...
+note: the lifetime `'a` as defined here...
   --> $DIR/type-checking-test-3.rs:17:16
    |
 LL | fn test_wrong2<'a>(x: &dyn Foo<'a>) {

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-4.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-4.stderr
@@ -6,7 +6,7 @@ LL |     let _ = x as &dyn Bar<'static, 'a>; // Error
    |
    = note: expected trait object `dyn Bar<'static, 'a>`
               found trait object `dyn Bar<'static, 'static>`
-note: the lifetime `'a` as defined on the function body at 16:16...
+note: the lifetime `'a` as defined here...
   --> $DIR/type-checking-test-4.rs:16:16
    |
 LL | fn test_wrong1<'a>(x: &dyn Foo<'static>, y: &'a u32) {
@@ -21,7 +21,7 @@ LL |     let _ = x as &dyn Bar<'a, 'static>; // Error
    |
    = note: expected trait object `dyn Bar<'a, 'static>`
               found trait object `dyn Bar<'static, 'static>`
-note: the lifetime `'a` as defined on the function body at 21:16...
+note: the lifetime `'a` as defined here...
   --> $DIR/type-checking-test-4.rs:21:16
    |
 LL | fn test_wrong2<'a>(x: &dyn Foo<'static>, y: &'a u32) {

--- a/src/test/ui/type-alias-impl-trait/bounds-are-checked.stderr
+++ b/src/test/ui/type-alias-impl-trait/bounds-are-checked.stderr
@@ -14,7 +14,7 @@ LL | type X<'a> = impl Into<&'static str> + From<&'a str>;
    |
    = note: expected trait `From<&'a str>`
               found trait `From<&'static str>`
-note: the lifetime `'a` as defined on the item at 6:8...
+note: the lifetime `'a` as defined here...
   --> $DIR/bounds-are-checked.rs:6:8
    |
 LL | type X<'a> = impl Into<&'static str> + From<&'a str>;

--- a/src/test/ui/type-alias-impl-trait/issue-74761-2.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-74761-2.rs
@@ -1,4 +1,3 @@
-#![feature(member_constraints)]
 #![feature(type_alias_impl_trait)]
 
 pub trait A {

--- a/src/test/ui/type-alias-impl-trait/issue-74761-2.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-74761-2.stderr
@@ -1,11 +1,11 @@
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-74761-2.rs:8:6
+  --> $DIR/issue-74761-2.rs:7:6
    |
 LL | impl<'a, 'b> A for () {
    |      ^^ unconstrained lifetime parameter
 
 error[E0207]: the lifetime parameter `'b` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-74761-2.rs:8:10
+  --> $DIR/issue-74761-2.rs:7:10
    |
 LL | impl<'a, 'b> A for () {
    |          ^^ unconstrained lifetime parameter

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -33,12 +33,12 @@ LL |     fn dummy2(self: &Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the anonymous lifetime defined on the method body at 37:21...
+note: the anonymous lifetime defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:37:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
@@ -52,12 +52,12 @@ LL |     fn dummy2(self: &Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the lifetime `'a` as defined on the impl at 35:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
-note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 37:21
+note: ...does not necessarily outlive the anonymous lifetime defined here
   --> $DIR/ufcs-explicit-self-bad.rs:37:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
@@ -71,12 +71,12 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the anonymous lifetime defined on the method body at 39:22...
+note: the anonymous lifetime defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:39:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
+note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
@@ -90,12 +90,12 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the lifetime `'a` as defined on the impl at 35:6...
+note: the lifetime `'a` as defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
-note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 39:22
+note: ...does not necessarily outlive the anonymous lifetime defined here
   --> $DIR/ufcs-explicit-self-bad.rs:39:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
@@ -4,7 +4,7 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         x.set(y);
    |               ^
    |
-note: ...the reference is valid for the anonymous lifetime #2 defined on the body at 16:14...
+note: ...the reference is valid for the anonymous lifetime #2 defined here...
   --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:16:14
    |
 LL |       doit(0, &|x, y| {
@@ -12,7 +12,7 @@ LL |       doit(0, &|x, y| {
 LL | |         x.set(y);
 LL | |     });
    | |_____^
-note: ...but the borrowed content is only valid for the anonymous lifetime #3 defined on the body at 16:14
+note: ...but the borrowed content is only valid for the anonymous lifetime #3 defined here
   --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:16:14
    |
 LL |       doit(0, &|x, y| {

--- a/src/test/ui/variance/variance-associated-types2.stderr
+++ b/src/test/ui/variance/variance-associated-types2.stderr
@@ -6,7 +6,7 @@ LL |     let _: Box<dyn Foo<Bar = &'a u32>> = make();
    |
    = note: expected trait object `dyn Foo<Bar = &'a u32>`
               found trait object `dyn Foo<Bar = &'static u32>`
-note: the lifetime `'a` as defined on the function body at 12:9...
+note: the lifetime `'a` as defined here...
   --> $DIR/variance-associated-types2.rs:12:9
    |
 LL | fn take<'a>(_: &'a u32) {

--- a/src/test/ui/variance/variance-btree-invariant-types.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.stderr
@@ -6,7 +6,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::IterMut<'_, &'new (), _>`
               found struct `std::collections::btree_map::IterMut<'_, &'static (), _>`
-note: the lifetime `'new` as defined on the function body at 3:21...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:3:21
    |
 LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
@@ -21,7 +21,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
               found struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
-note: the lifetime `'new` as defined on the function body at 6:21...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:6:21
    |
 LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
@@ -36,7 +36,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::IterMut<'_, &'static (), _>`
               found struct `std::collections::btree_map::IterMut<'_, &'new (), _>`
-note: the lifetime `'new` as defined on the function body at 9:24...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:9:24
    |
 LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
@@ -51,7 +51,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
               found struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
-note: the lifetime `'new` as defined on the function body at 12:24...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:12:24
    |
 LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
@@ -66,7 +66,7 @@ LL |     v
    |
    = note: expected struct `RangeMut<'_, &'new (), _>`
               found struct `RangeMut<'_, &'static (), _>`
-note: the lifetime `'new` as defined on the function body at 16:22...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:16:22
    |
 LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
@@ -81,7 +81,7 @@ LL |     v
    |
    = note: expected struct `RangeMut<'_, _, &'new ()>`
               found struct `RangeMut<'_, _, &'static ()>`
-note: the lifetime `'new` as defined on the function body at 19:22...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:19:22
    |
 LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
@@ -96,7 +96,7 @@ LL |     v
    |
    = note: expected struct `RangeMut<'_, &'static (), _>`
               found struct `RangeMut<'_, &'new (), _>`
-note: the lifetime `'new` as defined on the function body at 22:25...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:22:25
    |
 LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
@@ -111,7 +111,7 @@ LL |     v
    |
    = note: expected struct `RangeMut<'_, _, &'static ()>`
               found struct `RangeMut<'_, _, &'new ()>`
-note: the lifetime `'new` as defined on the function body at 25:25...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:25:25
    |
 LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
@@ -126,7 +126,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, &'new (), _>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, &'static (), _>`
-note: the lifetime `'new` as defined on the function body at 29:20...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:29:20
    |
 LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
@@ -141,7 +141,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, _, &'new ()>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, _, &'static ()>`
-note: the lifetime `'new` as defined on the function body at 33:20...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:33:20
    |
 LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
@@ -156,7 +156,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, &'static (), _>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, &'new (), _>`
-note: the lifetime `'new` as defined on the function body at 37:23...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:37:23
    |
 LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
@@ -171,7 +171,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, _, &'static ()>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, _, &'new ()>`
-note: the lifetime `'new` as defined on the function body at 41:23...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:41:23
    |
 LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
@@ -186,7 +186,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, &'new (), _>`
               found struct `std::collections::btree_map::VacantEntry<'_, &'static (), _>`
-note: the lifetime `'new` as defined on the function body at 46:20...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:46:20
    |
 LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
@@ -201,7 +201,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, _, &'new ()>`
               found struct `std::collections::btree_map::VacantEntry<'_, _, &'static ()>`
-note: the lifetime `'new` as defined on the function body at 50:20...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:50:20
    |
 LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
@@ -216,7 +216,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, &'static (), _>`
               found struct `std::collections::btree_map::VacantEntry<'_, &'new (), _>`
-note: the lifetime `'new` as defined on the function body at 54:23...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:54:23
    |
 LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
@@ -231,7 +231,7 @@ LL |     v
    |
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, _, &'static ()>`
               found struct `std::collections::btree_map::VacantEntry<'_, _, &'new ()>`
-note: the lifetime `'new` as defined on the function body at 58:23...
+note: the lifetime `'new` as defined here...
   --> $DIR/variance-btree-invariant-types.rs:58:23
    |
 LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)

--- a/src/test/ui/variance/variance-contravariant-arg-object.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-object.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-object.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-arg-object.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -25,12 +25,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 17:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-object.rs:17:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 17:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-arg-object.rs:17:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<G,&'min i32>()
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-trait-match.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-arg-trait-match.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<G,&'max i32>()
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 16:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-trait-match.rs:16:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 16:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-arg-trait-match.rs:16:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<&'min G>();
    |
    = note: expected type `<&'min G as Get>`
               found type `<&'max G as Get>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-self-trait-match.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-self-trait-match.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<&'max G>();
    |
    = note: expected type `<&'max G as Get>`
               found type `<&'min G as Get>`
-note: the lifetime `'min` as defined on the function body at 16:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-self-trait-match.rs:16:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 16:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-contravariant-self-trait-match.rs:16:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-covariant-arg-object.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-object.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-object.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-arg-object.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -25,12 +25,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 18:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-object.rs:18:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 18:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-arg-object.rs:18:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<G,&'min i32>()
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-trait-match.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-arg-trait-match.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<G,&'max i32>()
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 17:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-trait-match.rs:17:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 17:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-arg-trait-match.rs:17:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-covariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<&'min G>();
    |
    = note: expected type `<&'min G as Get>`
               found type `<&'max G as Get>`
-note: the lifetime `'min` as defined on the function body at 10:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-self-trait-match.rs:10:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 10:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-self-trait-match.rs:10:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<&'max G>();
    |
    = note: expected type `<&'max G as Get>`
               found type `<&'min G as Get>`
-note: the lifetime `'min` as defined on the function body at 17:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-self-trait-match.rs:17:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 17:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-covariant-self-trait-match.rs:17:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-invariant-arg-object.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-object.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 7:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-object.rs:7:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 7:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-arg-object.rs:7:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -25,12 +25,12 @@ LL |     v
    |
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 14:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-object.rs:14:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 14:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-arg-object.rs:14:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<G,&'min i32>()
    |
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
-note: the lifetime `'min` as defined on the function body at 7:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-trait-match.rs:7:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 7:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-arg-trait-match.rs:7:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<G,&'max i32>()
    |
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
-note: the lifetime `'min` as defined on the function body at 13:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-trait-match.rs:13:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 13:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-arg-trait-match.rs:13:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-invariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.stderr
@@ -6,12 +6,12 @@ LL |     impls_get::<&'min G>();
    |
    = note: expected type `<&'min G as Get>`
               found type `<&'max G as Get>`
-note: the lifetime `'min` as defined on the function body at 7:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-self-trait-match.rs:7:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 7:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-self-trait-match.rs:7:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -25,12 +25,12 @@ LL |     impls_get::<&'max G>();
    |
    = note: expected type `<&'max G as Get>`
               found type `<&'min G as Get>`
-note: the lifetime `'min` as defined on the function body at 13:21...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-self-trait-match.rs:13:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 13:27
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-invariant-self-trait-match.rs:13:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected struct `SomeStruct<&'min ()>`
               found struct `SomeStruct<&'max ()>`
-note: the lifetime `'min` as defined on the function body at 8:8...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-use-contravariant-struct-1.rs:8:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 8:13
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-use-contravariant-struct-1.rs:8:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)

--- a/src/test/ui/variance/variance-use-covariant-struct-1.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected struct `SomeStruct<&'max ()>`
               found struct `SomeStruct<&'min ()>`
-note: the lifetime `'min` as defined on the function body at 6:8...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-use-covariant-struct-1.rs:6:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |        ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 6:13
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-use-covariant-struct-1.rs:6:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)

--- a/src/test/ui/variance/variance-use-invariant-struct-1.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.stderr
@@ -6,12 +6,12 @@ LL |     v
    |
    = note: expected struct `SomeStruct<&'min ()>`
               found struct `SomeStruct<&'max ()>`
-note: the lifetime `'min` as defined on the function body at 8:8...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-use-invariant-struct-1.rs:8:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 8:13
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-use-invariant-struct-1.rs:8:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
@@ -25,12 +25,12 @@ LL |     v
    |
    = note: expected struct `SomeStruct<&'max ()>`
               found struct `SomeStruct<&'min ()>`
-note: the lifetime `'min` as defined on the function body at 15:8...
+note: the lifetime `'min` as defined here...
   --> $DIR/variance-use-invariant-struct-1.rs:15:8
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |        ^^^^
-note: ...does not necessarily outlive the lifetime `'max` as defined on the function body at 15:13
+note: ...does not necessarily outlive the lifetime `'max` as defined here
   --> $DIR/variance-use-invariant-struct-1.rs:15:13
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)

--- a/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
+++ b/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
@@ -17,7 +17,7 @@ note: because this has an unmet lifetime requirement
    |
 LL | pub struct Wrapper<T: Trait>(T);
    |                       ^^^^^ introduces a `'static` lifetime requirement
-note: the anonymous lifetime #1 defined on the method body at 16:5...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:16:5
    |
 LL |     pub fn repro(_: Wrapper<Ref>);

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -4,12 +4,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         u
    |         ^
    |
-note: ...the reference is valid for the lifetime `'a` as defined on the impl at 14:6...
+note: ...the reference is valid for the lifetime `'a` as defined here...
   --> $DIR/wf-static-method.rs:14:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |      ^^
-note: ...but the borrowed content is only valid for the lifetime `'b` as defined on the impl at 14:10
+note: ...but the borrowed content is only valid for the lifetime `'b` as defined here
   --> $DIR/wf-static-method.rs:14:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
@@ -21,12 +21,12 @@ error[E0478]: lifetime bound not satisfied
 LL |         let me = Self::make_me();
    |                  ^^^^
    |
-note: lifetime parameter instantiated with the lifetime `'b` as defined on the impl at 23:10
+note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/wf-static-method.rs:23:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
    |          ^^
-note: but lifetime parameter must outlive the lifetime `'a` as defined on the impl at 23:6
+note: but lifetime parameter must outlive the lifetime `'a` as defined here
   --> $DIR/wf-static-method.rs:23:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
@@ -38,12 +38,12 @@ error[E0312]: lifetime of reference outlives lifetime of borrowed content...
 LL |         u
    |         ^
    |
-note: ...the reference is valid for the lifetime `'a` as defined on the impl at 31:6...
+note: ...the reference is valid for the lifetime `'a` as defined here...
   --> $DIR/wf-static-method.rs:31:6
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
    |      ^^
-note: ...but the borrowed content is only valid for the lifetime `'b` as defined on the impl at 31:10
+note: ...but the borrowed content is only valid for the lifetime `'b` as defined here
   --> $DIR/wf-static-method.rs:31:10
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
@@ -55,7 +55,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` d
 LL |     <()>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 40:13...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/wf-static-method.rs:40:13
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -65,7 +65,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     <()>::static_evil(b)
    |                       ^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 40:9...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/wf-static-method.rs:40:9
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -82,7 +82,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` d
 LL |     <IndirectEvil>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 44:22...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/wf-static-method.rs:44:22
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -92,7 +92,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     <IndirectEvil>::static_evil(b)
    |                                 ^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 44:18...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/wf-static-method.rs:44:18
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -109,7 +109,7 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` d
 LL |     <Evil>::inherent_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'b` as defined on the function body at 49:22...
+note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
   --> $DIR/wf-static-method.rs:49:22
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -119,7 +119,7 @@ note: ...so that reference does not outlive borrowed content
    |
 LL |     <Evil>::inherent_evil(b)
    |                           ^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the function body at 49:18...
+note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/wf-static-method.rs:49:18
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {

--- a/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
@@ -6,7 +6,7 @@ LL |     let f = |x: &dyn TT| x.func(); //[default]~ ERROR: mismatched types
    |
    = note: expected reference `&(dyn TT + 'static)`
               found reference `&dyn TT`
-note: the anonymous lifetime #1 defined on the body at 13:13...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/ice-6256.rs:13:13
    |
 LL |     let f = |x: &dyn TT| x.func(); //[default]~ ERROR: mismatched types


### PR DESCRIPTION
This is an unnecessary repetition, as the diagnostic prints the span anyway in the source path right below the message.

I further removed the identification of the node, as that does not give any new information in any of the cases that are changed in tests.

EDIT: also inserted a suggestion that other diagnostics were already emitting