### PR TITLE
Side-step ICE on `RePlaceholder` in `eval_verify_bound`

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1167,6 +1167,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 self.scc_values.elements_contained_in(lower_bound_scc).next().is_none()
             }
 
+            // FIXME: this is likely to be incorrect, but it side-steps stable ICE #76168,
+            // without any changes to what we accept (or reject for that matter).
+            VerifyBound::OutlivedBy(ty::RePlaceholder(..)) => false,
+
             VerifyBound::OutlivedBy(r) => {
                 let r_vid = self.to_region_vid(r);
                 self.eval_outlives(r_vid, lower_bound)

--- a/src/test/ui/lifetimes/issue-76168.rs
+++ b/src/test/ui/lifetimes/issue-76168.rs
@@ -1,0 +1,17 @@
+// edition:2018
+#![feature(unboxed_closures)]
+use std::future::Future;
+
+async fn wrapper<F>(f: F)
+where for<'a> F: FnOnce<(&'a mut i32,)>,
+    for<'a> <F as FnOnce<(&'a mut i32,)>>::Output: Future<Output=()> + 'a
+{ //~ ERROR `<F as FnOnce<(&'a mut i32,)>>::Output` does not live long enough
+    let mut i = 41;
+    f(&mut i).await;
+}
+
+async fn add_one(i: &mut i32) {
+    *i = *i + 1;
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-76168.stderr
+++ b/src/test/ui/lifetimes/issue-76168.stderr
@@ -1,0 +1,11 @@
+error: `<F as FnOnce<(&'a mut i32,)>>::Output` does not live long enough
+  --> $DIR/issue-76168.rs:8:1
+   |
+LL | / {
+LL | |     let mut i = 41;
+LL | |     f(&mut i).await;
+LL | | }
+   | |_^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Address #76168.

I don't think this is the *correct* way of handling this, but it does get rid of a stable-to-stable regression ICE.

The previous output (before the regression) was:

```
error[E0310]: the parameter type `F` may not live long enough
  --> src/lib.rs:9:1
   |
9  | / {
10 | | }
   | |_^
   |
   = help: consider adding an explicit lifetime bound `F: 'static`...
```

while the output with this PR is

```
error: `<F as FnOnce<(&'a mut i32,)>>::Output` does not live long enough
  --> $DIR/issue-76168.rs:8:1
   |
LL | / {
LL | |     let mut i = 41;
LL | |     f(&mut i).await;
LL | | }
   | |_^
```