### PR TITLE
Deny `#[rustc_const_stable]` on `#[unstable]` functions

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -492,6 +492,8 @@ fn register_internals(store: &mut LintStore) {
     store.register_late_pass(|| Box::new(ExistingDocKeyword));
     store.register_lints(&TyTyKind::get_lints());
     store.register_late_pass(|| Box::new(TyTyKind));
+    store.register_lints(&IncompatibleStability::get_lints());
+    store.register_late_pass(|| Box::new(IncompatibleStability));
     store.register_group(
         false,
         "rustc::internal",
@@ -504,6 +506,7 @@ fn register_internals(store: &mut LintStore) {
             LintId::of(TY_PASS_BY_REFERENCE),
             LintId::of(USAGE_OF_QUALIFIED_TY),
             LintId::of(EXISTING_DOC_KEYWORD),
+            LintId::of(INCOMPATIBLE_STABILITY),
         ],
     );
 }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -53,6 +53,8 @@
     issue = "none"
 )]
 #![allow(missing_docs)]
+// intrinsics are never stable but may need to be const-stable for other items
+#![cfg_attr(not(bootstrap), allow(rustc::incompatible_stability))]
 
 use crate::marker::DiscriminantKind;
 use crate::mem;

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -628,7 +628,7 @@ macro_rules! saturating_int_impl {
             /// ```
             #[inline]
             #[unstable(feature = "saturating_int_impl", issue = "87920")]
-            #[rustc_const_stable(feature = "const_reverse_bits", since = "1.37.0")]
+            #[rustc_const_unstable(feature = "saturating_int_impl", issue = "87920")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             pub const fn reverse_bits(self) -> Self {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2208,7 +2208,7 @@ macro_rules! uint_impl {
         /// ```
         #[unstable(feature = "wrapping_next_power_of_two", issue = "32463",
                    reason = "needs decision on wrapping behaviour")]
-        #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]
+        #[rustc_const_unstable(feature = "wrapping_next_power_of_two", issue = "32463")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         pub const fn wrapping_next_power_of_two(self) -> Self {

--- a/src/test/ui/lint/incompatible_stability.rs
+++ b/src/test/ui/lint/incompatible_stability.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zunstable-options
 #![stable(feature = "stable", since = "1.0.0")]
-#![feature(staged_api, rustc_attrs)]
+#![feature(staged_api, rustc_attrs, intrinsics)]
 
 #[unstable(feature = "unstable", issue = "none")]
 #[rustc_const_stable(feature = "stable", since = "1.0.0")]
@@ -11,6 +11,14 @@ mod bar {
 
     #[rustc_const_stable(feature = "stable", since = "1.0.0")]
     const fn foo() {} //~ ERROR functions cannot be const-stable if they are unstable
+}
+
+mod intrinsics {
+    #![unstable(feature = "unstable", issue = "none")]
+    extern "rust-intrinsic" {
+        #[rustc_const_stable(feature = "stable", since = "1.0.0")]
+        pub fn transmute<T, U>(_: T) -> U; //~ ERROR functions cannot be const-stable if they are unstable
+    }
 }
 
 fn main() {}

--- a/src/test/ui/lint/incompatible_stability.rs
+++ b/src/test/ui/lint/incompatible_stability.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Zunstable-options
+#![stable(feature = "stable", since = "1.0.0")]
+#![feature(staged_api, rustc_attrs)]
+
+#[unstable(feature = "unstable", issue = "none")]
+#[rustc_const_stable(feature = "stable", since = "1.0.0")]
+const fn foo() {} //~ ERROR functions cannot be const-stable if they are unstable
+
+mod bar {
+    #![unstable(feature = "unstable", issue = "none")]
+
+    #[rustc_const_stable(feature = "stable", since = "1.0.0")]
+    const fn foo() {} //~ ERROR functions cannot be const-stable if they are unstable
+}
+
+fn main() {}

--- a/src/test/ui/lint/incompatible_stability.stderr
+++ b/src/test/ui/lint/incompatible_stability.stderr
@@ -12,5 +12,11 @@ error: functions cannot be const-stable if they are unstable
 LL |     const fn foo() {}
    |     ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: functions cannot be const-stable if they are unstable
+  --> $DIR/incompatible_stability.rs:20:9
+   |
+LL |         pub fn transmute<T, U>(_: T) -> U;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/incompatible_stability.stderr
+++ b/src/test/ui/lint/incompatible_stability.stderr
@@ -1,0 +1,16 @@
+error: functions cannot be const-stable if they are unstable
+  --> $DIR/incompatible_stability.rs:7:1
+   |
+LL | const fn foo() {}
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(rustc::incompatible_stability)]` on by default
+
+error: functions cannot be const-stable if they are unstable
+  --> $DIR/incompatible_stability.rs:13:5
+   |
+LL |     const fn foo() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This adds a lint against both function declarations and extern function declarations that are `#[unstable]` but declared `#[rustc_const_stable]`, as this is almost certainly a mistake.

Resolves #79551

@rustbot label A-const-fn A-lint A-stability C-enhancement T-libs

cc @oli-obk