### PR TITLE
add feature flag for `type_changing_struct_update`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -681,6 +681,10 @@ declare_features! (
     /// Allows using the `non_exhaustive_omitted_patterns` lint.
     (active, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554), None),
 
+    /// Allows creation of instances of a struct by moving fields that have
+    /// not changed from prior instances of the same struct (RFC #2528)
+    (incomplete, type_changing_struct_update, "1.58.0", Some(86555), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1335,6 +1335,7 @@ symbols! {
         type_alias_enum_variants,
         type_alias_impl_trait,
         type_ascription,
+        type_changing_struct_update,
         type_id,
         type_length_limit,
         type_macros,

--- a/src/test/ui/feature-gates/feature-gate-type_changing_struct_update.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_changing_struct_update.rs
@@ -1,0 +1,26 @@
+#[derive(Debug)]
+struct Machine<S> {
+    state: S,
+    common_field1: &'static str,
+    common_field2: i32,
+}
+#[derive(Debug)]
+struct State1;
+#[derive(Debug, PartialEq)]
+struct State2;
+
+fn update_to_state2() {
+    let m1: Machine<State1> = Machine {
+        state: State1,
+        common_field1: "hello",
+        common_field2: 2,
+    };
+    let m2: Machine<State2> = Machine {
+        state: State2,
+        ..m1 //~ ERROR mismatched types
+    };
+    // FIXME: this should trigger feature gate
+    assert_eq!(State2, m2.state);
+}
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-type_changing_struct_update.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_changing_struct_update.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/feature-gate-type_changing_struct_update.rs:20:11
+   |
+LL |         ..m1
+   |           ^^ expected struct `State2`, found struct `State1`
+   |
+   = note: expected struct `Machine<State2>`
+              found struct `Machine<State1>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This implements the PR0 part of the mentoring notes within #86618.

overrides the previous inactive #86646 pr.

r? @nikomatsakis 