### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,15 @@ gimli.debug = 0
 miniz_oxide.debug = 0
 object.debug = 0
 
+# The only package that ever uses debug builds is bootstrap.
+# We care a lot about bootstrap's compile times, so don't include debug info for
+# dependencies, only bootstrap itself.
+[profile.dev]
+debug = 0
+[profile.dev.package]
+# Only use debuginfo=1 to further reduce compile times.
+bootstrap.debug = 1
+
 # We want the RLS to use the version of Cargo that we've got vendored in this
 # repository to ensure that the same exact version of Cargo is used by both the
 # RLS and the Cargo binary itself. The RLS depends on Cargo as a git repository

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -64,7 +64,6 @@ Stabilised APIs
 - [`VecDeque::shrink_to`]
 - [`HashMap::shrink_to`]
 - [`HashSet::shrink_to`]
-- [`task::ready!`]
 
 These APIs are now usable in const contexts:
 
@@ -128,7 +127,6 @@ and related tools.
 [`VecDeque::shrink_to`]: https://doc.rust-lang.org/stable/std/collections/struct.VecDeque.html#method.shrink_to
 [`HashMap::shrink_to`]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.HashMap.html#method.shrink_to
 [`HashSet::shrink_to`]: https://doc.rust-lang.org/stable/std/collections/hash_set/struct.HashSet.html#method.shrink_to
-[`task::ready!`]: https://doc.rust-lang.org/stable/std/task/macro.ready.html
 [`std::mem::transmute`]: https://doc.rust-lang.org/stable/std/mem/fn.transmute.html
 [`slice::first`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.first
 [`slice::split_first`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.split_first

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1153,19 +1153,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         .convert_all(data);
     }
 
-    /// Convenient wrapper around `relate_tys::relate_types` -- see
-    /// that fn for docs.
-    fn relate_types(
-        &mut self,
-        a: Ty<'tcx>,
-        v: ty::Variance,
-        b: Ty<'tcx>,
-        locations: Locations,
-        category: ConstraintCategory,
-    ) -> Fallible<()> {
-        relate_tys::relate_types(self, a, v, b, locations, category)
-    }
-
     /// Try to relate `sub <: sup`
     fn sub_types(
         &mut self,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1163,16 +1163,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory,
     ) -> Fallible<()> {
-        relate_tys::relate_types(
-            self.infcx,
-            self.param_env,
-            a,
-            v,
-            b,
-            locations,
-            category,
-            self.borrowck_context,
-        )
+        relate_tys::relate_types(self, a, v, b, locations, category)
     }
 
     /// Try to relate `sub <: sup`

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -1,5 +1,5 @@
 use rustc_infer::infer::nll_relate::{NormalizationStrategy, TypeRelating, TypeRelatingDelegate};
-use rustc_infer::infer::{InferCtxt, NllRegionVariableOrigin};
+use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::relate::TypeRelation;
 use rustc_middle::ty::{self, Const, Ty};
@@ -7,7 +7,7 @@ use rustc_trait_selection::traits::query::Fallible;
 
 use crate::constraints::OutlivesConstraint;
 use crate::diagnostics::UniverseInfo;
-use crate::type_check::{BorrowCheckContext, Locations};
+use crate::type_check::{Locations, TypeChecker};
 
 /// Adds sufficient constraints to ensure that `a R b` where `R` depends on `v`:
 ///
@@ -17,27 +17,18 @@ use crate::type_check::{BorrowCheckContext, Locations};
 ///
 /// N.B., the type `a` is permitted to have unresolved inference
 /// variables, but not the type `b`.
-#[instrument(skip(infcx, param_env, borrowck_context), level = "debug")]
+#[instrument(skip(type_checker), level = "debug")]
 pub(super) fn relate_types<'tcx>(
-    infcx: &InferCtxt<'_, 'tcx>,
-    param_env: ty::ParamEnv<'tcx>,
+    type_checker: &mut TypeChecker<'_, 'tcx>,
     a: Ty<'tcx>,
     v: ty::Variance,
     b: Ty<'tcx>,
     locations: Locations,
     category: ConstraintCategory,
-    borrowck_context: &mut BorrowCheckContext<'_, 'tcx>,
 ) -> Fallible<()> {
     TypeRelating::new(
-        infcx,
-        NllTypeRelatingDelegate::new(
-            infcx,
-            borrowck_context,
-            param_env,
-            locations,
-            category,
-            UniverseInfo::relate(a, b),
-        ),
+        type_checker.infcx,
+        NllTypeRelatingDelegate::new(type_checker, locations, category, UniverseInfo::relate(a, b)),
         v,
     )
     .relate(a, b)?;
@@ -45,10 +36,7 @@ pub(super) fn relate_types<'tcx>(
 }
 
 struct NllTypeRelatingDelegate<'me, 'bccx, 'tcx> {
