### PR TITLE
Move decode of BytePos lower in Span decode

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -467,10 +467,6 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for Span {
 
         debug_assert!(tag == TAG_VALID_SPAN_LOCAL || tag == TAG_VALID_SPAN_FOREIGN);
 
-        let lo = BytePos::decode(decoder)?;
-        let len = BytePos::decode(decoder)?;
-        let hi = lo + len;
-
         let sess = if let Some(sess) = decoder.sess {
             sess
         } else {
@@ -536,6 +532,10 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for Span {
             let foreign_data = decoder.cdata().cstore.get_crate_data(cnum);
             foreign_data.imported_source_files(sess)
         };
+
+        let lo = BytePos::decode(decoder)?;
+        let len = BytePos::decode(decoder)?;
+        let hi = lo + len;
 
         let source_file = {
             // Optimize for the case that most spans within a translated item

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -303,12 +303,6 @@ impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for Span {
         };
 
         tag.encode(s)?;
-        lo.encode(s)?;
-
-        // Encode length which is usually less than span.hi and profits more
-        // from the variable-length integer encoding that we use.
-        let len = hi - lo;
-        len.encode(s)?;
 
         if tag == TAG_VALID_SPAN_FOREIGN {
             // This needs to be two lines to avoid holding the `s.source_file_cache`
@@ -316,6 +310,13 @@ impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for Span {
             let cnum = s.source_file_cache.0.cnum;
             cnum.encode(s)?;
         }
+
+        lo.encode(s)?;
+
+        // Encode length which is usually less than span.hi and profits more
+        // from the variable-length integer encoding that we use.
+        let len = hi - lo;
+        len.encode(s)?;
 
         Ok(())
     }


### PR DESCRIPTION
This helps avoid having LLVM fail to register allocate well and place these
values on the stack, which ends up being a performance hit on a number of
benchmarks due to the imposed reshuffling as a result.

(Or so is the theory -- perf should check that, I'm tired of hour+ builds locally with PGO...).

r? @ghost