### PR TITLE
Make Result::as_mut const

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -729,7 +729,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn as_mut(&mut self) -> Result<&mut T, &mut E> {
+    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    pub const fn as_mut(&mut self) -> Result<&mut T, &mut E> {
         match *self {
             Ok(ref mut x) => Ok(x),
             Err(ref mut x) => Err(x),

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -65,6 +65,7 @@
 #![feature(once_cell)]
 #![feature(unsized_tuple_coercion)]
 #![feature(const_option)]
+#![feature(const_result)]
 #![feature(integer_atomics)]
 #![feature(int_roundings)]
 #![feature(slice_group_by)]

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -353,6 +353,29 @@ fn result_const() {
 }
 
 #[test]
+const fn result_const_mut() {
+    let mut result: Result<usize, bool> = Ok(32);
+
+    {
+        let as_mut = result.as_mut();
+        match as_mut {
+            Ok(v) => *v = 42,
+            Err(_) => unreachable!(),
+        }
+    }
+
+    let mut result_err: Result<usize, bool> = Err(false);
+
+    {
+        let as_mut = result_err.as_mut();
+        match as_mut {
+            Ok(_) => unreachable!(),
+            Err(v) => *v = true,
+        }
+    }
+}
+
+#[test]
 fn result_opt_conversions() {
     #[derive(Copy, Clone, Debug, PartialEq)]
     struct BadNumErr;


### PR DESCRIPTION
Adding `const` for `Result::as_mut`.

Tracking issue: #82814