### PR TITLE
Fix function-names test for GDB 10.1

### DIFF
--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -9,36 +9,37 @@
 // gdb-command:info functions -q function_names::main
 // gdb-check:[...]static fn function_names::main();
 // gdb-command:info functions -q function_names::generic_func<*
-// gdb-check:[...]static fn function_names::generic_func(i32) -> i32;
+// gdb-check:[...]static fn function_names::generic_func<i32>(i32) -> i32;
 
 // Implementations
 // gdb-command:info functions -q function_names::.*::impl_function.*
-// gdb-check:[...]static fn function_names::GenericStruct<T1,T2>::impl_function();
+// gdb-check:[...]static fn function_names::GenericStruct<i32, i32>::impl_function<i32, i32>();
 // gdb-check:[...]static fn function_names::Mod1::TestStruct2::impl_function();
 // gdb-check:[...]static fn function_names::TestStruct1::impl_function();
 
 // Trait implementations
 // gdb-command:info functions -q function_names::.*::trait_function.*
-// gdb-check:[...]static fn <function_names::GenericStruct<T,i32> as function_names::TestTrait1>::trait_function();
-// gdb-check:[...]static fn <function_names::GenericStruct<[T; N],f32> as function_names::TestTrait1>::trait_function();
-// gdb-check:[...]static fn <function_names::Mod1::TestStruct2 as function_names::Mod1::TestTrait2>::trait_function();
-// gdb-check:[...]static fn <function_names::TestStruct1 as function_names::TestTrait1>::trait_function();
+// gdb-check:[...]static fn function_names::Mod1::{impl#1}::trait_function();
+// gdb-check:[...]static fn function_names::{impl#1}::trait_function();
+// gdb-check:[...]static fn function_names::{impl#3}::trait_function<i32>();
+// gdb-check:[...]static fn function_names::{impl#5}::trait_function3<function_names::TestStruct1>();
+// gdb-check:[...]static fn function_names::{impl#6}::trait_function<i32, 1>();
 
 // Closure
-// gdb-command:info functions -q function_names::.*::{{closure.*
-// gdb-check:[...]static fn function_names::GenericStruct<T1,T2>::impl_function::{{closure}}(*mut function_names::{impl#2}::impl_function::{closure#0});
-// gdb-check:[...]static fn function_names::generic_func::{{closure}}(*mut function_names::generic_func::{closure#0});
-// gdb-check:[...]static fn function_names::main::{{closure}}(*mut function_names::main::{closure#0});
+// gdb-command:info functions -q function_names::.*::{closure.*
+// gdb-check:[...]static fn function_names::generic_func::{closure#0}<i32>(*mut function_names::generic_func::{closure#0});
+// gdb-check:[...]static fn function_names::main::{closure#0}(*mut function_names::main::{closure#0});
+// gdb-check:[...]static fn function_names::{impl#2}::impl_function::{closure#0}<i32, i32>(*mut function_names::{impl#2}::impl_function::{closure#0});
 
 // Generator
 // Generators don't seem to appear in GDB's symbol table.
 
 // Const generic parameter
 // gdb-command:info functions -q function_names::const_generic_fn.*
-// gdb-check:[...]static fn function_names::const_generic_fn_bool();
-// gdb-check:[...]static fn function_names::const_generic_fn_non_int();
-// gdb-check:[...]static fn function_names::const_generic_fn_signed_int();
-// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_bool<false>();
+// gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#fe3cfa0214ac55c7}>();
+// gdb-check:[...]static fn function_names::const_generic_fn_signed_int<-7>();
+// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int<14>();
 
 // === CDB TESTS ===================================================================================
 
@@ -103,7 +104,7 @@ fn main() {
     GenericStruct::<TestStruct1, usize>::trait_function3();
 
     // Generic function
-    let _ = generic_func(42);
+    let _ = generic_func(42i32);
 
     // Closure
     let closure = || { TestStruct1 };


### PR DESCRIPTION
This PR updates the test output in `src/test/debuginfo/function-names.rs` for GDB 10.1.

This should fix issue https://github.com/rust-lang/rust/issues/89750 -- but not the underlying problem of CI ignoring tests if not viable debugger happens to be present.