### PR TITLE
Add a strange test for `unsafe_code` lint.

### DIFF
--- a/src/test/ui/lint/unsafe_code/auxiliary/forge_unsafe_block.rs
+++ b/src/test/ui/lint/unsafe_code/auxiliary/forge_unsafe_block.rs
@@ -1,0 +1,16 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn forge_unsafe_block(input: TokenStream) -> TokenStream {
+    let mut output = TokenStream::new();
+    output.extend(Some(TokenTree::from(Ident::new("unsafe", Span::call_site()))));
+    output.extend(Some(TokenTree::from(Group::new(Delimiter::Brace, input))));
+    output
+}

--- a/src/test/ui/lint/unsafe_code/forge_unsafe_block.rs
+++ b/src/test/ui/lint/unsafe_code/forge_unsafe_block.rs
@@ -1,0 +1,16 @@
+// check-pass
+// aux-build:forge_unsafe_block.rs
+
+#[macro_use]
+extern crate forge_unsafe_block;
+
+unsafe fn foo() {}
+
+#[forbid(unsafe_code)]
+fn main() {
+    // `forbid` doesn't work for non-user-provided unsafe blocks.
+    // see `UnsafeCode::check_expr`.
+    forge_unsafe_block! {
+        foo();
+    }
+}


### PR DESCRIPTION
The current behavior is a little surprising to me. I'm not sure whether people would change it, but at least let me document the current behavior with a test.

I learnt about this from the [totally-speedy-transmute](https://docs.rs/totally-speedy-transmute) crate.

cc #10599 the original implementation pr.