### PR TITLE
Revert enum discriminants

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,6 @@ Language
 
 - [The 2021 Edition is now stable.][rust#88100]
   See [the edition guide][rust-2021-edition-guide] for more details.
-- [You can now specify explicit discriminant values on any Rust enum.][rust#86860]
 - [The pattern in `binding @ pattern` can now also introduce new bindings.][rust#85305]
 - [Union field access is permitted in `const fn`.][rust#85769]
 
@@ -51,8 +50,6 @@ Stabilised APIs
 ---------------
 
 - [`std::os::unix::fs::chroot`]
-- [`Iterator::intersperse`]
-- [`Iterator::intersperse_with`]
 - [`UnsafeCell::raw_get`]
 - [`BufWriter::into_parts`]
 - [`core::panic::{UnwindSafe, RefUnwindSafe, AssertUnwindSafe}`]

--- a/compiler/rustc_error_codes/src/error_codes/E0732.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0732.md
@@ -3,6 +3,8 @@ An `enum` with a discriminant must specify a `#[repr(inttype)]`.
 Erroneous code example:
 
 ```compile_fail,E0732
+#![feature(arbitrary_enum_discriminant)]
+
 enum Enum { // error!
     Unit = 1,
     Tuple() = 2,
@@ -18,6 +20,8 @@ is a well-defined way to extract a variant's discriminant from a value;
 for instance:
 
 ```
+#![feature(arbitrary_enum_discriminant)]
+
 #[repr(u8)]
 enum Enum {
     Unit = 3,

--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -293,8 +293,6 @@ declare_features! (
     (accepted, const_fn_transmute, "1.56.0", Some(53605), None),
     /// Allows accessing fields of unions inside `const` functions.
     (accepted, const_fn_union, "1.56.0", Some(51909), None),
-    /// Allows explicit discriminants on non-unit enum variants.
-    (accepted, arbitrary_enum_discriminant, "1.56.0", Some(60553), None),
     /// Allows macro attributes to observe output of `#[derive]`.
     (accepted, macro_attributes_in_derive_output, "1.57.0", Some(81119), None),
     /// Allows panicking during const eval (producing compile-time errors).

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -464,6 +464,9 @@ declare_features! (
     /// Allows #[repr(transparent)] on unions (RFC 2645).
     (active, transparent_unions, "1.37.0", Some(60405), None),
 
+    /// Allows explicit discriminants on non-unit enum variants.
+    (active, arbitrary_enum_discriminant, "1.37.0", Some(60553), None),
+
     /// Allows `async || body` closures.
     (active, async_closure, "1.37.0", Some(62290), None),
 

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -1374,7 +1374,7 @@ fn check_enum<'tcx>(
         }
     }
 
-    if tcx.adt_def(def_id).repr.int.is_none() {
+    if tcx.adt_def(def_id).repr.int.is_none() && tcx.features().arbitrary_enum_discriminant {
         let is_unit = |var: &hir::Variant<'_>| matches!(var.data, hir::VariantData::Unit(..));
 
         let has_disr = |var: &hir::Variant<'_>| var.disr_expr.is_some();

--- a/src/doc/unstable-book/src/language-features/arbitrary-enum-discriminant.md
+++ b/src/doc/unstable-book/src/language-features/arbitrary-enum-discriminant.md
@@ -1,0 +1,37 @@
+# `arbitrary_enum_discriminant`
+
+The tracking issue for this feature is: [#60553]
+
+[#60553]: https://github.com/rust-lang/rust/issues/60553
+
+------------------------
+
+The `arbitrary_enum_discriminant` feature permits tuple-like and
+struct-like enum variants with `#[repr(<int-type>)]` to have explicit discriminants.
+
+## Examples
+
+```rust
+#![feature(arbitrary_enum_discriminant)]
+
+#[allow(dead_code)]
+#[repr(u8)]
+enum Enum {
+    Unit = 3,
+    Tuple(u16) = 2,
+    Struct {
+        a: u8,
+        b: u16,
+    } = 1,
+}
+
+impl Enum {
+    fn tag(&self) -> u8 {
+        unsafe { *(self as *const Self as *const u8) }
+    }
+}
+
+assert_eq!(3, Enum::Unit.tag());
+assert_eq!(2, Enum::Tuple(5).tag());
+assert_eq!(1, Enum::Struct{a: 7, b: 11}.tag());
+```

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.rs
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.rs
@@ -1,4 +1,5 @@
 #![crate_type="lib"]
+#![feature(arbitrary_enum_discriminant)]
 
 enum Enum {
 //~^ ERROR `#[repr(inttype)]` must be specified

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant-no-repr.stderr
@@ -1,5 +1,5 @@
 error[E0732]: `#[repr(inttype)]` must be specified
-  --> $DIR/arbitrary_enum_discriminant-no-repr.rs:3:1
+  --> $DIR/arbitrary_enum_discriminant-no-repr.rs:4:1
    |
 LL | / enum Enum {
 LL | |

--- a/src/test/ui/enum-discriminant/arbitrary_enum_discriminant.rs
+++ b/src/test/ui/enum-discriminant/arbitrary_enum_discriminant.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(const_raw_ptr_deref, test)]
+#![feature(arbitrary_enum_discriminant, const_raw_ptr_deref, test)]
 
 extern crate test;
 

--- a/src/test/ui/enum-discriminant/discriminant_value.rs
+++ b/src/test/ui/enum-discriminant/discriminant_value.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![allow(stable_features)]
-#![feature(core, core_intrinsics)]
+#![feature(arbitrary_enum_discriminant, core, core_intrinsics)]
 
 extern crate core;
 use core::intrinsics::discriminant_value;

--- a/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.rs
+++ b/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.rs
@@ -1,0 +1,10 @@
+#![crate_type="lib"]
+
+enum Enum {
+  Unit = 1,
+  //~^ ERROR custom discriminant values are not allowed in enums with tuple or struct variants
+  Tuple() = 2,
+  //~^ ERROR discriminants on non-unit variants are experimental
+  Struct{} = 3,
+  //~^ ERROR discriminants on non-unit variants are experimental
+}

--- a/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
+++ b/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
@@ -1,0 +1,36 @@
+error[E0658]: discriminants on non-unit variants are experimental
+  --> $DIR/feature-gate-arbitrary_enum_discriminant.rs:6:13
+   |
+LL |   Tuple() = 2,
+   |             ^
+   |
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
+
+error[E0658]: discriminants on non-unit variants are experimental
+  --> $DIR/feature-gate-arbitrary_enum_discriminant.rs:8:14
+   |
+LL |   Struct{} = 3,
+   |              ^
+   |
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
+
+error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
+  --> $DIR/feature-gate-arbitrary_enum_discriminant.rs:4:10
+   |
+LL |   Unit = 1,
+   |          ^ disallowed custom discriminant
+LL |
+LL |   Tuple() = 2,
+   |   ----------- tuple variant defined here
+LL |
+LL |   Struct{} = 3,
+   |   ------------ struct variant defined here
+   |
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.rs
+++ b/src/test/ui/enum-discriminant/issue-70453-generics-in-discr-ice-2.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics)]
+#![feature(arbitrary_enum_discriminant, core_intrinsics)]
 
 extern crate core;
 use core::intrinsics::discriminant_value;

--- a/src/test/ui/enum-discriminant/issue-70453-polymorphic-ctfe.rs
+++ b/src/test/ui/enum-discriminant/issue-70453-polymorphic-ctfe.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics)]
+#![feature(arbitrary_enum_discriminant, core_intrinsics)]
 
 extern crate core;
 use core::intrinsics::discriminant_value;

--- a/src/test/ui/enum-discriminant/issue-70509-partial_eq.rs
+++ b/src/test/ui/enum-discriminant/issue-70509-partial_eq.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(repr128)]
+#![feature(repr128, arbitrary_enum_discriminant)]
 //~^ WARN the feature `repr128` is incomplete
 
 #[derive(PartialEq, Debug)]

--- a/src/test/ui/enum-discriminant/issue-70509-partial_eq.stderr
+++ b/src/test/ui/enum-discriminant/issue-70509-partial_eq.stderr
@@ -1,7 +1,7 @@
 warning: the feature `repr128` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/issue-70509-partial_eq.rs:2:12
    |
-LL | #![feature(repr128)]
+LL | #![feature(repr128, arbitrary_enum_discriminant)]
    |            ^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -6,7 +6,7 @@
 
 // This test checks panic emitted from `mem::{uninitialized,zeroed}`.
 
-#![feature(never_type)]
+#![feature(never_type, arbitrary_enum_discriminant)]
 #![allow(deprecated, invalid_value)]
 
 use std::{

--- a/src/test/ui/parser/issue-17383.rs
+++ b/src/test/ui/parser/issue-17383.rs
@@ -1,0 +1,7 @@
+enum X {
+    A = 3,
+    //~^ ERROR custom discriminant values are not allowed in enums with tuple or struct variants
+    B(usize)
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-17383.stderr
+++ b/src/test/ui/parser/issue-17383.stderr
@@ -1,0 +1,15 @@
+error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
+  --> $DIR/issue-17383.rs:2:9
+   |
+LL |     A = 3,
+   |         ^ disallowed custom discriminant
+LL |
+LL |     B(usize)
+   |     -------- tuple variant defined here
+   |
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/parser/tag-variant-disr-non-nullary.rs
+++ b/src/test/ui/parser/tag-variant-disr-non-nullary.rs
@@ -1,0 +1,12 @@
+enum Color {
+    Red = 0xff0000,
+    //~^ ERROR custom discriminant values are not allowed in enums with tuple or struct variants
+    Green = 0x00ff00,
+    Blue = 0x0000ff,
+    Black = 0x000000,
+    White = 0xffffff,
+    Other(usize),
+    Other2(usize, usize),
+}
+
+fn main() {}

--- a/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
+++ b/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
@@ -1,0 +1,25 @@
+error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
+  --> $DIR/tag-variant-disr-non-nullary.rs:2:11
+   |
+LL |     Red = 0xff0000,
+   |           ^^^^^^^^ disallowed custom discriminant
+LL |
+LL |     Green = 0x00ff00,
+   |             ^^^^^^^^ disallowed custom discriminant
+LL |     Blue = 0x0000ff,
+   |            ^^^^^^^^ disallowed custom discriminant
+LL |     Black = 0x000000,
+   |             ^^^^^^^^ disallowed custom discriminant
+LL |     White = 0xffffff,
+   |             ^^^^^^^^ disallowed custom discriminant
+LL |     Other(usize),
+   |     ------------ tuple variant defined here
+LL |     Other2(usize, usize),
+   |     -------------------- tuple variant defined here
+   |
+   = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Reverts stabilization of arbitrary enum discriminants per https://github.com/rust-lang/rust/issues/88621#issuecomment-929482371.

Reopens #60553.