### PR TITLE
fix: alloc-optimisation is only for rust llvm

### DIFF
--- a/src/test/codegen/alloc-optimisation.rs
+++ b/src/test/codegen/alloc-optimisation.rs
@@ -1,4 +1,5 @@
 //
+// no-system-llvm
 // min-llvm-version: 10.0.1
 // compile-flags: -O
 #![crate_type="lib"]


### PR DESCRIPTION
As discussed at the bottom of #83485.

On a separate note I'll take this chance ask, is it worth pulling in that patch (to recognise `__rust_dealloc`) into Debian's system LLVM? The main factors for us to consider would be (1) is the optimisation significant and (2) is there not any significant negative impact to non-rust packages that use LLVM.