### PR TITLE
Improve perf measurements of `build_extern_trait_impl`

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -335,6 +335,8 @@ crate fn build_impl(
         return;
     }
 
+    let _prof_timer = cx.tcx.sess.prof.generic_activity("build_extern_trait_impl");
+
     let tcx = cx.tcx;
     let associated_trait = tcx.impl_trait_ref(did);
 

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -31,9 +31,7 @@ crate fn collect_trait_impls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
 
     for &cnum in cx.tcx.crates(()).iter() {
         for &(did, _) in cx.tcx.all_trait_implementations(cnum).iter() {
-            cx.tcx.sess.prof.generic_activity("build_extern_trait_impl").run(|| {
-                inline::build_impl(cx, None, did, None, &mut new_items);
-            });
+            inline::build_impl(cx, None, did, None, &mut new_items);
         }
     }
 


### PR DESCRIPTION
Before, it was only measuring one callsite of `build_impl`, and it
incremented the call count even if `build_impl` returned early because
the `did` was already inlined.

Now, it measures all calls, minus calls that return early.