### PR TITLE
Remove border-bottom from headings in most docblocks.

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -502,10 +502,6 @@ nav.sub {
 	white-space: pre-wrap;
 }
 
-.docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5, .docblock h6 {
-	border-bottom: 1px solid;
-}
-
 .top-doc .docblock h2 { font-size: 1.3em; }
 .top-doc .docblock h3 { font-size: 1.15em; }
 .top-doc .docblock h4,

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -129,8 +129,13 @@ h3 {
 }
 h1, h2, h3, h4, h5, h6 {
 	font-weight: 500;
+}
+h1, h2, h3, h4 {
 	margin: 20px 0 15px 0;
 	padding-bottom: 6px;
+}
+h5, h6 {
+	margin: 15px 0 5px 0;
 }
 h1.fqn {
 	display: flex;
@@ -505,7 +510,9 @@ nav.sub {
 .top-doc .docblock h2 { font-size: 1.3em; }
 .top-doc .docblock h3 { font-size: 1.15em; }
 .top-doc .docblock h4,
-.top-doc .docblock h5,
+.top-doc .docblock h5 {
+	font-size: 1.1em;
+}
 .top-doc .docblock h6 {
 	font-size: 1em;
 }


### PR DESCRIPTION
Headings in the top-doc docblock still get a border-bottom due to a rule
that covers all h2, h3, and h4. Method docblocks are generally h5, and
so don't get a border-bottom anymore.

This fixes a problem where a sub-sub-heading within a method would have
a line that went all the way across the page, creating a division that
made that sub-sub-heading look much more important than it really is.

Fixes #90033 

Demo at https://jacob.hoffman-andrews.com/rust/less-rule/std/string/struct.String.html

r? @GuillaumeGomez 