### PR TITLE
CI: make docker cache download and `docker load` time out after 10 minutes

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -70,7 +70,8 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       echo "Attempting to download $url"
       rm -f /tmp/rustci_docker_cache
       set +e
-      retry curl -y 30 -Y 10 --connect-timeout 30 -f -L -C - -o /tmp/rustci_docker_cache "$url"
+      retry curl --max-time 600 -y 30 -Y 10 --connect-timeout 30 -f -L -C - \
+        -o /tmp/rustci_docker_cache "$url"
       loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -72,6 +72,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       set +e
       retry curl --max-time 600 -y 30 -Y 10 --connect-timeout 30 -f -L -C - \
         -o /tmp/rustci_docker_cache "$url"
+      echo "Loading images into docker"
       loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -73,7 +73,10 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       retry curl --max-time 600 -y 30 -Y 10 --connect-timeout 30 -f -L -C - \
         -o /tmp/rustci_docker_cache "$url"
       echo "Loading images into docker"
-      loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
+      # docker load sometimes hangs in the CI, so time out after 10 minutes with TERM,
+      # KILL after 12 minutes
+      loaded_images=$(/usr/bin/timeout -k 720 600 docker load -i /tmp/rustci_docker_cache \
+        | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"
     fi


### PR DESCRIPTION
Might help to prevent timeouts we have been seeing:
* https://github.com/rust-lang-ci/rust/runs/3946294286?check_suite_focus=true#step:25:23
* https://github.com/rust-lang-ci/rust/runs/3956799200?check_suite_focus=true#step:25:22
* https://github.com/rust-lang-ci/rust/runs/3962928502?check_suite_focus=true#step:25:23
* https://github.com/rust-lang-ci/rust/runs/3967892291?check_suite_focus=true
* https://github.com/rust-lang-ci/rust/runs/3971202204?check_suite_focus=true

If the download or loading the images into docker times out the CI will still continue and rebuild the docker image from scratch.