### PR TITLE
Avoid copies while creating the metadata object file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,11 +2306,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "compiler_builtins",
- "crc32fast",
- "indexmap",
  "memchr",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "object"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c821014c18301591b89b843809ef953af9e3df0496c232d5c0611b0a52aac363"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -3706,7 +3715,7 @@ dependencies = [
  "itertools 0.9.0",
  "jobserver",
  "libc",
- "object",
+ "object 0.27.0",
  "pathdiff",
  "regex",
  "rustc_apfloat",
@@ -4984,7 +4993,7 @@ dependencies = [
  "hermit-abi",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.26.2",
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -38,6 +38,6 @@ rustc_target = { path = "../rustc_target" }
 rustc_session = { path = "../rustc_session" }
 
 [dependencies.object]
-version = "0.26.2"
+version = "0.27"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "unaligned", "archive", "write"]

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -327,8 +327,9 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             // metadata in rlib files is wrapped in a "dummy" object file for
             // the target platform so the rlib can be processed entirely by
             // normal linkers for the platform.
-            let metadata = create_metadata_file(sess, codegen_results.metadata.raw_data());
-            ab.add_file(&emit_metadata(sess, &metadata, tmpdir));
+            let out_filename = tmpdir.as_ref().join(METADATA_FILENAME);
+            create_metadata_file(sess, codegen_results.metadata.raw_data(), &out_filename);
+            ab.add_file(&out_filename);
 
             // After adding all files to the archive, we need to update the
             // symbol table of the archive. This currently dies on macOS (see
@@ -382,7 +383,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
     //
     // Note that this metdata format is kept in sync with
     // `rustc_codegen_ssa/src/back/metadata.rs`.
-    fn create_metadata_file(sess: &Session, metadata: &[u8]) -> Vec<u8> {
+    fn create_metadata_file(sess: &Session, metadata: &[u8], out_filename: &Path) {
         let endianness = match sess.target.options.endian {
             Endian::Little => Endianness::Little,
             Endian::Big => Endianness::Big,
@@ -423,16 +424,21 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             // WebAssembly and for targets not supported by the `object` crate
             // yet it means that work will need to be done in the `object` crate
             // to add a case above.
-            _ => return metadata.to_vec(),
+            _ => {
+                if let Err(e) = fs::write(out_filename, metadata) {
+                    sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e));
+                }
+                return;
+            }
         };
 
-        if sess.target.is_like_osx {
+        let file = if sess.target.is_like_osx {
             let mut file = Object::new(BinaryFormat::MachO, architecture, endianness);
 
             let section =
                 file.add_section(b"__DWARF".to_vec(), b".rmeta".to_vec(), SectionKind::Debug);
             file.append_section_data(section, metadata, 1);
-            file.write().unwrap()
+            file
         } else if sess.target.is_like_windows {
             const IMAGE_SCN_LNK_REMOVE: u32 = 0;
             let mut file = Object::new(BinaryFormat::Coff, architecture, endianness);
@@ -441,7 +447,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             file.section_mut(section).flags =
                 SectionFlags::Coff { characteristics: IMAGE_SCN_LNK_REMOVE };
             file.append_section_data(section, metadata, 1);
-            file.write().unwrap()
+            file
         } else {
             const SHF_EXCLUDE: u64 = 0x80000000;
             let mut file = Object::new(BinaryFormat::Elf, architecture, endianness);
@@ -473,7 +479,14 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             let section = file.add_section(Vec::new(), b".rmeta".to_vec(), SectionKind::Debug);
             file.section_mut(section).flags = SectionFlags::Elf { sh_flags: SHF_EXCLUDE };
             file.append_section_data(section, metadata, 1);
-            file.write().unwrap()
+            file
+        };
+        let out_file = match fs::File::create(out_filename) {
+            Ok(out_file) => io::BufWriter::new(out_file),
+            Err(e) => sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e)),
+        };
+        if let Err(e) = file.write_stream(out_file) {
+            sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e));
         }
     }
 }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -437,7 +437,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
 
             let section =
                 file.add_section(b"__DWARF".to_vec(), b".rmeta".to_vec(), SectionKind::Debug);
-            file.append_section_data(section, metadata, 1);
+            file.set_section_data(section, metadata, 1);
             file
         } else if sess.target.is_like_windows {
             const IMAGE_SCN_LNK_REMOVE: u32 = 0;
@@ -446,7 +446,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             let section = file.add_section(Vec::new(), b".rmeta".to_vec(), SectionKind::Debug);
             file.section_mut(section).flags =
                 SectionFlags::Coff { characteristics: IMAGE_SCN_LNK_REMOVE };
-            file.append_section_data(section, metadata, 1);
+            file.set_section_data(section, metadata, 1);
             file
         } else {
             const SHF_EXCLUDE: u64 = 0x80000000;
@@ -478,7 +478,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
 
             let section = file.add_section(Vec::new(), b".rmeta".to_vec(), SectionKind::Debug);
             file.section_mut(section).flags = SectionFlags::Elf { sh_flags: SHF_EXCLUDE };
-            file.append_section_data(section, metadata, 1);
+            file.set_section_data(section, metadata, 1);
             file
         };
         let out_file = match fs::File::create(out_filename) {


### PR DESCRIPTION
This is now possible thanks to https://github.com/gimli-rs/object/pull/369 and https://github.com/gimli-rs/object/pull/370.