### PR TITLE
Nicer error message if the user attempts to do let...else if

### DIFF
--- a/src/test/ui/let-else/let-else-if.rs
+++ b/src/test/ui/let-else/let-else-if.rs
@@ -1,0 +1,10 @@
+#![feature(let_else)]
+
+fn main() {
+    let Some(_) = Some(()) else if true {
+        //~^ ERROR conditional `else if` is not supported for `let...else`
+        return;
+    } else {
+        return;
+    };
+}

--- a/src/test/ui/let-else/let-else-if.stderr
+++ b/src/test/ui/let-else/let-else-if.stderr
@@ -1,0 +1,18 @@
+error: conditional `else if` is not supported for `let...else`
+  --> $DIR/let-else-if.rs:4:33
+   |
+LL |     let Some(_) = Some(()) else if true {
+   |                                 ^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL ~     let Some(_) = Some(()) else { if true {
+LL +
+LL +         return;
+LL +     } else {
+LL +         return;
+LL ~     } };
+   |
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Gives a nice "conditional `else if` is not supported for `let...else`" error when encountering a `let...else if` pattern, as suggested in the [let...else tracking issue](https://github.com/rust-lang/rust/issues/87335#issuecomment-944846205).