### PR TITLE
Disable new pass manager by default for the s390x targets.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -254,7 +254,11 @@ impl ModuleConfig {
             },
 
             inline_threshold: sess.opts.cg.inline_threshold,
-            new_llvm_pass_manager: sess.opts.debugging_opts.new_llvm_pass_manager,
+            new_llvm_pass_manager: sess
+                .opts
+                .debugging_opts
+                .new_llvm_pass_manager
+                .or(sess.target.llvm_new_pass_manager),
             emit_lifetime_markers: sess.emit_lifetime_markers(),
         }
     }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1350,6 +1350,9 @@ pub struct TargetOptions {
 
     /// Minimum number of bits in #[repr(C)] enum. Defaults to 32.
     pub c_enum_min_bits: u64,
+
+    /// Default for the new LLVM pass manager, usually unspecified (None).
+    pub llvm_new_pass_manager: Option<bool>,
 }
 
 impl Default for TargetOptions {
@@ -1455,6 +1458,7 @@ impl Default for TargetOptions {
             supported_sanitizers: SanitizerSet::empty(),
             default_adjusted_cabi: None,
             c_enum_min_bits: 32,
+            llvm_new_pass_manager: None,
         }
     }
 }

--- a/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
@@ -13,6 +13,10 @@ pub fn target() -> Target {
     base.max_atomic_width = Some(64);
     base.min_global_align = Some(16);
 
+    // FIXME: There are currently some troubles with the new pass manager
+    // and this target, see https://github.com/rust-lang/rust/issues/89609
+    base.llvm_new_pass_manager = Some(false);
+
     Target {
         llvm_target: "s390x-unknown-linux-gnu".to_string(),
         pointer_width: 64,

--- a/compiler/rustc_target/src/spec/s390x_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/s390x_unknown_linux_musl.rs
@@ -14,6 +14,10 @@ pub fn target() -> Target {
     base.min_global_align = Some(16);
     base.static_position_independent_executables = true;
 
+    // FIXME: There are currently some troubles with the new pass manager
+    // and this target, see https://github.com/rust-lang/rust/issues/89609
+    base.llvm_new_pass_manager = Some(false);
+
     Target {
         llvm_target: "s390x-unknown-linux-musl".to_string(),
         pointer_width: 64,


### PR DESCRIPTION
With this change target specifications can opt in to provide a default setting for using the new LLVM pass manager via `TargetOptions::new_llvm_pass_manager`. In this PR it is only set to `Some(false)` for s390x, disabling the new pass manager due to some major performance problems with it (see #89609). 

If no default is specified `rustc_codegen_llvm::back::write::should_use_new_llvm_pass_manager()` continues to enable the new pass manager iff the LLVM  version is 13 or higher.

The command line option `-Z new-llvm-pass-manager=(yes|no)` continues to override default values and should_use_new_llvm_pass_manager() logic.

This is meant as a temporary measure until the problems with s390x are fixed.