### PR TITLE
Use a hardcoded constant instead of calling OpenProcessToken.

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -676,17 +676,8 @@ if #[cfg(not(target_vendor = "uwp"))] {
 
     pub const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
-    pub const TOKEN_READ: DWORD = 0x20008;
-
-    #[link(name = "advapi32")]
-    extern "system" {
-        // Allowed but unused by UWP
-        pub fn OpenProcessToken(
-            ProcessHandle: HANDLE,
-            DesiredAccess: DWORD,
-            TokenHandle: *mut HANDLE,
-        ) -> BOOL;
-    }
+    // This value is hardcoded in processthreadsapi.h GetCurrentProcessToken()
+    pub const CURRENT_PROCESS_TOKEN: HANDLE = (-4isize) as HANDLE;
 
     #[link(name = "userenv")]
     extern "system" {

--- a/library/std/src/sys/windows/os.rs
+++ b/library/std/src/sys/windows/os.rs
@@ -281,17 +281,9 @@ pub fn temp_dir() -> PathBuf {
 #[cfg(not(target_vendor = "uwp"))]
 fn home_dir_crt() -> Option<PathBuf> {
     unsafe {
-        use crate::sys::handle::Handle;
-
-        let me = c::GetCurrentProcess();
-        let mut token = ptr::null_mut();
-        if c::OpenProcessToken(me, c::TOKEN_READ, &mut token) == 0 {
-            return None;
-        }
-        let _handle = Handle::from_raw_handle(token);
         super::fill_utf16_buf(
             |buf, mut sz| {
-                match c::GetUserProfileDirectoryW(token, buf, &mut sz) {
+                match c::GetUserProfileDirectoryW(c::CURRENT_PROCESS_TOKEN, buf, &mut sz) {
                     0 if c::GetLastError() != c::ERROR_INSUFFICIENT_BUFFER => 0,
                     0 => sz,
                     _ => sz - 1, // sz includes the null terminator

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -189,7 +189,6 @@ fn make_win_dist(
         "libmoldname.a",
         "libpthread.a",
         //Windows import libs
-        "libadvapi32.a",
         "libbcrypt.a",
         "libcomctl32.a",
         "libcomdlg32.a",

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -101,7 +101,7 @@ endif
 # Extra flags needed to compile a working executable with the standard library
 ifdef IS_WINDOWS
 ifdef IS_MSVC
-	EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib bcrypt.lib
+	EXTRACFLAGS := ws2_32.lib userenv.lib bcrypt.lib
 else
 	EXTRACFLAGS := -lws2_32 -luserenv -lbcrypt
 	EXTRACXXFLAGS := -lstdc++


### PR DESCRIPTION
GetCurrentProcessToken is defined in processthreadsapi.h as:
```c++
FORCEINLINE
HANDLE
GetCurrentProcessToken (
    VOID
    )
{
    return (HANDLE)(LONG_PTR) -4;
}
```

Since it's very unlikely that this constant will ever change, let's just use it instead of making api calls to get the same information.

This also (I think) removes the need for rust binaries to directly link against advapi32. Let me know if some changes are needed in those build-related bits, that I'm much less sure on.