### PR TITLE
Edit error messages for `rustc_resolve::AmbiguityKind` variants

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1165,14 +1165,9 @@ impl<'a> Resolver<'a> {
             (b1, b2, misc1, misc2, false)
         };
 
-        let mut err = struct_span_err!(
-            self.session,
-            ident.span,
-            E0659,
-            "`{ident}` is ambiguous ({why})",
-            why = kind.descr()
-        );
+        let mut err = struct_span_err!(self.session, ident.span, E0659, "`{ident}` is ambiguous");
         err.span_label(ident.span, "ambiguous name");
+        err.note(&format!("ambiguous because of {}", kind.descr()));
 
         let mut could_refer_to = |b: &NameBinding<'_>, misc: AmbiguityErrorMisc, also: &str| {
             let what = self.binding_description(b, ident, misc == AmbiguityErrorMisc::FromPrelude);

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -728,23 +728,21 @@ enum AmbiguityKind {
 impl AmbiguityKind {
     fn descr(self) -> &'static str {
         match self {
-            AmbiguityKind::Import => "name vs any other name during import resolution",
-            AmbiguityKind::BuiltinAttr => "built-in attribute vs any other name",
-            AmbiguityKind::DeriveHelper => "derive helper attribute vs any other name",
+            AmbiguityKind::Import => "multiple potential import sources",
+            AmbiguityKind::BuiltinAttr => "a name conflict with a builtin attribute",
+            AmbiguityKind::DeriveHelper => "a name conflict with a derive helper attribute",
             AmbiguityKind::MacroRulesVsModularized => {
-                "`macro_rules` vs non-`macro_rules` from other module"
+                "a conflict between a `macro_rules` name and a non-`macro_rules` name from another module"
             }
             AmbiguityKind::GlobVsOuter => {
-                "glob import vs any other name from outer scope during import/macro resolution"
+                "a conflict between a name from a glob import and an outer scope during import or macro resolution"
             }
-            AmbiguityKind::GlobVsGlob => "glob import vs glob import in the same module",
+            AmbiguityKind::GlobVsGlob => "multiple glob imports of a name in the same module",
             AmbiguityKind::GlobVsExpanded => {
-                "glob import vs macro-expanded name in the same \
-                 module during import/macro resolution"
+                "a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution"
             }
             AmbiguityKind::MoreExpandedVsOuter => {
-                "macro-expanded name vs less macro-expanded name \
-                 from outer scope during import/macro resolution"
+                "a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution"
             }
         }
     }

--- a/src/test/ui/binding/ambiguity-item.stderr
+++ b/src/test/ui/binding/ambiguity-item.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `f` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `f` is ambiguous
   --> $DIR/ambiguity-item.rs:14:13
    |
 LL |     let v = f;
    |             ^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function imported here
   --> $DIR/ambiguity-item.rs:6:5
    |
@@ -17,12 +18,13 @@ LL | use n::*; // OK, no conflict with `use m::*;`
    |     ^^^^
    = help: consider adding an explicit import of `f` to disambiguate
 
-error[E0659]: `f` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `f` is ambiguous
   --> $DIR/ambiguity-item.rs:16:9
    |
 LL |         f => {}
    |         ^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function imported here
   --> $DIR/ambiguity-item.rs:6:5
    |

--- a/src/test/ui/entry-point/imported_main_conflict.rs
+++ b/src/test/ui/entry-point/imported_main_conflict.rs
@@ -1,5 +1,5 @@
 #![feature(imported_main)]
-//~^ ERROR `main` is ambiguous (glob import vs glob import in the same module)
+//~^ ERROR `main` is ambiguous
 mod m1 { pub(crate) fn main() {} }
 mod m2 { pub(crate) fn main() {} }
 

--- a/src/test/ui/entry-point/imported_main_conflict.stderr
+++ b/src/test/ui/entry-point/imported_main_conflict.stderr
@@ -1,5 +1,6 @@
-error[E0659]: `main` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `main` is ambiguous
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `main` could refer to the function imported here
   --> $DIR/imported_main_conflict.rs:6:5
    |

--- a/src/test/ui/error-codes/E0659.stderr
+++ b/src/test/ui/error-codes/E0659.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `foo` is ambiguous
   --> $DIR/E0659.rs:15:15
    |
 LL |     collider::foo();
    |               ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/E0659.rs:10:13
    |

--- a/src/test/ui/imports/duplicate.stderr
+++ b/src/test/ui/imports/duplicate.stderr
@@ -8,12 +8,13 @@ LL |     use a::foo;
    |
    = note: `foo` must be defined only once in the value namespace of this module
 
-error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:46:15
    |
 LL |     use self::foo::bar;
    |               ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the module imported here
   --> $DIR/duplicate.rs:43:9
    |
@@ -27,12 +28,13 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:35:8
    |
 LL |     f::foo();
    |        ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/duplicate.rs:24:13
    |
@@ -46,12 +48,13 @@ LL |     pub use b::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-error[E0659]: `foo` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `foo` is ambiguous
   --> $DIR/duplicate.rs:49:9
    |
 LL |         foo::bar();
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the module imported here
   --> $DIR/duplicate.rs:43:9
    |

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -9,12 +9,13 @@ LL | define_other_core!();
    |
    = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `Vec` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `Vec` is ambiguous
   --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:13:9
    |
 LL |         Vec::panic!();
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `Vec` could refer to the crate imported here
   --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:5:9
    |

--- a/src/test/ui/imports/glob-shadowing.stderr
+++ b/src/test/ui/imports/glob-shadowing.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `env` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `env` is ambiguous
   --> $DIR/glob-shadowing.rs:11:17
    |
 LL |         let x = env!("PATH");
    |                 ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `env` could refer to a macro from prelude
 note: `env` could also refer to the macro imported here
   --> $DIR/glob-shadowing.rs:9:9
@@ -13,12 +14,13 @@ LL |     use m::*;
    = help: consider adding an explicit import of `env` to disambiguate
    = help: or use `self::env` to refer to this macro unambiguously
 
-error[E0659]: `env` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `env` is ambiguous
   --> $DIR/glob-shadowing.rs:19:21
    |
 LL |             let x = env!("PATH");
    |                     ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `env` could refer to a macro from prelude
 note: `env` could also refer to the macro imported here
   --> $DIR/glob-shadowing.rs:17:13
@@ -27,12 +29,13 @@ LL |         use m::*;
    |             ^^^^
    = help: consider adding an explicit import of `env` to disambiguate
 
-error[E0659]: `fenv` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `fenv` is ambiguous
   --> $DIR/glob-shadowing.rs:29:21
    |
 LL |             let x = fenv!();
    |                     ^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `fenv` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:27:13
    |

--- a/src/test/ui/imports/issue-53269.stderr
+++ b/src/test/ui/imports/issue-53269.stderr
@@ -4,12 +4,13 @@ error[E0432]: unresolved import `nonexistent_module`
 LL |     use nonexistent_module::mac;
    |         ^^^^^^^^^^^^^^^^^^ maybe a missing crate `nonexistent_module`?
 
-error[E0659]: `mac` is ambiguous (`macro_rules` vs non-`macro_rules` from other module)
+error[E0659]: `mac` is ambiguous
   --> $DIR/issue-53269.rs:8:5
    |
 LL |     mac!();
    |     ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a `macro_rules` name and a non-`macro_rules` name from another module
 note: `mac` could refer to the macro defined here
   --> $DIR/issue-53269.rs:3:1
    |

--- a/src/test/ui/imports/issue-55884-1.stderr
+++ b/src/test/ui/imports/issue-55884-1.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `S` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `S` is ambiguous
   --> $DIR/issue-55884-1.rs:19:12
    |
 LL |     use m::S;
    |            ^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
   --> $DIR/issue-55884-1.rs:14:13
    |

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -4,12 +4,13 @@ error[E0432]: unresolved import `empty::issue_56125`
 LL |     use empty::issue_56125;
    |         ^^^^^^^^^^^^^^^^^^ no `issue_56125` in `m3::empty`
 
-error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `issue_56125` is ambiguous
   --> $DIR/issue-56125.rs:6:9
    |
 LL |     use issue_56125::last_segment::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `issue_56125` could refer to a crate passed with `--extern`
    = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here
@@ -19,12 +20,13 @@ LL |     use issue_56125::last_segment::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `self::issue_56125` to refer to this module unambiguously
 
-error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `issue_56125` is ambiguous
   --> $DIR/issue-56125.rs:11:9
    |
 LL |     use issue_56125::non_last_segment::non_last_segment::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `issue_56125` could refer to a crate passed with `--extern`
    = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here
@@ -34,12 +36,13 @@ LL |     use issue_56125::non_last_segment::non_last_segment::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `self::issue_56125` to refer to this module unambiguously
 
-error[E0659]: `issue_56125` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `issue_56125` is ambiguous
   --> $DIR/issue-56125.rs:18:9
    |
 LL |     use issue_56125::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `issue_56125` could refer to a crate passed with `--extern`
    = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here

--- a/src/test/ui/imports/issue-57539.stderr
+++ b/src/test/ui/imports/issue-57539.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `core` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `core` is ambiguous
   --> $DIR/issue-57539.rs:4:9
    |
 LL |     use core;
    |         ^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `core` could refer to a built-in crate
    = help: use `::core` to refer to this crate unambiguously
 note: `core` could also refer to the module imported here

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `exported` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
+error[E0659]: `exported` is ambiguous
   --> $DIR/local-modularized-tricky-fail-1.rs:28:1
    |
 LL | exported!();
    | ^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `exported` could refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:5:5
    |
@@ -22,12 +23,13 @@ LL | use inner1::*;
    = help: consider adding an explicit import of `exported` to disambiguate
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `exported` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
+error[E0659]: `exported` is ambiguous
   --> $DIR/local-modularized-tricky-fail-1.rs:28:1
    |
 LL | exported!();
    | ^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `exported` could refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:5:5
    |
@@ -46,12 +48,13 @@ LL | use inner1::*;
    = help: consider adding an explicit import of `exported` to disambiguate
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `panic` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `panic` is ambiguous
   --> $DIR/local-modularized-tricky-fail-1.rs:36:5
    |
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
    = note: `panic` could refer to a macro from prelude
 note: `panic` could also refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:11:5
@@ -66,12 +69,13 @@ LL |       define_panic!();
    = help: use `crate::panic` to refer to this macro unambiguously
    = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `include` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `include` is ambiguous
   --> $DIR/local-modularized-tricky-fail-1.rs:47:1
    |
 LL | include!();
    | ^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
    = note: `include` could refer to a macro from prelude
 note: `include` could also refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:17:5

--- a/src/test/ui/imports/macro-paths.stderr
+++ b/src/test/ui/imports/macro-paths.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `bar` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
+error[E0659]: `bar` is ambiguous
   --> $DIR/macro-paths.rs:13:5
    |
 LL |     bar::m! {
    |     ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `bar` could refer to the module defined here
   --> $DIR/macro-paths.rs:14:9
    |
@@ -16,12 +17,13 @@ LL |     use foo::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `bar` to disambiguate
 
-error[E0659]: `baz` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `baz` is ambiguous
   --> $DIR/macro-paths.rs:23:5
    |
 LL |     baz::m! {
    |     ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `baz` could refer to the module defined here
   --> $DIR/macro-paths.rs:24:9
    |

--- a/src/test/ui/imports/macros.stderr
+++ b/src/test/ui/imports/macros.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `m` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/macros.rs:16:5
    |
 LL |     m! {
    |     ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `m` could refer to the macro imported here
   --> $DIR/macros.rs:18:13
    |
@@ -16,12 +17,13 @@ LL |     use two_macros::*;
    |         ^^^^^^^^^^^^^
    = help: consider adding an explicit import of `m` to disambiguate
 
-error[E0659]: `m` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/macros.rs:16:5
    |
 LL |     m! {
    |     ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `m` could refer to the macro imported here
   --> $DIR/macros.rs:18:13
    |
@@ -34,12 +36,13 @@ LL |     use two_macros::*;
    |         ^^^^^^^^^^^^^
    = help: consider adding an explicit import of `m` to disambiguate
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/macros.rs:30:9
    |
 LL |         m! {
    |         ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro imported here
   --> $DIR/macros.rs:31:17
    |

--- a/src/test/ui/imports/rfc-1560-warning-cycle.stderr
+++ b/src/test/ui/imports/rfc-1560-warning-cycle.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `Foo` is ambiguous (glob import vs glob import in the same module)
+error[E0659]: `Foo` is ambiguous
   --> $DIR/rfc-1560-warning-cycle.rs:9:17
    |
 LL |         fn f(_: Foo) {}
    |                 ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Foo` could refer to the struct imported here
   --> $DIR/rfc-1560-warning-cycle.rs:7:13
    |

--- a/src/test/ui/imports/shadow_builtin_macros.stderr
+++ b/src/test/ui/imports/shadow_builtin_macros.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `panic` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `panic` is ambiguous
   --> $DIR/shadow_builtin_macros.rs:15:14
    |
 LL |     fn f() { panic!(); }
    |              ^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `panic` could refer to a macro from prelude
 note: `panic` could also refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:14:9
@@ -13,12 +14,13 @@ LL |     use foo::*;
    = help: consider adding an explicit import of `panic` to disambiguate
    = help: or use `self::panic` to refer to this macro unambiguously
 
-error[E0659]: `panic` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `panic` is ambiguous
   --> $DIR/shadow_builtin_macros.rs:33:5
    |
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
    = note: `panic` could refer to a macro from prelude
 note: `panic` could also refer to the macro defined here
   --> $DIR/shadow_builtin_macros.rs:30:9
@@ -30,12 +32,13 @@ LL |     m!();
    |     ---- in this macro invocation
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `n` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `n` is ambiguous
   --> $DIR/shadow_builtin_macros.rs:49:5
    |
 LL |     n!();
    |     ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `n` could refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:48:9
    |
@@ -49,12 +52,13 @@ note: `n` could also refer to the macro imported here
 LL | #[macro_use(n)]
    |             ^
 
-error[E0659]: `panic` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `panic` is ambiguous
   --> $DIR/shadow_builtin_macros.rs:20:14
    |
 LL |     fn f() { panic!(); }
    |              ^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
    = note: `panic` could refer to a macro from prelude
 note: `panic` could also refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:19:26

--- a/src/test/ui/macros/ambiguity-legacy-vs-modern.stderr
+++ b/src/test/ui/macros/ambiguity-legacy-vs-modern.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `m` is ambiguous (`macro_rules` vs non-`macro_rules` from other module)
+error[E0659]: `m` is ambiguous
   --> $DIR/ambiguity-legacy-vs-modern.rs:31:9
    |
 LL |         m!()
    |         ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a `macro_rules` name and a non-`macro_rules` name from another module
 note: `m` could refer to the macro defined here
   --> $DIR/ambiguity-legacy-vs-modern.rs:26:5
    |
@@ -15,12 +16,13 @@ note: `m` could also refer to the macro defined here
 LL |         macro m() { 0 }
    |         ^^^^^^^^^^^^^^^
 
-error[E0659]: `m` is ambiguous (`macro_rules` vs non-`macro_rules` from other module)
+error[E0659]: `m` is ambiguous
   --> $DIR/ambiguity-legacy-vs-modern.rs:43:5
    |
 LL |     m!()
    |     ^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a `macro_rules` name and a non-`macro_rules` name from another module
 note: `m` could refer to the macro defined here
   --> $DIR/ambiguity-legacy-vs-modern.rs:40:9
    |

--- a/src/test/ui/macros/macro-path-prelude-shadowing.stderr
+++ b/src/test/ui/macros/macro-path-prelude-shadowing.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `std` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/macro-path-prelude-shadowing.rs:29:9
    |
 LL |         std::panic!();
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
    = note: `std` could refer to a built-in crate
 note: `std` could also refer to the module imported here
   --> $DIR/macro-path-prelude-shadowing.rs:27:9

--- a/src/test/ui/macros/macro-shadowing.stderr
+++ b/src/test/ui/macros/macro-shadowing.stderr
@@ -10,12 +10,13 @@ LL | m1!();
    = note: macro-expanded `#[macro_use]`s may not shadow existing macros (see RFC 1560)
    = note: this error originates in the macro `m1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `foo` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `foo` is ambiguous
   --> $DIR/macro-shadowing.rs:17:1
    |
 LL | foo!();
    | ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `foo` could refer to the macro defined here
   --> $DIR/macro-shadowing.rs:10:5
    |

--- a/src/test/ui/macros/out-of-order-shadowing.stderr
+++ b/src/test/ui/macros/out-of-order-shadowing.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `bar` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `bar` is ambiguous
   --> $DIR/out-of-order-shadowing.rs:5:1
    |
 LL | bar!();
    | ^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `bar` could refer to the macro defined here
   --> $DIR/out-of-order-shadowing.rs:4:1
    |

--- a/src/test/ui/macros/restricted-shadowing-legacy.stderr
+++ b/src/test/ui/macros/restricted-shadowing-legacy.stderr
@@ -1,4 +1,4 @@
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:101:13
    |
 LL |             m!();
@@ -7,6 +7,7 @@ LL |             m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -25,7 +26,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:139:42
    |
 LL |         macro_rules! gen_invoc { () => { m!() } }
@@ -34,6 +35,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -52,7 +54,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:148:9
    |
 LL |         m!();
@@ -61,6 +63,7 @@ LL |         m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -79,7 +82,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:164:9
    |
 LL |         m!();
@@ -88,6 +91,7 @@ LL |         m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -106,7 +110,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:180:13
    |
 LL |             m!();
@@ -115,6 +119,7 @@ LL |             m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -133,7 +138,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:218:42
    |
 LL |         macro_rules! gen_invoc { () => { m!() } }
@@ -142,6 +147,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -160,7 +166,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:232:9
    |
 LL |         m!();
@@ -169,6 +175,7 @@ LL |         m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |
@@ -187,7 +194,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-legacy.rs:262:42
    |
 LL |         macro_rules! gen_invoc { () => { m!() } }
@@ -196,6 +203,7 @@ LL |         macro_rules! gen_invoc { () => { m!() } }
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-legacy.rs:88:9
    |

--- a/src/test/ui/macros/restricted-shadowing-modern.stderr
+++ b/src/test/ui/macros/restricted-shadowing-modern.stderr
@@ -1,4 +1,4 @@
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:104:17
    |
 LL |                 m!();
@@ -7,6 +7,7 @@ LL |                 m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |
@@ -25,7 +26,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:147:33
    |
 LL |             macro gen_invoc() { m!() }
@@ -34,6 +35,7 @@ LL |             macro gen_invoc() { m!() }
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |
@@ -52,7 +54,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:156:13
    |
 LL |             m!();
@@ -61,6 +63,7 @@ LL |             m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |
@@ -79,7 +82,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:172:13
    |
 LL |             m!();
@@ -88,6 +91,7 @@ LL |             m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |
@@ -106,7 +110,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:190:17
    |
 LL |                 m!();
@@ -115,6 +119,7 @@ LL |                 m!();
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |
@@ -133,7 +138,7 @@ LL | include!();
    | ---------- in this macro invocation
    = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `m` is ambiguous
   --> $DIR/restricted-shadowing-modern.rs:233:33
    |
 LL |             macro gen_invoc() { m!() }
@@ -142,6 +147,7 @@ LL |             macro gen_invoc() { m!() }
 LL | include!();
    | ---------- in this macro invocation
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro defined here
   --> $DIR/restricted-shadowing-modern.rs:91:9
    |

--- a/src/test/ui/proc-macro/ambiguous-builtin-attrs.rs
+++ b/src/test/ui/proc-macro/ambiguous-builtin-attrs.rs
@@ -35,5 +35,5 @@ fn main() {
 }
 
 use deny as allow;
-#[allow(unused)] //~ ERROR `allow` is ambiguous (built-in attribute vs any other name)
+#[allow(unused)] //~ ERROR `allow` is ambiguous
 fn builtin_renamed() {}

--- a/src/test/ui/proc-macro/ambiguous-builtin-attrs.stderr
+++ b/src/test/ui/proc-macro/ambiguous-builtin-attrs.stderr
@@ -4,12 +4,13 @@ error[E0425]: cannot find value `NonExistent` in this scope
 LL |     NonExistent;
    |     ^^^^^^^^^^^ not found in this scope
 
-error[E0659]: `repr` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `repr` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:9:3
    |
 LL | #[repr(C)]
    |   ^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `repr` could refer to a built-in attribute
 note: `repr` could also refer to the attribute macro imported here
   --> $DIR/ambiguous-builtin-attrs.rs:6:5
@@ -18,12 +19,13 @@ LL | use builtin_attrs::*;
    |     ^^^^^^^^^^^^^^^^
    = help: use `crate::repr` to refer to this attribute macro unambiguously
 
-error[E0659]: `repr` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `repr` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:11:19
    |
 LL | #[cfg_attr(all(), repr(C))]
    |                   ^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `repr` could refer to a built-in attribute
 note: `repr` could also refer to the attribute macro imported here
   --> $DIR/ambiguous-builtin-attrs.rs:6:5
@@ -32,12 +34,13 @@ LL | use builtin_attrs::*;
    |     ^^^^^^^^^^^^^^^^
    = help: use `crate::repr` to refer to this attribute macro unambiguously
 
-error[E0659]: `repr` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `repr` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:20:34
    |
 LL | fn non_macro_expanded_location<#[repr(C)] T>() {
    |                                  ^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `repr` could refer to a built-in attribute
 note: `repr` could also refer to the attribute macro imported here
   --> $DIR/ambiguous-builtin-attrs.rs:6:5
@@ -46,12 +49,13 @@ LL | use builtin_attrs::*;
    |     ^^^^^^^^^^^^^^^^
    = help: use `crate::repr` to refer to this attribute macro unambiguously
 
-error[E0659]: `repr` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `repr` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:24:11
    |
 LL |         #[repr(C)]
    |           ^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `repr` could refer to a built-in attribute
 note: `repr` could also refer to the attribute macro imported here
   --> $DIR/ambiguous-builtin-attrs.rs:6:5
@@ -60,12 +64,13 @@ LL | use builtin_attrs::*;
    |     ^^^^^^^^^^^^^^^^
    = help: use `crate::repr` to refer to this attribute macro unambiguously
 
-error[E0659]: `allow` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `allow` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:38:3
    |
 LL | #[allow(unused)]
    |   ^^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `allow` could refer to a built-in attribute
 note: `allow` could also refer to the built-in attribute imported here
   --> $DIR/ambiguous-builtin-attrs.rs:37:5
@@ -74,12 +79,13 @@ LL | use deny as allow;
    |     ^^^^^^^^^^^^^
    = help: use `crate::allow` to refer to this built-in attribute unambiguously
 
-error[E0659]: `feature` is ambiguous (built-in attribute vs any other name)
+error[E0659]: `feature` is ambiguous
   --> $DIR/ambiguous-builtin-attrs.rs:3:4
    |
 LL | #![feature(decl_macro)]
    |    ^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a builtin attribute
    = note: `feature` could refer to a built-in attribute
 note: `feature` could also refer to the attribute macro imported here
   --> $DIR/ambiguous-builtin-attrs.rs:6:5

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -33,12 +33,13 @@ LL |             gen_helper_use!();
            crate::empty_helper
    = note: this error originates in the macro `gen_helper_use` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0659]: `empty_helper` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `empty_helper` is ambiguous
   --> $DIR/derive-helper-shadowing.rs:26:13
    |
 LL |         use empty_helper;
    |             ^^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `empty_helper` could refer to the derive helper attribute defined here
   --> $DIR/derive-helper-shadowing.rs:22:10
    |
@@ -51,12 +52,13 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `empty_helper` is ambiguous
   --> $DIR/derive-helper-shadowing.rs:19:3
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `empty_helper` could refer to the derive helper attribute defined here
   --> $DIR/derive-helper-shadowing.rs:22:10
    |

--- a/src/test/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
+++ b/src/test/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `empty_helper` is ambiguous
   --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:3
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `empty_helper` could refer to the derive helper attribute defined here
   --> $DIR/helper-attr-blocked-by-import-ambig.rs:10:10
    |

--- a/src/test/ui/proc-macro/issue-41211.stderr
+++ b/src/test/ui/proc-macro/issue-41211.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `identity_attr` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+error[E0659]: `identity_attr` is ambiguous
   --> $DIR/issue-41211.rs:11:4
    |
 LL | #![identity_attr]
    |    ^^^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `identity_attr` could refer to the attribute macro imported here
   --> $DIR/issue-41211.rs:14:5
    |

--- a/src/test/ui/proc-macro/proc-macro-attributes.stderr
+++ b/src/test/ui/proc-macro/proc-macro-attributes.stderr
@@ -4,12 +4,13 @@ error: cannot find attribute `C` in this scope
 LL | #[C]
    |   ^ help: a derive helper attribute with a similar name exists: `B`
 
-error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `B` is ambiguous
   --> $DIR/proc-macro-attributes.rs:6:3
    |
 LL | #[B]
    |   ^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `B` could refer to the derive helper attribute defined here
   --> $DIR/proc-macro-attributes.rs:19:10
    |
@@ -21,12 +22,13 @@ note: `B` could also refer to the derive macro imported here
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
-error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `B` is ambiguous
   --> $DIR/proc-macro-attributes.rs:10:3
    |
 LL | #[B(D)]
    |   ^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `B` could refer to the derive helper attribute defined here
   --> $DIR/proc-macro-attributes.rs:19:10
    |
@@ -38,12 +40,13 @@ note: `B` could also refer to the derive macro imported here
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
-error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `B` is ambiguous
   --> $DIR/proc-macro-attributes.rs:13:3
    |
 LL | #[B(E = "foo")]
    |   ^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `B` could refer to the derive helper attribute defined here
   --> $DIR/proc-macro-attributes.rs:19:10
    |
@@ -55,12 +58,13 @@ note: `B` could also refer to the derive macro imported here
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
-error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
+error[E0659]: `B` is ambiguous
   --> $DIR/proc-macro-attributes.rs:16:3
    |
 LL | #[B(arbitrary tokens)]
    |   ^ ambiguous name
    |
+   = note: ambiguous because of a name conflict with a derive helper attribute
 note: `B` could refer to the derive helper attribute defined here
   --> $DIR/proc-macro-attributes.rs:19:10
    |

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/ambiguity-macros-nested.rs:8:13
    |
 LL |     pub use std::io;
    |             ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `std` could refer to a built-in crate
    = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/ambiguity-macros.rs:7:5
    |
 LL | use std::io;
    |     ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `std` could refer to a built-in crate
    = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/ambiguity-nested.rs:8:13
    |
 LL |     pub use std::io;
    |             ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `std` could refer to a built-in crate
    = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/ambiguity.rs:5:5
    |
 LL | use std::io;
    |     ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `std` could refer to a built-in crate
    = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow-nested.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `sub` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `sub` is ambiguous
   --> $DIR/block-scoped-shadow-nested.rs:16:13
    |
 LL |         use sub::bar;
    |             ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `sub` could refer to the module imported here
   --> $DIR/block-scoped-shadow-nested.rs:14:9
    |

--- a/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/block-scoped-shadow.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `Foo` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `Foo` is ambiguous
   --> $DIR/block-scoped-shadow.rs:11:9
    |
 LL |     use Foo::*;
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `Foo` could refer to the enum defined here
   --> $DIR/block-scoped-shadow.rs:10:5
    |
@@ -16,12 +17,13 @@ LL | enum Foo {}
    | ^^^^^^^^^^^
    = help: use `crate::Foo` to refer to this enum unambiguously
 
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/block-scoped-shadow.rs:18:9
    |
 LL |     use std as foo;
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `std` could refer to the enum defined here
   --> $DIR/block-scoped-shadow.rs:17:5
    |
@@ -34,12 +36,13 @@ LL | struct std;
    | ^^^^^^^^^^^
    = help: use `crate::std` to refer to this struct unambiguously
 
-error[E0659]: `std` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `std` is ambiguous
   --> $DIR/block-scoped-shadow.rs:18:9
    |
 LL |     use std as foo;
    |         ^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `std` could refer to the function defined here
   --> $DIR/block-scoped-shadow.rs:16:5
    |

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
@@ -1,9 +1,10 @@
-error[E0659]: `issue_56596` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `issue_56596` is ambiguous
   --> $DIR/issue-56596.rs:12:5
    |
 LL | use issue_56596;
    |     ^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
    = note: `issue_56596` could refer to a crate passed with `--extern`
    = help: use `::issue_56596` to refer to this crate unambiguously
 note: `issue_56596` could also refer to the module imported here

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
@@ -10,12 +10,13 @@ note: consider marking `legacy_macro` as `pub` in the imported module
 LL |     pub use legacy_macro as _;
    |             ^^^^^^^^^^^^^^^^^
 
-error[E0659]: `legacy_macro` is ambiguous (name vs any other name during import resolution)
+error[E0659]: `legacy_macro` is ambiguous
   --> $DIR/macro-rules.rs:31:13
    |
 LL |         use legacy_macro as _;
    |             ^^^^^^^^^^^^ ambiguous name
    |
+   = note: ambiguous because of multiple potential import sources
 note: `legacy_macro` could refer to the macro defined here
   --> $DIR/macro-rules.rs:28:9
    |


### PR DESCRIPTION
Edit the language of the ambiguity descriptions for E0659. These strings now appear as notes.

Closes #79717.