### PR TITLE
fix the stage0 tools config file path in `config.toml.example`

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -202,15 +202,15 @@ changelog-seen = 2
 # You can use "$ROOT" to indicate the root of the git repository.
 #build-dir = "build"
 
-# Instead of downloading the src/stage0.txt version of Cargo specified, use
+# Instead of downloading the src/stage0.json version of Cargo specified, use
 # this Cargo binary instead to build all Rust code
 #cargo = "/path/to/cargo"
 
-# Instead of downloading the src/stage0.txt version of the compiler
+# Instead of downloading the src/stage0.json version of the compiler
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
 #rustc = "/path/to/rustc"
 
-# Instead of download the src/stage0.txt version of rustfmt specified,
+# Instead of download the src/stage0.json version of rustfmt specified,
 # use this rustfmt binary instead as the stage0 snapshot rustfmt.
 #rustfmt = "/path/to/rustfmt"
 


### PR DESCRIPTION
in  #88362  , the `stage0.txt ` have been switched to `stage0.json`  , but in `config.toml.example` the guide didn't change ,  this PR fix  this issue