### PR TITLE
Remove unused CSS rule

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -773,8 +773,6 @@ h2.small-section-header > .anchor {
 
 .item-table {
 	display: table-row;
-	/* align content left */
-	justify-items: start;
 }
 .item-row {
 	display: table-row;


### PR DESCRIPTION
As you can see in the firefox devtools:

![Screenshot from 2021-10-10 14-28-08](https://user-images.githubusercontent.com/3050060/136695689-16c77ceb-b1ab-40df-963a-048f2258e217.png)

It needs the display to be `grid` or `inline-grid`, which isn't the case.

r? @dns2utf8