### PR TITLE
Inline CStr::from_ptr

### DIFF
--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -1175,6 +1175,7 @@ impl CStr {
     /// }
     /// # }
     /// ```
+    #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a CStr {


### PR DESCRIPTION
Inlining this function is valuable, as it allows LLVM to apply `strlen`-specific optimizations without having to enable LTO.

For instance, the following function:

```rust
pub fn f(p: *const c_char) -> Option<u8> {
    unsafe { CStr::from_ptr(p) }.to_bytes().get(0).copied()
}
```

Looks like this if `CStr::from_ptr` is allowed to be inlined.

```asm
before:
        push    rax
        call    qword ptr [rip + std::ffi::c_str::CStr::from_ptr@GOTPCREL]
        mov     rcx, rax
        cmp     rdx, 1
        sete    dl
        test    rax, rax
        sete    al
        or      al, dl
        jne     .LBB1_2
        mov     dl, byte ptr [rcx]
.LBB1_2:
        xor     al, 1
        pop     rcx
        ret

after:
        mov     dl, byte ptr [rdi]
        test    dl, dl
        setne   al
        ret
```

Note that optimization turned this from O(N) to O(1) in terms of performance, as LLVM knows that it doesn't really need to call `strlen` to determine whether a string is empty or not.