### PR TITLE
Fix RUSTC_LOG handling

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1259,7 +1259,7 @@ pub fn init_env_logger(env: &str) {
     };
 
     let filter = match std::env::var(env) {
-        Ok(env) => EnvFilter::from_env(env),
+        Ok(env) => EnvFilter::new(env),
         _ => EnvFilter::default().add_directive(filter::Directive::from(LevelFilter::WARN)),
     };
 


### PR DESCRIPTION
Rustc was incorrectly reading the value of `RUSTC_LOG` as the environment vairable with the logging configuration, rather than the logging configuration itself.