### PR TITLE
Fix rare ICE during typeck in rustdoc scrape_examples

### DIFF
--- a/src/test/run-make/rustdoc-scrape-examples-invalid-expr/Makefile
+++ b/src/test/run-make/rustdoc-scrape-examples-invalid-expr/Makefile
@@ -1,0 +1,5 @@
+deps := ex
+
+-include ../rustdoc-scrape-examples-multiple/scrape.mk
+
+all: scrape

--- a/src/test/run-make/rustdoc-scrape-examples-invalid-expr/examples/ex.rs
+++ b/src/test/run-make/rustdoc-scrape-examples-invalid-expr/examples/ex.rs
@@ -1,0 +1,2 @@
+pub struct Foo([usize; foobar::f()]);
+fn main() {}

--- a/src/test/run-make/rustdoc-scrape-examples-invalid-expr/src/lib.rs
+++ b/src/test/run-make/rustdoc-scrape-examples-invalid-expr/src/lib.rs
@@ -1,0 +1,1 @@
+pub const fn f() -> usize { 5 }

--- a/src/test/run-make/rustdoc-scrape-examples-multiple/src/lib.rs
+++ b/src/test/run-make/rustdoc-scrape-examples-multiple/src/lib.rs
@@ -1,4 +1,6 @@
 // @has foobar/fn.ok.html '//*[@class="docblock scraped-example-list"]//*[@class="prev"]' ''
 // @has foobar/fn.ok.html '//*[@class="more-scraped-examples"]' ''
+// @has src/ex/ex.rs.html
+// @has foobar/fn.ok.html '//a[@href="../src/ex/ex.rs.html#2"]' ''
 
 pub fn ok() {}


### PR DESCRIPTION
While testing the `--scrape-examples` extension on the [wasmtime](https://github.com/bytecodealliance/wasmtime) repository, I found some additional edge cases. Specifically, when asking to typecheck a body containing a function call, I would sometimes get an ICE if:
* The body doesn't exist
* The function's HIR node didn't have a type

This adds checks for both of those conditions.

(Also this updates a test to check that the sources of a reverse-dependency are correctly generated and linked.)

r? @jyn514 