### PR TITLE
Use non-checking TLS relocation in aarch64 asm! sym test.

### DIFF
--- a/src/test/ui/asm/aarch64/sym.rs
+++ b/src/test/ui/asm/aarch64/sym.rs
@@ -55,7 +55,7 @@ macro_rules! static_tls_addr {
                 // Add the top 12 bits of the symbol's offset
                 "add {out}, {out}, :tprel_hi12:{sym}",
                 // And the bottom 12 bits
-                "add {out}, {out}, :tprel_lo12:{sym}",
+                "add {out}, {out}, :tprel_lo12_nc:{sym}",
                 out = out(reg) result,
                 sym = sym $s
             );


### PR DESCRIPTION
The checking variant ensures that the offset required is not larger than 12 bits - hence we wouldn't ever need the upper 12 bits.

It's unlikely to ever fail in this small test but this is technically correct.

This was noticed incidentally when we found that LLD doesn't support the `tprel_lo12` relocation, even though LLVM can apparently generate it when using `-mtls-size=12`.