### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -90,7 +90,7 @@ const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // FEAT_FRINTTS
     ("frintts", Some(sym::aarch64_target_feature)),
     // FEAT_I8MM
-    // ("i8mm", Some(sym::aarch64_target_feature)),
+    ("i8mm", Some(sym::aarch64_target_feature)),
     // FEAT_F32MM
     // ("f32mm", Some(sym::aarch64_target_feature)),
     // FEAT_F64MM

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -19,6 +19,7 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("crypto", Some(sym::arm_target_feature)),
     ("aes", Some(sym::arm_target_feature)),
     ("sha2", Some(sym::arm_target_feature)),
+    ("i8mm", Some(sym::arm_target_feature)),
     ("v5te", Some(sym::arm_target_feature)),
     ("v6", Some(sym::arm_target_feature)),
     ("v6k", Some(sym::arm_target_feature)),

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -553,9 +553,9 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// let mut v = ["a", "b", "c", "d"];
-    /// v.swap(1, 3);
-    /// assert!(v == ["a", "d", "c", "b"]);
+    /// let mut v = ["a", "b", "c", "d", "e];
+    /// v.swap(2, 4);
+    /// assert!(v == ["a", "b", "e", "d", "c"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -553,7 +553,7 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// let mut v = ["a", "b", "c", "d", "e];
+    /// let mut v = ["a", "b", "c", "d", "e"];
     /// v.swap(2, 4);
     /// assert!(v == ["a", "b", "e", "d", "c"]);
     /// ```

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1596,7 +1596,7 @@ fn render_impl(
                     error_codes: cx.shared.codes,
                     edition: cx.shared.edition(),
                     playground: &cx.shared.playground,
-                    heading_offset: HeadingOffset::H2
+                    heading_offset: HeadingOffset::H4
                 }
                 .into_string()
             );

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -983,7 +983,7 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
             if let Some(stability_class) = field.stability_class(cx.tcx()) {
                 write!(w, "<span class=\"stab {stab}\"></span>", stab = stability_class);
             }
-            document(w, cx, field, Some(it), HeadingOffset::H2);
+            document(w, cx, field, Some(it), HeadingOffset::H3);
         }
     }
     let def_id = it.def_id.expect_def_id();
@@ -1094,7 +1094,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
             w.write_str("</code>");
             render_stability_since(w, variant, it, cx.tcx());
             w.write_str("</div>");
-            document(w, cx, variant, Some(it), HeadingOffset::H2);
+            document(w, cx, variant, Some(it), HeadingOffset::H3);
             document_non_exhaustive(w, variant);
 
             use crate::clean::Variant;
@@ -1134,7 +1134,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                                 f = field.name.as_ref().unwrap(),
                                 t = ty.print(cx)
                             );
-                            document(w, cx, field, Some(variant), HeadingOffset::H2);
+                            document(w, cx, field, Some(variant), HeadingOffset::H4);
                         }
                         _ => unreachable!(),
                     }
@@ -1285,7 +1285,7 @@ fn item_struct(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
                     name = field_name,
                     ty = ty.print(cx)
                 );
-                document(w, cx, field, Some(it), HeadingOffset::H2);
+                document(w, cx, field, Some(it), HeadingOffset::H3);
             }
         }
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -532,7 +532,7 @@ nav.sub {
 	position: relative;
 }
 
