### PR TITLE
Check implementing type for `#[doc(hidden)]`

### DIFF
--- a/src/test/ui/hidden-doc-associated-item.rs
+++ b/src/test/ui/hidden-doc-associated-item.rs
@@ -1,0 +1,15 @@
+// check-pass
+// See issue #85526.
+// This test should produce no warnings.
+
+#![deny(missing_docs)]
+//! Crate docs
+
+#[doc(hidden)]
+pub struct Foo;
+
+impl Foo {
+    pub fn bar() {}
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #85526.