### PR TITLE
[EXPERIMENT] Make `CrateSource` an enum

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -237,6 +237,7 @@ E0455: include_str!("./error_codes/E0455.md"),
 E0458: include_str!("./error_codes/E0458.md"),
 E0459: include_str!("./error_codes/E0459.md"),
 E0463: include_str!("./error_codes/E0463.md"),
+E0464: include_str!("./error_codes/E0464.md"),
 E0466: include_str!("./error_codes/E0466.md"),
 E0468: include_str!("./error_codes/E0468.md"),
 E0469: include_str!("./error_codes/E0469.md"),
@@ -586,7 +587,6 @@ E0785: include_str!("./error_codes/E0785.md"),
     E0460, // found possibly newer version of crate `..`
     E0461, // couldn't find crate `..` with expected target triple ..
     E0462, // found staticlib `..` instead of rlib or dylib
-    E0464, // multiple matching crates for `..`
     E0465, // multiple .. candidates for `..` found
 //  E0467, removed
 //  E0470, removed

--- a/compiler/rustc_error_codes/src/error_codes/E0464.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0464.md
@@ -1,0 +1,6 @@
+The compiler found multiple library files with the requested crate name.
+
+This error can occur in several different cases -- for example, when using
+`extern crate` or passing `--extern` options without crate paths. It can also be
+caused by caching issues with the build directory, in which case `cargo clean`
+may help.

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -616,15 +616,7 @@ fn write_out_deps(
             boxed_resolver.borrow_mut().access(|resolver| {
                 for cnum in resolver.cstore().crates_untracked() {
                     let source = resolver.cstore().crate_source_untracked(cnum);
-                    if let Some((path, _)) = source.dylib {
-                        files.push(escape_dep_filename(&path.display().to_string()));
-                    }
-                    if let Some((path, _)) = source.rlib {
-                        files.push(escape_dep_filename(&path.display().to_string()));
-                    }
-                    if let Some((path, _)) = source.rmeta {
-                        files.push(escape_dep_filename(&path.display().to_string()));
-                    }
+                    files.push(escape_dep_filename(&source.path().display().to_string()));
                 }
             });
         }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -474,7 +474,7 @@ impl<'a> CrateLocator<'a> {
         } else if let Some((p, k)) = self.extract_one(rmetas, CrateFlavor::Rmeta, &mut slot)? {
             CrateSource::Rmeta(p, k)
         } else {
-            panic!("no source found")
+            return Ok(None);
         };
         Ok(slot.map(|(svh, metadata)| (svh, Library { source, metadata })))
     }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -467,16 +467,15 @@ impl<'a> CrateLocator<'a> {
         let mut slot = None;
         // Order here matters, rmeta should come first. See comment in
         // `extract_one` below.
-        let source =
-            if let Some((p, k)) = self.extract_one(rmetas, CrateFlavor::Rmeta, &mut slot)? {
-                CrateSource::Rmeta(p, k)
-            } else if let Some((p, k)) = self.extract_one(rlibs, CrateFlavor::Rlib, &mut slot)? {
-                CrateSource::Rlib(p, k)
-            } else if let Some((p, k)) = self.extract_one(dylibs, CrateFlavor::Dylib, &mut slot)? {
-                CrateSource::Dylib(p, k)
-            } else {
-                panic!("no source found")
-            };
+        let source = if let Some((p, k)) = self.extract_one(rlibs, CrateFlavor::Rlib, &mut slot)? {
+            CrateSource::Rlib(p, k)
+        } else if let Some((p, k)) = self.extract_one(dylibs, CrateFlavor::Dylib, &mut slot)? {
+            CrateSource::Dylib(p, k)
+        } else if let Some((p, k)) = self.extract_one(rmetas, CrateFlavor::Rmeta, &mut slot)? {
+            CrateSource::Rmeta(p, k)
+        } else {
+            panic!("no source found")
+        };
         Ok(slot.map(|(svh, metadata)| (svh, Library { source, metadata })))
     }
 

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -232,6 +232,7 @@ use rustc_span::Span;
 use rustc_target::spec::{Target, TargetTriple};
 
 use snap::read::FrameDecoder;
+use std::fmt::Write as _;
 use std::io::{Read, Result as IoResult, Write};
 use std::path::{Path, PathBuf};
 use std::{cmp, fmt, fs};
