### PR TITLE
Greatly improve rustdoc xpath checks

### DIFF
--- a/src/test/rustdoc/fn-type.rs
+++ b/src/test/rustdoc/fn-type.rs
@@ -8,6 +8,7 @@ pub struct Foo<'a, T> {
     pub hrtb_lifetime: for<'b, 'c> fn(one: &'b i32, two: &'c &'b i32) -> (&'b i32, &'c i32),
 }
 
-// @has 'foo/struct.Foo.html' '//span[@id="structfield.generic"]' "generic: fn(val: &T) -> T"
-// @has 'foo/struct.Foo.html' '//span[@id="structfield.lifetime"]' "lifetime: fn(val: &'a i32) -> i32"
-// @has 'foo/struct.Foo.html' '//span[@id="structfield.hrtb_lifetime"]' "hrtb_lifetime: for<'b, 'c> fn(one: &'b i32, two: &'c &'b i32) -> (&'b i32, &'c i32)"
+// @has 'foo/struct.Foo.html'
+// @has - '//span[@id="structfield.generic"]' "generic: fn(val: &T) -> T"
+// @has - '//span[@id="structfield.lifetime"]' "lifetime: fn(val: &'a i32) -> i32"
+// @has - '//span[@id="structfield.hrtb_lifetime"]' "hrtb_lifetime: for<'b, 'c> fn(one: &'b i32, two: &'c &'b i32) -> (&'b i32, &'c i32)"

--- a/src/test/rustdoc/inline_cross/renamed-via-module.rs
+++ b/src/test/rustdoc/inline_cross/renamed-via-module.rs
@@ -7,16 +7,16 @@
 extern crate foo;
 
 // @has foo/iter/index.html
-// @has - '//a/[@href="struct.DeprecatedStepBy.html"]' "DeprecatedStepBy"
-// @has - '//a/[@href="struct.StepBy.html"]' "StepBy"
+// @has - '//a[@href="struct.DeprecatedStepBy.html"]' "DeprecatedStepBy"
+// @has - '//a[@href="struct.StepBy.html"]' "StepBy"
 // @has foo/iter/struct.DeprecatedStepBy.html
 // @has - '//h1' "Struct foo::iter::DeprecatedStepBy"
 // @has foo/iter/struct.StepBy.html
 // @has - '//h1' "Struct foo::iter::StepBy"
 
 // @has bar/iter/index.html
-// @has - '//a/[@href="struct.DeprecatedStepBy.html"]' "DeprecatedStepBy"
-// @has - '//a/[@href="struct.StepBy.html"]' "StepBy"
+// @has - '//a[@href="struct.DeprecatedStepBy.html"]' "DeprecatedStepBy"
+// @has - '//a[@href="struct.StepBy.html"]' "StepBy"
 // @has bar/iter/struct.DeprecatedStepBy.html
 // @has - '//h1' "Struct bar::iter::DeprecatedStepBy"
 // @has bar/iter/struct.StepBy.html

--- a/src/test/rustdoc/intra-doc/private.rs
+++ b/src/test/rustdoc/intra-doc/private.rs
@@ -4,9 +4,9 @@
 // make sure to update `rustdoc-ui/intra-doc/private.rs` if you update this file
 
 /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
-// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html"]' 'DontDocMe'
-// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
-// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
+// @has private/struct.DocMe.html '//a[@href="struct.DontDocMe.html"]' 'DontDocMe'
+// @has private/struct.DocMe.html '//a[@href="struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
+// @has private/struct.DocMe.html '//a[@href="struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
 pub struct DocMe;
 struct DontDocMe {
     x: usize,

--- a/src/test/rustdoc/primitive/no_std.rs
+++ b/src/test/rustdoc/primitive/no_std.rs
@@ -2,8 +2,8 @@
 #![deny(warnings)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-// @has no_std/fn.foo.html '//a/[@href="{{channel}}/core/primitive.u8.html"]' 'u8'
-// @has no_std/fn.foo.html '//a/[@href="{{channel}}/core/primitive.u8.html"]' 'primitive link'
+// @has no_std/fn.foo.html '//a[@href="{{channel}}/core/primitive.u8.html"]' 'u8'
+// @has no_std/fn.foo.html '//a[@href="{{channel}}/core/primitive.u8.html"]' 'primitive link'
 /// Link to [primitive link][u8]
 pub fn foo() -> u8 {}
 

--- a/src/test/rustdoc/proc-macro.rs
+++ b/src/test/rustdoc/proc-macro.rs
@@ -6,7 +6,7 @@
 #![crate_name="some_macros"]
 
 // @has some_macros/index.html
-// @has - '//a/[@href="attr.some_proc_attr.html"]' 'some_proc_attr'
+// @has - '//a[@href="attr.some_proc_attr.html"]' 'some_proc_attr'
 
 //! include a link to [some_proc_macro] to make sure it works.
 

--- a/src/test/rustdoc/raw-ident-eliminate-r-hashtag.rs
+++ b/src/test/rustdoc/raw-ident-eliminate-r-hashtag.rs
@@ -8,13 +8,13 @@ pub mod internal {
     ///
     /// [name]: mod
     /// [other name]: crate::internal::mod
-    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="struct.mod.html"]' 'name'
-    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="struct.mod.html"]' 'other name'
+    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//a[@href="struct.mod.html"]' 'name'
+    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//a[@href="struct.mod.html"]' 'other name'
     pub struct B;
 }
 
 /// See [name].
 ///
 /// [name]: internal::mod
-// @has 'raw_ident_eliminate_r_hashtag/struct.A.html' '//*a[@href="internal/struct.mod.html"]' 'name'
+// @has 'raw_ident_eliminate_r_hashtag/struct.A.html' '//a[@href="internal/struct.mod.html"]' 'name'
 pub struct A;


### PR DESCRIPTION
Before that, we were using the XML parser from the python standard library which was... pretty limited and very nice on invalid XPaths while preventing to use nice features like `//*[text()="whatever"]`. This PR switches to `parsel`.

While doing this switch, I uncovered quite a lot of small bugs, one being in the HTML generated by rustdoc.

One question remains now: is it ok to ask for a new package to be installed (`parsel`) to run `src/test/rustdoc` test suite @Mark-Simulacrum ? If so, I can add a check into bootstrap and update the requirements in the CI.

r? @jyn514 