### PR TITLE
Remove dead code from `compiletest::json`

### DIFF
--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -74,8 +74,6 @@ struct DiagnosticSpanMacroExpansion {
 struct DiagnosticCode {
     /// The code itself.
     code: String,
-    /// An explanation for the code.
-    explanation: Option<String>,
 }
 
 pub fn rustfix_diagnostics_only(output: &str) -> String {


### PR DESCRIPTION
Currently getting a dead code warning on master. Might make sense to remove.