-    infcx: &'me InferCtxt<'me, 'tcx>,
-    borrowck_context: &'me mut BorrowCheckContext<'bccx, 'tcx>,
-
-    param_env: ty::ParamEnv<'tcx>,
+    type_checker: &'me mut TypeChecker<'bccx, 'tcx>,
 
     /// Where (and why) is this relation taking place?
     locations: Locations,
@@ -63,25 +51,24 @@ struct NllTypeRelatingDelegate<'me, 'bccx, 'tcx> {
 
 impl NllTypeRelatingDelegate<'me, 'bccx, 'tcx> {
     fn new(
-        infcx: &'me InferCtxt<'me, 'tcx>,
-        borrowck_context: &'me mut BorrowCheckContext<'bccx, 'tcx>,
-        param_env: ty::ParamEnv<'tcx>,
+        type_checker: &'me mut TypeChecker<'bccx, 'tcx>,
         locations: Locations,
         category: ConstraintCategory,
         universe_info: UniverseInfo<'tcx>,
     ) -> Self {
-        Self { infcx, borrowck_context, param_env, locations, category, universe_info }
+        Self { type_checker, locations, category, universe_info }
     }
 }
 
 impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        self.param_env
+        self.type_checker.param_env
     }
 
     fn create_next_universe(&mut self) -> ty::UniverseIndex {
-        let universe = self.infcx.create_next_universe();
-        self.borrowck_context
+        let universe = self.type_checker.infcx.create_next_universe();
+        self.type_checker
+            .borrowck_context
             .constraints
             .universe_causes
             .insert(universe, self.universe_info.clone());
@@ -90,15 +77,18 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
 
     fn next_existential_region_var(&mut self, from_forall: bool) -> ty::Region<'tcx> {
         let origin = NllRegionVariableOrigin::Existential { from_forall };
-        self.infcx.next_nll_region_var(origin)
+        self.type_checker.infcx.next_nll_region_var(origin)
     }
 
     fn next_placeholder_region(&mut self, placeholder: ty::PlaceholderRegion) -> ty::Region<'tcx> {
-        self.borrowck_context.constraints.placeholder_region(self.infcx, placeholder)
+        self.type_checker
+            .borrowck_context
+            .constraints
+            .placeholder_region(self.type_checker.infcx, placeholder)
     }
 
     fn generalize_existential(&mut self, universe: ty::UniverseIndex) -> ty::Region<'tcx> {