-.docblock > * {
+.docblock > :not(.information) {
 	max-width: 100%;
 	overflow-x: auto;
 }

--- a/src/test/rustdoc-gui/header-size.goml
+++ b/src/test/rustdoc-gui/header-size.goml
@@ -1,0 +1,99 @@
+// This test check that headers (a) have the correct heading level, and (b) are the right size.
+// The sizes may change as design changes, but try to make sure a lower header is never bigger than
+// its parent headers.
+// Most of these sizes are set in CSS in `em` units, so here's a conversion chart based on our
+// default 16px font size:
+// 24px    1.5em
+// 22.4px  1.4em
+// 20.8px  1.3em
+// 18.4px  1.15em
+// 17.6px  1.1em
+// 16px    1em
+// 15.2px  0.95em  
+goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+
+assert-css: ("h1.fqn", {"font-size": "24px"}) // 1.5em
+
+assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"}) // 1.15em
+assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"}) // 1.1em
+
+assert-css: ("h2#fields", {"font-size": "22.4px"}) // 1.4em
+assert-css: ("h3#title-for-field", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h4#sub-heading-for-field", {"font-size": "16px"})
+
+assert-css: ("h2#implementations", {"font-size": "22.4px"}) // 1.4em
+
+assert-css: ("#impl > h3.code-header", {"font-size": "16px"}) // 1em
+assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"}) // 1em
+
+assert-css: ("h4#title-for-struct-impl-doc", {"font-size": "16px"})
+assert-css: ("h5#sub-heading-for-struct-impl-doc", {"font-size": "16px"})
+assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"font-size": "15.2px"}) // 0.95em
+
+assert-css: ("h5#title-for-struct-impl-item-doc", {"font-size": "16px"}) // 1em
+assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"}) // 0.95em
+assert-css: ("h6#sub-sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"}) // 0.95em
+
+goto: file://|DOC_PATH|/test_docs/enum.HeavilyDocumentedEnum.html
+
+assert-css: ("h1.fqn", {"font-size": "24px"}) // 1.5em
+
+assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"}) // 1.15em
+assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"}) // 1.1em
+
+assert-css: ("h2#variants", {"font-size": "22.4px"}) // 1.4em
+
+assert-css: ("h3#none-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h4#none-prose-sub-heading", {"font-size": "16px"})
+
+assert-css: ("h3#wrapped-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h4#wrapped-prose-sub-heading", {"font-size": "16px"})
+
+assert-css: ("h4#wrapped0-prose-title", {"font-size": "16px"})
+assert-css: ("h5#wrapped0-prose-sub-heading", {"font-size": "16px"})
+
+assert-css: ("h4#structy-prose-title", {"font-size": "16px"})
+assert-css: ("h5#structy-prose-sub-heading", {"font-size": "16px"})
+
+assert-css: ("h2#implementations", {"font-size": "22.4px"}) // 1.4em
+
+assert-css: ("#impl > h3.code-header", {"font-size": "16px"}) // 1em
+assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"}) // 1em
+
+assert-css: ("h4#title-for-enum-impl-doc", {"font-size": "16px"})
+assert-css: ("h5#sub-heading-for-enum-impl-doc", {"font-size": "16px"})
+assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"font-size": "15.2px"}) // 0.95em
+
+assert-css: ("h5#title-for-enum-impl-item-doc", {"font-size": "16px"}) // 1em
+assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"}) // 0.95em
+assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"}) // 0.95em
+
+goto: file://|DOC_PATH|/test_docs/union.HeavilyDocumentedUnion.html
+
+assert-css: ("h1.fqn", {"font-size": "24px"}) // 1.5em
+
+assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"}) // 1.15em
+
+assert-css: ("h2#fields", {"font-size": "22.4px"}) // 1.4em
+
+assert-css: ("h3#title-for-union-variant", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h4#sub-heading-for-union-variant", {"font-size": "16px"})
+
+assert-css: ("h2#implementations", {"font-size": "22.4px"}) // 1.4em
+
+assert-css: ("#impl > h3.code-header", {"font-size": "16px"}) // 1em
+assert-css: ("h4#title-for-union-impl-doc", {"font-size": "16px"})
+assert-css: ("h5#sub-heading-for-union-impl-doc", {"font-size": "16px"})
+
+assert-css: ("h5#title-for-union-impl-item-doc", {"font-size": "16px"}) // 1em
+assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"font-size": "15.2px"}) // 0.95em
+
+goto: file://|DOC_PATH|/test_docs/macro.heavily_documented_macro.html
+
+assert-css: ("h1.fqn", {"font-size": "24px"}) // 1.5em
+
+assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"}) // 1.3em
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"}) // 1.15em

--- a/src/test/rustdoc-gui/overflow-tooltip-information.goml
+++ b/src/test/rustdoc-gui/overflow-tooltip-information.goml
@@ -1,0 +1,8 @@
+// The goal of this test is to ensure that the tooltip `.information` class doesn't
+// have overflow and max-width CSS rules set because they create a bug in firefox on
+// mac. For more information: https://github.com/rust-lang/rust/issues/89185
+goto: file://|DOC_PATH|/test_docs/fn.foo.html
+assert-css: (".docblock > .information", {
+    "overflow-x": "visible",
+    "max-width": "none"
+}, ALL)

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -13,7 +13,8 @@ assert-text: (".sidebar-elems > .items > ul > li:nth-child(4)", "Enums")
 assert-text: (".sidebar-elems > .items > ul > li:nth-child(5)", "Traits")
 assert-text: (".sidebar-elems > .items > ul > li:nth-child(6)", "Functions")
 assert-text: (".sidebar-elems > .items > ul > li:nth-child(7)", "Type Definitions")
