### PR TITLE
Revert "Stabilize `Iterator::intersperse()`"

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -4,7 +4,7 @@ use super::Peekable;
 ///
 /// This `struct` is created by [`Iterator::intersperse`]. See its documentation
 /// for more information.
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 #[derive(Debug, Clone)]
 pub struct Intersperse<I: Iterator>
 where
@@ -24,7 +24,7 @@ where
     }
 }
 
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 impl<I> Iterator for Intersperse<I>
 where
     I: Iterator,
@@ -61,7 +61,7 @@ where
 ///
 /// This `struct` is created by [`Iterator::intersperse_with`]. See its
 /// documentation for more information.
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 pub struct IntersperseWith<I, G>
 where
     I: Iterator,
@@ -71,7 +71,7 @@ where
     needs_sep: bool,
 }
 
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 impl<I, G> crate::fmt::Debug for IntersperseWith<I, G>
 where
     I: Iterator + crate::fmt::Debug,
@@ -87,7 +87,7 @@ where
     }
 }
 
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 impl<I, G> crate::clone::Clone for IntersperseWith<I, G>
 where
     I: Iterator + crate::clone::Clone,
@@ -113,7 +113,7 @@ where
     }
 }
 
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 impl<I, G> Iterator for IntersperseWith<I, G>
 where
     I: Iterator,

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -42,7 +42,7 @@ pub use self::flatten::Flatten;
 #[stable(feature = "iter_copied", since = "1.36.0")]
 pub use self::copied::Copied;
 
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 pub use self::intersperse::{Intersperse, IntersperseWith};
 
 #[stable(feature = "iter_map_while", since = "1.57.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -414,7 +414,7 @@ pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,
     Skip, SkipWhile, Take, TakeWhile, Zip,
 };
-#[stable(feature = "iter_intersperse", since = "1.56.0")]
+#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 pub use self::adapters::{Intersperse, IntersperseWith};
 
 pub(crate) use self::adapters::process_results;

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -539,6 +539,8 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
+    /// #![feature(iter_intersperse)]
+    ///
     /// let mut a = [0, 1, 2].iter().intersperse(&100);
     /// assert_eq!(a.next(), Some(&0));   // The first element from `a`.
     /// assert_eq!(a.next(), Some(&100)); // The separator.
@@ -549,8 +551,9 @@ pub trait Iterator {
     /// ```
     ///
     /// `intersperse` can be very useful to join an iterator's items using a common element:
-    ///
     /// ```
+    /// #![feature(iter_intersperse)]
+    ///
     /// let hello = ["Hello", "World", "!"].iter().copied().intersperse(" ").collect::<String>();
     /// assert_eq!(hello, "Hello World !");
     /// ```
@@ -558,7 +561,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse_with`]: Iterator::intersperse_with
     #[inline]
-    #[stable(feature = "iter_intersperse", since = "1.56.0")]
+    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
     fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
     where
         Self: Sized,
@@ -583,6 +586,8 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
+    /// #![feature(iter_intersperse)]
+    ///
     /// #[derive(PartialEq, Debug)]
     /// struct NotClone(usize);
     ///
@@ -599,8 +604,9 @@ pub trait Iterator {
     ///
     /// `intersperse_with` can be used in situations where the separator needs
     /// to be computed:
-    ///
     /// ```
+    /// #![feature(iter_intersperse)]
+    ///
     /// let src = ["Hello", "to", "all", "people", "!!"].iter().copied();
     ///
     /// // The closure mutably borrows its context to generate an item.
@@ -613,7 +619,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse`]: Iterator::intersperse
     #[inline]
-    #[stable(feature = "iter_intersperse", since = "1.56.0")]
+    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
     fn intersperse_with<G>(self, separator: G) -> IntersperseWith<Self, G>
     where
         Self: Sized,

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -48,6 +48,7 @@
 #![feature(int_log)]
 #![feature(iter_advance_by)]
 #![feature(iter_partition_in_place)]
+#![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(const_mut_refs)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -15,6 +15,7 @@
 #![feature(never_type)]
 #![feature(once_cell)]
 #![feature(type_ascription)]
+#![feature(iter_intersperse)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
 


### PR DESCRIPTION
Reverts rust-lang/rust#88548

First step in resolving https://github.com/rust-lang/rust/issues/88967