### PR TITLE
Edit explanation of test for nested type ascriptions

### DIFF
--- a/src/test/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.rs
+++ b/src/test/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.rs
@@ -1,5 +1,5 @@
 // Here we check that type ascription is syntactically invalid when
-// not in the top position of a ascribing a let binding or function parameter.
+// not in the top position of an ascribing `let` binding or function parameter.
 
 
 // This has no effect.


### PR DESCRIPTION
Fixes typo ("an ascribing") and removes extra.

Closes #88233.