### PR TITLE
Remove redundant Aligner

### DIFF
--- a/library/std/src/sync/mpsc/cache_aligned.rs
+++ b/library/std/src/sync/mpsc/cache_aligned.rs
@@ -2,10 +2,7 @@ use crate::ops::{Deref, DerefMut};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(align(64))]
-pub(super) struct Aligner;
-
-#[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(super) struct CacheAligned<T>(pub T, pub Aligner);
+pub(super) struct CacheAligned<T>(pub T);
 
 impl<T> Deref for CacheAligned<T> {
     type Target = T;
@@ -22,6 +19,6 @@ impl<T> DerefMut for CacheAligned<T> {
 
 impl<T> CacheAligned<T> {
     pub(super) fn new(t: T) -> Self {
-        CacheAligned(t, Aligner)
+        CacheAligned(t)
     }
 }


### PR DESCRIPTION
The `Aligner` struct seems to be unnecessary.
Previously noted by @arthurprs https://github.com/rust-lang/rust/pull/44963#discussion_r145340754
Reddit discussion: https://www.reddit.com/r/rust/comments/pfvvz2/aligner_and_cachealigned/
Playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=fa7ca554922755f9d1b62b017d785c6f