### PR TITLE
Add #[must_use] to thread::Builder

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -257,6 +257,7 @@ pub const fn require_unstable_const_init_thread_local() {}
 /// [`unwrap`]: crate::result::Result::unwrap
 /// [naming-threads]: ./index.html#naming-threads
 /// [stack-size]: ./index.html#stack-size
+#[must_use = "must eventually call `spawn()` on Thread builders"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 pub struct Builder {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -257,7 +257,7 @@ pub const fn require_unstable_const_init_thread_local() {}
 /// [`unwrap`]: crate::result::Result::unwrap
 /// [naming-threads]: ./index.html#naming-threads
 /// [stack-size]: ./index.html#stack-size
-#[must_use = "must eventually call `spawn()` on Thread builders"]
+#[must_use = "must eventually spawn the thread"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
 pub struct Builder {


### PR DESCRIPTION
I copied the wording of the [`fmt::Debug` builders](https://doc.rust-lang.org/src/core/fmt/builders.rs.html#444).

Affects:

```rust
std/src/thread/mod.rs:289:5   std::thread::Builder   fn new() -> Builder;
std/src/thread/mod.rs:318:5   std::thread::Builder   fn name(mut self, name: String) -> Builder;
std/src/thread/mod.rs:341:5   std::thread::Builder   fn stack_size(mut self, size: usize) -> Builder;
```

Parent issue: #89692

r? @joshtriplett
