### PR TITLE
Revert "resolve: Use NameBinding for local variables and generic parameters"

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1294,8 +1294,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
             // Walk backwards up the ribs in scope and collect candidates.
             for rib in self.ribs[ns].iter().rev() {
                 // Locals and type parameters
-                for (ident, binding) in &rib.bindings {
-                    let res = binding.res();
+                for (ident, &res) in &rib.bindings {
                     if filter_fn(res) {
                         names.push(TypoSuggestion::typo_from_res(ident.name, res));
                     }


### PR DESCRIPTION
This reverts commit 6162529a01473bbb2427fa27354cbafc3c514eee, that is, PR #89100.

Reverting per performance regression noted post-merge on that PR (https://github.com/rust-lang/rust/pull/89100#issuecomment-948065457).