### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast/src/util/parser.rs
+++ b/compiler/rustc_ast/src/util/parser.rs
@@ -357,13 +357,13 @@ impl ExprPrecedence {
     }
 }
 
-/// In `let p = e`, operators with precedence `<=` this one requires parenthesis in `e`.
+/// In `let p = e`, operators with precedence `<=` this one requires parentheses in `e`.
 pub fn prec_let_scrutinee_needs_par() -> usize {
     AssocOp::LAnd.precedence()
 }
 
 /// Suppose we have `let _ = e` and the `order` of `e`.
-/// Is the `order` such that `e` in `let _ = e` needs parenthesis when it is on the RHS?
+/// Is the `order` such that `e` in `let _ = e` needs parentheses when it is on the RHS?
 ///
 /// Conversely, suppose that we have `(let _ = a) OP b` and `order` is that of `OP`.
 /// Can we print this as `let _ = a OP b`?

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -113,7 +113,7 @@ impl<'a> AstValidator<'a> {
         if sess.opts.unstable_features.is_nightly_build() {
             sess.struct_span_err(expr.span, "`let` expressions are not supported here")
                 .note("only supported directly in conditions of `if`- and `while`-expressions")
-                .note("as well as when nested within `&&` and parenthesis in those conditions")
+                .note("as well as when nested within `&&` and parentheses in those conditions")
                 .emit();
         } else {
             sess.struct_span_err(expr.span, "expected expression, found statement (`let`)")

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1675,7 +1675,7 @@ impl<'a> State<'a> {
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr))
     }
 
-    // Does `expr` need parenthesis when printed in a condition position?
+    // Does `expr` need parentheses when printed in a condition position?
     //
     // These cases need parens due to the parse error observed in #26461: `if return {}`
     // parses as the erroneous construct `if (return {})`, not `if (return) {}`.

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1168,7 +1168,7 @@ impl<'a> State<'a> {
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
     }
 
