### PR TITLE
Erase late-bound regions before computing vtable debuginfo name.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -480,14 +480,11 @@ pub fn compute_debuginfo_vtable_name<'tcx>(
     }
 
     if let Some(trait_ref) = trait_ref {
-        push_item_name(tcx, trait_ref.skip_binder().def_id, true, &mut vtable_name);
+        let trait_ref =
+            tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), trait_ref);
+        push_item_name(tcx, trait_ref.def_id, true, &mut vtable_name);
         visited.clear();
-        push_generic_params_internal(
-            tcx,
-            trait_ref.skip_binder().substs,
-            &mut vtable_name,
-            &mut visited,
-        );
+        push_generic_params_internal(tcx, trait_ref.substs, &mut vtable_name, &mut visited);
     } else {
         vtable_name.push_str("_");
     }

--- a/src/test/codegen/debug-vtable.rs
+++ b/src/test/codegen/debug-vtable.rs
@@ -18,6 +18,9 @@
 // MSVC-LABEL: !DIGlobalVariable(name: "impl$<debug_vtable::Foo, _>::vtable$"
 // CHECK: !DISubrange(count: 3
 
+// NONMSVC-LABEL: !DIGlobalVariable(name: "<debug_vtable::bar::{closure#0} as core::ops::function::FnOnce<(core::option::Option<&dyn core::ops::function::Fn<(), Output=()>>)>>::{vtable}"
+// MSVC-LABEL: !DIGlobalVariable(name: "impl$<debug_vtable::bar::closure$0, core::ops::function::FnOnce<tuple$<enum$<core::option::Option<ref$<dyn$<core::ops::function::Fn<tuple$<>,assoc$<Output,tuple$<> > > > > >, {{.*}}, {{.*}}, Some> > > >::vtable$"
+
 #![crate_type = "lib"]
 
 pub struct Foo;
@@ -44,4 +47,11 @@ pub fn foo(x: &Foo) -> (u32, (u64, i8), &dyn Send) {
     let y: &dyn SomeTrait = x;
     let z: &dyn SomeTraitWithGenerics<u64, i8> = x;
     (y.method1(), z.method1(), x as &dyn Send)
+}
+
+// Constructing the debuginfo name for the FnOnce vtable below initially caused an ICE on MSVC
+// because the trait type contains a late bound region that needed to be erased before the type
+// layout for the niche enum `Option<&dyn Fn()>` could can be computed.
+pub fn bar() -> Box<dyn FnOnce(Option<&dyn Fn()>)> {
+    Box::new(|_x: Option<&dyn Fn()>| {})
 }

--- a/src/test/codegen/debug-vtable.rs
+++ b/src/test/codegen/debug-vtable.rs
@@ -51,7 +51,7 @@ pub fn foo(x: &Foo) -> (u32, (u64, i8), &dyn Send) {
 
 // Constructing the debuginfo name for the FnOnce vtable below initially caused an ICE on MSVC
 // because the trait type contains a late bound region that needed to be erased before the type
-// layout for the niche enum `Option<&dyn Fn()>` could can be computed.
+// layout for the niche enum `Option<&dyn Fn()>` could be computed.
 pub fn bar() -> Box<dyn FnOnce(Option<&dyn Fn()>)> {
     Box::new(|_x: Option<&dyn Fn()>| {})
 }


### PR DESCRIPTION
Fixes #90019.

The `msvc_enum_fallback()` for computing enum type names needs to access the memory layout of niche enums in order to determine the type name. `compute_debuginfo_vtable_name()` did not properly erase regions before computing type names which made memory layout computation ICE when encountering un-erased regions. 

r? @wesleywiser 