### PR TITLE
Ensure that pushing empty path works as before on verbatim paths

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1208,6 +1208,9 @@ impl PathBuf {
     /// * if `path` has a root but no prefix (e.g., `\windows`), it
     ///   replaces everything except for the prefix (if any) of `self`.
     /// * if `path` has a prefix but no root, it replaces `self`.
+    /// * if `self` has a verbatim prefix (e.g. `\\?\C:\windows`)
+    ///   and `path` is not empty, the new path is normalized: all references
+    ///   to `.` and `..` are removed.
     ///
     /// # Examples
     ///
@@ -1254,7 +1257,7 @@ impl PathBuf {
             self.as_mut_vec().truncate(0);
 
         // verbatim paths need . and .. removed
-        } else if comps.prefix_verbatim() {
+        } else if comps.prefix_verbatim() && !path.inner.is_empty() {
             let mut buf: Vec<_> = comps.collect();
             for c in path.components() {
                 match c {

--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1271,6 +1271,7 @@ pub fn test_push() {
         tp!(r"\\?\A:\x\y", "/foo", r"\\?\A:\foo");
         tp!(r"\\?\A:", r"..\foo\.", r"\\?\A:\foo");
         tp!(r"\\?\A:\x\y", r".\foo\.", r"\\?\A:\x\y\foo");
+        tp!(r"\\?\A:\x\y", r"", r"\\?\A:\x\y\");
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/89658

Signed-off-by: Sean Young <sean@mess.org>