### PR TITLE
Emit item no type error even if type inference fails

### DIFF
--- a/src/test/ui/parser/issue-89574.rs
+++ b/src/test/ui/parser/issue-89574.rs
@@ -1,0 +1,4 @@
+fn main() {
+    const EMPTY_ARRAY = [];
+    //~^ missing type for `const` item
+}

--- a/src/test/ui/parser/issue-89574.stderr
+++ b/src/test/ui/parser/issue-89574.stderr
@@ -1,0 +1,8 @@
+error: missing type for `const` item
+  --> $DIR/issue-89574.rs:2:11
+   |
+LL |     const EMPTY_ARRAY = [];
+   |           ^^^^^^^^^^^ help: provide a type for the item: `EMPTY_ARRAY: <type>`
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/item-free-const-no-body-semantic-fail.rs
+++ b/src/test/ui/parser/item-free-const-no-body-semantic-fail.rs
@@ -4,3 +4,4 @@ fn main() {}
 
 const A: u8; //~ ERROR free constant item without body
 const B; //~ ERROR free constant item without body
+//~^ ERROR missing type for `const` item

--- a/src/test/ui/parser/item-free-const-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/item-free-const-no-body-semantic-fail.stderr
@@ -14,5 +14,11 @@ LL | const B;
    |        |
    |        help: provide a definition for the constant: `= <expr>;`
 
-error: aborting due to 2 previous errors
+error: missing type for `const` item
+  --> $DIR/item-free-const-no-body-semantic-fail.rs:6:7
+   |
+LL | const B;
+   |       ^ help: provide a type for the item: `B: <type>`
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/item-free-static-no-body-semantic-fail.rs
+++ b/src/test/ui/parser/item-free-static-no-body-semantic-fail.rs
@@ -4,6 +4,8 @@ fn main() {}
 
 static A: u8; //~ ERROR free static item without body
 static B; //~ ERROR free static item without body
+//~^ ERROR missing type for `static` item
 
 static mut C: u8; //~ ERROR free static item without body
 static mut D; //~ ERROR free static item without body
+//~^ ERROR missing type for `static mut` item

--- a/src/test/ui/parser/item-free-static-no-body-semantic-fail.stderr
+++ b/src/test/ui/parser/item-free-static-no-body-semantic-fail.stderr
@@ -15,7 +15,7 @@ LL | static B;
    |         help: provide a definition for the static: `= <expr>;`
 
 error: free static item without body
-  --> $DIR/item-free-static-no-body-semantic-fail.rs:8:1
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:9:1
    |
 LL | static mut C: u8;
    | ^^^^^^^^^^^^^^^^-
@@ -23,12 +23,24 @@ LL | static mut C: u8;
    |                 help: provide a definition for the static: `= <expr>;`
 
 error: free static item without body
-  --> $DIR/item-free-static-no-body-semantic-fail.rs:9:1
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:10:1
    |
 LL | static mut D;
    | ^^^^^^^^^^^^-
    |             |
    |             help: provide a definition for the static: `= <expr>;`
 
-error: aborting due to 4 previous errors
+error: missing type for `static` item
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:6:8
+   |
+LL | static B;
+   |        ^ help: provide a type for the item: `B: <type>`
+
+error: missing type for `static mut` item
+  --> $DIR/item-free-static-no-body-semantic-fail.rs:10:12
+   |
+LL | static mut D;
+   |            ^ help: provide a type for the item: `D: <type>`
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/typeck/issue-79040.rs
+++ b/src/test/ui/typeck/issue-79040.rs
@@ -1,5 +1,5 @@
 fn main() {
     const FOO = "hello" + 1; //~ ERROR cannot add `{integer}` to `&str`
-    //~^ ERROR cannot add `{integer}` to `&str`
+    //~^ missing type for `const` item
     println!("{}", FOO);
 }

--- a/src/test/ui/typeck/issue-79040.stderr
+++ b/src/test/ui/typeck/issue-79040.stderr
@@ -6,13 +6,11 @@ LL |     const FOO = "hello" + 1;
    |                 |
    |                 &str
 
-error[E0369]: cannot add `{integer}` to `&str`
-  --> $DIR/issue-79040.rs:2:25
+error: missing type for `const` item
+  --> $DIR/issue-79040.rs:2:11
    |
 LL |     const FOO = "hello" + 1;
-   |                 ------- ^ - {integer}
-   |                 |
-   |                 &str
+   |           ^^^ help: provide a type for the item: `FOO: <type>`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fix #89574

The stashed error should be emitted regardless whether ty references error or not.