### PR TITLE
Implementation of GATs outlives lint

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1255,16 +1255,16 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         self.tainted_by_errors_flag.set(true)
     }
 
-    /// Process the region constraints and report any errors that
+    /// Process the region constraints and return any any errors that
     /// result. After this, no more unification operations should be
     /// done -- or the compiler will panic -- but it is legal to use
     /// `resolve_vars_if_possible` as well as `fully_resolve`.
-    pub fn resolve_regions_and_report_errors(
+    pub fn resolve_regions(
         &self,
         region_context: DefId,
         outlives_env: &OutlivesEnvironment<'tcx>,
         mode: RegionckMode,
-    ) {
+    ) -> Vec<RegionResolutionError<'tcx>> {
         let (var_infos, data) = {
             let mut inner = self.inner.borrow_mut();
             let inner = &mut *inner;
@@ -1289,6 +1289,21 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
         let old_value = self.lexical_region_resolutions.replace(Some(lexical_region_resolutions));
         assert!(old_value.is_none());
+
+        errors
+    }
+
+    /// Process the region constraints and report any errors that
+    /// result. After this, no more unification operations should be
+    /// done -- or the compiler will panic -- but it is legal to use
+    /// `resolve_vars_if_possible` as well as `fully_resolve`.
+    pub fn resolve_regions_and_report_errors(
+        &self,
+        region_context: DefId,
+        outlives_env: &OutlivesEnvironment<'tcx>,
+        mode: RegionckMode,
+    ) {
+        let errors = self.resolve_regions(region_context, outlives_env, mode);
 
         if !self.is_tainted_by_errors() {
             // As a heuristic, just skip reporting region errors

--- a/compiler/rustc_typeck/src/check/regionck.rs
+++ b/compiler/rustc_typeck/src/check/regionck.rs
@@ -104,7 +104,7 @@ macro_rules! ignore_err {
     };
 }
 
-trait OutlivesEnvironmentExt<'tcx> {
+pub(crate) trait OutlivesEnvironmentExt<'tcx> {
     fn add_implied_bounds(
         &mut self,
         infcx: &InferCtxt<'a, 'tcx>,

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -339,76 +339,36 @@ fn check_gat_where_clauses(
         // reflected in a where clause on the GAT itself.
         for (region, region_idx) in &visitor.regions {
             for (ty, ty_idx) in &visitor.types {
-                // Unfortunately, we have to use a new `InferCtxt` for each
-                // pair, because region constraints get added and solved there,
-                // and we need to test each pair individually.
-                tcx.infer_ctxt().enter(|infcx| {
-                    let mut outlives_environment = OutlivesEnvironment::new(param_env);
-                    outlives_environment.add_implied_bounds(&infcx, wf_tys.clone(), id, DUMMY_SP);
-                    outlives_environment.save_implied_bounds(id);
-                    let region_bound_pairs =
-                        outlives_environment.region_bound_pairs_map().get(&id).unwrap();
-
-                    let cause =
-                        ObligationCause::new(DUMMY_SP, id, ObligationCauseCode::MiscObligation);
-
-                    let sup_type = *ty;
-                    let sub_region = region;
-
-                    let origin = SubregionOrigin::from_obligation_cause(&cause, || {
-                        infer::RelateParamBound(cause.span, sup_type, None)
-                    });
-
-                    let outlives = &mut TypeOutlives::new(
-                        &infcx,
-                        tcx,
-                        &region_bound_pairs,
-                        Some(tcx.lifetimes.re_root_empty),
-                        param_env,
-                    );
-                    // In our example, requires that Self: 'a
-                    outlives.type_must_outlive(origin, sup_type, sub_region);
-
-                    let errors = infcx.resolve_regions(
-                        trait_item.def_id.to_def_id(),
-                        &outlives_environment,
-                        RegionckMode::default(),
-                    );
-
-                    debug!(?errors, "errors");
-
-                    // If we were able to prove that Self: 'a without an error,
-                    // it must be because of the implied or explicit bounds...
-                    if errors.is_empty() {
-                        debug!(?ty_idx, ?region_idx);
-                        debug!("required clause: {} must outlive {}", ty, region);
-                        // Translate into the generic parameters of the GAT. In
-                        // our example, the type was Self, which will also be
-                        // Self in the GAT.
-                        let ty_param = generics.param_at(*ty_idx, tcx);
-                        let ty_param = tcx.mk_ty(ty::Param(ty::ParamTy {
-                            index: ty_param.index,
-                            name: ty_param.name,
+                // In our example, requires that Self: 'a
+                if ty_known_to_outlive(tcx, id, param_env, &wf_tys, *ty, *region) {
+                    debug!(?ty_idx, ?region_idx);
+                    debug!("required clause: {} must outlive {}", ty, region);
+                    // Translate into the generic parameters of the GAT. In
+                    // our example, the type was Self, which will also be
+                    // Self in the GAT.
+                    let ty_param = generics.param_at(*ty_idx, tcx);
+                    let ty_param = tcx.mk_ty(ty::Param(ty::ParamTy {
+                        index: ty_param.index,
+                        name: ty_param.name,
+                    }));
+                    // Same for the region. In our example, 'a corresponds
+                    // to the 'me parameter.
+                    let region_param = generics.param_at(*region_idx, tcx);
+                    let region_param =
+                        tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
+                            def_id: region_param.def_id,
+                            index: region_param.index,
+                            name: region_param.name,
                         }));
-                        // Same for the region. In our example, 'a corresponds
-                        // to the 'me parameter.
-                        let region_param = generics.param_at(*region_idx, tcx);
-                        let region_param =
-                            tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
-                                def_id: region_param.def_id,
-                                index: region_param.index,
-                                name: region_param.name,
-                            }));
-                        // The predicate we expect to see. (In our example,
-                        // `Self: 'me`.)
-                        let clause = ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(
-                            ty_param,
-                            region_param,
-                        ));
-                        let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
-                        function_clauses.insert(clause);
-                    }
-                });
+                    // The predicate we expect to see. (In our example,
+                    // `Self: 'me`.)
+                    let clause = ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(
+                        ty_param,
+                        region_param,
+                    ));
+                    let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
+                    function_clauses.insert(clause);
+                }
             }
         }
 
@@ -422,62 +382,33 @@ fn check_gat_where_clauses(
                     continue;
                 }
 
