### PR TITLE
Add tracking issue number to const_cstr_unchecked

### DIFF
--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -1257,7 +1257,7 @@ impl CStr {
     #[inline]
     #[must_use]
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-    #[rustc_const_unstable(feature = "const_cstr_unchecked", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cstr_unchecked", issue = "90343")]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         // SAFETY: Casting to CStr is safe because its internal representation
         // is a [u8] too (safe only inside std).


### PR DESCRIPTION
Also created a tracking issue, see #90343.

I think it makes sense to stabilize this somewhat soon considering abuse of `transmute` to have this feature in constants, see https://crates.io/crates/cstr for an example. Code can be rewritten to use `mem::transmute` to work on stable.