### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1960,6 +1960,7 @@ declare_lint! {
     "detects proc macro derives using inaccessible names from parent modules",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #83583 <https://github.com/rust-lang/rust/issues/83583>",
+        reason: FutureIncompatibilityReason::FutureReleaseErrorReportNow,
     };
 }
 

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -740,7 +740,9 @@ fn get_metadata_section(
             // Header is okay -> inflate the actual metadata
             let compressed_bytes = &buf[header_len..];
             debug!("inflating {} bytes of compressed metadata", compressed_bytes.len());
-            let mut inflated = Vec::new();
+            // Assume the decompressed data will be at least the size of the compressed data, so we
+            // don't have to grow the buffer as much.
+            let mut inflated = Vec::with_capacity(compressed_bytes.len());
             match FrameDecoder::new(compressed_bytes).read_to_end(&mut inflated) {
                 Ok(_) => rustc_erase_owner!(OwningRef::new(inflated).map_owner_box()),
                 Err(_) => {

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -9,8 +9,9 @@
 #![feature(in_band_lifetimes)]
 #![feature(format_args_capture)]
 #![feature(iter_zip)]
-#![feature(nll)]
+#![feature(map_try_insert)]
 #![feature(min_specialization)]
+#![feature(nll)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -109,6 +109,7 @@ use rustc_middle::util;
 use rustc_session::config::EntryFnType;
 use rustc_span::{symbol::sym, Span, DUMMY_SP};
 use rustc_target::spec::abi::Abi;
+use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::error_reporting::InferCtxtExt as _;
 use rustc_trait_selection::traits::{
     self, ObligationCause, ObligationCauseCode, TraitEngine, TraitEngineExt as _,
@@ -328,7 +329,22 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
                 ObligationCauseCode::MainFunctionType,
             );
             let mut fulfillment_cx = traits::FulfillmentContext::new();
-            fulfillment_cx.register_bound(&infcx, ty::ParamEnv::empty(), return_ty, term_id, cause);
+            // normalize any potential projections in the return type, then add
+            // any possible obligations to the fulfillment context.
+            // HACK(ThePuzzlemaker) this feels symptomatic of a problem within
+            // checking trait fulfillment, not this here. I'm not sure why it
+            // works in the example in `fn test()` given in #88609? This also
+            // probably isn't the best way to do this.
+            let normalized = infcx.partially_normalize_associated_types_in(
+                cause.clone(),
+                ty::ParamEnv::empty(),
+                return_ty,
+            );
+            let new_ty = normalized.value;
+            for obligation in normalized.obligations {
+                fulfillment_cx.register_predicate_obligation(&infcx, obligation);
+            }
+            fulfillment_cx.register_bound(&infcx, ty::ParamEnv::empty(), new_ty, term_id, cause);
             if let Err(err) = fulfillment_cx.select_all_or_error(&infcx) {
                 infcx.report_fulfillment_errors(&err, None, false);
                 error = true;

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -305,7 +305,6 @@ macro_rules! impl_Exp {
                     n /= 10;
                     exponent += 1;
                 }
-                let trailing_zeros = exponent;
 
                 let (added_precision, subtracted_precision) = match f.precision() {
                     Some(fmt_prec) => {
@@ -333,7 +332,7 @@ macro_rules! impl_Exp {
                         n += 1;
                     }
                 }
-                (n, exponent, trailing_zeros, added_precision)
+                (n, exponent, exponent, added_precision)
             };
 
             // 39 digits (worst case u128) + . = 40

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1533,9 +1533,8 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
-            // Using `&` helps LLVM see that it is the same check made in division.
-            if unlikely!((self == Self::MIN) & (rhs == -1)) {
-                (0, true)
+            if unlikely!(rhs == -1) {
+                (0, self == Self::MIN)
             } else {
                 (self % rhs, false)
             }
@@ -1565,9 +1564,8 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
-            // Using `&` helps LLVM see that it is the same check made in division.
-            if unlikely!((self == Self::MIN) & (rhs == -1)) {
-                (0, true)
+            if unlikely!(rhs == -1) {
+                (0, self == Self::MIN)
             } else {
                 (self.rem_euclid(rhs), false)
             }

--- a/library/core/tests/fmt/num.rs
+++ b/library/core/tests/fmt/num.rs
@@ -146,7 +146,7 @@ fn test_format_int_exp_precision() {
     assert_eq!(format!("{:.1000e}", 1), format!("1.{}e0", "0".repeat(1000)));
     //test zero precision
     assert_eq!(format!("{:.0e}", 1), format!("1e0",));
-    assert_eq!(format!("{:.0e}", 25), format!("3e1",));
+    assert_eq!(format!("{:.0e}", 35), format!("4e1",));
 
     //test padding with precision (and sign)
     assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");

--- a/library/core/tests/fmt/num.rs
+++ b/library/core/tests/fmt/num.rs
@@ -146,6 +146,7 @@ fn test_format_int_exp_precision() {
     assert_eq!(format!("{:.1000e}", 1), format!("1.{}e0", "0".repeat(1000)));
     //test zero precision
     assert_eq!(format!("{:.0e}", 1), format!("1e0",));
+    assert_eq!(format!("{:.0e}", 25), format!("3e1",));
 
     //test padding with precision (and sign)
     assert_eq!(format!("{:+10.3e}", 1), "  +1.000e0");

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -333,10 +333,9 @@ impl Command {
             let mut set = MaybeUninit::<libc::sigset_t>::uninit();
             cvt(sigemptyset(set.as_mut_ptr()))?;
             cvt(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), ptr::null_mut()))?;
-            let ret = sys::signal(libc::SIGPIPE, libc::SIG_DFL);
-            if ret == libc::SIG_ERR {
-                return Err(io::Error::last_os_error());
-            }
+            let mut action: libc::sigaction = mem::zeroed();
+            action.sa_sigaction = libc::SIG_DFL;
+            cvt(libc::sigaction(libc::SIGPIPE, &action as *const _, ptr::null_mut()))?;
         }
 
         for callback in self.get_closures().iter_mut() {

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -335,7 +335,7 @@ impl Command {
             cvt(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), ptr::null_mut()))?;
             let mut action: libc::sigaction = mem::zeroed();
             action.sa_sigaction = libc::SIG_DFL;
-            cvt(libc::sigaction(libc::SIGPIPE, &action as *const _, ptr::null_mut()))?;
+            cvt(libc::sigaction(libc::SIGPIPE, &action, ptr::null_mut()))?;
         }
 
         for callback in self.get_closures().iter_mut() {

--- a/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
@@ -10,9 +10,10 @@ error: overly complex generic constant
   --> $DIR/array-size-in-generic-struct-param.rs:19:15
    |
 LL |     arr: [u8; CFG.arr_size],
-   |               ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |               ^^^^^^^^^^^^ field access is not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/closures.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/closures.stderr
@@ -4,9 +4,10 @@ error: overly complex generic constant
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    |                                   ^^^^-------^^
    |                                       |
-   |                                       unsupported operation in generic constant, this may be supported in the future
+   |                                       dereferencing is not supported in generic constants
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/generic_const_exprs/let-bindings.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/let-bindings.stderr
@@ -2,17 +2,19 @@ error: overly complex generic constant
   --> $DIR/let-bindings.rs:6:68
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                                                    ^^^^^^^^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/let-bindings.rs:6:35
    |
 LL | fn test<const N: usize>() -> [u8; { let x = N; N + 1 }] where [u8; { let x = N; N + 1 }]: Default {
-   |                                   ^^^^^^^^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                   ^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/unused_expr.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/unused_expr.stderr
@@ -2,25 +2,28 @@ error: overly complex generic constant
   --> $DIR/unused_expr.rs:4:34
    |
 LL | fn add<const N: usize>() -> [u8; { N + 1; 5 }] {
-   |                                  ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                  ^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/unused_expr.rs:9:34
    |
 LL | fn div<const N: usize>() -> [u8; { N / 1; 5 }] {
-   |                                  ^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                  ^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: overly complex generic constant
   --> $DIR/unused_expr.rs:16:38
    |
 LL | fn fn_call<const N: usize>() -> [u8; { foo(N); 5 }] {
-   |                                      ^^^^^^^^^^^^^ unsupported operation in generic constant, this may be supported in the future
+   |                                      ^^^^^^^^^^^^^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-67375.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-67375.full.stderr
@@ -4,7 +4,7 @@ error: overly complex generic constant
 LL |     inner: [(); { [|_: &T| {}; 0].len() }],
    |                 ^^---------------^^^^^^^^
    |                   |
-   |                   unsupported operation in generic constant
+   |                   pointer casts are not allowed in generic constants
    |
    = help: consider moving this anonymous constant into a `const` function
 

--- a/src/test/ui/const-generics/issues/issue-67945-2.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-67945-2.full.stderr
@@ -8,9 +8,10 @@ LL | |         let x: Option<Box<Self>> = None;
 LL | |
 LL | |         0
 LL | |     }],
-   | |_____^ unsupported operation in generic constant, this may be supported in the future
+   | |_____^ blocks are not supported in generic constant
    |
    = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error: aborting due to previous error
 

--- a/src/test/ui/duplicate_doc_alias.rs
+++ b/src/test/ui/duplicate_doc_alias.rs
@@ -1,0 +1,9 @@
+#![deny(unused_attributes)]
+
+#[doc(alias = "A")]
+#[doc(alias = "A")] //~ ERROR
+#[doc(alias = "B")]
+#[doc(alias("B"))] //~ ERROR
+pub struct Foo;
+
+fn main() {}

--- a/src/test/ui/duplicate_doc_alias.stderr
+++ b/src/test/ui/duplicate_doc_alias.stderr
@@ -1,0 +1,24 @@
+error: doc alias is duplicated
+  --> $DIR/duplicate_doc_alias.rs:4:7
+   |
+LL | #[doc(alias = "A")]
+   |       ----------- first defined here
+LL | #[doc(alias = "A")]
+   |       ^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/duplicate_doc_alias.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: doc alias is duplicated
+  --> $DIR/duplicate_doc_alias.rs:6:13
+   |
+LL | #[doc(alias = "B")]
+   |       ----------- first defined here
+LL | #[doc(alias("B"))]
+   |             ^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mir-dataflow/liveness-enum.rs
+++ b/src/test/ui/mir-dataflow/liveness-enum.rs
@@ -1,0 +1,22 @@
+#![feature(core_intrinsics, rustc_attrs)]
+
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_liveness, stop_after_dataflow)]
+fn foo() -> Option<i32> {
+    let mut x = None;
+
+    // `x` is live here since it is used in the next statement...
+    rustc_peek(x);
+
+    dbg!(x);
+
+    // But not here, since it is overwritten below
+    rustc_peek(x); //~ ERROR rustc_peek: bit not set
+
+    x = Some(4);
+
+    x
+}
+
+fn main() {}

--- a/src/test/ui/mir-dataflow/liveness-enum.stderr
+++ b/src/test/ui/mir-dataflow/liveness-enum.stderr
@@ -1,0 +1,10 @@
+error: rustc_peek: bit not set
+  --> $DIR/liveness-enum.rs:15:5
+   |
+LL |     rustc_peek(x);
+   |     ^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -82,3 +82,75 @@ LL |     #[derive(generate_mod::CheckDerive)]
 error: aborting due to 4 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0412`.
+Future incompatibility report: Future breakage diagnostic:
+warning: cannot find type `FromOutside` in this scope
+  --> $DIR/generate-mod.rs:16:10
+   |
+LL | #[derive(generate_mod::CheckDerive)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = note: `#[warn(proc_macro_derive_resolution_fallback)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+warning: cannot find type `OuterDerive` in this scope
+  --> $DIR/generate-mod.rs:16:10
+   |
+LL | #[derive(generate_mod::CheckDerive)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+warning: cannot find type `FromOutside` in this scope
+  --> $DIR/generate-mod.rs:23:14
+   |
+LL |     #[derive(generate_mod::CheckDerive)]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+warning: cannot find type `OuterDerive` in this scope
+  --> $DIR/generate-mod.rs:23:14
+   |
+LL |     #[derive(generate_mod::CheckDerive)]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+warning: cannot find type `FromOutside` in this scope
+  --> $DIR/generate-mod.rs:30:10
+   |
+LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+note: the lint level is defined here
+  --> $DIR/generate-mod.rs:30:10
+   |
+LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+warning: cannot find type `OuterDeriveLint` in this scope
+  --> $DIR/generate-mod.rs:30:10
+   |
+LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ names from parent modules are not accessible without an explicit import
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/src/test/ui/suggestions/ignore-nested-field-binding.fixed
+++ b/src/test/ui/suggestions/ignore-nested-field-binding.fixed
@@ -1,0 +1,20 @@
+// Regression test for #88403, where prefixing with an underscore was
+// erroneously suggested for a nested shorthand struct field binding.
+
+// run-rustfix
+#![allow(unused)]
+#![forbid(unused_variables)]
+
+struct Inner { i: i32 }
+struct Outer { o: Inner }
+
+fn foo(Outer { o: Inner { i: _ } }: Outer) {}
+//~^ ERROR: unused variable: `i`
+//~| HELP: try ignoring the field
+
+fn main() {
+    let s = Outer { o: Inner { i: 42 } };
+    let Outer { o: Inner { i: _ } } = s;
+    //~^ ERROR: unused variable: `i`
+    //~| HELP: try ignoring the field
+}

--- a/src/test/ui/suggestions/ignore-nested-field-binding.rs
+++ b/src/test/ui/suggestions/ignore-nested-field-binding.rs
@@ -1,0 +1,20 @@
+// Regression test for #88403, where prefixing with an underscore was
+// erroneously suggested for a nested shorthand struct field binding.
+
+// run-rustfix
+#![allow(unused)]
+#![forbid(unused_variables)]
+
+struct Inner { i: i32 }
+struct Outer { o: Inner }
+
+fn foo(Outer { o: Inner { i } }: Outer) {}
+//~^ ERROR: unused variable: `i`
+//~| HELP: try ignoring the field
+
+fn main() {
+    let s = Outer { o: Inner { i: 42 } };
+    let Outer { o: Inner { i } } = s;
+    //~^ ERROR: unused variable: `i`
+    //~| HELP: try ignoring the field
+}

--- a/src/test/ui/suggestions/ignore-nested-field-binding.stderr
+++ b/src/test/ui/suggestions/ignore-nested-field-binding.stderr
@@ -1,0 +1,20 @@
+error: unused variable: `i`
+  --> $DIR/ignore-nested-field-binding.rs:11:27
+   |
+LL | fn foo(Outer { o: Inner { i } }: Outer) {}
+   |                           ^ help: try ignoring the field: `i: _`
+   |
+note: the lint level is defined here
+  --> $DIR/ignore-nested-field-binding.rs:6:11
+   |
+LL | #![forbid(unused_variables)]
+   |           ^^^^^^^^^^^^^^^^
+
+error: unused variable: `i`
+  --> $DIR/ignore-nested-field-binding.rs:17:28
+   |
+LL |     let Outer { o: Inner { i } } = s;
+   |                            ^ help: try ignoring the field: `i: _`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/typeck/issue-88609.rs
+++ b/src/test/ui/typeck/issue-88609.rs
@@ -1,0 +1,19 @@
+// Regression test for #88609:
+// The return type for `main` is not normalized while checking if it implements
+// the trait `std::process::Termination`.
+
+// build-pass
+
+trait Same {
+    type Output;
+}
+
+impl<T> Same for T {
+    type Output = T;
+}
+
+type Unit = <() as Same>::Output;
+
+fn main() -> Result<Unit, std::io::Error> {
+    unimplemented!()
+}


### PR DESCRIPTION
Successful merges:

 - #88706 (Normalize associated type projections when checking return type of main)
 - #88828 (Use `libc::sigaction()` instead of `sys::signal()` to prevent a deadlock)
 - #88871 (Fix suggestion for nested struct patterns)
 - #89317 (Move generic error message to separate branches)
 - #89351 (for signed wrapping remainder, do not compare lhs with MIN)
 - #89442 (Add check for duplicated doc aliases)
 - #89502 (Fix Lower/UpperExp formatting for integers and precision zero)
 - #89523 (Make `proc_macro_derive_resolution_fallback` a future-breakage lint)
 - #89532 (Document behavior of  `MaybeLiveLocals` regarding enums and field-senstivity)
 - #89546 (Make an initial guess for metadata size to reduce buffer resizes)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88706,88828,88871,89317,89351,89442,89502,89523,89532,89546)
<!-- homu-ignore:end -->