### PR TITLE
Cfg hide more conditions for core and alloc

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -69,7 +69,12 @@
 )]
 #![cfg_attr(
     not(bootstrap),
-    doc(cfg_hide(not(test), not(any(test, bootstrap)), target_has_atomic = "ptr"))
+    doc(cfg_hide(
+        not(test),
+        not(any(test, bootstrap)),
+        any(not(feature = "miri-test-libstd"), test, doctest),
+        target_has_atomic = "ptr"
+    ))
 )]
 #![no_std]
 #![needs_allocator]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -64,6 +64,7 @@
     not(bootstrap),
     doc(cfg_hide(
         not(test),
+        any(not(feature = "miri-test-libstd"), test, doctest),
         target_pointer_width = "16",
         target_pointer_width = "32",
         target_pointer_width = "64",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/89663

Before:
![image](https://user-images.githubusercontent.com/3616612/136572816-a7844ac7-dc2f-4d79-87b4-7f9766421a83.png)

After: 
![image](https://user-images.githubusercontent.com/3616612/136572745-7d890726-8efd-4d74-83ac-ed06f4687741.png)

*Same for alloc*

r? @GuillaumeGomez 
