### PR TITLE
Update E0637 description to mention `&` w/o an explicit lifetime name

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0637.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0637.md
@@ -1,35 +1,51 @@
-An underscore `_` character has been used as the identifier for a lifetime.
+`'_` lifetime name or `&T` without an explicit lifetime name has been used
+on illegal place.
 
 Erroneous code example:
 
 ```compile_fail,E0106,E0637
-fn longest<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
-         //^^ `'_` is a reserved lifetime name
+fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+                     //^^ `'_` is a reserved lifetime name
     if str1.len() > str2.len() {
         str1
     } else {
         str2
     }
 }
+
+fn and_without_explicit_lifetime<T>()
+where
+    T: Into<&u32>,
+          //^ `&` without an explicit lifetime name
+{
+}
 ```
 
-`'_`, cannot be used as a lifetime identifier because it is a reserved for the
-anonymous lifetime. To fix this, use a lowercase letter such as 'a, or a series
-of lowercase letters such as `'foo`.  For more information, see [the
-book][bk-no].  For more information on using the anonymous lifetime in rust
-nightly, see [the nightly book][bk-al].
+First, `'_` cannot be used as a lifetime identifier in some places
+because it is a reserved for the anonymous lifetime. Second, `&T`
+without an explicit lifetime name cannot also be used in some places.
+To fix them, use a lowercase letter such as `'a`, or a series
+of lowercase letters such as `'foo`. For more information about lifetime
+identifier, see [the book][bk-no]. For more information on using
+the anonymous lifetime in Rust 2018, see [the Rust 2018 blog post][blog-al].
 
 Corrected example:
 
 ```
-fn longest<'a>(str1: &'a str, str2: &'a str) -> &'a str {
+fn underscore_lifetime<'a>(str1: &'a str, str2: &'a str) -> &'a str {
     if str1.len() > str2.len() {
         str1
     } else {
         str2
     }
 }
+
+fn and_without_explicit_lifetime<'foo, T>()
+where
+    T: Into<&'foo u32>,
+{
+}
 ```
 
 [bk-no]: https://doc.rust-lang.org/book/appendix-02-operators.html#non-operator-symbols
-[bk-al]: https://doc.rust-lang.org/nightly/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html
+[blog-al]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#more-lifetime-elision-rules

--- a/src/test/ui/error-codes/E0637.rs
+++ b/src/test/ui/error-codes/E0637.rs
@@ -1,9 +1,17 @@
-struct Foo<'a: '_>(&'a u8); //~ ERROR cannot be used here
-fn foo<'a: '_>(_: &'a u8) {} //~ ERROR cannot be used here
+fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+    //~^ ERROR: `'_` cannot be used here [E0637]
+    //~| ERROR: missing lifetime specifier
+    if str1.len() > str2.len() {
+        str1
+    } else {
+        str2
+    }
+}
 
-struct Bar<'a>(&'a u8);
-impl<'a: '_> Bar<'a> { //~ ERROR cannot be used here
-  fn bar() {}
+fn and_without_explicit_lifetime<T>()
+where
+    T: Into<&u32>, //~ ERROR: `&` without an explicit lifetime name cannot be used here [E0637]
+{
 }
 
 fn main() {}

--- a/src/test/ui/error-codes/E0637.stderr
+++ b/src/test/ui/error-codes/E0637.stderr
@@ -1,21 +1,28 @@
 error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:1:16
+  --> $DIR/E0637.rs:1:24
    |
-LL | struct Foo<'a: '_>(&'a u8);
-   |                ^^ `'_` is a reserved lifetime name
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                        ^^ `'_` is a reserved lifetime name
 
-error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:2:12
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:13:13
    |
-LL | fn foo<'a: '_>(_: &'a u8) {}
-   |            ^^ `'_` is a reserved lifetime name
+LL |     T: Into<&u32>,
+   |             ^ explicit lifetime name needed here
 
-error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:5:10
+error[E0106]: missing lifetime specifier
+  --> $DIR/E0637.rs:1:62
    |
-LL | impl<'a: '_> Bar<'a> {
-   |          ^^ `'_` is a reserved lifetime name
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                  -------        -------      ^^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `str1` or `str2`
+help: consider introducing a named lifetime parameter
+   |
+LL | fn underscore_lifetime<'a, '_>(str1: &'a str, str2: &'a str) -> &'a str {
+   |                        +++            ~~             ~~          ~~
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0637`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Deal with https://github.com/rust-lang/rust/issues/89824#issuecomment-941598647. Another solution would be splitting the error code into two as (I think) it's a bit unclear to users why they have the same error code.