### PR TITLE
Remove trailing semicolon from macro call span

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1087,25 +1087,19 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                 let MacCallStmt { mac, style, attrs, .. } = mac.into_inner();
                 Ok((style == MacStmtStyle::Semicolon, mac, attrs.into()))
             }
-            StmtKind::Item(ref item) if matches!(item.kind, ItemKind::MacCall(..)) => {
-                match stmt.kind {
-                    StmtKind::Item(item) => match item.into_inner() {
-                        ast::Item { kind: ItemKind::MacCall(mac), attrs, .. } => {
-                            Ok((mac.args.need_semicolon(), mac, attrs))
-                        }
-                        _ => unreachable!(),
-                    },
+            StmtKind::Item(item) if matches!(item.kind, ItemKind::MacCall(..)) => {
+                match item.into_inner() {
+                    ast::Item { kind: ItemKind::MacCall(mac), attrs, .. } => {
+                        Ok((mac.args.need_semicolon(), mac, attrs))
+                    }
                     _ => unreachable!(),
                 }
             }
-            StmtKind::Semi(ref expr) if matches!(expr.kind, ast::ExprKind::MacCall(..)) => {
-                match stmt.kind {
-                    StmtKind::Semi(expr) => match expr.into_inner() {
-                        ast::Expr { kind: ast::ExprKind::MacCall(mac), attrs, .. } => {
-                            Ok((mac.args.need_semicolon(), mac, attrs.into()))
-                        }
-                        _ => unreachable!(),
-                    },
+            StmtKind::Semi(expr) if matches!(expr.kind, ast::ExprKind::MacCall(..)) => {
+                match expr.into_inner() {
+                    ast::Expr { kind: ast::ExprKind::MacCall(mac), attrs, .. } => {
+                        Ok((mac.args.need_semicolon(), mac, attrs.into()))
+                    }
                     _ => unreachable!(),
                 }
             }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -653,6 +653,18 @@ impl SourceMap {
         })
     }
 
+    /// Extends the given `Span` while the next character matches the predicate
+    pub fn span_extend_while(
+        &self,
+        span: Span,
+        f: impl Fn(char) -> bool,
+    ) -> Result<Span, SpanSnippetError> {
+        self.span_to_source(span, |s, _start, end| {
+            let n = s[end..].char_indices().find(|&(_, c)| !f(c)).map_or(s.len() - end, |(i, _)| i);
+            Ok(span.with_hi(span.hi() + BytePos(n as u32)))
+        })
+    }
+
     /// Extends the given `Span` to just after the next occurrence of `c`.
     pub fn span_extend_to_next_char(&self, sp: Span, c: char, accept_newlines: bool) -> Span {
         if let Ok(next_source) = self.span_to_next_source(sp) {
@@ -1012,6 +1024,32 @@ impl SourceMap {
         let source_file_index = self.lookup_source_file_idx(sp.lo());
         let source_file = &self.files()[source_file_index];
         source_file.is_imported()
+    }
+
+    /// Gets the span of a statement. If the statement is a macro expansion, the
+    /// span in the context of the block span is found. The trailing semicolon is included
+    /// on a best-effort basis.
+    pub fn stmt_span(&self, stmt_span: Span, block_span: Span) -> Span {
+        if !stmt_span.from_expansion() {
+            return stmt_span;
+        }
+        let mac_call = original_sp(stmt_span, block_span);
+        self.mac_call_stmt_semi_span(mac_call).map_or(mac_call, |s| mac_call.with_hi(s.hi()))
+    }
+
+    /// Tries to find the span of the semicolon of a macro call statement.
+    /// The input must be the *call site* span of a statement from macro expansion.
+    ///
+    ///           v output
+    ///     mac!();
+    ///     ^^^^^^ input
+    pub fn mac_call_stmt_semi_span(&self, mac_call: Span) -> Option<Span> {
+        let span = self.span_extend_while(mac_call, char::is_whitespace).ok()?;
+        let span = span.shrink_to_hi().with_hi(BytePos(span.hi().0.checked_add(1)?));
+        if self.span_to_snippet(span).as_deref() != Ok(";") {
+            return None;
+        }
+        Some(span)
     }
 }
 

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1171,8 +1171,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         {
             return None;
         }
-        let original_span = original_sp(last_stmt.span, blk.span);
-        Some((original_span.with_lo(original_span.hi() - BytePos(1)), needs_box))
+        let span = if last_stmt.span.from_expansion() {
+            let mac_call = original_sp(last_stmt.span, blk.span);
+            self.tcx.sess.source_map().mac_call_stmt_semi_span(mac_call)?
+        } else {
+            last_stmt.span.with_lo(last_stmt.span.hi() - BytePos(1))
+        };
+        Some((span, needs_box))
     }
 
     // Instantiates the given path, which must refer to an item with the given

--- a/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm.main.UnreachablePropagation.diff
@@ -59,7 +59,7 @@
           StorageDead(_6);                 // scope 2 at $DIR/unreachable_asm.rs:18:9: 18:10
           StorageDead(_5);                 // scope 2 at $DIR/unreachable_asm.rs:18:9: 18:10
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:9: 21:37
-          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm.rs:21:18: 21:35
+          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm.rs:21:18: 21:34
           _7 = const ();                   // scope 3 at $DIR/unreachable_asm.rs:21:9: 21:37
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm.rs:21:36: 21:37
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm.rs:22:9: 22:21

--- a/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_asm_2.main.UnreachablePropagation.diff
@@ -49,7 +49,7 @@
   
       bb3: {
           StorageLive(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:13: 16:41
-          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm_2.rs:16:22: 16:39
+          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 3 at $DIR/unreachable_asm_2.rs:16:22: 16:38
           _7 = const ();                   // scope 3 at $DIR/unreachable_asm_2.rs:16:13: 16:41
           StorageDead(_7);                 // scope 2 at $DIR/unreachable_asm_2.rs:16:40: 16:41
           _4 = const 21_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:17:13: 17:20
@@ -60,7 +60,7 @@
   
       bb4: {
           StorageLive(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:13: 20:41
-          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 4 at $DIR/unreachable_asm_2.rs:20:22: 20:39
+          llvm_asm!(LlvmInlineAsmInner { asm: "NOP", asm_str_style: Cooked, outputs: [], inputs: [], clobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : []); // scope 4 at $DIR/unreachable_asm_2.rs:20:22: 20:38
           _8 = const ();                   // scope 4 at $DIR/unreachable_asm_2.rs:20:13: 20:41
           StorageDead(_8);                 // scope 2 at $DIR/unreachable_asm_2.rs:20:40: 20:41
           _4 = const 42_i32;               // scope 2 at $DIR/unreachable_asm_2.rs:21:13: 21:20

--- a/src/test/rustdoc-ui/intra-doc/warning.stderr
+++ b/src/test/rustdoc-ui/intra-doc/warning.stderr
@@ -88,7 +88,7 @@ LL |         #[doc = $f]
    |         ^^^^^^^^^^^
 ...
 LL | f!("Foo\nbar [BarF] bar\nbaz");
-   | ------------------------------- in this macro invocation
+   | ------------------------------ in this macro invocation
    |
    = note: the link appears in this line:
            

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -18,7 +18,7 @@ LL |         impl LintPass for Custom {
    |              ^^^^^^^^
 ...
 LL | custom_lint_pass_macro!();
-   | -------------------------- in this macro invocation
+   | ------------------------- in this macro invocation
    |
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
    = note: this error originates in the macro `custom_lint_pass_macro` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.stderr
+++ b/src/test/ui-fulldeps/issue-76270-panic-in-libproc-macro.stderr
@@ -2,7 +2,7 @@ error: proc macro panicked
   --> $DIR/issue-76270-panic-in-libproc-macro.rs:15:1
    |
 LL | proc_macro_panic::panic_in_libproc_macro!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: `""` is not a valid identifier
 

--- a/src/test/ui/annotate-snippet/multispan.stderr
+++ b/src/test/ui/annotate-snippet/multispan.stderr
@@ -2,41 +2,41 @@ error: hello to you, too!
   --> $DIR/multispan.rs:15:5
    |
 LL |     hello!(hi);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:18:5
    |
 LL |     hello!(hi hi);
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:21:5
    |
 LL |     hello!(hi hi hi);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:24:5
    |
 LL |     hello!(hi hey hi yo hi beep beep hi hi);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:25:5
    |
 LL |     hello!(hi there, hi how are you? hi... hi.);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:26:5
    |
 LL |     hello!(whoah. hi di hi di ho);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 error: hello to you, too!
   --> $DIR/multispan.rs:27:5
    |
 LL |     hello!(hi good hi and good bye);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/src/test/ui/asm/aarch64/interpolated-idents.stderr
+++ b/src/test/ui/asm/aarch64/interpolated-idents.stderr
@@ -7,7 +7,7 @@ LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noretur
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack options);
-   | |_________________________________- in this macro invocation
+   | |________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noretur
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack options);
-   | |_________________________________- in this macro invocation
+   | |________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,12 +38,12 @@ LL |       m!(in out lateout inout inlateout const sym
    | |
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack options);
-   | |                                 -
-   | |_________________________________|
-   | |_________________________________in this macro invocation
-   | |_________________________________in this macro invocation
-   | |_________________________________in this macro invocation
-   |                                   in this macro invocation
+   | |                                -
+   | |________________________________|
+   | |________________________________in this macro invocation
+   | |________________________________in this macro invocation
+   | |________________________________in this macro invocation
+   |                                  in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/asm/aarch64/parse-error.stderr
+++ b/src/test/ui/asm/aarch64/parse-error.stderr
@@ -2,7 +2,7 @@ error: requires at least a template string argument
   --> $DIR/parse-error.rs:9:9
    |
 LL |         asm!();
-   |         ^^^^^^^
+   |         ^^^^^^
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:11:14
@@ -236,7 +236,7 @@ error: requires at least a template string argument
   --> $DIR/parse-error.rs:90:1
    |
 LL | global_asm!();
-   | ^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:92:13

--- a/src/test/ui/asm/aarch64/type-check-2.stderr
+++ b/src/test/ui/asm/aarch64/type-check-2.stderr
@@ -77,7 +77,7 @@ error[E0381]: use of possibly-uninitialized variable: `y`
   --> $DIR/type-check-2.rs:20:9
    |
 LL |         asm!("{}", inout(reg) y);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `y`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `y`
 
 error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-2.rs:28:29

--- a/src/test/ui/asm/bad-arch.mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.mirunsafeck.stderr
@@ -2,13 +2,13 @@ error[E0472]: inline assembly is unsupported on this target
   --> $DIR/bad-arch.rs:22:9
    |
 LL |         asm!("");
-   |         ^^^^^^^^^
+   |         ^^^^^^^^
 
 error[E0472]: inline assembly is unsupported on this target
   --> $DIR/bad-arch.rs:27:1
    |
 LL | global_asm!("");
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `global_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/asm/bad-arch.thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.thirunsafeck.stderr
@@ -2,13 +2,13 @@ error[E0472]: inline assembly is unsupported on this target
   --> $DIR/bad-arch.rs:22:9
    |
 LL |         asm!("");
-   |         ^^^^^^^^^
+   |         ^^^^^^^^
 
 error[E0472]: inline assembly is unsupported on this target
   --> $DIR/bad-arch.rs:27:1
    |
 LL | global_asm!("");
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `global_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -111,7 +111,7 @@ LL | |          in(reg) a,
 ...  |
 LL | |          sym G,
 LL | |     );
-   | |______^
+   | |_____^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -156,7 +156,7 @@ warning: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:89:5
    |
 LL |     asm!("");
-   |     ^^^^^^^^^
+   |     ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -165,7 +165,7 @@ warning: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:92:5
    |
 LL |     asm!("");
-   |     ^^^^^^^^^
+   |     ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -174,7 +174,7 @@ warning: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:95:5
    |
 LL |     asm!("");
-   |     ^^^^^^^^^
+   |     ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -188,13 +188,13 @@ LL | |
 LL | |     asm!("");
 ...  |
 LL | |     asm!("");
-   | |     --------- multiple asm blocks are unsupported in naked functions
+   | |     -------- multiple asm blocks are unsupported in naked functions
 ...  |
 LL | |     asm!("");
-   | |     --------- multiple asm blocks are unsupported in naked functions
+   | |     -------- multiple asm blocks are unsupported in naked functions
 ...  |
 LL | |     asm!("", options(noreturn));
-   | |     ---------------------------- multiple asm blocks are unsupported in naked functions
+   | |     --------------------------- multiple asm blocks are unsupported in naked functions
 LL | | }
    | |_^
    |
@@ -228,7 +228,7 @@ warning: the LLVM-style inline assembly is unsupported in naked functions
   --> $DIR/naked-functions.rs:116:5
    |
 LL |     llvm_asm!("");
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -255,7 +255,7 @@ warning: asm options unsupported in naked functions: `nomem`, `preserves_flags`
   --> $DIR/naked-functions.rs:124:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -264,7 +264,7 @@ warning: asm options unsupported in naked functions: `nostack`, `pure`, `readonl
   --> $DIR/naked-functions.rs:131:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
@@ -273,7 +273,7 @@ warning: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:131:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>

--- a/src/test/ui/asm/rustfix-asm.stderr
+++ b/src/test/ui/asm/rustfix-asm.stderr
@@ -2,7 +2,7 @@ error: the legacy LLVM-style asm! syntax is no longer supported
   --> $DIR/rustfix-asm.rs:11:9
    |
 LL |         asm!("" :: "r" (x));
-   |         ----^^^^^^^^^^^^^^^^
+   |         ----^^^^^^^^^^^^^^^
    |         |
    |         help: replace with: `llvm_asm!`
    |
@@ -13,7 +13,7 @@ error: the legacy LLVM-style asm! syntax is no longer supported
   --> $DIR/rustfix-asm.rs:13:9
    |
 LL |         asm!("" : "=r" (y));
-   |         ----^^^^^^^^^^^^^^^^
+   |         ----^^^^^^^^^^^^^^^
    |         |
    |         help: replace with: `llvm_asm!`
    |

--- a/src/test/ui/asm/type-check-4.stderr
+++ b/src/test/ui/asm/type-check-4.stderr
@@ -4,7 +4,7 @@ error[E0506]: cannot assign to `a` because it is borrowed
 LL |         let p = &a;
    |                 -- borrow of `a` occurs here
 LL |         asm!("{}", out(reg) a);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `a` occurs here
+   |         ^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `a` occurs here
 LL |
 LL |         println!("{}", p);
    |                        - borrow later used here

--- a/src/test/ui/asm/x86_64/interpolated-idents.stderr
+++ b/src/test/ui/asm/x86_64/interpolated-idents.stderr
@@ -7,7 +7,7 @@ LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noretur
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
-   | |____________________________________________- in this macro invocation
+   | |___________________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noretur
 LL | /     m!(in out lateout inout inlateout const sym
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
-   | |____________________________________________- in this macro invocation
+   | |___________________________________________- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,12 +38,12 @@ LL |       m!(in out lateout inout inlateout const sym
    | |
 LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
-   | |                                            -
-   | |____________________________________________|
-   | |____________________________________________in this macro invocation
-   | |____________________________________________in this macro invocation
-   | |____________________________________________in this macro invocation
-   |                                              in this macro invocation
+   | |                                           -
+   | |___________________________________________|
+   | |___________________________________________in this macro invocation
+   | |___________________________________________in this macro invocation
+   | |___________________________________________in this macro invocation
+   |                                             in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/asm/x86_64/parse-error.stderr
+++ b/src/test/ui/asm/x86_64/parse-error.stderr
@@ -2,7 +2,7 @@ error: requires at least a template string argument
   --> $DIR/parse-error.rs:9:9
    |
 LL |         asm!();
-   |         ^^^^^^^
+   |         ^^^^^^
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:11:14
@@ -236,7 +236,7 @@ error: requires at least a template string argument
   --> $DIR/parse-error.rs:90:1
    |
 LL | global_asm!();
-   | ^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:92:13

--- a/src/test/ui/asm/x86_64/type-check-2.stderr
+++ b/src/test/ui/asm/x86_64/type-check-2.stderr
@@ -77,7 +77,7 @@ error[E0381]: use of possibly-uninitialized variable: `y`
   --> $DIR/type-check-2.rs:16:9
    |
 LL |         asm!("{}", inout(reg) y);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `y`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `y`
 
 error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-2.rs:24:29

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -20,7 +20,7 @@ error: erroneous constant used
   --> $DIR/defaults-not-assumed-fail.rs:34:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>

--- a/src/test/ui/async-await/issue-73541-2.stderr
+++ b/src/test/ui/async-await/issue-73541-2.stderr
@@ -8,7 +8,7 @@ LL |                 continue 'a
    |                          ^^ unreachable label `'a`
 ...
 LL |                 b!();
-   |                 ----- in this macro invocation
+   |                 ---- in this macro invocation
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
    = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/attributes/key-value-expansion.stderr
+++ b/src/test/ui/attributes/key-value-expansion.stderr
@@ -11,7 +11,7 @@ LL |         bug!("bug" + stringify!(found));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | bug!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = note: this error originates in the macro `bug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -31,7 +31,7 @@ LL |         doc_comment! {format!("{coor}", coor = stringify!($t1)).as_str()}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | some_macro!(u8);
-   | ---------------- in this macro invocation
+   | --------------- in this macro invocation
    |
    = note: this error originates in the macro `some_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/attributes/nonterminal-expansion.stderr
+++ b/src/test/ui/attributes/nonterminal-expansion.stderr
@@ -5,7 +5,7 @@ LL |         #[repr(align($n))]
    |                      ^^
 ...
 LL | pass_nonterminal!(n!());
-   | ------------------------ in this macro invocation
+   | ----------------------- in this macro invocation
    |
    = note: this error originates in the macro `pass_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         #[repr(align($n))]
    |                ^^^^^^^^^
 ...
 LL | pass_nonterminal!(n!());
-   | ------------------------ in this macro invocation
+   | ----------------------- in this macro invocation
    |
    = note: this error originates in the macro `pass_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/binop/issue-77910-1.stderr
+++ b/src/test/ui/binop/issue-77910-1.stderr
@@ -2,7 +2,7 @@ error[E0369]: binary operation `==` cannot be applied to type `for<'r> fn(&'r i3
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL |     assert_eq!(foo, y);
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |     |
    |     for<'r> fn(&'r i32) -> &'r i32 {foo}
    |     _
@@ -13,7 +13,7 @@ error[E0277]: `for<'r> fn(&'r i32) -> &'r i32 {foo}` doesn't implement `Debug`
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL |     assert_eq!(foo, y);
-   |     ^^^^^^^^^^^^^^^^^^^ `for<'r> fn(&'r i32) -> &'r i32 {foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^ `for<'r> fn(&'r i32) -> &'r i32 {foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `for<'r> fn(&'r i32) -> &'r i32 {foo}`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/block-result/consider-removing-last-semi.fixed
+++ b/src/test/ui/block-result/consider-removing-last-semi.fixed
@@ -10,4 +10,11 @@ pub fn g() -> String {  //~ ERROR mismatched types
     "removeme".to_string()
 }
 
+pub fn macro_tests() -> u32 {  //~ ERROR mismatched types
+    macro_rules! mac {
+        () => (1);
+    }
+    mac!()
+}
+
 fn main() {}

--- a/src/test/ui/block-result/consider-removing-last-semi.rs
+++ b/src/test/ui/block-result/consider-removing-last-semi.rs
@@ -10,4 +10,11 @@ pub fn g() -> String {  //~ ERROR mismatched types
     "removeme".to_string();
 }
 
+pub fn macro_tests() -> u32 {  //~ ERROR mismatched types
+    macro_rules! mac {
+        () => (1);
+    }
+    mac!();
+}
+
 fn main() {}

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -20,6 +20,17 @@ LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/consider-removing-last-semi.rs:13:25
+   |
+LL | pub fn macro_tests() -> u32 {
+   |        -----------      ^^^ expected `u32`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+...
+LL |     mac!();
+   |           - help: consider removing this semicolon
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -5,9 +5,6 @@ LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `String`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
-...
-LL |     ;
-   |     - help: consider removing this semicolon
 
 error[E0308]: mismatched types
   --> $DIR/issue-13428.rs:11:13

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -10,7 +10,7 @@ LL |         let a = $c;
   ::: $DIR/move-error-snippets.rs:21:1
    |
 LL | sss!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = note: this error originates in the macro `aaa` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
@@ -17,7 +17,7 @@ LL | |         let x = a.0;
    | |                 --- in Rust 2018, this closure captures all of `a`, but in Rust 2021, it will only capture `a.0`
 LL | |         println!("{:?}", x);
 LL | |     });
-   | |_______- in this macro invocation
+   | |______- in this macro invocation
    |
 note: the lint level is defined here
   --> $DIR/closure-body-macro-fragment.rs:4:9

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -2,7 +2,7 @@ error: requires at least a format string argument
   --> $DIR/bad-format-args.rs:2:5
    |
 LL |     format!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -2,7 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
   --> $DIR/issue-28308.rs:2:5
    |
 LL |     assert!("foo");
-   |     ^^^^^^^^^^^^^^^ cannot apply unary operator `!`
+   |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/compile_error_macro.stderr
+++ b/src/test/ui/compile_error_macro.stderr
@@ -2,7 +2,7 @@ error: a very descriptive error message
   --> $DIR/compile_error_macro.rs:2:5
    |
 LL |     compile_error!("a very descriptive error message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -59,7 +59,7 @@ LL |         #[cfg(feature = $expr)]
    |                         ^^^^^
 ...
 LL | generate_s10!(concat!("nonexistent"));
-   | -------------------------------------- in this macro invocation
+   | ------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -70,7 +70,7 @@ LL |         #[cfg(feature = $expr)]
    |                         ^^^^^
 ...
 LL | generate_s10!(concat!("nonexistent"));
-   | -------------------------------------- in this macro invocation
+   | ------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
@@ -5,7 +5,7 @@ LL |         #[cfg_attr(all(), unknown)]
    |                           ^^^^^^^
 ...
 LL | foo!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/const-external-macro-const-err.stderr
+++ b/src/test/ui/consts/const-external-macro-const-err.stderr
@@ -2,7 +2,7 @@ error: any use of this value will cause an error
   --> $DIR/const-external-macro-const-err.rs:12:5
    |
 LL |     static_assert!(2 + 2 == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
    |
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/consts/issue-32829.stderr
+++ b/src/test/ui/consts/issue-32829.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-32829.rs:1:22
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
-   |                      ^^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
+   |                      ^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/issue-66693.stderr
+++ b/src/test/ui/consts/issue-66693.stderr
@@ -18,7 +18,7 @@ error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:11:5
    |
 LL |     panic!(&1);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:11:14
    |
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
    |
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:20:14
    |
 LL |     unsafe { asm!("nop"); }
-   |              ^^^^^^^^^^^^ inline assembly is not supported
+   |              ^^^^^^^^^^^ inline assembly is not supported
 
 warning: skipping const checks
    |
@@ -18,12 +18,12 @@ help: skipping check that does not even have a feature gate
   --> $DIR/inline_asm.rs:11:14
    |
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
   --> $DIR/inline_asm.rs:20:14
    |
 LL |     unsafe { asm!("nop"); }
-   |              ^^^^^^^^^^^^
+   |              ^^^^^^^^^^^
    = note: this warning originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted

--- a/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
@@ -2,7 +2,7 @@ error: 1 positional argument in format string, but no arguments were given
   --> $DIR/main.rs:6:5
    |
 LL |     myprintln!("{}");
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/cross/cross-file-errors/main.stderr
+++ b/src/test/ui/cross/cross-file-errors/main.stderr
@@ -7,7 +7,7 @@ LL |         _
   ::: $DIR/main.rs:5:5
    |
 LL |     underscore!();
-   |     -------------- in this macro invocation
+   |     ------------- in this macro invocation
    |
    = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
@@ -22,7 +22,7 @@ LL |         _
   ::: $DIR/main.rs:5:5
    |
 LL |     underscore!();
-   |     -------------- in this macro invocation
+   |     ------------- in this macro invocation
    |
    = note: this error originates in the macro `underscore` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/deprecation/deprecation-lint-2.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-2.stderr
@@ -2,7 +2,7 @@ error: use of deprecated function `deprecation_lint::deprecated`: text
   --> $DIR/deprecation-lint-2.rs:12:5
    |
 LL |     macro_test!();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/deprecation-lint-2.rs:4:9

--- a/src/test/ui/did_you_mean/bad-assoc-expr.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.stderr
@@ -53,7 +53,7 @@ LL |     ($ty: ty) => ($ty::clone(&0))
    |                   ^^^^^^^^^^ help: try: `<$ty>::clone`
 ...
 LL |     expr!(u8);
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
    = note: this error originates in the macro `expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/did_you_mean/recursion_limit_macro.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit_macro.stderr
@@ -5,7 +5,7 @@ LL |     ($t:tt $($tail:tt)*) => { recurse!($($tail)*) };
    |                               ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     recurse!(0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9);
-   |     -------------------------------------------------- in this macro invocation
+   |     ------------------------------------------------- in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "20"]` attribute to your crate (`recursion_limit_macro`)
    = note: this error originates in the macro `recurse` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/directory_ownership/macro-expanded-mod.stderr
+++ b/src/test/ui/directory_ownership/macro-expanded-mod.stderr
@@ -5,7 +5,7 @@ LL |         mod $i;
    |         ^^^^^^^
 ...
 LL |     mod_decl!(foo);
-   |     --------------- in this macro invocation
+   |     -------------- in this macro invocation
    |
    = note: this error originates in the macro `mod_decl` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
+++ b/src/test/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
@@ -5,7 +5,7 @@ LL |         use a::$crate::b;
    |                ^^^^^^ `$crate` in paths can only be used in start position
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         use a::$crate;
    |             ^^^^^^^^^ no `$crate` in `a`
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         type A = a::$crate;
    |                     ^^^^^^ `$crate` in paths can only be used in start position
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/dollar-crate/dollar-crate-is-keyword.stderr
+++ b/src/test/ui/dollar-crate/dollar-crate-is-keyword.stderr
@@ -5,7 +5,7 @@ LL |             struct $crate {}
    |                    ^^^^^^ expected identifier, found reserved identifier
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         use $crate as $crate;
    |                       ^^^^^^ expected identifier, found reserved identifier
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         use $crate;
    |         ^^^^^^^^^^^
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |         use $crate as $crate;
    |         ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | m!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/editions/edition-imports-2015.stderr
+++ b/src/test/ui/editions/edition-imports-2015.stderr
@@ -2,7 +2,7 @@ error: cannot glob-import all possible crates
   --> $DIR/edition-imports-2015.rs:23:5
    |
 LL |     gen_glob!();
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
    |
    = note: this error originates in the macro `gen_glob` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/editions/edition-imports-2018.stderr
+++ b/src/test/ui/editions/edition-imports-2018.stderr
@@ -2,7 +2,7 @@ error: cannot glob-import all possible crates
   --> $DIR/edition-imports-2018.rs:24:5
    |
 LL |     gen_glob!();
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
    |
    = note: this error originates in the macro `gen_glob` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
+++ b/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `E`
   --> $DIR/edition-imports-virtual-2015-gated.rs:8:5
    |
 LL |     gen_gated!();
-   |     ^^^^^^^^^^^^^ could not find `E` in the list of imported crates
+   |     ^^^^^^^^^^^^ could not find `E` in the list of imported crates
    |
    = note: this error originates in the macro `gen_gated` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/empty/empty-comment.stderr
+++ b/src/test/ui/empty/empty-comment.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! one_arg_macro {
    | -------------------------- when calling this macro
 ...
 LL |     one_arg_macro!(/**/);
-   |     ^^^^^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0660.stderr
+++ b/src/test/ui/error-codes/E0660.stderr
@@ -2,13 +2,13 @@ error[E0660]: malformed inline assembly
   --> $DIR/E0660.rs:6:5
    |
 LL |     llvm_asm!("nop" "nop");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0660]: malformed inline assembly
   --> $DIR/E0660.rs:8:5
    |
 LL |     llvm_asm!("nop" "nop" : "=r"(a));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -7,7 +7,7 @@ LL |               if let $p = $e $b
 LL | /     foo!(a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
-   | |_______- in this macro invocation
+   | |______- in this macro invocation
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this pattern will always match, so the `if let` is useless
@@ -23,7 +23,7 @@ LL |               if let $p = $e $b
 LL | /     bar!(a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
-   | |_______- in this macro invocation
+   | |______- in this macro invocation
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`

--- a/src/test/ui/extenv/extenv-no-args.stderr
+++ b/src/test/ui/extenv/extenv-no-args.stderr
@@ -2,7 +2,7 @@ error: env! takes 1 or 2 arguments
   --> $DIR/extenv-no-args.rs:1:13
    |
 LL | fn main() { env!(); }
-   |             ^^^^^^^
+   |             ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/extenv-not-defined-custom.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-custom.stderr
@@ -2,7 +2,7 @@ error: my error message
   --> $DIR/extenv-not-defined-custom.rs:1:13
    |
 LL | fn main() { env!("__HOPEFULLY_NOT_DEFINED__", "my error message"); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/extenv/extenv-not-defined-default.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-default.stderr
@@ -2,7 +2,7 @@ error: environment variable `__HOPEFULLY_NOT_DEFINED__` not defined
   --> $DIR/extenv-not-defined-default.rs:2:5
    |
 LL |     env!("__HOPEFULLY_NOT_DEFINED__");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/extenv/extenv-too-many-args.stderr
+++ b/src/test/ui/extenv/extenv-too-many-args.stderr
@@ -2,7 +2,7 @@ error: env! takes 1 or 2 arguments
   --> $DIR/extenv-too-many-args.rs:1:13
    |
 LL | fn main() { env!("one", "two", "three"); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/extoption_env-no-args.stderr
+++ b/src/test/ui/extoption_env-no-args.stderr
@@ -2,7 +2,7 @@ error: option_env! takes 1 argument
   --> $DIR/extoption_env-no-args.rs:1:13
    |
 LL | fn main() { option_env!(); }
-   |             ^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/extoption_env-too-many-args.stderr
+++ b/src/test/ui/extoption_env-too-many-args.stderr
@@ -2,7 +2,7 @@ error: option_env! takes 1 argument
   --> $DIR/extoption_env-too-many-args.rs:1:13
    |
 LL | fn main() { option_env!("one", "two"); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
@@ -5,7 +5,7 @@ LL |         #[allow_internal_unsafe]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | bar!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
@@ -5,7 +5,7 @@ LL |         #[allow_internal_unstable()]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | bar!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -11,7 +11,7 @@ error[E0425]: cannot find value `ab` in this scope
   --> $DIR/feature-gate-concat_idents2.rs:2:5
    |
 LL |     concat_idents!(a, b);
-   |     ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |     ^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/feature-gates/thread-local-const-init.stderr
+++ b/src/test/ui/feature-gates/thread-local-const-init.stderr
@@ -2,7 +2,7 @@ error[E0658]: use of unstable library feature 'thread_local_const_init'
   --> $DIR/thread-local-const-init.rs:1:1
    |
 LL | thread_local!(static X: u32 = const { 0 });
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #84223 <https://github.com/rust-lang/rust/issues/84223> for more information
    = help: add `#![feature(thread_local_const_init)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/trace_macros-gate.stderr
+++ b/src/test/ui/feature-gates/trace_macros-gate.stderr
@@ -11,7 +11,7 @@ error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-gate.rs:4:5
    |
 LL |     trace_macros!();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:6:5
@@ -38,7 +38,7 @@ LL |         ($x: ident) => { trace_macros!($x) }
    |                          ^^^^^^^^^^^^
 ...
 LL |     expando!(true);
-   |     --------------- in this macro invocation
+   |     -------------- in this macro invocation
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable

--- a/src/test/ui/fmt/ifmt-bad-format-args.stderr
+++ b/src/test/ui/fmt/ifmt-bad-format-args.stderr
@@ -2,7 +2,7 @@ error: requires at least a format string argument
   --> $DIR/ifmt-bad-format-args.rs:2:5
    |
 LL |     format_args!();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
@@ -29,7 +29,7 @@ LL |             let ...$e;
    |                 ^^^ help: use `..=` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
@@ -37,7 +37,7 @@ LL |             let $e...;
    |                   ^^^ help: use `..` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -49,7 +49,7 @@ LL |             let $e..=;
    |                   ^^^ help: use `..` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/hygiene/assoc_item_ctxt.stderr
+++ b/src/test/ui/hygiene/assoc_item_ctxt.stderr
@@ -8,7 +8,7 @@ LL |             fn method() {}
    |             not a member of trait `Tr`
 ...
 LL |     mac_trait_impl!();
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = note: this error originates in the macro `mac_trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -22,7 +22,7 @@ LL |         impl Tr for u8 {
    |         ^^^^^^^^^^^^^^ missing `method` in implementation
 ...
 LL |     mac_trait_impl!();
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = note: this error originates in the macro `mac_trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/duplicate_lifetimes.stderr
+++ b/src/test/ui/hygiene/duplicate_lifetimes.stderr
@@ -5,7 +5,7 @@ LL |     fn g<$a, 'a>() {}
    |              ^^ declared twice
 ...
 LL | m!('a);
-   | -------
+   | ------
    | |  |
    | |  previous declaration here
    | in this macro invocation
@@ -19,7 +19,7 @@ LL |     fn h<$a, 'a>() {}
    |              ^^ declared twice
 ...
 LL | n!('a);
-   | -------
+   | ------
    | |  |
    | |  previous declaration here
    | in this macro invocation

--- a/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -14,7 +14,7 @@ LL |         use my_core;
    |             ^^^^^^^ no `my_core` in the root
 ...
 LL | a!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -25,7 +25,7 @@ LL |         fn f() { my_core::mem::drop(0); }
    |                  ^^^^^^^ use of undeclared crate or module `my_core`
 ...
 LL | a!();
-   | ----- in this macro invocation
+   | ---- in this macro invocation
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/fields-definition.stderr
+++ b/src/test/ui/hygiene/fields-definition.stderr
@@ -7,7 +7,7 @@ LL |             $a: u8,
    |             ^^^^^^ field already declared
 ...
 LL | legacy!(a);
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
    = note: this error originates in the macro `legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/generate-mod.stderr
+++ b/src/test/ui/hygiene/generate-mod.stderr
@@ -17,7 +17,7 @@ LL |         type A = FromOutside;
    |                  ^^^^^^^^^^^ not found in this scope
 ...
 LL |     genmod_transparent!();
-   |     ---------------------- in this macro invocation
+   |     --------------------- in this macro invocation
    |
    = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -28,7 +28,7 @@ LL |         type Inner = Outer;
    |                      ^^^^^ not found in this scope
 ...
 LL |     genmod_transparent!();
-   |     ---------------------- in this macro invocation
+   |     --------------------- in this macro invocation
    |
    = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -39,7 +39,7 @@ LL |         type A = FromOutside;
    |                  ^^^^^^^^^^^ not found in this scope
 ...
 LL |     genmod_legacy!();
-   |     ----------------- in this macro invocation
+   |     ---------------- in this macro invocation
    |
    = note: this error originates in the macro `genmod_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ LL |         type Inner = Outer;
    |                      ^^^^^ not found in this scope
 ...
 LL |     genmod_legacy!();
-   |     ----------------- in this macro invocation
+   |     ---------------- in this macro invocation
    |
    = note: this error originates in the macro `genmod_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -32,7 +32,7 @@ error[E0425]: cannot find function `f` in this scope
   --> $DIR/globs.rs:61:12
    |
 LL | n!(f);
-   | ------ in this macro invocation
+   | ----- in this macro invocation
 ...
 LL |         n!(f);
    |            ^ not found in this scope
@@ -45,7 +45,7 @@ error[E0425]: cannot find function `f` in this scope
   --> $DIR/globs.rs:65:17
    |
 LL | n!(f);
-   | ------ in this macro invocation
+   | ----- in this macro invocation
 ...
 LL |                 f
    |                 ^ not found in this scope

--- a/src/test/ui/hygiene/hygienic-label-1.stderr
+++ b/src/test/ui/hygiene/hygienic-label-1.stderr
@@ -5,7 +5,7 @@ LL |     () => { break 'x; }
    |                   ^^ undeclared label `'x`
 ...
 LL |     'x: loop { foo!(); }
-   |                ------- in this macro invocation
+   |                ------ in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/hygienic-label-3.stderr
+++ b/src/test/ui/hygiene/hygienic-label-3.stderr
@@ -5,7 +5,7 @@ LL |     () => { break 'x; }
    |                   ^^ undeclared label `'x`
 ...
 LL |         foo!();
-   |         ------- in this macro invocation
+   |         ------ in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -8,7 +8,7 @@ LL |         'x: loop {
    |         -- first declared here
 LL |             // this 'x should refer to the outer loop, lexically
 LL |             loop_x!(break 'x);
-   |             ------------------ in this macro invocation
+   |             ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -40,7 +40,7 @@ LL |         'x: loop {
    |         -- first declared here
 ...
 LL |             loop_x!(break 'x);
-   |             ------------------ in this macro invocation
+   |             ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -54,7 +54,7 @@ LL |         'x: loop { $e }
    |         label `'x` already in scope
 ...
 LL |             loop_x!(break 'x);
-   |             ------------------ in this macro invocation
+   |             ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -68,7 +68,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             loop_x!(break 'x);
-   |             ------------------ in this macro invocation
+   |             ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -118,7 +118,7 @@ LL |         'x: loop {
    |         -- first declared here
 ...
 LL |             while_true!(break 'x);
-   |             ---------------------- in this macro invocation
+   |             --------------------- in this macro invocation
    |
    = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -132,7 +132,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |             while_true!(break 'x);
-   |             ---------------------- in this macro invocation
+   |             --------------------- in this macro invocation
    |
    = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -146,7 +146,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             while_true!(break 'x);
-   |             ---------------------- in this macro invocation
+   |             --------------------- in this macro invocation
    |
    = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -160,7 +160,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |             while_true!(break 'x);
-   |             ---------------------- in this macro invocation
+   |             --------------------- in this macro invocation
    |
    = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -174,7 +174,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             while_true!(break 'x);
-   |             ---------------------- in this macro invocation
+   |             --------------------- in this macro invocation
    |
    = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -242,7 +242,7 @@ LL |         'x: loop {
    |         -- first declared here
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -256,7 +256,7 @@ LL |         'x: for _ in 0..1 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -270,7 +270,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -284,7 +284,7 @@ LL |         'x: for _ in 0..1 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -298,7 +298,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -312,7 +312,7 @@ LL |         'x: for _ in 0..1 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -326,7 +326,7 @@ LL |         'x: for _ in 0..1 {
    |         -- first declared here
 ...
 LL |             run_once!(continue 'x);
-   |             ----------------------- in this macro invocation
+   |             ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -8,7 +8,7 @@ LL |     'x: for _ in 0..1 {
    |     -- first declared here
 LL |         // this 'x should refer to the outer loop, lexically
 LL |         loop_x!(break 'x);
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -40,7 +40,7 @@ LL |     'x: for _ in 0..1 {
    |     -- first declared here
 ...
 LL |         loop_x!(break 'x);
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -54,7 +54,7 @@ LL |         'x: loop { $e }
    |         label `'x` already in scope
 ...
 LL |         loop_x!(break 'x);
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -68,7 +68,7 @@ LL |     'x: loop {
    |     -- first declared here
 ...
 LL |         loop_x!(break 'x);
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -118,7 +118,7 @@ LL |     'x: for _ in 0..1 {
    |     -- first declared here
 ...
 LL |         while_x!(break 'x);
-   |         ------------------- in this macro invocation
+   |         ------------------ in this macro invocation
    |
    = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -132,7 +132,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |         while_x!(break 'x);
-   |         ------------------- in this macro invocation
+   |         ------------------ in this macro invocation
    |
    = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -146,7 +146,7 @@ LL |     'x: loop {
    |     -- first declared here
 ...
 LL |         while_x!(break 'x);
-   |         ------------------- in this macro invocation
+   |         ------------------ in this macro invocation
    |
    = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -160,7 +160,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |         while_x!(break 'x);
-   |         ------------------- in this macro invocation
+   |         ------------------ in this macro invocation
    |
    = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -174,7 +174,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
 ...
 LL |         while_x!(break 'x);
-   |         ------------------- in this macro invocation
+   |         ------------------ in this macro invocation
    |
    = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -242,7 +242,7 @@ LL |     'x: for _ in 0..1 {
    |     -- first declared here
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -256,7 +256,7 @@ LL |         'x: for _ in 0..1 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -270,7 +270,7 @@ LL |     'x: loop {
    |     -- first declared here
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -284,7 +284,7 @@ LL |         'x: for _ in 0..1 { $e }
    |         ^^ label `'x` already in scope
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -298,7 +298,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -312,7 +312,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -326,7 +326,7 @@ LL |     'x: for _ in 0..1 {
    |     -- first declared here
 ...
 LL |         run_once!(continue 'x);
-   |         ----------------------- in this macro invocation
+   |         ---------------------- in this macro invocation
    |
    = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/impl_items.stderr
+++ b/src/test/ui/hygiene/impl_items.stderr
@@ -5,7 +5,7 @@ LL |         let _: () = S.f();
    |                       ^ private type
 ...
 LL |     foo::m!();
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
    = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/hygiene/missing-self-diag.stderr
+++ b/src/test/ui/hygiene/missing-self-diag.stderr
@@ -6,7 +6,7 @@ LL |           self.bar();
 ...
 LL | /     pub fn foo(&self) {
 LL | |         call_bar!();
-   | |         ------------ in this macro invocation
+   | |         ----------- in this macro invocation
 LL | |     }
    | |_____- this function has a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
    |

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -2,7 +2,7 @@ error[E0433]: failed to resolve: use of undeclared type `Vec`
   --> $DIR/no_implicit_prelude.rs:11:9
    |
 LL |     fn f() { ::bar::m!(); }
-   |              ------------ in this macro invocation
+   |              ----------- in this macro invocation
 ...
 LL |         Vec::new();
    |         ^^^ not found in this scope
@@ -17,7 +17,7 @@ error[E0599]: no method named `clone` found for unit type `()` in the current sc
   --> $DIR/no_implicit_prelude.rs:12:12
    |
 LL |     fn f() { ::bar::m!(); }
-   |              ------------ in this macro invocation
+   |              ----------- in this macro invocation
 ...
 LL |         ().clone()
    |            ^^^^^ method not found in `()`

--- a/src/test/ui/hygiene/privacy-early.stderr
+++ b/src/test/ui/hygiene/privacy-early.stderr
@@ -5,7 +5,7 @@ LL |         use f as g;
    |             ^^^^^^
 ...
 LL |     foo::m!();
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
 note: consider marking `f` as `pub` in the imported module
   --> $DIR/privacy-early.rs:10:13
@@ -14,7 +14,7 @@ LL |         use f as g;
    |             ^^^^^^
 ...
 LL |     foo::m!();
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/hygiene/trait_items.stderr
+++ b/src/test/ui/hygiene/trait_items.stderr
@@ -5,7 +5,7 @@ LL |         fn f(&self) {}
    |            - the method is available for `()` here
 ...
 LL |     fn f() { ::baz::m!(); }
-   |              ------------ in this macro invocation
+   |              ----------- in this macro invocation
 ...
 LL |     pub macro m() { ().f() }
    |                        ^ method not found in `()`

--- a/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -5,7 +5,7 @@ LL |         extern crate std as non_existent;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_std_as_non_existent!();
-   | ------------------------------ in this macro invocation
+   | ----------------------------- in this macro invocation
    |
    = note: this error originates in the macro `define_std_as_non_existent` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -5,7 +5,7 @@ LL |         extern crate std as core;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_other_core!();
-   | --------------------- in this macro invocation
+   | -------------------- in this macro invocation
    |
    = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -22,7 +22,7 @@ LL |         extern crate std as Vec;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_vec!();
-   | -------------- in this macro invocation
+   | ------------- in this macro invocation
 note: `Vec` could also refer to the struct defined here
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    |

--- a/src/test/ui/imports/import-crate-var.stderr
+++ b/src/test/ui/imports/import-crate-var.stderr
@@ -2,7 +2,7 @@ error: `$crate` may not be imported
   --> $DIR/import-crate-var.rs:6:5
    |
 LL |     m!();
-   |     ^^^^^
+   |     ^^^^
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -13,7 +13,7 @@ LL | |     }
    | |_____^
 ...
 LL |       define_exported!();
-   |       ------------------- in this macro invocation
+   |       ------------------ in this macro invocation
 note: `exported` could also refer to the macro imported here
   --> $DIR/local-modularized-tricky-fail-1.rs:22:5
    |
@@ -37,7 +37,7 @@ LL | |     }
    | |_____^
 ...
 LL |       define_exported!();
-   |       ------------------- in this macro invocation
+   |       ------------------ in this macro invocation
 note: `exported` could also refer to the macro imported here
   --> $DIR/local-modularized-tricky-fail-1.rs:22:5
    |
@@ -62,7 +62,7 @@ LL | |     }
    | |_____^
 ...
 LL |       define_panic!();
-   |       ---------------- in this macro invocation
+   |       --------------- in this macro invocation
    = help: use `crate::panic` to refer to this macro unambiguously
    = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ LL | |     }
    | |_____^
 ...
 LL |       define_include!();
-   |       ------------------ in this macro invocation
+   |       ----------------- in this macro invocation
    = help: use `crate::include` to refer to this macro unambiguously
    = note: this error originates in the macro `define_include` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -16,7 +16,7 @@ LL | |     }
    | |_____^
 ...
 LL |   define_exported!();
-   |   ------------------- in this macro invocation
+   |   ------------------ in this macro invocation
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
@@ -36,7 +36,7 @@ LL | |     }
    | |_____^
 ...
 LL |   define_exported!();
-   |   ------------------- in this macro invocation
+   |   ------------------ in this macro invocation
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/imports/shadow_builtin_macros.stderr
+++ b/src/test/ui/imports/shadow_builtin_macros.stderr
@@ -27,7 +27,7 @@ LL |         macro_rules! panic { () => {} }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |     } }
 LL |     m!();
-   |     ----- in this macro invocation
+   |     ---- in this macro invocation
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `n` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -35,7 +35,7 @@ LL |         fn $fn_name(gift: &str) -> $type_name {
    |                                    ^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
 ...
 LL | autowrapper!(Autowrapped, autowrap_gift, 'a);
-   | --------------------------------------------- in this macro invocation
+   | -------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `autowrapper` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/inference/deref-suggestion.stderr
+++ b/src/test/ui/inference/deref-suggestion.stderr
@@ -56,7 +56,7 @@ error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:36:5
    |
 LL |     assert_eq!(3i32, &3i32);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `&i32`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `&i32`
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/internal/internal-unstable-noallow.stderr
+++ b/src/test/ui/internal/internal-unstable-noallow.stderr
@@ -2,7 +2,7 @@ error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable-noallow.rs:16:5
    |
 LL |     call_unstable_noallow!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this error originates in the macro `call_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -11,7 +11,7 @@ error[E0658]: use of unstable library feature 'struct_field'
   --> $DIR/internal-unstable-noallow.rs:18:5
    |
 LL |     construct_unstable_noallow!(0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(struct_field)]` to the crate attributes to enable
    = note: this error originates in the macro `construct_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/internal/internal-unstable.stderr
+++ b/src/test/ui/internal/internal-unstable.stderr
@@ -37,7 +37,7 @@ LL |         internal_unstable::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     bar!(internal_unstable::unstable());
-   |     ------------------------------------ in this macro invocation
+   |     ----------------------------------- in this macro invocation
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/issues/issue-14091-2.stderr
+++ b/src/test/ui/issues/issue-14091-2.stderr
@@ -2,7 +2,7 @@ error[E0600]: cannot apply unary operator `!` to type `BytePos`
   --> $DIR/issue-14091-2.rs:15:5
    |
 LL |     assert!(x, x);
-   |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
+   |     ^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
 note: an implementation of `Not` might be missing for `BytePos`
   --> $DIR/issue-14091-2.rs:6:1

--- a/src/test/ui/issues/issue-14091.stderr
+++ b/src/test/ui/issues/issue-14091.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-14091.rs:2:5
    |
 LL |     assert!(1,1);
-   |     ^^^^^^^^^^^^^ expected `bool`, found integer
+   |     ^^^^^^^^^^^^ expected `bool`, found integer
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16966.stderr
+++ b/src/test/ui/issues/issue-16966.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-16966.rs:2:5
    |
 LL |     panic!(std::default::Default::default());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `M` declared on the function `begin_panic`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `M` declared on the function `begin_panic`
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-19163.stderr
+++ b/src/test/ui/issues/issue-19163.stderr
@@ -2,7 +2,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/issue-19163.rs:9:5
    |
 LL |     mywrite!(&v, "Hello world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
    |
    = note: this error originates in the macro `mywrite` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-2150.stderr
+++ b/src/test/ui/issues/issue-2150.stderr
@@ -2,7 +2,7 @@ error: unreachable statement
   --> $DIR/issue-2150.rs:8:5
    |
 LL |     panic!();
-   |     --------- any code following this expression is unreachable
+   |     -------- any code following this expression is unreachable
 LL |     for x in &v { i += 1; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |

--- a/src/test/ui/issues/issue-25385.stderr
+++ b/src/test/ui/issues/issue-25385.stderr
@@ -5,7 +5,7 @@ LL |     ($e:expr) => { $e.foo() }
    |                       ^^^ method not found in `i32`
 ...
 LL |     foo!(a);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-26093.stderr
+++ b/src/test/ui/issues/issue-26093.stderr
@@ -5,7 +5,7 @@ LL |         $thing = 42;
    |                ^
 ...
 LL |     not_a_place!(99);
-   |     -----------------
+   |     ----------------
    |     |            |
    |     |            cannot assign to this expression
    |     in this macro invocation
@@ -19,7 +19,7 @@ LL |         $thing += 42;
    |                ^^
 ...
 LL |     not_a_place!(99);
-   |     -----------------
+   |     ----------------
    |     |            |
    |     |            cannot assign to this expression
    |     in this macro invocation

--- a/src/test/ui/issues/issue-29084.stderr
+++ b/src/test/ui/issues/issue-29084.stderr
@@ -5,7 +5,7 @@ LL |         bar(&mut $d);
    |             ^^^^^^^ expected `u8`, found `&mut u8`
 ...
 LL |     foo!(0u8);
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-31011.stderr
+++ b/src/test/ui/issues/issue-31011.stderr
@@ -8,7 +8,7 @@ LL | fn wrap<T>(context: &T) -> ()
    |         - type parameter 'T' declared here
 LL | {
 LL |     log!(context, "entered wrapper");
-   |     --------------------------------- in this macro invocation
+   |     -------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `log` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-32655.stderr
+++ b/src/test/ui/issues/issue-32655.stderr
@@ -5,7 +5,7 @@ LL |         #[derive_Clone]
    |           ^^^^^^^^^^^^
 ...
 LL | foo!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-32782.stderr
+++ b/src/test/ui/issues/issue-32782.stderr
@@ -5,7 +5,7 @@ LL |         #[allow_internal_unstable]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | foo!();
-   | ------- in this macro invocation
+   | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/issues/issue-39848.stderr
+++ b/src/test/ui/issues/issue-39848.stderr
@@ -9,7 +9,7 @@ LL |         if $tgt.has_$field() {}
    |         this `if` expression has a condition, but no block
 ...
 LL |     get_opt!(bar, foo);
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `get_opt` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-42954.stderr
+++ b/src/test/ui/issues/issue-42954.stderr
@@ -7,7 +7,7 @@ LL |         $i as u32 < 0
    |                   not interpreted as comparison
 ...
 LL |     is_plainly_printable!(c);
-   |     ------------------------- in this macro invocation
+   |     ------------------------ in this macro invocation
    |
    = note: this error originates in the macro `is_plainly_printable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try comparing the cast value

--- a/src/test/ui/issues/issue-51848.stderr
+++ b/src/test/ui/issues/issue-51848.stderr
@@ -7,7 +7,7 @@ LL |         println!("{");
    |                   because of this opening brace
 ...
 LL |     macro_with_error!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: if you intended to print `{`, you can escape it using `{{`
    = note: this error originates in the macro `macro_with_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/issues/issue-53251.stderr
+++ b/src/test/ui/issues/issue-53251.stderr
@@ -7,7 +7,7 @@ LL |                 S::f::<i64>();
    |                    expected 0 generic arguments
 ...
 LL | impl_add!(a b);
-   | --------------- in this macro invocation
+   | -------------- in this macro invocation
    |
 note: associated function defined here, with 0 generic parameters
   --> $DIR/issue-53251.rs:4:8
@@ -25,7 +25,7 @@ LL |                 S::f::<i64>();
    |                    expected 0 generic arguments
 ...
 LL | impl_add!(a b);
-   | --------------- in this macro invocation
+   | -------------- in this macro invocation
    |
 note: associated function defined here, with 0 generic parameters
   --> $DIR/issue-53251.rs:4:8

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -72,7 +72,7 @@ error[E0369]: binary operation `==` cannot be applied to type `fn(usize) -> Foo 
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     fn(usize) -> Foo {Foo::Bar}
    |     fn(usize) -> Foo {Foo::Bar}
@@ -83,7 +83,7 @@ error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `fn(usize) -> Foo {Foo::Bar}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ `fn(usize) -> Foo {Foo::Bar}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `fn(usize) -> Foo {Foo::Bar}`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/issues/issue-6596-1.stderr
+++ b/src/test/ui/issues/issue-6596-1.stderr
@@ -5,7 +5,7 @@ LL |         $nonexistent
    |         ^^^^^^^^^^^^ expected expression
 ...
 LL |     e!(foo);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `e` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -5,7 +5,7 @@ LL |         { $inp $nonexistent }
    |                ^^^^^^^^^^^^ expected one of 8 possible tokens
 ...
 LL |     g!(foo);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `g` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
+++ b/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
@@ -11,7 +11,7 @@ LL |         $($c)ö* {}
    |                 ^^ expected `bool`, found `()`
 ...
 LL |     x!(if);
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
+++ b/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
@@ -2,7 +2,7 @@ error[E0369]: binary operation `==` cannot be applied to type `fn() -> i32 {a}`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL |     assert_eq!(a, 0);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |     |
    |     fn() -> i32 {a}
    |     {integer}
@@ -14,7 +14,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL |     assert_eq!(a, 0);
-   |     ^^^^^^^^^^^^^^^^^ expected fn item, found integer
+   |     ^^^^^^^^^^^^^^^^ expected fn item, found integer
    |
    = note: expected fn item `fn() -> i32 {a}`
                  found type `i32`
@@ -27,7 +27,7 @@ LL | fn a() -> i32 {
    |    - consider calling this function
 ...
 LL |     assert_eq!(a, 0);
-   |     ^^^^^^^^^^^^^^^^^ `fn() -> i32 {a}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^ `fn() -> i32 {a}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `fn() -> i32 {a}`
    = help: use parentheses to call the function: `a()`

--- a/src/test/ui/issues/issue-7970a.stderr
+++ b/src/test/ui/issues/issue-7970a.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! one_arg_macro {
    | -------------------------- when calling this macro
 ...
 LL |     one_arg_macro!();
-   |     ^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-stability2.stderr
+++ b/src/test/ui/lint/lint-stability2.stderr
@@ -2,7 +2,7 @@ error: use of deprecated function `lint_stability::deprecated`: text
   --> $DIR/lint-stability2.rs:12:5
    |
 LL |     macro_test!();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-stability2.rs:4:9

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -5,7 +5,7 @@ LL |     () => {use std::string::ToString;}
    |                ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | mod a { foo!(); }
-   |         ------- in this macro invocation
+   |         ------ in this macro invocation
    |
 note: the lint level is defined here
   --> $DIR/lints-in-foreign-macros.rs:4:9

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -126,7 +126,7 @@ LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     define_empty_struct_with_visibility!(pub, Fluorine);
-   |     ----------------------------------------------------
+   |     ---------------------------------------------------
    |     |                                    |
    |     |                                    help: consider restricting its visibility: `pub(crate)`
    |     in this macro invocation

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -126,7 +126,7 @@ LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     define_empty_struct_with_visibility!(pub, Fluorine);
-   |     ----------------------------------------------------
+   |     ---------------------------------------------------
    |     |                                    |
    |     |                                    help: consider restricting its visibility: `crate`
    |     in this macro invocation

--- a/src/test/ui/lint/unused/unused-macro-rules.stderr
+++ b/src/test/ui/lint/unused/unused-macro-rules.stderr
@@ -21,7 +21,7 @@ LL | |         }
    | |_________^
 ...
 LL |   create_macro!();
-   |   ---------------- in this macro invocation
+   |   --------------- in this macro invocation
    |
    = note: this error originates in the macro `create_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -28,13 +28,12 @@ error[E0308]: mismatched types
   --> $DIR/liveness-return-last-stmt-semi.rs:4:41
    |
 LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
-   |                                ---      ^^^    - help: consider removing this semicolon
-   |                                |        |
-   |                                |        expected `i32`, found `()`
+   |                                ---      ^^^ expected `i32`, found `()`
+   |                                |
    |                                implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
+++ b/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
@@ -18,7 +18,7 @@ error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:38:9
    |
 LL |         llvm_asm!("addb $1, $0" : "={rax}"((0i32, rax)));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/llvm-asm/issue-62046.stderr
+++ b/src/test/ui/llvm-asm/issue-62046.stderr
@@ -2,7 +2,7 @@ error[E0668]: malformed inline assembly
   --> $DIR/issue-62046.rs:9:9
    |
 LL |         llvm_asm!("nop" : "+r"("r15"));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/llvm-asm/llvm-asm-parse-errors.stderr
+++ b/src/test/ui/llvm-asm/llvm-asm-parse-errors.stderr
@@ -2,7 +2,7 @@ error: macro requires a string literal as an argument
   --> $DIR/llvm-asm-parse-errors.rs:5:5
    |
 LL |     llvm_asm!();
-   |     ^^^^^^^^^^^^ string literal required
+   |     ^^^^^^^^^^^ string literal required
 
 error: expected string literal
   --> $DIR/llvm-asm-parse-errors.rs:6:23

--- a/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
+++ b/src/test/ui/macro_backtrace/main.-Zmacro-backtrace.stderr
@@ -8,7 +8,7 @@ LL | | }
    | |_- in this expansion of `pong!`
 ...
 LL |       pong!();
-   |       -------- in this macro invocation
+   |       ------- in this macro invocation
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:10:20
@@ -20,14 +20,14 @@ LL | |  }
    | |__- in this expansion of `pong!` (#2)
 ...
 LL |        ping!();
-   |        -------- in this macro invocation (#1)
+   |        ------- in this macro invocation (#1)
    |
   ::: $DIR/auxiliary/ping.rs:5:1
    |
 LL |  / macro_rules! ping {
 LL |  |     () => {
 LL |  |         pong!();
-   |  |         -------- in this macro invocation (#2)
+   |  |         ------- in this macro invocation (#2)
 LL |  |     }
 LL |  | }
    |  |_- in this expansion of `ping!` (#1)
@@ -42,14 +42,14 @@ LL | |  }
    | |__- in this expansion of `pong!` (#5)
 ...
 LL |        deep!();
-   |        -------- in this macro invocation (#1)
+   |        ------- in this macro invocation (#1)
    |
   ::: $DIR/auxiliary/ping.rs:5:1
    |
 LL |  / macro_rules! ping {
 LL |  |     () => {
 LL |  |         pong!();
-   |  |         -------- in this macro invocation (#5)
+   |  |         ------- in this macro invocation (#5)
 LL |  |     }
 LL |  | }
    |  |_- in this expansion of `ping!` (#4)
@@ -57,7 +57,7 @@ LL |  | }
 LL | /  macro_rules! deep {
 LL | |      () => {
 LL | |          foo!();
-   | |          ------- in this macro invocation (#2)
+   | |          ------ in this macro invocation (#2)
 LL | |      }
 LL | |  }
    | |__- in this expansion of `deep!` (#1)
@@ -65,7 +65,7 @@ LL | |  }
 LL | /  macro_rules! foo {
 LL | |      () => {
 LL | |          bar!();
-   | |          ------- in this macro invocation (#3)
+   | |          ------ in this macro invocation (#3)
 LL | |      }
 LL | |  }
    | |__- in this expansion of `foo!` (#2)
@@ -73,7 +73,7 @@ LL | |  }
 LL | /  macro_rules! bar {
 LL | |      () => {
 LL | |          ping!();
-   | |          -------- in this macro invocation (#4)
+   | |          ------- in this macro invocation (#4)
 LL | |      }
 LL | |  }
    | |__- in this expansion of `bar!` (#3)

--- a/src/test/ui/macro_backtrace/main.default.stderr
+++ b/src/test/ui/macro_backtrace/main.default.stderr
@@ -5,7 +5,7 @@ LL |     () => { syntax error };
    |                    ^^^^^ expected one of 8 possible tokens
 ...
 LL |     pong!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |     () => { syntax error };
    |                    ^^^^^ expected one of 8 possible tokens
 ...
 LL |     ping!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |     () => { syntax error };
    |                    ^^^^^ expected one of 8 possible tokens
 ...
 LL |     deep!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/assert-trailing-junk.stderr
+++ b/src/test/ui/macros/assert-trailing-junk.stderr
@@ -38,7 +38,7 @@ error: macro requires an expression as an argument
   --> $DIR/assert-trailing-junk.rs:19:5
    |
 LL |     assert!(true;);
-   |     ^^^^^^^^^^^^-^^
+   |     ^^^^^^^^^^^^-^
    |                 |
    |                 help: try removing semicolon
 

--- a/src/test/ui/macros/assert.stderr
+++ b/src/test/ui/macros/assert.stderr
@@ -2,7 +2,7 @@ error: macro requires a boolean expression as an argument
   --> $DIR/assert.rs:2:5
    |
 LL |     assert!();
-   |     ^^^^^^^^^^ boolean expression required
+   |     ^^^^^^^^^ boolean expression required
 
 error: expected expression, found keyword `struct`
   --> $DIR/assert.rs:3:13
@@ -14,7 +14,7 @@ error: macro requires a boolean expression as an argument
   --> $DIR/assert.rs:4:5
    |
 LL |     debug_assert!();
-   |     ^^^^^^^^^^^^^^^^ boolean expression required
+   |     ^^^^^^^^^^^^^^^ boolean expression required
    |
    = note: this error originates in the macro `debug_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/cfg.stderr
+++ b/src/test/ui/macros/cfg.stderr
@@ -2,7 +2,7 @@ error: macro requires a cfg-pattern as an argument
   --> $DIR/cfg.rs:2:5
    |
 LL |     cfg!();
-   |     ^^^^^^^ cfg-pattern required
+   |     ^^^^^^ cfg-pattern required
    |
    = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -2,7 +2,7 @@ error: requires at least a format string argument
   --> $DIR/format-parse-errors.rs:4:5
    |
 LL |     format!();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/global-asm.stderr
+++ b/src/test/ui/macros/global-asm.stderr
@@ -2,7 +2,7 @@ error: requires at least a template string argument
   --> $DIR/global-asm.rs:4:5
    |
 LL |     global_asm!();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: expected expression, found keyword `struct`
   --> $DIR/global-asm.rs:5:17

--- a/src/test/ui/macros/issue-54441.stderr
+++ b/src/test/ui/macros/issue-54441.stderr
@@ -5,7 +5,7 @@ LL |         let
    |         ^^^
 ...
 LL |     m!();
-   |     ----- caused by the macro expansion here
+   |     ---- caused by the macro expansion here
    |
    = note: the usage of `m!` is likely invalid in foreign item context
 

--- a/src/test/ui/macros/issue-78325-inconsistent-resolution.stderr
+++ b/src/test/ui/macros/issue-78325-inconsistent-resolution.stderr
@@ -5,7 +5,7 @@ LL |         extern crate std as core;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_other_core!();
-   | --------------------- in this macro invocation
+   | -------------------- in this macro invocation
    |
    = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.stderr
+++ b/src/test/ui/macros/issue-84632-eager-expansion-recursion-limit.stderr
@@ -5,7 +5,7 @@ LL |     (A, $($A:ident),*) => (concat!("", a!($($A),*)))
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     a!(A, A, A, A, A, A, A, A, A, A, A);
-   |     ------------------------------------ in this macro invocation
+   |     ----------------------------------- in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "30"]` attribute to your crate (`issue_84632_eager_expansion_recursion_limit`)
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/macros/macro-at-most-once-rep-2015.stderr
+++ b/src/test/ui/macros/macro-at-most-once-rep-2015.stderr
@@ -38,7 +38,7 @@ LL | macro_rules! barplus {
    | -------------------- when calling this macro
 ...
 LL |     barplus!();
-   |     ^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^ missing tokens in macro arguments
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:30:15
@@ -74,7 +74,7 @@ LL | macro_rules! barstar {
    | -------------------- when calling this macro
 ...
 LL |     barstar!();
-   |     ^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^ missing tokens in macro arguments
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2015.rs:37:15

--- a/src/test/ui/macros/macro-at-most-once-rep-2018.stderr
+++ b/src/test/ui/macros/macro-at-most-once-rep-2018.stderr
@@ -38,7 +38,7 @@ LL | macro_rules! barplus {
    | -------------------- when calling this macro
 ...
 LL |     barplus!();
-   |     ^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^ missing tokens in macro arguments
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:30:15
@@ -74,7 +74,7 @@ LL | macro_rules! barstar {
    | -------------------- when calling this macro
 ...
 LL |     barstar!();
-   |     ^^^^^^^^^^^ missing tokens in macro arguments
+   |     ^^^^^^^^^^ missing tokens in macro arguments
 
 error: unexpected end of macro invocation
   --> $DIR/macro-at-most-once-rep-2018.rs:37:15

--- a/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -5,7 +5,7 @@ LL |           1.fake()
    |             ^^^^ method not found in `{integer}`
 ...
 LL |     fake_method_stmt!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `fake_method_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |           1.fake
    |             ^^^^
 ...
 LL |     fake_field_stmt!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `fake_field_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |           (1).0
    |               ^
 ...
 LL |     fake_anon_field_stmt!();
-   |     ------------------------ in this macro invocation
+   |     ----------------------- in this macro invocation
    |
    = note: this error originates in the macro `fake_anon_field_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |           2.0.neg()
    |               ^^^
 ...
 LL |     real_method_stmt!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `real_method_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `f32`

--- a/src/test/ui/macros/macro-backtrace-nested.stderr
+++ b/src/test/ui/macros/macro-backtrace-nested.stderr
@@ -16,7 +16,7 @@ LL |     () => (fake)
    |            ^^^^ not found in this scope
 ...
 LL |     call_nested_expr_sum!();
-   |     ------------------------ in this macro invocation
+   |     ----------------------- in this macro invocation
    |
    = note: this error originates in the macro `nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/macro-backtrace-println.stderr
+++ b/src/test/ui/macros/macro-backtrace-println.stderr
@@ -5,7 +5,7 @@ LL |     ($fmt:expr) => (myprint!(concat!($fmt, "\n")));
    |                              ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     myprintln!("{}");
-   |     ----------------- in this macro invocation
+   |     ---------------- in this macro invocation
    |
    = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/macro-comma-support.stderr
+++ b/src/test/ui/macros/macro-comma-support.stderr
@@ -2,13 +2,13 @@ error: lel
   --> $DIR/macro-comma-support.rs:6:5
    |
 LL |     compile_error!("lel");
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: lel
   --> $DIR/macro-comma-support.rs:7:5
    |
 LL |     compile_error!("lel",);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -38,7 +38,7 @@ LL |     () => ( i ; typeof );
    |                 ^^^^^^ expected expression
 ...
 LL |     m!();
-   |     ----- in this macro invocation
+   |     ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
@@ -7,7 +7,7 @@ LL |         'b: loop {
 LL |     'b: loop {
    |     -- first declared here
 LL |         br2!('b);
-   |         --------- in this macro invocation
+   |         -------- in this macro invocation
    |
    = note: this warning originates in the macro `br2` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/macro-local-data-key-priv.stderr
+++ b/src/test/ui/macros/macro-local-data-key-priv.stderr
@@ -8,7 +8,7 @@ note: the constant `baz` is defined here
   --> $DIR/macro-local-data-key-priv.rs:4:5
    |
 LL |     thread_local!(static baz: f64 = 0.0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/macros/macro-shadowing.stderr
+++ b/src/test/ui/macros/macro-shadowing.stderr
@@ -5,7 +5,7 @@ LL |     #[macro_use]
    |     ^^^^^^^^^^^^
 ...
 LL | m1!();
-   | ------ in this macro invocation
+   | ----- in this macro invocation
    |
    = note: macro-expanded `#[macro_use]`s may not shadow existing macros (see RFC 1560)
    = note: this error originates in the macro `m1` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -23,7 +23,7 @@ LL |     macro_rules! foo { () => {} }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | m1!();
-   | ------ in this macro invocation
+   | ----- in this macro invocation
 note: `foo` could also refer to the macro defined here
   --> $DIR/macro-shadowing.rs:5:1
    |

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -142,7 +142,7 @@ error: concat_idents! requires ident args
   --> $DIR/macros-nonfatal-errors.rs:102:5
    |
 LL |     concat_idents!("not", "idents");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:104:17
@@ -166,7 +166,7 @@ error: environment variable `RUST_HOPEFULLY_THIS_DOESNT_EXIST` not defined
   --> $DIR/macros-nonfatal-errors.rs:107:5
    |
 LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -197,7 +197,7 @@ error: couldn't read $DIR/i'd be quite surprised if a file with this name existe
   --> $DIR/macros-nonfatal-errors.rs:114:5
    |
 LL |     include_str!("i'd be quite surprised if a file with this name existed");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -211,7 +211,7 @@ error: couldn't read $DIR/i'd be quite surprised if a file with this name existe
   --> $DIR/macros-nonfatal-errors.rs:116:5
    |
 LL |     include_bytes!("i'd be quite surprised if a file with this name existed");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -219,7 +219,7 @@ error: trace_macros! accepts only `true` or `false`
   --> $DIR/macros-nonfatal-errors.rs:118:5
    |
 LL |     trace_macros!(invalid);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 27 previous errors
 

--- a/src/test/ui/macros/must-use-in-macro-55516.stderr
+++ b/src/test/ui/macros/must-use-in-macro-55516.stderr
@@ -2,7 +2,7 @@ warning: unused `Result` that must be used
   --> $DIR/must-use-in-macro-55516.rs:9:5
    |
 LL |     write!(&mut example, "{}", 42);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-W unused-must-use` implied by `-W unused`
    = note: this `Result` may be an `Err` variant, which should be handled

--- a/src/test/ui/macros/nonterminal-matching.stderr
+++ b/src/test/ui/macros/nonterminal-matching.stderr
@@ -8,7 +8,7 @@ LL |     n!(a $nt_item b);
    |          ^^^^^^^^ no rules expected this token in macro call
 ...
 LL | complex_nonterminal!(enum E {});
-   | -------------------------------- in this macro invocation
+   | ------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `complex_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/out-of-order-shadowing.stderr
+++ b/src/test/ui/macros/out-of-order-shadowing.stderr
@@ -8,7 +8,7 @@ note: `bar` could refer to the macro defined here
   --> $DIR/out-of-order-shadowing.rs:4:1
    |
 LL | define_macro!(bar);
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^
 note: `bar` could also refer to the macro defined here
   --> $DIR/out-of-order-shadowing.rs:3:1
    |

--- a/src/test/ui/macros/restricted-shadowing-legacy.stderr
+++ b/src/test/ui/macros/restricted-shadowing-legacy.stderr
@@ -5,7 +5,7 @@ LL |             m!();
    |             ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -14,7 +14,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:97:9
    |
@@ -22,7 +22,7 @@ LL |         macro_rules! m { () => {} }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -32,7 +32,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
    |                                          ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -41,7 +41,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:135:9
    |
@@ -49,7 +49,7 @@ LL |         macro_rules! m { () => {} }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -59,7 +59,7 @@ LL |         m!();
    |         ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -68,7 +68,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:144:9
    |
@@ -76,7 +76,7 @@ LL |         macro_rules! m { () => {} }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -86,7 +86,7 @@ LL |         m!();
    |         ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -95,7 +95,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:85:9
    |
@@ -103,7 +103,7 @@ LL |         macro_rules! m { () => { Wrong } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -113,7 +113,7 @@ LL |             m!();
    |             ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -122,7 +122,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:85:9
    |
@@ -130,7 +130,7 @@ LL |         macro_rules! m { () => { Wrong } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -140,7 +140,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
    |                                          ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -149,7 +149,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:85:9
    |
@@ -157,7 +157,7 @@ LL |         macro_rules! m { () => { Wrong } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -167,7 +167,7 @@ LL |         m!();
    |         ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -176,7 +176,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:227:13
    |
@@ -184,7 +184,7 @@ LL |             macro_rules! m { () => {} }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -194,7 +194,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
    |                                          ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
@@ -203,7 +203,7 @@ LL |         macro_rules! m { () => { Right } }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:257:13
    |
@@ -211,7 +211,7 @@ LL |             macro_rules! m { () => {} }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors

--- a/src/test/ui/macros/restricted-shadowing-modern.stderr
+++ b/src/test/ui/macros/restricted-shadowing-modern.stderr
@@ -5,7 +5,7 @@ LL |                 m!();
    |                 ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -14,7 +14,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:99:9
    |
@@ -22,7 +22,7 @@ LL |         macro m() {}
    |         ^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -32,7 +32,7 @@ LL |             macro gen_invoc() { m!() }
    |                                 ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -41,7 +41,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:143:9
    |
@@ -49,7 +49,7 @@ LL |         macro m() {}
    |         ^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -59,7 +59,7 @@ LL |             m!();
    |             ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -68,7 +68,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:153:9
    |
@@ -76,7 +76,7 @@ LL |         macro m() {}
    |         ^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -86,7 +86,7 @@ LL |             m!();
    |             ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -95,7 +95,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:87:9
    |
@@ -103,7 +103,7 @@ LL |         macro m() { Wrong }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -113,7 +113,7 @@ LL |                 m!();
    |                 ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -122,7 +122,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:87:9
    |
@@ -130,7 +130,7 @@ LL |         macro m() { Wrong }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
@@ -140,7 +140,7 @@ LL |             macro gen_invoc() { m!() }
    |                                 ^ ambiguous name
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
@@ -149,7 +149,7 @@ LL |         macro m() { Right }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
 note: `m` could also refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:87:9
    |
@@ -157,7 +157,7 @@ LL |         macro m() { Wrong }
    |         ^^^^^^^^^^^^^^^^^^^
 ...
 LL | include!();
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors

--- a/src/test/ui/macros/same-sequence-span.stderr
+++ b/src/test/ui/macros/same-sequence-span.stderr
@@ -18,7 +18,7 @@ error: `$x:expr` may be followed by `$y:tt`, which is not allowed for `expr` fra
   --> $DIR/same-sequence-span.rs:19:1
    |
 LL |   proc_macro_sequence::make_foo!();
-   |   ^--------------------------------
+   |   ^-------------------------------
    |   |
    |  _in this macro invocation
    | |
@@ -34,7 +34,7 @@ error: `$x:expr` may be followed by `=`, which is not allowed for `expr` fragmen
   --> $DIR/same-sequence-span.rs:19:1
    |
 LL | proc_macro_sequence::make_foo!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not allowed after `expr` fragments
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
    = note: this error originates in the macro `proc_macro_sequence::make_foo` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/macros/span-covering-argument-1.stderr
+++ b/src/test/ui/macros/span-covering-argument-1.stderr
@@ -7,7 +7,7 @@ LL |             *&mut $s = 0;
    |              ^^^^^^^ cannot borrow as mutable
 ...
 LL |     bad!(foo whatever);
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `bad` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/macros/trace-macro.stderr
+++ b/src/test/ui/macros/trace-macro.stderr
@@ -2,7 +2,7 @@ note: trace_macro
   --> $DIR/trace-macro.rs:5:5
    |
 LL |     println!("Hello, World!");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `println! { "Hello, World!" }`
    = note: to `{ $crate :: io :: _print($crate :: format_args_nl! ("Hello, World!")) ; }`

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -8,7 +8,7 @@ LL |         my_faulty_macro!(bcd);
    |                          ^^^ no rules expected this token in macro call
 ...
 LL |     my_faulty_macro!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `my_faulty_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ note: trace_macro
   --> $DIR/trace_faulty_macros.rs:31:5
    |
 LL |     my_faulty_macro!();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_faulty_macro! {  }`
    = note: to `my_faulty_macro! (bcd) ;`
@@ -26,10 +26,10 @@ error: recursion limit reached while expanding `my_recursive_macro!`
   --> $DIR/trace_faulty_macros.rs:22:9
    |
 LL |         my_recursive_macro!();
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     my_recursive_macro!();
-   |     ---------------------- in this macro invocation
+   |     --------------------- in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "8"]` attribute to your crate (`trace_faulty_macros`)
    = note: this error originates in the macro `my_recursive_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -38,7 +38,7 @@ note: trace_macro
   --> $DIR/trace_faulty_macros.rs:32:5
    |
 LL |     my_recursive_macro!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_recursive_macro! {  }`
    = note: to `my_recursive_macro! () ;`

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -5,7 +5,7 @@ LL |                   $arr.len() * size_of($arr[0]));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
 ...
 LL |     write!(hello);
-   |     -------------- in this macro invocation
+   |     ------------- in this macro invocation
    |
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
@@ -20,7 +20,7 @@ LL |     ($x:expr) => ($x as ())
    |                   ^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
 ...
 LL |     cast!(2);
-   |     --------- in this macro invocation
+   |     -------- in this macro invocation
    |
    = note: this error originates in the macro `cast` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/modules/issue-56411.stderr
+++ b/src/test/ui/modules/issue-56411.stderr
@@ -10,7 +10,7 @@ LL |             pub use self::$name;
    |                     you can use `as` to change the binding name of the import
 ...
 LL | import!(("issue-56411-aux.rs", issue_56411_aux));
-   | ------------------------------------------------- in this macro invocation
+   | ------------------------------------------------ in this macro invocation
    |
    = note: `issue_56411_aux` must be defined only once in the type namespace of this module
    = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -22,7 +22,7 @@ LL |             pub use self::$name;
    |                     ^^^^^^^^^^^ re-export of private `issue_56411_aux`
 ...
 LL | import!(("issue-56411-aux.rs", issue_56411_aux));
-   | ------------------------------------------------- in this macro invocation
+   | ------------------------------------------------ in this macro invocation
    |
    = note: consider declaring type or module `issue_56411_aux` with `pub`
    = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/non-fmt-panic.stderr
+++ b/src/test/ui/non-fmt-panic.stderr
@@ -199,7 +199,7 @@ warning: panic message contains braces
   --> $DIR/non-fmt-panic.rs:31:5
    |
 LL |     panic!(concat!("{", "{"));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this message is not used as a format string, but will be in Rust 2021
 help: add a "{}" format string to use the message literally

--- a/src/test/ui/parser/bad-interpolated-block.stderr
+++ b/src/test/ui/parser/bad-interpolated-block.stderr
@@ -7,7 +7,7 @@ LL |         'lab: $b;
    |         the `block` fragment is within this context
 ...
 LL |     m!({});
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |         unsafe $b;
    |         the `block` fragment is within this context
 ...
 LL |     m!({});
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -31,7 +31,7 @@ LL |         |x: u8| -> () $b;
    |                       ^^ the `block` fragment is within this context
 ...
 LL |     m!({});
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/float-field-interpolated.stderr
+++ b/src/test/ui/parser/float-field-interpolated.stderr
@@ -5,7 +5,7 @@ LL |         { s.$b; }
    |             ^^
 ...
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
-   |     ---------------------------------------- in this macro invocation
+   |     --------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         { s.$b; }
    |             ^^ expected one of `.`, `;`, `?`, `}`, or an operator
 ...
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
-   |     ---------------------------------------- in this macro invocation
+   |     --------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         { s.$c; }
    |             ^^
 ...
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
-   |     ---------------------------------------- in this macro invocation
+   |     --------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |         { s.$c; }
    |             ^^ expected one of `.`, `;`, `?`, `}`, or an operator
 ...
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
-   |     ---------------------------------------- in this macro invocation
+   |     --------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/issue-44406.stderr
+++ b/src/test/ui/parser/issue-44406.stderr
@@ -16,7 +16,7 @@ LL |         bar(baz: $rest)
    |         ^^^^^^^^^^^^^^^
 ...
 LL |     foo!(true);
-   |     ----------- in this macro invocation
+   |     ---------- in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: if `bar` is a struct, use braces as delimiters

--- a/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
+++ b/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
@@ -13,7 +13,7 @@ LL |         enum BadE {}
    |         ^^^^^^^^^
 ...
 LL |     expand_to_enum!();
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
    = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -33,7 +33,7 @@ LL |         enum BadE {}
    |         ^^^^^^^^^
 ...
 LL |     expand_to_enum!();
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
    = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -53,7 +53,7 @@ LL |         enum BadE {}
    |         ^^^^^^^^^
 ...
 LL |     expand_to_enum!();
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
    = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
+++ b/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
@@ -17,7 +17,7 @@ LL |         fn w<$lt>(w: &mut $lt i32) {}
    |                      ^^^^^^^^ help: place the lifetime before `mut`: `&$lt mut`
 ...
 LL | mac!('a);
-   | --------- in this macro invocation
+   | -------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/issue-87812-path.stderr
+++ b/src/test/ui/parser/issue-87812-path.stderr
@@ -7,7 +7,7 @@ LL |         let _: usize = $f;
    |                expected due to this
 ...
 LL |     foo!(Baz);
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/labeled-no-colon-expr.stderr
+++ b/src/test/ui/parser/labeled-no-colon-expr.stderr
@@ -68,7 +68,7 @@ LL |             'l5 $b;
    |             the `block` fragment is within this context
 ...
 LL |     m!({});
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/macro/issue-37113.stderr
+++ b/src/test/ui/parser/macro/issue-37113.stderr
@@ -5,7 +5,7 @@ LL |             $( $t, )*
    |                ^^ expected identifier
 ...
 LL |     test_macro!(String,);
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/macro/issue-37234.stderr
+++ b/src/test/ui/parser/macro/issue-37234.stderr
@@ -5,7 +5,7 @@ LL |         let x = 5 "";
    |                   ^^ expected one of `.`, `;`, `?`, `else`, or an operator
 ...
 LL |     failed!();
-   |     ---------- in this macro invocation
+   |     --------- in this macro invocation
    |
    = note: this error originates in the macro `failed` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/macro/macro-incomplete-parse.stderr
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.stderr
@@ -5,7 +5,7 @@ LL |         ,
    |         ^
 ...
 LL | ignored_item!();
-   | ---------------- caused by the macro expansion here
+   | --------------- caused by the macro expansion here
    |
    = note: the usage of `ignored_item!` is likely invalid in item context
 
@@ -16,7 +16,7 @@ LL |     () => ( 1,
    |              ^ expected one of `.`, `;`, `?`, `}`, or an operator
 ...
 LL |     ignored_expr!();
-   |     ---------------- in this macro invocation
+   |     --------------- in this macro invocation
    |
    = note: this error originates in the macro `ignored_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/macro/pub-item-macro.stderr
+++ b/src/test/ui/parser/macro/pub-item-macro.stderr
@@ -5,7 +5,7 @@ LL |     pub priv_x!();
    |     ^^^ help: remove the visibility
 ...
 LL |     pub_x!();
-   |     --------- in this macro invocation
+   |     -------- in this macro invocation
    |
    = help: try adjusting the macro to put `pub` inside the invocation
    = note: this error originates in the macro `pub_x` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -23,7 +23,7 @@ LL |         static x: u32 = 0;
    |         ^^^^^^^^^^^^^^^^^^
 ...
 LL |     pub_x!();
-   |     --------- in this macro invocation
+   |     -------- in this macro invocation
    = note: this error originates in the macro `priv_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/parser/macro/trait-non-item-macros.stderr
+++ b/src/test/ui/parser/macro/trait-non-item-macros.stderr
@@ -5,7 +5,7 @@ LL |         $a
    |         ^^
 ...
 LL |     bah!(2);
-   |     -------- caused by the macro expansion here
+   |     ------- caused by the macro expansion here
    |
    = note: the usage of `bah!` is likely invalid in trait item context
 

--- a/src/test/ui/parser/missing-semicolon.stderr
+++ b/src/test/ui/parser/missing-semicolon.stderr
@@ -5,7 +5,7 @@ LL |         $( let x = $e1 )*;
    |            ^^^ expected one of `.`, `;`, `?`, `else`, or an operator
 ...
 LL | fn main() { m!(0, 0; 0, 0); }
-   |             --------------- in this macro invocation
+   |             -------------- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/mut-patterns.stderr
+++ b/src/test/ui/parser/mut-patterns.stderr
@@ -106,7 +106,7 @@ LL |             let mut $p = 0;
    |                     ^^ expected identifier
 ...
 LL |     foo!(x);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -165,7 +165,7 @@ LL |             let ...$e;
    |                 ^^^ help: use `..=` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -176,7 +176,7 @@ LL |             let $e...;
    |                   ^^^ help: use `..` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -188,7 +188,7 @@ LL |             let $e..=;
    |                   ^^^ help: use `..` instead
 ...
 LL |     mac!(0);
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -277,7 +277,7 @@ LL |             let $e1...$e2;
    |                    ^^^ help: use `..=` for an inclusive range
 ...
 LL |     mac2!(0, 1);
-   |     ------------ in this macro invocation
+   |     ----------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -5,7 +5,7 @@ LL |         let value = Pub::method;
    |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         Pub.method();
    |             ^^^^^^ private type
 ...
 LL |     priv_nominal::mac!();
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |         Pub::CONST;
    |         ^^^^^^^^^^ private associated constant
 ...
 LL |     priv_nominal::mac!();
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -49,7 +49,7 @@ LL |         let value = Pub::method;
    |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -71,7 +71,7 @@ LL |         Pub.method(loop {});
    |             ^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ LL |         let value = Pub::method::<Priv>;
    |                     ^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -93,7 +93,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -104,7 +104,7 @@ LL |         Pub.method::<Priv>();
    |         ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -115,7 +115,7 @@ LL |         let value = <Pub>::method;
    |                     ^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -126,7 +126,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -137,7 +137,7 @@ LL |         let value = Pub::method;
    |                     ^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,7 +148,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -159,7 +159,7 @@ LL |         let value = <Pub>::static_method;
    |                     ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -170,7 +170,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -181,7 +181,7 @@ LL |         let value = Pub::static_method;
    |                     ^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -192,7 +192,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -203,7 +203,7 @@ LL |         Pub(Priv).method();
    |                   ^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,7 +214,7 @@ LL |         <Pub>::CONST;
    |          ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -225,7 +225,7 @@ LL |         Pub::CONST;
    |         ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/privacy/associated-item-privacy-trait.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-trait.stderr
@@ -5,7 +5,7 @@ LL |         let value = <Pub as PrivTr>::method;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         Pub.method();
    |             ^^^^^^ private type
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |         <Pub as PrivTr>::CONST;
    |         ^^^^^^^^^^^^^^^^^^^^^^ private associated constant
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -49,7 +49,7 @@ LL |         let _: <Pub as PrivTr>::AssocTy;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ private associated type
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ LL |         pub type InSignatureTy = <Pub as PrivTr>::AssocTy;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -71,7 +71,7 @@ LL |         pub trait InSignatureTr: PrivTr {}
    |                                  ^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ LL |         impl PrivTr for u8 {}
    |              ^^^^^^ private trait
 ...
 LL |     priv_trait::mac!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -93,7 +93,7 @@ LL |         let value = <Pub as PubTr>::method;
    |                     ^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -104,7 +104,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -115,7 +115,7 @@ LL |         Pub.method(loop {});
    |             ^^^^^^ private type
 ...
 LL |     priv_signature::mac!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -126,7 +126,7 @@ LL |         let value = <Pub as PubTr>::method::<Priv>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -137,7 +137,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,7 +148,7 @@ LL |         Pub.method::<Priv>();
    |         ^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_substs::mac!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -159,7 +159,7 @@ LL |         let value = <Pub as PubTr>::method;
    |                     ^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -170,7 +170,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -181,7 +181,7 @@ LL |         let value = <Pub as PubTr<_>>::method;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -192,7 +192,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -203,7 +203,7 @@ LL |         Pub.method();
    |         ^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,7 +214,7 @@ LL |         let value = <Priv as PubTr<_>>::method;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -225,7 +225,7 @@ LL |         value;
    |         ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -236,7 +236,7 @@ LL |         Priv.method();
    |         ^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -247,7 +247,7 @@ LL |         <Pub as PubTr>::CONST;
    |         ^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -258,7 +258,7 @@ LL |         <Pub as PubTr<_>>::CONST;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -269,7 +269,7 @@ LL |         <Priv as PubTr<_>>::CONST;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -280,7 +280,7 @@ LL |         let _: <Pub as PubTr<_>>::AssocTy;
    |                              ^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -291,7 +291,7 @@ LL |         let _: <Priv as PubTr<_>>::AssocTy;
    |                 ^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -302,7 +302,7 @@ LL |         pub type InSignatureTy1 = <Pub as PubTr>::AssocTy;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -313,7 +313,7 @@ LL |         pub type InSignatureTy2 = <Priv as PubTr<Pub>>::AssocTy;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -324,7 +324,7 @@ LL |         impl PubTr for u8 {}
    |              ^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -5,7 +5,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |             ^ private trait
 ...
 LL |     priv_trait::mac1!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |         type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
    |                               ^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac1!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -49,7 +49,7 @@ LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
    |             ^ private trait
 ...
 LL |     priv_trait::mac2!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -71,7 +71,7 @@ LL |         type InSignatureTy1 = Box<dyn PrivTr<AssocTy = u8>>;
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ LL |         trait InSignatureTr1: PrivTr<AssocTy = u8> {}
    |                               ^^^^^^^^^^^^^^^^^^^^ private trait
 ...
 LL |     priv_trait::mac2!();
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -93,7 +93,7 @@ LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
    |             ^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -104,7 +104,7 @@ LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -115,7 +115,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |             ^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -126,7 +126,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -137,7 +137,7 @@ LL |         pub type InSignatureTy1 = Box<dyn PubTrWithParam<AssocTy = u8>>;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,7 +148,7 @@ LL |         pub type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -159,7 +159,7 @@ LL |         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -170,7 +170,7 @@ LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
    |                               ^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
-   |     --------------------------- in this macro invocation
+   |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -2,7 +2,7 @@ error: type `fn() {ext::priv_fn}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error: static `PRIV_STATIC` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private static
+   |     ^^^^^^^^^ private static
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error: type `ext::PrivEnum` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
-   |     ^^^^^^^^^^ private type
+   |     ^^^^^^^^^ private type
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -113,7 +113,7 @@ LL |         priv_fn;
    |         ^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -124,7 +124,7 @@ LL |         PrivEnum::Variant;
    |         ^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -135,7 +135,7 @@ LL |         <u8 as PrivTrait>::method;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -146,7 +146,7 @@ LL |         PrivTupleStruct;
    |         ^^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -157,7 +157,7 @@ LL |         PubTupleStruct;
    |         ^^^^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -168,7 +168,7 @@ LL |         Pub(0u8).priv_method();
    |                  ^^^^^^^^^^^ private type
 ...
 LL |     m::m!();
-   |     -------- in this macro invocation
+   |     ------- in this macro invocation
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -27,7 +27,7 @@ LL |         #[empty_helper]
    |           ^^^^^^^^^^^^
 ...
 LL |             gen_helper_use!();
-   |             ------------------ in this macro invocation
+   |             ----------------- in this macro invocation
    |
    = note: consider importing this attribute macro:
            crate::empty_helper

--- a/src/test/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/src/test/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -2,10 +2,10 @@ error[E0426]: use of undeclared label `'label_use`
   --> $DIR/gen-macro-rules-hygiene.rs:12:1
    |
 LL | gen_macro_rules!();
-   | ^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
+   | ^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
 ...
 LL |         generated!();
-   |         ------------- in this macro invocation
+   |         ------------ in this macro invocation
    |
    = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -13,10 +13,10 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:12:1
    |
 LL | gen_macro_rules!();
-   | ^^^^^^^^^^^^^^^^^^^ not found in this scope
+   | ^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |         generated!();
-   |         ------------- in this macro invocation
+   |         ------------ in this macro invocation
    |
    = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:9:1
    |
 LL | generate_mod::check!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   | ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: consider importing this struct:
            FromOutside
@@ -12,7 +12,7 @@ error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:9:1
    |
 LL | generate_mod::check!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   | ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: consider importing this struct:
            Outer

--- a/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
+++ b/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
@@ -7,7 +7,7 @@ LL |         #[my_macro] struct One($name);
   ::: $DIR/group-compat-hack.rs:27:5
    |
 LL |     impl_macros!(Foo);
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = note: `#[warn(proc_macro_back_compat)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -24,7 +24,7 @@ LL |         #[my_macro] struct One($name);
   ::: $DIR/group-compat-hack.rs:44:5
    |
 LL |     impl_macros!(Foo);
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -40,7 +40,7 @@ LL |         #[my_macro] struct Two($name);
   ::: $DIR/group-compat-hack.rs:46:5
    |
 LL |     arrays!(Foo);
-   |     ------------- in this macro invocation
+   |     ------------ in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -56,7 +56,7 @@ LL |         #[my_macro] struct Three($T);
   ::: $DIR/group-compat-hack.rs:55:5
    |
 LL |     tuple_from_req!(Foo);
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -72,7 +72,7 @@ LL |         #[my_macro] struct Three($T);
   ::: $DIR/group-compat-hack.rs:63:5
    |
 LL |     tuple_from_req!(Foo);
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -91,7 +91,7 @@ LL |         #[my_macro] struct One($name);
   ::: $DIR/group-compat-hack.rs:27:5
    |
 LL |     impl_macros!(Foo);
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = note: `#[warn(proc_macro_back_compat)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -109,7 +109,7 @@ LL |         #[my_macro] struct One($name);
   ::: $DIR/group-compat-hack.rs:44:5
    |
 LL |     impl_macros!(Foo);
-   |     ------------------ in this macro invocation
+   |     ----------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -126,7 +126,7 @@ LL |         #[my_macro] struct Two($name);
   ::: $DIR/group-compat-hack.rs:46:5
    |
 LL |     arrays!(Foo);
-   |     ------------- in this macro invocation
+   |     ------------ in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -143,7 +143,7 @@ LL |         #[my_macro] struct Three($T);
   ::: $DIR/group-compat-hack.rs:55:5
    |
 LL |     tuple_from_req!(Foo);
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
@@ -160,7 +160,7 @@ LL |         #[my_macro] struct Three($T);
   ::: $DIR/group-compat-hack.rs:63:5
    |
 LL |     tuple_from_req!(Foo);
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -2,7 +2,7 @@ error: proc macro panicked
   --> $DIR/invalid-punct-ident-1.rs:19:1
    |
 LL | invalid_punct!();
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
    |
    = help: message: unsupported character `'`'`
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
@@ -2,7 +2,7 @@ error: proc macro panicked
   --> $DIR/invalid-punct-ident-2.rs:19:1
    |
 LL | invalid_ident!();
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
    |
    = help: message: `"*"` is not a valid identifier
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
@@ -2,7 +2,7 @@ error: proc macro panicked
   --> $DIR/invalid-punct-ident-3.rs:19:1
    |
 LL | invalid_raw_ident!();
-   | ^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: `self` cannot be a raw identifier
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -2,7 +2,7 @@ error: unexpected closing delimiter: `)`
   --> $DIR/invalid-punct-ident-4.rs:6:1
    |
 LL | lexer_failure!();
-   | ^^^^^^^^^^^^^^^^^ unexpected closing delimiter
+   | ^^^^^^^^^^^^^^^^ unexpected closing delimiter
    |
    = note: this error originates in the macro `lexer_failure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error: proc macro panicked
   --> $DIR/invalid-punct-ident-4.rs:6:1
    |
 LL | lexer_failure!();
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/invalid-punct-ident-4.rs:11:33

--- a/src/test/ui/proc-macro/issue-83510.stderr
+++ b/src/test/ui/proc-macro/issue-83510.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `Foo` in this scope
   --> $DIR/issue-83510.rs:5:1
    |
 LL | issue_83510::dance_like_you_want_to_ice!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0404]: expected trait, found struct `Box`
   --> $DIR/issue-83510.rs:5:1
    |
 LL | issue_83510::dance_like_you_want_to_ice!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a trait
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a trait
    |
    = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0405]: cannot find trait `Baz` in this scope
   --> $DIR/issue-83510.rs:5:1
    |
 LL | issue_83510::dance_like_you_want_to_ice!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0658]: inherent associated types are unstable
   --> $DIR/issue-83510.rs:5:1
    |
 LL | issue_83510::dance_like_you_want_to_ice!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable

--- a/src/test/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `foobar2` in this scope
   --> $DIR/lints_in_proc_macros.rs:9:5
    |
 LL |     bang_proc_macro2!();
-   |     ^^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `foobar`
+   |     ^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `foobar`
    |
    = note: this error originates in the macro `bang_proc_macro2` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/macro-rules-derive.stderr
+++ b/src/test/ui/proc-macro/macro-rules-derive.stderr
@@ -5,7 +5,7 @@ LL |             field: MissingType
    |                    ^^^^^^^^^^^ not found in this scope
 ...
 LL | produce_it!(MyName);
-   | -------------------- in this macro invocation
+   | ------------------- in this macro invocation
    |
    = note: this error originates in the macro `produce_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -2,7 +2,7 @@ error[E0426]: use of undeclared label `'label_use`
   --> $DIR/mixed-site-span.rs:13:9
    |
 LL |         proc_macro_rules!();
-   |         ^^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
+   |         ^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
    |
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/mixed-site-span.rs:13:9
    |
 LL |         proc_macro_rules!();
-   |         ^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |         ^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,7 +24,7 @@ error[E0412]: cannot find type `ItemUse` in crate `$crate`
   --> $DIR/mixed-site-span.rs:24:1
    |
 LL | pass_dollar_crate!();
-   | ^^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
+   | ^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
    |
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/multispan.stderr
+++ b/src/test/ui/proc-macro/multispan.stderr
@@ -2,7 +2,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:12:5
    |
 LL |     hello!(hi);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:12:12
@@ -15,7 +15,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:15:5
    |
 LL |     hello!(hi hi);
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:15:12
@@ -28,7 +28,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:18:5
    |
 LL |     hello!(hi hi hi);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:18:12
@@ -41,7 +41,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:21:5
    |
 LL |     hello!(hi hey hi yo hi beep beep hi hi);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:21:12
@@ -54,7 +54,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:22:5
    |
 LL |     hello!(hi there, hi how are you? hi... hi.);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:22:12
@@ -67,7 +67,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:23:5
    |
 LL |     hello!(whoah. hi di hi di ho);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:23:19
@@ -80,7 +80,7 @@ error: hello to you, too!
   --> $DIR/multispan.rs:24:5
    |
 LL |     hello!(hi good hi and good bye);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: found these 'hi's
   --> $DIR/multispan.rs:24:12

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -5,7 +5,7 @@ LL |     three!($a, $b);
    |            ^^
 ...
 LL |     one!("hello", "world");
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |     three!($a, $b);
    |                ^^
 ...
 LL |     one!("hello", "world");
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -24,10 +24,10 @@ error: first parent: "hello"
   --> $DIR/parent-source-spans.rs:10:5
    |
 LL |     two!($a, $b);
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 ...
 LL |     one!("hello", "world");
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -35,10 +35,10 @@ error: second parent: "world"
   --> $DIR/parent-source-spans.rs:10:5
    |
 LL |     two!($a, $b);
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 ...
 LL |     one!("hello", "world");
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -46,25 +46,25 @@ error: first grandparent: "hello"
   --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: second grandparent: "world"
   --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: first source: "hello"
   --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: second source: "world"
   --> $DIR/parent-source-spans.rs:36:5
    |
 LL |     one!("hello", "world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: first final: "yay"
   --> $DIR/parent-source-spans.rs:16:12
@@ -73,7 +73,7 @@ LL |     three!($a, $b);
    |            ^^
 ...
 LL |     two!("yay", "rust");
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -84,7 +84,7 @@ LL |     three!($a, $b);
    |                ^^
 ...
 LL |     two!("yay", "rust");
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
    = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -92,25 +92,25 @@ error: first parent: "yay"
   --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: second parent: "rust"
   --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: first source: "yay"
   --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: second source: "rust"
   --> $DIR/parent-source-spans.rs:42:5
    |
 LL |     two!("yay", "rust");
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: first final: "hip"
   --> $DIR/parent-source-spans.rs:48:12
@@ -140,10 +140,10 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
 ...
 LL |     one!("hello", "world");
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
@@ -156,10 +156,10 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
 ...
 LL |     two!("yay", "rust");
-   |     -------------------- in this macro invocation
+   |     ------------------- in this macro invocation
    |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |
@@ -172,10 +172,10 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
 ...
 LL |     three!("hip", "hop");
-   |     --------------------- in this macro invocation
+   |     -------------------- in this macro invocation
    |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |

--- a/src/test/ui/proc-macro/raw-ident.stderr
+++ b/src/test/ui/proc-macro/raw-ident.stderr
@@ -2,7 +2,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
   --> $DIR/raw-ident.rs:15:5
    |
 LL |     make_bad_struct!(S);
-   |     ^^^^^^^^^^^^^^^^^^^^ expected one of 8 possible tokens
+   |     ^^^^^^^^^^^^^^^^^^^ expected one of 8 possible tokens
    |
    = note: this error originates in the macro `make_bad_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/span-api-tests.rs
+++ b/src/test/ui/proc-macro/span-api-tests.rs
@@ -41,7 +41,7 @@ fn main() {
         reemit!(macro_stringify!(Hello, world!)),
         "reemit!(macro_stringify!(Hello, world!))"
     );
-    let r = "reemit!(assert_eq!(macro_stringify!(Hello, world!), r));";
+    let r = "reemit!(assert_eq!(macro_stringify!(Hello, world!), r))";
     reemit!(assert_eq!(macro_stringify!(Hello, world!), r));
 
     assert_eq!(macro_stringify!(

--- a/src/test/ui/proc-macro/span-from-proc-macro.stderr
+++ b/src/test/ui/proc-macro/span-from-proc-macro.stderr
@@ -38,7 +38,7 @@ LL |         my_ident
   ::: $DIR/span-from-proc-macro.rs:16:5
    |
 LL |     other_error_from_bang!();
-   |     ------------------------- in this macro invocation
+   |     ------------------------ in this macro invocation
 
 error[E0308]: mismatched types
   --> $DIR/auxiliary/span-from-proc-macro.rs:16:36
@@ -54,7 +54,7 @@ LL | pub fn error_from_bang(_input: TokenStream) -> TokenStream {
   ::: $DIR/span-from-proc-macro.rs:15:5
    |
 LL |     error_from_bang!();
-   |     ------------------- in this macro invocation
+   |     ------------------ in this macro invocation
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/subspan.stderr
+++ b/src/test/ui/proc-macro/subspan.stderr
@@ -2,7 +2,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:11:1
    |
 LL | subspan!("hi");
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:11:11
@@ -15,7 +15,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:14:1
    |
 LL | subspan!("hihi");
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:14:11
@@ -28,7 +28,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:17:1
    |
 LL | subspan!("hihihi");
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:17:11
@@ -41,7 +41,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:20:1
    |
 LL | subspan!("why I hide? hi!");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:20:17
@@ -54,7 +54,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:21:1
    |
 LL | subspan!("hey, hi, hidy, hidy, hi hi");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:21:16
@@ -67,7 +67,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:22:1
    |
 LL | subspan!("this is a hi, and this is another hi");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:22:12
@@ -80,7 +80,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:23:1
    |
 LL | subspan!("how are you this evening");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:23:24
@@ -93,7 +93,7 @@ error: found 'hi's
   --> $DIR/subspan.rs:24:1
    |
 LL | subspan!("this is highly eradic");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: here
   --> $DIR/subspan.rs:24:12

--- a/src/test/ui/proc-macro/three-equals.stderr
+++ b/src/test/ui/proc-macro/three-equals.stderr
@@ -2,7 +2,7 @@ error: found 2 equal signs, need exactly 3
   --> $DIR/three-equals.rs:12:5
    |
 LL |     three_equals!(==);
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
    |
    = help: input must be: `===`
    = note: this error originates in the macro `three_equals` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/proc-macro/weird-hygiene.stderr
+++ b/src/test/ui/proc-macro/weird-hygiene.stderr
@@ -5,7 +5,7 @@ LL |             Value = (stringify!($tokens + hidden_ident), 1).1
    |                                           ^^^^^^^^^^^^ not found in this scope
 ...
 LL |     other!(50);
-   |     ----------- in this macro invocation
+   |     ---------- in this macro invocation
    |
    = note: this error originates in the macro `inner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |             hidden_ident
    |             ^^^^^^^^^^^^ not found in this scope
 ...
 LL |     invoke_it!(25);
-   |     --------------- in this macro invocation
+   |     -------------- in this macro invocation
    |
    = note: this error originates in the macro `invoke_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -4,7 +4,7 @@ error: unreachable statement
 LL |         continue;
    |         -------- any code following this expression is unreachable
 LL |         println!("hi");
-   |         ^^^^^^^^^^^^^^^ unreachable statement
+   |         ^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_again.rs:3:9

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -18,7 +18,7 @@ error: unreachable statement
 LL |         return;
    |         ------ any code following this expression is unreachable
 LL |         println!("foo");
-   |         ^^^^^^^^^^^^^^^^ unreachable statement
+   |         ^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -22,7 +22,7 @@ LL |         return;
    |         ------ any code following this expression is unreachable
 ...
 LL |     println!("But I am.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -4,7 +4,7 @@ error: unreachable statement
 LL |     loop { return; }
    |            ------ any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_loop.rs:4:9
@@ -19,7 +19,7 @@ error: unreachable statement
 LL |     loop { return; }
    |            ------ any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -29,7 +29,7 @@ error: unreachable statement
 LL |     loop { 'middle: loop { loop { break 'middle; } } }
    |     -------------------------------------------------- any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -4,7 +4,7 @@ error: unreachable statement
 LL |     match () { () => return }
    |     ------------------------- any code following this `match` expression is unreachable, as all arms diverge
 LL |     println!("I am dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_match.rs:4:9
@@ -19,7 +19,7 @@ error: unreachable statement
 LL |     match () { () if false => return, () => return }
    |     ------------------------------------------------ any code following this `match` expression is unreachable, as all arms diverge
 LL |     println!("I am dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/reachable/unreachable-code-ret.stderr
+++ b/src/test/ui/reachable/unreachable-code-ret.stderr
@@ -4,7 +4,7 @@ error: unreachable statement
 LL |     return;
    |     ------ any code following this expression is unreachable
 LL |     println!("Paul is dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/unreachable-code-ret.rs:3:9

--- a/src/test/ui/recursion_limit/zero.rs
+++ b/src/test/ui/recursion_limit/zero.rs
@@ -7,6 +7,6 @@ macro_rules! test {
     ($tt:tt) => { test!(); };
 }
 
-test!(test); //~ ERROR 10:1: 10:13: recursion limit reached while expanding `test!`
+test!(test); //~ ERROR recursion limit reached while expanding `test!`
 
 fn main() {}

--- a/src/test/ui/recursion_limit/zero.stderr
+++ b/src/test/ui/recursion_limit/zero.stderr
@@ -2,7 +2,7 @@ error: recursion limit reached while expanding `test!`
   --> $DIR/zero.rs:10:1
    |
 LL | test!(test);
-   | ^^^^^^^^^^^^
+   | ^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`zero`)
 

--- a/src/test/ui/regions/regions-var-type-out-of-scope.stderr
+++ b/src/test/ui/regions/regions-var-type-out-of-scope.stderr
@@ -6,7 +6,7 @@ LL |         x = &id(3);
    |              |
    |              creates a temporary which is freed while still in use
 LL |         assert_eq!(*x, 3);
-   |         ------------------ borrow later used here
+   |         ----------------- borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/src/test/ui/resolve/issue-82865.stderr
+++ b/src/test/ui/resolve/issue-82865.stderr
@@ -11,7 +11,7 @@ LL |     Box::z
    |          ^ function or associated item not found in `Box<_, _>`
 ...
 LL |     mac!();
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -15,7 +15,7 @@ LL | |             }
    | |_____________^
 ...
 LL |       m!();
-   |       ----- in this macro invocation
+   |       ---- in this macro invocation
    = help: use `self::std` to refer to this module unambiguously
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -15,7 +15,7 @@ LL | |         }
    | |_________^
 ...
 LL |   m!();
-   |   ----- in this macro invocation
+   |   ---- in this macro invocation
    = help: use `crate::std` to refer to this module unambiguously
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.stderr
@@ -2,7 +2,7 @@ error: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-via-macro-2.rs:15:5
    |
 LL |     m2021::number_of_tokens_in_a_prefixed_integer_literal!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
    |
    = note: prefixed identifiers and literals are reserved since Rust 2021
    = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_integer_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -11,7 +11,7 @@ error: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-via-macro-2.rs:17:5
    |
 LL |     m2021::number_of_tokens_in_a_prefixed_char_literal!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
    |
    = note: prefixed identifiers and literals are reserved since Rust 2021
    = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_char_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -20,7 +20,7 @@ error: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-via-macro-2.rs:19:5
    |
 LL |     m2021::number_of_tokens_in_a_prefixed_string_literal!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
    |
    = note: prefixed identifiers and literals are reserved since Rust 2021
    = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_string_literal` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/simd/shuffle-not-out-of-bounds.stderr
+++ b/src/test/ui/simd/shuffle-not-out-of-bounds.stderr
@@ -5,7 +5,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle2);
-   |     -------------------------------------------- in this macro invocation
+   |     ------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle4);
-   |     -------------------------------------------- in this macro invocation
+   |     ------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -27,7 +27,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle8);
-   |     -------------------------------------------- in this macro invocation
+   |     ------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -38,7 +38,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle16);
-   |     ----------------------------------------------- in this macro invocation
+   |     ---------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -49,7 +49,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle32);
-   |     ----------------------------------------------- in this macro invocation
+   |     ---------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle64);
-   |     ----------------------------------------------- in this macro invocation
+   |     ---------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -5,7 +5,7 @@ LL |         $b $a;
    |              ^
 ...
 LL |     m!(S struct);
-   |     ------------- in this macro invocation
+   |     ------------ in this macro invocation
    |
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9

--- a/src/test/ui/span/transitive-dep-span.stderr
+++ b/src/test/ui/span/transitive-dep-span.stderr
@@ -10,7 +10,7 @@ LL | |         }
   ::: $DIR/transitive-dep-span.rs:13:1
    |
 LL |   transitive_dep_two::parse_error!();
-   |   -----------------------------------
+   |   ----------------------------------
    |   |
    |   in this macro invocation
    |   in this macro invocation

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | /     intrinsic_match! {
 LL | |         "abc"
 LL | |     };
-   | |______^ expected `&str`, found struct `String`
+   | |_____^ expected `&str`, found struct `String`
    |
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/suggestions/dont-suggest-try_into-in-macros.stderr
+++ b/src/test/ui/suggestions/dont-suggest-try_into-in-macros.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-try_into-in-macros.rs:2:5
    |
 LL |     assert_eq!(10u64, 10usize);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/suggestions/suggest-ref-macro.stderr
+++ b/src/test/ui/suggestions/suggest-ref-macro.stderr
@@ -8,7 +8,7 @@ LL |         x(123);
    |           help: consider mutably borrowing here: `&mut 123`
 ...
 LL |     bla!();
-   |     ------- in this macro invocation
+   |     ------ in this macro invocation
    |
    = note: this error originates in the macro `bla` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/symbol-names/const-generics-structural-demangling.stderr
+++ b/src/test/ui/symbol-names/const-generics-structural-demangling.stderr
@@ -131,7 +131,7 @@ LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 ...
 LL | duplicate_field_name_test!(x);
-   | ------------------------------ in this macro invocation
+   | ----------------------------- in this macro invocation
    |
    = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -142,7 +142,7 @@ LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 ...
 LL | duplicate_field_name_test!(x);
-   | ------------------------------ in this macro invocation
+   | ----------------------------- in this macro invocation
    |
    = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -153,7 +153,7 @@ LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 ...
 LL | duplicate_field_name_test!(x);
-   | ------------------------------ in this macro invocation
+   | ----------------------------- in this macro invocation
    |
    = note: this error originates in the macro `duplicate_field_name_test` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/trace_macros-format.stderr
+++ b/src/test/ui/trace_macros-format.stderr
@@ -2,37 +2,37 @@ error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:4:5
    |
 LL |     trace_macros!();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:5:5
    |
 LL |     trace_macros!(1);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:6:5
    |
 LL |     trace_macros!(ident);
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:7:5
    |
 LL |     trace_macros!(for);
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:8:5
    |
 LL |     trace_macros!(true,);
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-format.rs:9:5
    |
 LL |     trace_macros!(false 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/try-block/try-block-opt-init.stderr
+++ b/src/test/ui/try-block/try-block-opt-init.stderr
@@ -2,7 +2,7 @@ error[E0381]: borrow of possibly-uninitialized variable: `cfg_res`
   --> $DIR/try-block-opt-init.rs:15:5
    |
 LL |     assert_eq!(cfg_res, 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `cfg_res`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `cfg_res`
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/unsafe/inline_asm.mir.stderr
+++ b/src/test/ui/unsafe/inline_asm.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: use of inline assembly is unsafe and requires unsafe function or b
   --> $DIR/inline_asm.rs:10:5
    |
 LL |     asm!("nop");
-   |     ^^^^^^^^^^^^ use of inline assembly
+   |     ^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: use of inline assembly is unsafe and requires unsafe function or b
   --> $DIR/inline_asm.rs:11:5
    |
 LL |     llvm_asm!("nop");
-   |     ^^^^^^^^^^^^^^^^^ use of inline assembly
+   |     ^^^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/unsafe/inline_asm.thir.stderr
+++ b/src/test/ui/unsafe/inline_asm.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: use of inline assembly is unsafe and requires unsafe function or b
   --> $DIR/inline_asm.rs:10:5
    |
 LL |     asm!("nop");
-   |     ^^^^^^^^^^^^ use of inline assembly
+   |     ^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: use of inline assembly is unsafe and requires unsafe function or b
   --> $DIR/inline_asm.rs:11:5
    |
 LL |     llvm_asm!("nop");
-   |     ^^^^^^^^^^^^^^^^^ use of inline assembly
+   |     ^^^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
    = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -7,7 +7,7 @@ LL |               while let $p = $e $b
 LL | /     foo!(_a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
-   | |_______- in this macro invocation
+   | |______- in this macro invocation
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this pattern will always match, so the loop will never exit
@@ -23,7 +23,7 @@ LL |               while let $p = $e $b
 LL | /     bar!(_a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
-   | |_______- in this macro invocation
+   | |______- in this macro invocation
    |
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it

--- a/src/tools/clippy/clippy_lints/src/format.rs
+++ b/src/tools/clippy/clippy_lints/src/format.rs
@@ -90,12 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessFormat {
     }
 }
 
-fn span_useless_format(cx: &LateContext<'_>, span: Span, mut sugg: String, mut applicability: Applicability) {
-    // The callsite span contains the statement semicolon for some reason.
-    if snippet_with_applicability(cx, span, "..", &mut applicability).ends_with(';') {
-        sugg.push(';');
-    }
-
+fn span_useless_format(cx: &LateContext<'_>, span: Span, sugg: String, applicability: Applicability) {
     span_lint_and_sugg(
         cx,
         USELESS_FORMAT,

--- a/src/tools/clippy/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
+++ b/src/tools/clippy/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
@@ -82,13 +82,13 @@ error: use of irregular braces for `eprint!` macro
   --> $DIR/conf_nonstandard_macro_braces.rs:57:5
    |
 LL |     eprint!("test if user config overrides defaults");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: consider writing `eprint!["test if user config overrides defaults"];`
+help: consider writing `eprint!["test if user config overrides defaults"]`
   --> $DIR/conf_nonstandard_macro_braces.rs:57:5
    |
 LL |     eprint!("test if user config overrides defaults");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/asm_syntax.stderr
+++ b/src/tools/clippy/tests/ui/asm_syntax.stderr
@@ -2,7 +2,7 @@ error: Intel x86 assembly syntax used
   --> $DIR/asm_syntax.rs:9:9
    |
 LL |         asm!("");
-   |         ^^^^^^^^^
+   |         ^^^^^^^^
    |
    = note: `-D clippy::inline-asm-x86-intel-syntax` implied by `-D warnings`
    = help: use AT&T x86 assembly syntax
@@ -11,7 +11,7 @@ error: Intel x86 assembly syntax used
   --> $DIR/asm_syntax.rs:10:9
    |
 LL |         asm!("", options());
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^
    |
    = help: use AT&T x86 assembly syntax
 
@@ -19,7 +19,7 @@ error: Intel x86 assembly syntax used
   --> $DIR/asm_syntax.rs:11:9
    |
 LL |         asm!("", options(nostack));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use AT&T x86 assembly syntax
 
@@ -27,7 +27,7 @@ error: AT&T x86 assembly syntax used
   --> $DIR/asm_syntax.rs:23:9
    |
 LL |         asm!("", options(att_syntax));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::inline-asm-x86-att-syntax` implied by `-D warnings`
    = help: use Intel x86 assembly syntax
@@ -36,7 +36,7 @@ error: AT&T x86 assembly syntax used
   --> $DIR/asm_syntax.rs:24:9
    |
 LL |         asm!("", options(nostack, att_syntax));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use Intel x86 assembly syntax
 

--- a/src/tools/clippy/tests/ui/assertions_on_constants.stderr
+++ b/src/tools/clippy/tests/ui/assertions_on_constants.stderr
@@ -2,7 +2,7 @@ error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:11:5
    |
 LL |     assert!(true);
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
    = note: `-D clippy::assertions-on-constants` implied by `-D warnings`
    = help: remove it
@@ -12,7 +12,7 @@ error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:12:5
    |
 LL |     assert!(false);
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = help: use `panic!()` or `unreachable!()`
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -21,7 +21,7 @@ error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:13:5
    |
 LL |     assert!(true, "true message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: remove it
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -30,7 +30,7 @@ error: `assert!(false, "false message")` should probably be replaced
   --> $DIR/assertions_on_constants.rs:14:5
    |
 LL |     assert!(false, "false message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!("false message")` or `unreachable!("false message")`
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -39,7 +39,7 @@ error: `assert!(false, msg.to_uppercase())` should probably be replaced
   --> $DIR/assertions_on_constants.rs:17:5
    |
 LL |     assert!(false, msg.to_uppercase());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!(msg.to_uppercase())` or `unreachable!(msg.to_uppercase())`
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -48,7 +48,7 @@ error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:20:5
    |
 LL |     assert!(B);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
    = help: remove it
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -57,7 +57,7 @@ error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:23:5
    |
 LL |     assert!(C);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
    = help: use `panic!()` or `unreachable!()`
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -66,7 +66,7 @@ error: `assert!(false, "C message")` should probably be replaced
   --> $DIR/assertions_on_constants.rs:24:5
    |
 LL |     assert!(C, "C message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!("C message")` or `unreachable!("C message")`
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -75,7 +75,7 @@ error: `debug_assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:26:5
    |
 LL |     debug_assert!(true);
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
    |
    = help: remove it
    = note: this error originates in the macro `$crate::assert` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/tools/clippy/tests/ui/bool_assert_comparison.stderr
+++ b/src/tools/clippy/tests/ui/bool_assert_comparison.stderr
@@ -2,7 +2,7 @@ error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:69:5
    |
 LL |     assert_eq!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
    |
    = note: `-D clippy::bool-assert-comparison` implied by `-D warnings`
 
@@ -10,127 +10,127 @@ error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:70:5
    |
 LL |     assert_eq!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:71:5
    |
 LL |     assert_eq!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:76:5
    |
 LL |     assert_eq!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:79:5
    |
 LL |     assert_ne!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:80:5
    |
 LL |     assert_ne!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:81:5
    |
 LL |     assert_ne!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:86:5
    |
 LL |     assert_ne!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:89:5
    |
 LL |     debug_assert_eq!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:90:5
    |
 LL |     debug_assert_eq!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:91:5
    |
 LL |     debug_assert_eq!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:96:5
    |
 LL |     debug_assert_eq!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:99:5
    |
 LL |     debug_assert_ne!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:100:5
    |
 LL |     debug_assert_ne!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:101:5
    |
 LL |     debug_assert_ne!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:106:5
    |
 LL |     debug_assert_ne!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:111:5
    |
 LL |     assert_eq!("a".is_empty(), false, "tadam {}", 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:112:5
    |
 LL |     assert_eq!("a".is_empty(), false, "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:113:5
    |
 LL |     assert_eq!(false, "a".is_empty(), "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:118:5
    |
 LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:119:5
    |
 LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:120:5
    |
 LL |     debug_assert_eq!(false, "a".is_empty(), "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
 
 error: aborting due to 22 previous errors
 

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -71,7 +71,7 @@ LL |             $a.unwrap(); // unnecessary
    |             ^^^^^^^^^^^
 ...
 LL |     m!(x);
-   |     ------ in this macro invocation
+   |     ----- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/collapsible_match2.stderr
+++ b/src/tools/clippy/tests/ui/collapsible_match2.stderr
@@ -46,7 +46,7 @@ LL | |                     },
    | |_____________________^
 ...
 LL |           mac!(res_opt => Ok(val), val => Some(n), foo(n));
-   |           ------------------------------------------------- in this macro invocation
+   |           ------------------------------------------------ in this macro invocation
    |
 help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:46:28

--- a/src/tools/clippy/tests/ui/crashes/ice-6255.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6255.stderr
@@ -5,7 +5,7 @@ LL |         extern crate std as core;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_other_core!();
-   | --------------------- in this macro invocation
+   | -------------------- in this macro invocation
    |
    = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/declare_interior_mutable_const/others.stderr
+++ b/src/tools/clippy/tests/ui/declare_interior_mutable_const/others.stderr
@@ -31,7 +31,7 @@ LL |         const $name: $ty = $e;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | declare_const!(_ONCE: Once = Once::new()); //~ ERROR interior mutable
-   | ------------------------------------------ in this macro invocation
+   | ----------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/declare_interior_mutable_const/traits.stderr
+++ b/src/tools/clippy/tests/ui/declare_interior_mutable_const/traits.stderr
@@ -13,7 +13,7 @@ LL |         const $name: $ty = $e;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     declare_const!(ANOTHER_ATOMIC: AtomicUsize = Self::ATOMIC); //~ ERROR interior mutable
-   |     ----------------------------------------------------------- in this macro invocation
+   |     ---------------------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/default_numeric_fallback_f64.stderr
+++ b/src/tools/clippy/tests/ui/default_numeric_fallback_f64.stderr
@@ -139,7 +139,7 @@ LL |             let x = 22.;
    |                     ^^^ help: consider adding suffix: `22.0_f64`
 ...
 LL |         internal_macro!();
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this error originates in the macro `internal_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/default_numeric_fallback_i32.stderr
+++ b/src/tools/clippy/tests/ui/default_numeric_fallback_i32.stderr
@@ -151,7 +151,7 @@ LL |             let x = 22;
    |                     ^^ help: consider adding suffix: `22_i32`
 ...
 LL |         internal_macro!();
-   |         ------------------ in this macro invocation
+   |         ----------------- in this macro invocation
    |
    = note: this error originates in the macro `internal_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/doc_unsafe.stderr
+++ b/src/tools/clippy/tests/ui/doc_unsafe.stderr
@@ -47,7 +47,7 @@ LL | |         }
    | |_________^
 ...
 LL |   very_unsafe!();
-   |   --------------- in this macro invocation
+   |   -------------- in this macro invocation
    |
    = note: this error originates in the macro `very_unsafe` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/eq_op_macros.stderr
+++ b/src/tools/clippy/tests/ui/eq_op_macros.stderr
@@ -5,7 +5,7 @@ LL |         assert_eq!(a, a);
    |                    ^^^^
 ...
 LL |     assert_in_macro_def!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: `-D clippy::eq-op` implied by `-D warnings`
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -17,7 +17,7 @@ LL |         assert_ne!(a, a);
    |                    ^^^^
 ...
 LL |     assert_in_macro_def!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -52,7 +52,7 @@ LL |         debug_assert_eq!(a, a);
    |                          ^^^^
 ...
 LL |     assert_in_macro_def!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -63,7 +63,7 @@ LL |         debug_assert_ne!(a, a);
    |                          ^^^^
 ...
 LL |     assert_in_macro_def!();
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/fallible_impl_from.stderr
+++ b/src/tools/clippy/tests/ui/fallible_impl_from.stderr
@@ -37,7 +37,7 @@ note: potential failure(s)
   --> $DIR/fallible_impl_from.rs:30:13
    |
 LL |             panic!();
-   |             ^^^^^^^^^
+   |             ^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
@@ -60,11 +60,11 @@ LL |         let s = s.unwrap();
    |                 ^^^^^^^^^^
 LL |         if !s.is_empty() {
 LL |             panic!("42");
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^
 LL |         } else if s.parse::<u32>().unwrap() != 42 {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
@@ -86,7 +86,7 @@ note: potential failure(s)
 LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/src/tools/clippy/tests/ui/format.stderr
+++ b/src/tools/clippy/tests/ui/format.stderr
@@ -2,7 +2,7 @@ error: useless use of `format!`
   --> $DIR/format.rs:13:5
    |
 LL |     format!("foo");
-   |     ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
    |
    = note: `-D clippy::useless-format` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: useless use of `format!`
   --> $DIR/format.rs:14:5
    |
 LL |     format!("{{}}");
-   |     ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{}".to_string();`
+   |     ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{}".to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:15:5
    |
 LL |     format!("{{}} abc {{}}");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{} abc {}".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{} abc {}".to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:16:5
@@ -25,61 +25,61 @@ LL | /     format!(
 LL | |         r##"foo {{}}
 LL | | " bar"##
 LL | |     );
-   | |______^
+   | |_____^
    |
 help: consider using `.to_string()`
    |
 LL ~     r##"foo {}
-LL + " bar"##.to_string();
+LL ~ " bar"##.to_string();
    |
 
 error: useless use of `format!`
   --> $DIR/format.rs:21:5
    |
 LL |     format!("{}", "foo");
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:25:5
    |
 LL |     format!("{:+}", "foo"); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:26:5
    |
 LL |     format!("{:<}", "foo"); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:31:5
    |
 LL |     format!("{}", arg);
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:35:5
    |
 LL |     format!("{:+}", arg); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:36:5
    |
 LL |     format!("{:<}", arg); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:63:5
    |
 LL |     format!("{}", 42.to_string());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `42.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `42.to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:65:5
    |
 LL |     format!("{}", x.display().to_string());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.display().to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.display().to_string()`
 
 error: useless use of `format!`
   --> $DIR/format.rs:69:18

--- a/src/tools/clippy/tests/ui/implicit_hasher.stderr
+++ b/src/tools/clippy/tests/ui/implicit_hasher.stderr
@@ -107,7 +107,7 @@ LL |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V> {
    |                                           ^^^^^^^^^^^^^
 ...
 LL | gen!(impl);
-   | ----------- in this macro invocation
+   | ---------- in this macro invocation
    |
    = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter
@@ -126,7 +126,7 @@ LL |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>)
    |                                 ^^^^^^^^^^^^^^^^^
 ...
 LL | gen!(fn bar);
-   | ------------- in this macro invocation
+   | ------------ in this macro invocation
    |
    = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter
@@ -141,7 +141,7 @@ LL |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>)
    |                                                               ^^^^^^^^^^^^
 ...
 LL | gen!(fn bar);
-   | ------------- in this macro invocation
+   | ------------ in this macro invocation
    |
    = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter

--- a/src/tools/clippy/tests/ui/item_after_statement.stderr
+++ b/src/tools/clippy/tests/ui/item_after_statement.stderr
@@ -25,7 +25,7 @@ LL | |             }
    | |_____________^
 ...
 LL |       b!();
-   |       ----- in this macro invocation
+   |       ---- in this macro invocation
    |
    = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/mem_replace_macro.stderr
+++ b/src/tools/clippy/tests/ui/mem_replace_macro.stderr
@@ -5,7 +5,7 @@ LL |         std::mem::replace($s, Default::default())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     take!(s);
-   |     --------- in this macro invocation
+   |     -------- in this macro invocation
    |
    = note: `-D clippy::mem-replace-with-default` implied by `-D warnings`
    = note: this error originates in the macro `take` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/tools/clippy/tests/ui/missing_panics_doc.stderr
+++ b/src/tools/clippy/tests/ui/missing_panics_doc.stderr
@@ -91,7 +91,7 @@ note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:39:5
    |
 LL |     assert_eq!(x, 0);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
@@ -107,7 +107,7 @@ note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:45:5
    |
 LL |     assert_ne!(x, 0);
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors

--- a/src/tools/clippy/tests/ui/panic_in_result_fn.stderr
+++ b/src/tools/clippy/tests/ui/panic_in_result_fn.stderr
@@ -13,7 +13,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:9:9
    |
 LL |         panic!("error");
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -30,7 +30,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:14:9
    |
 LL |         unimplemented!();
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -47,7 +47,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:19:9
    |
 LL |         unreachable!();
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^
    = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -64,7 +64,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:24:9
    |
 LL |         todo!("Finish this");
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -81,7 +81,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:55:5
    |
 LL |     panic!("error");
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -98,7 +98,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn.rs:69:5
    |
 LL |     todo!("finish main method");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors

--- a/src/tools/clippy/tests/ui/panic_in_result_fn_assertions.stderr
+++ b/src/tools/clippy/tests/ui/panic_in_result_fn_assertions.stderr
@@ -14,7 +14,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn_assertions.rs:9:9
    |
 LL |         assert!(x == 5, "wrong argument");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -32,7 +32,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn_assertions.rs:15:9
    |
 LL |         assert_eq!(x, 5);
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
@@ -50,7 +50,7 @@ note: return Err() instead of panicking
   --> $DIR/panic_in_result_fn_assertions.rs:21:9
    |
 LL |         assert_ne!(x, 1);
-   |         ^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/tools/clippy/tests/ui/panicking_macros.stderr
+++ b/src/tools/clippy/tests/ui/panicking_macros.stderr
@@ -2,7 +2,7 @@ error: `panic` should not be present in production code
   --> $DIR/panicking_macros.rs:8:5
    |
 LL |     panic!();
-   |     ^^^^^^^^^
+   |     ^^^^^^^^
    |
    = note: `-D clippy::panic` implied by `-D warnings`
 
@@ -10,19 +10,19 @@ error: `panic` should not be present in production code
   --> $DIR/panicking_macros.rs:9:5
    |
 LL |     panic!("message");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
 
 error: `panic` should not be present in production code
   --> $DIR/panicking_macros.rs:10:5
    |
 LL |     panic!("{} {}", "panic with", "multiple arguments");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:16:5
    |
 LL |     todo!();
-   |     ^^^^^^^^
+   |     ^^^^^^^
    |
    = note: `-D clippy::todo` implied by `-D warnings`
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -31,7 +31,7 @@ error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:17:5
    |
 LL |     todo!("message");
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -39,7 +39,7 @@ error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:18:5
    |
 LL |     todo!("{} {}", "panic with", "multiple arguments");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -47,7 +47,7 @@ error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:24:5
    |
 LL |     unimplemented!();
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unimplemented` implied by `-D warnings`
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -56,7 +56,7 @@ error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:25:5
    |
 LL |     unimplemented!("message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -64,7 +64,7 @@ error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:26:5
    |
 LL |     unimplemented!("{} {}", "panic with", "multiple arguments");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -72,7 +72,7 @@ error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:32:5
    |
 LL |     unreachable!();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unreachable` implied by `-D warnings`
    = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -81,7 +81,7 @@ error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:33:5
    |
 LL |     unreachable!("message");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -89,7 +89,7 @@ error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:34:5
    |
 LL |     unreachable!("{} {}", "panic with", "multiple arguments");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -97,13 +97,13 @@ error: `panic` should not be present in production code
   --> $DIR/panicking_macros.rs:40:5
    |
 LL |     panic!();
-   |     ^^^^^^^^^
+   |     ^^^^^^^^
 
 error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:41:5
    |
 LL |     todo!();
-   |     ^^^^^^^^
+   |     ^^^^^^^
    |
    = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -111,7 +111,7 @@ error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:42:5
    |
 LL |     unimplemented!();
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -119,7 +119,7 @@ error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:43:5
    |
 LL |     unreachable!();
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/pattern_type_mismatch/syntax.stderr
+++ b/src/tools/clippy/tests/ui/pattern_type_mismatch/syntax.stderr
@@ -70,7 +70,7 @@ LL |                 Some(_) => (),
    |                 ^^^^^^^
 ...
 LL |     matching_macro!(value);
-   |     ----------------------- in this macro invocation
+   |     ---------------------- in this macro invocation
    |
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
    = note: this error originates in the macro `matching_macro` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/tools/clippy/tests/ui/toplevel_ref_arg.stderr
+++ b/src/tools/clippy/tests/ui/toplevel_ref_arg.stderr
@@ -37,7 +37,7 @@ LL |         let ref _y = 42;
    |         ----^^^^^^------ help: try: `let _y = &42;`
 ...
 LL |         gen_binding!();
-   |         --------------- in this macro invocation
+   |         -------------- in this macro invocation
    |
    = note: this error originates in the macro `gen_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/toplevel_ref_arg_non_rustfix.stderr
+++ b/src/tools/clippy/tests/ui/toplevel_ref_arg_non_rustfix.stderr
@@ -13,7 +13,7 @@ LL |         fn fun_example(ref _x: usize) {}
    |                        ^^^^^^
 ...
 LL |         gen_function!();
-   |         ---------------- in this macro invocation
+   |         --------------- in this macro invocation
    |
    = note: this error originates in the macro `gen_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/try_err.stderr
+++ b/src/tools/clippy/tests/ui/try_err.stderr
@@ -35,7 +35,7 @@ LL |             Err(_) => Err(1)?,
    |                       ^^^^^^^ help: try this: `return Err(1)`
 ...
 LL |     try_validation!(Ok::<_, i32>(5));
-   |     --------------------------------- in this macro invocation
+   |     -------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `try_validation` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -46,7 +46,7 @@ LL |             Err(_) => Err(ret_one!())?,
    |                       ^^^^^^^^^^^^^^^^ help: try this: `return Err(ret_one!())`
 ...
 LL |     try_validation_in_macro!(Ok::<_, i32>(5));
-   |     ------------------------------------------ in this macro invocation
+   |     ----------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `try_validation_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/clippy/tests/ui/unit_cmp.stderr
+++ b/src/tools/clippy/tests/ui/unit_cmp.stderr
@@ -32,7 +32,7 @@ LL | |         },
 ...  |
 LL | |         }
 LL | |     );
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -46,7 +46,7 @@ LL | |         },
 ...  |
 LL | |         }
 LL | |     );
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `$crate::assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ LL | |         },
 ...  |
 LL | |         }
 LL | |     );
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ LL | |         },
 ...  |
 LL | |         }
 LL | |     );
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `$crate::assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
Macro call site spans are now less surprising/more consistent since they no longer contain a semicolon after the macro call.

The downside is that we need to do a little guesswork to get the semicolon in diagnostics. But this should not be noticeable since it is rare for the semicolon to not immediately follow the macro call.