### PR TITLE
updating docs to mention usage of AtomicBool

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -62,7 +62,7 @@
 //! some atomic operations. Maximally portable code will want to be careful
 //! about which atomic types are used. `AtomicUsize` and `AtomicIsize` are
 //! generally the most portable, but even then they're not available everywhere.
-//! For reference, the `std` library requires pointer-sized atomics, although
+//! For reference, the `std` library requires `AtomicBool`s and pointer-sized atomics, although
 //! `core` does not.
 //!
 //! Currently you'll need to use `#[cfg(target_arch)]` primarily to


### PR DESCRIPTION
Mouse mentioned we should point out that atomic bool is used by the std lib these days. ( https://github.com/m-ou-se/getrandom/pull/1 )