### PR TITLE
Fix invalid rules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ __pycache__/
 *$py.class
 
 ## Node
-**node_modules
-**package-lock.json
+node_modules
+package-lock.json
 
 ## Rustdoc GUI tests
 src/test/rustdoc-gui/src/**.lock


### PR DESCRIPTION
`**node_modules` in a .gitignore is the same than
`*node_modules` or `*****node_modules`.

It matches every file whose name ends with `node_modules`,
including `not_node_modules`.

The intent here was obviously to have `**/node_modules`
which is the same than just `node_modules`.

Reference on git ignoring rules format: https://git-scm.com/docs/gitignore