### PR TITLE
`alloc`: add unstable cfg features `no_rc` and `no_sync`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -69,6 +69,8 @@
     any(not(feature = "miri-test-libstd"), test, doctest),
     no_global_oom_handling,
     not(no_global_oom_handling),
+    not(no_rc),
+    not(no_sync),
     target_has_atomic = "ptr"
 ))]
 #![no_std]
@@ -223,16 +225,17 @@ mod boxed {
 }
 pub mod borrow;
 pub mod collections;
-#[cfg(not(no_global_oom_handling))]
+#[cfg(all(not(no_rc), not(no_sync), not(no_global_oom_handling)))]
 pub mod ffi;
 pub mod fmt;
+#[cfg(not(no_rc))]
 pub mod rc;
 pub mod slice;
 pub mod str;
 pub mod string;
-#[cfg(target_has_atomic = "ptr")]
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 pub mod sync;
-#[cfg(all(not(no_global_oom_handling), target_has_atomic = "ptr"))]
+#[cfg(all(not(no_global_oom_handling), not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 pub mod task;
 #[cfg(test)]
 mod tests;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -197,6 +197,8 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (Some(Mode::Std), "stdarch_intel_sde", None),
     (Some(Mode::Std), "no_fp_fmt_parse", None),
     (Some(Mode::Std), "no_global_oom_handling", None),
+    (Some(Mode::Std), "no_rc", None),
+    (Some(Mode::Std), "no_sync", None),
     (Some(Mode::Std), "freebsd12", None),
     (Some(Mode::Std), "backtrace_in_libstd", None),
     /* Extra values not defined in the built-in targets yet, but used in std */

--- a/src/test/run-make-fulldeps/alloc-no-rc/Makefile
+++ b/src/test/run-make-fulldeps/alloc-no-rc/Makefile
@@ -1,0 +1,4 @@
+include ../tools.mk
+
+all:
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_rc

--- a/src/test/run-make-fulldeps/alloc-no-sync/Makefile
+++ b/src/test/run-make-fulldeps/alloc-no-sync/Makefile
@@ -1,0 +1,4 @@
+include ../tools.mk
+
+all:
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_sync


### PR DESCRIPTION
In Rust for Linux we are using these to make `alloc` a bit more modular.

See https://github.com/rust-lang/rust/pull/86048 and https://github.com/rust-lang/rust/pull/84266 for similar requests.

Of course, the particular names are not important.