### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -558,7 +558,7 @@ impl<'me, 'tcx> BoundVarReplacer<'me, 'tcx> {
     fn universe_for(&mut self, debruijn: ty::DebruijnIndex) -> ty::UniverseIndex {
         let infcx = self.infcx;
         let index =
-            self.universe_indices.len() - debruijn.as_usize() + self.current_index.as_usize() - 1;
+            self.universe_indices.len() + self.current_index.as_usize() - debruijn.as_usize() - 1;
         let universe = self.universe_indices[index].unwrap_or_else(|| {
             for i in self.universe_indices.iter_mut().take(index + 1) {
                 *i = i.or_else(|| Some(infcx.create_next_universe()))

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -42,7 +42,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::{Coercion, InferOk, InferResult};
-use rustc_infer::traits::Obligation;
+use rustc_infer::traits::{Obligation, TraitEngine, TraitEngineExt};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability, PointerCast,
@@ -146,6 +146,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             .and_then(|InferOk { value: ty, obligations }| success(f(ty), ty, obligations))
     }
 
+    #[instrument(skip(self))]
     fn coerce(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> CoerceResult<'tcx> {
         // First, remove any resolved type variables (at the top level, at least):
         let a = self.shallow_resolve(a);
@@ -941,6 +942,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // We don't ever need two-phase here since we throw out the result of the coercion
         let coerce = Coerce::new(self, cause, AllowTwoPhase::No);
         self.probe(|_| coerce.coerce(source, target)).is_ok()
+    }
+
+    /// Same as `try_coerce()`, but without side-effects and attempts to select
+    /// all predicates created by the coercion. This is useful for e.g. checking
+    /// that associated types are correct.
+    pub fn can_coerce_and_satisfy_predicates(&self, expr_ty: Ty<'tcx>, target: Ty<'tcx>) -> bool {
+        let source = self.resolve_vars_with_obligations(expr_ty);
+        debug!("coercion::can_with_predicates({:?} -> {:?})", source, target);
+
+        let cause = self.cause(rustc_span::DUMMY_SP, ObligationCauseCode::ExprAssignable);
+        // We don't ever need two-phase here since we throw out the result of the coercion
+        let coerce = Coerce::new(self, cause, AllowTwoPhase::No);
+        self.probe(|_| {
+            let ok = match coerce.coerce(source, target) {
+                Ok(ok) => ok,
+                _ => return false,
+            };
+            let mut fcx = traits::FulfillmentContext::new_in_snapshot();
+            fcx.register_predicate_obligations(self, ok.obligations);
+            fcx.select_where_possible(&self).is_ok()
+        })
     }
 
     /// Given a type and a target type, this function will calculate and return

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -934,20 +934,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Same as `try_coerce()`, but without side-effects.
+    ///
+    /// Returns false if the coercion creates any obligations that result in
+    /// errors.
     pub fn can_coerce(&self, expr_ty: Ty<'tcx>, target: Ty<'tcx>) -> bool {
-        let source = self.resolve_vars_with_obligations(expr_ty);
-        debug!("coercion::can({:?} -> {:?})", source, target);
-
-        let cause = self.cause(rustc_span::DUMMY_SP, ObligationCauseCode::ExprAssignable);
-        // We don't ever need two-phase here since we throw out the result of the coercion
-        let coerce = Coerce::new(self, cause, AllowTwoPhase::No);
-        self.probe(|_| coerce.coerce(source, target)).is_ok()
-    }
-
-    /// Same as `try_coerce()`, but without side-effects and attempts to select
-    /// all predicates created by the coercion. This is useful for e.g. checking
-    /// that associated types are correct.
-    pub fn can_coerce_and_satisfy_predicates(&self, expr_ty: Ty<'tcx>, target: Ty<'tcx>) -> bool {
         let source = self.resolve_vars_with_obligations(expr_ty);
         debug!("coercion::can_with_predicates({:?} -> {:?})", source, target);
 

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -341,7 +341,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 for (sp, label) in spans_and_labels {
                     multi_span.push_span_label(sp, label);
                 }
-                err.span_note(multi_span, "closures can only be coerced to `fn` types if they do not capture any variables");
+                err.span_note(
+                    multi_span,
+                    "closures can only be coerced to `fn` types if they do not capture any variables"
+                );
             }
         }
     }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -364,11 +364,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         }
         let pin_did = self.tcx.lang_items().pin_type();
