### PR TITLE
Rust 1.57.0 beta release

### DIFF
--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-nightly
+beta


### PR DESCRIPTION
This PR bumps 1.57.0 to the beta channel.

r? @ghost
cc @rust-lang/release 