### PR TITLE
Reset qualifs when a storage of a local ends

### DIFF
--- a/src/test/ui/consts/promoted-storage.rs
+++ b/src/test/ui/consts/promoted-storage.rs
@@ -1,0 +1,20 @@
+// Check that storage statements reset local qualification.
+// check-pass
+use std::cell::Cell;
+
+const C: Option<Cell<u32>> = {
+    let mut c = None;
+    let mut i = 0;
+    while i == 0 {
+        let mut x = None;
+        c = x;
+        x = Some(Cell::new(0));
+        let _ = x;
+        i += 1;
+    }
+    c
+};
+
+fn main() {
+    let _: &'static _ = &C;
+}


### PR DESCRIPTION
Reset qualifs when a storage of a local ends to ensure that the local qualifs
are affected by the state from previous loop iterations only if the local is
kept alive.

The change should be forward compatible with a stricter handling of indirect
assignments, since storage dead invalidates all existing pointers to the local.


