### PR TITLE
Cleanup: Get rid of -static-libstdc++ argument unused warning

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -515,7 +515,8 @@ fn configure_cmake(
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");
     if builder.config.llvm_static_stdcpp && !target.contains("msvc") && !target.contains("netbsd") {
-        cxxflags.push_str(" -static-libstdc++");
+        cfg.define("CMAKE_SHARED_LINKER_FLAGS", "-static-libstdc++");
+        cfg.define("CMAKE_EXE_LINKER_FLAGS", "-static-libstdc++");
     }
     if let Some(ref s) = builder.config.llvm_cxxflags {
         cxxflags.push_str(&format!(" {}", s));


### PR DESCRIPTION
Building llvm with llvm.static-libstdcpp enabled leads to lots of warnings like this as this is linker-only option:
```
warning: argument unused during compilation: '-static-libstdc++' [-Wunused-command-line-argument]
```
 Just setting it for linking shared libraries and executables gets rid of the warning.

@rustbot label +A-rustbuild +C-cleanup +T-infra