### PR TITLE
Greatly reduce amount of debuginfo compiled for bootstrap itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,15 @@ gimli.debug = 0
 miniz_oxide.debug = 0
 object.debug = 0
 
+# The only package that ever uses debug builds is bootstrap.
+# We care a lot about bootstrap's compile times, so don't include debug info for
+# dependencies, only bootstrap itself.
+[profile.dev]
+debug = 0
+[profile.dev.package]
+# Only use debuginfo=1 to further reduce compile times.
+bootstrap.debug = 1
+
 # We want the RLS to use the version of Cargo that we've got vendored in this
 # repository to ensure that the same exact version of Cargo is used by both the
 # RLS and the Cargo binary itself. The RLS depends on Cargo as a git repository

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -921,10 +921,9 @@ class RustBuild(object):
         env["LIBRARY_PATH"] = os.path.join(self.bin_root(True), "lib") + \
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
+
         # preserve existing RUSTFLAGS
         env.setdefault("RUSTFLAGS", "")
-        env["RUSTFLAGS"] += " -Cdebuginfo=2"
-
         build_section = "target.{}".format(self.build)
         target_features = []
         if self.get_toml("crt-static", build_section) == "true":


### PR DESCRIPTION
Rather than compiling rustbuild and all its dependencies with
`debuginfo=2`, this compiles dependencies without debuginfo and
rustbuild with `debuginfo=1`. On my laptop, this brings compile times
down from ~1:20 to ~1:05.

See also https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/async.20in.20bootstrap.3F/near/254847594.

r? @Mark-Simulacrum 