### PR TITLE
Avoid generating empty closures for fieldless enum variants

### DIFF
--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -247,13 +247,24 @@ fn encodable_body(
                     })
                     .collect();
 
-                let result = quote! { ::rustc_serialize::Encoder::emit_enum_variant(
-                    __encoder,
-                   #variant_name,
-                   #variant_idx,
-                   #field_idx,
-                   |__encoder| { ::std::result::Result::Ok({ #encode_fields }) }
-                ) };
+                let result = if field_idx != 0 {
+                    quote! {
+                        ::rustc_serialize::Encoder::emit_enum_variant(
+                            __encoder,
+                            #variant_name,
+                            #variant_idx,
+                            #field_idx,
+                            |__encoder| { ::std::result::Result::Ok({ #encode_fields }) }
+                        )
+                    }
+                } else {
+                    quote! {
+                        ::rustc_serialize::Encoder::emit_fieldless_enum_variant::<#variant_idx>(
+                            __encoder,
+                            #variant_name,
+                        )
+                    }
+                };
                 variant_idx += 1;
                 result
             });

--- a/compiler/rustc_serialize/src/json.rs
+++ b/compiler/rustc_serialize/src/json.rs
@@ -589,6 +589,13 @@ impl<'a> crate::Encoder for Encoder<'a> {
         }
     }
 
+    fn emit_fieldless_enum_variant<const ID: usize>(
+        &mut self,
+        name: &str,
+    ) -> Result<(), Self::Error> {
+        escape_str(self.writer, name)
+    }
+
     fn emit_enum_variant_arg<F>(&mut self, first: bool, f: F) -> EncodeResult
     where
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
@@ -883,6 +890,13 @@ impl<'a> crate::Encoder for PrettyEncoder<'a> {
             write!(self.writer, "}}")?;
             Ok(())
         }
+    }
+
+    fn emit_fieldless_enum_variant<const ID: usize>(
+        &mut self,
+        name: &str,
+    ) -> Result<(), Self::Error> {
+        escape_str(self.writer, name)
     }
 
     fn emit_enum_variant_arg<F>(&mut self, first: bool, f: F) -> EncodeResult

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -58,6 +58,20 @@ pub trait Encoder {
         f(self)
     }
 
+    // We put the field index in a const generic to allow the emit_usize to be
+    // compiled into a more efficient form. In practice, the variant index is
+    // known at compile-time, and that knowledge allows much more efficient
+    // codegen than we'd otherwise get. LLVM isn't always able to make the
+    // optimization that would otherwise be necessary here, likely due to the
+    // multiple levels of inlining and const-prop that are needed.
+    #[inline]
+    fn emit_fieldless_enum_variant<const ID: usize>(
+        &mut self,
+        _v_name: &str,
+    ) -> Result<(), Self::Error> {
+        self.emit_usize(ID)
+    }
+
     #[inline]
     fn emit_enum_variant_arg<F>(&mut self, _first: bool, f: F) -> Result<(), Self::Error>
     where


### PR DESCRIPTION
For many enums, this avoids generating lots of tiny stubs that need to be codegen'd and then inlined and removed by LLVM. perf shows this to be a fairly small, but significant, win on rustc bootstrap time -- with minimal impact on runtime performance (which is at times even positive).