### PR TITLE
Fix min LLVM version for bpf-types test

### DIFF
--- a/src/test/assembly/asm/bpf-types.rs
+++ b/src/test/assembly/asm/bpf-types.rs
@@ -1,4 +1,4 @@
-// min-llvm-version: 10.0.1
+// min-llvm-version: 13.0
 // assembly-output: emit-asm
 // compile-flags: --target bpfel-unknown-none -C target_feature=+alu32
 // needs-llvm-components: bpf


### PR DESCRIPTION
The test requires https://reviews.llvm.org/D102118 which was released in LLVM 13.

Closes #89689