### PR TITLE
Add error::Report type 

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -811,6 +811,8 @@ impl dyn Error + Send + Sync {
 /// An error reporter that exposes the entire error chain for printing.
 /// It also exposes options for formatting the error chain, either entirely on a single line,
 /// or in multi-line format with each cause in the error chain on a new line.
+/// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the
+/// wrapped error be `Send`, `Sync`, or `'static`.
 ///
 /// # Examples
 ///
@@ -822,68 +824,31 @@ impl dyn Error + Send + Sync {
 /// use std::fmt;
 ///
 /// #[derive(Debug)]
-/// struct SuperError {
-///     side: SuperErrorSideKick,
+/// struct SuperError<'a> {
+///     side: &'a str,
 /// }
 ///
-/// impl fmt::Display for SuperError {
+/// impl<'a> fmt::Display for SuperError<'a> {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperError is here!")
+///         write!(f, "SuperError is here: {}", self.side)
 ///     }
 /// }
 ///
-/// impl Error for SuperError {
-///     fn source(&self) -> Option<&(dyn Error + 'static)> {
-///         Some(&self.side)
-///     }
-/// }
-///
-/// #[derive(Debug)]
-/// struct SuperErrorSideKick;
-///
-/// impl fmt::Display for SuperErrorSideKick {
-///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperErrorSideKick is here!")
-///     }
-/// }
-///
-/// impl Error for SuperErrorSideKick {}
+/// impl<'a> Error for SuperError<'a> {}
 ///
 /// // Note that the error doesn't need to be `Send` or `Sync`.
 /// impl !Send for SuperError {}
 /// impl !Sync for SuperError {}
 ///
 /// fn main() {
-///     let error = SuperError { side: SuperErrorSideKick };
+///     let msg = String::from("Huzzah!");
+///     let error = SuperError { side: &msg };
 ///     let report = Report::new(&error).pretty(true);
 ///
 ///     println!("{}", report);
 /// }
 /// ```
-///
-/// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the
-/// wrapped error be `Send`, `Sync`, or `'static`.
-///
-/// ```rust
-/// # #![feature(error_reporter)]
-/// # use std::fmt;
-/// # use std::error::{Error, Report};
-/// #[derive(Debug)]
-/// struct SuperError<'a> {
-///     side: &'a str,
-/// }
-/// impl<'a> fmt::Display for SuperError<'a> {
-///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperError is here: {}", self.side)
-///     }
-/// }
-/// impl<'a> Error for SuperError<'a> {}
-/// fn main() {
-///     let msg = String::from("Huzzah!");
-///     let report = Report::new(SuperError { side: &msg });
-///     println!("{}", report);
-/// }
-/// ```
+
 #[unstable(feature = "error_reporter", issue = "90172")]
 pub struct Report<E> {
     /// The error being reported.

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -850,7 +850,7 @@ impl dyn Error + Send + Sync {
 ///
 /// fn main() {
 ///     let error = SuperError { side: SuperErrorSideKick };
-///     let report = Report::new(&error).pretty();
+///     let report = Report::new(&error).pretty(true);
 ///
 ///     println!("{}", report);
 /// }
@@ -874,15 +874,15 @@ where
 
     /// Enable pretty-printing the report.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn pretty(mut self) -> Self {
-        self.pretty = true;
+    pub fn pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
         self
     }
 
     /// Enable showing a backtrace for the report.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn show_backtrace(mut self) -> Self {
-        self.show_backtrace = true;
+    pub fn show_backtrace(mut self, show_backtrace: bool) -> Self {
+        self.show_backtrace = show_backtrace;
         self
     }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -857,7 +857,7 @@ impl dyn Error + Send + Sync {
 /// ```
 #[unstable(feature = "error_reporter", issue = "90172")]
 pub struct Report<E> {
-    source: E,
+    error: E,
     show_backtrace: bool,
     pretty: bool,
 }
@@ -868,8 +868,8 @@ where
 {
     /// Create a new `Report` from an input error.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn new(source: E) -> Report<E> {
-        Report { source, show_backtrace: false, pretty: false }
+    pub fn new(error: E) -> Report<E> {
+        Report { error, show_backtrace: false, pretty: false }
     }
 
     /// Enable pretty-printing the report.
@@ -889,9 +889,9 @@ where
     /// Format the report as a single line.
     #[unstable(feature = "error_reporter", issue = "90172")]
     fn fmt_singleline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.source)?;
+        write!(f, "{}", self.error)?;
 
-        let sources = self.source.source().into_iter().flat_map(<dyn Error>::chain);
+        let sources = self.error.source().into_iter().flat_map(<dyn Error>::chain);
 
         for cause in sources {
             write!(f, ": {}", cause)?;
@@ -903,7 +903,7 @@ where
     /// Format the report as multiple lines, with each error cause on its own line.
     #[unstable(feature = "error_reporter", issue = "90172")]
     fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let error = &self.source;
+        let error = &self.error;
 
         write!(f, "{}", error)?;
 
@@ -950,8 +950,8 @@ impl<E> From<E> for Report<E>
 where
     E: Error,
 {
-    fn from(source: E) -> Self {
-        Report::new(source)
+    fn from(error: E) -> Self {
+        Report::new(error)
     }
 }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -837,8 +837,8 @@ impl dyn Error + Send + Sync {
 /// impl<'a> Error for SuperError<'a> {}
 ///
 /// // Note that the error doesn't need to be `Send` or `Sync`.
-/// impl !Send for SuperError {}
-/// impl !Sync for SuperError {}
+/// impl<'a> !Send for SuperError<'a> {}
+/// impl<'a> !Sync for SuperError<'a> {}
 ///
 /// fn main() {
 ///     let msg = String::from("Huzzah!");

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -814,7 +814,7 @@ impl dyn Error + Send + Sync {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// #![feature(error_reporter)]
 /// #![feature(negative_impls)]
 ///

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -809,6 +809,7 @@ impl dyn Error + Send + Sync {
 }
 
 /// An error reporter that exposes the entire error chain for printing.
+///
 /// It also exposes options for formatting the error chain, either entirely on a single line,
 /// or in multi-line format with each cause in the error chain on a new line.
 /// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -956,7 +956,7 @@ where
     }
 }
 
-// This type intentionally outputs the same format for `Display` and `Debug`for
+// This type intentionally outputs the same format for `Display` and `Debug` for
 // situations where you unwrap a `Report` or return it from main.
 #[unstable(feature = "error_reporter", issue = "90172")]
 impl<E> fmt::Debug for Report<E>

--- a/library/std/src/error/tests.rs
+++ b/library/std/src/error/tests.rs
@@ -35,3 +35,294 @@ fn downcasting() {
         Err(e) => assert_eq!(*e.downcast::<A>().unwrap(), A),
     }
 }
+
+use crate::backtrace;
+use crate::env;
+use crate::error::Report;
+
+#[derive(Debug)]
+struct SuperError {
+    side: SuperErrorSideKick,
+}
+
+impl fmt::Display for SuperError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SuperError is here!")
+    }
+}
+
+impl Error for SuperError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.side)
+    }
+}
+
+#[derive(Debug)]
+struct SuperErrorSideKick;
+
+impl fmt::Display for SuperErrorSideKick {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SuperErrorSideKick is here!")
+    }
+}
+
+impl Error for SuperErrorSideKick {}
+
+#[test]
+fn single_line_formatting() {
+    let error = SuperError { side: SuperErrorSideKick };
+    let report = Report::new(&error);
+    let actual = report.to_string();
+    let expected = String::from("SuperError is here!: SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn multi_line_formatting() {
+    let error = SuperError { side: SuperErrorSideKick };
+    let report = Report::new(&error).pretty(true);
+    let actual = report.to_string();
+    let expected =
+        String::from("SuperError is here!\n\nCaused by:\n    SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_no_sources_formats_single_line_correctly() {
+    let report = Report::new(SuperErrorSideKick);
+    let actual = report.to_string();
+    let expected = String::from("SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_no_sources_formats_multi_line_correctly() {
+    let report = Report::new(SuperErrorSideKick).pretty(true);
+    let actual = report.to_string();
+    let expected = String::from("SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_backtrace_outputs_correctly() {
+    use backtrace::Backtrace;
+
+    env::remove_var("RUST_BACKTRACE");
+
+    #[derive(Debug)]
+    struct ErrorWithBacktrace<'a> {
+        msg: &'a str,
+        trace: Backtrace,
+    }
+
+    impl<'a> fmt::Display for ErrorWithBacktrace<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Error with backtrace: {}", self.msg)
+        }
+    }
+
+    impl<'a> Error for ErrorWithBacktrace<'a> {
+        fn backtrace(&self) -> Option<&Backtrace> {
+            Some(&self.trace)
+        }
+    }
+
+    let msg = String::from("The source of the error");
+    let report = Report::new(ErrorWithBacktrace { msg: &msg, trace: Backtrace::capture() })
+        .pretty(true)
+        .show_backtrace(true);
+
+    let expected = String::from(
+        "Error with backtrace: The source of the error\n\nStack backtrace:\ndisabled backtrace",
+    );
+
+    assert_eq!(expected, report.to_string());
+}
+
+#[derive(Debug)]
+struct GenericError<D> {
+    message: D,
+    source: Option<Box<dyn Error + 'static>>,
+}
+
+impl<D> GenericError<D> {
+    fn new(message: D) -> GenericError<D> {
+        Self { message, source: None }
+    }
+
+    fn new_with_source<E>(message: D, source: E) -> GenericError<D>
+    where
+        E: Error + 'static,
+    {
+        let source: Box<dyn Error + 'static> = Box::new(source);
+        let source = Some(source);
+        GenericError { message, source }
+    }
+}
+
+impl<D> fmt::Display for GenericError<D>
+where
+    D: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.message, f)
+    }
+}
+
+impl<D> Error for GenericError<D>
+where
+    D: fmt::Debug + fmt::Display,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+#[test]
+fn error_formats_single_line_with_rude_display_impl() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("line 1\nline 2")?;
+            f.write_str("\nline 3\nline 4\n")?;
+            f.write_str("line 5\nline 6")?;
+            Ok(())
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error);
+    let expected = r#"line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_formats_multi_line_with_rude_display_impl() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("line 1\nline 2")?;
+            f.write_str("\nline 3\nline 4\n")?;
+            f.write_str("line 5\nline 6")?;
+            Ok(())
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+
+Caused by:
+   0: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6
+   1: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6
+   2: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn errors_that_start_with_newline_formats_correctly() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("\nThe message\n")
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"
+The message
+
+
+Caused by:
+   0: The message
+   1: The message"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn errors_with_string_interpolation_formats_correctly() {
+    #[derive(Debug)]
+    struct MyMessage(usize);
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Got an error code: ({}). ", self.0)?;
+            write!(f, "What would you like to do in response?")
+        }
+    }
+
+    let error = GenericError::new(MyMessage(10));
+    let error = GenericError::new_with_source(MyMessage(20), error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"Got an error code: (20). What would you like to do in response?
+
+Caused by:
+    Got an error code: (10). What would you like to do in response?"#;
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
This implements `std::error::Report`, a wrapper around an error that exposes the entire error chain, along with options to format the output of the report as either a single line or as multiple lines. 

Tracking issue: #90172. 