### PR TITLE
Deduplicate regions ids before merging them

### DIFF
--- a/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
@@ -192,6 +192,7 @@ impl ItemLikeVisitor<'v> for InherentOverlapChecker<'tcx> {
                             .collect::<SmallVec<[RegionId; 8]>>();
                         // Sort the id list so that the algorithm is deterministic
                         ids.sort_unstable();
+                        ids.dedup();
                         let ids = ids;
                         match &ids[..] {
                             // Create a new connected region

--- a/src/test/ui/inherent-impls-overlap-check/no-overlap.rs
+++ b/src/test/ui/inherent-impls-overlap-check/no-overlap.rs
@@ -31,4 +31,23 @@ repeat::repeat_with_idents!(impl Bar<A> { fn IDENT() {} });
 impl Bar<A> { fn foo() {} }
 impl Bar<B> { fn foo() {} }
 
+// Regression test for issue #89820:
+
+impl Bar<u8> {
+    pub fn a() {}
+    pub fn aa() {}
+}
+
+impl Bar<u16> {
+    pub fn b() {}
+    pub fn bb() {}
+}
+
+impl Bar<u32> {
+    pub fn a() {}
+    pub fn aa() {}
+    pub fn bb() {}
+    pub fn b() {}
+}
+
 fn main() {}


### PR DESCRIPTION
The merging code does not expect to see any duplicates.

Fixes #89820.

r? @cjgillot 