-        self.infcx.next_nll_region_var_in_universe(
+        self.type_checker.infcx.next_nll_region_var_in_universe(
             NllRegionVariableOrigin::Existential { from_forall: false },
             universe,
         )
@@ -110,15 +100,17 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
         sub: ty::Region<'tcx>,
         info: ty::VarianceDiagInfo<'tcx>,
     ) {
-        let sub = self.borrowck_context.universal_regions.to_region_vid(sub);
-        let sup = self.borrowck_context.universal_regions.to_region_vid(sup);
-        self.borrowck_context.constraints.outlives_constraints.push(OutlivesConstraint {
-            sup,
-            sub,
-            locations: self.locations,
-            category: self.category,
-            variance_info: info,
-        });
+        let sub = self.type_checker.borrowck_context.universal_regions.to_region_vid(sub);
+        let sup = self.type_checker.borrowck_context.universal_regions.to_region_vid(sup);
+        self.type_checker.borrowck_context.constraints.outlives_constraints.push(
+            OutlivesConstraint {
+                sup,
+                sub,
+                locations: self.locations,
+                category: self.category,
+                variance_info: info,
+            },
+        );
     }
 
     // We don't have to worry about the equality of consts during borrow checking

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -242,6 +242,7 @@ E0468: include_str!("./error_codes/E0468.md"),
 E0469: include_str!("./error_codes/E0469.md"),
 E0477: include_str!("./error_codes/E0477.md"),
 E0478: include_str!("./error_codes/E0478.md"),
+E0482: include_str!("./error_codes/E0482.md"),
 E0491: include_str!("./error_codes/E0491.md"),
 E0492: include_str!("./error_codes/E0492.md"),
 E0493: include_str!("./error_codes/E0493.md"),
@@ -599,7 +600,6 @@ E0785: include_str!("./error_codes/E0785.md"),
 //  E0479, // the type `..` (provided as the value of a type parameter) is...
 //  E0480, // lifetime of method receiver does not outlive the method call
 //  E0481, // lifetime of function argument does not outlive the function call
-    E0482, // lifetime of return value does not outlive the function call
 //  E0483, // lifetime of operand does not outlive the operation
 //  E0484, // reference is not valid at the time of borrow
 //  E0485, // automatically reference is not valid at the time of borrow

--- a/compiler/rustc_error_codes/src/error_codes/E0482.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0482.md
@@ -1,50 +1,50 @@
-A lifetime of return value does not outlive the function call.
+A lifetime of a returned value does not outlive the function call.
 
 Erroneous code example:
 
 ```compile_fail,E0482
 fn prefix<'a>(
     words: impl Iterator<Item = &'a str>
-) -> impl Iterator<Item = String> {
+) -> impl Iterator<Item = String> { // error!
     words.map(|v| format!("foo-{}", v))
 }
 ```
 
-To fix this error, make the lifetime of the returned value explicit.
+To fix this error, make the lifetime of the returned value explicit:
 
 ```
 fn prefix<'a>(
     words: impl Iterator<Item = &'a str> + 'a
-) -> impl Iterator<Item = String> + 'a {
+) -> impl Iterator<Item = String> + 'a { // ok!
     words.map(|v| format!("foo-{}", v))
 }
 ```
 
-[`impl Trait`] feature in return type have implicit `'static` lifetime
-restriction and the type implementing the `Iterator` passed to the function
-lives just `'a`, so shorter time.
+The [`impl Trait`] feature in this example uses an implicit `'static` lifetime
+restriction in the returned type. However the type implementing the `Iterator`
+passed to the function lives just as long as `'a`, which is not long enough.
 
 The solution involves adding lifetime bound to both function argument and
 the return value to make sure that the values inside the iterator
 are not dropped when the function goes out of the scope.
 
-Alternative solution would be to guarantee that the `Item` references
+An alternative solution would be to guarantee that the `Item` references
 in the iterator are alive for the whole lifetime of the program.
 
 ```
 fn prefix(
     words: impl Iterator<Item = &'static str>
-) -> impl Iterator<Item = String> {
+) -> impl Iterator<Item = String> {  // ok!
     words.map(|v| format!("foo-{}", v))
 }
 ```
 
-Similar lifetime problem might arise when returning closures.
-
-Erroneous code example:
+A similar lifetime problem might arise when returning closures:
 
 ```compile_fail,E0482
-fn foo(x: &mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] {
+fn foo(
+    x: &mut Vec<i32>
+) -> impl FnMut(&mut Vec<i32>) -> &[i32] { // error!
     |y| {
         y.append(x);
         y
@@ -52,11 +52,13 @@ fn foo(x: &mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] {
 }
 ```
 
