### PR TITLE
Restrict the aarch64 outline atomics test to Linux

### DIFF
--- a/src/test/assembly/asm/aarch64-outline-atomics.rs
+++ b/src/test/assembly/asm/aarch64-outline-atomics.rs
@@ -4,6 +4,7 @@
 // compile-flags: --target aarch64-unknown-linux-gnu
 // needs-llvm-components: aarch64
 // only-aarch64
+// only-linux
 
 #![crate_type = "rlib"]
 


### PR DESCRIPTION
The test was introduced in #83655, which enables the `outline-atomics` feature for aarch64-unknown-linux-* but not for any other aarch64 targets. The test did not check for Linux causing test failures on aarch64-apple-darwin.

r? @workingjubilee 