### PR TITLE
Change default panic strategy to abort for wasm32-unknown-emscripten

### DIFF
--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -35,7 +35,7 @@ pub fn target() -> Target {
         exe_suffix: ".js".to_string(),
         linker: None,
         is_like_emscripten: true,
-        panic_strategy: PanicStrategy::Unwind,
+        panic_strategy: PanicStrategy::Abort,
         post_link_args,
         families: vec!["unix".to_string()],
         ..options


### PR DESCRIPTION
Emscripten v2.0.10 removed __gxx_personality_v0 function stub that panic-unwind in wam32-unknown-emscripten target depends on. This causes linker error when using newer versions of emscripten compiler. As mentioned in https://github.com/rust-lang/rust/issues/85821#issuecomment-851739742 the __gxx_personality_v0 function was just a stub in emscripten for several years and therefor the panic-unwind strategy was broken all the time. Changing default to abort fixes builds  (issue 85821) with recent version of emscripten yet we are not loosing any functionality as the panic-unwind was broken anyway. Fixes  rust-lang/rust#85821