### PR TITLE
Introduce MIR summary to avoid loading large bodies without inlining them

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -201,6 +201,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     const_param_default => { table }
     thir_abstract_const => { table }
     optimized_mir => { table }
+    optimized_mir_summary => { table }
     mir_for_ctfe => { table }
     promoted_mir => { table }
     def_span => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1352,6 +1352,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             debug!("EntryBuilder::encode_mir({:?})", def_id);
             if encode_opt {
                 record!(self.tables.optimized_mir[def_id.to_def_id()] <- self.tcx.optimized_mir(def_id));
+                record!(self.tables.optimized_mir_summary[def_id.to_def_id()] <- self.tcx.optimized_mir_summary(def_id));
             }
             if encode_const {
                 record!(self.tables.mir_for_ctfe[def_id.to_def_id()] <- self.tcx.mir_for_ctfe(def_id));

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -360,6 +360,7 @@ define_tables! {
     optimized_mir: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     mir_for_ctfe: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     promoted_mir: Table<DefIndex, LazyValue<IndexVec<mir::Promoted, mir::Body<'static>>>>,
+    optimized_mir_summary: Table<DefIndex, LazyValue<mir::Summary>>,
     // FIXME(compiler-errors): Why isn't this a LazyArray?
     thir_abstract_const: Table<DefIndex, LazyValue<&'static [ty::abstract_const::Node<'static>]>>,
     impl_parent: Table<DefIndex, RawDefId>,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2900,3 +2900,10 @@ impl Location {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, HashStable, Encodable, Decodable)]
+pub struct Summary {
+    pub inlining_cost: usize,
+    pub bbcount: usize,
+    pub diverges: bool,
+}

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -431,6 +431,13 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    /// Summary of `optimized_mir` to avoid decoding it when we are not planning to use it.
+    query optimized_mir_summary(key: DefId) -> mir::Summary {
+        desc { |tcx| "summarizing MIR for `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { key.is_local() }
+        separate_provide_extern
+    }
+
     /// Returns coverage summary info for a function, after executing the `InstrumentCoverage`
     /// MIR pass (assuming the -Cinstrument-coverage option is enabled).
     query coverageinfo(key: ty::InstanceDef<'tcx>) -> mir::CoverageInfo {

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -54,6 +54,7 @@ trivially_parameterized_over_tcx! {
     crate::middle::codegen_fn_attrs::CodegenFnAttrs,
     crate::middle::exported_symbols::SymbolExportInfo,
     crate::mir::ConstQualifs,
+    crate::mir::Summary,
     ty::Generics,
     ty::ImplPolarity,
     ty::ReprOptions,


### PR DESCRIPTION
MIR inlining loads the bodies of all callees in order to assess whether to inline them. This implies useless decoding of large MIR bodies, which may incur a significant cost (https://github.com/rust-lang/rust/issues/80536).

In order to avoid loading such large MIR, this PR introduces a MIR summary structure with pre-computed statistics. Those statistics are used as a fast-reject path for inlining.

r? @wesleywiser 