-Analogically, solution here is to use explicit return lifetime
+Analogically, a solution here is to use explicit return lifetime
 and move the ownership of the variable to the closure.
 
 ```
-fn foo<'a>(x: &'a mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] + 'a {
+fn foo<'a>(
+    x: &'a mut Vec<i32>
+) -> impl FnMut(&mut Vec<i32>) -> &[i32] + 'a { // ok!
     move |y| {
         y.append(x);
         y
@@ -64,5 +66,8 @@ fn foo<'a>(x: &'a mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] + 'a {
 }
 ```
 
-- [`impl Trait`]: https://doc.rust-lang.org/reference/types/impl-trait.html
-- [RFC 1951]: https://rust-lang.github.io/rfcs/1951-expand-impl-trait.html
+To better understand the lifetime treatment in the [`impl Trait`],
+please see the [RFC 1951].
+
+[`impl Trait`]: https://doc.rust-lang.org/reference/types/impl-trait.html
+[RFC 1951]: https://rust-lang.github.io/rfcs/1951-expand-impl-trait.html

--- a/compiler/rustc_error_codes/src/error_codes/E0482.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0482.md
@@ -1,0 +1,68 @@
+A lifetime of return value does not outlive the function call.
+
+Erroneous code example:
+
+```compile_fail,E0482
+fn prefix<'a>(
+    words: impl Iterator<Item = &'a str>
+) -> impl Iterator<Item = String> {
+    words.map(|v| format!("foo-{}", v))
+}
+```
+
+To fix this error, make the lifetime of the returned value explicit.
+
+```
+fn prefix<'a>(
+    words: impl Iterator<Item = &'a str> + 'a
+) -> impl Iterator<Item = String> + 'a {
+    words.map(|v| format!("foo-{}", v))
+}
+```
+
+[`impl Trait`] feature in return type have implicit `'static` lifetime
+restriction and the type implementing the `Iterator` passed to the function
+lives just `'a`, so shorter time.
+
+The solution involves adding lifetime bound to both function argument and
+the return value to make sure that the values inside the iterator
+are not dropped when the function goes out of the scope.
+
+Alternative solution would be to guarantee that the `Item` references
+in the iterator are alive for the whole lifetime of the program.
+
+```
+fn prefix(
+    words: impl Iterator<Item = &'static str>
+) -> impl Iterator<Item = String> {
+    words.map(|v| format!("foo-{}", v))
+}
+```
+
+Similar lifetime problem might arise when returning closures.
+
+Erroneous code example:
+
+```compile_fail,E0482
+fn foo(x: &mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] {
+    |y| {
+        y.append(x);
+        y
+    }
+}
+```
+
+Analogically, solution here is to use explicit return lifetime
+and move the ownership of the variable to the closure.
+
+```
+fn foo<'a>(x: &'a mut Vec<i32>) -> impl FnMut(&mut Vec<i32>) -> &[i32] + 'a {
+    move |y| {
+        y.append(x);
+        y
+    }
+}
+```
+
+- [`impl Trait`]: https://doc.rust-lang.org/reference/types/impl-trait.html
+- [RFC 1951]: https://rust-lang.github.io/rfcs/1951-expand-impl-trait.html

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -741,6 +741,12 @@ impl<I: Idx, T> IndexVec<I, Option<T>> {
         self.ensure_contains_elem(index, || None);
         self[index].get_or_insert_with(value)
     }
