### PR TITLE
Stabilise `is_aarch64_feature_detected!` under `simd_aarch64` feature 

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -546,13 +546,14 @@ pub mod arch {
     #[doc(no_inline)] // Note (#82861): required for correct documentation
     pub use core::arch::*;
 
+    #[stable(feature = "simd_aarch64", since = "1.60.0")]
+    pub use std_detect::is_aarch64_feature_detected;
     #[stable(feature = "simd_x86", since = "1.27.0")]
     pub use std_detect::is_x86_feature_detected;
     #[unstable(feature = "stdsimd", issue = "48556")]
     pub use std_detect::{
-        is_aarch64_feature_detected, is_arm_feature_detected, is_mips64_feature_detected,
-        is_mips_feature_detected, is_powerpc64_feature_detected, is_powerpc_feature_detected,
-        is_riscv_feature_detected,
+        is_arm_feature_detected, is_mips64_feature_detected, is_mips_feature_detected,
+        is_powerpc64_feature_detected, is_powerpc_feature_detected, is_riscv_feature_detected,
     };
 }
 

--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -3,10 +3,9 @@
 #![cfg_attr(
     any(
         all(target_arch = "arm", any(target_os = "linux", target_os = "android")),
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "android")),
+        all(bootstrap, target_arch = "aarch64", any(target_os = "linux", target_os = "android")),
         all(target_arch = "powerpc", target_os = "linux"),
         all(target_arch = "powerpc64", target_os = "linux"),
-        any(target_arch = "x86", target_arch = "x86_64"),
     ),
     feature(stdsimd)
 )]
@@ -46,7 +45,8 @@ fn aarch64_linux() {
     println!("flagm: {}", is_aarch64_feature_detected!("flagm"));
     println!("ssbs: {}", is_aarch64_feature_detected!("ssbs"));
     println!("sb: {}", is_aarch64_feature_detected!("sb"));
-    println!("pauth: {}", is_aarch64_feature_detected!("pauth"));
+    println!("paca: {}", is_aarch64_feature_detected!("paca"));
+    println!("pacg: {}", is_aarch64_feature_detected!("pacg"));
     println!("dpb: {}", is_aarch64_feature_detected!("dpb"));
     println!("dpb2: {}", is_aarch64_feature_detected!("dpb2"));
     println!("sve2: {}", is_aarch64_feature_detected!("sve2"));


### PR DESCRIPTION
Initial implementation, looking for feedback on the approach here. https://github.com/rust-lang/rust/issues/86941

One point I noticed was that I haven't seen different "since" versions for the same feature - does this mean that other features can't be added to to the `simd_aarch64` feature once this is in stable? If so it might need a more specific name.

r? @Amanieu 