### PR TITLE
Endless Iterators

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -1,3 +1,4 @@
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{DoubleEndedIterator, FusedIterator, Iterator, TrustedLen};
 use crate::ops::Try;
 
@@ -324,3 +325,9 @@ where
     B: TrustedLen<Item = A::Item>,
 {
 }
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<A: EndlessIterator, B> EndlessIterator for Chain<A, B> where B: Iterator<Item = A::Item> {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<A, B: EndlessIterator> EndlessIterator for Chain<A, B> where A: Iterator<Item = B::Item> {}

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -1,6 +1,7 @@
 use crate::iter::adapters::{
     zip::try_get_unchecked, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -138,6 +139,14 @@ where
 unsafe impl<'a, I, T: 'a> TrustedLen for Cloned<I>
 where
     I: TrustedLen<Item = &'a T>,
+    T: Clone,
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<'a, I, T: 'a> EndlessIterator for Cloned<I>
+where
+    I: EndlessIterator<Item = &'a T>,
     T: Clone,
 {
 }

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -1,6 +1,7 @@
 use crate::iter::adapters::{
     zip::try_get_unchecked, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -164,6 +165,14 @@ where
 unsafe impl<'a, I, T: 'a> TrustedLen for Copied<I>
 where
     I: TrustedLen<Item = &'a T>,
+    T: Copy,
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<'a, I, T: 'a> EndlessIterator for Copied<I>
+where
+    I: EndlessIterator<Item = &'a T>,
     T: Copy,
 {
 }

--- a/library/core/src/iter/adapters/cycle.rs
+++ b/library/core/src/iter/adapters/cycle.rs
@@ -1,4 +1,10 @@
-use crate::{iter::FusedIterator, ops::Try};
+use crate::{
+    iter::{
+        traits::{EndlessIterator, EndlessOrExact},
+        FusedIterator,
+    },
+    ops::Try,
+};
 
 /// An iterator that repeats endlessly.
 ///
@@ -106,3 +112,6 @@ where
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Cycle<I> where I: Clone + Iterator {}
+
+#[unstable(issue = "none", feature = "none")]
+unsafe impl<I> EndlessIterator for Cycle<I> where I: Clone + EndlessOrExact {}

--- a/library/core/src/iter/adapters/filter.rs
+++ b/library/core/src/iter/adapters/filter.rs
@@ -1,4 +1,5 @@
 use crate::fmt;
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
 use crate::ops::Try;
 
@@ -150,3 +151,6 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Filter<I, P> where P: FnMut(&I::Item) -> bool {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator, P> EndlessIterator for Filter<I, P> where P: FnMut(&I::Item) -> bool {}

--- a/library/core/src/iter/adapters/filter_map.rs
+++ b/library/core/src/iter/adapters/filter_map.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
+use crate::iter::{adapters::SourceIter, traits::EndlessIterator, FusedIterator, InPlaceIterable};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
@@ -144,6 +144,12 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for FilterMap<I, F> where
+    F: FnMut(I::Item) -> Option<B>
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<B, I: EndlessIterator, F> EndlessIterator for FilterMap<I, F> where
     F: FnMut(I::Item) -> Option<B>
 {
 }

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -1,4 +1,5 @@
 use crate::fmt;
+use crate::iter::traits::{EndlessIterator, EndlessOrExact};
 use crate::iter::{DoubleEndedIterator, Fuse, FusedIterator, Iterator, Map, TrustedLen};
 use crate::ops::Try;
 
@@ -138,6 +139,26 @@ where
 {
 }
 
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I, U, F> EndlessIterator for FlatMap<I, U, F>
+where
+    I: EndlessIterator,
+    U: IntoIterator,
+    U::IntoIter: EndlessOrExact,
+    F: FnMut(I::Item) -> U,
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I, U, F> EndlessIterator for FlatMap<I, U, F>
+where
+    I: EndlessOrExact,
+    U: IntoIterator,
+    U::IntoIter: EndlessIterator,
+    F: FnMut(I::Item) -> U,
+{
+}
+
 /// An iterator that flattens one level of nesting in an iterator of things
 /// that can be turned into iterators.
 ///
@@ -259,6 +280,22 @@ unsafe impl<I> TrustedLen for Flatten<I>
 where
     I: TrustedLen,
     <I as Iterator>::Item: TrustedConstSize,
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I> EndlessIterator for Flatten<I>
+where
+    I: EndlessIterator,
+    I::Item: EndlessOrExact,
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I> EndlessIterator for Flatten<I>
+where
+    I: EndlessOrExact,
+    I::Item: EndlessIterator,
 {
 }
 

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -1,5 +1,6 @@
 use crate::intrinsics;
 use crate::iter::adapters::zip::try_get_unchecked;
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{
     DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen, TrustedRandomAccess,
     TrustedRandomAccessNoCoerce,
@@ -232,6 +233,9 @@ where
 {
     const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
 }
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator> EndlessIterator for Fuse<I> {}
 
 /// Fuse specialization trait
 ///

--- a/library/core/src/iter/adapters/inspect.rs
+++ b/library/core/src/iter/adapters/inspect.rs
@@ -1,4 +1,5 @@
 use crate::fmt;
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
 use crate::ops::Try;
 
@@ -164,3 +165,6 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable, F> InPlaceIterable for Inspect<I, F> where F: FnMut(&I::Item) {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator, F> EndlessIterator for Inspect<I, F> where F: FnMut(&I::Item) {}

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -1,3 +1,5 @@
+use crate::iter::traits::EndlessIterator;
+
 use super::Peekable;
 
 /// An iterator adapter that places a separator between all elements.
@@ -56,6 +58,9 @@ where
         intersperse_size_hint(&self.iter, self.needs_sep)
     }
 }
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator> EndlessIterator for Intersperse<I> where I::Item: Clone {}
 
 /// An iterator adapter that places a separator between all elements.
 ///
@@ -185,3 +190,6 @@ where
         accum
     })
 }
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator, G: FnMut() -> I::Item> EndlessIterator for IntersperseWith<I, G> {}

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -2,6 +2,7 @@ use crate::fmt;
 use crate::iter::adapters::{
     zip::try_get_unchecked, SourceIter, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 
@@ -216,3 +217,11 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<B, I: InPlaceIterable, F> InPlaceIterable for Map<I, F> where F: FnMut(I::Item) -> B {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<B, I, F> EndlessIterator for Map<I, F>
+where
+    I: EndlessIterator,
+    F: FnMut(I::Item) -> B,
+{
+}

--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -1,3 +1,4 @@
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{adapters::SourceIter, FusedIterator, TrustedLen};
 use crate::ops::{ControlFlow, Try};
 
@@ -333,3 +334,6 @@ where
         unsafe { SourceIter::as_inner(&mut self.iter) }
     }
 }
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator> EndlessIterator for Peekable<I> {}

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -1,3 +1,4 @@
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -135,3 +136,6 @@ impl<I> FusedIterator for Rev<I> where I: FusedIterator + DoubleEndedIterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Rev<I> where I: TrustedLen + DoubleEndedIterator {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I> EndlessIterator for Rev<I> where I: EndlessIterator + DoubleEndedIterator {}

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -1,5 +1,5 @@
 use crate::intrinsics::unlikely;
-use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
+use crate::iter::{adapters::SourceIter, traits::EndlessIterator, FusedIterator, InPlaceIterable};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator that skips over `n` elements of `iter`.
@@ -237,3 +237,6 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable> InPlaceIterable for Skip<I> {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator> EndlessIterator for Skip<I> {}

--- a/library/core/src/iter/adapters/skip_while.rs
+++ b/library/core/src/iter/adapters/skip_while.rs
@@ -1,4 +1,5 @@
 use crate::fmt;
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
 use crate::ops::Try;
 
@@ -120,6 +121,12 @@ where
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: InPlaceIterable, F> InPlaceIterable for SkipWhile<I, F> where
+    F: FnMut(&I::Item) -> bool
+{
+}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator, F> EndlessIterator for SkipWhile<I, F> where
     F: FnMut(&I::Item) -> bool
 {
 }

--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -1,4 +1,8 @@
-use crate::{intrinsics, iter::from_fn, ops::Try};
+use crate::{
+    intrinsics,
+    iter::{from_fn, traits::EndlessIterator},
+    ops::Try,
+};
 
 /// An iterator for stepping iterators by a custom amount.
 ///
@@ -233,3 +237,6 @@ where
 // StepBy can only make the iterator shorter, so the len will still fit.
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 impl<I> ExactSizeIterator for StepBy<I> where I: ExactSizeIterator {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<I: EndlessIterator> EndlessIterator for StepBy<I> {}

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -1,5 +1,7 @@
 use crate::cmp;
-use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable, TrustedLen};
+use crate::iter::{
+    adapters::SourceIter, traits::EndlessOrExact, FusedIterator, InPlaceIterable, TrustedLen,
+};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
@@ -234,7 +236,7 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I> ExactSizeIterator for Take<I> where I: ExactSizeIterator {}
+impl<I> ExactSizeIterator for Take<I> where I: EndlessOrExact {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I> FusedIterator for Take<I> where I: FusedIterator {}

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -1,5 +1,6 @@
 use crate::cmp;
 use crate::fmt::{self, Debug};
+use crate::iter::traits::EndlessIterator;
 use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
 use crate::iter::{InPlaceIterable, SourceIter, TrustedLen};
 
@@ -434,6 +435,12 @@ where
 // An additional method returning the number of times the source has been logically advanced
 // (without calling next()) would be needed to properly drop the remainder of the source.
 unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where A::Item: Copy {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<A: EndlessIterator, B: Iterator> EndlessIterator for Zip<A, B> {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<A: Iterator, B: EndlessIterator> EndlessIterator for Zip<A, B> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Debug, B: Debug> Debug for Zip<A, B> {

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -1,4 +1,4 @@
-use crate::iter::{FusedIterator, TrustedLen};
+use crate::iter::{traits::EndlessIterator, FusedIterator, TrustedLen};
 
 /// Creates a new iterator that endlessly repeats a single element.
 ///
@@ -127,3 +127,6 @@ impl<A: Clone> FusedIterator for Repeat<A> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A: Clone> TrustedLen for Repeat<A> {}
+
+#[unstable(issue = "none", feature = "endless")]
+unsafe impl<A: Clone> EndlessIterator for Repeat<A> {}

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -72,3 +72,26 @@ pub unsafe trait InPlaceIterable: Iterator {}
 #[unstable(feature = "trusted_step", issue = "85731")]
 #[rustc_specialization_trait]
 pub unsafe trait TrustedStep: Step {}
+
+/// An iterator that is either empty or endless.
+///
+/// The iterator reports a size hint that is either `0, Some(0)` or `usize::MAX, None`.
+/// Since this is used to implement `ExactSizeIterator` for some adapters, iterators that
+/// are only empty should not implement this.
+///
+/// # Safety
+///
+/// The implementation must either be endless or empty.
+#[unstable(issue = "none", feature = "endless")]
+#[marker]
+pub unsafe trait EndlessIterator: Iterator {}
+
+#[unstable(issue = "none", feature = "endless")]
+#[marker]
+pub trait EndlessOrExact: Iterator {}
+
+#[unstable(issue = "none", feature = "endless")]
+impl<T: EndlessIterator> EndlessOrExact for T {}
+
+#[unstable(issue = "none", feature = "endless")]
+impl<T: ExactSizeIterator> EndlessOrExact for T {}

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -11,6 +11,10 @@ pub use self::double_ended::DoubleEndedIterator;
 pub use self::exact_size::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::iterator::Iterator;
+#[unstable(issue = "none", feature = "endless")]
+pub use self::marker::EndlessIterator;
+#[unstable(issue = "none", feature = "endless")]
+pub(super) use self::marker::EndlessOrExact;
 #[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::marker::InPlaceIterable;
 #[unstable(feature = "trusted_step", issue = "85731")]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -167,6 +167,7 @@
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(llvm_asm)]
+#![feature(marker_trait_attr)]
 #![feature(min_specialization)]
 #![feature(mixed_integer_ops)]
 #![cfg_attr(not(bootstrap), feature(must_not_suspend))]


### PR DESCRIPTION
Endless Iterators: iterators that are either empty or yields elements infinitely.

Implement `ExactSizeIterator` for `Take` when the underlying iterator 
`: ExactSizeIterator | EndlessIterator`. This could have benefits since `repeat(item).take(x)` is pretty common.