+        // This guards the `unwrap` and `mk_box` below.
+        if pin_did.is_none() || self.tcx.lang_items().owned_box().is_none() {
+            return false;
+        }
         match expected.kind() {
-            ty::Adt(def, _) if Some(def.did) != pin_did => return false,
-            // This guards the `unwrap` and `mk_box` below.
-            _ if pin_did.is_none() || self.tcx.lang_items().owned_box().is_none() => return false,
-            _ => {}
+            ty::Adt(def, _) if Some(def.did) == pin_did => (),
+            _ => return false,
         }
         let box_found = self.tcx.mk_box(found);
         let pin_box_found = self.tcx.mk_lang_item(box_found, LangItem::Pin).unwrap();

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -373,7 +373,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let box_found = self.tcx.mk_box(found);
         let pin_box_found = self.tcx.mk_lang_item(box_found, LangItem::Pin).unwrap();
         let pin_found = self.tcx.mk_lang_item(found, LangItem::Pin).unwrap();
-        if self.can_coerce_and_satisfy_predicates(pin_box_found, expected) {
+        if self.can_coerce(pin_box_found, expected) {
             debug!("can coerce {:?} to {:?}, suggesting Box::pin", pin_box_found, expected);
             match found.kind() {
                 ty::Adt(def, _) if def.is_box() => {
@@ -391,7 +391,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             true
-        } else if self.can_coerce_and_satisfy_predicates(pin_found, expected) {
+        } else if self.can_coerce(pin_found, expected) {
             match found.kind() {
                 ty::Adt(def, _) if def.is_box() => {
                     err.help("use `Box::pin`");

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -74,6 +74,7 @@
         not(any(test, bootstrap)),
         any(not(feature = "miri-test-libstd"), test, doctest),
         no_global_oom_handling,
+        not(no_global_oom_handling),
         target_has_atomic = "ptr"
     ))
 )]

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -536,7 +536,7 @@ pub trait FromStr: Sized {
     ///
     /// If parsing succeeds, return the value inside [`Ok`], otherwise
     /// when the string is ill-formatted return an error specific to the
-    /// inside [`Err`]. The error type is specific to implementation of the trait.
+    /// inside [`Err`]. The error type is specific to the implementation of the trait.
     ///
     /// # Examples
     ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -195,7 +195,15 @@
     test(no_crate_inject, attr(deny(warnings))),
     test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
 )]
-#![cfg_attr(not(bootstrap), doc(cfg_hide(not(test), not(any(test, bootstrap)))))]
+#![cfg_attr(
+    not(bootstrap),
+    doc(cfg_hide(
+        not(test),
+        not(any(test, bootstrap)),
+        no_global_oom_handling,
+        not(no_global_oom_handling)
+    ))
+)]
 // Don't link to std. We are std.
 #![no_std]
 #![warn(deprecated_in_future)]

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -824,15 +824,10 @@ impl Config {
                 };
             }
 
-            if config.llvm_thin_lto {
-                // If we're building with ThinLTO on, we want to link to LLVM
-                // shared, to avoid re-doing ThinLTO (which happens in the link
-                // step) with each stage.
-                assert_ne!(
-                    llvm.link_shared,
-                    Some(false),
-                    "setting link-shared=false is incompatible with thin-lto=true"
-                );
+            if config.llvm_thin_lto && llvm.link_shared.is_none() {
+                // If we're building with ThinLTO on, by default we want to link
+                // to LLVM shared, to avoid re-doing ThinLTO (which happens in
+                // the link step) with each stage.
                 config.llvm_link_shared = true;
             }
         }

--- a/src/test/ui/cross/cross-borrow-trait.stderr
+++ b/src/test/ui/cross/cross-borrow-trait.stderr
@@ -2,10 +2,8 @@ error[E0308]: mismatched types
   --> $DIR/cross-borrow-trait.rs:10:26
    |
 LL |     let _y: &dyn Trait = x;
