### PR TITLE
Improve Duration::try_from_secs_f32/64 accuracy by directly processing exponent and mantissa

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -602,7 +602,7 @@ impl Error for char::ParseCharError {
 impl Error for alloc::collections::TryReserveError {}
 
 #[unstable(feature = "duration_checked_float", issue = "83400")]
-impl Error for time::FromSecsError {}
+impl Error for time::FromFloatSecsError {}
 
 // Copied from `any.rs`.
 impl dyn Error + 'static {

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -45,7 +45,7 @@ use crate::sys_common::FromInner;
 pub use core::time::Duration;
 
 #[unstable(feature = "duration_checked_float", issue = "83400")]
-pub use core::time::FromSecsError;
+pub use core::time::FromFloatSecsError;
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with [`Duration`].


### PR DESCRIPTION
Closes: #90225

The methods now implement direct processing of exponent and mantissa, which should result in the best possible conversion accuracy (modulo truncation, i.e. float value of 19.995 ns will be represented as 19 ns).