### PR TITLE
Support versioned dylibs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -464,9 +464,9 @@ impl<'a> Linker for GccLinker<'a> {
         self.linker_arg("-znorelro");
     }
 
-    fn link_rust_dylib(&mut self, lib: Symbol, _path: &Path) {
+    fn link_rust_dylib(&mut self, _lib: Symbol, path: &Path) {
         self.hint_dynamic();
-        self.cmd.arg(format!("-l{}", lib));
+        self.cmd.arg(format!("-l:{}", path.file_name().unwrap().to_str().unwrap()));
     }
 
     fn link_framework(&mut self, framework: Symbol, as_needed: bool) {
@@ -837,7 +837,7 @@ impl<'a> Linker for MsvcLinker<'a> {
         // check to see if the file is there and just omit linking to it if it's
         // not present.
         let name = format!("{}.dll.lib", lib);
-        if path.join(&name).exists() {
+        if path.parent().unwrap_or_else(|| Path::new("")).join(&name).exists() {
             self.cmd.arg(name);
         }
     }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -238,6 +238,35 @@ use std::path::{Path, PathBuf};
 use std::{cmp, fmt, fs};
 use tracing::{debug, info, warn};
 
+// Converts a library file-stem into a cc -l argument
+pub fn unlib<'a>(target: &Target, stem: &'a str) -> &'a str {
+    if stem.starts_with("lib") && !target.is_like_windows { &stem[3..] } else { stem }
+}
+
+/// Returns Some(symbol_name) if `file` could be a valid dylib
+/// Example (assuming target is GNU/Linux):
+///   - `libsomecrate.asdf` -> `None`
+///   - `libsomecrate.so` -> `Some(somecreate)`
+///   - `libsomecrate.so.0.1` -> `Some(somecreate)`
+///   - `libsomecrate.so.a.4` -> `None`
+pub fn get_dylib_symbol_name<'a>(file: &'a str, target: &Target) -> Option<&'a str> {
+    // test if the targets dll_suffix is found within the filename. If it
+    // is check if all of the chars following it are either a digit (0-9)
+    // or a dot.
+    file.find(&target.dll_suffix)
+        .map(|idx| {
+            match file
+                .chars()
+                .skip(idx + idx + target.dll_suffix.len())
+                .all(|c| c.is_ascii_digit() || c == '.')
+            {
+                true => file.get(0..idx).map(|s| unlib(target, s)),
+                false => None,
+            }
+        })
+        .flatten()
+}
+
 #[derive(Clone)]
 crate struct CrateLocator<'a> {
     // Immutable per-session configuration.
@@ -365,25 +394,6 @@ impl<'a> CrateLocator<'a> {
         self.find_library_crate("", &mut seen_paths)
     }
 
-    /// Returns true if `file` has a suffix that could be a valid dylib
-    /// Example (assuming target has .so as dll_suffix):
-    ///   - `libsomecrate.asdf` -> `false`
-    ///   - `libsomecrate.so` -> `true`
-    ///   - `libsomecrate.so.0.1` -> `true`
-    ///   - `libsomecrate.so.a.4` -> `false`
-    fn test_dylib_suffix(&self, file: &str) -> bool {
-        // test if the targets dll_suffix is found within the filename. If it
-        // is check if all of the chars following it are either in range 0x30
-        // to 0x39 (0-9) or 0x2E (.).
-        match file.find(&self.target.dll_suffix) {
-            Some(idx) => file
-                .chars()
-                .skip(idx + self.target.dll_suffix.len())
-                .all(|c| c as u32 >= 0x30 && c as u32 <= 0x39 || c as u32 == 0x2E),
-            None => false,
-        }
-    }
-
     fn find_library_crate(
         &mut self,
         extra_prefix: &str,
@@ -421,7 +431,9 @@ impl<'a> CrateLocator<'a> {
                 (&file[(rlib_prefix.len())..(file.len() - ".rlib".len())], CrateFlavor::Rlib)
             } else if file.starts_with(&rlib_prefix) && file.ends_with(".rmeta") {
                 (&file[(rlib_prefix.len())..(file.len() - ".rmeta".len())], CrateFlavor::Rmeta)
-            } else if file.starts_with(&dylib_prefix) && self.test_dylib_suffix(file) {
+            } else if file.starts_with(&dylib_prefix)
+                && get_dylib_symbol_name(file, &self.target).is_some()
+            {
                 (
                     &file[(dylib_prefix.len())..(file.len() - self.target.dll_suffix.len())],
                     CrateFlavor::Dylib,
@@ -700,7 +712,8 @@ impl<'a> CrateLocator<'a> {
             };
 
             if file.starts_with("lib") && (file.ends_with(".rlib") || file.ends_with(".rmeta"))
-                || file.starts_with(&self.target.dll_prefix) && self.test_dylib_suffix(file)
+                || file.starts_with(&self.target.dll_prefix)
+                    && get_dylib_symbol_name(file, &self.target).is_some()
             {
                 // Make sure there's at most one rlib and at most one dylib.
                 // Note to take care and match against the non-canonicalized name:


### PR DESCRIPTION
Right now, rustc fails when trying to link against a versioned dylib crate (e.g. `libsomecrate.so.0.1`). This can happen if you use [mesonbuild/meson](https://github.com/mesonbuild/meson/) as build system rather than cargo and you add a `library` (a dylib for cargo) as dependency.

```
note: extern location for somerandom is of an unknown type: subprojects/dep/libsomecrate.so.0.1
  = help: file name should be lib*.rlib or lib*..so
```

This patch tries to address this by replacing the simple `ends_with` `dll_suffix` check with a better one.