### PR TITLE
ci: temporarily disable overflow checks again.

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -90,7 +90,9 @@ else
   fi
 
   # Same for overflow checks
-  if [ "$NO_OVERFLOW_CHECKS" = "" ]; then
+  # Note: temporarily disabled to prevent CI failures due to overflow in rustc-rayon dependency
+  # Reenable once https://github.com/rust-lang/rust/issues/90227 is fixed
+  if [ "$NO_OVERFLOW_CHECKS" = "" ] && false; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-overflow-checks"
   fi
 


### PR DESCRIPTION
#89776 enabled overflow checks in CI but these lead to two failures already:

https://github.com/rust-lang/rust/pull/90042#issuecomment-950263825
https://github.com/rust-lang/rust/pull/90222#issuecomment-950269305

The (first?) problem has been identified: https://github.com/rust-lang/rust/issues/90227

This PR temporarily disables the overflow checks again so we don't have to deal with the "spurious" CI failures until rustc-rayon is fixed.

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/ci.20failed.20with.20.20.22attempt.20to.20subtract.20with.20overflow.22