### PR TITLE
rustdoc: Box some fields of `GenericParamDefKind` to reduce size

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -430,7 +430,7 @@ impl Clean<GenericParamDef> for ty::GenericParamDef {
                 self.name,
                 GenericParamDefKind::Const {
                     did: self.def_id,
-                    ty: cx.tcx.type_of(self.def_id).clean(cx),
+                    ty: Box::new(cx.tcx.type_of(self.def_id).clean(cx)),
                     default: match has_default {
                         true => Some(Box::new(cx.tcx.const_param_default(self.def_id).to_string())),
                         false => None,
@@ -470,7 +470,7 @@ impl Clean<GenericParamDef> for hir::GenericParam<'_> {
                 self.name.ident().name,
                 GenericParamDefKind::Const {
                     did: cx.tcx.hir().local_def_id(self.hir_id).to_def_id(),
-                    ty: ty.clean(cx),
+                    ty: Box::new(ty.clean(cx)),
                     default: default.map(|ct| {
                         let def_id = cx.tcx.hir().local_def_id(ct.hir_id);
                         Box::new(ty::Const::from_anon_const(cx.tcx, def_id).to_string())

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -421,7 +421,7 @@ impl Clean<GenericParamDef> for ty::GenericParamDef {
                     GenericParamDefKind::Type {
                         did: self.def_id,
                         bounds: vec![], // These are filled in from the where-clauses.
-                        default,
+                        default: default.map(Box::new),
                         synthetic,
                     },
                 )
@@ -432,7 +432,7 @@ impl Clean<GenericParamDef> for ty::GenericParamDef {
                     did: self.def_id,
                     ty: cx.tcx.type_of(self.def_id).clean(cx),
                     default: match has_default {
-                        true => Some(cx.tcx.const_param_default(self.def_id).to_string()),
+                        true => Some(Box::new(cx.tcx.const_param_default(self.def_id).to_string())),
                         false => None,
                     },
                 },
@@ -462,7 +462,7 @@ impl Clean<GenericParamDef> for hir::GenericParam<'_> {
                 GenericParamDefKind::Type {
                     did: cx.tcx.hir().local_def_id(self.hir_id).to_def_id(),
                     bounds: self.bounds.clean(cx),
-                    default: default.clean(cx),
+                    default: default.clean(cx).map(Box::new),
                     synthetic,
                 },
             ),
@@ -473,7 +473,7 @@ impl Clean<GenericParamDef> for hir::GenericParam<'_> {
                     ty: ty.clean(cx),
                     default: default.map(|ct| {
                         let def_id = cx.tcx.hir().local_def_id(ct.hir_id);
-                        ty::Const::from_anon_const(cx.tcx, def_id).to_string()
+                        Box::new(ty::Const::from_anon_const(cx.tcx, def_id).to_string())
                     }),
                 },
             ),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1219,13 +1219,13 @@ crate enum GenericParamDefKind {
     Type {
         did: DefId,
         bounds: Vec<GenericBound>,
-        default: Option<Type>,
+        default: Option<Box<Type>>,
         synthetic: Option<hir::SyntheticTyParamKind>,
     },
     Const {
         did: DefId,
         ty: Type,
-        default: Option<String>,
+        default: Option<Box<String>>,
     },
 }
 
@@ -1239,7 +1239,7 @@ impl GenericParamDefKind {
     // any embedded types, but `get_type` seems to be the wrong name for that.
     crate fn get_type(&self) -> Option<Type> {
         match self {
-            GenericParamDefKind::Type { default, .. } => default.clone(),
+            GenericParamDefKind::Type { default, .. } => default.as_deref().cloned(),
             GenericParamDefKind::Const { ty, .. } => Some(ty.clone()),
             GenericParamDefKind::Lifetime { .. } => None,
         }
@@ -1254,7 +1254,7 @@ crate struct GenericParamDef {
 
 // `GenericParamDef` is used in many places. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericParamDef, 120);
+rustc_data_structures::static_assert_size!(GenericParamDef, 104);
 
 impl GenericParamDef {
     crate fn is_synthetic_type_param(&self) -> bool {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1252,6 +1252,10 @@ crate struct GenericParamDef {
     crate kind: GenericParamDefKind,
 }
 
+// `GenericParamDef` is used in many places. Make sure it doesn't unintentionally get bigger.
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+rustc_data_structures::static_assert_size!(GenericParamDef, 120);
+
 impl GenericParamDef {
     crate fn is_synthetic_type_param(&self) -> bool {
         match self.kind {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1224,7 +1224,7 @@ crate enum GenericParamDefKind {
     },
     Const {
         did: DefId,
-        ty: Type,
+        ty: Box<Type>,
         default: Option<Box<String>>,
     },
 }
@@ -1240,7 +1240,7 @@ impl GenericParamDefKind {
     crate fn get_type(&self) -> Option<Type> {
         match self {
             GenericParamDefKind::Type { default, .. } => default.as_deref().cloned(),
-            GenericParamDefKind::Const { ty, .. } => Some(ty.clone()),
+            GenericParamDefKind::Const { ty, .. } => Some((&**ty).clone()),
             GenericParamDefKind::Lifetime { .. } => None,
         }
     }
@@ -1254,7 +1254,7 @@ crate struct GenericParamDef {
 
 // `GenericParamDef` is used in many places. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericParamDef, 104);
+rustc_data_structures::static_assert_size!(GenericParamDef, 56);
 
 impl GenericParamDef {
     crate fn is_synthetic_type_param(&self) -> bool {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -333,7 +333,7 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
                 default: default.map(|x| (*x).into_tcx(tcx)),
             },
             Const { did: _, ty, default } => {
-                GenericParamDefKind::Const { ty: ty.into_tcx(tcx), default: default.map(|x| *x) }
+                GenericParamDefKind::Const { ty: (*ty).into_tcx(tcx), default: default.map(|x| *x) }
             }
         }
     }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -330,10 +330,10 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
             },
             Type { did: _, bounds, default, synthetic: _ } => GenericParamDefKind::Type {
                 bounds: bounds.into_iter().map(|x| x.into_tcx(tcx)).collect(),
-                default: default.map(|x| x.into_tcx(tcx)),
+                default: default.map(|x| (*x).into_tcx(tcx)),
             },
             Const { did: _, ty, default } => {
-                GenericParamDefKind::Const { ty: ty.into_tcx(tcx), default }
+                GenericParamDefKind::Const { ty: ty.into_tcx(tcx), default: default.map(|x| *x) }
             }
         }
     }


### PR DESCRIPTION
This change shrinks `GenericParamDef` from 120 to 56 bytes. `GenericParamDef` is
used a lot, so the extra indirection should hopefully be worth the size savings.

r? @ghost
