### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -264,14 +264,14 @@ impl EvaluationResult {
 /// Indicates that trait evaluation caused overflow and in which pass.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, HashStable)]
 pub enum OverflowError {
-    Cannonical,
+    Canonical,
     ErrorReporting,
 }
 
 impl<'tcx> From<OverflowError> for SelectionError<'tcx> {
     fn from(overflow_error: OverflowError) -> SelectionError<'tcx> {
         match overflow_error {
-            OverflowError::Cannonical => SelectionError::Overflow,
+            OverflowError::Canonical => SelectionError::Overflow,
             OverflowError::ErrorReporting => SelectionError::ErrorReporting,
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -83,10 +83,10 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
     ) -> EvaluationResult {
         match self.evaluate_obligation(obligation) {
             Ok(result) => result,
-            Err(OverflowError::Cannonical) => {
+            Err(OverflowError::Canonical) => {
                 let mut selcx = SelectionContext::with_query_mode(&self, TraitQueryMode::Standard);
                 selcx.evaluate_root_obligation(obligation).unwrap_or_else(|r| match r {
-                    OverflowError::Cannonical => {
+                    OverflowError::Canonical => {
                         span_bug!(
                             obligation.cause.span,
                             "Overflow should be caught earlier in standard query mode: {:?}, {:?}",

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -161,7 +161,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     Ok(Some(EvaluatedCandidate { candidate: c, evaluation: eval }))
                 }
                 Ok(_) => Ok(None),
-                Err(OverflowError::Cannonical) => Err(Overflow),
+                Err(OverflowError::Canonical) => Err(Overflow),
                 Err(OverflowError::ErrorReporting) => Err(ErrorReporting),
             })
             .flat_map(Result::transpose)

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -900,7 +900,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         match self.candidate_from_obligation(stack) {
             Ok(Some(c)) => self.evaluate_candidate(stack, &c),
             Ok(None) => Ok(EvaluatedToAmbig),
-            Err(Overflow) => Err(OverflowError::Cannonical),
+            Err(Overflow) => Err(OverflowError::Canonical),
             Err(ErrorReporting) => Err(OverflowError::ErrorReporting),
             Err(..) => Ok(EvaluatedToErr),
         }
@@ -1064,7 +1064,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     self.infcx.report_overflow_error(error_obligation, true);
                 }
                 TraitQueryMode::Canonical => {
-                    return Err(OverflowError::Cannonical);
+                    return Err(OverflowError::Canonical);
                 }
             }
         }

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -242,14 +242,13 @@ impl<R: Seek> BufReader<R> {
                 self.pos = new_pos as usize;
                 return Ok(());
             }
-        } else {
-            if let Some(new_pos) = pos.checked_add(offset as u64) {
-                if new_pos <= self.cap as u64 {
-                    self.pos = new_pos as usize;
-                    return Ok(());
-                }
+        } else if let Some(new_pos) = pos.checked_add(offset as u64) {
+            if new_pos <= self.cap as u64 {
+                self.pos = new_pos as usize;
+                return Ok(());
             }
         }
+
         self.seek(SeekFrom::Current(offset)).map(drop)
     }
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -558,7 +558,7 @@ impl IntoInner<Handle> for File {
 
 impl FromInner<Handle> for File {
     fn from_inner(handle: Handle) -> File {
-        File { handle: handle }
+        File { handle }
     }
 }
 
@@ -672,7 +672,7 @@ impl FilePermissions {
 
 impl FileType {
     fn new(attrs: c::DWORD, reparse_tag: c::DWORD) -> FileType {
-        FileType { attributes: attrs, reparse_tag: reparse_tag }
+        FileType { attributes: attrs, reparse_tag }
     }
     pub fn is_dir(&self) -> bool {
         !self.is_symlink() && self.is_directory()

--- a/library/std/src/sys/windows/stack_overflow.rs
+++ b/library/std/src/sys/windows/stack_overflow.rs
@@ -9,10 +9,10 @@ impl Handler {
     pub unsafe fn new() -> Handler {
         // This API isn't available on XP, so don't panic in that case and just
         // pray it works out ok.
-        if c::SetThreadStackGuarantee(&mut 0x5000) == 0 {
-            if c::GetLastError() as u32 != c::ERROR_CALL_NOT_IMPLEMENTED as u32 {
-                panic!("failed to reserve stack space for exception handling");
-            }
+        if c::SetThreadStackGuarantee(&mut 0x5000) == 0
+            && c::GetLastError() as u32 != c::ERROR_CALL_NOT_IMPLEMENTED as u32
+        {
+            panic!("failed to reserve stack space for exception handling");
         }
         Handler
     }

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -93,10 +93,8 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
         if stop {
             return false;
         }
-        if !hit {
-            if start {
-                res = bt_fmt.frame().print_raw(frame.ip(), None, None, None);
-            }
+        if !hit && start {
+            res = bt_fmt.frame().print_raw(frame.ip(), None, None, None);
         }
 
         idx += 1;

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             );
                             match infcx.evaluate_obligation(&obligation) {
                                 Ok(eval_result) if eval_result.may_apply() => {}
-                                Err(traits::OverflowError::Cannonical) => {}
+                                Err(traits::OverflowError::Canonical) => {}
                                 Err(traits::OverflowError::ErrorReporting) => {}
                                 _ => {
                                     return false;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1969,4 +1969,8 @@ details.undocumented[open] > summary::before {
 	.docblock {
 		margin-left: 12px;
 	}
+
+	.docblock code {
+		overflow-wrap: anywhere;
+	}
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -773,8 +773,6 @@ h2.small-section-header > .anchor {
 
 .item-table {
 	display: table-row;
-	/* align content left */
-	justify-items: start;
 }
 .item-row {
 	display: table-row;

--- a/src/test/rustdoc-gui/docblock-big-code-mobile.goml
+++ b/src/test/rustdoc-gui/docblock-big-code-mobile.goml
@@ -1,0 +1,9 @@
+// If we have a long `<code>`, we need to ensure that it'll be fully displayed on mobile, meaning
+// that it'll be on two lines.
+emulate: "iPhone 8" // it has the following size: (375, 667)
+goto: file://|DOC_PATH|/test_docs/long_code_block/index.html
+// We now check that the block is on two lines:
+show-text: true // We need to enable text draw to be able to have the "real" size
+// Little explanations for this test: if the text wasn't displayed on two lines, it would take
+// around 20px (which is the font size).
+assert-property: (".docblock p > code", {"offsetHeight": "42"})

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -120,3 +120,6 @@ pub type SomeType = u32;
 pub mod huge_amount_of_consts {
     include!(concat!(env!("OUT_DIR"), "/huge_amount_of_consts.rs"));
 }
+
+/// Very long code text `hereIgoWithLongTextBecauseWhyNotAndWhyWouldntI`.
+pub mod long_code_block {}

--- a/src/test/ui/wasm/simd-to-array-80108.rs
+++ b/src/test/ui/wasm/simd-to-array-80108.rs
@@ -1,0 +1,15 @@
+// only-wasm32
+// compile-flags: --crate-type=lib -Copt-level=2
+// build-pass
+#![feature(repr_simd)]
+
+// Regression test for #80108
+
+#[repr(simd)]
+pub struct Vector([i32; 4]);
+
+impl Vector {
+    pub const fn to_array(self) -> [i32; 4] {
+        self.0
+    }
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2067,9 +2067,9 @@ impl<'test> TestCx<'test> {
 
     fn maybe_dump_to_stdout(&self, out: &str, err: &str) {
         if self.config.verbose {
-            println!("------{}------------------------------", "stdout");
+            println!("------stdout------------------------------");
             println!("{}", out);
-            println!("------{}------------------------------", "stderr");
+            println!("------stderr------------------------------");
             println!("{}", err);
             println!("------------------------------------------");
         }

--- a/src/tools/compiletest/src/runtest/debugger.rs
+++ b/src/tools/compiletest/src/runtest/debugger.rs
@@ -1,0 +1,56 @@
+use crate::common::Config;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+pub(super) struct DebuggerCommands {
+    pub commands: Vec<String>,
+    pub check_lines: Vec<String>,
+    pub breakpoint_lines: Vec<usize>,
+}
+
+impl DebuggerCommands {
+    pub(super) fn parse_from(
+        file: &Path,
+        config: &Config,
+        debugger_prefixes: &[&str],
+    ) -> Result<Self, String> {
+        let directives = debugger_prefixes
+            .iter()
+            .map(|prefix| (format!("{}-command", prefix), format!("{}-check", prefix)))
+            .collect::<Vec<_>>();
+
+        let mut breakpoint_lines = vec![];
+        let mut commands = vec![];
+        let mut check_lines = vec![];
+        let mut counter = 1;
+        let reader = BufReader::new(File::open(file).unwrap());
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    let line =
+                        if line.starts_with("//") { line[2..].trim_start() } else { line.as_str() };
+
+                    if line.contains("#break") {
+                        breakpoint_lines.push(counter);
+                    }
+
+                    for &(ref command_directive, ref check_directive) in &directives {
+                        config
+                            .parse_name_value_directive(&line, command_directive)
+                            .map(|cmd| commands.push(cmd));
+
+                        config
+                            .parse_name_value_directive(&line, check_directive)
+                            .map(|cmd| check_lines.push(cmd));
+                    }
+                }
+                Err(e) => return Err(format!("Error while parsing debugger commands: {}", e)),
+            }
+            counter += 1;
+        }
+
+        Ok(Self { commands, check_lines, breakpoint_lines })
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #89579 (Add regression test for issue 80108)
 - #89632 (Fix docblock code display on mobile)
 - #89691 (Move `DebuggerCommands` and `check_debugger_output` to a separate module)
 - #89707 (Apply clippy suggestions for std)
 - #89722 (Fix spelling: Cannonical -> Canonical)
 - #89736 (Remove unused CSS rule)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89579,89632,89691,89707,89722,89736)
<!-- homu-ignore:end -->