### PR TITLE
Clarify docs for `std::os::unix::fs::symlink`

### DIFF
--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -883,7 +883,8 @@ impl DirEntryExt2 for fs::DirEntry {
 
 /// Creates a new symbolic link on the filesystem.
 ///
-/// The `link` path will be a symbolic link pointing to the `original` path.
+/// The second path given will become a symbolic link pointing to
+/// the first, original path.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
These docs currently use literal terms (`link` and `original`) found only in the source code. This makes the meaning and order of the arguments clear.

(I routinely get confused about symlinks. I *think* I've got this right. If so, I suspect this will help others.)