### PR TITLE
Show detailed expected/found types in error message when trait paths are the same

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2060,14 +2060,24 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     expected: exp_found.expected.print_only_trait_path(),
                     found: exp_found.found.print_only_trait_path(),
                 };
-                self.expected_found_str(pretty_exp_found)
+                match self.expected_found_str(pretty_exp_found) {
+                    Some((expected, found)) if expected == found => {
+                        self.expected_found_str(exp_found)
+                    }
+                    ret => ret,
+                }
             }
             infer::PolyTraitRefs(exp_found) => {
                 let pretty_exp_found = ty::error::ExpectedFound {
                     expected: exp_found.expected.print_only_trait_path(),
                     found: exp_found.found.print_only_trait_path(),
                 };
-                self.expected_found_str(pretty_exp_found)
+                match self.expected_found_str(pretty_exp_found) {
+                    Some((expected, found)) if expected == found => {
+                        self.expected_found_str(exp_found)
+                    }
+                    ret => ret,
+                }
             }
         }
     }

--- a/src/test/ui/error-codes/E0308-2.stderr
+++ b/src/test/ui/error-codes/E0308-2.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL | impl Eq for &dyn DynEq {}
    |      ^^ lifetime mismatch
    |
-   = note: expected trait `PartialEq`
-              found trait `PartialEq`
+   = note: expected trait `<&dyn DynEq as PartialEq>`
+              found trait `<&(dyn DynEq + 'static) as PartialEq>`
 note: the lifetime `'_` as defined on the impl at 9:13...
   --> $DIR/E0308-2.rs:9:13
    |

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -19,8 +19,8 @@ note: ...so that the types are compatible
    |
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
    |        ^^^^^^^^^
-   = note: expected `Publisher<'_>`
-              found `Publisher<'_>`
+   = note: expected `<MyStruct<'a> as Publisher<'_>>`
+              found `<MyStruct<'_> as Publisher<'_>>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-65230.rs
+++ b/src/test/ui/issues/issue-65230.rs
@@ -1,0 +1,19 @@
+trait T {
+    type U;
+    fn f(&self) -> Self::U;
+}
+
+struct X<'a>(&'a mut i32);
+
+impl<'a> T for X<'a> {
+    type U = &'a i32;
+    fn f(&self) -> Self::U {
+        self.0
+    }
+    //~^^^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'a`
+    //
+    // Return type of `f` has lifetime `'a` but it tries to return `self.0` which
+    // has lifetime `'_`.
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-65230.rs
+++ b/src/test/ui/issues/issue-65230.rs
@@ -1,19 +1,11 @@
-trait T {
-    type U;
-    fn f(&self) -> Self::U;
-}
+trait T0 {}
+trait T1: T0 {}
 
-struct X<'a>(&'a mut i32);
+trait T2 {}
 
