### PR TITLE
Fix wrong niche calculation when 2+ niches are placed at the start

### DIFF
--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -1117,7 +1117,7 @@ impl Niche {
         // In practice this means that enums with `count > 1` are unlikely to claim niche zero, since they have to fit perfectly.
         // If niche zero is already reserved, the selection of bounds are of little interest.
         let move_start = |v: WrappingRange| {
-            let start = v.start.wrapping_sub(1) & max_value;
+            let start = v.start.wrapping_sub(count) & max_value;
             Some((start, Scalar { value, valid_range: v.with_start(start) }))
         };
         let move_end = |v: WrappingRange| {

--- a/src/test/ui/enum-discriminant/issue-90038.rs
+++ b/src/test/ui/enum-discriminant/issue-90038.rs
@@ -1,0 +1,21 @@
+// run-pass
+
+#[repr(u32)]
+pub enum Foo {
+    // Greater than or equal to 2
+    A = 2,
+}
+
+pub enum Bar {
+    A(Foo),
+    // More than two const variants
+    B,
+    C,
+}
+
+fn main() {
+    match Bar::A(Foo::A) {
+        Bar::A(_) => (),
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
When the niche is at the start, existing code incorrectly uses 1 instead of count for subtraction.

Fix #90038

@rustbot label: T-compiler