### PR TITLE
Add InferCtxt::with_opaque_type_inference to get_body_with_borrowck_facts

### DIFF
--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -31,7 +31,7 @@ pub fn get_body_with_borrowck_facts<'tcx>(
     def: ty::WithOptConstParam<LocalDefId>,
 ) -> BodyWithBorrowckFacts<'tcx> {
     let (input_body, promoted) = tcx.mir_promoted(def);
-    tcx.infer_ctxt().enter(|infcx| {
+    tcx.infer_ctxt().with_opaque_type_inference(def.did).enter(|infcx| {
         let input_body: &Body<'_> = &input_body.borrow();
         let promoted: &IndexVec<_, _> = &promoted.borrow();
         *super::do_mir_borrowck(&infcx, input_body, promoted, true).1.unwrap()


### PR DESCRIPTION
`mir_borrowck` uses `with_opaque_type_inference` before calling `do_mir_borrowck`: https://github.com/rust-lang/rust/blob/0eabf25b90396dead0b2a1aaa275af18a1ae6008/compiler/rustc_borrowck/src/lib.rs#L132

However `get_body_with_borrowck_facts` does not. Therefore I get an ICE eg when calling this function on the bodies of an async function as described here: https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20ICE.20when.20using.20get_body_with_borrowck_facts.20with.20async

This change fixes that bug.

r? @nikomatsakis 