### PR TITLE
Change `char` type in debuginfo to DW_ATE_UTF

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -87,7 +87,7 @@ const DW_ATE_signed: c_uint = 0x05;
 #[allow(non_upper_case_globals)]
 const DW_ATE_unsigned: c_uint = 0x07;
 #[allow(non_upper_case_globals)]
-const DW_ATE_unsigned_char: c_uint = 0x08;
+const DW_ATE_UTF: c_uint = 0x10;
 
 pub const UNKNOWN_LINE_NUMBER: c_uint = 0;
 pub const UNKNOWN_COLUMN_NUMBER: c_uint = 0;
@@ -933,7 +933,7 @@ fn basic_type_metadata<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'l
         ty::Never => ("!", DW_ATE_unsigned),
         ty::Tuple(elements) if elements.is_empty() => ("()", DW_ATE_unsigned),
         ty::Bool => ("bool", DW_ATE_boolean),
-        ty::Char => ("char", DW_ATE_unsigned_char),
+        ty::Char => ("char", DW_ATE_UTF),
         ty::Int(int_ty) if cpp_like_debuginfo => (int_ty.msvc_basic_name(), DW_ATE_signed),
         ty::Uint(uint_ty) if cpp_like_debuginfo => (uint_ty.msvc_basic_name(), DW_ATE_unsigned),
         ty::Float(float_ty) if cpp_like_debuginfo => (float_ty.msvc_basic_name(), DW_ATE_float),

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -104,7 +104,8 @@
 // cdb-check:b                : false [Type: bool]
 // cdb-command:dx i
 // cdb-check:i                : -1 [Type: [...]]
-// The variable 'c' doesn't appear for some reason...
+// cdb-command:dx c
+// cdb-check:c                : 0x61 'a' [Type: char32_t]
 // cdb-command:dx i8
 // cdb-check:i8               : 68 [Type: char]
 // cdb-command:dx i16

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -14,8 +14,7 @@
 // gdb-check:$2 = -1
 
 // gdb-command:print *char_ref
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdb-check:$3 = 97
 
 // gdb-command:print *i8_ref
 // gdbg-check:$4 = 68 'D'

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -16,8 +16,7 @@
 // gdb-check:$2 = -1
 
 // gdb-command:print *char_ref
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdb-check:$3 = 97
 
 // gdb-command:print/d *i8_ref
 // gdb-check:$4 = 68


### PR DESCRIPTION
Rust previously encoded the `char` type as DW_ATE_unsigned_char. The more appropriate encoding is `DW_ATE_UTF`.

Clang also uses the DW_ATE_UTF for `char32_t` in C++.

This fixes the display of the `char` type in the Windows debuggers. Without this change, the variable did not show in the locals window.
![image](https://user-images.githubusercontent.com/704597/137368067-9b3e4dc8-a075-44ba-a687-bf3810a44e5a.png)

LLDB 13 is also able to display the char value, when before it failed with `need to add support for DW_TAG_base_type 'char' encoded with DW_ATE = 0x8, bit_size = 32`

r? @wesleywiser
