### PR TITLE
emitter: current substitution can be multi-line

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -341,7 +341,7 @@ impl CodeSuggestion {
                     });
                     buf.push_str(&part.snippet);
                     let cur_hi = sm.lookup_char_pos(part.span.hi());
-                    if prev_hi.line == cur_lo.line {
+                    if prev_hi.line == cur_lo.line && cur_hi.line == cur_lo.line {
                         // Account for the difference between the width of the current code and the
                         // snippet being suggested, so that the *later* suggestions are correctly
                         // aligned on the screen.

--- a/src/test/ui/errors/issue-89280-emitter-overflow-splice-lines.rs
+++ b/src/test/ui/errors/issue-89280-emitter-overflow-splice-lines.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+trait X {
+    fn test(x: u32, (
+//~^ WARN anonymous parameters are deprecated and will be removed in the next edition
+//~^^ WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+    )) {}
+}
+
+fn main() {}

--- a/src/test/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
+++ b/src/test/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
@@ -1,0 +1,23 @@
+warning: anonymous parameters are deprecated and will be removed in the next edition
+  --> $DIR/issue-89280-emitter-overflow-splice-lines.rs:4:21
+   |
+LL |       fn test(x: u32, (
+   |  _____________________^
+LL | |
+LL | |
+LL | |     )) {}
+   | |_____^
+   |
+   = note: `#[warn(anonymous_parameters)]` on by default
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
+help: try naming the parameter or explicitly ignoring it
+   |
+LL ~     fn test(x: u32, _: (
+LL +
+LL +
+LL ~     )) {}
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #89280.

In `splice_lines`, there is some arithmetic to compute the required alignment such that future substitutions in a suggestion are aligned correctly. However, this assumed that the current substitution's span was only on a single line. In circumstances where this was not true, it could result in a arithmetic overflow when the substitution's end column was less than the substitution's start column.

r? @oli-obk 