### PR TITLE
Inline hash function for Discriminant

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -984,6 +984,7 @@ impl<T> cmp::Eq for Discriminant<T> {}
 
 #[stable(feature = "discriminant_value", since = "1.21.0")]
 impl<T> hash::Hash for Discriminant<T> {
+    #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }


### PR DESCRIPTION
Discriminants are being (stable-)hashed a lot of times, especially in the `clap` benchmark. Inlining this function produced a small icount improvement (~1%) for `clap` IncrFull/Check locally.

By the way, where are these opaque Discriminants being created in the compiler? I couldn't find it. It would be interesting for me to see how is the corresponding hash function implemented (probably with some automatic derive?).

r? @Mark-Simulacrum 