### PR TITLE
Do not mention a reexported item if it's private

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -829,6 +829,15 @@ impl<'a> Resolver<'a> {
                     return;
                 }
 
+                // #90113: Do not count an inaccessible reexported item as a candidate.
+                if let NameBindingKind::Import { binding, .. } = name_binding.kind {
+                    if this.is_accessible_from(binding.vis, parent_scope.module)
+                        && !this.is_accessible_from(name_binding.vis, parent_scope.module)
+                    {
+                        return;
+                    }
+                }
+
                 // collect results based on the filter function
                 // avoid suggesting anything from the same module in which we are resolving
                 if ident.name == lookup_ident.name

--- a/src/test/ui/resolve/issue-90113.rs
+++ b/src/test/ui/resolve/issue-90113.rs
@@ -1,0 +1,21 @@
+mod list {
+    pub use self::List::Cons;
+
+    pub enum List<T> {
+        Cons(T, Box<List<T>>),
+    }
+}
+
+mod alias {
+    use crate::list::List;
+
+    pub type Foo = List<String>;
+}
+
+fn foo(l: crate::alias::Foo) {
+    match l {
+        Cons(..) => {} //~ ERROR: cannot find tuple struct or tuple variant `Cons` in this scope
+    }
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-90113.stderr
+++ b/src/test/ui/resolve/issue-90113.stderr
@@ -1,0 +1,14 @@
+error[E0531]: cannot find tuple struct or tuple variant `Cons` in this scope
+  --> $DIR/issue-90113.rs:17:9
+   |
+LL |         Cons(..) => {}
+   |         ^^^^ not found in this scope
+   |
+help: consider importing this tuple variant
+   |
+LL | use list::List::Cons;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0531`.


### PR DESCRIPTION
Fixes #90113
The _actual_ regression was introduced in #73652, then #88838 made it worse. This fixes the issue by not counting such an import as a candidate.