### PR TITLE
Fix alignment of method headings for scannability

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -152,10 +152,15 @@ h1.fqn > .in-band > a:hover {
 h2, h3, h4 {
 	border-bottom: 1px solid;
 }
-h3.code-header, h4.code-header {
+h3.code-header {
+	font-size: 1.1em;
+}
+h4.code-header {
 	font-size: 1em;
+}
+h3.code-header, h4.code-header {
 	font-weight: 600;
-	border: none;
+	border-bottom-style: none;
 	padding: 0;
 	margin: 0;
 }
@@ -173,12 +178,6 @@ h3.code-header, h4.code-header {
 	margin-top: 16px;
 	margin-bottom: 10px;
 	position: relative;
-}
-.impl, .method.trait-impl,
-.type.trait-impl,
-.associatedconstant.trait-impl,
-.associatedtype.trait-impl {
-	padding-left: 15px;
 }
 
 div.impl-items > div {
@@ -669,13 +668,6 @@ nav.sub {
 	left: -19px;
 }
 
-.content .impl-items .method, .content .impl-items > .type, .impl-items > .associatedconstant,
-.impl-items > .associatedtype, .content .impl-items details > summary > .type,
-.impl-items details > summary > .associatedconstant,
-.impl-items details > summary > .associatedtype {
-	margin-left: 20px;
-}
-
 .content .impl-items .docblock, .content .impl-items .item-info {
 	margin-bottom: .6em;
 }
@@ -746,7 +738,7 @@ a {
 .anchor {
 	display: none;
 	position: absolute;
-	left: 0;
+	left: -0.5em;
 	background: none !important;
 }
 .anchor.field {
@@ -1579,14 +1571,14 @@ details.rustdoc-toggle > summary.hideme::before {
 
 details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
-	left: -23px;
+	left: -24px;
 	top: 3px;
 }
 
 .impl-items > details.rustdoc-toggle > summary:not(.hideme)::before,
 .undocumented > details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
-	left: -2px;
+	left: -24px;
 }
 
 /* When a "hideme" summary is open and the "Expand description" or "Show

--- a/src/test/rustdoc-gui/anchor-navigable.goml
+++ b/src/test/rustdoc-gui/anchor-navigable.goml
@@ -1,0 +1,11 @@
+// The `impl Foo` heading underneath `Implementations` has a §
+// anchor to its left (used for linking to that heading). The anchor only shows
+// up when hovering the `impl Foo`. This test ensures there's no gap between the
+// anchor and the `impl Foo`. If there were a gap, this would cause an annoying
+// problem: you hover `impl Foo` to see the anchor, then when you move your
+// mouse to the left, the anchor disappears before you reach it.
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+// We check that ".item-info" is bigger than its content.
+move-cursor-to: ".impl"
+assert-property: (".impl > a.anchor", {"offsetWidth": "9"})
+assert-css: (".impl > a.anchor", {"left": "-8px"})


### PR DESCRIPTION
We sometimes use indentation to indicate something is a heading: The section that comes after is indented by 24px relative to the heading. However, the relationship between the "Implementations" section heading, the `impl` headings it contains, and the `pub fn` subheadings within each impl, is awkward. It goes **Implementations**, 15px indent, `impl`, 5px indent, `pub fn`, 4px indent, docblock.

I line up `impl` and `pub fn` with the `Implementations` heading, give `impl` a larger font size to indicate it is higher in the hierarchy, and indent the docblock a full 24px relative to their parent, matching the indents we use elsewhere to distinguish section headings. By letting the `pub fn` stick out to the left of the docblock, I think this makes methods significantly more scannable.

Related to #59829

r? @camelid 

[Old](https://doc.rust-lang.org/nightly/std/string/struct.String.html#implementations):

[![image](https://user-images.githubusercontent.com/220205/138380233-9c63a0f2-0f80-40a3-ab3d-a1ee9fb7c5d8.png)](https://doc.rust-lang.org/nightly/std/string/struct.String.html#implementations)

[New](https://jacob.hoffman-andrews.com/rust/outdent-methods/std/string/struct.String.html#implementations):

[![image](https://user-images.githubusercontent.com/220205/138392479-b45fce3f-bf43-42e0-81ee-c4bb9ac35cda.png)](https://jacob.hoffman-andrews.com/rust/outdent-methods/std/string/struct.String.html#implementations)
