### PR TITLE
Fix Duration::from_secs_f32

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -812,7 +812,7 @@ impl Duration {
     #[inline]
     pub const fn try_from_secs_f32(secs: f32) -> Result<Duration, FromSecsError> {
         const MAX_NANOS_F32: f32 = ((u64::MAX as u128 + 1) * (NANOS_PER_SEC as u128)) as f32;
-        let nanos = secs * (NANOS_PER_SEC as f32);
+        let nanos = secs as f64 * (NANOS_PER_SEC as f64);
         if !nanos.is_finite() {
             Err(FromSecsError { kind: FromSecsErrorKind::NonFinite })
         } else if nanos >= MAX_NANOS_F32 {


### PR DESCRIPTION
Currently the function is returning wrong values, eg:
Duration::from_secs_f32(30.0);
is giving:
30.000001024s (30s + 1024ns)
This commit fixes this problem.

Fixes: #90225