### PR TITLE
Add aarch64-apple-darwin to list of platforms with CI LLVM

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -770,6 +770,7 @@ impl Config {
                     // FIXME: this is duplicated in bootstrap.py
                     let supported_platforms = [
                         "aarch64-unknown-linux-gnu",
+                        "aarch64-apple-darwin",
                         "i686-pc-windows-gnu",
                         "i686-pc-windows-msvc",
                         "i686-unknown-linux-gnu",


### PR DESCRIPTION
`aarch64-apple-darwin` is Tier 2 with Host Tools, and has CI LLVM builds.