### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
4 commits in 7fbbf4e8f23e3c24b8afff541dcb17e53eb5ff88..6c1bc24b8b49d4bc965f67d7037906dc199c72b7
2021-10-19 02:16:48 +0000 to 2021-10-24 17:51:41 +0000
- Fix a clippy warning (rust-lang/cargo#10002)
- Upgrade Cargo to the 2021 edition (rust-lang/cargo#10000)
- Don't canonicalize executable path (rust-lang/cargo#9991)
- Bump to 0.59.0, update changelog (rust-lang/cargo#9998)