### PR TITLE
Changed slice.swap documentation for better readability

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -553,9 +553,9 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// let mut v = ["a", "b", "c", "d"];
-    /// v.swap(1, 3);
-    /// assert!(v == ["a", "d", "c", "b"]);
+    /// let mut v = ["a", "b", "c", "d", "e];
+    /// v.swap(2, 4);
+    /// assert!(v == ["a", "b", "e", "d", "c"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -553,7 +553,7 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// let mut v = ["a", "b", "c", "d", "e];
+    /// let mut v = ["a", "b", "c", "d", "e"];
     /// v.swap(2, 4);
     /// assert!(v == ["a", "b", "e", "d", "c"]);
     /// ```


### PR DESCRIPTION
The example exchanges the letters "b" and "d", these can be easily confused and are hard to read for people with dyslexia.
Therefore, I changed the example to a more easily readable one.

This is just a small fix and it's not urgent by any means, but I spent 5 minutes trying to understand why I couldn't see any change so I fixed it.

Anyway, thank you for all your works!