### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1743,7 +1743,7 @@ extern "C" {
 
     pub fn LLVMDisposeMessage(message: *mut c_char);
 
-    pub fn LLVMStartMultithreaded() -> Bool;
+    pub fn LLVMIsMultithreaded() -> Bool;
 
     /// Returns a string describing the last error caused by an LLVMRust* call.
     pub fn LLVMRustGetLastError() -> *const c_char;

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -17,35 +17,25 @@ use std::path::Path;
 use std::ptr;
 use std::slice;
 use std::str;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
-static POISONED: AtomicBool = AtomicBool::new(false);
 static INIT: Once = Once::new();
 
 pub(crate) fn init(sess: &Session) {
     unsafe {
         // Before we touch LLVM, make sure that multithreading is enabled.
+        if llvm::LLVMIsMultithreaded() != 1 {
+            bug!("LLVM compiled without support for threads");
+        }
         INIT.call_once(|| {
-            if llvm::LLVMStartMultithreaded() != 1 {
-                // use an extra bool to make sure that all future usage of LLVM
-                // cannot proceed despite the Once not running more than once.
-                POISONED.store(true, Ordering::SeqCst);
-            }
-
             configure_llvm(sess);
         });
-
-        if POISONED.load(Ordering::SeqCst) {
-            bug!("couldn't enable multi-threaded LLVM");
-        }
     }
 }
 
 fn require_inited() {
-    INIT.call_once(|| bug!("llvm is not initialized"));
-    if POISONED.load(Ordering::SeqCst) {
-        bug!("couldn't enable multi-threaded LLVM");
+    if !INIT.is_completed() {
+        bug!("LLVM is not initialized");
     }
 }
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -309,8 +309,9 @@ where
 
     // Check the qualifs of the value of `const` items.
     if let Some(ct) = constant.literal.const_for_ty() {
-        if let ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs_: _, promoted }) = ct.val {
-            assert!(promoted.is_none());
+        if let ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs_: _, promoted: None }) =
+            ct.val
+        {
             // Don't peek inside trait associated constants.
             if cx.tcx.trait_of_item(def.did).is_none() {
                 let qualifs = if let Some((did, param_did)) = def.as_const_arg() {

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -46,6 +46,9 @@ pub trait Qualif {
     /// Whether this `Qualif` is cleared when a local is moved from.
     const IS_CLEARED_ON_MOVE: bool = false;
 
+    /// Whether this `Qualif` might be evaluated after the promotion and can encounter a promoted.
+    const ALLOW_PROMOTED: bool = false;
+
     /// Extracts the field of `ConstQualifs` that corresponds to this `Qualif`.
     fn in_qualifs(qualifs: &ConstQualifs) -> bool;
 
@@ -129,6 +132,7 @@ pub struct NeedsNonConstDrop;
 impl Qualif for NeedsNonConstDrop {
     const ANALYSIS_NAME: &'static str = "flow_needs_nonconst_drop";
     const IS_CLEARED_ON_MOVE: bool = true;
+    const ALLOW_PROMOTED: bool = true;
 
     fn in_qualifs(qualifs: &ConstQualifs) -> bool {
         qualifs.needs_non_const_drop
@@ -309,11 +313,13 @@ where
 
     // Check the qualifs of the value of `const` items.
     if let Some(ct) = constant.literal.const_for_ty() {
-        if let ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs_: _, promoted: None }) =
-            ct.val
-        {
+        if let ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs_: _, promoted }) = ct.val {
+            // Use qualifs of the type for the promoted. Promoteds in MIR body should be possible
+            // only for `NeedsNonConstDrop` with precise drop checking. This is the only const
+            // check performed after the promotion. Verify that with an assertion.
+            assert!(promoted.is_none() || Q::ALLOW_PROMOTED);
             // Don't peek inside trait associated constants.
-            if cx.tcx.trait_of_item(def.did).is_none() {
+            if promoted.is_none() && cx.tcx.trait_of_item(def.did).is_none() {
                 let qualifs = if let Some((did, param_did)) = def.as_const_arg() {
                     cx.tcx.at(constant.span).mir_const_qualif_const_arg((did, param_did))
                 } else {

--- a/compiler/rustc_error_codes/src/error_codes/E0637.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0637.md
@@ -1,35 +1,51 @@
-An underscore `_` character has been used as the identifier for a lifetime.
+`'_` lifetime name or `&T` without an explicit lifetime name has been used
+on illegal place.
 
 Erroneous code example:
 
 ```compile_fail,E0106,E0637
-fn longest<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
-         //^^ `'_` is a reserved lifetime name
+fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+                     //^^ `'_` is a reserved lifetime name
     if str1.len() > str2.len() {
         str1
     } else {
         str2
     }
 }
+
+fn and_without_explicit_lifetime<T>()
+where
+    T: Into<&u32>,
+          //^ `&` without an explicit lifetime name
+{
+}
 ```
 
-`'_`, cannot be used as a lifetime identifier because it is a reserved for the
-anonymous lifetime. To fix this, use a lowercase letter such as 'a, or a series
-of lowercase letters such as `'foo`.  For more information, see [the
-book][bk-no].  For more information on using the anonymous lifetime in rust
-nightly, see [the nightly book][bk-al].
+First, `'_` cannot be used as a lifetime identifier in some places
+because it is a reserved for the anonymous lifetime. Second, `&T`
+without an explicit lifetime name cannot also be used in some places.
+To fix them, use a lowercase letter such as `'a`, or a series
+of lowercase letters such as `'foo`. For more information about lifetime
+identifier, see [the book][bk-no]. For more information on using
+the anonymous lifetime in Rust 2018, see [the Rust 2018 blog post][blog-al].
 
 Corrected example:
 
 ```
-fn longest<'a>(str1: &'a str, str2: &'a str) -> &'a str {
+fn underscore_lifetime<'a>(str1: &'a str, str2: &'a str) -> &'a str {
     if str1.len() > str2.len() {
         str1
     } else {
         str2
     }
 }
+
+fn and_without_explicit_lifetime<'foo, T>()
+where
+    T: Into<&'foo u32>,
+{
+}
 ```
 
 [bk-no]: https://doc.rust-lang.org/book/appendix-02-operators.html#non-operator-symbols
-[bk-al]: https://doc.rust-lang.org/nightly/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html
+[blog-al]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#more-lifetime-elision-rules

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -19,9 +19,7 @@ use std::mem;
 struct Marker(LocalExpnId, Transparency);
 
 impl MutVisitor for Marker {
-    fn token_visiting_enabled(&self) -> bool {
-        true
-    }
+    const VISIT_TOKENS: bool = true;
 
     fn visit_span(&mut self, span: &mut Span) {
         *span = span.apply_mark(self.0.to_expn_id(), self.1)

--- a/compiler/rustc_expand/src/mut_visit/tests.rs
+++ b/compiler/rustc_expand/src/mut_visit/tests.rs
@@ -15,9 +15,8 @@ fn print_crate_items(krate: &ast::Crate) -> String {
 struct ToZzIdentMutVisitor;
 
 impl MutVisitor for ToZzIdentMutVisitor {
-    fn token_visiting_enabled(&self) -> bool {
-        true
-    }
+    const VISIT_TOKENS: bool = true;
+
     fn visit_ident(&mut self, ident: &mut Ident) {
         *ident = Ident::from_str("zz");
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -130,6 +130,9 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
                     traits::NonStructuralMatchTy::Opaque => {
                         "opaque types cannot be used in patterns".to_string()
                     }
+                    traits::NonStructuralMatchTy::Closure => {
+                        "closures cannot be used in patterns".to_string()
+                    }
                     traits::NonStructuralMatchTy::Generator => {
                         "generators cannot be used in patterns".to_string()
                     }

--- a/compiler/rustc_trait_selection/src/traits/structural_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_match.rs
@@ -17,6 +17,7 @@ pub enum NonStructuralMatchTy<'tcx> {
     Dynamic,
     Foreign,
     Opaque,
+    Closure,
     Generator,
     Projection,
 }
@@ -154,6 +155,9 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
             ty::Projection(..) => {
                 return ControlFlow::Break(NonStructuralMatchTy::Projection);
             }
+            ty::Closure(..) => {
+                return ControlFlow::Break(NonStructuralMatchTy::Closure);
+            }
             ty::Generator(..) | ty::GeneratorWitness(..) => {
                 return ControlFlow::Break(NonStructuralMatchTy::Generator);
             }
@@ -197,7 +201,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for Search<'a, 'tcx> {
                 // First check all contained types and then tell the caller to continue searching.
                 return ty.super_visit_with(self);
             }
-            ty::Closure(..) | ty::Infer(_) | ty::Placeholder(_) | ty::Bound(..) => {
+            ty::Infer(_) | ty::Placeholder(_) | ty::Bound(..) => {
                 bug!("unexpected type during structural-match checking: {:?}", ty);
             }
             ty::Error(_) => {

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -162,9 +162,9 @@ use super::SpecExtend;
 /// item's ordering relative to any other item, as determined by the [`Ord`]
 /// trait, changes while it is in the heap. This is normally only possible
 /// through [`Cell`], [`RefCell`], global state, I/O, or unsafe code. The
-/// behavior resulting from such a logic error is not specified, but will
-/// not result in undefined behavior. This could include panics, incorrect
-/// results, aborts, memory leaks, and non-termination.
+/// behavior resulting from such a logic error is not specified (it
+/// could include panics, incorrect results, aborts, memory leaks, or
+/// non-termination) but will not be undefined behavior.
 ///
 /// # Examples
 ///

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -61,9 +61,9 @@ pub(super) const MIN_LEN: usize = node::MIN_LEN_AFTER_SPLIT;
 /// It is a logic error for a key to be modified in such a way that the key's ordering relative to
 /// any other key, as determined by the [`Ord`] trait, changes while it is in the map. This is
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
-/// The behavior resulting from such a logic error is not specified, but will not result in
-/// undefined behavior. This could include panics, incorrect results, aborts, memory leaks, and
-/// non-termination.
+/// The behavior resulting from such a logic error is not specified (it could include panics,
+/// incorrect results, aborts, memory leaks, or non-termination) but will not be undefined
+/// behavior.
 ///
 /// [B-Tree]: https://en.wikipedia.org/wiki/B-tree
 /// [`Cell`]: core::cell::Cell

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -23,9 +23,9 @@ use super::Recover;
 /// It is a logic error for an item to be modified in such a way that the item's ordering relative
 /// to any other item, as determined by the [`Ord`] trait, changes while it is in the set. This is
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
-/// The behavior resulting from such a logic error is not specified, but will not result in
-/// undefined behavior. This could include panics, incorrect results, aborts, memory leaks, and
-/// non-termination.
+/// The behavior resulting from such a logic error is not specified (it could include panics,
+/// incorrect results, aborts, memory leaks, or non-termination) but will not be undefined
+/// behavior.
 ///
 /// [`Ord`]: core::cmp::Ord
 /// [`Cell`]: core::cell::Cell

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -756,7 +756,7 @@ impl Duration {
         } else if nanos >= MAX_NANOS_F64 {
             Err(FromSecsError { kind: FromSecsErrorKind::Overflow })
         } else if nanos < 0.0 {
-            Err(FromSecsError { kind: FromSecsErrorKind::Underflow })
+            Err(FromSecsError { kind: FromSecsErrorKind::Negative })
         } else {
             let nanos = nanos as u128;
             Ok(Duration {
@@ -818,7 +818,7 @@ impl Duration {
         } else if nanos >= MAX_NANOS_F32 {
             Err(FromSecsError { kind: FromSecsErrorKind::Overflow })
         } else if nanos < 0.0 {
-            Err(FromSecsError { kind: FromSecsErrorKind::Underflow })
+            Err(FromSecsError { kind: FromSecsErrorKind::Negative })
         } else {
             let nanos = nanos as u128;
             Ok(Duration {
@@ -1274,11 +1274,9 @@ pub struct FromSecsError {
 impl FromSecsError {
     const fn description(&self) -> &'static str {
         match self.kind {
-            FromSecsErrorKind::NonFinite => {
-                "got non-finite value when converting float to duration"
-            }
+            FromSecsErrorKind::NonFinite => "non-finite value when converting float to duration",
             FromSecsErrorKind::Overflow => "overflow when converting float to duration",
-            FromSecsErrorKind::Underflow => "underflow when converting float to duration",
+            FromSecsErrorKind::Negative => "negative value when converting float to duration",
         }
     }
 }
@@ -1292,10 +1290,10 @@ impl fmt::Display for FromSecsError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FromSecsErrorKind {
-    // Value is not a finite value (either infinity or NaN).
+    // Value is not a finite value (either + or - infinity or NaN).
     NonFinite,
     // Value is too large to store in a `Duration`.
     Overflow,
-    // Value is less than `0.0`.
-    Underflow,
+    // Value is negative.
+    Negative,
 }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -38,8 +38,8 @@ use super::map::{map_try_reserve_error, RandomState};
 /// determined by the [`Eq`] trait, changes while it is in the set. This is
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or
 /// unsafe code. The behavior resulting from such a logic error is not
-/// specified, but will not result in undefined behavior. This could include
-/// panics, incorrect results, aborts, memory leaks, and non-termination.
+/// specified (it could include panics, incorrect results, aborts, memory
+/// leaks, or non-termination) but will not be undefined behavior.
 ///
 /// # Examples
 ///

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -70,7 +70,8 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       echo "Attempting to download $url"
       rm -f /tmp/rustci_docker_cache
       set +e
-      retry curl -y 30 -Y 10 --connect-timeout 30 -f -L -C - -o /tmp/rustci_docker_cache "$url"
+      retry curl --max-time 600 -y 30 -Y 10 --connect-timeout 30 -f -L -C - \
+        -o /tmp/rustci_docker_cache "$url"
       loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -72,6 +72,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       set +e
       retry curl --max-time 600 -y 30 -Y 10 --connect-timeout 30 -f -L -C - \
         -o /tmp/rustci_docker_cache "$url"
+      echo "Loading images into docker"
       loaded_images=$(docker load -i /tmp/rustci_docker_cache | sed 's/.* sha/sha/')
       set -e
       echo "Downloaded containers:\n$loaded_images"

--- a/src/test/ui/const-generics/defaults/default-annotation.rs
+++ b/src/test/ui/const-generics/defaults/default-annotation.rs
@@ -2,7 +2,7 @@
 #![feature(staged_api)]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
-// FIXME(const_generics): It seems like we aren't testing the right thing here,
+// FIXME(const_generics_defaults): It seems like we aren't testing the right thing here,
 // I would assume that we want the attributes to apply to the const parameter defaults
 // themselves.
 #![stable(feature = "const_default_test", since="none")]

--- a/src/test/ui/const-generics/defaults/doesnt_infer.rs
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.rs
@@ -1,0 +1,15 @@
+#![feature(const_generics_defaults)]
+
+// test that defaulted const params are not used to help type inference
+
+struct Foo<const N: u32 = 2>;
+
+impl<const N: u32> Foo<N> {
+    fn foo() -> Self { loop {} }
+}
+
+fn main() {
+    let foo = Foo::<1>::foo();
+    let foo = Foo::foo();
+    //~^ error: type annotations needed for `Foo<{_: u32}>`
+}

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for `Foo<{_: u32}>`
+  --> $DIR/doesnt_infer.rs:13:15
+   |
+LL |     let foo = Foo::foo();
+   |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
+   |         |
+   |         consider giving `foo` the explicit type `Foo<{_: u32}>`, where the type parameter `N` is specified
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/defaults/rp_impl_trait.rs
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait.rs
@@ -1,0 +1,31 @@
+// run-pass
+#![feature(const_generics_defaults)]
+
+struct Uwu<const N: u32 = 1, const M: u32 = N>;
+
+trait Trait {}
+impl<const N: u32> Trait for Uwu<N> {}
+
+fn rawr<const N: u32>() -> impl Trait {
+    Uwu::<N>
+}
+
+trait Traitor<const N: u8 = 1, const M: u8 = N> { }
+
+impl<const N: u8> Traitor<N> for u32 {}
+impl Traitor<1, 1> for u64 {}
+
+fn uwu<const N: u8>() -> impl Traitor<N> {
+    1_u32
+}
+
+fn owo() -> impl Traitor {
+    1_u64
+}
+
+fn main() {
+    rawr::<3>();
+    rawr::<7>();
+    uwu::<{ u8::MAX }>();
+    owo();
+}

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
@@ -1,0 +1,33 @@
+#![feature(const_generics_defaults)]
+
+struct Uwu<const N: u32 = 1, const M: u32 = N>;
+
+trait Trait {}
+impl<const N: u32> Trait for Uwu<N> {}
+
+fn rawr() -> impl Trait {
+    //~^ error: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
+    Uwu::<10, 12>
+}
+
+trait Traitor<const N: u8 = 1, const M: u8 = N> { }
+
+impl<const N: u8> Traitor<N, 2> for u32 {}
+impl Traitor<1, 2> for u64 {}
+
+
+fn uwu<const N: u8>() -> impl Traitor<N> {
+    //~^ error: the trait bound `u32: Traitor<N, N>` is not satisfied
+    1_u32
+}
+
+fn owo() -> impl Traitor {
+    //~^ error: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
+    1_u64
+}
+
+fn main() {
+    rawr();
+    uwu();
+    owo();
+}

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
+  --> $DIR/rp_impl_trait_fail.rs:8:14
+   |
+LL | fn rawr() -> impl Trait {
+   |              ^^^^^^^^^^ the trait `Trait` is not implemented for `Uwu<10_u32, 12_u32>`
+   |
+   = help: the following implementations were found:
+             <Uwu<N> as Trait>
+
+error[E0277]: the trait bound `u32: Traitor<N, N>` is not satisfied
+  --> $DIR/rp_impl_trait_fail.rs:19:26
+   |
+LL | fn uwu<const N: u8>() -> impl Traitor<N> {
+   |                          ^^^^^^^^^^^^^^^ the trait `Traitor<N, N>` is not implemented for `u32`
+   |
+   = help: the following implementations were found:
+             <u32 as Traitor<N, 2_u8>>
+
+error[E0277]: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
+  --> $DIR/rp_impl_trait_fail.rs:24:13
+   |
+LL | fn owo() -> impl Traitor {
+   |             ^^^^^^^^^^^^ the trait `Traitor<1_u8, 1_u8>` is not implemented for `u64`
+   |
+   = help: the following implementations were found:
+             <u64 as Traitor<1_u8, 2_u8>>
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/trait_objects.rs
+++ b/src/test/ui/const-generics/defaults/trait_objects.rs
@@ -1,0 +1,45 @@
+// run-pass
+#![feature(const_generics_defaults)]
+
+trait Trait<const N: u8 = 12> {
+    fn uwu(&self) -> u8 {
+        N
+    }
+}
+
+impl Trait for u32 {}
+
+impl Trait<12> for u64 {
+    fn uwu(&self) -> u8 {
+        *self as u8
+    }
+}
+
+fn foo(arg: &dyn Trait) -> u8 {
+    arg.uwu()
+}
+
+trait Traitor<const N: u8 = 1, const M: u8 = N> {
+    fn owo(&self) -> u8 {
+        M
+    }
+}
+
+impl Traitor<2> for bool { }
+impl Traitor for u8 {
+    fn owo(&self) -> u8 {
+        *self
+    }
+}
+
+fn bar<const N: u8>(arg: &dyn Traitor<N>) -> u8 {
+    arg.owo()
+}
+
+fn main() {
+    assert_eq!(foo(&10_u32), 12);
+    assert_eq!(foo(&3_u64), 3);
+    
+    assert_eq!(bar(&true), 2);
+    assert_eq!(bar(&1_u8), 1);
+}

--- a/src/test/ui/const-generics/defaults/trait_objects.rs
+++ b/src/test/ui/const-generics/defaults/trait_objects.rs
@@ -39,7 +39,7 @@ fn bar<const N: u8>(arg: &dyn Traitor<N>) -> u8 {
 fn main() {
     assert_eq!(foo(&10_u32), 12);
     assert_eq!(foo(&3_u64), 3);
-    
+
     assert_eq!(bar(&true), 2);
     assert_eq!(bar(&1_u8), 1);
 }

--- a/src/test/ui/const-generics/defaults/trait_objects_fail.rs
+++ b/src/test/ui/const-generics/defaults/trait_objects_fail.rs
@@ -1,0 +1,32 @@
+#![feature(const_generics_defaults)]
+
+trait Trait<const N: u8 = 12> {
+    fn uwu(&self) -> u8 {
+        N
+    }
+}
+
+impl Trait<2> for u32 {}
+
+fn foo(arg: &dyn Trait) -> u8 {
+    arg.uwu()
+}
+
+trait Traitor<const N: u8 = 1, const M: u8 = N> {
+    fn owo(&self) -> u8 {
+        M
+    }
+}
+
+impl Traitor<2, 3> for bool { }
+
+fn bar<const N: u8>(arg: &dyn Traitor<N>) -> u8 {
+    arg.owo()
+}
+
+fn main() {
+    foo(&10_u32);
+    //~^ error: the trait bound `u32: Trait` is not satisfied
+    bar(&true);
+    //~^ error: the trait bound `bool: Traitor<{_: u8}, {_: u8}>` is not satisfied
+}

--- a/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `u32: Trait` is not satisfied
+  --> $DIR/trait_objects_fail.rs:28:9
+   |
+LL |     foo(&10_u32);
+   |     --- ^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <u32 as Trait<2_u8>>
+   = note: required for the cast to the object type `dyn Trait`
+
+error[E0277]: the trait bound `bool: Traitor<{_: u8}, {_: u8}>` is not satisfied
+  --> $DIR/trait_objects_fail.rs:30:9
+   |
+LL |     bar(&true);
+   |     --- ^^^^^ the trait `Traitor<{_: u8}, {_: u8}>` is not implemented for `bool`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <bool as Traitor<2_u8, 3_u8>>
+   = note: required for the cast to the object type `dyn Traitor<{_: u8}, {_: u8}>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/wfness.rs
+++ b/src/test/ui/const-generics/defaults/wfness.rs
@@ -11,7 +11,7 @@ struct WhereClause<const N: u8 = 2> where (): Trait<N>;
 trait Traitor<T, const N: u8> {}
 struct WhereClauseTooGeneric<T = u32, const N: u8 = 2>(T) where (): Traitor<T, N>;
 
-// no error on struct def 
+// no error on struct def
 struct DependentDefaultWfness<const N: u8 = 1, T = WhereClause<N>>(T);
 fn foo() -> DependentDefaultWfness {
     //~^ error: the trait bound `(): Trait<1_u8>` is not satisfied

--- a/src/test/ui/const-generics/defaults/wfness.rs
+++ b/src/test/ui/const-generics/defaults/wfness.rs
@@ -1,0 +1,21 @@
+#![feature(const_generics_defaults)]
+
+struct Ooopsies<const N: u8 = { u8::MAX + 1 }>;
+//~^ error: evaluation of constant value failed
+
+trait Trait<const N: u8> {}
+impl Trait<3> for () {}
+struct WhereClause<const N: u8 = 2> where (): Trait<N>;
+//~^ error: the trait bound `(): Trait<2_u8>` is not satisfied
+
+trait Traitor<T, const N: u8> {}
+struct WhereClauseTooGeneric<T = u32, const N: u8 = 2>(T) where (): Traitor<T, N>;
+
+// no error on struct def 
+struct DependentDefaultWfness<const N: u8 = 1, T = WhereClause<N>>(T);
+fn foo() -> DependentDefaultWfness {
+    //~^ error: the trait bound `(): Trait<1_u8>` is not satisfied
+    loop {}
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/wfness.stderr
+++ b/src/test/ui/const-generics/defaults/wfness.stderr
@@ -1,0 +1,38 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/wfness.rs:3:33
+   |
+LL | struct Ooopsies<const N: u8 = { u8::MAX + 1 }>;
+   |                                 ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
+
+error[E0277]: the trait bound `(): Trait<2_u8>` is not satisfied
+  --> $DIR/wfness.rs:8:47
+   |
+LL | struct WhereClause<const N: u8 = 2> where (): Trait<N>;
+   |                                               ^^^^^^^^ the trait `Trait<2_u8>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as Trait<3_u8>>
+note: required by `WhereClause`
+  --> $DIR/wfness.rs:8:1
+   |
+LL | struct WhereClause<const N: u8 = 2> where (): Trait<N>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `(): Trait<1_u8>` is not satisfied
+  --> $DIR/wfness.rs:16:13
+   |
+LL | fn foo() -> DependentDefaultWfness {
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<1_u8>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as Trait<3_u8>>
+note: required by a bound in `WhereClause`
+  --> $DIR/wfness.rs:8:47
+   |
+LL | struct WhereClause<const N: u8 = 2> where (): Trait<N>;
+   |                                               ^^^^^^^^ required by this bound in `WhereClause`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0080, E0277.
+For more information about an error, try `rustc --explain E0080`.

--- a/src/test/ui/const-generics/defaults/wrong-order.rs
+++ b/src/test/ui/const-generics/defaults/wrong-order.rs
@@ -5,4 +5,7 @@ struct A<T = u32, const N: usize> {
     arg: T,
 }
 
+struct Foo<const N: u8 = 3, T>(T);
+//~^ error: generic parameters with a default must be trailing
+
 fn main() {}

--- a/src/test/ui/const-generics/defaults/wrong-order.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.stderr
@@ -4,5 +4,11 @@ error: generic parameters with a default must be trailing
 LL | struct A<T = u32, const N: usize> {
    |          ^
 
-error: aborting due to previous error
+error: generic parameters with a default must be trailing
+  --> $DIR/wrong-order.rs:8:18
+   |
+LL | struct Foo<const N: u8 = 3, T>(T);
+   |                  ^
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/closure-structural-match-issue-90013.rs
+++ b/src/test/ui/consts/closure-structural-match-issue-90013.rs
@@ -1,0 +1,8 @@
+// Regression test for issue 90013.
+// check-pass
+#![allow(incomplete_features)]
+#![feature(inline_const)]
+
+fn main() {
+    const { || {} };
+}

--- a/src/test/ui/consts/precise-drop-with-promoted.rs
+++ b/src/test/ui/consts/precise-drop-with-promoted.rs
@@ -1,0 +1,9 @@
+// Regression test for issue #89938.
+// check-pass
+// compile-flags: --crate-type=lib
+#![feature(const_precise_live_drops)]
+
+pub const fn f() {
+    let _: Option<String> = None;
+    let _: &'static Option<String> = &None;
+}

--- a/src/test/ui/error-codes/E0637.rs
+++ b/src/test/ui/error-codes/E0637.rs
@@ -1,9 +1,17 @@
-struct Foo<'a: '_>(&'a u8); //~ ERROR cannot be used here
-fn foo<'a: '_>(_: &'a u8) {} //~ ERROR cannot be used here
+fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+    //~^ ERROR: `'_` cannot be used here [E0637]
+    //~| ERROR: missing lifetime specifier
+    if str1.len() > str2.len() {
+        str1
+    } else {
+        str2
+    }
+}
 
-struct Bar<'a>(&'a u8);
-impl<'a: '_> Bar<'a> { //~ ERROR cannot be used here
-  fn bar() {}
+fn and_without_explicit_lifetime<T>()
+where
+    T: Into<&u32>, //~ ERROR: `&` without an explicit lifetime name cannot be used here [E0637]
+{
 }
 
 fn main() {}

--- a/src/test/ui/error-codes/E0637.stderr
+++ b/src/test/ui/error-codes/E0637.stderr
@@ -1,21 +1,28 @@
 error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:1:16
+  --> $DIR/E0637.rs:1:24
    |
-LL | struct Foo<'a: '_>(&'a u8);
-   |                ^^ `'_` is a reserved lifetime name
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                        ^^ `'_` is a reserved lifetime name
 
-error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:2:12
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:13:13
    |
-LL | fn foo<'a: '_>(_: &'a u8) {}
-   |            ^^ `'_` is a reserved lifetime name
+LL |     T: Into<&u32>,
+   |             ^ explicit lifetime name needed here
 
-error[E0637]: `'_` cannot be used here
-  --> $DIR/E0637.rs:5:10
+error[E0106]: missing lifetime specifier
+  --> $DIR/E0637.rs:1:62
    |
-LL | impl<'a: '_> Bar<'a> {
-   |          ^^ `'_` is a reserved lifetime name
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                  -------        -------      ^^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `str1` or `str2`
+help: consider introducing a named lifetime parameter
+   |
+LL | fn underscore_lifetime<'a, '_>(str1: &'a str, str2: &'a str) -> &'a str {
+   |                        +++            ~~             ~~          ~~
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0637`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/nll/issue-78561.rs
+++ b/src/test/ui/nll/issue-78561.rs
@@ -1,0 +1,23 @@
+// check-pass
+#![feature(type_alias_impl_trait)]
+
+pub trait Trait {
+    type A;
+
+    fn f() -> Self::A;
+}
+
+pub trait Tr2<'a, 'b> {}
+
+pub struct A<T>(T);
+pub trait Tr {
+    type B;
+}
+
+impl<'a, 'b, T: Tr<B = dyn Tr2<'a, 'b>>> Trait for A<T> {
+    type A = impl core::fmt::Debug;
+
+    fn f() -> Self::A {}
+}
+
+fn main() {}

--- a/src/test/ui/pattern/non-structural-match-types.rs
+++ b/src/test/ui/pattern/non-structural-match-types.rs
@@ -1,0 +1,14 @@
+// edition:2021
+#![allow(incomplete_features)]
+#![allow(unreachable_code)]
+#![feature(const_async_blocks)]
+#![feature(inline_const)]
+
+fn main() {
+    match loop {} {
+        const { || {} } => {}, //~ ERROR cannot be used in patterns
+    }
+    match loop {} {
+        const { async {} } => {}, //~ ERROR cannot be used in patterns
+    }
+}

--- a/src/test/ui/pattern/non-structural-match-types.stderr
+++ b/src/test/ui/pattern/non-structural-match-types.stderr
@@ -1,0 +1,14 @@
+error: `[closure@$DIR/non-structural-match-types.rs:9:17: 9:22]` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:9:9
+   |
+LL |         const { || {} } => {},
+   |         ^^^^^^^^^^^^^^^
+
+error: `impl Future` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:12:9
+   |
+LL |         const { async {} } => {},
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/query-system/issue-83479.rs
+++ b/src/test/ui/query-system/issue-83479.rs
@@ -1,0 +1,16 @@
+#![feature(type_alias_impl_trait)]
+
+type PairCoupledTypes: Trait<
+    //~^ ERROR: bounds on `type`s in this context have no effect
+    //~| ERROR: cannot find trait `Trait` in this scope
+    [u32; {
+        static FOO: usize; //~ ERROR: free static item without body
+    }],
+> = impl Trait<
+    //~^ ERROR: cannot find trait `Trait` in this scope
+    [u32; {
+        static FOO: usize; //~ ERROR: free static item without body
+    }],
+>;
+
+fn main() {}

--- a/src/test/ui/query-system/issue-83479.stderr
+++ b/src/test/ui/query-system/issue-83479.stderr
@@ -1,0 +1,44 @@
+error: bounds on `type`s in this context have no effect
+  --> $DIR/issue-83479.rs:3:24
+   |
+LL |   type PairCoupledTypes: Trait<
+   |  ________________________^
+LL | |
+LL | |
+LL | |     [u32; {
+LL | |         static FOO: usize;
+LL | |     }],
+LL | | > = impl Trait<
+   | |_^
+
+error: free static item without body
+  --> $DIR/issue-83479.rs:7:9
+   |
+LL |         static FOO: usize;
+   |         ^^^^^^^^^^^^^^^^^-
+   |                          |
+   |                          help: provide a definition for the static: `= <expr>;`
+
+error: free static item without body
+  --> $DIR/issue-83479.rs:12:9
+   |
+LL |         static FOO: usize;
+   |         ^^^^^^^^^^^^^^^^^-
+   |                          |
+   |                          help: provide a definition for the static: `= <expr>;`
+
+error[E0405]: cannot find trait `Trait` in this scope
+  --> $DIR/issue-83479.rs:3:24
+   |
+LL | type PairCoupledTypes: Trait<
+   |                        ^^^^^ not found in this scope
+
+error[E0405]: cannot find trait `Trait` in this scope
+  --> $DIR/issue-83479.rs:9:10
+   |
+LL | > = impl Trait<
+   |          ^^^^^ not found in this scope
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0405`.

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 1330;
+const ROOT_ENTRY_LIMIT: usize = 1331;
 const ISSUES_ENTRY_LIMIT: usize = 2488;
 
 fn check_entries(path: &Path, bad: &mut bool) {

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,8 +5,8 @@ allow-unauthenticated = [
     "requires-nightly",
     "regression-*",
     "perf-*",
-    # I-* without I-nominated
-    "I-*", "!I-nominated",
+    # I-* without I-*nominated
+    "I-*", "!I-*nominated",
     "AsyncAwait-OnDeck",
 ]
 


### PR DESCRIPTION
Successful merges:

 - #87537 (Clarify undefined behaviour in binary heap, btree and hashset docs)
 - #89808 (Cleanup LLVM multi-threading checks)
 - #89922 (Update E0637 description to mention `&` w/o an explicit lifetime name)
 - #89944 (Change `Duration::[try_]from_secs_{f32, f64}` underflow error)
 - #89991 (rustc_ast: Turn `MutVisitor::token_visiting_enabled` into a constant)
 - #90028 (Reject closures in patterns)
 - #90069 (Fix const qualification when executed after promotion)
 - #90078 (Add a regression test for issue-83479)
 - #90114 (Add some tests for const_generics_defaults)
 - #90115 (Add test for issue #78561)
 - #90122 (CI: make docker cache download attempt time out after 10 minutes)
 - #90129 (triagebot: Treat `I-*nominated` like `I-nominated`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87537,89808,89922,89944,89991,90028,90069,90078,90114,90115,90122,90129)
<!-- homu-ignore:end -->