@@ -918,21 +919,22 @@ impl CrateError {
                 libraries.sort_by_cached_key(|lib| lib.source.paths().next().unwrap().clone());
                 let candidates = libraries
                     .iter()
-                    .filter_map(|lib| {
+                    .map(|lib| {
                         let crate_name = &lib.metadata.get_root().name().as_str();
-                        match (&lib.source.dylib, &lib.source.rlib) {
-                            (Some((pd, _)), Some((pr, _))) => Some(format!(
-                                "\ncrate `{}`: {}\n{:>padding$}",
-                                crate_name,
-                                pd.display(),
-                                pr.display(),
-                                padding = 8 + crate_name.len()
-                            )),
-                            (Some((p, _)), None) | (None, Some((p, _))) => {
-                                Some(format!("\ncrate `{}`: {}", crate_name, p.display()))
-                            }
-                            (None, None) => None,
+                        let mut paths = lib.source.paths();
+
+                        // This `unwrap()` should be okay because there has to be at least one
+                        // source file. `CrateSource`'s docs confirm that too.
+                        let mut s = format!(
+                            "\ncrate `{}`: {}",
+                            crate_name,
+                            paths.next().unwrap().display()
+                        );
+                        let padding = 8 + crate_name.len();
+                        for path in paths {
+                            write!(s, "\n{:>padding$}", path.display(), padding = padding).unwrap();
                         }
+                        s
                     })
                     .collect::<String>();
                 err.note(&format!("candidates:{}", candidates));

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -229,7 +229,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         syms
     }
 
-    crate_extern_paths => { vec![cdata.source().path().clone()] }
+    crate_extern_paths => { cdata.source().path().clone() }
     expn_that_defined => { cdata.get_expn_that_defined(def_id.index, tcx.sess) }
 }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -229,7 +229,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         syms
     }
 
-    crate_extern_paths => { cdata.source().paths().cloned().collect() }
+    crate_extern_paths => { vec![cdata.source().path().clone()] }
     expn_that_defined => { cdata.get_expn_that_defined(def_id.index, tcx.sess) }
 }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1326,9 +1326,9 @@ rustc_queries! {
         eval_always
         desc { "looking up the extra filename for a crate" }
     }
-    query crate_extern_paths(_: CrateNum) -> Vec<PathBuf> {
+    query crate_extern_paths(_: CrateNum) -> PathBuf {
         eval_always
-        desc { "looking up the paths for extern crates" }
+        desc { "looking up the path for an external crate" }
     }
 
     /// Given a crate and a trait, look up all impls of that trait in the crate.

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -152,18 +152,9 @@ impl LanguageItemCollector<'tcx> {
                         let note = if def_id.is_local() {
                             format!("{} definition in the local crate (`{}`)", which, crate_name)
                         } else {
-                            let paths: Vec<_> = self
-                                .tcx
-                                .crate_extern_paths(def_id.krate)
-                                .iter()
-                                .map(|p| p.display().to_string())
-                                .collect();
-                            format!(
-                                "{} definition in `{}` loaded from {}",
-                                which,
-                                crate_name,
-                                paths.join(", ")
-                            )
+                            let path =
+                                self.tcx.crate_extern_paths(def_id.krate).display().to_string();
+                            format!("{} definition in `{}` loaded from {}", which, crate_name, path)
                         };
                         err.note(&note);
                     };

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -47,11 +47,6 @@ impl CrateSource {
     }
 
     #[inline]
-    pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
-        std::iter::once(self.path())
-    }
-
-    #[inline]
     pub fn is_dylib(&self) -> bool {
         self.as_dylib().is_some()
     }

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -21,16 +21,73 @@ use std::path::{Path, PathBuf};
 /// Where a crate came from on the local filesystem. One of these three options
 /// must be non-None.
 #[derive(PartialEq, Clone, Debug, HashStable_Generic, Encodable, Decodable)]
