### PR TITLE
Gives a nicer error if the programmer uses the `<=>` operator.

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -213,6 +213,25 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            if op.node == AssocOp::LessEqual
+                && self.token.kind == token::Gt
+                && self.prev_token.span.hi() == self.token.span.lo()
+            {
+                // Look for C++'s `<=>`
+                let sp = op.span.to(self.token.span);
+                self.struct_span_err(sp, &format!("invalid comparison operator `<=>`"))
+                    .span_suggestion_short(
+                        sp,
+                        &format!(
+                            "`<=>` is not a valid comparison operator, use std::cmp::Ordering"
+                        ),
+                        "<=>".to_string(),
+                        Applicability::Unspecified,
+                    )
+                    .emit();
+                self.bump();
+            }
+
             if (op.node == AssocOp::Equal || op.node == AssocOp::NotEqual)
                 && self.token.kind == token::Eq
                 && self.prev_token.span.hi() == self.token.span.lo()

--- a/src/test/ui/spaceship-operator.rs
+++ b/src/test/ui/spaceship-operator.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("{}", 1 <=> 2);
+    //~^ERROR invalid comparison operator `<=>`
+}

--- a/src/test/ui/spaceship-operator.stderr
+++ b/src/test/ui/spaceship-operator.stderr
@@ -1,0 +1,8 @@
+error: invalid comparison operator `<=>`
+  --> $DIR/spaceship-operator.rs:2:22
+   |
+LL |     println!("{}", 1 <=> 2);
+   |                      ^^^ help: `<=>` is not a valid comparison operator, use std::cmp::Ordering
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Produces a better diagnostic than before, directs the user to use Ordering.

## Open questions
How should the Ordering recommendation be done? Is doing it as-is fine, or is there some better way?
Should this suggestion be changed to be automatically appliable? How do I do that?