### PR TITLE
Remove FIXME since there is nothing to be fixed

### DIFF
--- a/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.rs
+++ b/src/test/rustdoc-ui/ambiguous-inherent-assoc-ty.rs
@@ -11,7 +11,6 @@ impl Struct {
     pub const AssocConst: Self::AssocTy = 42;
     //~^ ERROR ambiguous associated type
     //~| HELP use fully-qualified syntax
-    // FIXME: for some reason, the error is shown twice with rustdoc but only once with rustc
     //~| ERROR ambiguous associated type
     //~| HELP use fully-qualified syntax
 }


### PR DESCRIPTION
Resolves #88593.

The errors are deduplicated when displayed to users. They only appear
multiple times in UI tests.

cc @jyn514 
r? @camelid 