### PR TITLE
Fix missing remaining compiler specific cfg information

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -74,6 +74,7 @@
         not(any(test, bootstrap)),
         any(not(feature = "miri-test-libstd"), test, doctest),
         no_global_oom_handling,
+        not(no_global_oom_handling),
         target_has_atomic = "ptr"
     ))
 )]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -195,7 +195,15 @@
     test(no_crate_inject, attr(deny(warnings))),
     test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
 )]
-#![cfg_attr(not(bootstrap), doc(cfg_hide(not(test), not(any(test, bootstrap)))))]
+#![cfg_attr(
+    not(bootstrap),
+    doc(cfg_hide(
+        not(test),
+        not(any(test, bootstrap)),
+        no_global_oom_handling,
+        not(no_global_oom_handling)
+    ))
+)]
 // Don't link to std. We are std.
 #![no_std]
 #![warn(deprecated_in_future)]


### PR DESCRIPTION
Follow-up of #89596. We forgot a few of them:

![Screenshot from 2021-10-14 11-36-44](https://user-images.githubusercontent.com/3050060/137292700-64ebc59f-d9d2-41f2-be3a-fa5bf211523c.png)
![Screenshot from 2021-10-14 11-36-56](https://user-images.githubusercontent.com/3050060/137292703-f63fa4e5-2c56-446b-9f86-3652f03dfe59.png)

r? @notriddle 