### PR TITLE
triagebot: Treat `I-*nominated` like `I-nominated`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,8 +5,8 @@ allow-unauthenticated = [
     "requires-nightly",
     "regression-*",
     "perf-*",
-    # I-* without I-nominated
-    "I-*", "!I-nominated",
+    # I-* without I-*nominated
+    "I-*", "!I-*nominated",
     "AsyncAwait-OnDeck",
 ]
 


### PR DESCRIPTION
rustbot doesn't allow unauthenticated users to set `I-nominated`; apply the same permissions to the new `I-*nominated` labels.