### PR TITLE
Add #[must_use] to stdin/stdout/stderr locks

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -256,6 +256,7 @@ pub struct Stdin {
 ///     Ok(())
 /// }
 /// ```
+#[must_use = "if unused stdin will immediately unlock"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StdinLock<'a> {
     inner: MutexGuard<'a, BufReader<StdinRaw>>,
@@ -624,6 +625,7 @@ pub struct Stdout {
 /// When operating in a console, the Windows implementation of this stream does not support
 /// non-UTF-8 byte sequences. Attempting to write bytes that are not valid UTF-8 will return
 /// an error.
+#[must_use = "if unused stdout will immediately unlock"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StdoutLock<'a> {
     inner: ReentrantMutexGuard<'a, RefCell<LineWriter<StdoutRaw>>>,
@@ -907,6 +909,7 @@ pub struct Stderr {
 /// When operating in a console, the Windows implementation of this stream does not support
 /// non-UTF-8 byte sequences. Attempting to write bytes that are not valid UTF-8 will return
 /// an error.
+#[must_use = "if unused stderr will immediately unlock"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StderrLock<'a> {
     inner: ReentrantMutexGuard<'a, RefCell<StderrRaw>>,


### PR DESCRIPTION
Affected methods:

```rust
std::io           fn stdin_locked() -> StdinLock<'static>;
std::io::Stdin    fn lock(&self) -> StdinLock<'_>;
std::io::Stdin    fn into_locked(self) -> StdinLock<'static>;
std::io           fn stdout_locked() -> StdoutLock<'static>;
std::io::Stdout   fn lock(&self) -> StdoutLock<'_>;
std::io::Stdout   fn into_locked(self) -> StdoutLock<'static>;
std::io           fn stderr_locked() -> StderrLock<'static>;
std::io::Stderr   fn lock(&self) -> StderrLock<'_>;
std::io::Stderr   fn into_locked(self) -> StderrLock<'static>;
```

Parent issue: https://github.com/rust-lang/rust/issues/89692