-impl<'a> T for X<'a> {
-    type U = &'a i32;
-    fn f(&self) -> Self::U {
-        self.0
-    }
-    //~^^^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'a`
-    //
-    // Return type of `f` has lifetime `'a` but it tries to return `self.0` which
-    // has lifetime `'_`.
-}
+impl<'a> T0 for &'a (dyn T2 + 'static) {}
+
+impl T1 for &dyn T2 {}
+//~^ ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/issues/issue-65230.stderr
+++ b/src/test/ui/issues/issue-65230.stderr
@@ -1,0 +1,38 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/issue-65230.rs:10:28
+   |
+LL |       fn f(&self) -> Self::U {
+   |  ____________________________^
+LL | |         self.0
+LL | |     }
+   | |_____^
+   |
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 10:10...
+  --> $DIR/issue-65230.rs:10:10
+   |
+LL |     fn f(&self) -> Self::U {
+   |          ^^^^^
+note: ...so that reference does not outlive borrowed content
+  --> $DIR/issue-65230.rs:11:9
+   |
+LL |         self.0
+   |         ^^^^^^
+note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 8:6...
+  --> $DIR/issue-65230.rs:8:6
+   |
+LL | impl<'a> T for X<'a> {
+   |      ^^
+note: ...so that the types are compatible
+  --> $DIR/issue-65230.rs:10:28
+   |
+LL |       fn f(&self) -> Self::U {
+   |  ____________________________^
+LL | |         self.0
+LL | |     }
+   | |_____^
+   = note: expected `<X<'a> as T>`
+              found `<X<'_> as T>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/issues/issue-65230.stderr
+++ b/src/test/ui/issues/issue-65230.stderr
@@ -1,38 +1,18 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/issue-65230.rs:10:28
-   |
-LL |       fn f(&self) -> Self::U {
-   |  ____________________________^
-LL | |         self.0
-LL | |     }
-   | |_____^
-   |
-note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 10:10...
-  --> $DIR/issue-65230.rs:10:10
-   |
-LL |     fn f(&self) -> Self::U {
-   |          ^^^^^
-note: ...so that reference does not outlive borrowed content
-  --> $DIR/issue-65230.rs:11:9
-   |
-LL |         self.0
-   |         ^^^^^^
-note: but, the lifetime must be valid for the lifetime `'a` as defined on the impl at 8:6...
+error[E0308]: mismatched types
   --> $DIR/issue-65230.rs:8:6
    |
-LL | impl<'a> T for X<'a> {
-   |      ^^
-note: ...so that the types are compatible
-  --> $DIR/issue-65230.rs:10:28
+LL | impl T1 for &dyn T2 {}
+   |      ^^ lifetime mismatch
    |
-LL |       fn f(&self) -> Self::U {
-   |  ____________________________^
-LL | |         self.0
-LL | |     }
-   | |_____^
-   = note: expected `<X<'a> as T>`
-              found `<X<'_> as T>`
+   = note: expected trait `<&dyn T2 as T0>`
+              found trait `<&(dyn T2 + 'static) as T0>`
+note: the lifetime `'_` as defined on the impl at 8:13...
+  --> $DIR/issue-65230.rs:8:13
+   |
+LL | impl T1 for &dyn T2 {}
+   |             ^
+   = note: ...does not necessarily outlive the static lifetime
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0495`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/nll/issue-50716.stderr
+++ b/src/test/ui/nll/issue-50716.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let _x = *s;
    |         ^^ lifetime mismatch
    |
-   = note: expected type `Sized`
-              found type `Sized`
+   = note: expected type `<<&'a T as A>::X as Sized>`
+              found type `<<&'static T as A>::X as Sized>`
 note: the lifetime `'a` as defined on the function body at 9:8...
   --> $DIR/issue-50716.rs:9:8
    |

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'min G as Get>`
+              found type `<&'max G as Get>`
 note: the lifetime `'min` as defined on the function body at 10:21...
   --> $DIR/variance-contravariant-self-trait-match.rs:10:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'max G as Get>`
+              found type `<&'min G as Get>`
 note: the lifetime `'min` as defined on the function body at 16:21...
   --> $DIR/variance-contravariant-self-trait-match.rs:16:21
    |

--- a/src/test/ui/variance/variance-covariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'min G as Get>`
+              found type `<&'max G as Get>`
 note: the lifetime `'min` as defined on the function body at 10:21...
   --> $DIR/variance-covariant-self-trait-match.rs:10:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'max G as Get>`
+              found type `<&'min G as Get>`
 note: the lifetime `'min` as defined on the function body at 17:21...
   --> $DIR/variance-covariant-self-trait-match.rs:17:21
    |

--- a/src/test/ui/variance/variance-invariant-self-trait-match.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'min G as Get>`
+              found type `<&'max G as Get>`
 note: the lifetime `'min` as defined on the function body at 7:21...
   --> $DIR/variance-invariant-self-trait-match.rs:7:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get`
-              found type `Get`
+   = note: expected type `<&'max G as Get>`
+              found type `<&'min G as Get>`
 note: the lifetime `'min` as defined on the function body at 13:21...
   --> $DIR/variance-invariant-self-trait-match.rs:13:21
    |


### PR DESCRIPTION
Fixes #65230.

### Issue solved by this PR

```rust
trait T {
    type U;
    fn f(&self) -> Self::U;
}

struct X<'a>(&'a mut i32);

impl<'a> T for X<'a> {
    type U = &'a i32;
    fn f(&self) -> Self::U {
        self.0
    }
}

fn main() {}
```

Compiler generates the following note:

```
note: ...so that the types are compatible
  --> test.rs:10:28
   |
10 |       fn f(&self) -> Self::U {
   |  ____________________________^
11 | |         self.0
12 | |     }
   | |_____^
   = note: expected `T`
              found `T`
```

This note is not useful since the expected type and the found type are the same.

### How this PR solve the issue

When the expected type and the found type are exactly the same in string representation, the note falls back to the detailed string representation of trait ref:

```
note: ...so that the types are compatible
  --> test.rs:10:28
   |
10 |       fn f(&self) -> Self::U {
   |  ____________________________^
11 | |         self.0
12 | |     }
   | |_____^
   = note: expected `<X<'a> as T>`
              found `<X<'_> as T>`
```

So that a user can notice what was different between the expected one and the found one.