### PR TITLE
Remove a mention to `copy_from_slice` from `clone_from_slice` doc

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2953,9 +2953,6 @@ impl<T> [T] {
     ///
     /// The length of `src` must be the same as `self`.
     ///
-    /// If `T` implements `Copy`, it can be more performant to use
-    /// [`copy_from_slice`].
-    ///
     /// # Panics
     ///
     /// This function will panic if the two slices have different lengths.


### PR DESCRIPTION
Fixes #84736
I think removing it would be the best but I'm happy to clarify it instead if someone would like.