### PR TITLE
Add Read::is_append_only method to optimize read_to_string

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -640,10 +640,9 @@ impl Read for File {
         io::default_read_to_end(self, buf)
     }
 
-    // Reserves space in the buffer based on the file size when available.
-    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        buf.reserve(buffer_capacity_required(self));
-        io::default_read_to_string(self, buf)
+    unsafe fn is_append_only(&self) -> bool {
+        // `io::default_read_to_end` is append-only.
+        true
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -698,10 +697,9 @@ impl Read for &File {
         io::default_read_to_end(self, buf)
     }
 
-    // Reserves space in the buffer based on the file size when available.
-    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        buf.reserve(buffer_capacity_required(self));
-        io::default_read_to_string(self, buf)
+    unsafe fn is_append_only(&self) -> bool {
+        // `io::default_read_to_end` is append-only.
+        true
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -318,40 +318,8 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread + self.inner.read_to_end(buf)?)
     }
 
-    // The inner reader might have an optimized `read_to_end`. Drain our buffer and then
-    // delegate to the inner implementation.
-    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        // In the general `else` case below we must read bytes into a side buffer, check
-        // that they are valid UTF-8, and then append them to `buf`. This requires a
-        // potentially large memcpy.
-        //
-        // If `buf` is empty--the most common case--we can leverage `append_to_string`
-        // to read directly into `buf`'s internal byte buffer, saving an allocation and
-        // a memcpy.
-        if buf.is_empty() {
-            // `append_to_string`'s safety relies on the buffer only being appended to since
-            // it only checks the UTF-8 validity of new data. If there were existing content in
-            // `buf` then an untrustworthy reader (i.e. `self.inner`) could not only append
-            // bytes but also modify existing bytes and render them invalid. On the other hand,
-            // if `buf` is empty then by definition any writes must be appends and
-            // `append_to_string` will validate all of the new bytes.
-            unsafe { crate::io::append_to_string(buf, |b| self.read_to_end(b)) }
-        } else {
-            // We cannot append our byte buffer directly onto the `buf` String as there could
-            // be an incomplete UTF-8 sequence that has only been partially read. We must read
-            // everything into a side buffer first and then call `from_utf8` on the complete
-            // buffer.
-            let mut bytes = Vec::new();
-            self.read_to_end(&mut bytes)?;
-            let string = crate::str::from_utf8(&bytes).map_err(|_| {
-                io::Error::new_const(
-                    io::ErrorKind::InvalidData,
-                    &"stream did not contain valid UTF-8",
-                )
-            })?;
-            *buf += string;
-            Ok(string.len())
-        }
+    unsafe fn is_append_only(&self) -> bool {
+        self.inner.is_append_only()
     }
 }
 

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -45,6 +45,11 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
+    unsafe fn is_append_only(&self) -> bool {
+        (**self).is_append_only()
+    }
+
+    #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         (**self).read_exact(buf)
     }
@@ -146,6 +151,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     #[inline]
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         (**self).read_to_string(buf)
+    }
+
+    #[inline]
+    unsafe fn is_append_only(&self) -> bool {
+        (**self).is_append_only()
     }
 
     #[inline]
@@ -296,6 +306,10 @@ impl Read for &[u8] {
         let len = self.len();
         *self = &self[len..];
         Ok(len)
+    }
+
+    unsafe fn is_append_only(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
I've added a new method called `is_append_only` to the `Read` trait. It returns true if `read_to_end` and `read_to_string` can be trusted not to read or overwrite any existing data in their input buffer.

These readers use it to signal that they have optimized `read_to_end` methods:

* `[u8]` extends the input buffer to the full slice size all at once instead of doubling its size repeatedly until it's big enough.

* `File` pre-allocates enough space for the full file size, allowing for fewer `read` syscalls and reducing buffer reallocations.

These readers take advantage of it:

* If `BufReader` wraps a `[u8]` or `File` its `read_to_string` will call their optimized `read_to_end`s.

Overall, this fixes a [slow path] where `BufReader::read_to_string` would be forced to read into a side buffer when passed a non-empty input buffer.

[slow path]: https://github.com/rust-lang/rust/pull/89582#discussion_r725158871