### PR TITLE
doc: guarantee call order for sort_by_cached_key

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -374,7 +374,8 @@ impl<T> [T] {
     /// During sorting, the key function is called only once per element.
     ///
     /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* + *n* \* log(*n*))
-    /// worst-case, where the key function is *O*(*m*).
+    /// worst-case, where the key function is *O*(*m*). If the slice requires sorting,
+    /// the key function is called on all elements of the slice in the original order.
     ///
     /// For simple key functions (e.g., functions that are property accesses or
     /// basic operations), [`sort_by_key`](slice::sort_by_key) is likely to be

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -371,11 +371,11 @@ impl<T> [T] {
 
     /// Sorts the slice with a key extraction function.
     ///
-    /// During sorting, the key function is called only once per element.
+    /// During sorting, the key function is called at most once per element, by using
+    /// temporary storage to remember the results of key evaluation.
     ///
     /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* + *n* \* log(*n*))
-    /// worst-case, where the key function is *O*(*m*). If the slice requires sorting,
-    /// the key function is called on all elements of the slice in the original order.
+    /// worst-case, where the key function is *O*(*m*).
     ///
     /// For simple key functions (e.g., functions that are property accesses or
     /// basic operations), [`sort_by_key`](slice::sort_by_key) is likely to be

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -373,6 +373,8 @@ impl<T> [T] {
     ///
     /// During sorting, the key function is called at most once per element, by using
     /// temporary storage to remember the results of key evaluation.
+    /// The order of calls to the key function is unspecified and may change in future versions
+    /// of the standard library.
     ///
     /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* + *n* \* log(*n*))
     /// worst-case, where the key function is *O*(*m*).


### PR DESCRIPTION
`slice::sort_by_cached_key` takes a caching function `f: impl FnMut(&T) -> K`, which means that the order that calls to the caching function are made is user-visible. This adds a clause to the documentation to promise the current behavior, which is that `f` is called on all elements of the slice from left to right, unless the slice has len < 2 in which case `f` is not called.

For example, this can be used to ensure that the following code is a correct way to involve the index of the element in the sort key:
```rust
let mut index = 0;
slice.sort_by_cached_key(|x| (my_key(index, x), index += 1).0);
```