-assert-text: (".sidebar-elems > .items > ul > li:nth-child(8)", "Keywords")
+assert-text: (".sidebar-elems > .items > ul > li:nth-child(8)", "Unions")
+assert-text: (".sidebar-elems > .items > ul > li:nth-child(9)", "Keywords")
 assert-text: ("#structs + .item-table .item-left > a", "Foo")
 click: "#structs + .item-table .item-left > a"
 

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -131,3 +131,129 @@ macro_rules! repro {
 }
 
 pub use crate::repro as repro2;
+
+/// # Top-doc Prose title
+///
+/// Text below title.
+///
+/// ## Top-doc Prose sub-heading
+///
+/// Text below sub-heading.
+///
+/// ### Top-doc Prose sub-sub-heading
+///
+/// Text below sub-sub-heading
+pub struct HeavilyDocumentedStruct {
+    /// # Title for field
+    /// ## Sub-heading for field
+    pub nothing: (),
+}
+
+/// # Title for struct impl doc
+///
+/// Text below heading.
+///
+/// ## Sub-heading for struct impl doc
+///
+/// Text below sub-heading.
+///
+/// ### Sub-sub-heading for struct impl doc
+///
+/// Text below sub-sub-heading.
+///
+impl HeavilyDocumentedStruct {
+    /// # Title for struct impl-item doc
+    /// Text below title.
+    /// ## Sub-heading for struct impl-item doc
+    /// Text below sub-heading.
+    /// ### Sub-sub-heading for struct impl-item doc
+    /// Text below sub-sub-heading.
+    pub fn do_nothing() {}
+}
+
+/// # Top-doc Prose title
+///
+/// Text below title.
+///
+/// ## Top-doc Prose sub-heading
+///
+/// Text below sub-heading.
+///
+/// ### Top-doc Prose sub-sub-heading
+///
+/// Text below sub-sub-heading
+pub enum HeavilyDocumentedEnum {
+    /// # None prose title
+    /// ## None prose sub-heading
+    None,
+    /// # Wrapped prose title
+    /// ## Wrapped prose sub-heading
+    Wrapped(
+        /// # Wrapped.0 prose title
+        /// ## Wrapped.0 prose sub-heading
+        String,
+        String,
+    ),
+    Structy {
+        /// # Structy prose title
+        /// ## Structy prose sub-heading
+        alpha: String,
+        beta: String,
+    },
+}
+
+/// # Title for enum impl doc
+///
+/// Text below heading.
+///
+/// ## Sub-heading for enum impl doc
+///
+/// Text below sub-heading.
+///
+/// ### Sub-sub-heading for enum impl doc
+///
+/// Text below sub-sub-heading.
+///
+impl HeavilyDocumentedEnum {
+    /// # Title for enum impl-item doc
+    /// Text below title.
+    /// ## Sub-heading for enum impl-item doc
+    /// Text below sub-heading.
+    /// ### Sub-sub-heading for enum impl-item doc
+    /// Text below sub-sub-heading.
+    pub fn do_nothing() {}
+}
+
+/// # Top-doc prose title
+///
+/// Text below heading.
+///
+/// ## Top-doc prose sub-heading
+///
+/// Text below heading.
+pub union HeavilyDocumentedUnion {
+    /// # Title for union variant
+    /// ## Sub-heading for union variant
+    pub nothing: (),
+    pub something: f32,
+}
+
+/// # Title for union impl doc
+/// ## Sub-heading for union impl doc
+impl HeavilyDocumentedUnion {
+    /// # Title for union impl-item doc
+    /// ## Sub-heading for union impl-item doc
+    pub fn do_nothing() {}
+}
+
+/// # Top-doc prose title
+///
+/// Text below heading.
+///
+/// ## Top-doc prose sub-heading
+///
+/// Text below heading.
+#[macro_export]
+macro_rules! heavily_documented_macro {
+    () => {};
+}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-56556.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-56556.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+fn foo<T>(t: T) -> usize
+where
+    for<'a> &'a T: IntoIterator,
+    for<'a> <&'a T as IntoIterator>::IntoIter: ExactSizeIterator,
+{
+    t.into_iter().len()
+}
+
+fn main() {
+    foo::<Vec<u32>>(vec![]);
+}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-76956.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-76956.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+use std::ops::Deref;
+
+struct Data {
+    boxed: Box<&'static i32>
+}
+
+impl Data {
+    fn use_data(&self, user: impl for <'a> FnOnce(<Box<&'a i32> as Deref>::Target)) {
+        user(*self.boxed)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #90017 (Add a couple tests for normalize under binder issues)
 - #90079 (enable `i8mm` target feature on aarch64 and arm)
 - #90186 (Fix documentation header sizes)
 - #90233 (Tooltip overflow)
 - #90257 (Changed slice.swap documentation for better readability)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90017,90079,90186,90233,90257)
<!-- homu-ignore:end -->