### PR TITLE
Fix macro_rules! duplication when reexported in the same module

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -87,13 +87,21 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         // the rexport defines the path that a user will actually see. Accordingly,
         // we add the rexport as an item here, and then skip over the original
         // definition in `visit_item()` below.
+        //
+        // We also skip `#[macro_export] macro_rules!` that have alredy been inserted,
+        // this can append if within the same module a `#[macro_export] macro_rules!`
+        // is declared but also a reexport of itself producing two export of the same
+        // macro in the same module.
+        let mut inserted = FxHashSet::default();
         for export in self.cx.tcx.module_exports(CRATE_DEF_ID).unwrap_or(&[]) {
             if let Res::Def(DefKind::Macro(_), def_id) = export.res {
                 if let Some(local_def_id) = def_id.as_local() {
                     if self.cx.tcx.has_attr(def_id, sym::macro_export) {
-                        let hir_id = self.cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
-                        let item = self.cx.tcx.hir().expect_item(hir_id);
-                        top_level_module.items.push((item, None));
+                        if !inserted.insert(def_id) {
+                            let hir_id = self.cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
+                            let item = self.cx.tcx.hir().expect_item(hir_id);
+                            top_level_module.items.push((item, None));
+                        }
                     }
                 }
             }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             if let Res::Def(DefKind::Macro(_), def_id) = export.res {
                 if let Some(local_def_id) = def_id.as_local() {
                     if self.cx.tcx.has_attr(def_id, sym::macro_export) {
-                        if !inserted.insert(def_id) {
+                        if inserted.insert(def_id) {
                             let hir_id = self.cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
                             let item = self.cx.tcx.hir().expect_item(hir_id);
                             top_level_module.items.push((item, None));

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -88,9 +88,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         // we add the rexport as an item here, and then skip over the original
         // definition in `visit_item()` below.
         //
-        // We also skip `#[macro_export] macro_rules!` that have alredy been inserted,
-        // this can append if within the same module a `#[macro_export] macro_rules!`
-        // is declared but also a reexport of itself producing two export of the same
+        // We also skip `#[macro_export] macro_rules!` that have already been inserted,
+        // it can happen if within the same module a `#[macro_export] macro_rules!`
+        // is declared but also a reexport of itself producing two exports of the same
         // macro in the same module.
         let mut inserted = FxHashSet::default();
         for export in self.cx.tcx.module_exports(CRATE_DEF_ID).unwrap_or(&[]) {

--- a/src/test/rustdoc-json/reexport/macro.rs
+++ b/src/test/rustdoc-json/reexport/macro.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @count macro.json "$.index[*][?(@.name=='macro')].inner.items[*]" 2
+
+// @set repro_id = macro.json "$.index[*][?(@.name=='repro')].id"
+// @has - "$.index[*][?(@.name=='macro')].inner.items[*]" $repro_id
+#[macro_export]
+macro_rules! repro {
+    () => {};
+}
+
+// @set repro2_id = macro.json "$.index[*][?(@.inner.name=='repro2')].id"
+// @has - "$.index[*][?(@.name=='macro')].inner.items[*]" $repro2_id
+pub use crate::repro as repro2;

--- a/src/test/rustdoc/issue-89852.rs
+++ b/src/test/rustdoc/issue-89852.rs
@@ -3,12 +3,12 @@
 #![no_core]
 #![feature(no_core)]
 
-// @count issue_89852/index.html '//*[@class="macro"]' 2
-// @has - '//*[@class="macro"]/@href' 'macro.repro.html'
+// @matches 'issue_89852/sidebar-items.js' '"repro"'
+// @!matches 'issue_89852/sidebar-items.js' '"repro".*"repro"'
+
 #[macro_export]
 macro_rules! repro {
     () => {};
 }
 
-// @!has issue_89852/macro.repro.html '//*[@class="macro"]/@content' 'repro2'
 pub use crate::repro as repro2;

--- a/src/test/rustdoc/issue-89852.rs
+++ b/src/test/rustdoc/issue-89852.rs
@@ -1,0 +1,14 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @count issue_89852/index.html '//*[@class="macro"]' 2
+// @has - '//*[@class="macro"]/@href' 'macro.repro.html'
+#[macro_export]
+macro_rules! repro {
+    () => {};
+}
+
+// @!has issue_89852/macro.repro.html '//*[@class="macro"]/@content' 'repro2'
+pub use crate::repro as repro2;


### PR DESCRIPTION
This can append if within the same module a `#[macro_export] macro_rules!`
is declared but also a reexport of itself producing two export of the same
macro in the same module. In that case we only want to document it once.

Before:
```
Module {
    is_crate: true,
    items: [
        Id("0:4"),   // pub use crate::repro as repro2;
        Id("0:3"),   // macro_rules! repro
        Id("0:3"),   // duplicate, same as above
    ],
}
```

After:
```
Module {
    is_crate: true,
    items: [
        Id("0:4"),   // pub use crate::repro as repro2;
        Id("0:3"),   // macro_rules! repro
    ],
}
```

Fixes https://github.com/rust-lang/rust/issues/89852