### PR TITLE
Avoid adjusting TLS data twice for queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,7 @@ dependencies = [
  "rustc_plugin_impl",
  "rustc_privacy",
  "rustc_query_impl",
+ "rustc_query_system",
  "rustc_resolve",
  "rustc_serialize",
  "rustc_session",

--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -55,7 +55,7 @@ use std::io::{BufWriter, Write};
 pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
     tcx.dep_graph.with_ignore(|| {
         if tcx.sess.opts.debugging_opts.dump_dep_graph {
-            tcx.dep_graph.with_query(dump_graph);
+            tcx.dep_graph.with_debug(dump_graph);
         }
 
         if !tcx.sess.opts.debugging_opts.query_dep_graph {
@@ -207,7 +207,7 @@ fn check_paths<'tcx>(tcx: TyCtxt<'tcx>, if_this_changed: &Sources, then_this_wou
         }
         return;
     }
-    tcx.dep_graph.with_query(|query| {
+    tcx.dep_graph.with_debug(|query| {
         for &(_, source_def_id, ref source_dep_node) in if_this_changed {
             let dependents = query.transitive_predecessors(source_dep_node);
             for &(target_span, ref target_pass, _, ref target_dep_node) in then_this_would_need {

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -42,6 +42,7 @@ rustc_lint = { path = "../rustc_lint" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_plugin_impl = { path = "../rustc_plugin_impl" }
 rustc_privacy = { path = "../rustc_privacy" }
+rustc_query_system = { path = "../rustc_query_system" }
 rustc_query_impl = { path = "../rustc_query_impl" }
 rustc_resolve = { path = "../rustc_resolve" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -9,7 +9,6 @@
 //! The functions in this file should fall back to the default set in their
 //! origin crate when the `TyCtxt` is not present in TLS.
 
-use rustc_errors::{Diagnostic, TRACK_DIAGNOSTICS};
 use rustc_middle::ty::tls;
 use std::fmt;
 
@@ -35,20 +34,6 @@ fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
     })
 }
 
-/// This is a callback from `rustc_ast` as it cannot access the implicit state
-/// in `rustc_middle` otherwise. It is used to when diagnostic messages are
-/// emitted and stores them in the current query, if there is one.
-fn track_diagnostic(diagnostic: &Diagnostic) {
-    tls::with_context_opt(|icx| {
-        if let Some(icx) = icx {
-            if let Some(diagnostics) = icx.diagnostics {
-                let mut diagnostics = diagnostics.lock();
-                diagnostics.extend(Some(diagnostic.clone()));
-            }
-        }
-    })
-}
-
 /// This is a callback from `rustc_hir` as it cannot access the implicit state
 /// in `rustc_middle` otherwise.
 fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -68,5 +53,5 @@ pub fn setup_callbacks() {
     rustc_span::SPAN_DEBUG.swap(&(span_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
     rustc_span::SPAN_TRACK.swap(&(track_span_parent as fn(_)));
     rustc_hir::def_id::DEF_ID_DEBUG.swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
-    TRACK_DIAGNOSTICS.swap(&(track_diagnostic as fn(&_)));
+    rustc_errors::TRACK_DIAGNOSTICS.swap(&(rustc_query_system::tls::track_diagnostic as fn(&_)));
 }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -9,7 +9,9 @@
 //! The functions in this file should fall back to the default set in their
 //! origin crate when the `TyCtxt` is not present in TLS.
 
+use rustc_middle::dep_graph::DepNodeExt;
 use rustc_middle::ty::tls;
+use rustc_query_system::dep_graph::DepNode;
 use std::fmt;
 
 /// This is a callback from `rustc_ast` as it cannot access the implicit state
@@ -47,11 +49,32 @@ fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) ->
     write!(f, ")")
 }
 
+fn dep_node_debug(node: &DepNode, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{:?}(", node.kind)?;
+
+    tls::with_opt(|opt_tcx| {
+        if let Some(tcx) = opt_tcx {
+            if let Some(def_id) = node.extract_def_id(tcx) {
+                write!(f, "{}", tcx.def_path_debug_str(def_id))
+            } else if let Some(ref s) = tcx.dep_graph.dep_node_debug_str(*node) {
+                write!(f, "{}", s)
+            } else {
+                write!(f, "{}", node.hash)
+            }
+        } else {
+            write!(f, "{}", node.hash)
+        }
+    })?;
+
+    write!(f, ")")
+}
+
 /// Sets up the callbacks in prior crates which we want to refer to the
 /// TyCtxt in.
 pub fn setup_callbacks() {
     rustc_span::SPAN_DEBUG.swap(&(span_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
     rustc_span::SPAN_TRACK.swap(&(track_span_parent as fn(_)));
     rustc_hir::def_id::DEF_ID_DEBUG.swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
+    rustc_query_system::dep_graph::NODE_DEBUG.swap(&(dep_node_debug as _));
     rustc_errors::TRACK_DIAGNOSTICS.swap(&(rustc_query_system::tls::track_diagnostic as fn(&_)));
 }

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -231,7 +231,7 @@ pub fn try_print_query_stack(handler: &Handler, num_frames: Option<usize>) {
     // state if it was responsible for triggering the panic.
     let i = ty::tls::with_context_opt(|icx| {
         if let Some(icx) = icx {
-            QueryCtxt::from_tcx(icx.tcx).try_print_query_stack(icx.query, handler, num_frames)
+            QueryCtxt::from_tcx(icx.tcx).try_print_query_stack(handler, num_frames)
         } else {
             0
         }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -781,7 +781,10 @@ impl<'tcx> QueryContext<'tcx> {
         F: FnOnce(TyCtxt<'tcx>) -> R,
     {
         let icx = ty::tls::ImplicitCtxt::new(self.gcx);
-        ty::tls::enter_context(&icx, |_| f(icx.tcx))
+        let qcx = rustc_query_system::tls::ImplicitCtxt::<rustc_middle::dep_graph::DepKind>::new();
+        ty::tls::enter_context(&icx, |_| {
+            rustc_query_system::tls::enter_context(&qcx, |_| f(icx.tcx))
+        })
     }
 }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -781,10 +781,7 @@ impl<'tcx> QueryContext<'tcx> {
         F: FnOnce(TyCtxt<'tcx>) -> R,
     {
         let icx = ty::tls::ImplicitCtxt::new(self.gcx);
-        let qcx = rustc_query_system::tls::ImplicitCtxt::new();
-        ty::tls::enter_context(&icx, |_| {
-            rustc_query_system::tls::enter_context(&qcx, |_| f(icx.tcx))
-        })
+        ty::tls::enter_context(&icx, |_| f(icx.tcx))
     }
 }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -781,7 +781,7 @@ impl<'tcx> QueryContext<'tcx> {
         F: FnOnce(TyCtxt<'tcx>) -> R,
     {
         let icx = ty::tls::ImplicitCtxt::new(self.gcx);
-        let qcx = rustc_query_system::tls::ImplicitCtxt::<rustc_middle::dep_graph::DepKind>::new();
+        let qcx = rustc_query_system::tls::ImplicitCtxt::new();
         ty::tls::enter_context(&icx, |_| {
             rustc_query_system::tls::enter_context(&qcx, |_| f(icx.tcx))
         })

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -154,24 +154,22 @@ pub fn setup_callbacks_and_run_in_thread_pool_with_globals<F: FnOnce() -> R + Se
 /// Must only be called when a deadlock is about to happen.
 #[cfg(parallel_compiler)]
 unsafe fn handle_deadlock() {
-    use rustc_query_system::tls as qls;
     let registry = rustc_rayon_core::Registry::current();
 
     let context = tls::get_tlv();
     assert!(context != 0);
     rustc_data_structures::sync::assert_sync::<tls::ImplicitCtxt<'_>>();
     let icx: &tls::ImplicitCtxt<'_> = &*(context as *const tls::ImplicitCtxt<'_>);
-    rustc_data_structures::sync::assert_sync::<qls::ImplicitCtxt<'_>>();
-    let qcx: &qls::ImplicitCtxt<'_> = &*(context as *const qls::ImplicitCtxt<'_>);
+
+    // We do not need to copy the query ImplicitCtxt since this deadlock handler is not part of a
+    // normal query invocation.
 
     let session_globals = rustc_span::with_session_globals(|sg| sg as *const _);
     let session_globals = &*session_globals;
     thread::spawn(move || {
         tls::enter_context(icx, |_| {
-            qls::enter_context(icx, |_| {
-                rustc_span::set_session_globals_then(session_globals, || {
-                    tls::with(|tcx| QueryCtxt::from_tcx(tcx).deadlock(&registry))
-                })
+            rustc_span::set_session_globals_then(session_globals, || {
+                tls::with(|tcx| QueryCtxt::from_tcx(tcx).deadlock(&registry))
             })
         });
     });

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -504,6 +504,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                 }
             }
         }
+        #[macro_export]
         macro_rules! rustc_dep_node_append {
             ([$($macro:tt)*][$($other:tt)*]) => {
                 $($macro)*(

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -216,6 +216,8 @@ static_assert_size!(DepNode, 18);
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 static_assert_size!(DepNode, 24);
 
+static_assert_size!(DepKind, 2);
+
 pub trait DepNodeExt: Sized {
     /// Construct a DepNode from the given DepKind and DefPathHash. This
     /// method will assert that the given DepKind actually requires a

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -1,6 +1,5 @@
 use crate::ty::{self, TyCtxt};
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::sync::Lock;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::Session;
 
@@ -43,27 +42,6 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         })?;
 
         write!(f, ")")
-    }
-
-    fn with_deps<OP, R>(task_deps: Option<&Lock<TaskDeps>>, op: OP) -> R
-    where
-        OP: FnOnce() -> R,
-    {
-        ty::tls::with_context(|icx| {
-            let icx = ty::tls::ImplicitCtxt { task_deps, ..icx.clone() };
-
-            ty::tls::enter_context(&icx, |_| op())
-        })
-    }
-
-    fn read_deps<OP>(op: OP)
-    where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>),
-    {
-        ty::tls::with_context_opt(|icx| {
-            let icx = if let Some(icx) = icx { icx } else { return };
-            op(icx.task_deps)
-        })
     }
 }
 

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -64,6 +64,8 @@ extern crate rustc_macros;
 #[macro_use]
 extern crate rustc_data_structures;
 #[macro_use]
+extern crate rustc_query_system;
+#[macro_use]
 extern crate tracing;
 #[macro_use]
 extern crate smallvec;
@@ -73,9 +75,6 @@ mod tests;
 
 #[macro_use]
 mod macros;
-
-#[macro_use]
-pub mod query;
 
 #[macro_use]
 pub mod arena;

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -216,7 +216,7 @@ fn layout_of<'tcx>(
     tcx: TyCtxt<'tcx>,
     query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
 ) -> Result<TyAndLayout<'tcx>, LayoutError<'tcx>> {
-    ty::tls::with_related_context(tcx, move |icx| {
+    ty::tls::with_context(move |icx| {
         let (param_env, ty) = query.into_parts();
 
         if !tcx.recursion_limit().value_within_limit(icx.layout_depth) {

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -60,7 +60,6 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-pub(crate) use rustc_query_system::query::QueryJobId;
 use rustc_query_system::query::*;
 
 #[derive(Copy, Clone)]

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -13,6 +13,8 @@
 extern crate rustc_macros;
 #[macro_use]
 extern crate rustc_middle;
+#[macro_use]
+extern crate rustc_query_system;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -46,7 +46,7 @@ impl HasDepContext for QueryCtxt<'tcx> {
 
 impl QueryContext for QueryCtxt<'tcx> {
     fn current_query_job(&self) -> Option<QueryJobId<Self::DepKind>> {
-        tls::with_related_context(**self, |icx| icx.query)
+        tls::with_context(|icx| icx.query)
     }
 
     fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind>> {
@@ -89,9 +89,9 @@ impl QueryContext for QueryCtxt<'tcx> {
         compute: impl FnOnce() -> R,
     ) -> R {
         // The `TyCtxt` stored in TLS has the same global interner lifetime
-        // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes
+        // as `self`, so we use `with_context` to relate the 'tcx lifetimes
         // when accessing the `ImplicitCtxt`.
-        tls::with_related_context(**self, move |current_icx| {
+        tls::with_context(move |current_icx| {
             // Update the `ImplicitCtxt` to point to our new query job.
             let new_icx = ImplicitCtxt {
                 tcx: **self,

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -29,7 +29,6 @@ impl<'tcx> std::ops::Deref for QueryCtxt<'tcx> {
 }
 
 impl HasDepContext for QueryCtxt<'tcx> {
-    type DepKind = rustc_middle::dep_graph::DepKind;
     type DepContext = TyCtxt<'tcx>;
 
     #[inline]
@@ -39,7 +38,7 @@ impl HasDepContext for QueryCtxt<'tcx> {
 }
 
 impl QueryContext for QueryCtxt<'tcx> {
-    fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind>> {
+    fn try_collect_active_jobs(&self) -> Option<QueryMap> {
         self.queries.try_collect_active_jobs(**self)
     }
 
@@ -254,7 +253,7 @@ macro_rules! define_queries {
             type Cache = query_storage::$name<$tcx>;
 
             #[inline(always)]
-            fn query_state<'a>(tcx: QueryCtxt<$tcx>) -> &'a QueryState<crate::dep_graph::DepKind, Self::Key>
+            fn query_state<'a>(tcx: QueryCtxt<$tcx>) -> &'a QueryState<Self::Key>
                 where QueryCtxt<$tcx>: 'a
             {
                 &tcx.queries.$name
@@ -406,10 +405,7 @@ macro_rules! define_queries_struct {
 
             pub on_disk_cache: Option<OnDiskCache<$tcx>>,
 
-            $($(#[$attr])*  $name: QueryState<
-                crate::dep_graph::DepKind,
-                query_keys::$name<$tcx>,
-            >,)*
+            $($(#[$attr])*  $name: QueryState<query_keys::$name<$tcx>>,)*
         }
 
         impl<$tcx> Queries<$tcx> {
@@ -429,7 +425,7 @@ macro_rules! define_queries_struct {
             pub(crate) fn try_collect_active_jobs(
                 &$tcx self,
                 tcx: TyCtxt<$tcx>,
-            ) -> Option<QueryMap<crate::dep_graph::DepKind>> {
+            ) -> Option<QueryMap> {
                 let tcx = QueryCtxt { tcx, queries: self };
                 let mut jobs = QueryMap::default();
 

--- a/compiler/rustc_query_system/src/decl.rs
+++ b/compiler/rustc_query_system/src/decl.rs
@@ -52,7 +52,7 @@ rustc_queries! {
     ///
     /// This can be conveniently accessed by methods on `tcx.hir()`.
     /// Avoid calling this query directly.
-    query hir_owner(key: LocalDefId) -> Option<crate::hir::Owner<'tcx>> {
+    query hir_owner(key: LocalDefId) -> Option<rustc_middle::hir::Owner<'tcx>> {
         desc { |tcx| "HIR owner of `{}`", tcx.def_path_str(key.to_def_id()) }
     }
 
@@ -1139,7 +1139,7 @@ rustc_queries! {
         desc { "dylib dependency formats of crate" }
     }
 
-    query dependency_formats(_: ()) -> Lrc<crate::middle::dependency_format::Dependencies> {
+    query dependency_formats(_: ()) -> Lrc<rustc_middle::middle::dependency_format::Dependencies> {
         desc { "get the linkage format of all dependencies" }
     }
 

--- a/compiler/rustc_query_system/src/dep_graph/debug.rs
+++ b/compiler/rustc_query_system/src/dep_graph/debug.rs
@@ -1,6 +1,6 @@
 //! Code for debugging the dep-graph.
 
-use super::{DepKind, DepNode, DepNodeIndex};
+use super::{DepNode, DepNodeIndex};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lock;
 use std::error::Error;
@@ -28,7 +28,7 @@ impl DepNodeFilter {
     }
 
     /// Tests whether `node` meets the filter, returning true if so.
-    pub fn test<K: DepKind>(&self, node: &DepNode<K>) -> bool {
+    pub fn test(&self, node: &DepNode) -> bool {
         let debug_str = format!("{:?}", node);
         self.text.split('&').map(|s| s.trim()).all(|f| debug_str.contains(f))
     }
@@ -36,14 +36,14 @@ impl DepNodeFilter {
 
 /// A filter like `F -> G` where `F` and `G` are valid dep-node
 /// filters. This can be used to test the source/target independently.
-pub struct EdgeFilter<K: DepKind> {
+pub struct EdgeFilter {
     pub source: DepNodeFilter,
     pub target: DepNodeFilter,
-    pub index_to_node: Lock<FxHashMap<DepNodeIndex, DepNode<K>>>,
+    pub index_to_node: Lock<FxHashMap<DepNodeIndex, DepNode>>,
 }
 
-impl<K: DepKind> EdgeFilter<K> {
-    pub fn new(test: &str) -> Result<EdgeFilter<K>, Box<dyn Error>> {
+impl EdgeFilter {
+    pub fn new(test: &str) -> Result<EdgeFilter, Box<dyn Error>> {
         let parts: Vec<_> = test.split("->").collect();
         if parts.len() != 2 {
             Err(format!("expected a filter like `a&b -> c&d`, not `{}`", test).into())
@@ -57,7 +57,7 @@ impl<K: DepKind> EdgeFilter<K> {
     }
 
     #[cfg(debug_assertions)]
-    pub fn test(&self, source: &DepNode<K>, target: &DepNode<K>) -> bool {
+    pub fn test(&self, source: &DepNode, target: &DepNode) -> bool {
         self.source.test(source) && self.target.test(target)
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
@@ -43,10 +43,10 @@ rustc_dep_node_append!([define_dep_nodes!][ <'tcx>
 
     [anon] TraitSelect,
 
-    // WARNING: if `Symbol` is changed, make sure you update `make_compile_codegen_unit` below.
+    // WARNING: if `Symbol` is changed, make sure you update `make_compile_codegen_unit`.
     [] CompileCodegenUnit(Symbol),
 
-    // WARNING: if `MonoItem` is changed, make sure you update `make_compile_mono_item` below.
+    // WARNING: if `MonoItem` is changed, make sure you update `make_compile_mono_item`.
     // Only used by rustc_codegen_cranelift
     [] CompileMonoItem(MonoItem),
 ]);

--- a/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
@@ -62,6 +62,7 @@ static_assert_size!(DepNode, 24);
 
 impl DepNode {
     /// Used in testing
+    #[inline]
     pub fn has_label_string(label: &str) -> bool {
         dep_kind_from_label_string(label).is_ok()
     }

--- a/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_kind.rs
@@ -1,0 +1,68 @@
+use super::DepNode;
+
+macro_rules! define_dep_nodes {
+    (<$tcx:tt>
+    $(
+        [$($attrs:tt)*]
+        $variant:ident $(( $tuple_arg_ty:ty $(,)? ))*
+      ,)*
+    ) => (
+        #[macro_export]
+        macro_rules! make_dep_kind_array {
+            ($mod:ident) => {[ $($mod::$variant()),* ]};
+        }
+
+        /// This enum serves as an index into arrays built by `make_dep_kind_array`.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Encodable, Decodable)]
+        #[allow(non_camel_case_types)]
+        pub enum DepKind {
+            $($variant),*
+        }
+
+        pub fn dep_kind_from_label_string(label: &str) -> Result<DepKind, ()> {
+            match label {
+                $(stringify!($variant) => Ok(DepKind::$variant),)*
+                _ => Err(()),
+            }
+        }
+
+        /// Contains variant => str representations for constructing
+        /// DepNode groups for tests.
+        #[allow(dead_code, non_upper_case_globals)]
+        pub mod label_strs {
+           $(
+                pub const $variant: &str = stringify!($variant);
+            )*
+        }
+    );
+}
+
+rustc_dep_node_append!([define_dep_nodes!][ <'tcx>
+    // We use this for most things when incr. comp. is turned off.
+    [] Null,
+
+    [anon] TraitSelect,
+
+    // WARNING: if `Symbol` is changed, make sure you update `make_compile_codegen_unit` below.
+    [] CompileCodegenUnit(Symbol),
+
+    // WARNING: if `MonoItem` is changed, make sure you update `make_compile_mono_item` below.
+    // Only used by rustc_codegen_cranelift
+    [] CompileMonoItem(MonoItem),
+]);
+
+// We keep a lot of `DepNode`s in memory during compilation. It's not
+// required that their size stay the same, but we don't want to change
+// it inadvertently. This assert just ensures we're aware of any change.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+static_assert_size!(DepNode, 18);
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+static_assert_size!(DepNode, 24);
+
+impl DepNode {
+    /// Used in testing
+    pub fn has_label_string(label: &str) -> bool {
+        dep_kind_from_label_string(label).is_ok()
+    }
+}

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -61,6 +61,7 @@ impl DepNode {
     /// Creates a new, parameterless DepNode. This method will assert
     /// that the DepNode corresponding to the given DepKind actually
     /// does not require any parameters.
+    #[inline]
     pub fn new_no_params<Ctxt>(tcx: Ctxt, kind: DepKind) -> DepNode
     where
         Ctxt: super::DepContext,
@@ -92,6 +93,7 @@ impl DepNode {
 }
 
 impl fmt::Debug for DepNode {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (*NODE_DEBUG)(self, f)
     }
@@ -170,6 +172,7 @@ pub struct WorkProductId {
 }
 
 impl WorkProductId {
+    #[inline]
     pub fn from_cgu_name(cgu_name: &str) -> WorkProductId {
         let mut hasher = StableHasher::new();
         cgu_name.len().hash(&mut hasher);

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -140,6 +140,7 @@ impl DepGraph {
         }
     }
 
+    #[inline]
     pub fn new_disabled() -> DepGraph {
         DepGraph { data: None, virtual_dep_node_index: Lrc::new(AtomicU32::new(0)) }
     }
@@ -156,6 +157,7 @@ impl DepGraph {
         }
     }
 
+    #[inline]
     pub fn assert_ignored(&self) {
         if let Some(..) = self.data {
             crate::tls::read_deps(|task_deps| {
@@ -422,18 +424,21 @@ impl DepGraph {
         self.data.is_some() && self.dep_node_index_of_opt(dep_node).is_some()
     }
 
+    #[inline]
     pub fn prev_fingerprint_of(&self, dep_node: &DepNode) -> Option<Fingerprint> {
         self.data.as_ref().unwrap().previous.fingerprint_of(dep_node)
     }
 
     /// Checks whether a previous work product exists for `v` and, if
     /// so, return the path that leads to it. Used to skip doing work.
+    #[inline]
     pub fn previous_work_product(&self, v: &WorkProductId) -> Option<WorkProduct> {
         self.data.as_ref().and_then(|data| data.previous_work_products.get(v).cloned())
     }
 
     /// Access the map of work-products created during the cached run. Only
     /// used during saving of the dep-graph.
+    #[inline]
     pub fn previous_work_products(&self) -> &FxHashMap<WorkProductId, WorkProduct> {
         &self.data.as_ref().unwrap().previous_work_products
     }
@@ -452,10 +457,12 @@ impl DepGraph {
         dep_node_debug.borrow_mut().insert(dep_node, debug_str);
     }
 
+    #[inline]
     pub fn dep_node_debug_str(&self, dep_node: DepNode) -> Option<String> {
         self.data.as_ref()?.dep_node_debug.borrow().get(&dep_node).cloned()
     }
 
+    #[inline]
     fn node_color(&self, dep_node: &DepNode) -> Option<DepNodeColor> {
         if let Some(ref data) = self.data {
             if let Some(prev_index) = data.previous.node_to_index_opt(dep_node) {
@@ -709,12 +716,14 @@ impl DepGraph {
 
     // Returns true if the given node has been marked as red during the
     // current compilation session. Used in various assertions
+    #[inline]
     pub fn is_red(&self, dep_node: &DepNode) -> bool {
         self.node_color(dep_node) == Some(DepNodeColor::Red)
     }
 
     // Returns true if the given node has been marked as green during the
     // current compilation session. Used in various assertions
+    #[inline]
     pub fn is_green(&self, dep_node: &DepNode) -> bool {
         self.node_color(dep_node).map_or(false, |c| c.is_green())
     }
@@ -755,6 +764,7 @@ impl DepGraph {
         }
     }
 
+    #[inline]
     pub fn encode(&self, profiler: &SelfProfilerRef) -> FileEncodeResult {
         if let Some(data) = &self.data {
             data.current.encoder.steal().finish(profiler)
@@ -763,6 +773,7 @@ impl DepGraph {
         }
     }
 
+    #[inline]
     pub(crate) fn next_virtual_depnode_index(&self) -> DepNodeIndex {
         let index = self.virtual_dep_node_index.fetch_add(1, Relaxed);
         DepNodeIndex::from_u32(index)
@@ -929,6 +940,7 @@ impl CurrentDepGraph {
     }
 
     #[cfg(debug_assertions)]
+    #[inline]
     fn record_edge(&self, dep_node_index: DepNodeIndex, key: DepNode) {
         if let Some(forbidden_edge) = &self.forbidden_edge {
             forbidden_edge.index_to_node.lock().insert(dep_node_index, key);
@@ -937,6 +949,7 @@ impl CurrentDepGraph {
 
     /// Writes the node to the current dep-graph and allocates a `DepNodeIndex` for it.
     /// Assumes that this is a node that has no equivalent in the previous dep-graph.
+    #[inline]
     fn intern_new_node(
         &self,
         profiler: &SelfProfilerRef,
@@ -957,6 +970,7 @@ impl CurrentDepGraph {
         }
     }
 
+    #[inline]
     fn intern_node(
         &self,
         profiler: &SelfProfilerRef,
@@ -1059,6 +1073,7 @@ impl CurrentDepGraph {
         }
     }
 
+    #[inline]
     fn promote_node_and_deps_to_current(
         &self,
         profiler: &SelfProfilerRef,
@@ -1129,6 +1144,7 @@ const COMPRESSED_RED: u32 = 1;
 const COMPRESSED_FIRST_GREEN: u32 = 2;
 
 impl DepNodeColorMap {
+    #[inline]
     fn new(size: usize) -> DepNodeColorMap {
         DepNodeColorMap { values: (0..size).map(|_| AtomicU32::new(COMPRESSED_NONE)).collect() }
     }
@@ -1144,6 +1160,7 @@ impl DepNodeColorMap {
         }
     }
 
+    #[inline]
     fn insert(&self, index: SerializedDepNodeIndex, color: DepNodeColor) {
         self.values[index].store(
             match color {

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -25,8 +25,8 @@ use crate::query::{QueryContext, QuerySideEffects};
 use {super::debug::EdgeFilter, std::env};
 
 #[derive(Clone)]
-pub struct DepGraph<K: DepKind> {
-    data: Option<Lrc<DepGraphData<K>>>,
+pub struct DepGraph {
+    data: Option<Lrc<DepGraphData>>,
 
     /// This field is used for assigning DepNodeIndices when running in
     /// non-incremental mode. Even in non-incremental mode we make sure that
@@ -66,16 +66,16 @@ impl DepNodeColor {
     }
 }
 
-struct DepGraphData<K: DepKind> {
+struct DepGraphData {
     /// The new encoding of the dependency graph, optimized for red/green
     /// tracking. The `current` field is the dependency graph of only the
     /// current compilation session: We don't merge the previous dep-graph into
     /// current one anymore, but we do reference shared data to save space.
-    current: CurrentDepGraph<K>,
+    current: CurrentDepGraph,
 
     /// The dep-graph from the previous compilation session. It contains all
     /// nodes and edges as well as all fingerprints of nodes that have them.
-    previous: SerializedDepGraph<K>,
+    previous: SerializedDepGraph,
 
     colors: DepNodeColorMap,
 
@@ -87,7 +87,7 @@ struct DepGraphData<K: DepKind> {
     /// this map. We can later look for and extract that data.
     previous_work_products: FxHashMap<WorkProductId, WorkProduct>,
 
-    dep_node_debug: Lock<FxHashMap<DepNode<K>, String>>,
+    dep_node_debug: Lock<FxHashMap<DepNode, String>>,
 }
 
 pub fn hash_result<R>(hcx: &mut StableHashingContext<'_>, result: &R) -> Fingerprint
@@ -99,15 +99,15 @@ where
     stable_hasher.finish()
 }
 
-impl<K: DepKind> DepGraph<K> {
+impl DepGraph {
     pub fn new(
         profiler: &SelfProfilerRef,
-        prev_graph: SerializedDepGraph<K>,
+        prev_graph: SerializedDepGraph,
         prev_work_products: FxHashMap<WorkProductId, WorkProduct>,
         encoder: FileEncoder,
         record_graph: bool,
         record_stats: bool,
-    ) -> DepGraph<K> {
+    ) -> DepGraph {
         let prev_graph_node_count = prev_graph.node_count();
 
         let current = CurrentDepGraph::new(
@@ -121,7 +121,7 @@ impl<K: DepKind> DepGraph<K> {
         // Instantiate a dependy-less node only once for anonymous queries.
         let _green_node_index = current.intern_new_node(
             profiler,
-            DepNode { kind: DepKind::NULL, hash: current.anon_id_seed.into() },
+            DepNode { kind: DepKind::Null, hash: current.anon_id_seed.into() },
             smallvec![],
             Fingerprint::ZERO,
         );
@@ -140,7 +140,7 @@ impl<K: DepKind> DepGraph<K> {
         }
     }
 
-    pub fn new_disabled() -> DepGraph<K> {
+    pub fn new_disabled() -> DepGraph {
         DepGraph { data: None, virtual_dep_node_index: Lrc::new(AtomicU32::new(0)) }
     }
 
@@ -150,7 +150,7 @@ impl<K: DepKind> DepGraph<K> {
         self.data.is_some()
     }
 
-    pub fn with_query(&self, f: impl Fn(&DepGraphQuery<K>)) {
+    pub fn with_query(&self, f: impl Fn(&DepGraphQuery)) {
         if let Some(data) = &self.data {
             data.current.encoder.borrow().with_query(f)
         }
@@ -158,7 +158,7 @@ impl<K: DepKind> DepGraph<K> {
 
     pub fn assert_ignored(&self) {
         if let Some(..) = self.data {
-            crate::tls::read_deps::<K, _>(|task_deps| {
+            crate::tls::read_deps(|task_deps| {
                 assert!(task_deps.is_none(), "expected no task dependency tracking");
             })
         }
@@ -168,7 +168,7 @@ impl<K: DepKind> DepGraph<K> {
     where
         OP: FnOnce() -> R,
     {
-        crate::tls::with_deps::<K, _, _>(None, op)
+        crate::tls::with_deps(None, op)
     }
 
     /// Starts a new dep-graph task. Dep-graph tasks are specified
@@ -198,9 +198,9 @@ impl<K: DepKind> DepGraph<K> {
     ///   `arg` parameter.
     ///
     /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/incremental-compilation.html
-    pub fn with_task<Ctxt: HasDepContext<DepKind = K>, A: Debug, R>(
+    pub fn with_task<Ctxt: HasDepContext, A: Debug, R>(
         &self,
-        key: DepNode<K>,
+        key: DepNode,
         cx: Ctxt,
         arg: A,
         task: fn(Ctxt, A) -> R,
@@ -217,9 +217,9 @@ impl<K: DepKind> DepGraph<K> {
         }
     }
 
-    fn with_task_impl<Ctxt: HasDepContext<DepKind = K>, A: Debug, R>(
+    fn with_task_impl<Ctxt: HasDepContext, A: Debug, R>(
         &self,
-        key: DepNode<K>,
+        key: DepNode,
         cx: Ctxt,
         arg: A,
         task: fn(Ctxt, A) -> R,
@@ -293,10 +293,10 @@ impl<K: DepKind> DepGraph<K> {
 
     /// Executes something within an "anonymous" task, that is, a task the
     /// `DepNode` of which is determined by the list of inputs it read from.
-    pub fn with_anon_task<Ctxt: DepContext<DepKind = K>, OP, R>(
+    pub fn with_anon_task<Ctxt: DepContext, OP, R>(
         &self,
         cx: Ctxt,
-        dep_kind: K,
+        dep_kind: DepKind,
         op: OP,
     ) -> (R, DepNodeIndex)
     where
@@ -305,7 +305,7 @@ impl<K: DepKind> DepGraph<K> {
         debug_assert!(!cx.is_eval_always(dep_kind));
 
         if let Some(ref data) = self.data {
-            let task_deps = Lock::new(TaskDeps::<K>::default());
+            let task_deps = Lock::new(TaskDeps::default());
             let result = crate::tls::with_deps(Some(&task_deps), op);
             let task_deps = task_deps.into_inner();
             let task_deps = task_deps.reads;
@@ -401,12 +401,12 @@ impl<K: DepKind> DepGraph<K> {
     }
 
     #[inline]
-    pub fn dep_node_index_of(&self, dep_node: &DepNode<K>) -> DepNodeIndex {
+    pub fn dep_node_index_of(&self, dep_node: &DepNode) -> DepNodeIndex {
         self.dep_node_index_of_opt(dep_node).unwrap()
     }
 
     #[inline]
-    pub fn dep_node_index_of_opt(&self, dep_node: &DepNode<K>) -> Option<DepNodeIndex> {
+    pub fn dep_node_index_of_opt(&self, dep_node: &DepNode) -> Option<DepNodeIndex> {
         let data = self.data.as_ref().unwrap();
         let current = &data.current;
 
@@ -418,11 +418,11 @@ impl<K: DepKind> DepGraph<K> {
     }
 
     #[inline]
-    pub fn dep_node_exists(&self, dep_node: &DepNode<K>) -> bool {
+    pub fn dep_node_exists(&self, dep_node: &DepNode) -> bool {
         self.data.is_some() && self.dep_node_index_of_opt(dep_node).is_some()
     }
 
-    pub fn prev_fingerprint_of(&self, dep_node: &DepNode<K>) -> Option<Fingerprint> {
+    pub fn prev_fingerprint_of(&self, dep_node: &DepNode) -> Option<Fingerprint> {
         self.data.as_ref().unwrap().previous.fingerprint_of(dep_node)
     }
 
@@ -439,7 +439,7 @@ impl<K: DepKind> DepGraph<K> {
     }
 
     #[inline(always)]
-    pub fn register_dep_node_debug_str<F>(&self, dep_node: DepNode<K>, debug_str_gen: F)
+    pub fn register_dep_node_debug_str<F>(&self, dep_node: DepNode, debug_str_gen: F)
     where
         F: FnOnce() -> String,
     {
@@ -452,11 +452,11 @@ impl<K: DepKind> DepGraph<K> {
         dep_node_debug.borrow_mut().insert(dep_node, debug_str);
     }
 
-    pub fn dep_node_debug_str(&self, dep_node: DepNode<K>) -> Option<String> {
+    pub fn dep_node_debug_str(&self, dep_node: DepNode) -> Option<String> {
         self.data.as_ref()?.dep_node_debug.borrow().get(&dep_node).cloned()
     }
 
-    fn node_color(&self, dep_node: &DepNode<K>) -> Option<DepNodeColor> {
+    fn node_color(&self, dep_node: &DepNode) -> Option<DepNodeColor> {
         if let Some(ref data) = self.data {
             if let Some(prev_index) = data.previous.node_to_index_opt(dep_node) {
                 return data.colors.get(prev_index);
@@ -474,10 +474,10 @@ impl<K: DepKind> DepGraph<K> {
     /// A node will have an index, when it's already been marked green, or when we can mark it
     /// green. This function will mark the current task as a reader of the specified node, when
     /// a node index can be found for that node.
-    pub fn try_mark_green<Ctxt: QueryContext<DepKind = K>>(
+    pub fn try_mark_green<Ctxt: QueryContext>(
         &self,
         tcx: Ctxt,
-        dep_node: &DepNode<K>,
+        dep_node: &DepNode,
     ) -> Option<(SerializedDepNodeIndex, DepNodeIndex)> {
         debug_assert!(!tcx.dep_context().is_eval_always(dep_node.kind));
 
@@ -501,12 +501,12 @@ impl<K: DepKind> DepGraph<K> {
         }
     }
 
-    fn try_mark_parent_green<Ctxt: QueryContext<DepKind = K>>(
+    fn try_mark_parent_green<Ctxt: QueryContext>(
         &self,
         tcx: Ctxt,
-        data: &DepGraphData<K>,
+        data: &DepGraphData,
         parent_dep_node_index: SerializedDepNodeIndex,
-        dep_node: &DepNode<K>,
+        dep_node: &DepNode,
     ) -> Option<()> {
         let dep_dep_node_color = data.colors.get(parent_dep_node_index);
         let dep_dep_node = &data.previous.index_to_node(parent_dep_node_index);
@@ -613,12 +613,12 @@ impl<K: DepKind> DepGraph<K> {
     }
 
     /// Try to mark a dep-node which existed in the previous compilation session as green.
-    fn try_mark_previous_green<Ctxt: QueryContext<DepKind = K>>(
+    fn try_mark_previous_green<Ctxt: QueryContext>(
         &self,
         tcx: Ctxt,
-        data: &DepGraphData<K>,
+        data: &DepGraphData,
         prev_dep_node_index: SerializedDepNodeIndex,
-        dep_node: &DepNode<K>,
+        dep_node: &DepNode,
     ) -> Option<DepNodeIndex> {
         debug!("try_mark_previous_green({:?}) - BEGIN", dep_node);
 
@@ -683,10 +683,10 @@ impl<K: DepKind> DepGraph<K> {
     /// This may be called concurrently on multiple threads for the same dep node.
     #[cold]
     #[inline(never)]
-    fn emit_side_effects<Ctxt: QueryContext<DepKind = K>>(
+    fn emit_side_effects<Ctxt: QueryContext>(
         &self,
         tcx: Ctxt,
-        data: &DepGraphData<K>,
+        data: &DepGraphData,
         dep_node_index: DepNodeIndex,
         side_effects: QuerySideEffects,
     ) {
@@ -709,13 +709,13 @@ impl<K: DepKind> DepGraph<K> {
 
     // Returns true if the given node has been marked as red during the
     // current compilation session. Used in various assertions
-    pub fn is_red(&self, dep_node: &DepNode<K>) -> bool {
+    pub fn is_red(&self, dep_node: &DepNode) -> bool {
         self.node_color(dep_node) == Some(DepNodeColor::Red)
     }
 
     // Returns true if the given node has been marked as green during the
     // current compilation session. Used in various assertions
-    pub fn is_green(&self, dep_node: &DepNode<K>) -> bool {
+    pub fn is_green(&self, dep_node: &DepNode) -> bool {
         self.node_color(dep_node).map_or(false, |c| c.is_green())
     }
 
@@ -727,7 +727,7 @@ impl<K: DepKind> DepGraph<K> {
     //
     // This method will only load queries that will end up in the disk cache.
     // Other queries will not be executed.
-    pub fn exec_cache_promotions<Ctxt: DepContext<DepKind = K>>(&self, tcx: Ctxt) {
+    pub fn exec_cache_promotions<Ctxt: DepContext>(&self, tcx: Ctxt) {
         let _prof_timer = tcx.profiler().generic_activity("incr_comp_query_cache_promotion");
 
         let data = self.data.as_ref().unwrap();
@@ -835,15 +835,15 @@ rustc_index::newtype_index! {
 /// `new_node_to_index` and `data`, or `prev_index_to_index` and `data`. When
 /// manipulating both, we acquire `new_node_to_index` or `prev_index_to_index`
 /// first, and `data` second.
-pub(super) struct CurrentDepGraph<K: DepKind> {
-    encoder: Steal<GraphEncoder<K>>,
-    new_node_to_index: Sharded<FxHashMap<DepNode<K>, DepNodeIndex>>,
+pub(super) struct CurrentDepGraph {
+    encoder: Steal<GraphEncoder>,
+    new_node_to_index: Sharded<FxHashMap<DepNode, DepNodeIndex>>,
     prev_index_to_index: Lock<IndexVec<SerializedDepNodeIndex, Option<DepNodeIndex>>>,
 
     /// Used to trap when a specific edge is added to the graph.
     /// This is used for debug purposes and is only active with `debug_assertions`.
     #[cfg(debug_assertions)]
-    forbidden_edge: Option<EdgeFilter<K>>,
+    forbidden_edge: Option<EdgeFilter>,
 
     /// Anonymous `DepNode`s are nodes whose IDs we compute from the list of
     /// their edges. This has the beneficial side-effect that multiple anonymous
@@ -870,14 +870,14 @@ pub(super) struct CurrentDepGraph<K: DepKind> {
     node_intern_event_id: Option<EventId>,
 }
 
-impl<K: DepKind> CurrentDepGraph<K> {
+impl CurrentDepGraph {
     fn new(
         profiler: &SelfProfilerRef,
         prev_graph_node_count: usize,
         encoder: FileEncoder,
         record_graph: bool,
         record_stats: bool,
-    ) -> CurrentDepGraph<K> {
+    ) -> CurrentDepGraph {
         use std::time::{SystemTime, UNIX_EPOCH};
 
         let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -929,7 +929,7 @@ impl<K: DepKind> CurrentDepGraph<K> {
     }
 
     #[cfg(debug_assertions)]
-    fn record_edge(&self, dep_node_index: DepNodeIndex, key: DepNode<K>) {
+    fn record_edge(&self, dep_node_index: DepNodeIndex, key: DepNode) {
         if let Some(forbidden_edge) = &self.forbidden_edge {
             forbidden_edge.index_to_node.lock().insert(dep_node_index, key);
         }
@@ -940,7 +940,7 @@ impl<K: DepKind> CurrentDepGraph<K> {
     fn intern_new_node(
         &self,
         profiler: &SelfProfilerRef,
-        key: DepNode<K>,
+        key: DepNode,
         edges: EdgesVec,
         current_fingerprint: Fingerprint,
     ) -> DepNodeIndex {
@@ -960,8 +960,8 @@ impl<K: DepKind> CurrentDepGraph<K> {
     fn intern_node(
         &self,
         profiler: &SelfProfilerRef,
-        prev_graph: &SerializedDepGraph<K>,
-        key: DepNode<K>,
+        prev_graph: &SerializedDepGraph,
+        key: DepNode,
         edges: EdgesVec,
         fingerprint: Option<Fingerprint>,
         print_status: bool,
@@ -1062,7 +1062,7 @@ impl<K: DepKind> CurrentDepGraph<K> {
     fn promote_node_and_deps_to_current(
         &self,
         profiler: &SelfProfilerRef,
-        prev_graph: &SerializedDepGraph<K>,
+        prev_graph: &SerializedDepGraph,
         prev_index: SerializedDepNodeIndex,
     ) -> DepNodeIndex {
         self.debug_assert_not_in_new_nodes(prev_graph, prev_index);
@@ -1094,7 +1094,7 @@ impl<K: DepKind> CurrentDepGraph<K> {
     #[inline]
     fn debug_assert_not_in_new_nodes(
         &self,
-        prev_graph: &SerializedDepGraph<K>,
+        prev_graph: &SerializedDepGraph,
         prev_index: SerializedDepNodeIndex,
     ) {
         let node = &prev_graph.index_to_node(prev_index);
@@ -1109,24 +1109,13 @@ impl<K: DepKind> CurrentDepGraph<K> {
 const TASK_DEPS_READS_CAP: usize = 8;
 type EdgesVec = SmallVec<[DepNodeIndex; TASK_DEPS_READS_CAP]>;
 
-pub struct TaskDeps<K> {
+#[derive(Default)]
+pub struct TaskDeps {
     #[cfg(debug_assertions)]
-    node: Option<DepNode<K>>,
+    node: Option<DepNode>,
     reads: EdgesVec,
     read_set: FxHashSet<DepNodeIndex>,
-    phantom_data: PhantomData<DepNode<K>>,
-}
-
-impl<K> Default for TaskDeps<K> {
-    fn default() -> Self {
-        Self {
-            #[cfg(debug_assertions)]
-            node: None,
-            reads: EdgesVec::new(),
-            read_set: FxHashSet::default(),
-            phantom_data: PhantomData,
-        }
-    }
+    phantom_data: PhantomData<DepNode>,
 }
 
 // A data structure that stores Option<DepNodeColor> values as a contiguous

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -11,7 +11,6 @@ pub use serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 
 use crate::ich::StableHashingContext;
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::sync::Lock;
 use rustc_serialize::{opaque::FileEncoder, Encodable};
 use rustc_session::Session;
 
@@ -88,14 +87,4 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + Encodable<FileEncoder>
 
     /// Implementation of `std::fmt::Debug` for `DepNode`.
     fn debug_node(node: &DepNode<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result;
-
-    /// Execute the operation with provided dependencies.
-    fn with_deps<OP, R>(deps: Option<&Lock<TaskDeps<Self>>>, op: OP) -> R
-    where
-        OP: FnOnce() -> R;
-
-    /// Access dependencies from current implicit context.
-    fn read_deps<OP>(op: OP)
-    where
-        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>);
 }

--- a/compiler/rustc_query_system/src/dep_graph/query.rs
+++ b/compiler/rustc_query_system/src/dep_graph/query.rs
@@ -2,16 +2,16 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::graph::implementation::{Direction, Graph, NodeIndex, INCOMING};
 use rustc_index::vec::IndexVec;
 
-use super::{DepKind, DepNode, DepNodeIndex};
+use super::{DepNode, DepNodeIndex};
 
-pub struct DepGraphQuery<K> {
-    pub graph: Graph<DepNode<K>, ()>,
-    pub indices: FxHashMap<DepNode<K>, NodeIndex>,
+pub struct DepGraphQuery {
+    pub graph: Graph<DepNode, ()>,
+    pub indices: FxHashMap<DepNode, NodeIndex>,
     pub dep_index_to_index: IndexVec<DepNodeIndex, Option<NodeIndex>>,
 }
 
-impl<K: DepKind> DepGraphQuery<K> {
-    pub fn new(prev_node_count: usize) -> DepGraphQuery<K> {
+impl DepGraphQuery {
+    pub fn new(prev_node_count: usize) -> DepGraphQuery {
         let node_count = prev_node_count + prev_node_count / 4;
         let edge_count = 6 * node_count;
 
@@ -22,7 +22,7 @@ impl<K: DepKind> DepGraphQuery<K> {
         DepGraphQuery { graph, indices, dep_index_to_index }
     }
 
-    pub fn push(&mut self, index: DepNodeIndex, node: DepNode<K>, edges: &[DepNodeIndex]) {
+    pub fn push(&mut self, index: DepNodeIndex, node: DepNode, edges: &[DepNodeIndex]) {
         let source = self.graph.add_node(node);
         if index.index() >= self.dep_index_to_index.len() {
             self.dep_index_to_index.resize(index.index() + 1, None);
@@ -40,11 +40,11 @@ impl<K: DepKind> DepGraphQuery<K> {
         }
     }
 
-    pub fn nodes(&self) -> Vec<&DepNode<K>> {
+    pub fn nodes(&self) -> Vec<&DepNode> {
         self.graph.all_nodes().iter().map(|n| &n.data).collect()
     }
 
-    pub fn edges(&self) -> Vec<(&DepNode<K>, &DepNode<K>)> {
+    pub fn edges(&self) -> Vec<(&DepNode, &DepNode)> {
         self.graph
             .all_edges()
             .iter()
@@ -53,7 +53,7 @@ impl<K: DepKind> DepGraphQuery<K> {
             .collect()
     }
 
-    fn reachable_nodes(&self, node: &DepNode<K>, direction: Direction) -> Vec<&DepNode<K>> {
+    fn reachable_nodes(&self, node: &DepNode, direction: Direction) -> Vec<&DepNode> {
         if let Some(&index) = self.indices.get(node) {
             self.graph.depth_traverse(index, direction).map(|s| self.graph.node_data(s)).collect()
         } else {
@@ -62,7 +62,7 @@ impl<K: DepKind> DepGraphQuery<K> {
     }
 
     /// All nodes that can reach `node`.
-    pub fn transitive_predecessors(&self, node: &DepNode<K>) -> Vec<&DepNode<K>> {
+    pub fn transitive_predecessors(&self, node: &DepNode) -> Vec<&DepNode> {
         self.reachable_nodes(node, INCOMING)
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -53,6 +53,7 @@ pub struct SerializedDepGraph {
 }
 
 impl Default for SerializedDepGraph {
+    #[inline]
     fn default() -> Self {
         SerializedDepGraph {
             nodes: Default::default(),
@@ -91,6 +92,7 @@ impl SerializedDepGraph {
         self.fingerprints[dep_node_index]
     }
 
+    #[inline]
     pub fn node_count(&self) -> usize {
         self.index.len()
     }
@@ -153,7 +155,7 @@ impl<'a> Decodable<opaque::Decoder<'a>> for SerializedDepGraph {
     }
 }
 
-#[derive(Debug, Encodable, Decodable)]
+#[derive(Debug, Encodable)]
 pub struct NodeInfo {
     node: DepNode,
     fingerprint: Fingerprint,
@@ -175,6 +177,7 @@ struct EncoderState {
 }
 
 impl EncoderState {
+    #[inline]
     fn new(encoder: FileEncoder, record_stats: bool) -> Self {
         Self {
             encoder,
@@ -247,6 +250,7 @@ pub struct GraphEncoder {
 }
 
 impl GraphEncoder {
+    #[inline]
     pub fn new(
         encoder: FileEncoder,
         prev_node_count: usize,
@@ -320,6 +324,7 @@ impl GraphEncoder {
         }
     }
 
+    #[inline]
     pub(crate) fn send(
         &self,
         profiler: &SelfProfilerRef,
@@ -332,6 +337,7 @@ impl GraphEncoder {
         self.status.lock().encode_node(&node, &self.record_graph)
     }
 
+    #[inline]
     pub fn finish(self, profiler: &SelfProfilerRef) -> FileEncodeResult {
         let _prof_timer = profiler.generic_activity("incr_comp_encode_dep_graph");
         self.status.into_inner().finish(profiler)

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -35,9 +35,9 @@ rustc_index::newtype_index! {
 
 /// Data for use when recompiling the **current crate**.
 #[derive(Debug)]
-pub struct SerializedDepGraph<K: DepKind> {
+pub struct SerializedDepGraph {
     /// The set of all DepNodes in the graph
-    nodes: IndexVec<SerializedDepNodeIndex, DepNode<K>>,
+    nodes: IndexVec<SerializedDepNodeIndex, DepNode>,
     /// The set of all Fingerprints in the graph. Each Fingerprint corresponds to
     /// the DepNode at the same index in the nodes vector.
     fingerprints: IndexVec<SerializedDepNodeIndex, Fingerprint>,
@@ -49,10 +49,10 @@ pub struct SerializedDepGraph<K: DepKind> {
     /// implicit in edge_list_indices.
     edge_list_data: Vec<SerializedDepNodeIndex>,
     /// Reciprocal map to `nodes`.
-    index: FxHashMap<DepNode<K>, SerializedDepNodeIndex>,
+    index: FxHashMap<DepNode, SerializedDepNodeIndex>,
 }
 
-impl<K: DepKind> Default for SerializedDepGraph<K> {
+impl Default for SerializedDepGraph {
     fn default() -> Self {
         SerializedDepGraph {
             nodes: Default::default(),
@@ -64,7 +64,7 @@ impl<K: DepKind> Default for SerializedDepGraph<K> {
     }
 }
 
-impl<K: DepKind> SerializedDepGraph<K> {
+impl SerializedDepGraph {
     #[inline]
     pub fn edge_targets_from(&self, source: SerializedDepNodeIndex) -> &[SerializedDepNodeIndex] {
         let targets = self.edge_list_indices[source];
@@ -72,17 +72,17 @@ impl<K: DepKind> SerializedDepGraph<K> {
     }
 
     #[inline]
-    pub fn index_to_node(&self, dep_node_index: SerializedDepNodeIndex) -> DepNode<K> {
+    pub fn index_to_node(&self, dep_node_index: SerializedDepNodeIndex) -> DepNode {
         self.nodes[dep_node_index]
     }
 
     #[inline]
-    pub fn node_to_index_opt(&self, dep_node: &DepNode<K>) -> Option<SerializedDepNodeIndex> {
+    pub fn node_to_index_opt(&self, dep_node: &DepNode) -> Option<SerializedDepNodeIndex> {
         self.index.get(dep_node).cloned()
     }
 
     #[inline]
-    pub fn fingerprint_of(&self, dep_node: &DepNode<K>) -> Option<Fingerprint> {
+    pub fn fingerprint_of(&self, dep_node: &DepNode) -> Option<Fingerprint> {
         self.index.get(dep_node).map(|&node_index| self.fingerprints[node_index])
     }
 
@@ -96,11 +96,9 @@ impl<K: DepKind> SerializedDepGraph<K> {
     }
 }
 
-impl<'a, K: DepKind + Decodable<opaque::Decoder<'a>>> Decodable<opaque::Decoder<'a>>
-    for SerializedDepGraph<K>
-{
+impl<'a> Decodable<opaque::Decoder<'a>> for SerializedDepGraph {
     #[instrument(level = "debug", skip(d))]
-    fn decode(d: &mut opaque::Decoder<'a>) -> Result<SerializedDepGraph<K>, String> {
+    fn decode(d: &mut opaque::Decoder<'a>) -> Result<SerializedDepGraph, String> {
         let start_position = d.position();
 
         // The last 16 bytes are the node count and edge count.
@@ -123,7 +121,7 @@ impl<'a, K: DepKind + Decodable<opaque::Decoder<'a>>> Decodable<opaque::Decoder<
 
         for _index in 0..node_count {
             d.read_struct(|d| {
-                let dep_node: DepNode<K> = d.read_struct_field("node", Decodable::decode)?;
+                let dep_node: DepNode = d.read_struct_field("node", Decodable::decode)?;
                 let _i: SerializedDepNodeIndex = nodes.push(dep_node);
                 debug_assert_eq!(_i.index(), _index);
 
@@ -156,27 +154,27 @@ impl<'a, K: DepKind + Decodable<opaque::Decoder<'a>>> Decodable<opaque::Decoder<
 }
 
 #[derive(Debug, Encodable, Decodable)]
-pub struct NodeInfo<K: DepKind> {
-    node: DepNode<K>,
+pub struct NodeInfo {
+    node: DepNode,
     fingerprint: Fingerprint,
     edges: SmallVec<[DepNodeIndex; 8]>,
 }
 
-struct Stat<K: DepKind> {
-    kind: K,
+struct Stat {
+    kind: DepKind,
     node_counter: u64,
     edge_counter: u64,
 }
 
-struct EncoderState<K: DepKind> {
+struct EncoderState {
     encoder: FileEncoder,
     total_node_count: usize,
     total_edge_count: usize,
     result: FileEncodeResult,
-    stats: Option<FxHashMap<K, Stat<K>>>,
+    stats: Option<FxHashMap<DepKind, Stat>>,
 }
 
-impl<K: DepKind> EncoderState<K> {
+impl EncoderState {
     fn new(encoder: FileEncoder, record_stats: bool) -> Self {
         Self {
             encoder,
@@ -190,8 +188,8 @@ impl<K: DepKind> EncoderState<K> {
     #[instrument(level = "debug", skip(self, record_graph))]
     fn encode_node(
         &mut self,
-        node: &NodeInfo<K>,
-        record_graph: &Option<Lock<DepGraphQuery<K>>>,
+        node: &NodeInfo,
+        record_graph: &Option<Lock<DepGraphQuery>>,
     ) -> DepNodeIndex {
         let index = DepNodeIndex::new(self.total_node_count);
         self.total_node_count += 1;
@@ -243,12 +241,12 @@ impl<K: DepKind> EncoderState<K> {
     }
 }
 
-pub struct GraphEncoder<K: DepKind> {
-    status: Lock<EncoderState<K>>,
-    record_graph: Option<Lock<DepGraphQuery<K>>>,
+pub struct GraphEncoder {
+    status: Lock<EncoderState>,
+    record_graph: Option<Lock<DepGraphQuery>>,
 }
 
-impl<K: DepKind + Encodable<FileEncoder>> GraphEncoder<K> {
+impl GraphEncoder {
     pub fn new(
         encoder: FileEncoder,
         prev_node_count: usize,
@@ -261,7 +259,7 @@ impl<K: DepKind + Encodable<FileEncoder>> GraphEncoder<K> {
         GraphEncoder { status, record_graph }
     }
 
-    pub(crate) fn with_query(&self, f: impl Fn(&DepGraphQuery<K>)) {
+    pub(crate) fn with_query(&self, f: impl Fn(&DepGraphQuery)) {
         if let Some(record_graph) = &self.record_graph {
             f(&record_graph.lock())
         }
@@ -325,7 +323,7 @@ impl<K: DepKind + Encodable<FileEncoder>> GraphEncoder<K> {
     pub(crate) fn send(
         &self,
         profiler: &SelfProfilerRef,
-        node: DepNode<K>,
+        node: DepNode,
         fingerprint: Fingerprint,
         edges: SmallVec<[DepNodeIndex; 8]>,
     ) -> DepNodeIndex {

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -14,6 +14,9 @@ extern crate rustc_data_structures;
 #[macro_use]
 extern crate rustc_macros;
 
+#[macro_use]
+pub mod decl;
+
 pub mod cache;
 pub mod dep_graph;
 pub mod ich;

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -21,3 +21,5 @@ pub mod cache;
 pub mod dep_graph;
 pub mod ich;
 pub mod query;
+
+pub mod tls;

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -1,5 +1,6 @@
 //! Query configuration and description traits.
 
+use crate::dep_graph::DepKind;
 use crate::dep_graph::DepNode;
 use crate::dep_graph::SerializedDepNodeIndex;
 use crate::ich::StableHashingContext;
@@ -21,7 +22,7 @@ pub trait QueryConfig {
 
 pub(crate) struct QueryVtable<CTX: QueryContext, K, V> {
     pub anon: bool,
-    pub dep_kind: CTX::DepKind,
+    pub dep_kind: DepKind,
     pub eval_always: bool,
 
     pub compute: fn(CTX::DepContext, K) -> V,
@@ -32,7 +33,7 @@ pub(crate) struct QueryVtable<CTX: QueryContext, K, V> {
 }
 
 impl<CTX: QueryContext, K, V> QueryVtable<CTX, K, V> {
-    pub(crate) fn to_dep_node(&self, tcx: CTX::DepContext, key: &K) -> DepNode<CTX::DepKind>
+    pub(crate) fn to_dep_node(&self, tcx: CTX::DepContext, key: &K) -> DepNode
     where
         K: crate::dep_graph::DepNodeParams<CTX::DepContext>,
     {
@@ -55,7 +56,7 @@ impl<CTX: QueryContext, K, V> QueryVtable<CTX, K, V> {
 pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
     const ANON: bool;
     const EVAL_ALWAYS: bool;
-    const DEP_KIND: CTX::DepKind;
+    const DEP_KIND: DepKind;
     const HASH_RESULT: Option<
         fn(hcx: &mut StableHashingContext<'_>, result: &Self::Value) -> Fingerprint,
     >;
@@ -63,7 +64,7 @@ pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
     type Cache: QueryCache<Key = Self::Key, Stored = Self::Stored, Value = Self::Value>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(tcx: CTX) -> &'a QueryState<CTX::DepKind, Self::Key>
+    fn query_state<'a>(tcx: CTX) -> &'a QueryState<Self::Key>
     where
         CTX: 'a;
 

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -1,4 +1,5 @@
 use crate::dep_graph::DepContext;
+use crate::dep_graph::DepKind;
 use crate::query::plumbing::CycleError;
 use crate::query::{QueryContext, QueryStackFrame, SimpleDefKind};
 
@@ -13,7 +14,6 @@ use std::num::NonZeroU32;
 
 #[cfg(parallel_compiler)]
 use {
-    crate::dep_graph::DepKind,
     parking_lot::{Condvar, Mutex},
     rustc_data_structures::fx::FxHashSet,
     rustc_data_structures::sync::Lock,
@@ -33,7 +33,7 @@ pub struct QueryInfo {
     pub query: QueryStackFrame,
 }
 
-pub type QueryMap<D> = FxHashMap<QueryJobId<D>, QueryJobInfo<D>>;
+pub type QueryMap = FxHashMap<QueryJobId, QueryJobInfo>;
 
 /// A value uniquely identifying an active query job within a shard in the query cache.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
@@ -41,7 +41,7 @@ pub struct QueryShardJobId(pub NonZeroU32);
 
 /// A value uniquely identifying an active query job.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct QueryJobId<D> {
+pub struct QueryJobId {
     /// Which job within a shard is this
     pub job: QueryShardJobId,
 
@@ -49,64 +49,58 @@ pub struct QueryJobId<D> {
     pub shard: u16,
 
     /// What kind of query this job is.
-    pub kind: D,
+    pub kind: DepKind,
 }
 
-impl<D> QueryJobId<D>
-where
-    D: Copy + Clone + Eq + Hash,
-{
-    pub fn new(job: QueryShardJobId, shard: usize, kind: D) -> Self {
+impl QueryJobId {
+    pub fn new(job: QueryShardJobId, shard: usize, kind: DepKind) -> Self {
         QueryJobId { job, shard: u16::try_from(shard).unwrap(), kind }
     }
 
-    fn query(self, map: &QueryMap<D>) -> QueryStackFrame {
+    fn query(self, map: &QueryMap) -> QueryStackFrame {
         map.get(&self).unwrap().query.clone()
     }
 
     #[cfg(parallel_compiler)]
-    fn span(self, map: &QueryMap<D>) -> Span {
+    fn span(self, map: &QueryMap) -> Span {
         map.get(&self).unwrap().job.span
     }
 
     #[cfg(parallel_compiler)]
-    fn parent(self, map: &QueryMap<D>) -> Option<QueryJobId<D>> {
+    fn parent(self, map: &QueryMap) -> Option<QueryJobId> {
         map.get(&self).unwrap().job.parent
     }
 
     #[cfg(parallel_compiler)]
-    fn latch<'a>(self, map: &'a QueryMap<D>) -> Option<&'a QueryLatch<D>> {
+    fn latch<'a>(self, map: &'a QueryMap) -> Option<&'a QueryLatch> {
         map.get(&self).unwrap().job.latch.as_ref()
     }
 }
 
-pub struct QueryJobInfo<D> {
+pub struct QueryJobInfo {
     pub query: QueryStackFrame,
-    pub job: QueryJob<D>,
+    pub job: QueryJob,
 }
 
 /// Represents an active query job.
 #[derive(Clone)]
-pub struct QueryJob<D> {
+pub struct QueryJob {
     pub id: QueryShardJobId,
 
     /// The span corresponding to the reason for which this query was required.
     pub span: Span,
 
     /// The parent query job which created this job and is implicitly waiting on it.
-    pub parent: Option<QueryJobId<D>>,
+    pub parent: Option<QueryJobId>,
 
     /// The latch that is used to wait on this job.
     #[cfg(parallel_compiler)]
-    latch: Option<QueryLatch<D>>,
+    latch: Option<QueryLatch>,
 }
 
-impl<D> QueryJob<D>
-where
-    D: Copy + Clone + Eq + Hash,
-{
+impl QueryJob {
     /// Creates a new query job.
-    pub fn new(id: QueryShardJobId, span: Span, parent: Option<QueryJobId<D>>) -> Self {
+    pub fn new(id: QueryShardJobId, span: Span, parent: Option<QueryJobId>) -> Self {
         QueryJob {
             id,
             span,
@@ -117,7 +111,7 @@ where
     }
 
     #[cfg(parallel_compiler)]
-    pub(super) fn latch(&mut self) -> QueryLatch<D> {
+    pub(super) fn latch(&mut self) -> QueryLatch {
         if self.latch.is_none() {
             self.latch = Some(QueryLatch::new());
         }
@@ -139,16 +133,13 @@ where
 }
 
 #[cfg(not(parallel_compiler))]
-impl<D> QueryJobId<D>
-where
-    D: Copy + Clone + Eq + Hash,
-{
+impl QueryJobId {
     #[cold]
     #[inline(never)]
     pub(super) fn find_cycle_in_stack(
         &self,
-        query_map: QueryMap<D>,
-        current_job: &Option<QueryJobId<D>>,
+        query_map: QueryMap,
+        current_job: &Option<QueryJobId>,
         span: Span,
     ) -> CycleError {
         // Find the waitee amongst `current_job` parents
@@ -184,15 +175,15 @@ where
 }
 
 #[cfg(parallel_compiler)]
-struct QueryWaiter<D> {
-    query: Option<QueryJobId<D>>,
+struct QueryWaiter {
+    query: Option<QueryJobId>,
     condvar: Condvar,
     span: Span,
     cycle: Lock<Option<CycleError>>,
 }
 
 #[cfg(parallel_compiler)]
-impl<D> QueryWaiter<D> {
+impl QueryWaiter {
     fn notify(&self, registry: &rayon_core::Registry) {
         rayon_core::mark_unblocked(registry);
         self.condvar.notify_one();
@@ -200,19 +191,19 @@ impl<D> QueryWaiter<D> {
 }
 
 #[cfg(parallel_compiler)]
-struct QueryLatchInfo<D> {
+struct QueryLatchInfo {
     complete: bool,
-    waiters: Vec<Lrc<QueryWaiter<D>>>,
+    waiters: Vec<Lrc<QueryWaiter>>,
 }
 
 #[cfg(parallel_compiler)]
 #[derive(Clone)]
-pub(super) struct QueryLatch<D> {
-    info: Lrc<Mutex<QueryLatchInfo<D>>>,
+pub(super) struct QueryLatch {
+    info: Lrc<Mutex<QueryLatchInfo>>,
 }
 
 #[cfg(parallel_compiler)]
-impl<D: Eq + Hash> QueryLatch<D> {
+impl QueryLatch {
     fn new() -> Self {
         QueryLatch {
             info: Lrc::new(Mutex::new(QueryLatchInfo { complete: false, waiters: Vec::new() })),
@@ -221,13 +212,9 @@ impl<D: Eq + Hash> QueryLatch<D> {
 }
 
 #[cfg(parallel_compiler)]
-impl<D> QueryLatch<D> {
+impl QueryLatch {
     /// Awaits for the query job to complete.
-    pub(super) fn wait_on(
-        &self,
-        query: Option<QueryJobId<D>>,
-        span: Span,
-    ) -> Result<(), CycleError> {
+    pub(super) fn wait_on(&self, query: Option<QueryJobId>, span: Span) -> Result<(), CycleError> {
         let waiter =
             Lrc::new(QueryWaiter { query, span, cycle: Lock::new(None), condvar: Condvar::new() });
         self.wait_on_inner(&waiter);
@@ -242,7 +229,7 @@ impl<D> QueryLatch<D> {
     }
 
     /// Awaits the caller on this latch by blocking the current thread.
-    fn wait_on_inner(&self, waiter: &Lrc<QueryWaiter<D>>) {
+    fn wait_on_inner(&self, waiter: &Lrc<QueryWaiter>) {
         let mut info = self.info.lock();
         if !info.complete {
             // We push the waiter on to the `waiters` list. It can be accessed inside
@@ -276,7 +263,7 @@ impl<D> QueryLatch<D> {
 
     /// Removes a single waiter from the list of waiters.
     /// This is used to break query cycles.
-    fn extract_waiter(&self, waiter: usize) -> Lrc<QueryWaiter<D>> {
+    fn extract_waiter(&self, waiter: usize) -> Lrc<QueryWaiter> {
         let mut info = self.info.lock();
         debug_assert!(!info.complete);
         // Remove the waiter from the list of waiters
@@ -286,7 +273,7 @@ impl<D> QueryLatch<D> {
 
 /// A resumable waiter of a query. The usize is the index into waiters in the query's latch
 #[cfg(parallel_compiler)]
-type Waiter<D> = (QueryJobId<D>, usize);
+type Waiter = (QueryJobId, usize);
 
 /// Visits all the non-resumable and resumable waiters of a query.
 /// Only waiters in a query are visited.
@@ -298,14 +285,9 @@ type Waiter<D> = (QueryJobId<D>, usize);
 /// required information to resume the waiter.
 /// If all `visit` calls returns None, this function also returns None.
 #[cfg(parallel_compiler)]
-fn visit_waiters<D, F>(
-    query_map: &QueryMap<D>,
-    query: QueryJobId<D>,
-    mut visit: F,
-) -> Option<Option<Waiter<D>>>
+fn visit_waiters<F>(query_map: &QueryMap, query: QueryJobId, mut visit: F) -> Option<Option<Waiter>>
 where
-    D: Copy + Clone + Eq + Hash,
-    F: FnMut(Span, QueryJobId<D>) -> Option<Option<Waiter<D>>>,
+    F: FnMut(Span, QueryJobId) -> Option<Option<Waiter>>,
 {
     // Visit the parent query which is a non-resumable waiter since it's on the same stack
     if let Some(parent) = query.parent(query_map) {
@@ -334,16 +316,13 @@ where
 /// If a cycle is detected, this initial value is replaced with the span causing
 /// the cycle.
 #[cfg(parallel_compiler)]
-fn cycle_check<D>(
-    query_map: &QueryMap<D>,
-    query: QueryJobId<D>,
+fn cycle_check(
+    query_map: &QueryMap,
+    query: QueryJobId,
     span: Span,
-    stack: &mut Vec<(Span, QueryJobId<D>)>,
-    visited: &mut FxHashSet<QueryJobId<D>>,
-) -> Option<Option<Waiter<D>>>
-where
-    D: Copy + Clone + Eq + Hash,
-{
+    stack: &mut Vec<(Span, QueryJobId)>,
+    visited: &mut FxHashSet<QueryJobId>,
+) -> Option<Option<Waiter>> {
     if !visited.insert(query) {
         return if let Some(p) = stack.iter().position(|q| q.1 == query) {
             // We detected a query cycle, fix up the initial span and return Some
@@ -378,14 +357,11 @@ where
 /// from `query` without going through any of the queries in `visited`.
 /// This is achieved with a depth first search.
 #[cfg(parallel_compiler)]
-fn connected_to_root<D>(
-    query_map: &QueryMap<D>,
-    query: QueryJobId<D>,
-    visited: &mut FxHashSet<QueryJobId<D>>,
-) -> bool
-where
-    D: Copy + Clone + Eq + Hash,
-{
+fn connected_to_root(
+    query_map: &QueryMap,
+    query: QueryJobId,
+    visited: &mut FxHashSet<QueryJobId>,
+) -> bool {
     // We already visited this or we're deliberately ignoring it
     if !visited.insert(query) {
         return false;
@@ -404,10 +380,9 @@ where
 
 // Deterministically pick an query from a list
 #[cfg(parallel_compiler)]
-fn pick_query<'a, D, T, F>(query_map: &QueryMap<D>, queries: &'a [T], f: F) -> &'a T
+fn pick_query<'a, T, F>(query_map: &QueryMap, queries: &'a [T], f: F) -> &'a T
 where
-    D: Copy + Clone + Eq + Hash,
-    F: Fn(&T) -> (Span, QueryJobId<D>),
+    F: Fn(&T) -> (Span, QueryJobId),
 {
     // Deterministically pick an entry point
     // FIXME: Sort this instead
@@ -431,10 +406,10 @@ where
 /// If a cycle was not found, the starting query is removed from `jobs` and
 /// the function returns false.
 #[cfg(parallel_compiler)]
-fn remove_cycle<D: DepKind>(
-    query_map: &QueryMap<D>,
-    jobs: &mut Vec<QueryJobId<D>>,
-    wakelist: &mut Vec<Lrc<QueryWaiter<D>>>,
+fn remove_cycle(
+    query_map: &QueryMap,
+    jobs: &mut Vec<QueryJobId>,
+    wakelist: &mut Vec<Lrc<QueryWaiter>>,
 ) -> bool {
     let mut visited = FxHashSet::default();
     let mut stack = Vec::new();
@@ -489,7 +464,7 @@ fn remove_cycle<D: DepKind>(
                     }
                 }
             })
-            .collect::<Vec<(Span, QueryJobId<D>, Option<(Span, QueryJobId<D>)>)>>();
+            .collect::<Vec<(Span, QueryJobId, Option<(Span, QueryJobId)>)>>();
 
         // Deterministically pick an entry point
         let (_, entry_point, usage) = pick_query(query_map, &entry_points, |e| (e.0, e.1));
@@ -544,7 +519,7 @@ pub fn deadlock<CTX: QueryContext>(tcx: CTX, registry: &rayon_core::Registry) {
 
     let mut wakelist = Vec::new();
     let query_map = tcx.try_collect_active_jobs().unwrap();
-    let mut jobs: Vec<QueryJobId<CTX::DepKind>> = query_map.keys().cloned().collect();
+    let mut jobs: Vec<QueryJobId> = query_map.keys().cloned().collect();
 
     let mut found_cycle = false;
 

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -53,25 +53,30 @@ pub struct QueryJobId {
 }
 
 impl QueryJobId {
+    #[inline]
     pub fn new(job: QueryShardJobId, shard: usize, kind: DepKind) -> Self {
         QueryJobId { job, shard: u16::try_from(shard).unwrap(), kind }
     }
 
+    #[inline]
     fn query(self, map: &QueryMap) -> QueryStackFrame {
         map.get(&self).unwrap().query.clone()
     }
 
     #[cfg(parallel_compiler)]
+    #[inline]
     fn span(self, map: &QueryMap) -> Span {
         map.get(&self).unwrap().job.span
     }
 
     #[cfg(parallel_compiler)]
+    #[inline]
     fn parent(self, map: &QueryMap) -> Option<QueryJobId> {
         map.get(&self).unwrap().job.parent
     }
 
     #[cfg(parallel_compiler)]
+    #[inline]
     fn latch<'a>(self, map: &'a QueryMap) -> Option<&'a QueryLatch> {
         map.get(&self).unwrap().job.latch.as_ref()
     }
@@ -100,6 +105,7 @@ pub struct QueryJob {
 
 impl QueryJob {
     /// Creates a new query job.
+    #[inline]
     pub fn new(id: QueryShardJobId, span: Span, parent: Option<QueryJobId>) -> Self {
         QueryJob {
             id,
@@ -111,6 +117,7 @@ impl QueryJob {
     }
 
     #[cfg(parallel_compiler)]
+    #[inline]
     pub(super) fn latch(&mut self) -> QueryLatch {
         if self.latch.is_none() {
             self.latch = Some(QueryLatch::new());
@@ -122,6 +129,7 @@ impl QueryJob {
     ///
     /// This does nothing for single threaded rustc,
     /// as there are no concurrent jobs which could be waiting on us
+    #[inline]
     pub fn signal_complete(self) {
         #[cfg(parallel_compiler)]
         {
@@ -204,6 +212,7 @@ pub(super) struct QueryLatch {
 
 #[cfg(parallel_compiler)]
 impl QueryLatch {
+    #[inline]
     fn new() -> Self {
         QueryLatch {
             info: Lrc::new(Mutex::new(QueryLatchInfo { complete: false, waiters: Vec::new() })),
@@ -214,6 +223,7 @@ impl QueryLatch {
 #[cfg(parallel_compiler)]
 impl QueryLatch {
     /// Awaits for the query job to complete.
+    #[inline]
     pub(super) fn wait_on(&self, query: Option<QueryJobId>, span: Span) -> Result<(), CycleError> {
         let waiter =
             Lrc::new(QueryWaiter { query, span, cycle: Lock::new(None), condvar: Condvar::new() });
@@ -229,6 +239,7 @@ impl QueryLatch {
     }
 
     /// Awaits the caller on this latch by blocking the current thread.
+    #[inline]
     fn wait_on_inner(&self, waiter: &Lrc<QueryWaiter>) {
         let mut info = self.info.lock();
         if !info.complete {
@@ -251,6 +262,7 @@ impl QueryLatch {
     }
 
     /// Sets the latch and resumes all waiters on it
+    #[inline]
     fn set(&self) {
         let mut info = self.info.lock();
         debug_assert!(!info.complete);
@@ -263,6 +275,7 @@ impl QueryLatch {
 
     /// Removes a single waiter from the list of waiters.
     /// This is used to break query cycles.
+    #[inline]
     fn extract_waiter(&self, waiter: usize) -> Lrc<QueryWaiter> {
         let mut info = self.info.lock();
         debug_assert!(!info.complete);

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -630,10 +630,11 @@ pub(crate) fn report_cycle<'a>(
 
 pub fn print_query_stack<CTX: QueryContext>(
     tcx: CTX,
-    mut current_query: Option<QueryJobId<CTX::DepKind>>,
     handler: &Handler,
     num_frames: Option<usize>,
 ) -> usize {
+    let mut current_query = crate::tls::current_query_job();
+
     // Be careful relying on global state here: this code is called from
     // a panic hook, which means that the global `Handler` may be in a weird
     // state if it was responsible for triggering the panic.

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -16,7 +16,6 @@ pub use self::config::{QueryAccessors, QueryConfig, QueryDescription};
 
 use crate::dep_graph::{DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
 
-use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::Diagnostic;
 use rustc_span::Span;
@@ -117,9 +116,6 @@ impl QuerySideEffects {
 }
 
 pub trait QueryContext: HasDepContext {
-    /// Get the query information from the TLS context.
-    fn current_query_job(&self) -> Option<QueryJobId<Self::DepKind>>;
-
     fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind>>;
 
     /// Load side effects associated to the node in the previous session.
@@ -134,14 +130,4 @@ pub trait QueryContext: HasDepContext {
         dep_node_index: DepNodeIndex,
         side_effects: QuerySideEffects,
     );
-
-    /// Executes a job by changing the `ImplicitCtxt` to point to the
-    /// new query job while it executes. It returns the diagnostics
-    /// captured during execution and the actual result.
-    fn start_query<R>(
-        &self,
-        token: QueryJobId<Self::DepKind>,
-        diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
-        compute: impl FnOnce() -> R,
-    ) -> R;
 }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -116,7 +116,7 @@ impl QuerySideEffects {
 }
 
 pub trait QueryContext: HasDepContext {
-    fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind>>;
+    fn try_collect_active_jobs(&self) -> Option<QueryMap>;
 
     /// Load side effects associated to the node in the previous session.
     fn load_side_effects(&self, prev_dep_node_index: SerializedDepNodeIndex) -> QuerySideEffects;

--- a/compiler/rustc_query_system/src/tls.rs
+++ b/compiler/rustc_query_system/src/tls.rs
@@ -1,0 +1,177 @@
+use crate::dep_graph::TaskDeps;
+use crate::query::QueryJobId;
+use rustc_data_structures::sync::{self, Lock};
+use rustc_data_structures::thin_vec::ThinVec;
+use rustc_errors::Diagnostic;
+
+#[cfg(not(parallel_compiler))]
+use std::cell::Cell;
+
+#[cfg(parallel_compiler)]
+use rustc_rayon_core as rayon_core;
+
+type FakeDepKind = u16;
+
+/// This is the implicit state of rustc. It contains the current
+/// query. It is updated when
+/// executing a new query.
+#[derive(Clone)]
+pub struct ImplicitCtxt<'a, K> {
+    /// The current query job, if any. This is updated by `JobOwner::start` in
+    /// `ty::query::plumbing` when executing a query.
+    query: Option<QueryJobId<K>>,
+
+    /// Where to store diagnostics for the current query job, if any.
+    /// This is updated by `JobOwner::start` in `ty::query::plumbing` when executing a query.
+    diagnostics: Option<&'a Lock<ThinVec<Diagnostic>>>,
+
+    /// The current dep graph task. This is used to add dependencies to queries
+    /// when executing them.
+    task_deps: Option<&'a Lock<TaskDeps<K>>>,
+}
+
+impl<'a, K> ImplicitCtxt<'a, K> {
+    pub fn new() -> Self {
+        ImplicitCtxt { query: None, diagnostics: None, task_deps: None }
+    }
+}
+
+/// Sets Rayon's thread-local variable, which is preserved for Rayon jobs
+/// to `value` during the call to `f`. It is restored to its previous value after.
+/// This is used to set the pointer to the new `ImplicitCtxt`.
+#[cfg(parallel_compiler)]
+#[inline]
+fn set_tlv<F: FnOnce() -> R, R>(value: usize, f: F) -> R {
+    rayon_core::tlv::with(value, f)
+}
+
+/// Gets Rayon's thread-local variable, which is preserved for Rayon jobs.
+/// This is used to get the pointer to the current `ImplicitCtxt`.
+#[cfg(parallel_compiler)]
+#[inline]
+pub fn get_tlv() -> usize {
+    rayon_core::tlv::get()
+}
+
+#[cfg(not(parallel_compiler))]
+thread_local! {
+    /// A thread local variable that stores a pointer to the current `ImplicitCtxt`.
+    static TLV: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Sets TLV to `value` during the call to `f`.
+/// It is restored to its previous value after.
+/// This is used to set the pointer to the new `ImplicitCtxt`.
+#[cfg(not(parallel_compiler))]
+#[inline]
+fn set_tlv<F: FnOnce() -> R, R>(value: usize, f: F) -> R {
+    let old = get_tlv();
+    let _reset = rustc_data_structures::OnDrop(move || TLV.with(|tlv| tlv.set(old)));
+    TLV.with(|tlv| tlv.set(value));
+    f()
+}
+
+/// Gets the pointer to the current `ImplicitCtxt`.
+#[cfg(not(parallel_compiler))]
+#[inline]
+fn get_tlv() -> usize {
+    TLV.with(|tlv| tlv.get())
+}
+
+/// Sets `context` as the new current `ImplicitCtxt` for the duration of the function `f`.
+#[inline]
+pub fn enter_context<'a, K, F, R>(context: &ImplicitCtxt<'a, K>, f: F) -> R
+where
+    F: FnOnce(&ImplicitCtxt<'a, K>) -> R,
+{
+    set_tlv(context as *const _ as usize, || f(&context))
+}
+
+/// Allows access to the current `ImplicitCtxt` in a closure if one is available.
+#[inline]
+fn with_context_opt<K, F, R>(f: F) -> R
+where
+    F: for<'a> FnOnce(Option<&ImplicitCtxt<'a, K>>) -> R,
+{
+    let context = get_tlv();
+    if context == 0 {
+        f(None)
+    } else {
+        // We could get a `ImplicitCtxt` pointer from another thread.
+        // Ensure that `ImplicitCtxt` is `Sync`.
+        sync::assert_sync::<ImplicitCtxt<'_, K>>();
+
+        unsafe { f(Some(&*(context as *const ImplicitCtxt<'_, K>))) }
+    }
+}
+
+/// Allows access to the current `ImplicitCtxt`.
+/// Panics if there is no `ImplicitCtxt` available.
+#[inline]
+fn with_context<K, F, R>(f: F) -> R
+where
+    F: for<'a> FnOnce(&ImplicitCtxt<'a, K>) -> R,
+{
+    with_context_opt(|opt_context| f(opt_context.expect("no ImplicitCtxt stored in tls")))
+}
+
+/// This is a callback from `rustc_ast` as it cannot access the implicit state
+/// in `rustc_middle` otherwise. It is used to when diagnostic messages are
+/// emitted and stores them in the current query, if there is one.
+pub fn track_diagnostic(diagnostic: &Diagnostic) {
+    with_context_opt::<FakeDepKind, _, _>(|icx| {
+        if let Some(icx) = icx {
+            if let Some(ref diagnostics) = icx.diagnostics {
+                let mut diagnostics = diagnostics.lock();
+                diagnostics.extend(Some(diagnostic.clone()));
+            }
+        }
+    })
+}
+
+pub fn with_deps<K, OP, R>(task_deps: Option<&Lock<TaskDeps<K>>>, op: OP) -> R
+where
+    K: Clone,
+    OP: FnOnce() -> R,
+{
+    crate::tls::with_context(|icx| {
+        let icx = crate::tls::ImplicitCtxt { task_deps, ..icx.clone() };
+
+        crate::tls::enter_context(&icx, |_| op())
+    })
+}
+
+pub fn read_deps<K, OP>(op: OP)
+where
+    OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<K>>>),
+{
+    crate::tls::with_context_opt(|icx| {
+        let icx = if let Some(icx) = icx { icx } else { return };
+        op(icx.task_deps)
+    })
+}
+
+/// Get the query information from the TLS context.
+#[inline(always)]
+pub fn current_query_job<K: Copy>() -> Option<QueryJobId<K>> {
+    with_context(|icx| icx.query)
+}
+
+/// Executes a job by changing the `ImplicitCtxt` to point to the
+/// new query job while it executes. It returns the diagnostics
+/// captured during execution and the actual result.
+#[inline(always)]
+pub fn start_query<K, R>(
+    token: QueryJobId<K>,
+    diagnostics: Option<&Lock<ThinVec<Diagnostic>>>,
+    compute: impl FnOnce() -> R,
+) -> R {
+    with_context(move |current_icx| {
+        // Update the `ImplicitCtxt` to point to our new query job.
+        let new_icx =
+            ImplicitCtxt { query: Some(token), diagnostics, task_deps: current_icx.task_deps };
+
+        // Use the `ImplicitCtxt` while we execute the query.
+        enter_context(&new_icx, |_| rustc_data_structures::stack::ensure_sufficient_stack(compute))
+    })
+}


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/pull/86038

Each query adjusts TLS information twice: once to adjust job id and record diagnostics, and once to record dependencies. This PR attempts to do it only once using dedicated functions for queries.

r? @Mark-Simulacrum 
Blocked on #86038 