### PR TITLE
Cfg hide no_global_oom_handling and no_fp_fmt_parse

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -73,6 +73,7 @@
         not(test),
         not(any(test, bootstrap)),
         any(not(feature = "miri-test-libstd"), test, doctest),
+        no_global_oom_handling,
         target_has_atomic = "ptr"
     ))
 )]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -65,6 +65,7 @@
     doc(cfg_hide(
         not(test),
         any(not(feature = "miri-test-libstd"), test, doctest),
+        no_fp_fmt_parse,
         target_pointer_width = "16",
         target_pointer_width = "32",
         target_pointer_width = "64",


### PR DESCRIPTION
These are unstable sysroot customisation cfg options that only projects building their own sysroot will use (e.g. Rust-for-linux). Most users shouldn't care. `no_global_oom_handling` can be especially annoying since it's applied on many commonly used alloc crate methods (e.g. `Box::new`, `Vec::push`).

r? @GuillaumeGomez