### PR TITLE
Postpone the evaluation of constant expressions that depend on inference variables

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -1,5 +1,6 @@
 use crate::infer::type_variable::TypeVariableOriginKind;
 use crate::infer::InferCtxt;
+use crate::rustc_middle::ty::TypeFoldable;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace};
@@ -390,36 +391,75 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
             }
             GenericArgKind::Const(ct) => {
-                if let ty::ConstKind::Infer(InferConst::Var(vid)) = ct.val {
-                    let origin =
-                        self.inner.borrow_mut().const_unification_table().probe_value(vid).origin;
-                    if let ConstVariableOriginKind::ConstParameterDefinition(name, def_id) =
-                        origin.kind
-                    {
-                        return InferenceDiagnosticsData {
-                            name: name.to_string(),
-                            span: Some(origin.span),
-                            kind: UnderspecifiedArgKind::Const { is_parameter: true },
-                            parent: InferenceDiagnosticsParentData::for_def_id(self.tcx, def_id),
-                        };
-                    }
+                match ct.val {
+                    ty::ConstKind::Infer(InferConst::Var(vid)) => {
+                        let origin = self
+                            .inner
+                            .borrow_mut()
+                            .const_unification_table()
+                            .probe_value(vid)
+                            .origin;
+                        if let ConstVariableOriginKind::ConstParameterDefinition(name, def_id) =
+                            origin.kind
+                        {
+                            return InferenceDiagnosticsData {
+                                name: name.to_string(),
+                                span: Some(origin.span),
+                                kind: UnderspecifiedArgKind::Const { is_parameter: true },
+                                parent: InferenceDiagnosticsParentData::for_def_id(
+                                    self.tcx, def_id,
+                                ),
+                            };
+                        }
 
-                    debug_assert!(!origin.span.is_dummy());
-                    let mut s = String::new();
-                    let mut printer =
-                        ty::print::FmtPrinter::new(self.tcx, &mut s, Namespace::ValueNS);
-                    if let Some(highlight) = highlight {
-                        printer.region_highlight_mode = highlight;
+                        debug_assert!(!origin.span.is_dummy());
+                        let mut s = String::new();
+                        let mut printer =
+                            ty::print::FmtPrinter::new(self.tcx, &mut s, Namespace::ValueNS);
+                        if let Some(highlight) = highlight {
+                            printer.region_highlight_mode = highlight;
+                        }
+                        let _ = ct.print(printer);
+                        InferenceDiagnosticsData {
+                            name: s,
+                            span: Some(origin.span),
+                            kind: UnderspecifiedArgKind::Const { is_parameter: false },
+                            parent: None,
+                        }
                     }
-                    let _ = ct.print(printer);
-                    InferenceDiagnosticsData {
-                        name: s,
-                        span: Some(origin.span),
-                        kind: UnderspecifiedArgKind::Const { is_parameter: false },
-                        parent: None,
+                    ty::ConstKind::Unevaluated(ty::Unevaluated {
+                        substs_: Some(substs), ..
+                    }) => {
+                        assert!(substs.has_infer_types_or_consts());
+
+                        // FIXME: We only use the first inference variable we encounter in
+                        // `substs` here, this gives insufficiently informative diagnostics
+                        // in case there are multiple inference variables
+                        for s in substs.iter() {
+                            match s.unpack() {
+                                GenericArgKind::Type(t) => match t.kind() {
+                                    ty::Infer(_) => {
+                                        return self.extract_inference_diagnostics_data(s, None);
+                                    }
+                                    _ => {}
+                                },
+                                GenericArgKind::Const(c) => match c.val {
+                                    ty::ConstKind::Infer(InferConst::Var(_)) => {
+                                        return self.extract_inference_diagnostics_data(s, None);
+                                    }
+                                    _ => {}
+                                },
+                                _ => {}
+                            }
+                        }
+                        bug!(
+                            "expected an inference variable in substs of unevaluated const {:?}",
+                            ct
+                        );
                     }
-                } else {
-                    bug!("unexpect const: {:?}", ct);
+                    _ => {
+                        bug!("unexpect const: {:?}", ct);
+                    }
                 }
             }
             GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),

--- a/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.rs
@@ -27,4 +27,5 @@ fn main() {
     //~^ ERROR type annotations needed
 
     _q = foo::<_, 2>(_q);
+    //~^ ERROR type annotations needed
 }

--- a/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.rs
@@ -1,4 +1,3 @@
-// run-pass
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
@@ -22,8 +21,10 @@ where
 }
 
 fn main() {
-    // Test that we can correctly infer `T` which requires evaluating
-    // `{ N + 1 }` which has substs containing an inference var
+    // FIXME(generic_const_exprs): We can't correctly infer `T` which requires
+    // evaluating `{ N + 1 }` which has substs containing an inference var
     let mut _q = Default::default();
+    //~^ ERROR type annotations needed
+
     _q = foo::<_, 2>(_q);
 }

--- a/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.stderr
@@ -4,6 +4,30 @@ error[E0282]: type annotations needed
 LL |     let mut _q = Default::default();
    |         ^^^^^^ consider giving `_q` a type
 
-error: aborting due to previous error
+error[E0283]: type annotations needed
+  --> $DIR/const_eval_resolve_canonical.rs:29:10
+   |
+LL |     _q = foo::<_, 2>(_q);
+   |          ^^^^^^^^^^^ cannot infer type
+   |
+note: multiple `impl`s satisfying `(): Foo<{ N + 1 }>` found
+  --> $DIR/const_eval_resolve_canonical.rs:8:1
+   |
+LL | impl Foo<0> for () {
+   | ^^^^^^^^^^^^^^^^^^
+...
+LL | impl Foo<3> for () {
+   | ^^^^^^^^^^^^^^^^^^
+note: required by a bound in `foo`
+  --> $DIR/const_eval_resolve_canonical.rs:18:9
+   |
+LL | fn foo<T, const N: usize>(_: T) -> <() as Foo<{ N + 1 }>>::Assoc
+   |    --- required by a bound in this
+LL | where
+LL |     (): Foo<{ N + 1 }>,
+   |         ^^^^^^^^^^^^^^ required by this bound in `foo`
 
-For more information about this error, try `rustc --explain E0282`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/const_eval_resolve_canonical.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/const_eval_resolve_canonical.rs:26:9
+   |
+LL |     let mut _q = Default::default();
+   |         ^^^^^^ consider giving `_q` a type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/issues/issue-83249.rs
+++ b/src/test/ui/const-generics/issues/issue-83249.rs
@@ -1,0 +1,23 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+trait Foo {
+    const N: usize;
+}
+
+impl Foo for u8 {
+    const N: usize = 1;
+}
+
+fn foo<T: Foo>(_: [u8; T::N]) -> T {
+    todo!()
+}
+
+pub fn bar() {
+    let _: u8 = foo([0; 1]);
+
+    let _ = foo([0; 1]);
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-83249.stderr
+++ b/src/test/ui/const-generics/issues/issue-83249.stderr
@@ -1,22 +1,11 @@
-error[E0283]: type annotations needed
+error[E0282]: type annotations needed
   --> $DIR/issue-83249.rs:19:13
    |
 LL |     let _ = foo([0; 1]);
    |         -   ^^^ cannot infer type for type parameter `T` declared on the function `foo`
    |         |
    |         consider giving this pattern a type
-   |
-   = note: cannot satisfy `_: Foo`
-note: required by a bound in `foo`
-  --> $DIR/issue-83249.rs:12:11
-   |
-LL | fn foo<T: Foo>(_: [u8; T::N]) -> T {
-   |           ^^^ required by this bound in `foo`
-help: consider specifying the type argument in the function call
-   |
-LL |     let _ = foo::<T>([0; 1]);
-   |                +++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/issues/issue-83249.stderr
+++ b/src/test/ui/const-generics/issues/issue-83249.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed
+  --> $DIR/issue-83249.rs:19:13
+   |
+LL |     let _ = foo([0; 1]);
+   |         -   ^^^ cannot infer type for type parameter `T` declared on the function `foo`
+   |         |
+   |         consider giving this pattern a type
+   |
+   = note: cannot satisfy `_: Foo`
+note: required by a bound in `foo`
+  --> $DIR/issue-83249.rs:12:11
+   |
+LL | fn foo<T: Foo>(_: [u8; T::N]) -> T {
+   |           ^^^ required by this bound in `foo`
+help: consider specifying the type argument in the function call
+   |
+LL |     let _ = foo::<T>([0; 1]);
+   |                +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/const-generics/issues/issue-83288.rs
+++ b/src/test/ui/const-generics/issues/issue-83288.rs
@@ -1,0 +1,69 @@
+// build-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use std::{marker::PhantomData, ops::Mul};
+
+pub enum Nil {}
+pub struct Cons<T, L> {
+    _phantom: PhantomData<(T, L)>,
+}
+
+pub trait Indices<const N: usize> {
+    const RANK: usize;
+    const NUM_ELEMS: usize;
+}
+
+impl<const N: usize> Indices<N> for Nil {
+    const RANK: usize = 0;
+    const NUM_ELEMS: usize = 1;
+}
+
+impl<T, I: Indices<N>, const N: usize> Indices<N> for Cons<T, I> {
+    const RANK: usize = I::RANK + 1;
+    const NUM_ELEMS: usize = I::NUM_ELEMS * N;
+}
+
+pub trait Concat<J> {
+    type Output;
+}
+
+impl<J> Concat<J> for Nil {
+    type Output = J;
+}
+
+impl<T, I, J> Concat<J> for Cons<T, I>
+where
+    I: Concat<J>,
+{
+    type Output = Cons<T, <I as Concat<J>>::Output>;
+}
+
+pub struct Tensor<I: Indices<N>, const N: usize>
+where
+    [u8; I::NUM_ELEMS]: Sized,
+{
+    pub data: [u8; I::NUM_ELEMS],
+    _phantom: PhantomData<I>,
+}
+
+impl<I: Indices<N>, J: Indices<N>, const N: usize> Mul<Tensor<J, N>> for Tensor<I, N>
+where
+    I: Concat<J>,
+    <I as Concat<J>>::Output: Indices<N>,
+    [u8; I::NUM_ELEMS]: Sized,
+    [u8; J::NUM_ELEMS]: Sized,
+    [u8; <I as Concat<J>>::Output::NUM_ELEMS]: Sized,
+{
+    type Output = Tensor<<I as Concat<J>>::Output, N>;
+
+    fn mul(self, _rhs: Tensor<J, N>) -> Self::Output {
+        Tensor {
+            data: [0u8; <I as Concat<J>>::Output::NUM_ELEMS],
+            _phantom: PhantomData,
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-87470.rs
+++ b/src/test/ui/const-generics/issues/issue-87470.rs
@@ -1,0 +1,24 @@
+// build-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait TraitWithConst {
+    const SOME_CONST: usize;
+}
+
+pub trait OtherTrait: TraitWithConst {
+    fn some_fn(self) -> [u8 ; <Self as TraitWithConst>::SOME_CONST];
+}
+
+impl TraitWithConst for f32 {
+    const SOME_CONST: usize = 32;
+}
+
+impl OtherTrait for f32 {
+    fn some_fn(self) -> [u8 ; <Self as TraitWithConst>::SOME_CONST] {
+        [0; 32]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-87964.rs
+++ b/src/test/ui/const-generics/issues/issue-87964.rs
@@ -1,0 +1,29 @@
+// build-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait Target {
+    const LENGTH: usize;
+}
+
+
+pub struct Container<T: Target>
+where
+    [(); T::LENGTH]: Sized,
+{
+    _target: T,
+}
+
+impl<T: Target> Container<T>
+where
+    [(); T::LENGTH]: Sized,
+{
+    pub fn start(
+        _target: T,
+    ) -> Container<T> {
+        Container { _target }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-89146.rs
+++ b/src/test/ui/const-generics/issues/issue-89146.rs
@@ -1,0 +1,26 @@
+// build-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+pub trait Foo {
+    const SIZE: usize;
+
+    fn to_bytes(&self) -> [u8; Self::SIZE];
+}
+
+pub fn bar<G: Foo>(a: &G) -> u8
+where
+    [(); G::SIZE]: Sized,
+{
+    deeper_bar(a)
+}
+
+fn deeper_bar<G: Foo>(a: &G) -> u8
+where
+    [(); G::SIZE]: Sized,
+{
+    a.to_bytes()[0]
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-89320.rs
+++ b/src/test/ui/const-generics/issues/issue-89320.rs
@@ -1,0 +1,19 @@
+// build-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait Enumerable {
+    const N: usize;
+}
+
+#[derive(Clone)]
+pub struct SymmetricGroup<S>
+where
+    S: Enumerable,
+    [(); S::N]: Sized,
+{
+    _phantom: std::marker::PhantomData<S>,
+}
+
+fn main() {}


### PR DESCRIPTION
Previously `delay_span_bug` calls were triggered once an inference variable was included in the substs of a constant that was to be evaluated. Some of these would merely have resulted in trait candidates being rejected, hence no real error was ever encountered, but the triggering of the `delay_span_bug` then caused an ICE in later stages of the compiler due to no error ever occurring.
We now postpone the evaluation of these constants, so any trait obligation fulfillment will simply stall on this constant and the existing type inference machinery of the compiler handles any type errors if present.

Fixes https://github.com/rust-lang/rust/issues/89320
Fixes https://github.com/rust-lang/rust/issues/89146
Fixes https://github.com/rust-lang/rust/issues/87964
Fixes https://github.com/rust-lang/rust/issues/87470
Fixes https://github.com/rust-lang/rust/issues/83288
Fixes https://github.com/rust-lang/rust/issues/83249
Fixes https://github.com/rust-lang/rust/issues/90654

I want to thank @BoxyUwU for cooperating on this and for providing some help.

r? @lcnr maybe?