### PR TITLE
fix minor spelling error in Poll::ready docs

### DIFF
--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -97,7 +97,7 @@ impl<T> Poll<T> {
     /// Extracts the successful type of a [`Poll<T>`].
     ///
     /// When combined with the `?` operator, this function will
-    /// propogate any [`Poll::Pending`] values to the caller, and
+    /// propagate any [`Poll::Pending`] values to the caller, and
     /// extract the `T` from [`Poll::Ready`].
     ///
     /// # Examples


### PR DESCRIPTION
Fixes minor spelling error in the proposed `Poll::ready` docs. Not that my opinion matters, but +1 on the original PR (#89651), it reads much nicer to me than the `ready!` macro.