### PR TITLE
Fix ICE when forgetting to `Box` a parameter to a `Self::func` call

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -420,7 +420,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             ..
                         },
                         method,
-                    )) if Some(recv_ty.def_id()) == pin_did && method.ident.name == sym::new => {
+                    )) if recv_ty.opt_def_id() == pin_did && method.ident.name == sym::new => {
                         err.span_suggestion(
                             fn_name.span,
                             "use `Box::pin` to pin and box this expression",

--- a/src/test/ui/suggestions/issue-90213-expected-boxfuture-self-ice.rs
+++ b/src/test/ui/suggestions/issue-90213-expected-boxfuture-self-ice.rs
@@ -1,0 +1,13 @@
+// Checks that we do not ICE when comparing `Self` to `Pin`
+// edition:2021
+
+struct S;
+
+impl S {
+    fn foo(_: Box<Option<S>>) {}
+    fn bar() {
+        Self::foo(None) //~ ERROR mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-90213-expected-boxfuture-self-ice.stderr
+++ b/src/test/ui/suggestions/issue-90213-expected-boxfuture-self-ice.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-90213-expected-boxfuture-self-ice.rs:9:19
+   |
+LL |         Self::foo(None)
+   |                   ^^^^ expected struct `Box`, found enum `Option`
+   |
+   = note: expected struct `Box<Option<S>>`
+                found enum `Option<_>`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Self::foo(Box::new(None))
+   |                   +++++++++    +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Closes #90213 .

Assuming we can get the `DefId` of the receiver causes an ICE if the receiver is `Self`. We can just avoid doing this though.