### PR TITLE
Elide clone operation when calling `iter::Cloned::advance_{back}_by()`

### DIFF
--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -60,6 +60,11 @@ where
         self.it.map(T::clone).fold(init, f)
     }
 
+    #[inline]
+    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+        self.it.advance_by(n)
+    }
+
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
@@ -95,6 +100,11 @@ where
         F: FnMut(Acc, Self::Item) -> Acc,
     {
         self.it.map(T::clone).rfold(init, f)
+    }
+
+    #[inline]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+        self.it.advance_back_by(n)
     }
 }
 

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -61,6 +61,16 @@ where
     }
 
     #[inline]
+    fn count(self) -> usize {
+        self.it.count()
+    }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> {
+        self.it.last().cloned()
+    }
+
+    #[inline]
     fn advance_by(&mut self, n: usize) -> Result<(), usize> {
         self.it.advance_by(n)
     }

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -33,7 +33,7 @@ where
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         if unlikely(self.n > 0) {
-            self.iter.nth(crate::mem::take(&mut self.n) - 1);
+            let _ = self.iter.advance_by(crate::mem::take(&mut self.n));
         }
         self.iter.next()
     }

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -107,8 +107,14 @@ pub trait DoubleEndedIterator: Iterator {
     /// outer iterator until it finds an inner iterator that is not empty, which then often
     /// allows it to return a more accurate `size_hint()` than in its initial state.
     ///
+    /// Implementations may elide side-effects such as calling closures or `clone` when they are
+    /// not necessary to determine by how many steps an iterator can be advanced. For example
+    /// [`Cloned::advance_back_by`] avoids unnecessary allocations by directly advancing its inner iterator
+    /// instead.
+    ///
     /// [`advance_by`]: Iterator::advance_by
     /// [`Flatten`]: crate::iter::Flatten
+    /// [`Cloned::advance_back_by`]: crate::iter::Cloned::advance_back_by
     /// [`next_back`]: DoubleEndedIterator::next_back
     ///
     /// # Examples

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -250,7 +250,13 @@ pub trait Iterator {
     /// can advance its outer iterator until it finds an inner iterator that is not empty, which
     /// then often allows it to return a more accurate `size_hint()` than in its initial state.
     ///
+    /// Implementations may elide side-effects such as calling closures or `clone` when they are
+    /// not necessary to determine by how many steps an iterator can be advanced. For example
+    /// [`Cloned::advance_by`] avoids unnecessary allocations by directly advancing its inner iterator
+    /// instead.
+    ///
     /// [`Flatten`]: crate::iter::Flatten
+    /// [`Cloned::advance_by`]: crate::iter::Cloned::advance_by
     /// [`next`]: Iterator::next
     ///
     /// # Examples


### PR DESCRIPTION
This is a change in user-visible behavior. It will not only affect `advance_by` (which is still unstable) but also the stable `nth`, `nth_back` and `Skip`, `Take` and other adapters that make use of these methods.
It is also a bit of a test-balloon, if it gets approved there are a few more places where other side-effects could be skipped too.

I'm not sure if it is needed at this stage, but a note about side-effects could also be added to the `std::iter` module.

Part of #77404