+
+    #[inline]
+    pub fn remove(&mut self, index: I) -> Option<T> {
+        self.ensure_contains_elem(index, || None);
+        self[index].take()
+    }
 }
 
 impl<I: Idx, T: Clone> IndexVec<I, T> {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -704,7 +704,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 .filter_map(|lang_item| self.tcx.lang_items().require(*lang_item).ok())
                 .collect();
 
-        never_suggest_borrow.push(self.tcx.get_diagnostic_item(sym::Send).unwrap());
+        if let Some(def_id) = self.tcx.get_diagnostic_item(sym::Send) {
+            never_suggest_borrow.push(def_id);
+        }
 
         let param_env = obligation.param_env;
         let trait_ref = poly_trait_ref.skip_binder();

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -63,6 +63,7 @@ This API is completely unstable and subject to change.
 #![feature(in_band_lifetimes)]
 #![feature(is_sorted)]
 #![feature(iter_zip)]
+#![feature(min_specialization)]
 #![feature(nll)]
 #![feature(try_blocks)]
 #![feature(never_type)]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -30,7 +30,8 @@ use crate::hash::Hasher;
 /// [arc]: ../../std/sync/struct.Arc.html
 /// [ub]: ../../reference/behavior-considered-undefined.html
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "Send")]
+#[cfg_attr(all(not(test), bootstrap), rustc_diagnostic_item = "send_trait")]
+#[cfg_attr(all(not(test), not(bootstrap)), rustc_diagnostic_item = "Send")]
 #[rustc_on_unimplemented(
     message = "`{Self}` cannot be sent between threads safely",
     label = "`{Self}` cannot be sent between threads safely"

--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -13,5 +13,5 @@ pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 mod ready;
 #[unstable(feature = "ready_macro", issue = "70922")]
 pub use ready::ready;
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 pub use ready::Ready;

--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -11,7 +11,7 @@ mod wake;
 pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 
 mod ready;
-#[stable(feature = "ready_macro", since = "1.56.0")]
+#[unstable(feature = "ready_macro", issue = "70922")]
 pub use ready::ready;
 #[unstable(feature = "poll_ready", issue = "none")]
 pub use ready::Ready;

--- a/library/core/src/task/mod.rs
+++ b/library/core/src/task/mod.rs
@@ -13,3 +13,5 @@ pub use self::wake::{Context, RawWaker, RawWakerVTable, Waker};
 mod ready;
 #[stable(feature = "ready_macro", since = "1.56.0")]
 pub use ready::ready;
+#[unstable(feature = "poll_ready", issue = "none")]
+pub use ready::Ready;

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -121,7 +121,7 @@ impl<T> Poll<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "poll_ready", issue = "none")]
+    #[unstable(feature = "poll_ready", issue = "89780")]
     pub fn ready(self) -> Ready<T> {
         Ready(self)
     }

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -3,6 +3,7 @@
 use crate::convert;
 use crate::ops::{self, ControlFlow};
 use crate::result::Result;
+use crate::task::Ready;
 
 /// Indicates whether a value is available or if the current task has been
 /// scheduled to receive a wakeup instead.
