### PR TITLE
Document `setgroups` call caused by `std::os::unix::process::CommandExt.uid`

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -21,6 +21,14 @@ pub trait CommandExt: Sealed {
     /// Sets the child process's user ID. This translates to a
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
+    ///
+    /// # Notes
+    ///
+    /// This will also trigger a call to `setgroups(0, NULL)` in the
+    /// child process if the parent is root and no groups have been
+    /// specified.
+    /// This removes supplementary groups that might have given the child
+    /// unwanted permissions.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn uid(
         &mut self,


### PR DESCRIPTION
Fixes  #39186
It's a small change but this is my first time contributing to open source so any feedback is very appreciated.

I also have some questions:
I documented that the `setgroup` call only happens when the parent is root. But this is potentially not the desired behavior, as described in #88716.
What more needs to happen decision-wise for that? Does #88716 remaining open mean that it is an approved and wanted change? I could fix that issue in this PR too if that would be ok.