### PR TITLE
Add missing word to `FromStr` trait documentation

### DIFF
--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -536,7 +536,7 @@ pub trait FromStr: Sized {
     ///
     /// If parsing succeeds, return the value inside [`Ok`], otherwise
     /// when the string is ill-formatted return an error specific to the
-    /// inside [`Err`]. The error type is specific to implementation of the trait.
+    /// inside [`Err`]. The error type is specific to the implementation of the trait.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The doc comment is getting a bit wide, let me know if I should restructure it/add a new line.