### PR TITLE
Stabilize proc_macro::is_available

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -61,7 +61,7 @@ use std::{error, fmt, iter, mem};
 /// non-panicking way to detect whether the infrastructure required to use the
 /// API of proc_macro is presently available. Returns true if invoked from
 /// inside of a procedural macro, false if invoked from any other binary.
-#[unstable(feature = "proc_macro_is_available", issue = "71436")]
+#[stable(feature = "proc_macro_is_available", since = "1.57.0")]
 pub fn is_available() -> bool {
     bridge::Bridge::is_available()
 }

--- a/src/test/ui/proc-macro/auxiliary/is-available.rs
+++ b/src/test/ui/proc-macro/auxiliary/is-available.rs
@@ -2,7 +2,6 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_is_available)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/proc-macro/is-available.rs
+++ b/src/test/ui/proc-macro/is-available.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-#![feature(proc_macro_is_available)]
-
 extern crate proc_macro;
 
 // aux-build:is-available.rs


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/71436

The FCP for the stabilization of `proc_macro::is_available` has completed.