### PR TITLE
Cleanup .item-table CSS

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -772,7 +772,7 @@ h2.small-section-header > .anchor {
 .block a.current.crate { font-weight: 500; }
 
 .item-table {
-	display: table-row;
+	display: table;
 }
 .item-row {
 	display: table-row;


### PR DESCRIPTION
The main table-like element must be `display: table;`

r? @GuillaumeGomez 