### PR TITLE
Run cargo unittests by default with x.py test

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -259,6 +259,7 @@ pub struct Cargo {
 impl Step for Cargo {
     type Output = ();
     const ONLY_HOSTS: bool = true;
+    const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/tools/cargo")


### PR DESCRIPTION
Cargo is vital, so its functionality should be tested for all tier 1 platforms in the CI. This PR includes it in the default x.py testsuite.

This adds about 5 min. to x.py test on my Mac.

@rustbot label A-rustbuild A-testsuite T-cargo T-infra

r? @Mark-Simulacrum 