### PR TITLE
Add test for debug logging during incremental compilation

### DIFF
--- a/src/test/incremental/auxiliary/rustc-rust-log-aux.rs
+++ b/src/test/incremental/auxiliary/rustc-rust-log-aux.rs
@@ -1,0 +1,8 @@
+// rustc-env:RUSTC_LOG=debug
+#[cfg(rpass1)]
+pub fn foo() {}
+
+#[cfg(rpass2)]
+pub fn foo() {
+    println!();
+}

--- a/src/test/incremental/rustc-rust-log.rs
+++ b/src/test/incremental/rustc-rust-log.rs
@@ -1,0 +1,16 @@
+// revisions: rpass1 rpass2
+// This test is just checking that we won't ICE if logging is turned
+// on; don't bother trying to compare that (copious) output.
+//
+// dont-check-compiler-stdout
+// dont-check-compiler-stderr
+// aux-build: rustc-rust-log-aux.rs
+// rustc-env:RUSTC_LOG=debug
+
+#[cfg(rpass1)]
+fn main() {}
+
+#[cfg(rpass2)]
+fn main() {
+    println!();
+}

--- a/src/test/ui/rustc-rust-log.rs
+++ b/src/test/ui/rustc-rust-log.rs
@@ -1,9 +1,6 @@
 // run-pass
 // This test is just checking that we won't ICE if logging is turned
-// on; don't bother trying to compare that (copious) output. (Note
-// also that this test potentially silly, since we do not build+test
-// debug versions of rustc as part of our continuous integration
-// process...)
+// on; don't bother trying to compare that (copious) output.
 //
 // dont-check-compiler-stdout
 // dont-check-compiler-stderr


### PR DESCRIPTION
Debug logging during incremental compilation had been broken for some
time, until #89343 fixed it (among other things). Add a test so this is
less likely to break without being noticed. This test is nearly a copy
of the `src/test/ui/rustc-rust-log.rs` test, but tests debug logging in
the incremental compliation code paths.