### PR TITLE
Make Option::as_mut const

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -646,7 +646,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn as_mut(&mut self) -> Option<&mut T> {
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    pub const fn as_mut(&mut self) -> Option<&mut T> {
         match *self {
             Some(ref mut x) => Some(x),
             None => None,

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -10,6 +10,7 @@
 #![feature(const_assume)]
 #![feature(const_cell_into_inner)]
 #![feature(const_maybe_uninit_assume_init)]
+#![cfg_attr(bootstrap, feature(const_panic))]
 #![feature(const_ptr_read)]
 #![feature(const_ptr_write)]
 #![feature(const_ptr_offset)]

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -380,6 +380,14 @@ const fn option_const_mut() {
 
     let _take = option.take();
     let _replace = option.replace(42);
+
+    {
+        let as_mut = option.as_mut();
+        match as_mut {
+            Some(v) => *v = 32,
+            None => unreachable!(),
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Adding `const` for `Option::as_mut`.

Tracking issue: #67441