### PR TITLE
Prevent duplicate caller bounds candidates by exposing default substs in Unevaluated

### DIFF
--- a/src/test/ui/const-generics/expose-default-substs-param-env.rs
+++ b/src/test/ui/const-generics/expose-default-substs-param-env.rs
@@ -1,0 +1,9 @@
+// build-pass
+
+#![feature(generic_const_exprs)]
+#![allow(unused_braces, incomplete_features)]
+
+pub trait Foo<const N: usize> {}
+pub trait Bar: Foo<{ 1 }> { }
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-89334.rs
+++ b/src/test/ui/const-generics/issues/issue-89334.rs
@@ -1,0 +1,16 @@
+// build-pass
+
+#![feature(generic_const_exprs)]
+#![allow(unused_braces, incomplete_features)]
+
+pub trait AnotherTrait{
+    const ARRAY_SIZE: usize;
+}
+pub trait Shard<T: AnotherTrait>:
+    AsMut<[[u8; T::ARRAY_SIZE]]>
+where
+    [(); T::ARRAY_SIZE]: Sized
+{
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/89334

The changes introduced in https://github.com/rust-lang/rust/pull/87280 allowed for "duplicate" caller bounds candidates to be assembled that only differed in their default substs having been "exposed" or not and resulted in an ambiguity error during trait selection. To fix this we expose the defaults substs during the creation of the ParamEnv. 

r? @lcnr 