### PR TITLE
Add an item-info for non-public visibility, and remove redundant `pub`

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -956,10 +956,12 @@ body.blur > :not(#help) {
 	padding: 0 20px 20px 17px;;
 }
 
-.item-info .stab {
+.item-info .stab,
+.item-info .visibility {
 	display: table;
 }
-.stab {
+.stab,
+.visibility {
 	border-width: 1px;
 	border-style: solid;
 	padding: 3px;
@@ -971,7 +973,8 @@ body.blur > :not(#help) {
 	display: inline;
 }
 
-.stab .emoji {
+.stab .emoji
+.visibility .emoji {
 	font-size: 1.5em;
 }
 

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -222,6 +222,7 @@ details.undocumented > summary::before {
 	color: #000;
 }
 
+.visibility { background: #FFF5D6; border-color: #FFC600; }
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
 .stab.deprecated { background: #ffc4c4; border-color: #db7b7b; }
 .stab.portability { background: #F3DFFF; border-color: #b07bdb; }

--- a/src/test/rustdoc/document-private.rs
+++ b/src/test/rustdoc/document-private.rs
@@ -1,0 +1,213 @@
+// compile-flags: --document-private-items
+#![crate_name = "foo"]
+
+pub mod outmost_mod {
+    pub mod outer_mod {
+        pub mod inner_mod {
+            /// This function is visible within `outer_mod`
+            pub(in crate::outmost_mod::outer_mod) fn outer_mod_visible_fn() {}
+
+            /// This function is visible to the entire crate
+            pub(crate) fn crate_visible_fn() {}
+
+            /// This function is visible within `outer_mod`
+            pub(super) fn super_mod_visible_fn() {
+                /// This function is visible since we're in the same `mod`
+                inner_mod_visible_fn();
+            }
+
+            /// This function is visible only within `inner_mod`,
+            /// which is the same as leaving it private.
+            pub(self) fn inner_mod_visible_fn() {}
+
+            pub mod inmost_mod {
+                // @has 'foo/outmost_mod/outer_mod/inner_mod/inmost_mod/struct.Foo.html'
+                // @count   - '//*[@class="visibility"]' 7
+                pub struct Boo {
+                    /// rhubarb rhubarb rhubarb
+                    // @matches - '//*[@class="visibility"]' 'Visibility: private'
+                    alpha: usize,
+                    /// durian durian durian
+                    pub beta: usize,
+                    /// sasquatch sasquatch sasquatch
+                    pub(crate) gamma: usize,
+                }
+
+                impl Boo {
+                    /// Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium
+                    /// doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore
+                    /// veritatis et quasi architecto
+                    pub fn new() -> Foo {
+                        Foo(0)
+                    }
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    ///
+                    /// # Examples:
+                    ///
+                    ///
+                    /// ```no_run
+                    /// not_pub()
+                    /// ```
+                    #[deprecated(since = "0.2.1", note = "The rust_foo version is more advanced")]
+                    fn not_pub() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(crate) fn pub_crate() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(super) fn pub_super() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(self) fn pub_self() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(in crate::outmost_mod::outer_mod) fn pub_inner_mod() {}
+                }
+
+                pub struct Foo(
+                    /// rhubarb rhubarb rhubarb
+                    usize,
+                    /// durian durian durian
+                    pub usize,
+                    /// sasquatch sasqutch sasquatch
+                    pub(crate) usize,
+                );
+
+                impl Foo {
+                    /// Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium
+                    /// doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore
+                    /// veritatis et quasi architecto
+                    pub fn new() -> Foo {
+                        Foo(0)
+                    }
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    ///
+                    /// # Examples:
+                    ///
+                    ///
+                    /// ```no_run
+                    /// not_pub()
+                    /// ```
+                    #[deprecated(since = "0.2.1", note = "The rust_foo version is more advanced")]
+                    fn not_pub() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(crate) fn pub_crate() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(super) fn pub_super() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(self) fn pub_self() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(in crate::outmost_mod::outer_mod) fn pub_inner_mod() {}
+                }
+
+                /// ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur?
+                /// Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam
+                /// nihil molestiae consequatur,
+                pub enum Baz {
+                    Size(usize),
+                }
+
+                pub enum Bar {
+                    /// ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+                    /// Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam
+                    /// nihil molestiae consequatur,
+                    Fizz,
+                    /// ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+                    /// Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam
+                    /// nihil molestiae consequatur,
+                    Pop,
+                    /// ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+                    /// Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam
+                    /// nihil molestiae consequatur,
+                    Bang,
+                }
+
+                impl Bar {
+                    /// Sed ut perspiciatis, unde omnis iste natus error sit voluptatem accusantium
+                    /// doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore
+                    /// veritatis et quasi architecto
+                    pub fn new() -> Bar {
+                        Fizz
+                    }
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    ///
+                    /// # Examples:
+                    ///
+                    ///
+                    /// ```no_run
+                    /// not_pub()
+                    /// ```
+                    #[deprecated(since = "0.2.1", note = "The rust_foo version is more advanced")]
+                    fn not_pub() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(crate) fn pub_crate() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(super) fn pub_super() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(self) fn pub_self() {}
+
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    pub(in crate::outmost_mod::outer_mod) fn pub_inner_mod() {}
+                }
+
+                pub trait Zepp {
+                    fn required_method();
+
+                    fn optional_method() {}
+                }
+
+                /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas
+                /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                /// qui ratione voluptatem sequi
+                pub struct Zeppish;
+
+                impl Zepp for Zeppish {
+                    /// beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia
+                    /// sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos,
+                    /// qui ratione voluptatem sequi
+                    fn required_method() {}
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
For most documentation, the `pub` in front of each method is redundant: you know the method is public because you are reading the documentation.

However, when running with `--document-private`, it's important to see which items are public and which are private. This adds an item-info tag for private items showing their visibility, and removes the `pub` from methods and fields.

This doesn't currently touch the summary code block at the top of the page, which will still have `pub` or `pub(crate)` or whatever is appropriate.

This refactors some code in Visibility to allow better reuse.

Part of #59829. Note: [one of the pieces of feedback](https://github.com/rust-lang/rust/issues/59853) there was that the item-infos (experimental, deprecated, platform-specific, etc) are too prominent. That may be the case, but for this change, I think the important thing is matching the other item-infos, and we can change the style of item-infos later if we want to.

r? @GuillaumeGomez
/cc @camelid 

Demo:

https://jacob.hoffman-andrews.com/rust/document-private/foo/outer_mod/inner_mod/inmost_mod/struct.Boo.html
https://jacob.hoffman-andrews.com/rust/document-private/foo/outmost_mod/outer_mod/inner_mod/inmost_mod/struct.Foo.html
https://jacob.hoffman-andrews.com/rust/document-private/foo/outmost_mod/outer_mod/inner_mod/inmost_mod/enum.Bar.html

![image](https://user-images.githubusercontent.com/220205/138615942-f05ee40a-42c5-4f03-bba7-94d44960d314.png)
