### PR TITLE
Suggest a case insensitive match name regardless of levenshtein distance

### DIFF
--- a/compiler/rustc_span/src/lev_distance/tests.rs
+++ b/compiler/rustc_span/src/lev_distance/tests.rs
@@ -31,15 +31,11 @@ fn test_find_best_match_for_name() {
 
         assert_eq!(find_best_match_for_name(&input, Symbol::intern("1111111111"), None), None);
 
-        let input = vec![Symbol::intern("aAAA")];
-        assert_eq!(
-            find_best_match_for_name(&input, Symbol::intern("AAAA"), None),
-            Some(Symbol::intern("aAAA"))
-        );
-
         let input = vec![Symbol::intern("AAAA")];
-        // Returns None because `lev_distance > max_dist / 3`
-        assert_eq!(find_best_match_for_name(&input, Symbol::intern("aaaa"), None), None);
+        assert_eq!(
+            find_best_match_for_name(&input, Symbol::intern("aaaa"), None),
+            Some(Symbol::intern("AAAA"))
+        );
 
         let input = vec![Symbol::intern("AAAA")];
         assert_eq!(

--- a/src/test/ui/hygiene/rustc-macro-transparency.stderr
+++ b/src/test/ui/hygiene/rustc-macro-transparency.stderr
@@ -2,11 +2,14 @@ error[E0425]: cannot find value `Opaque` in this scope
   --> $DIR/rustc-macro-transparency.rs:26:5
    |
 LL |     Opaque;
-   |     ^^^^^^ help: a local variable with a similar name exists (notice the capitalization): `opaque`
+   |     ^^^^^^ not found in this scope
 
 error[E0423]: expected value, found macro `semitransparent`
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
+LL |     struct SemiTransparent;
+   |     ----------------------- similarly named unit struct `SemiTransparent` defined here
+...
 LL |     semitransparent;
    |     ^^^^^^^^^^^^^^^ not a value
    |
@@ -14,10 +17,17 @@ help: use `!` to invoke the macro
    |
 LL |     semitransparent!;
    |                    +
+help: a unit struct with a similar name exists
+   |
+LL |     SemiTransparent;
+   |     ~~~~~~~~~~~~~~~
 
 error[E0423]: expected value, found macro `opaque`
   --> $DIR/rustc-macro-transparency.rs:30:5
    |
+LL |     struct Opaque;
+   |     -------------- similarly named unit struct `Opaque` defined here
+...
 LL |     opaque;
    |     ^^^^^^ not a value
    |
@@ -25,6 +35,10 @@ help: use `!` to invoke the macro
    |
 LL |     opaque!;
    |           +
+help: a unit struct with a similar name exists
+   |
+LL |     Opaque;
+   |     ~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -5,7 +5,10 @@ LL | enum Delicious {
    | -------------- variant or associated item `PIE` not found here
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
-   |                                                       ^^^ variant or associated item not found in `Delicious`
+   |                                                       ^^^
+   |                                                       |
+   |                                                       variant or associated item not found in `Delicious`
+   |                                                       help: there is a variant with a similar name: `Pie`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #86170

Currently, `find_best_match_for_name` only returns a case insensitive match name depending on a Levenshtein distance. It's a bit unfortunate that that hides some suggestions for typos like `Bar` -> `BAR`. That idea is from https://github.com/rust-lang/rust/pull/46347#discussion_r153701834, but I think it still makes some sense to show a candidate when we find a case insensitive match name as it's more like a typo.
Skipped the `candidate != lookup` check because the current (i.e, `levenshtein_match`) returns the exact same `Symbol` anyway but it doesn't seem to confuse anything on UI tests.

r? @estebank