-pub struct CrateSource {
-    pub dylib: Option<(PathBuf, PathKind)>,
-    pub rlib: Option<(PathBuf, PathKind)>,
-    pub rmeta: Option<(PathBuf, PathKind)>,
+pub enum CrateSource {
+    Dylib(PathBuf, PathKind),
+    Rlib(PathBuf, PathKind),
+    Rmeta(PathBuf, PathKind),
 }
 
 impl CrateSource {
     #[inline]
+    pub fn path(&self) -> &PathBuf {
+        match self {
+            CrateSource::Dylib(p, _) => p,
+            CrateSource::Rlib(p, _) => p,
+            CrateSource::Rmeta(p, _) => p,
+        }
+    }
+
+    #[inline]
+    pub fn kind(&self) -> PathKind {
+        match *self {
+            CrateSource::Dylib(_, k) => k,
+            CrateSource::Rlib(_, k) => k,
+            CrateSource::Rmeta(_, k) => k,
+        }
+    }
+
+    #[inline]
     pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
-        self.dylib.iter().chain(self.rlib.iter()).chain(self.rmeta.iter()).map(|p| &p.0)
+        std::iter::once(self.path())
+    }
+
+    #[inline]
+    pub fn is_dylib(&self) -> bool {
+        self.as_dylib().is_some()
+    }
+
+    #[inline]
+    pub fn as_dylib(&self) -> Option<(&PathBuf, PathKind)> {
+        match self {
+            CrateSource::Dylib(p, k) => Some((p, *k)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_rlib(&self) -> bool {
+        self.as_rlib().is_some()
+    }
+
+    #[inline]
+    pub fn as_rlib(&self) -> Option<(&PathBuf, PathKind)> {
+        match self {
+            CrateSource::Rlib(p, k) => Some((p, *k)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_rmeta(&self) -> bool {
+        self.as_rmeta().is_some()
+    }
+
+    #[inline]
+    pub fn as_rmeta(&self) -> Option<(&PathBuf, PathKind)> {
+        match self {
+            CrateSource::Rmeta(p, k) => Some((p, *k)),
+            _ => None,
+        }
     }
 }
 

--- a/src/test/ui/crate-loading/auxiliary/crateresolve2-1.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve2-1.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-1 --emit=metadata
+#![crate_name = "crateresolve2"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 10 }

--- a/src/test/ui/crate-loading/auxiliary/crateresolve2-2.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve2-2.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-2 --emit=metadata
+#![crate_name = "crateresolve2"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 20 }

--- a/src/test/ui/crate-loading/auxiliary/crateresolve2-3.rs
+++ b/src/test/ui/crate-loading/auxiliary/crateresolve2-3.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-3 --emit=metadata
+#![crate_name = "crateresolve2"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 30 }

--- a/src/test/ui/crate-loading/crateresolve1.rs
+++ b/src/test/ui/crate-loading/crateresolve1.rs
@@ -1,10 +1,12 @@
-// dont-check-compiler-stderr
 // aux-build:crateresolve1-1.rs
 // aux-build:crateresolve1-2.rs
 // aux-build:crateresolve1-3.rs
-// error-pattern:multiple matching crates for `crateresolve1`
+
+// normalize-stderr-test: "\.so" -> ".dylib"
+// normalize-stderr-test: "\.dll" -> ".dylib"
 
 extern crate crateresolve1;
+//~^ ERROR multiple matching crates for `crateresolve1`
 
 fn main() {
 }

--- a/src/test/ui/crate-loading/crateresolve1.stderr
+++ b/src/test/ui/crate-loading/crateresolve1.stderr
@@ -11,3 +11,4 @@ LL | extern crate crateresolve1;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0464`.

--- a/src/test/ui/crate-loading/crateresolve1.stderr
+++ b/src/test/ui/crate-loading/crateresolve1.stderr
@@ -1,0 +1,13 @@
+error[E0464]: multiple matching crates for `crateresolve1`
+  --> $DIR/crateresolve1.rs:8:1
+   |
+LL | extern crate crateresolve1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: candidates:
+           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-1.dylib
+           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-2.dylib
+           crate `crateresolve1`: $TEST_BUILD_DIR/crate-loading/crateresolve1/auxiliary/libcrateresolve1-3.dylib
+
+error: aborting due to previous error
+

--- a/src/test/ui/crate-loading/crateresolve2.rs
+++ b/src/test/ui/crate-loading/crateresolve2.rs
@@ -1,0 +1,11 @@
+// check-fail
+
+// aux-build:crateresolve2-1.rs
+// aux-build:crateresolve2-2.rs
+// aux-build:crateresolve2-3.rs
+
+extern crate crateresolve2;
+//~^ ERROR multiple matching crates for `crateresolve2`
+
+fn main() {
+}

--- a/src/test/ui/crate-loading/crateresolve2.stderr
+++ b/src/test/ui/crate-loading/crateresolve2.stderr
@@ -5,6 +5,9 @@ LL | extern crate crateresolve2;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: candidates:
+           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-1.rmeta
+           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-2.rmeta
+           crate `crateresolve2`: $TEST_BUILD_DIR/crate-loading/crateresolve2/auxiliary/libcrateresolve2-3.rmeta
 
 error: aborting due to previous error
 

--- a/src/test/ui/crate-loading/crateresolve2.stderr
+++ b/src/test/ui/crate-loading/crateresolve2.stderr
@@ -11,3 +11,4 @@ LL | extern crate crateresolve2;
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0464`.

--- a/src/test/ui/crate-loading/crateresolve2.stderr
+++ b/src/test/ui/crate-loading/crateresolve2.stderr
@@ -1,0 +1,10 @@
+error[E0464]: multiple matching crates for `crateresolve2`
+  --> $DIR/crateresolve2.rs:7:1
+   |
+LL | extern crate crateresolve2;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: candidates:
+
+error: aborting due to previous error
+

--- a/src/test/ui/error-codes/E0464.rs
+++ b/src/test/ui/error-codes/E0464.rs
@@ -1,0 +1,12 @@
+// aux-build:crateresolve1-1.rs
+// aux-build:crateresolve1-2.rs
+// aux-build:crateresolve1-3.rs
+
+// normalize-stderr-test: "\.so" -> ".dylib"
+// normalize-stderr-test: "\.dll" -> ".dylib"
+
+extern crate crateresolve1;
+//~^ ERROR multiple matching crates for `crateresolve1`
+
+fn main() {
+}

--- a/src/test/ui/error-codes/E0464.stderr
+++ b/src/test/ui/error-codes/E0464.stderr
@@ -1,0 +1,14 @@
+error[E0464]: multiple matching crates for `crateresolve1`
+  --> $DIR/E0464.rs:8:1
+   |
+LL | extern crate crateresolve1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: candidates:
+           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-1.dylib
+           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-2.dylib
+           crate `crateresolve1`: $TEST_BUILD_DIR/error-codes/E0464/auxiliary/libcrateresolve1-3.dylib
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0464`.

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-1.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-1.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-1
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 10 }

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-2.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-2.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-2
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 20 }

--- a/src/test/ui/error-codes/auxiliary/crateresolve1-3.rs
+++ b/src/test/ui/error-codes/auxiliary/crateresolve1-3.rs
@@ -1,0 +1,5 @@
+// compile-flags:-C extra-filename=-3
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 30 }

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -4,6 +4,7 @@ use clippy_utils::get_attr;
 use rustc_ast::ast::{Attribute, InlineAsmTemplatePiece};
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_session::cstore::CrateSource;
 use rustc_session::Session;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
@@ -364,11 +365,16 @@ fn print_item(cx: &LateContext<'_>, item: &hir::Item<'_>) {
         hir::ItemKind::ExternCrate(ref _renamed_from) => {
             if let Some(crate_id) = cx.tcx.extern_mod_stmt_cnum(did) {
                 let source = cx.tcx.used_crate_source(crate_id);
-                if let Some(ref src) = source.dylib {
-                    println!("extern crate dylib source: {:?}", src.0);
-                }
-                if let Some(ref src) = source.rlib {
-                    println!("extern crate rlib source: {:?}", src.0);
+                match source.as_ref() {
+                    CrateSource::Dylib(path, _) => {
+                        println!("extern crate dylib source: {:?}", path)
+                    },
+                    CrateSource::Rlib(path, _) => {
+                        println!("extern crate rlib source: {:?}", path)
+                    },
+                    CrateSource::Rmeta(path, _) => {
+                        println!("extern crate rmeta source: {:?}", path)
+                    },
                 }
             } else {
                 println!("weird extern crate without a crate id");

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -15,7 +15,7 @@ const EXEMPTED_FROM_TEST: &[&str] = &[
 ];
 
 // Some error codes don't have any tests apparently...
-const IGNORE_EXPLANATION_CHECK: &[&str] = &["E0570", "E0601", "E0602", "E0729"];
+const IGNORE_EXPLANATION_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E0729"];
 
 // If the file path contains any of these, we don't want to try to extract error codes from it.
 //

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -10,8 +10,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0227", "E0279", "E0280", "E0313", "E0377", "E0461", "E0462", "E0464", "E0465", "E0476",
-    "E0482", "E0514", "E0519", "E0523", "E0554", "E0640", "E0717", "E0729",
+    "E0227", "E0279", "E0280", "E0313", "E0377", "E0461", "E0462", "E0465", "E0476", "E0482",
+    "E0514", "E0519", "E0523", "E0554", "E0640", "E0717", "E0729",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
This depends on #89587.

In practice, it seems like the compiler doesn't need to try to fetch all of
them.

r? @ghost
