### PR TITLE
CI: Use mirror for libisl downloads for more docker dist builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-aarch64-linux/aarch64-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-aarch64-linux/aarch64-linux-gnu.config
@@ -37,7 +37,8 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_FORCE_DOWNLOAD is not set
 CT_CONNECT_TIMEOUT=10
 # CT_ONLY_DOWNLOAD is not set
-# CT_USE_MIRROR is not set
+CT_USE_MIRROR=y
+CT_MIRROR_BASE_URL="https://ci-mirrors.rust-lang.org/rustc"
 
 #
 # Extracting

--- a/src/ci/docker/host-x86_64/dist-powerpc-linux/powerpc-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-powerpc-linux/powerpc-linux-gnu.config
@@ -37,7 +37,8 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_FORCE_DOWNLOAD is not set
 CT_CONNECT_TIMEOUT=10
 # CT_ONLY_DOWNLOAD is not set
-# CT_USE_MIRROR is not set
+CT_USE_MIRROR=y
+CT_MIRROR_BASE_URL="https://ci-mirrors.rust-lang.org/rustc"
 
 #
 # Extracting

--- a/src/ci/docker/host-x86_64/dist-powerpc64-linux/powerpc64-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-powerpc64-linux/powerpc64-linux-gnu.config
@@ -37,7 +37,8 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_FORCE_DOWNLOAD is not set
 CT_CONNECT_TIMEOUT=10
 # CT_ONLY_DOWNLOAD is not set
-# CT_USE_MIRROR is not set
+CT_USE_MIRROR=y
+CT_MIRROR_BASE_URL="https://ci-mirrors.rust-lang.org/rustc"
 
 #
 # Extracting

--- a/src/ci/docker/host-x86_64/dist-s390x-linux/s390x-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-s390x-linux/s390x-linux-gnu.config
@@ -37,7 +37,8 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_FORCE_DOWNLOAD is not set
 CT_CONNECT_TIMEOUT=10
 # CT_ONLY_DOWNLOAD is not set
-# CT_USE_MIRROR is not set
+CT_USE_MIRROR=y
+CT_MIRROR_BASE_URL="https://ci-mirrors.rust-lang.org/rustc"
 
 #
 # Extracting


### PR DESCRIPTION
http://isl.gforge.inria.fr fell from the net a couple of days ago. It hosts libisl source tarballs required by crosstool-ng, which we use for our docker dist cross-compilation builds. Some of the affected builds were already fixed in #89599.

This PR sets a mirror URL for the other builds requiring libisl-0.14. They use an older version of crosstool-ng (1.22.0), which has only one mirror setting for all downloads.

r? @Mark-Simulacrum