### PR TITLE
ty::pretty: prevent infinite recursion for `extern crate` paths.

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -350,18 +350,19 @@ pub trait PrettyPrinter<'tcx>:
             match self.tcx().extern_crate(def_id) {
                 Some(&ExternCrate { src, dependency_of, span, .. }) => match (src, dependency_of) {
                     (ExternCrateSource::Extern(def_id), LOCAL_CRATE) => {
-                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
-                        return Ok((
-                            if !span.is_dummy() {
-                                self.print_def_path(def_id, &[])?
-                            } else {
-                                self.path_crate(cnum)?
-                            },
-                            true,
-                        ));
+                        // NOTE(eddyb) the only reason `span` might be dummy,
+                        // that we're aware of, is that it's the `std`/`core`
+                        // `extern crate` injected by default.
+                        // FIXME(eddyb) find something better to key this on,
+                        // or avoid ending up with `ExternCrateSource::Extern`,
+                        // for the injected `std`/`core`.
+                        if span.is_dummy() {
+                            return Ok((self.path_crate(cnum)?, true));
+                        }
+
+                        return Ok((self.print_def_path(def_id, &[])?, true));
                     }
                     (ExternCrateSource::Path, LOCAL_CRATE) => {
-                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
                         return Ok((self.path_crate(cnum)?, true));
                     }
                     _ => {}

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-55779-extern-trait.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-55779-extern-trait.rs
@@ -1,0 +1,1 @@
+pub trait Trait { fn no_op(&self); }

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-87932-a.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-87932-a.rs
@@ -1,0 +1,3 @@
+pub trait Deserialize {
+    fn deserialize();
+}

--- a/src/test/ui/rust-2018/uniform-paths/issue-55779.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-55779.rs
@@ -1,0 +1,29 @@
+// run-pass
+// edition:2018
+// aux-crate:issue_55779_extern_trait=issue-55779-extern-trait.rs
+
+use issue_55779_extern_trait::Trait;
+
+struct Local;
+struct Helper;
+
+impl Trait for Local {
+    fn no_op(&self)
+    {
+        // (Unused) extern crate declaration necessary to reproduce bug
+        extern crate issue_55779_extern_trait;
+
+        // This one works
+        // impl Trait for Helper { fn no_op(&self) { } }
+
+        // This one infinite-loops
+        const _IMPL_SERIALIZE_FOR_HELPER: () = {
+            // (extern crate can also appear here to reproduce bug,
+            // as in originating example from serde)
+            impl Trait for Helper { fn no_op(&self) { } }
+        };
+
+    }
+}
+
+fn main() { }

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.rs
@@ -1,0 +1,15 @@
+// edition:2018
+// aux-crate:issue_87932_a=issue-87932-a.rs
+
+pub struct A {}
+
+impl issue_87932_a::Deserialize for A {
+    fn deserialize() {
+        extern crate issue_87932_a as _a;
+    }
+}
+
+fn main() {
+    A::deserialize();
+    //~^ ERROR no function or associated item named `deserialize` found for struct `A`
+}

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no function or associated item named `deserialize` found for struct `A` in the current scope
+  --> $DIR/issue-87932.rs:13:8
+   |
+LL | pub struct A {}
+   | ------------ function or associated item `deserialize` not found for this
+...
+LL |     A::deserialize();
+   |        ^^^^^^^^^^^ function or associated item not found in `A`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use <crate::A as issue_87932_a::Deserialize>::deserialize::_a::Deserialize;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #55779, fixes #87932.

This fix is based on @estebank's idea in https://github.com/rust-lang/rust/issues/55779#issuecomment-614758510 - but instead of trying to get `try_print_visible_def_path_recur`'s cycle detection to work in this case, this PR "just" disables the "visible path" feature when printing the path to an `extern crate`, so that the old recursion chain of `try_print_visible_def_path -> print_def_path -> try_print_visible_def_path`, is now impossible.

Both tests have been confirmed to crash `rustc` because of a stack overflow, without the fix.