@@ -91,6 +92,38 @@ impl<T> Poll<T> {
     #[stable(feature = "futures_api", since = "1.36.0")]
     pub const fn is_pending(&self) -> bool {
         !self.is_ready()
+    }
+
+    /// Extracts the successful type of a [`Poll<T>`].
+    ///
+    /// When combined with the `?` operator, this function will
+    /// propogate any [`Poll::Pending`] values to the caller, and
+    /// extract the `T` from [`Poll::Ready`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(poll_ready)]
+    ///
+    /// use std::task::{Context, Poll};
+    /// use std::future::{self, Future};
+    /// use std::pin::Pin;
+    ///
+    /// pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
+    ///     let mut fut = future::ready(42);
+    ///     let fut = Pin::new(&mut fut);
+    ///
+    ///     let num = fut.poll(cx).ready()?;
+    ///     # drop(num);
+    ///     // ... use num
+    ///
+    ///     Poll::Ready(())
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "poll_ready", issue = "none")]
+    pub fn ready(self) -> Ready<T> {
+        Ready(self)
     }
 }
 

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -67,10 +67,10 @@ pub macro ready($e:expr) {
 /// Extracts the successful type of a [`Poll<T>`].
 ///
 /// See [`Poll::ready`] for details.
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 pub struct Ready<T>(pub(crate) Poll<T>);
 
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 impl<T> Try for Ready<T> {
     type Output = T;
     type Residual = Ready<convert::Infallible>;
@@ -89,7 +89,7 @@ impl<T> Try for Ready<T> {
     }
 }
 
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 impl<T> FromResidual for Ready<T> {
     #[inline]
     fn from_residual(residual: Ready<convert::Infallible>) -> Self {
@@ -99,7 +99,7 @@ impl<T> FromResidual for Ready<T> {
     }
 }
 
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 impl<T> FromResidual<Ready<convert::Infallible>> for Poll<T> {
     #[inline]
     fn from_residual(residual: Ready<convert::Infallible>) -> Self {
@@ -109,7 +109,7 @@ impl<T> FromResidual<Ready<convert::Infallible>> for Poll<T> {
     }
 }
 
-#[unstable(feature = "poll_ready", issue = "none")]
+#[unstable(feature = "poll_ready", issue = "89780")]
 impl<T> fmt::Debug for Ready<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Ready").finish()

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -13,6 +13,8 @@ use core::task::Poll;
 /// # Examples
 ///
 /// ```
+/// #![feature(ready_macro)]
+///
 /// use std::task::{ready, Context, Poll};
 /// use std::future::{self, Future};
 /// use std::pin::Pin;
@@ -32,6 +34,7 @@ use core::task::Poll;
 /// The `ready!` call expands to:
 ///
 /// ```
+/// # #![feature(ready_macro)]
 /// # use std::task::{Context, Poll};
 /// # use std::future::{self, Future};
 /// # use std::pin::Pin;
@@ -50,7 +53,7 @@ use core::task::Poll;
 ///     # Poll::Ready(())
 /// # }
 /// ```
-#[stable(feature = "ready_macro", since = "1.56.0")]
+#[unstable(feature = "ready_macro", issue = "70922")]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro ready($e:expr) {
     match $e {

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -1,3 +1,8 @@
+use core::convert;
+use core::fmt;
+use core::ops::{ControlFlow, FromResidual, Try};
+use core::task::Poll;
+
 /// Extracts the successful type of a [`Poll<T>`].
 ///
 /// This macro bakes in propagation of [`Pending`] signals by returning early.
@@ -53,5 +58,57 @@ pub macro ready($e:expr) {
         $crate::task::Poll::Pending => {
             return $crate::task::Poll::Pending;
         }
+    }
+}
+
+/// Extracts the successful type of a [`Poll<T>`].
+///
+/// See [`Poll::ready`] for details.
+#[unstable(feature = "poll_ready", issue = "none")]
+pub struct Ready<T>(pub(crate) Poll<T>);
+
+#[unstable(feature = "poll_ready", issue = "none")]
+impl<T> Try for Ready<T> {
+    type Output = T;
+    type Residual = Ready<convert::Infallible>;
+
+    #[inline]
+    fn from_output(output: Self::Output) -> Self {
+        Ready(Poll::Ready(output))
+    }
+
+    #[inline]
+    fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+        match self.0 {
+            Poll::Ready(v) => ControlFlow::Continue(v),
+            Poll::Pending => ControlFlow::Break(Ready(Poll::Pending)),
+        }
+    }
+}
+
+#[unstable(feature = "poll_ready", issue = "none")]
+impl<T> FromResidual for Ready<T> {
+    #[inline]
+    fn from_residual(residual: Ready<convert::Infallible>) -> Self {
+        match residual.0 {
+            Poll::Pending => Ready(Poll::Pending),
+        }
+    }
+}
+
+#[unstable(feature = "poll_ready", issue = "none")]
+impl<T> FromResidual<Ready<convert::Infallible>> for Poll<T> {
+    #[inline]
+    fn from_residual(residual: Ready<convert::Infallible>) -> Self {
+        match residual.0 {
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[unstable(feature = "poll_ready", issue = "none")]
+impl<T> fmt::Debug for Ready<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Ready").finish()
     }
 }

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -921,10 +921,9 @@ class RustBuild(object):
         env["LIBRARY_PATH"] = os.path.join(self.bin_root(True), "lib") + \
             (os.pathsep + env["LIBRARY_PATH"]) \
             if "LIBRARY_PATH" in env else ""
+
         # preserve existing RUSTFLAGS
         env.setdefault("RUSTFLAGS", "")
-        env["RUSTFLAGS"] += " -Cdebuginfo=2"
-
         build_section = "target.{}".format(self.build)
         target_features = []
         if self.get_toml("crt-static", build_section) == "true":

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1342,12 +1342,6 @@ impl<'a> Builder<'a> {
                 rustdocflags.arg("-Dwarnings");
             }
 
-            // FIXME(#58633) hide "unused attribute" errors in incremental
-            // builds of the standard library, as the underlying checks are
-            // not yet properly integrated with incremental recompilation.
-            if mode == Mode::Std && compiler.stage == 0 && self.config.incremental {
-                lint_flags.push("-Aunused-attributes");
-            }
             // This does not use RUSTFLAGS due to caching issues with Cargo.
             // Clippy is treated as an "in tree" tool, but shares the same
             // cache as other "submodule" tools. With these options set in

--- a/src/test/debuginfo/function-names.rs
+++ b/src/test/debuginfo/function-names.rs
@@ -9,36 +9,37 @@
 // gdb-command:info functions -q function_names::main
 // gdb-check:[...]static fn function_names::main();
 // gdb-command:info functions -q function_names::generic_func<*
-// gdb-check:[...]static fn function_names::generic_func(i32) -> i32;
+// gdb-check:[...]static fn function_names::generic_func<i32>(i32) -> i32;
 
 // Implementations
 // gdb-command:info functions -q function_names::.*::impl_function.*
-// gdb-check:[...]static fn function_names::GenericStruct<T1,T2>::impl_function();
+// gdb-check:[...]static fn function_names::GenericStruct<i32, i32>::impl_function<i32, i32>();
 // gdb-check:[...]static fn function_names::Mod1::TestStruct2::impl_function();
 // gdb-check:[...]static fn function_names::TestStruct1::impl_function();
 
 // Trait implementations
 // gdb-command:info functions -q function_names::.*::trait_function.*
-// gdb-check:[...]static fn <function_names::GenericStruct<T,i32> as function_names::TestTrait1>::trait_function();
-// gdb-check:[...]static fn <function_names::GenericStruct<[T; N],f32> as function_names::TestTrait1>::trait_function();
-// gdb-check:[...]static fn <function_names::Mod1::TestStruct2 as function_names::Mod1::TestTrait2>::trait_function();
-// gdb-check:[...]static fn <function_names::TestStruct1 as function_names::TestTrait1>::trait_function();
+// gdb-check:[...]static fn function_names::Mod1::{impl#1}::trait_function();
+// gdb-check:[...]static fn function_names::{impl#1}::trait_function();
+// gdb-check:[...]static fn function_names::{impl#3}::trait_function<i32>();
+// gdb-check:[...]static fn function_names::{impl#5}::trait_function3<function_names::TestStruct1>();
+// gdb-check:[...]static fn function_names::{impl#6}::trait_function<i32, 1>();
 
 // Closure
-// gdb-command:info functions -q function_names::.*::{{closure.*
-// gdb-check:[...]static fn function_names::GenericStruct<T1,T2>::impl_function::{{closure}}(*mut function_names::{impl#2}::impl_function::{closure#0});
-// gdb-check:[...]static fn function_names::generic_func::{{closure}}(*mut function_names::generic_func::{closure#0});
-// gdb-check:[...]static fn function_names::main::{{closure}}(*mut function_names::main::{closure#0});
+// gdb-command:info functions -q function_names::.*::{closure.*
+// gdb-check:[...]static fn function_names::generic_func::{closure#0}<i32>(*mut function_names::generic_func::{closure#0});
+// gdb-check:[...]static fn function_names::main::{closure#0}(*mut function_names::main::{closure#0});
+// gdb-check:[...]static fn function_names::{impl#2}::impl_function::{closure#0}<i32, i32>(*mut function_names::{impl#2}::impl_function::{closure#0});
 
 // Generator
 // Generators don't seem to appear in GDB's symbol table.
 
 // Const generic parameter
 // gdb-command:info functions -q function_names::const_generic_fn.*
-// gdb-check:[...]static fn function_names::const_generic_fn_bool();
-// gdb-check:[...]static fn function_names::const_generic_fn_non_int();
-// gdb-check:[...]static fn function_names::const_generic_fn_signed_int();
-// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int();
+// gdb-check:[...]static fn function_names::const_generic_fn_bool<false>();
+// gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#fe3cfa0214ac55c7}>();
+// gdb-check:[...]static fn function_names::const_generic_fn_signed_int<-7>();
+// gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int<14>();
 
 // === CDB TESTS ===================================================================================
 
@@ -103,7 +104,7 @@ fn main() {
     GenericStruct::<TestStruct1, usize>::trait_function3();
 
     // Generic function
-    let _ = generic_func(42);
+    let _ = generic_func(42i32);
 
     // Closure
     let closure = || { TestStruct1 };

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
@@ -1,4 +1,5 @@
 #![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
 
 trait Tr {
     fn req(&self);
@@ -17,11 +18,6 @@ struct S;
 impl const Tr for S {
     fn req(&self) {}
 } //~^^ ERROR const trait implementations may not use non-const default functions
-
-impl const Tr for u8 {
-    fn req(&self) {}
-    fn prov(&self) {}
-}
 
 impl const Tr for u16 {
     fn prov(&self) {}

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
@@ -1,5 +1,5 @@
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:17:1
+  --> $DIR/impl-with-default-fn-fail.rs:18:1
    |
 LL | / impl const Tr for S {
 LL | |     fn req(&self) {}
@@ -9,7 +9,7 @@ LL | | }
    = note: `prov` not implemented
 
 error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn.rs:32:1
+  --> $DIR/impl-with-default-fn-fail.rs:28:1
    |
 LL | / impl const Tr for u32 {
 LL | |     fn req(&self) {}
@@ -20,7 +20,7 @@ LL | | }
    = note: `prov` not implemented
 
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn.rs:26:1
+  --> $DIR/impl-with-default-fn-fail.rs:22:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
@@ -1,0 +1,34 @@
+// check-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+
+trait Tr {
+    fn req(&self);
+
+    fn prov(&self) {
+        println!("lul");
+        self.req();
+    }
+
+    #[default_method_body_is_const]
+    fn default() {}
+}
+
+impl const Tr for u8 {
+    fn req(&self) {}
+    fn prov(&self) {}
+}
+
+macro_rules! impl_tr {
+    ($ty: ty) => {
+        impl const Tr for $ty {
+            fn req(&self) {}
+            fn prov(&self) {}
+        }
+    }
+}
+
+impl_tr!(u64);
+
+fn main() {}

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
     "E0227", "E0279", "E0280", "E0313", "E0377", "E0461", "E0462", "E0464", "E0465", "E0476",
-    "E0482", "E0514", "E0519", "E0523", "E0554", "E0640", "E0717", "E0729",
+    "E0514", "E0519", "E0523", "E0554", "E0640", "E0717", "E0729",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
Successful merges:

 - #89471 (Use Ancestory to check default fn in const impl instead of comparing idents)
 - #89643 (Fix inherent impl overlap check.)
 - #89651 (Add `Poll::ready` and revert stabilization of `task::ready!`)
 - #89675 (Re-use TypeChecker instead of passing around some of its fields )
 - #89710 (Add long explanation for error E0482)
 - #89756 (Greatly reduce amount of debuginfo compiled for bootstrap itself)
 - #89760 (Remove hack ignoring unused attributes for stage 0 std)
 - #89772 (Fix function-names test for GDB 10.1)
 - #89785 (Fix ICE when compiling nightly std/rustc on beta compiler)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89471,89643,89651,89675,89710,89756,89760,89772,89785)
<!-- homu-ignore:end -->