### PR TITLE
Update linker-plugin-lto.md

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -94,7 +94,7 @@ rustc -Clinker-plugin-lto="/path/to/LLVMgold.so" -L. -Copt-level=2 ./main.rs
 ```sh
 rustup toolchain install --profile minimal nightly
 MINOR_VERSION=$(rustc +nightly --version | cut -d . -f 2)
-LOWER_BOUND=44
+LOWER_BOUND=56
 
 llvm_version() {
     toolchain="$1"
@@ -123,19 +123,29 @@ LLVM. However, the approximation is usually reliable.
 The following table shows known good combinations of toolchain versions.
 
 | Rust Version | Clang Version |
-|--------------|---------------|
-| Rust 1.34    |    Clang 8    |
-| Rust 1.35    |    Clang 8    |
-| Rust 1.36    |    Clang 8    |
-| Rust 1.37    |    Clang 8    |
-| Rust 1.38    |    Clang 9    |
-| Rust 1.39    |    Clang 9    |
-| Rust 1.40    |    Clang 9    |
-| Rust 1.41    |    Clang 9    |
-| Rust 1.42    |    Clang 9    |
-| Rust 1.43    |    Clang 9    |
-| Rust 1.44    |    Clang 9    |
-| Rust 1.45    |    Clang 10   |
-| Rust 1.46    |    Clang 10   |
+| ------------ | ------------- |
+| Rust 1.34    | Clang 8       |
+| Rust 1.35    | Clang 8       |
+| Rust 1.36    | Clang 8       |
+| Rust 1.37    | Clang 8       |
+| Rust 1.38    | Clang 9       |
+| Rust 1.39    | Clang 9       |
+| Rust 1.40    | Clang 9       |
+| Rust 1.41    | Clang 9       |
+| Rust 1.42    | Clang 9       |
+| Rust 1.43    | Clang 9       |
+| Rust 1.44    | Clang 9       |
+| Rust 1.45    | Clang 10      |
+| Rust 1.46    | Clang 10      |
+| Rust 1.47    | Clang 11      |
+| Rust 1.48    | Clang 11      |
+| Rust 1.49    | Clang 11(?)   |
+| Rust 1.50    | Clang 11(?)   |
+| Rust 1.51    | Clang 11.0.1  |
+| Rust 1.52    | Clang 12.0.0  |
+| Rust 1.53    | Clang 12.0.1  |
+| Rust 1.54    | Clang 12.0.1  |
+| Rust 1.55    | Clang 12.0.1  |
+| Rust 1.56    | Clang 13.0.0  |
 
 Note that the compatibility policy for this feature might change in the future.

--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -139,8 +139,8 @@ The following table shows known good combinations of toolchain versions.
 | Rust 1.46    | Clang 10      |
 | Rust 1.47    | Clang 11      |
 | Rust 1.48    | Clang 11      |
-| Rust 1.49    | Clang 11(?)   |
-| Rust 1.50    | Clang 11(?)   |
+| Rust 1.49    | Clang 11      |
+| Rust 1.50    | Clang 11      |
 | Rust 1.51    | Clang 11.0.1  |
 | Rust 1.52    | Clang 12.0.0  |
 | Rust 1.53    | Clang 12.0.1  |


### PR DESCRIPTION
The script provided doesn't have a clang LLVM version provided for Rust 1.49.0 or 1.50.0. Does anyone know why that might be?