### PR TITLE
Moved format-version constant to rustdoc-json-types

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -255,7 +255,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 9,
+            format_version: types::FORMAT_VERSION,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -510,5 +510,8 @@ pub struct Static {
     pub expr: String,
 }
 
+/// rustdoc format-version.
+pub const FORMAT_VERSION: u32 = 9;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Addresses #88620

Moved format-version constant from rustdoc to rustdoc-json-types.