-                // Unfortunately, we have to use a new `InferCtxt` for each
-                // pair, because region constraints get added and solved there,
-                // and we need to test each pair individually.
-                tcx.infer_ctxt().enter(|infcx| {
-                    let mut outlives_environment = OutlivesEnvironment::new(param_env);
-                    outlives_environment.add_implied_bounds(&infcx, wf_tys.clone(), id, DUMMY_SP);
-                    outlives_environment.save_implied_bounds(id);
-
-                    let cause =
-                        ObligationCause::new(DUMMY_SP, id, ObligationCauseCode::MiscObligation);
-
-                    let origin = SubregionOrigin::from_obligation_cause(&cause, || {
-                        infer::RelateRegionParamBound(cause.span)
-                    });
-
-                    use rustc_infer::infer::outlives::obligations::TypeOutlivesDelegate;
-                    (&infcx).push_sub_region_constraint(origin, region_a, region_b);
-
-                    let errors = infcx.resolve_regions(
-                        trait_item.def_id.to_def_id(),
-                        &outlives_environment,
-                        RegionckMode::default(),
-                    );
-
-                    debug!(?errors, "errors");
-
-                    // If we were able to prove that Self: 'a without an error,
-                    // it must be because of the implied or explicit bounds...
-                    if errors.is_empty() {
-                        debug!(?region_a_idx, ?region_b_idx);
-                        debug!("required clause: {} must outlive {}", region_a, region_b);
-                        // Translate into the generic parameters of the GAT.
-                        let region_a_param = generics.param_at(*region_a_idx, tcx);
-                        let region_a_param =
-                            tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
-                                def_id: region_a_param.def_id,
-                                index: region_a_param.index,
-                                name: region_a_param.name,
-                            }));
-                        // Same for the region.
-                        let region_b_param = generics.param_at(*region_b_idx, tcx);
-                        let region_b_param =
-                            tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
-                                def_id: region_b_param.def_id,
-                                index: region_b_param.index,
-                                name: region_b_param.name,
-                            }));
-                        // The predicate we expect to see.
-                        let clause = ty::PredicateKind::RegionOutlives(ty::OutlivesPredicate(
-                            region_a_param,
-                            region_b_param,
-                        ));
-                        let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
-                        function_clauses.insert(clause);
-                    }
-                });
+                if region_known_to_outlive(tcx, id, param_env, &wf_tys, *region_a, *region_b) {
+                    debug!(?region_a_idx, ?region_b_idx);
+                    debug!("required clause: {} must outlive {}", region_a, region_b);
+                    // Translate into the generic parameters of the GAT.
+                    let region_a_param = generics.param_at(*region_a_idx, tcx);
+                    let region_a_param =
+                        tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
+                            def_id: region_a_param.def_id,
+                            index: region_a_param.index,
+                            name: region_a_param.name,
+                        }));
+                    // Same for the region.
+                    let region_b_param = generics.param_at(*region_b_idx, tcx);
+                    let region_b_param =
+                        tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
+                            def_id: region_b_param.def_id,
+                            index: region_b_param.index,
+                            name: region_b_param.name,
+                        }));
+                    // The predicate we expect to see.
+                    let clause = ty::PredicateKind::RegionOutlives(ty::OutlivesPredicate(
+                        region_a_param,
+                        region_b_param,
+                    ));
+                    let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
+                    function_clauses.insert(clause);
+                }
             }
         }
 
@@ -528,6 +459,96 @@ fn check_gat_where_clauses(
             err.emit()
         }
     }
+}
+
+/// Given a known `param_env` and a set of well formed types, can we prove that
+/// `ty` outlives `region`.
+fn ty_known_to_outlive<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    id: hir::HirId,
+    param_env: ty::ParamEnv<'tcx>,
+    wf_tys: &FxHashSet<Ty<'tcx>>,
+    ty: Ty<'tcx>,
+    region: ty::Region<'tcx>,
+) -> bool {
+    // Unfortunately, we have to use a new `InferCtxt` each call, because
+    // region constraints get added and solved there and we need to test each
+    // call individually.
+    tcx.infer_ctxt().enter(|infcx| {
+        let mut outlives_environment = OutlivesEnvironment::new(param_env);
+        outlives_environment.add_implied_bounds(&infcx, wf_tys.clone(), id, DUMMY_SP);
+        outlives_environment.save_implied_bounds(id);
+        let region_bound_pairs = outlives_environment.region_bound_pairs_map().get(&id).unwrap();
+
+        let cause = ObligationCause::new(DUMMY_SP, id, ObligationCauseCode::MiscObligation);
+
+        let sup_type = ty;
+        let sub_region = region;
+
+        let origin = SubregionOrigin::from_obligation_cause(&cause, || {
+            infer::RelateParamBound(cause.span, sup_type, None)
+        });
+
+        let outlives = &mut TypeOutlives::new(
+            &infcx,
+            tcx,
+            &region_bound_pairs,
+            Some(infcx.tcx.lifetimes.re_root_empty),
+            param_env,
+        );
+        outlives.type_must_outlive(origin, sup_type, sub_region);
+
+        let errors = infcx.resolve_regions(
+            id.expect_owner().to_def_id(),
+            &outlives_environment,
+            RegionckMode::default(),
+        );
+
+        debug!(?errors, "errors");
+
+        // If we were able to prove that the type outlives the region without
+        // an error, it must be because of the implied or explicit bounds...
+        errors.is_empty()
+    })
+}
+
+fn region_known_to_outlive<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    id: hir::HirId,
+    param_env: ty::ParamEnv<'tcx>,
+    wf_tys: &FxHashSet<Ty<'tcx>>,
+    region_a: ty::Region<'tcx>,
+    region_b: ty::Region<'tcx>,
+) -> bool {
+    // Unfortunately, we have to use a new `InferCtxt` each call, because
+    // region constraints get added and solved there and we need to test each
+    // call individually.
+    tcx.infer_ctxt().enter(|infcx| {
+        let mut outlives_environment = OutlivesEnvironment::new(param_env);
+        outlives_environment.add_implied_bounds(&infcx, wf_tys.clone(), id, DUMMY_SP);
+        outlives_environment.save_implied_bounds(id);
+
+        let cause = ObligationCause::new(DUMMY_SP, id, ObligationCauseCode::MiscObligation);
+
+        let origin = SubregionOrigin::from_obligation_cause(&cause, || {
+            infer::RelateRegionParamBound(cause.span)
+        });
+
+        use rustc_infer::infer::outlives::obligations::TypeOutlivesDelegate;
+        (&infcx).push_sub_region_constraint(origin, region_a, region_b);
+
+        let errors = infcx.resolve_regions(
+            id.expect_owner().to_def_id(),
+            &outlives_environment,
+            RegionckMode::default(),
+        );
+
+        debug!(?errors, "errors");
+
+        // If we were able to prove that the type outlives the region without
+        // an error, it must be because of the implied or explicit bounds...
+        errors.is_empty()
+    })
 }
 
 /// TypeVisitor that looks for uses of GATs like

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -301,7 +301,6 @@ fn check_gat_where_clauses(
         sig.output().visit_with(&mut visitor);
         let mut wf_tys = FxHashSet::default();
         wf_tys.extend(sig.inputs());
-        // FIXME: normalize and add normalized inputs?
 
         for (region, region_idx) in &visitor.regions {
             for (ty, ty_idx) in &visitor.types {
@@ -423,12 +422,9 @@ impl<'tcx> TypeVisitor<'tcx> for GATSubstCollector<'tcx> {
                         GenericArgKind::Lifetime(lt) => {
                             self.regions.insert((lt, idx));
                         }
-                        GenericArgKind::Type(t) => match t.kind() {
-                            ty::Param(_) => {
-                                self.types.insert((t, idx));
-                            }
-                            _ => {}
-                        },
+                        GenericArgKind::Type(t) => {
+                            self.types.insert((t, idx));
+                        }
                         _ => {}
                     }
                 }

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -1,6 +1,7 @@
 use crate::check::{FnCtxt, Inherited};
 use crate::constrained_generic_params::{identify_constrained_generic_params, Parameter};
 
+use crate::traits::query::type_op::{self, TypeOp, TypeOpOutput};
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
@@ -15,13 +16,14 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::hir::map as hir_map;
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts, Subst};
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
-use rustc_middle::ty::{self, AdtKind, GenericParamDefKind, ToPredicate, Ty, TyCtxt, TypeFoldable, TypeVisitor, WithConstness};
-use rustc_session::lint;
+use rustc_middle::ty::{
+    self, AdtKind, GenericParamDefKind, ToPredicate, Ty, TyCtxt, TypeFoldable, TypeVisitor,
+    WithConstness,
+};
 use rustc_session::parse::feature_err;
 use rustc_span::symbol::{sym, Ident, Symbol};
