### PR TITLE
Remove unneeded into_iter

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -412,7 +412,7 @@ impl FromWithTcx<clean::Type> for Type {
                         .map(|t| {
                             clean::GenericBound::TraitBound(t, rustc_hir::TraitBoundModifier::None)
                         })
-                        .chain(lt.into_iter().map(clean::GenericBound::Outlives))
+                        .chain(lt.map(clean::GenericBound::Outlives))
                         .map(|bound| bound.into_tcx(tcx))
                         .collect(),
                 }


### PR DESCRIPTION
As @camelid mentionned [here](https://github.com/rust-lang/rust/pull/89430#discussion_r735889324), the `into_iter` was unneeded.

r? @camelid 