### PR TITLE
Document clippy on nightly-rustc

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -482,6 +482,7 @@ impl<'a> Builder<'a> {
                 doc::RustByExample,
                 doc::RustcBook,
                 doc::CargoBook,
+                doc::Clippy,
                 doc::EmbeddedBook,
                 doc::EditionGuide,
             ),

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -755,6 +755,7 @@ tool_doc!(
     "src/tools/rustfmt",
     ["rustfmt-nightly", "rustfmt-config_proc_macro"],
 );
+tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"]);
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {


### PR DESCRIPTION
Adding Clippy's docs to nightly-rustc, based on commit 01cf0bde. This PR only adds `clippy_utils` to the documentation. I've decided to only document one crate for now, as `clippy_lints` etc. contain very specific and undocumented functions which aren't really reusable. I'm guessing that they would mostly clutter up the search results with little benefit.

`./x.py --stage 1 doc src/tools/clippy` if working fine now after the help that `@jyn514` and `@ehuss` have provided. A big THANK YOU to them!