-use rustc_span::{DUMMY_SP, Span};
-use rustc_trait_selection::traits::query::evaluate_obligation::{InferCtxtExt as _};
-use rustc_trait_selection::traits::query::outlives_bounds::{InferCtxtExt as _};
+use rustc_span::Span;
+use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
 use rustc_trait_selection::traits::{self, ObligationCause, ObligationCauseCode, WellFormedLoc};
 
 use std::convert::TryInto;
@@ -255,75 +257,119 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         }
     }
 
-    // Require that the user writes as where clauses on GATs the implicit
-    // outlives bounds involving trait parameters in trait functions and
-    // lifetimes passed as GAT substs. See `self-outlives-lint` test.
+    check_gat_where_clauses(tcx, trait_item, encl_trait_def_id);
+}
+
+/// Require that the user writes as where clauses on GATs the implicit
+/// outlives bounds involving trait parameters in trait functions and
+/// lifetimes passed as GAT substs. See `self-outlives-lint` test.
+fn check_gat_where_clauses(
+    tcx: TyCtxt<'_>,
+    trait_item: &hir::TraitItem<'_>,
+    encl_trait_def_id: DefId,
+) {
     let item = tcx.associated_item(trait_item.def_id);
+    // If the current trait item isn't a type, it isn't a GAT
+    if !matches!(item.kind, ty::AssocKind::Type) {
+        return;
+    }
     let generics: &ty::Generics = tcx.generics_of(trait_item.def_id);
-    if matches!(item.kind, ty::AssocKind::Type) && generics.params.len() > 0 {
-        let associated_items: &ty::AssocItems<'_> = tcx.associated_items(encl_trait_def_id);
-        associated_items
-            .in_definition_order()
-            .filter(|item| matches!(item.kind, ty::AssocKind::Fn))
-            .for_each(|item| {
-                tcx.infer_ctxt().enter(|infcx| {
-                    let sig: ty::Binder<'_, ty::FnSig<'_>> = tcx.fn_sig(item.def_id);
-                    let sig = infcx.replace_bound_vars_with_placeholders(sig);
-                    let output = sig.output();
-                    let mut visitor = RegionsInGATs {
-                        tcx,
-                        gat: trait_item.def_id.to_def_id(),
-                        regions: FxHashSet::default(),
-                    };
-                    output.visit_with(&mut visitor);
-                    for input in sig.inputs() {
-                        let bounds = infcx.implied_outlives_bounds(ty::ParamEnv::empty(), hir_id, input, DUMMY_SP);
-                        debug!(?bounds);
-                        let mut clauses = FxHashSet::default();
-                        for bound in bounds {
-                            match bound {
-                                traits::query::OutlivesBound::RegionSubParam(r, p) => {
-                                    for idx in visitor.regions.iter().filter(|(proj_r, _)| proj_r == &r).map(|r| r.1) {
-                                        let param_r = tcx.mk_region(ty::RegionKind::ReEarlyBound(ty::EarlyBoundRegion {
-                                            def_id: generics.params[idx].def_id,
-                                            index: idx as u32,
-                                            name: generics.params[idx].name,
-                                        }));
-                                        let clause = ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(tcx.mk_ty(ty::Param(p)), param_r));
-                                        let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
-                                        clauses.insert(clause);
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        debug!(?clauses);
-                        if !clauses.is_empty() {
-                            let written_predicates: ty::GenericPredicates<'_> = tcx.predicates_of(trait_item.def_id);
-                            for clause in clauses {
-                                let found = written_predicates.predicates.iter().find(|p| p.0 == clause).is_some();
-                                debug!(?clause, ?found);
-                                let mut error = tcx.sess.struct_span_err(
-                                    trait_item.generics.span,
-                                    &format!("Missing bound: {}", clause),
+    // If the current associated type doesn't have any (own) params, it's not a GAT
+    if generics.params.len() == 0 {
+        return;
+    }
+    let associated_items: &ty::AssocItems<'_> = tcx.associated_items(encl_trait_def_id);
+    // For every function in this trait...
+    for item in
+        associated_items.in_definition_order().filter(|item| matches!(item.kind, ty::AssocKind::Fn))
+    {
+        tcx.infer_ctxt().enter(|infcx| {
+            let sig: ty::Binder<'_, ty::FnSig<'_>> = tcx.fn_sig(item.def_id);
+            let sig = infcx.replace_bound_vars_with_placeholders(sig);
+            // Find out what regions are passed as GAT substs
+            let mut visitor = GATSubstCollector {
+                tcx,
+                gat: trait_item.def_id.to_def_id(),
+                regions: FxHashSet::default(),
+                _types: FxHashSet::default(),
+            };
+            sig.output().visit_with(&mut visitor);
+            // If there are none, then it nothing to do
+            if visitor.regions.is_empty() {
+                return;
+            }
+            let mut clauses = FxHashSet::default();
+            // Otherwise, find the clauses required from implied bounds
+            for input in sig.inputs() {
+                // For a given input type, find the implied bounds
+                let TypeOpOutput { output: bounds, .. } = match ty::ParamEnv::empty()
+                    .and(type_op::implied_outlives_bounds::ImpliedOutlivesBounds { ty: input })
+                    .fully_perform(&infcx)
+                {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                };
+                debug!(?bounds);
+                for bound in bounds {
+                    match bound {
+                        traits::query::OutlivesBound::RegionSubParam(r, p) => {
+                            // If the implied bound is a `RegionSubParam` and
+                            // the region is used a GAT subst...
+                            for idx in visitor
+                                .regions
+                                .iter()
+                                .filter(|(proj_r, _)| proj_r == &r)
+                                .map(|r| r.1)
+                            {
+                                // Then create a clause that is required on the GAT
+                                let param_r = tcx.mk_region(ty::RegionKind::ReEarlyBound(
+                                    ty::EarlyBoundRegion {
+                                        def_id: generics.params[idx].def_id,
+                                        index: idx as u32,
+                                        name: generics.params[idx].name,
+                                    },
+                                ));
+                                let clause = ty::PredicateKind::TypeOutlives(
+                                    ty::OutlivesPredicate(tcx.mk_ty(ty::Param(p)), param_r),
                                 );
-                                error.emit();
+                                let clause = tcx.mk_predicate(ty::Binder::dummy(clause));
+                                clauses.insert(clause);
                             }
                         }
+                        _ => {}
                     }
-                })
-            });
+                }
+            }
+            // If there are any missing clauses, emit an error
+            debug!(?clauses);
+            if !clauses.is_empty() {
+                let written_predicates: ty::GenericPredicates<'_> =
+                    tcx.predicates_of(trait_item.def_id);
+                for clause in clauses {
+                    let found =
+                        written_predicates.predicates.iter().find(|p| p.0 == clause).is_some();
+                    debug!(?clause, ?found);
+                    let mut error = tcx.sess.struct_span_err(
+                        trait_item.generics.span,
+                        &format!("Missing bound: {}", clause),
+                    );
+                    error.emit();
+                }
+            }
+        })
     }
 }
 
-struct RegionsInGATs<'tcx> {
+struct GATSubstCollector<'tcx> {
     tcx: TyCtxt<'tcx>,
     gat: DefId,
     // Which region appears and which parameter index its subsituted for
     regions: FxHashSet<(ty::Region<'tcx>, usize)>,
+    // Which params appears and which parameter index its subsituted for
+    _types: FxHashSet<(Ty<'tcx>, usize)>,
 }
 
-impl<'tcx> TypeVisitor<'tcx> for RegionsInGATs<'tcx> {
+impl<'tcx> TypeVisitor<'tcx> for GATSubstCollector<'tcx> {
     type BreakTy = !;
 
     fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -69,6 +69,7 @@ This API is completely unstable and subject to change.
 #![feature(never_type)]
 #![feature(slice_partition_dedup)]
 #![feature(control_flow_enum)]
+#![feature(hash_drain_filter)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/test/ui/generic-associated-types/collections-project-default.rs
+++ b/src/test/ui/generic-associated-types/collections-project-default.rs
@@ -8,7 +8,7 @@
 // check that we don't normalize with trait defaults.
 
 trait Collection<T> {
-    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter;
+    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter, Self: 'iter;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
     type Sibling<U>: Collection<U> =

--- a/src/test/ui/generic-associated-types/collections.rs
+++ b/src/test/ui/generic-associated-types/collections.rs
@@ -8,7 +8,7 @@
 // run-pass
 
 trait Collection<T> {
-    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter;
+    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter, Self: 'iter;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
     type Sibling<U>: Collection<U> =

--- a/src/test/ui/generic-associated-types/generic-associated-type-bounds.rs
+++ b/src/test/ui/generic-associated-types/generic-associated-type-bounds.rs
@@ -3,7 +3,7 @@
 #![feature(generic_associated_types)]
 
 pub trait X {
-    type Y<'a>;
+    type Y<'a> where Self: 'a;
     fn m(&self) -> Self::Y<'_>;
 }
 

--- a/src/test/ui/generic-associated-types/issue-70303.rs
+++ b/src/test/ui/generic-associated-types/issue-70303.rs
@@ -3,7 +3,7 @@
 #![feature(generic_associated_types)]
 
 trait Document {
-    type Cursor<'a>: DocCursor<'a>;
+    type Cursor<'a>: DocCursor<'a> where Self: 'a;
 
     fn cursor(&self) -> Self::Cursor<'_>;
 }

--- a/src/test/ui/generic-associated-types/issue-76535.rs
+++ b/src/test/ui/generic-associated-types/issue-76535.rs
@@ -3,7 +3,7 @@
 pub trait SubTrait {}
 
 pub trait SuperTrait {
-    type SubType<'a>: SubTrait;
+    type SubType<'a>: SubTrait where Self: 'a;
 
     fn get_sub<'a>(&'a mut self) -> Self::SubType<'a>;
 }

--- a/src/test/ui/generic-associated-types/issue-76535.stderr
+++ b/src/test/ui/generic-associated-types/issue-76535.stderr
@@ -7,7 +7,7 @@ LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruc
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/issue-76535.rs:6:10
    |
-LL |     type SubType<'a>: SubTrait;
+LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ --
 help: add missing lifetime argument
    |
@@ -25,7 +25,7 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
 LL | pub trait SuperTrait {
    |           ---------- this trait cannot be made into an object...
-LL |     type SubType<'a>: SubTrait;
+LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
 
@@ -40,7 +40,7 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
 LL | pub trait SuperTrait {
    |           ---------- this trait cannot be made into an object...
-LL |     type SubType<'a>: SubTrait;
+LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
    = note: required because of the requirements on the impl of `CoerceUnsized<Box<dyn SuperTrait<SubType = SubStruct<'_>>>>` for `Box<SuperStruct>`

--- a/src/test/ui/generic-associated-types/issue-79422.rs
+++ b/src/test/ui/generic-associated-types/issue-79422.rs
@@ -17,12 +17,12 @@ impl<'a, T> RefCont<'a, T> for Box<T> {
 }
 
 trait MapLike<K, V> {
-    type VRefCont<'a>: RefCont<'a, V>;
+    type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
     fn get<'a>(&'a self, key: &K) -> Option<Self::VRefCont<'a>>;
 }
 
 impl<K: Ord, V: 'static> MapLike<K, V> for std::collections::BTreeMap<K, V> {
-    type VRefCont<'a> = &'a V;
+    type VRefCont<'a> where Self: 'a = &'a V;
     fn get<'a>(&'a self, key: &K) -> Option<&'a V> {
         std::collections::BTreeMap::get(self, key)
     }

--- a/src/test/ui/generic-associated-types/issue-79422.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.stderr
@@ -7,7 +7,7 @@ LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/issue-79422.rs:20:10
    |
-LL |     type VRefCont<'a>: RefCont<'a, V>;
+LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ --
 help: add missing lifetime argument
    |
@@ -25,7 +25,7 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
 LL | trait MapLike<K, V> {
    |       ------- this trait cannot be made into an object...
-LL |     type VRefCont<'a>: RefCont<'a, V>;
+LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
 
@@ -40,7 +40,7 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
 LL | trait MapLike<K, V> {
    |       ------- this trait cannot be made into an object...
-LL |     type VRefCont<'a>: RefCont<'a, V>;
+LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
    = note: required because of the requirements on the impl of `CoerceUnsized<Box<dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>>>` for `Box<BTreeMap<u8, u8>>`

--- a/src/test/ui/generic-associated-types/issue-86787.rs
+++ b/src/test/ui/generic-associated-types/issue-86787.rs
@@ -9,6 +9,7 @@ enum Either<L, R> {
 pub trait HasChildrenOf {
     type T;
     type TRef<'a>;
+    //~^ Missing required bounds
 
     fn ref_children<'a>(&'a self) -> Vec<Self::TRef<'a>>;
     fn take_children(self) -> Vec<Self::T>;
@@ -20,9 +21,9 @@ where
     Right: HasChildrenOf,
 {
     type T = Either<Left::T, Right::T>;
+    // We used to error below because the where clause doesn't match the trait.
+    // Now, we error early on the trait itself.
     type TRef<'a>
-    //~^ `impl` associated type signature
-    //~^^ `impl` associated type signature
     where
     <Left as HasChildrenOf>::T: 'a,
     <Right as HasChildrenOf>::T: 'a

--- a/src/test/ui/generic-associated-types/issue-86787.stderr
+++ b/src/test/ui/generic-associated-types/issue-86787.stderr
@@ -1,32 +1,10 @@
-error: `impl` associated type signature for `TRef` doesn't match `trait` associated type signature
-  --> $DIR/issue-86787.rs:23:5
+error: Missing required bounds on TRef
+  --> $DIR/issue-86787.rs:11:5
    |
-LL |       type TRef<'a>;
-   |       -------------- expected
-...
-LL | /     type TRef<'a>
-LL | |
-LL | |
-LL | |     where
-LL | |     <Left as HasChildrenOf>::T: 'a,
-LL | |     <Right as HasChildrenOf>::T: 'a
-LL | |     = Either<&'a Left::T, &'a Right::T>;
-   | |________________________________________^ found
+LL |     type TRef<'a>;
+   |     ^^^^^^^^^^^^^-
+   |                  |
+   |                  help: add the required where clauses: `where Self: 'a`
 
-error: `impl` associated type signature for `TRef` doesn't match `trait` associated type signature
-  --> $DIR/issue-86787.rs:23:5
-   |
-LL |       type TRef<'a>;
-   |       -------------- expected
-...
-LL | /     type TRef<'a>
-LL | |
-LL | |
-LL | |     where
-LL | |     <Left as HasChildrenOf>::T: 'a,
-LL | |     <Right as HasChildrenOf>::T: 'a
-LL | |     = Either<&'a Left::T, &'a Right::T>;
-   | |________________________________________^ found
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-88287.rs
+++ b/src/test/ui/generic-associated-types/issue-88287.rs
@@ -13,7 +13,8 @@ trait SearchableResource<Criteria> {
 trait SearchableResourceExt<Criteria>: SearchableResource<Criteria> {
     type Future<'f, A: 'f + ?Sized, B: 'f>: Future<Output = Result<Vec<A::SearchResult>, ()>> + 'f
     where
-        A: SearchableResource<B>;
+        A: SearchableResource<B>,
+        Self: 'f;
 
     fn search<'c>(&'c self, client: &'c ()) -> Self::Future<'c, Self, Criteria>;
 }
@@ -29,6 +30,7 @@ where
     type Future<'f, A, B: 'f>
     where
         A: SearchableResource<B> + ?Sized + 'f,
+        Self: 'f,
     = SearchFutureTy<'f, A, B>;
 
     fn search<'c>(&'c self, _client: &'c ()) -> Self::Future<'c, Self, Criteria> {

--- a/src/test/ui/generic-associated-types/issue-88360.rs
+++ b/src/test/ui/generic-associated-types/issue-88360.rs
@@ -1,13 +1,14 @@
 #![feature(generic_associated_types)]
 
 trait GatTrait {
-    type Gat<'a>;
+    type Gat<'a> where Self: 'a;
 
     fn test(&self) -> Self::Gat<'_>;
 }
 
 trait SuperTrait<T>
 where
+    Self: 'static,
     for<'a> Self: GatTrait<Gat<'a> = &'a T>,
 {
     fn copy(&self) -> Self::Gat<'_> where T: Copy {

--- a/src/test/ui/generic-associated-types/issue-88360.stderr
+++ b/src/test/ui/generic-associated-types/issue-88360.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-88360.rs:14:9
+  --> $DIR/issue-88360.rs:15:9
    |
 LL | trait SuperTrait<T>
    |                  - this type parameter

--- a/src/test/ui/generic-associated-types/projection-type-lifetime-mismatch.rs
+++ b/src/test/ui/generic-associated-types/projection-type-lifetime-mismatch.rs
@@ -1,7 +1,7 @@
 #![feature(generic_associated_types)]
 
 pub trait X {
-    type Y<'a>;
+    type Y<'a> where Self: 'a;
     fn m(&self) -> Self::Y<'_>;
 }
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -45,7 +45,6 @@ trait Deserializer3<T, U> {
 
 trait Deserializer4 {
     type Out<'x>;
-    //~^ Missing bound
     fn deserialize<'a, T>(&self, input: &'a T) -> Self::Out<'a>;
 }
 
@@ -53,7 +52,6 @@ struct Wrap<T>(T);
 
 trait Des {
     type Out<'x, D>;
-    //~^ Missing bound
     fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, Wrap<T>>;
 }
 /*
@@ -92,5 +90,5 @@ impl Des3 for () {
     }
 }
 */
-  
+
 fn main() {}

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -109,6 +109,7 @@ trait NoGat<'a> {
 }
 
 // Lifetime is not on function; except `Self: 'a`
+// FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetime<'a> {
     type Bar<'b>;
     //~^ Missing required bounds
@@ -116,6 +117,7 @@ trait TraitLifetime<'a> {
 }
 
 // Like above, but we have a where clause that can prove what we want
+// FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetimeWhere<'a> where Self: 'a {
     type Bar<'b>;
     //~^ Missing required bounds

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -4,6 +4,7 @@
 
 trait Iterable {
     type Item<'x>;
+    //~^ Missing bound
     fn iter<'a>(&'a self) -> Self::Item<'a>;
 }
 
@@ -18,6 +19,7 @@ impl<T> Iterable for T {
 
 trait Deserializer<T> {
     type Out<'x>;
+    //~^ Missing bound
     fn deserialize<'a>(&self, input: &'a T) -> Self::Out<'a>;
 }
 
@@ -30,12 +32,65 @@ impl<T> Deserializer<T> for () {
 
 trait Deserializer2<T> {
     type Out<'x>;
+    //~^ Missing bound
     fn deserialize2<'a, 'b: 'a>(&self, input: &'a T, input2: &'b T) -> Self::Out<'a>;
 }
 
 trait Deserializer3<T, U> {
     type Out<'x, 'y>;
+    //~^ Missing bound
+    //~^^ Missing bound
     fn deserialize2<'a, 'b>(&self, input: &'a T, input2: &'b U) -> Self::Out<'a, 'b>;
 }
 
+trait Deserializer4 {
+    type Out<'x>;
+    //~^ Missing bound
+    fn deserialize<'a, T>(&self, input: &'a T) -> Self::Out<'a>;
+}
+
+struct Wrap<T>(T);
+
+trait Des {
+    type Out<'x, D>;
+    //~^ Missing bound
+    fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, Wrap<T>>;
+}
+/*
+impl Des for () {
+    type Out<'x, D> = &'x D;
+    fn des<'a, T>(&self, data: &'a Wrap<T>) -> Self::Out<'a, Wrap<T>> {
+        data
+    }
+}
+*/
+
+trait Des2 {
+    type Out<'x, D>;
+    //~^ Missing bound
+    fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, T>;
+}
+/*
+impl Des2 for () {
+    type Out<'x, D> = &'x D;
+    fn des<'a, T>(&self, data: &'a Wrap<T>) -> Self::Out<'a, T> {
+        data
+    }
+}
+*/
+
+trait Des3 {
+    type Out<'x, D>;
+    //~^ Missing bound
+    fn des<'z, T>(&self, data: &'z T) -> Self::Out<'z, T>;
+}
+/*
+impl Des3 for () {
+    type Out<'x, D> = &'x D;
+    fn des<'a, T>(&self, data: &'a T) -> Self::Out<'a, T> {
+          data
+    }
+}
+*/
+  
 fn main() {}

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -1,0 +1,41 @@
+#![feature(generic_associated_types)]
+
+// check-fail
+
+trait Iterable {
+    type Item<'x>;
+    fn iter<'a>(&'a self) -> Self::Item<'a>;
+}
+
+/*
+impl<T> Iterable for T {
+    type Item<'a> = &'a T;
+    fn iter<'a>(&'a self) -> Self::Item<'a> {
+        self
+    }
+}
+*/
+
+trait Deserializer<T> {
+    type Out<'x>;
+    fn deserialize<'a>(&self, input: &'a T) -> Self::Out<'a>;
+}
+
+/*
+impl<T> Deserializer<T> for () {
+    type Out<'a> = &'a T;
+    fn deserialize<'a>(&self, input: &'a T) -> Self::Out<'a> { input }
+}
+*/
+
+trait Deserializer2<T> {
+    type Out<'x>;
+    fn deserialize2<'a, 'b: 'a>(&self, input: &'a T, input2: &'b T) -> Self::Out<'a>;
+}
+
+trait Deserializer3<T, U> {
+    type Out<'x, 'y>;
+    fn deserialize2<'a, 'b>(&self, input: &'a T, input2: &'b U) -> Self::Out<'a, 'b>;
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -54,10 +54,10 @@ trait Deserializer4 {
 
 struct Wrap<T>(T);
 
-// Even though we might theoretically want `D: 'x`, because we pass `Wrap<T>` and
-// we see `&'z Wrap<T>`, we are conservative and only add bounds for direct params
+// We pass `Wrap<T>` and we see `&'z Wrap<T>`, so we require `D: 'x`
 trait Des {
     type Out<'x, D>;
+    //~^ Missing required bounds
     fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, Wrap<T>>;
 }
 /*

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -16,12 +16,6 @@ error: Missing bound: T: 'x
 LL |     type Out<'x>;
    |             ^^^^
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:40:13
-   |
-LL |     type Out<'x, 'y>;
-   |             ^^^^^^^^
-
 error: Missing bound: U: 'y
   --> $DIR/self-outlives-lint.rs:40:13
    |
@@ -29,28 +23,22 @@ LL |     type Out<'x, 'y>;
    |             ^^^^^^^^
 
 error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:47:13
+  --> $DIR/self-outlives-lint.rs:40:13
    |
-LL |     type Out<'x>;
-   |             ^^^^
+LL |     type Out<'x, 'y>;
+   |             ^^^^^^^^
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:55:13
-   |
-LL |     type Out<'x, D>;
-   |             ^^^^^^^
-
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:69:13
+error: Missing bound: D: 'x
+  --> $DIR/self-outlives-lint.rs:67:13
    |
 LL |     type Out<'x, D>;
    |             ^^^^^^^
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:83:13
+error: Missing bound: D: 'x
+  --> $DIR/self-outlives-lint.rs:81:13
    |
 LL |     type Out<'x, D>;
    |             ^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -86,5 +86,13 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |                                                       |
    |                                                       help: add the required where clauses: `where Self: 'a`
 
-error: aborting due to 11 previous errors
+error: Missing required bounds on Bar
+  --> $DIR/self-outlives-lint.rs:148:5
+   |
+LL |     type Bar<'a, 'b>;
+   |     ^^^^^^^^^^^^^^^^-
+   |                     |
+   |                     help: add the required where clauses: `where 'a: 'b`
+
+error: aborting due to 12 previous errors
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,0 +1,56 @@
+error: Missing bound: Self: 'x
+  --> $DIR/self-outlives-lint.rs:6:14
+   |
+LL |     type Item<'x>;
+   |              ^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:21:13
+   |
+LL |     type Out<'x>;
+   |             ^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:34:13
+   |
+LL |     type Out<'x>;
+   |             ^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:40:13
+   |
+LL |     type Out<'x, 'y>;
+   |             ^^^^^^^^
+
+error: Missing bound: U: 'y
+  --> $DIR/self-outlives-lint.rs:40:13
+   |
+LL |     type Out<'x, 'y>;
+   |             ^^^^^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:47:13
+   |
+LL |     type Out<'x>;
+   |             ^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:55:13
+   |
+LL |     type Out<'x, D>;
+   |             ^^^^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:69:13
+   |
+LL |     type Out<'x, D>;
+   |             ^^^^^^^
+
+error: Missing bound: T: 'x
+  --> $DIR/self-outlives-lint.rs:83:13
+   |
+LL |     type Out<'x, D>;
+   |             ^^^^^^^
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,44 +1,50 @@
-error: Missing bound: Self: 'x
-  --> $DIR/self-outlives-lint.rs:6:14
+error: Missing required bounds on Item
+  --> $DIR/self-outlives-lint.rs:7:5
    |
 LL |     type Item<'x>;
-   |              ^^^^
+   |     ^^^^^^^^^^^^^-
+   |                  |
+   |                  help: add the required where clauses: `where Self: 'x`
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:21:13
+error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:23:5
    |
 LL |     type Out<'x>;
-   |             ^^^^
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clauses: `where T: 'x`
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:34:13
+error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:37:5
    |
 LL |     type Out<'x>;
-   |             ^^^^
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clauses: `where T: 'x`
 
-error: Missing bound: U: 'y
-  --> $DIR/self-outlives-lint.rs:40:13
+error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:44:5
    |
 LL |     type Out<'x, 'y>;
-   |             ^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^-
+   |                     |
+   |                     help: add the required where clauses: `where U: 'y, T: 'x`
 
-error: Missing bound: T: 'x
-  --> $DIR/self-outlives-lint.rs:40:13
-   |
-LL |     type Out<'x, 'y>;
-   |             ^^^^^^^^
-
-error: Missing bound: D: 'x
-  --> $DIR/self-outlives-lint.rs:67:13
+error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:75:5
    |
 LL |     type Out<'x, D>;
-   |             ^^^^^^^
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clauses: `where D: 'x`
 
-error: Missing bound: D: 'x
-  --> $DIR/self-outlives-lint.rs:81:13
+error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:90:5
    |
 LL |     type Out<'x, D>;
-   |             ^^^^^^^
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clauses: `where D: 'x`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -28,7 +28,7 @@ error: Missing required bounds on Out
 LL |     type Out<'x, 'y>;
    |     ^^^^^^^^^^^^^^^^-
    |                     |
-   |                     help: add the required where clauses: `where U: 'y, T: 'x`
+   |                     help: add the required where clauses: `where T: 'x, U: 'y`
 
 error: Missing required bounds on Out
   --> $DIR/self-outlives-lint.rs:61:5
@@ -55,23 +55,23 @@ LL |     type Out<'x, D>;
    |                    help: add the required where clauses: `where D: 'x`
 
 error: Missing required bounds on Bar
-  --> $DIR/self-outlives-lint.rs:113:5
+  --> $DIR/self-outlives-lint.rs:114:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where Self: 'b, Self: 'a`
+   |                 help: add the required where clauses: `where Self: 'a, Self: 'b`
 
 error: Missing required bounds on Bar
-  --> $DIR/self-outlives-lint.rs:120:5
+  --> $DIR/self-outlives-lint.rs:122:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where Self: 'b, Self: 'a`
+   |                 help: add the required where clauses: `where Self: 'a, Self: 'b`
 
 error: Missing required bounds on Bar
-  --> $DIR/self-outlives-lint.rs:127:5
+  --> $DIR/self-outlives-lint.rs:129:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -79,7 +79,7 @@ LL |     type Bar<'b>;
    |                 help: add the required where clauses: `where Self: 'b`
 
 error: Missing required bounds on Iterator
-  --> $DIR/self-outlives-lint.rs:141:5
+  --> $DIR/self-outlives-lint.rs:143:5
    |
 LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -87,7 +87,7 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |                                                       help: add the required where clauses: `where Self: 'a`
 
 error: Missing required bounds on Bar
-  --> $DIR/self-outlives-lint.rs:148:5
+  --> $DIR/self-outlives-lint.rs:150:5
    |
 LL |     type Bar<'a, 'b>;
    |     ^^^^^^^^^^^^^^^^-

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,5 +1,5 @@
 error: Missing required bounds on Item
-  --> $DIR/self-outlives-lint.rs:7:5
+  --> $DIR/self-outlives-lint.rs:9:5
    |
 LL |     type Item<'x>;
    |     ^^^^^^^^^^^^^-
@@ -7,7 +7,7 @@ LL |     type Item<'x>;
    |                  help: add the required where clauses: `where Self: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:23:5
+  --> $DIR/self-outlives-lint.rs:25:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -15,7 +15,7 @@ LL |     type Out<'x>;
    |                 help: add the required where clauses: `where T: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:37:5
+  --> $DIR/self-outlives-lint.rs:39:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -23,7 +23,7 @@ LL |     type Out<'x>;
    |                 help: add the required where clauses: `where T: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:44:5
+  --> $DIR/self-outlives-lint.rs:46:5
    |
 LL |     type Out<'x, 'y>;
    |     ^^^^^^^^^^^^^^^^-
@@ -31,7 +31,7 @@ LL |     type Out<'x, 'y>;
    |                     help: add the required where clauses: `where U: 'y, T: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:59:5
+  --> $DIR/self-outlives-lint.rs:61:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -39,7 +39,7 @@ LL |     type Out<'x, D>;
    |                    help: add the required where clauses: `where D: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:75:5
+  --> $DIR/self-outlives-lint.rs:77:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -47,12 +47,44 @@ LL |     type Out<'x, D>;
    |                    help: add the required where clauses: `where D: 'x`
 
 error: Missing required bounds on Out
-  --> $DIR/self-outlives-lint.rs:90:5
+  --> $DIR/self-outlives-lint.rs:92:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
    |                    |
    |                    help: add the required where clauses: `where D: 'x`
 
-error: aborting due to 7 previous errors
+error: Missing required bounds on Bar
+  --> $DIR/self-outlives-lint.rs:113:5
+   |
+LL |     type Bar<'b>;
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clauses: `where Self: 'b, Self: 'a`
+
+error: Missing required bounds on Bar
+  --> $DIR/self-outlives-lint.rs:120:5
+   |
+LL |     type Bar<'b>;
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clauses: `where Self: 'b, Self: 'a`
+
+error: Missing required bounds on Bar
+  --> $DIR/self-outlives-lint.rs:127:5
+   |
+LL |     type Bar<'b>;
+   |     ^^^^^^^^^^^^-
+   |                 |
+   |                 help: add the required where clauses: `where Self: 'b`
+
+error: Missing required bounds on Iterator
+  --> $DIR/self-outlives-lint.rs:141:5
+   |
+LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                       |
+   |                                                       help: add the required where clauses: `where Self: 'a`
+
+error: aborting due to 11 previous errors
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -31,6 +31,14 @@ LL |     type Out<'x, 'y>;
    |                     help: add the required where clauses: `where U: 'y, T: 'x`
 
 error: Missing required bounds on Out
+  --> $DIR/self-outlives-lint.rs:59:5
+   |
+LL |     type Out<'x, D>;
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clauses: `where D: 'x`
+
+error: Missing required bounds on Out
   --> $DIR/self-outlives-lint.rs:75:5
    |
 LL |     type Out<'x, D>;
@@ -46,5 +54,5 @@ LL |     type Out<'x, D>;
    |                    |
    |                    help: add the required where clauses: `where D: 'x`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/generic-associated-types/streaming_iterator.rs
+++ b/src/test/ui/generic-associated-types/streaming_iterator.rs
@@ -5,12 +5,12 @@
 use std::fmt::Display;
 
 trait StreamingIterator {
-    type Item<'a>;
+    type Item<'a> where Self: 'a;
     // Applying the lifetime parameter `'a` to `Self::Item` inside the trait.
     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>>;
 }
 
-struct Foo<T: StreamingIterator> {
+struct Foo<T: StreamingIterator + 'static> {
     // Applying a concrete lifetime to the constructor outside the trait.
     bar: <T as StreamingIterator>::Item<'static>,
 }
@@ -30,7 +30,7 @@ struct StreamEnumerate<I> {
 }
 
 impl<I: StreamingIterator> StreamingIterator for StreamEnumerate<I> {
-    type Item<'a> = (usize, I::Item<'a>);
+    type Item<'a> where Self: 'a = (usize, I::Item<'a>);
     fn next<'a>(&'a mut self) -> Option<Self::Item<'a>> {
         match self.iter.next() {
             None => None,
@@ -44,7 +44,7 @@ impl<I: StreamingIterator> StreamingIterator for StreamEnumerate<I> {
 }
 
 impl<I: Iterator> StreamingIterator for I {
-    type Item<'a> = <I as Iterator>::Item;
+    type Item<'a> where Self: 'a = <I as Iterator>::Item;
     fn next(&mut self) -> Option<<I as StreamingIterator>::Item<'_>> {
         Iterator::next(self)
     }

--- a/src/test/ui/generic-associated-types/variance_constraints.rs
+++ b/src/test/ui/generic-associated-types/variance_constraints.rs
@@ -3,7 +3,7 @@
 #![feature(generic_associated_types)]
 
 trait A {
-    type B<'a>;
+    type B<'a> where Self: 'a;
 
     fn make_b<'a>(&'a self) -> Self::B<'a>;
 }


### PR DESCRIPTION
See #87479 for background. Closes #87479

The basic premise of this lint/error is to require the user to write where clauses on a GAT when those bounds can be implied or proven from any function on the trait returning that GAT.

## Intuitive Explanation (Attempt) ##
Let's take this trait definition as an example:
```rust
trait Iterable {
    type Item<'x>;
    fn iter<'a>(&'a self) -> Self::Item<'a>;
}
```
Let's focus on the `iter` function. The first thing to realize is that we know that `Self: 'a` because of `&'a self`. If an impl wants `Self::Item` to contain any data with references, then those references must be derived from `&'a self`. Thus, they must live only as long as `'a`. Furthermore, because of the `Self: 'a` implied bound, they must live only as long as `Self`. Since it's `'a` is used in place of `'x`, it is reasonable to assume that any value of `Self::Item<'x>`, and thus `'x`, will only be able to live as long as `Self`. Therefore, we require this bound on `Item` in the trait.

As another example:
```rust
trait Deserializer<T> {
    type Out<'x>;
    fn deserialize<'a>(&self, input: &'a T) -> Self::Out<'a>;
}
```
The intuition is similar here, except rather than a `Self: 'a` implied bound, we have a `T: 'a` implied bound. Thus, the data on `Self::Out<'a>` is derived from `&'a T`, and thus it is reasonable to expect that the lifetime `'x` will always be less than `T`.

## Implementation Algorithm ##
* Given a GAT `<P0 as Trait<P1..Pi>>::G<Pi...Pn>` declared as `trait T<A1..Ai> for A0 { type G<Ai...An>; }` used in return type of one associated function `F`
* Given env `E` (including implied bounds) for `F`
* For each lifetime parameter `'a` in `P0...Pn`:
    * For each other type parameter `Pi != 'a` in `P0...Pn`: // FIXME: this include of lifetime parameters too
        * If `E => (P: 'a)`:
            * Require where clause `Ai: 'a`

## Follow-up questions ##
* What should we do when we don't pass params exactly?
For this example:
```rust
trait Des {
    type Out<'x, D>;
    fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, Wrap<T>>;
}
```
Should we be requiring a `D: 'x` clause? We pass `Wrap<T>` as `D` and `'z` as `'x`, and should be able to prove that `Wrap<T>: 'z`.


r? @nikomatsakis 