### PR TITLE
Associated consts sidebar

### DIFF
--- a/src/test/rustdoc/associated-consts.rs
+++ b/src/test/rustdoc/associated-consts.rs
@@ -1,0 +1,31 @@
+#![crate_name = "foo"]
+
+pub trait Trait {
+    const FOO: u32 = 12;
+
+    fn foo();
+}
+
+pub struct Bar;
+
+// @has 'foo/struct.Bar.html'
+// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @has - '//div[@class="sidebar-elems"]//div[@class="sidebar-links"]/a' 'FOO'
+impl Trait for Bar {
+    const FOO: u32 = 1;
+
+    fn foo() {}
+}
+
+pub enum Foo {
+    A,
+}
+
+// @has 'foo/enum.Foo.html'
+// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @has - '//div[@class="sidebar-elems"]//div[@class="sidebar-links"]/a' 'FOO'
+impl Trait for Foo {
+    const FOO: u32 = 1;
+
+    fn foo() {}
+}


### PR DESCRIPTION
Fixes #89354.

A screenshot with `f32`:

![Screenshot from 2021-10-12 15-07-57](https://user-images.githubusercontent.com/3050060/136962078-5faf7b87-7ea5-4d7a-99a4-b2afd77b78e2.png)