-    // Does `expr` need parenthesis when printed in a condition position?
+    // Does `expr` need parentheses when printed in a condition position?
     //
     // These cases need parens due to the parse error observed in #26461: `if return {}`
     // parses as the erroneous construct `if (return {})`, not `if (return) {}`.

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -670,7 +670,7 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// The parenthesis are not needed, and should be removed. This is the
+    /// The parentheses are not needed, and should be removed. This is the
     /// preferred style for writing these expressions.
     pub(super) UNUSED_PARENS,
     Warn,

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -350,18 +350,19 @@ pub trait PrettyPrinter<'tcx>:
             match self.tcx().extern_crate(def_id) {
                 Some(&ExternCrate { src, dependency_of, span, .. }) => match (src, dependency_of) {
                     (ExternCrateSource::Extern(def_id), LOCAL_CRATE) => {
-                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
-                        return Ok((
-                            if !span.is_dummy() {
-                                self.print_def_path(def_id, &[])?
-                            } else {
-                                self.path_crate(cnum)?
-                            },
-                            true,
-                        ));
+                        // NOTE(eddyb) the only reason `span` might be dummy,
+                        // that we're aware of, is that it's the `std`/`core`
+                        // `extern crate` injected by default.
+                        // FIXME(eddyb) find something better to key this on,
+                        // or avoid ending up with `ExternCrateSource::Extern`,
+                        // for the injected `std`/`core`.
+                        if span.is_dummy() {
+                            return Ok((self.path_crate(cnum)?, true));
+                        }
+
+                        return Ok((self.print_def_path(def_id, &[])?, true));
                     }
                     (ExternCrateSource::Path, LOCAL_CRATE) => {
-                        debug!("try_print_visible_def_path: def_id={:?}", def_id);
                         return Ok((self.path_crate(cnum)?, true));
                     }
                     _ => {}

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1342,10 +1342,10 @@ impl<'a> Parser<'a> {
 
                 self.struct_span_err(
                     MultiSpan::from_spans(vec![begin_par_sp, self.prev_token.span]),
-                    "unexpected parenthesis surrounding `for` loop head",
+                    "unexpected parentheses surrounding `for` loop head",
                 )
                 .multipart_suggestion(
-                    "remove parenthesis in `for` loop",
+                    "remove parentheses in `for` loop",
                     vec![(begin_par_sp, String::new()), (self.prev_token.span, String::new())],
                     // With e.g. `for (x) in y)` this would replace `(x) in y)`
                     // with `x) in y)` which is syntactically invalid.

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1258,7 +1258,7 @@ impl<'a> Parser<'a> {
     /// Parses `pub`, `pub(crate)` and `pub(in path)` plus shortcuts `crate` for `pub(crate)`,
     /// `pub(self)` for `pub(in self)` and `pub(super)` for `pub(in super)`.
     /// If the following element can't be a tuple (i.e., it's a function definition), then
-    /// it's not a tuple struct field), and the contents within the parentheses isn't valid,
+    /// it's not a tuple struct field), and the contents within the parentheses aren't valid,
     /// so emit a proper diagnostic.
     // Public for rustfmt usage.
     pub fn parse_visibility(&mut self, fbt: FollowedByType) -> PResult<'a, Visibility> {

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -328,7 +328,7 @@ impl<'a> Parser<'a> {
                     ),
                 )
                 .multipart_suggestion(
-                    "wrap the expression in parenthesis",
+                    "wrap the expression in parentheses",
                     suggs,
                     Applicability::MachineApplicable,
                 )
@@ -349,7 +349,7 @@ impl<'a> Parser<'a> {
                 "right curly brace `}` before `else` in a `let...else` statement not allowed",
             )
             .multipart_suggestion(
-                "try wrapping the expression in parenthesis",
+                "try wrapping the expression in parentheses",
                 suggs,
                 Applicability::MachineApplicable,
             )

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -430,7 +430,7 @@ impl<'a> Parser<'a> {
     }
 
     // Parses the `typeof(EXPR)`.
-    // To avoid ambiguity, the type is surrounded by parenthesis.
+    // To avoid ambiguity, the type is surrounded by parentheses.
     fn parse_typeof_ty(&mut self) -> PResult<'a, TyKind> {
         self.expect(&token::OpenDelim(token::Paren))?;
         let expr = self.parse_anon_const_expr()?;

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1552,7 +1552,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
             matches!(source, PathSource::TupleStruct(..)) || source.is_call();
         if suggest_only_tuple_variants {
             // Suggest only tuple variants regardless of whether they have fields and do not
-            // suggest path with added parenthesis.
+            // suggest path with added parentheses.
             let mut suggestable_variants = variants
                 .iter()
                 .filter(|(.., kind)| *kind == CtorKind::Fn)

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -300,7 +300,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let end = callee_span.shrink_to_hi();
             err.multipart_suggestion(
                 "if you meant to create this closure and immediately call it, surround the \
-                closure with parenthesis",
+                closure with parentheses",
                 vec![(start, "(".to_string()), (end, ")".to_string())],
                 Applicability::MaybeIncorrect,
             );
@@ -383,7 +383,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         call_expr.span,
                         &format!(
                             "`{}` is a unit variant, you need to write it \
-                                 without the parenthesis",
+                                 without the parentheses",
                             path
                         ),
                         path.to_string(),

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -492,7 +492,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         other_ty: Ty<'tcx>,
         op: hir::BinOp,
         is_assign: IsAssign,
-    ) -> bool /* did we suggest to call a function because of missing parenthesis? */ {
+    ) -> bool /* did we suggest to call a function because of missing parentheses? */ {
         err.span_label(span, ty.to_string());
         if let FnDef(def_id, _) = *ty.kind() {
             let source_map = self.tcx.sess.source_map();

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -729,7 +729,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn as_mut(&mut self) -> Result<&mut T, &mut E> {
+    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    pub const fn as_mut(&mut self) -> Result<&mut T, &mut E> {
         match *self {
             Ok(ref mut x) => Ok(x),
             Err(ref mut x) => Err(x),

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2953,9 +2953,6 @@ impl<T> [T] {
     ///
     /// The length of `src` must be the same as `self`.
     ///
-    /// If `T` implements `Copy`, it can be more performant to use
-    /// [`copy_from_slice`].
-    ///
     /// # Panics
     ///
     /// This function will panic if the two slices have different lengths.

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -65,6 +65,7 @@
 #![feature(once_cell)]
 #![feature(unsized_tuple_coercion)]
 #![feature(const_option)]
+#![feature(const_result)]
 #![feature(integer_atomics)]
 #![feature(int_roundings)]
 #![feature(slice_group_by)]

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -353,6 +353,29 @@ fn result_const() {
 }
 
 #[test]
+const fn result_const_mut() {
+    let mut result: Result<usize, bool> = Ok(32);
+
+    {
+        let as_mut = result.as_mut();
+        match as_mut {
+            Ok(v) => *v = 42,
+            Err(_) => unreachable!(),
+        }
+    }
+
+    let mut result_err: Result<usize, bool> = Err(false);
+
+    {
+        let as_mut = result_err.as_mut();
+        match as_mut {
+            Ok(_) => unreachable!(),
+            Err(v) => *v = true,
+        }
+    }
+}
+
+#[test]
 fn result_opt_conversions() {
     #[derive(Copy, Clone, Debug, PartialEq)]
     struct BadNumErr;

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -492,10 +492,11 @@ class RustBuild(object):
 
     def downloading_llvm(self):
         opt = self.get_toml('download-ci-llvm', 'llvm')
-        # This is currently all tier 1 targets (since others may not have CI
-        # artifacts)
+        # This is currently all tier 1 targets and tier 2 targets with host tools
+        # (since others may not have CI artifacts)
         # https://doc.rust-lang.org/rustc/platform-support.html#tier-1
         supported_platforms = [
+            # tier 1
             "aarch64-unknown-linux-gnu",
             "i686-pc-windows-gnu",
             "i686-pc-windows-msvc",
@@ -504,6 +505,26 @@ class RustBuild(object):
             "x86_64-apple-darwin",
             "x86_64-pc-windows-gnu",
             "x86_64-pc-windows-msvc",
+            # tier 2 with host tools
+            "aarch64-apple-darwin",
+            "aarch64-pc-windows-msvc",
+            "aarch64-unknown-linux-musl",
+            "arm-unknown-linux-gnueabi",
+            "arm-unknown-linux-gnueabihf",
+            "armv7-unknown-linux-gnueabihf",
+            "mips-unknown-linux-gnu",
+            "mips64-unknown-linux-gnuabi64",
+            "mips64el-unknown-linux-gnuabi64",
+            "mipsel-unknown-linux-gnu",
+            "powerpc-unknown-linux-gnu",
+            "powerpc64-unknown-linux-gnu",
+            "powerpc64le-unknown-linux-gnu",
+            "riscv64gc-unknown-linux-gnu",
+            "s390x-unknown-linux-gnu",
+            "x86_64-unknown-freebsd",
+            "x86_64-unknown-illumos",
+            "x86_64-unknown-linux-musl",
+            "x86_64-unknown-netbsd",
         ]
         return opt == "true" \
             or (opt == "if-available" and self.build in supported_platforms)

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -765,10 +765,12 @@ impl Config {
             config.llvm_from_ci = match llvm.download_ci_llvm {
                 Some(StringOrBool::String(s)) => {
                     assert!(s == "if-available", "unknown option `{}` for download-ci-llvm", s);
-                    // This is currently all tier 1 targets (since others may not have CI artifacts)
+                    // This is currently all tier 1 targets and tier 2 targets with host tools
+                    // (since others may not have CI artifacts)
                     // https://doc.rust-lang.org/rustc/platform-support.html#tier-1
                     // FIXME: this is duplicated in bootstrap.py
                     let supported_platforms = [
+                        // tier 1
                         "aarch64-unknown-linux-gnu",
                         "i686-pc-windows-gnu",
                         "i686-pc-windows-msvc",
@@ -777,6 +779,26 @@ impl Config {
                         "x86_64-apple-darwin",
                         "x86_64-pc-windows-gnu",
                         "x86_64-pc-windows-msvc",
+                        // tier 2 with host tools
+                        "aarch64-apple-darwin",
+                        "aarch64-pc-windows-msvc",
+                        "aarch64-unknown-linux-musl",
+                        "arm-unknown-linux-gnueabi",
+                        "arm-unknown-linux-gnueabihf",
+                        "armv7-unknown-linux-gnueabihf",
+                        "mips-unknown-linux-gnu",
+                        "mips64-unknown-linux-gnuabi64",
+                        "mips64el-unknown-linux-gnuabi64",
+                        "mipsel-unknown-linux-gnu",
+                        "powerpc-unknown-linux-gnu",
+                        "powerpc64-unknown-linux-gnu",
+                        "powerpc64le-unknown-linux-gnu",
+                        "riscv64gc-unknown-linux-gnu",
+                        "s390x-unknown-linux-gnu",
+                        "x86_64-unknown-freebsd",
+                        "x86_64-unknown-illumos",
+                        "x86_64-unknown-linux-musl",
+                        "x86_64-unknown-netbsd",
                     ];
                     supported_platforms.contains(&&*config.build.triple)
                 }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -576,7 +576,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                                         rhs,
                                     });
                                     continue; // If something other than a Fn ends up
-                                    // with parenthesis, leave it alone
+                                    // with parentheses, leave it alone
                                 }
                             }
 

--- a/src/test/ui/empty/empty-struct-unit-expr.stderr
+++ b/src/test/ui/empty/empty-struct-unit-expr.stderr
@@ -20,7 +20,7 @@ LL |     let e4 = E::Empty4();
    |              |
    |              call expression requires function
    |
-help: `E::Empty4` is a unit variant, you need to write it without the parenthesis
+help: `E::Empty4` is a unit variant, you need to write it without the parentheses
    |
 LL |     let e4 = E::Empty4;
    |              ~~~~~~~~~
@@ -41,7 +41,7 @@ LL |     let xe4 = XE::XEmpty4();
    |               |
    |               call expression requires function
    |
-help: `XE::XEmpty4` is a unit variant, you need to write it without the parenthesis
+help: `XE::XEmpty4` is a unit variant, you need to write it without the parentheses
    |
 LL |     let xe4 = XE::XEmpty4;
    |               ~~~~~~~~~~~

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -9,7 +9,7 @@ LL |     X::Entry();
    |     |
    |     call expression requires function
    |
-help: `X::Entry` is a unit variant, you need to write it without the parenthesis
+help: `X::Entry` is a unit variant, you need to write it without the parentheses
    |
 LL |     X::Entry;
    |     ~~~~~~~~

--- a/src/test/ui/generic-associated-types/issue-85921.rs
+++ b/src/test/ui/generic-associated-types/issue-85921.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+trait Trait {
+    type Assoc<'a>;
+
+    fn with_assoc(f: impl FnOnce(Self::Assoc<'_>));
+}
+
+impl Trait for () {
+    type Assoc<'a> = i32;
+
+    fn with_assoc(f: impl FnOnce(Self::Assoc<'_>)) {
+        f(5i32)
+    }
+}
+
+fn main() {}

--- a/src/test/ui/let-else/let-else-bool-binop-init.stderr
+++ b/src/test/ui/let-else/let-else-bool-binop-init.stderr
@@ -4,7 +4,7 @@ error: a `&&` expression cannot be directly assigned in `let...else`
 LL |     let true = true && false else { return };
    |                ^^^^^^^^^^^^^
    |
-help: wrap the expression in parenthesis
+help: wrap the expression in parentheses
    |
 LL |     let true = (true && false) else { return };
    |                +             +
@@ -15,7 +15,7 @@ error: a `||` expression cannot be directly assigned in `let...else`
 LL |     let true = true || false else { return };
    |                ^^^^^^^^^^^^^
    |
-help: wrap the expression in parenthesis
+help: wrap the expression in parentheses
    |
 LL |     let true = (true || false) else { return };
    |                +             +

--- a/src/test/ui/let-else/let-else-brace-before-else.stderr
+++ b/src/test/ui/let-else/let-else-brace-before-else.stderr
@@ -4,7 +4,7 @@ error: right curly brace `}` before `else` in a `let...else` statement not allow
 LL |     let Some(1) = { Some(1) } else {
    |                             ^
    |
-help: try wrapping the expression in parenthesis
+help: try wrapping the expression in parentheses
    |
 LL |     let Some(1) = ({ Some(1) }) else {
    |                   +           +
@@ -15,7 +15,7 @@ error: right curly brace `}` before `else` in a `let...else` statement not allow
 LL |     let Some(1) = loop { break Some(1) } else {
    |                                        ^
    |
-help: try wrapping the expression in parenthesis
+help: try wrapping the expression in parentheses
    |
 LL |     let Some(1) = (loop { break Some(1) }) else {
    |                   +                      +
@@ -26,7 +26,7 @@ error: right curly brace `}` before `else` in a `let...else` statement not allow
 LL |     let 2 = 1 + match 1 { n => n } else {
    |                                  ^
    |
-help: try wrapping the expression in parenthesis
+help: try wrapping the expression in parentheses
    |
 LL |     let 2 = 1 + (match 1 { n => n }) else {
    |                 +                  +
@@ -37,7 +37,7 @@ error: right curly brace `}` before `else` in a `let...else` statement not allow
 LL |     let Some(1) = unsafe { unsafe_fn() } else {
    |                                        ^
    |
-help: try wrapping the expression in parenthesis
+help: try wrapping the expression in parentheses
    |
 LL |     let Some(1) = (unsafe { unsafe_fn() }) else {
    |                   +                      +

--- a/src/test/ui/parser/recover-for-loop-parens-around-head.rs
+++ b/src/test/ui/parser/recover-for-loop-parens-around-head.rs
@@ -9,7 +9,7 @@ fn main() {
 
     for ( elem in vec ) {
         //~^ ERROR expected one of `)`, `,`, `@`, or `|`, found keyword `in`
-        //~| ERROR unexpected parenthesis surrounding `for` loop head
+        //~| ERROR unexpected parentheses surrounding `for` loop head
         const RECOVERY_WITNESS: () = 0; //~ ERROR mismatched types
     }
 }

--- a/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
+++ b/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
@@ -4,13 +4,13 @@ error: expected one of `)`, `,`, `@`, or `|`, found keyword `in`
 LL |     for ( elem in vec ) {
    |                ^^ expected one of `)`, `,`, `@`, or `|`
 
-error: unexpected parenthesis surrounding `for` loop head
+error: unexpected parentheses surrounding `for` loop head
   --> $DIR/recover-for-loop-parens-around-head.rs:10:9
    |
 LL |     for ( elem in vec ) {
    |         ^             ^
    |
-help: remove parenthesis in `for` loop
+help: remove parentheses in `for` loop
    |
 LL -     for ( elem in vec ) {
 LL +     for  elem in vec  {

--- a/src/test/ui/pattern/issue-67037-pat-tup-scrut-ty-diff-less-fields.rs
+++ b/src/test/ui/pattern/issue-67037-pat-tup-scrut-ty-diff-less-fields.rs
@@ -5,7 +5,7 @@
 // the tuple struct pattern, has 0 fields, but requires 1 field.
 //
 // In emitting E0023, we try to see if this is a case of e.g., `Some(a, b, c)` but where
-// the scrutinee was of type `Some((a, b, c))`, and suggest that parenthesis be added.
+// the scrutinee was of type `Some((a, b, c))`, and suggest that parentheses be added.
 //
 // However, we did not account for the expected type being different than the tuple pattern type.
 // This caused an issue when the tuple pattern type (`P<T>`) was generic.

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -338,7 +338,7 @@ LL |         let _ = Z::Unit();
    |                 |
    |                 call expression requires function
    |
-help: `Z::Unit` is a unit variant, you need to write it without the parenthesis
+help: `Z::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL |         let _ = Z::Unit;
    |                 ~~~~~~~
@@ -372,7 +372,7 @@ LL |     let _: E = m::E::Unit();
    |                |
    |                call expression requires function
    |
-help: `m::E::Unit` is a unit variant, you need to write it without the parenthesis
+help: `m::E::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL |     let _: E = m::E::Unit;
    |                ~~~~~~~~~~
@@ -406,7 +406,7 @@ LL |     let _: E = E::Unit();
    |                |
    |                call expression requires function
    |
-help: `E::Unit` is a unit variant, you need to write it without the parenthesis
+help: `E::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL |     let _: E = E::Unit;
    |                ~~~~~~~

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -16,7 +16,7 @@ LL |     if &let 0 = 0 {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:33:9
@@ -25,7 +25,7 @@ LL |     if !let 0 = 0 {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:34:9
@@ -34,7 +34,7 @@ LL |     if *let 0 = 0 {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:36:9
@@ -43,7 +43,7 @@ LL |     if -let 0 = 0 {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:44:9
@@ -52,7 +52,7 @@ LL |     if (let 0 = 0)? {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:48:16
@@ -61,7 +61,7 @@ LL |     if true || let 0 = 0 {}
    |                ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:49:17
@@ -70,7 +70,7 @@ LL |     if (true || let 0 = 0) {}
    |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:50:25
@@ -79,7 +79,7 @@ LL |     if true && (true || let 0 = 0) {}
    |                         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:51:25
@@ -88,7 +88,7 @@ LL |     if true || (true && let 0 = 0) {}
    |                         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:54:12
@@ -97,7 +97,7 @@ LL |     if x = let 0 = 0 {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:57:15
@@ -106,7 +106,7 @@ LL |     if true..(let 0 = 0) {}
    |               ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:59:11
@@ -115,7 +115,7 @@ LL |     if ..(let 0 = 0) {}
    |           ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:61:9
@@ -124,7 +124,7 @@ LL |     if (let 0 = 0).. {}
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:65:8
@@ -133,7 +133,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:69:8
@@ -142,7 +142,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:76:8
@@ -151,7 +151,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:84:8
@@ -160,7 +160,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:90:19
@@ -169,7 +169,7 @@ LL |     if let true = let true = true {}
    |                   ^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:94:12
@@ -178,7 +178,7 @@ LL |     while &let 0 = 0 {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:97:12
@@ -187,7 +187,7 @@ LL |     while !let 0 = 0 {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:98:12
@@ -196,7 +196,7 @@ LL |     while *let 0 = 0 {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:100:12
@@ -205,7 +205,7 @@ LL |     while -let 0 = 0 {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:108:12
@@ -214,7 +214,7 @@ LL |     while (let 0 = 0)? {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:112:19
@@ -223,7 +223,7 @@ LL |     while true || let 0 = 0 {}
    |                   ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:113:20
@@ -232,7 +232,7 @@ LL |     while (true || let 0 = 0) {}
    |                    ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:114:28
@@ -241,7 +241,7 @@ LL |     while true && (true || let 0 = 0) {}
    |                            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:115:28
@@ -250,7 +250,7 @@ LL |     while true || (true && let 0 = 0) {}
    |                            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:118:15
@@ -259,7 +259,7 @@ LL |     while x = let 0 = 0 {}
    |               ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:121:18
@@ -268,7 +268,7 @@ LL |     while true..(let 0 = 0) {}
    |                  ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:123:14
@@ -277,7 +277,7 @@ LL |     while ..(let 0 = 0) {}
    |              ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:125:12
@@ -286,7 +286,7 @@ LL |     while (let 0 = 0).. {}
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:129:11
@@ -295,7 +295,7 @@ LL |     while let Range { start: _, end: _ } = true..true && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:133:11
@@ -304,7 +304,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:140:11
@@ -313,7 +313,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:148:11
@@ -322,7 +322,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:154:22
@@ -331,7 +331,7 @@ LL |     while let true = let true = true {}
    |                      ^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:168:6
@@ -340,7 +340,7 @@ LL |     &let 0 = 0;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:170:6
@@ -349,7 +349,7 @@ LL |     !let 0 = 0;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:171:6
@@ -358,7 +358,7 @@ LL |     *let 0 = 0;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:173:6
@@ -367,7 +367,7 @@ LL |     -let 0 = 0;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:181:6
@@ -376,7 +376,7 @@ LL |     (let 0 = 0)?;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:185:13
@@ -385,7 +385,7 @@ LL |     true || let 0 = 0;
    |             ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:186:14
@@ -394,7 +394,7 @@ LL |     (true || let 0 = 0);
    |              ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:187:22
@@ -403,7 +403,7 @@ LL |     true && (true || let 0 = 0);
    |                      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:190:9
@@ -412,7 +412,7 @@ LL |     x = let 0 = 0;
    |         ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:192:12
@@ -421,7 +421,7 @@ LL |     true..(let 0 = 0);
    |            ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:193:8
@@ -430,7 +430,7 @@ LL |     ..(let 0 = 0);
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:194:6
@@ -439,7 +439,7 @@ LL |     (let 0 = 0)..;
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:196:6
@@ -448,7 +448,7 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:200:6
@@ -457,7 +457,7 @@ LL |     (let true = let true = true);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:204:6
@@ -466,7 +466,7 @@ LL |     &let 0 = 0
    |      ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:215:17
@@ -475,7 +475,7 @@ LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:219:17
@@ -484,7 +484,7 @@ LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:223:17
@@ -493,7 +493,7 @@ LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:233:17
@@ -502,7 +502,7 @@ LL |         true && let 1 = 1
    |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
+   = note: as well as when nested within `&&` and parentheses in those conditions
 
 warning: the feature `let_chains` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/disallowed-positions.rs:20:12

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-55779-extern-trait.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-55779-extern-trait.rs
@@ -1,0 +1,1 @@
+pub trait Trait { fn no_op(&self); }

--- a/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-87932-a.rs
+++ b/src/test/ui/rust-2018/uniform-paths/auxiliary/issue-87932-a.rs
@@ -1,0 +1,3 @@
+pub trait Deserialize {
+    fn deserialize();
+}

--- a/src/test/ui/rust-2018/uniform-paths/issue-55779.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-55779.rs
@@ -1,0 +1,29 @@
+// run-pass
+// edition:2018
+// aux-crate:issue_55779_extern_trait=issue-55779-extern-trait.rs
+
+use issue_55779_extern_trait::Trait;
+
+struct Local;
+struct Helper;
+
+impl Trait for Local {
+    fn no_op(&self)
+    {
+        // (Unused) extern crate declaration necessary to reproduce bug
+        extern crate issue_55779_extern_trait;
+
+        // This one works
+        // impl Trait for Helper { fn no_op(&self) { } }
+
+        // This one infinite-loops
+        const _IMPL_SERIALIZE_FOR_HELPER: () = {
+            // (extern crate can also appear here to reproduce bug,
+            // as in originating example from serde)
+            impl Trait for Helper { fn no_op(&self) { } }
+        };
+
+    }
+}
+
+fn main() { }

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.rs
@@ -1,0 +1,15 @@
+// edition:2018
+// aux-crate:issue_87932_a=issue-87932-a.rs
+
+pub struct A {}
+
+impl issue_87932_a::Deserialize for A {
+    fn deserialize() {
+        extern crate issue_87932_a as _a;
+    }
+}
+
+fn main() {
+    A::deserialize();
+    //~^ ERROR no function or associated item named `deserialize` found for struct `A`
+}

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no function or associated item named `deserialize` found for struct `A` in the current scope
+  --> $DIR/issue-87932.rs:13:8
+   |
+LL | pub struct A {}
+   | ------------ function or associated item `deserialize` not found for this
+...
+LL |     A::deserialize();
+   |        ^^^^^^^^^^^ function or associated item not found in `A`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use <crate::A as issue_87932_a::Deserialize>::deserialize::_a::Deserialize;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
@@ -6,7 +6,7 @@ LL |     let _ = ||{}();
    |               |
    |               call expression requires function
    |
-help: if you meant to create this closure and immediately call it, surround the closure with parenthesis
+help: if you meant to create this closure and immediately call it, surround the closure with parentheses
    |
 LL |     let _ = (||{})();
    |             +    +

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -27,7 +27,7 @@ LL |     Alias::Unit();
    |     |
    |     call expression requires function
    |
-help: `Alias::Unit` is a unit variant, you need to write it without the parenthesis
+help: `Alias::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL |     Alias::Unit;
    |     ~~~~~~~~~~~

--- a/src/test/ui/type-alias-impl-trait/issue-89686.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.rs
@@ -1,0 +1,24 @@
+// edition:2018
+
+#![feature(type_alias_impl_trait)]
+
+use std::future::Future;
+
+type G<'a, T> = impl Future<Output = ()>;
+//~^ ERROR: type mismatch resolving `<impl Future as Future>::Output == ()`
+//~| ERROR: the trait bound `T: Trait` is not satisfied
+
+trait Trait {
+    type F: Future<Output = ()>;
+
+    fn f(&self) -> Self::F;
+
+    fn g<'a>(&'a self) -> G<'a, Self>
+    where
+        Self: Sized,
+    {
+        async move { self.f().await }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-89686.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.stderr
@@ -1,0 +1,34 @@
+error[E0271]: type mismatch resolving `<impl Future as Future>::Output == ()`
+  --> $DIR/issue-89686.rs:7:17
+   |
+LL | type G<'a, T> = impl Future<Output = ()>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+...
+LL |         async move { self.f().await }
+   |                    ------------------ the found `async` block
+   |
+  ::: $SRC_DIR/core/src/future/mod.rs:LL:COL
+   |
+LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
+   |                                           ------------------------------- the found opaque type
+   |
+   = note:    expected unit type `()`
+           found associated type `<impl Future as Future>::Output`
+   = help: consider constraining the associated type `<impl Future as Future>::Output` to `()`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error[E0277]: the trait bound `T: Trait` is not satisfied
+  --> $DIR/issue-89686.rs:7:17
+   |
+LL | type G<'a, T> = impl Future<Output = ()>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | type G<'a, T: Trait> = impl Future<Output = ()>;
+   |             +++++++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/tools/clippy/clippy_lints/src/manual_unwrap_or.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_unwrap_or.rs
@@ -98,7 +98,7 @@ fn lint_manual_unwrap_or<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
                 reindent_multiline(or_body_snippet.into(), true, Some(indent));
 
             let suggestion = if scrutinee.span.from_expansion() {
-                    // we don't want parenthesis around macro, e.g. `(some_macro!()).unwrap_or(0)`
+                    // we don't want parentheses around macro, e.g. `(some_macro!()).unwrap_or(0)`
                     sugg::Sugg::hir_with_macro_callsite(cx, scrutinee, "..")
                 }
                 else {

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -16,10 +16,10 @@ use std::convert::TryInto;
 use std::fmt::Display;
 use std::ops::{Add, Neg, Not, Sub};
 
-/// A helper type to build suggestion correctly handling parenthesis.
+/// A helper type to build suggestion correctly handling parentheses.
 #[derive(Clone, PartialEq)]
 pub enum Sugg<'a> {
-    /// An expression that never needs parenthesis such as `1337` or `[0; 42]`.
+    /// An expression that never needs parentheses such as `1337` or `[0; 42]`.
     NonParen(Cow<'a, str>),
     /// An expression that does not fit in other variants.
     MaybeParen(Cow<'a, str>),
@@ -283,7 +283,7 @@ impl<'a> Sugg<'a> {
         }
     }
 
-    /// Adds parenthesis to any expression that might need them. Suitable to the
+    /// Adds parentheses to any expression that might need them. Suitable to the
     /// `self` argument of a method call
     /// (e.g., to build `bar.foo()` or `(1 + 2).foo()`).
     pub fn maybe_par(self) -> Self {

--- a/src/tools/clippy/tests/ui/manual_unwrap_or.fixed
+++ b/src/tools/clippy/tests/ui/manual_unwrap_or.fixed
@@ -74,10 +74,10 @@ fn result_unwrap_or() {
     let a = Ok::<i32, &str>(1);
     a.unwrap_or(42);
 
-    // int case, suggestion must surround Result expr with parenthesis
+    // int case, suggestion must surround Result expr with parentheses
     (Ok(1) as Result<i32, &str>).unwrap_or(42);
 
-    // method call case, suggestion must not surround Result expr `s.method()` with parenthesis
+    // method call case, suggestion must not surround Result expr `s.method()` with parentheses
     struct S {}
     impl S {
         fn method(self) -> Option<i32> {

--- a/src/tools/clippy/tests/ui/manual_unwrap_or.rs
+++ b/src/tools/clippy/tests/ui/manual_unwrap_or.rs
@@ -95,13 +95,13 @@ fn result_unwrap_or() {
         Err(_) => 42,
     };
 
-    // int case, suggestion must surround Result expr with parenthesis
+    // int case, suggestion must surround Result expr with parentheses
     match Ok(1) as Result<i32, &str> {
         Ok(i) => i,
         Err(_) => 42,
     };
 
-    // method call case, suggestion must not surround Result expr `s.method()` with parenthesis
+    // method call case, suggestion must not surround Result expr `s.method()` with parentheses
     struct S {}
     impl S {
         fn method(self) -> Option<i32> {

--- a/src/tools/clippy/tests/ui/useless_conversion.fixed
+++ b/src/tools/clippy/tests/ui/useless_conversion.fixed
@@ -66,7 +66,7 @@ fn main() {
     let _ = vec![1, 2, 3].into_iter();
     let _: String = format!("Hello {}", "world");
 
-    // keep parenthesis around `a + b` for suggestion (see #4750)
+    // keep parentheses around `a + b` for suggestion (see #4750)
     let a: i32 = 1;
     let b: i32 = 1;
     let _ = (a + b) * 3;

--- a/src/tools/clippy/tests/ui/useless_conversion.rs
+++ b/src/tools/clippy/tests/ui/useless_conversion.rs
@@ -66,7 +66,7 @@ fn main() {
     let _ = vec![1, 2, 3].into_iter().into_iter();
     let _: String = format!("Hello {}", "world").into();
 
-    // keep parenthesis around `a + b` for suggestion (see #4750)
+    // keep parentheses around `a + b` for suggestion (see #4750)
     let a: i32 = 1;
     let b: i32 = 1;
     let _ = i32::from(a + b) * 3;


### PR DESCRIPTION
Successful merges:

 - #89738 (ty::pretty: prevent infinite recursion for `extern crate` paths.)
 - #89888 (Make `llvm.download-ci-llvm="if-available"` work for tier 2 targets with host tools)
 - #89945 (Remove a mention to `copy_from_slice` from `clone_from_slice` doc)
 - #89946 (Fix an ICE with TAITs and Future)
 - #89963 (Some "parenthesis" and "parentheses" fixes)
 - #89975 (Add a regression test for #85921)
 - #89977 (Make Result::as_mut const)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89738,89888,89945,89946,89963,89975,89977)
<!-- homu-ignore:end -->