-   |             ----------   ^
-   |             |            |
-   |             |            expected `&dyn Trait`, found struct `Box`
-   |             |            help: consider borrowing here: `&x`
+   |             ----------   ^ expected `&dyn Trait`, found struct `Box`
+   |             |
    |             expected due to this
    |
    = note: expected reference `&dyn Trait`

--- a/src/test/ui/dst/dst-bad-coercions.stderr
+++ b/src/test/ui/dst/dst-bad-coercions.stderr
@@ -13,10 +13,8 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:15:21
    |
 LL |     let y: &dyn T = x;
-   |            ------   ^
-   |            |        |
-   |            |        expected `&dyn T`, found *-ptr
-   |            |        help: consider borrowing here: `&x`
+   |            ------   ^ expected `&dyn T`, found *-ptr
+   |            |
    |            expected due to this
    |
    = note: expected reference `&dyn T`
@@ -37,10 +35,8 @@ error[E0308]: mismatched types
   --> $DIR/dst-bad-coercions.rs:20:21
    |
 LL |     let y: &dyn T = x;
-   |            ------   ^
-   |            |        |
-   |            |        expected `&dyn T`, found *-ptr
-   |            |        help: consider borrowing here: `&x`
+   |            ------   ^ expected `&dyn T`, found *-ptr
+   |            |
    |            expected due to this
    |
    = note: expected reference `&dyn T`

--- a/src/test/ui/suggestions/box-future-wrong-output.rs
+++ b/src/test/ui/suggestions/box-future-wrong-output.rs
@@ -1,0 +1,22 @@
+// Issue #72117
+// edition:2018
+
+use core::future::Future;
+use core::pin::Pin;
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+impl<T: ?Sized> FutureExt for T where T: Future {}
+trait FutureExt: Future {
+    fn boxed<'a>(self) -> BoxFuture<'a, Self::Output>
+    where
+        Self: Sized + Send + 'a,
+    {
+        Box::pin(self)
+    }
+}
+
+fn main() {
+    let _: BoxFuture<'static, bool> = async {}.boxed();
+    //~^ ERROR: mismatched types
+}

--- a/src/test/ui/suggestions/box-future-wrong-output.stderr
+++ b/src/test/ui/suggestions/box-future-wrong-output.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/box-future-wrong-output.rs:20:39
+   |
+LL |     let _: BoxFuture<'static, bool> = async {}.boxed();
+   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Pin<Box<(dyn Future<Output = bool> + Send + 'static)>>`
+              found struct `Pin<Box<dyn Future<Output = ()> + Send>>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.rs
+++ b/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.rs
@@ -11,13 +11,13 @@ fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> 
     x //~ ERROR mismatched types
 }
 
-// This case is still subpar:
-// `Pin::new(x)`: store this in the heap by calling `Box::new`: `Box::new(x)`
-// Should suggest changing the code from `Pin::new` to `Box::pin`.
 fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
     Box::new(x) //~ ERROR mismatched types
 }
 
+// This case is still subpar:
+// `Pin::new(x)`: store this in the heap by calling `Box::new`: `Box::new(x)`
+// Should suggest changing the code from `Pin::new` to `Box::pin`.
 fn baz<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
     Pin::new(x) //~ ERROR mismatched types
     //~^ ERROR E0277

--- a/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/src/test/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -15,7 +15,7 @@ LL |     Box::pin(x)
    |     +++++++++ +
 
 error[E0308]: mismatched types
-  --> $DIR/expected-boxed-future-isnt-pinned.rs:18:5
+  --> $DIR/expected-boxed-future-isnt-pinned.rs:15:5
    |
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
    |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type


### PR DESCRIPTION
Successful merges:

 - #89390 (Fix incorrect Box::pin suggestion)
 - #89433 (Fix ctrl-c causing reads of stdin to return empty on Windows.)
 - #89823 (Switch order of terms to prevent overflow)
 - #89865 (Allow static linking LLVM with ThinLTO)
 - #89873 (Add missing word to `FromStr` trait documentation)
 - #89878 (Fix missing remaining compiler specific cfg information)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89390,89433,89823,89865,89873,89878)
<!-- homu-ignore:end -->