### PR TITLE
macos11 builds are 2x as slow, switch back to 10.15 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
               DIST_REQUIRE_ALL_TOOLS: 1
-            os: macos-latest
+            os: macos-10.15
           - name: dist-x86_64-apple-alt
             env:
               SCRIPT: "./x.py dist"
@@ -306,7 +306,7 @@ jobs:
               MACOSX_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
-            os: macos-latest
+            os: macos-10.15
           - name: x86_64-apple
             env:
               SCRIPT: "./x.py --stage 2 test"
@@ -316,7 +316,7 @@ jobs:
               MACOSX_STD_DEPLOYMENT_TARGET: 10.7
               NO_LLVM_ASSERTIONS: 1
               NO_DEBUG_ASSERTIONS: 1
-            os: macos-latest
+            os: macos-10.15
           - name: dist-aarch64-apple
             env:
               SCRIPT: "./x.py dist --stage 2"
@@ -330,7 +330,7 @@ jobs:
               NO_DEBUG_ASSERTIONS: 1
               DIST_REQUIRE_ALL_TOOLS: 1
               JEMALLOC_SYS_WITH_LG_PAGE: 14
-            os: macos-latest
+            os: macos-10.15
           - name: x86_64-msvc-1
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -77,7 +77,7 @@ x--expand-yaml-anchors--remove:
     <<: *base-job
 
   - &job-macos-xl
-    os: macos-latest  # We don't have an XL builder for this
+    os: macos-10.15  # We don't have an XL builder for this
     <<: *base-job
 
   - &job-windows-xl


### PR DESCRIPTION
#89774 ran into a timeout due to [apple builders](https://github.com/rust-lang-ci/rust/runs/3870515641). The major difference I see compared to the [previous auto merge](https://github.com/rust-lang-ci/rust/runs/3868837822) is that it now uses macos11 instead of 10.