### PR TITLE
Make `core::slice::from_raw_parts[_mut]` const

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -105,6 +105,7 @@
 #![feature(const_caller_location)]
 #![feature(const_cell_into_inner)]
 #![feature(const_discriminant)]
+#![cfg_attr(not(bootstrap), feature(const_eval_select))]
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
 #![feature(const_fmt_arguments_new)]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -83,7 +83,7 @@ use crate::ptr;
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "none")]
+#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
 pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
     debug_check_data_len(data, len);
 
@@ -122,7 +122,7 @@ pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "none")]
+#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
 pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
     debug_check_data_len(data as _, len);
 
@@ -132,8 +132,8 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
 
 // In debug builds checks that `data` pointer is aligned and non-null and that slice with given `len` would cover less than half the address space
 #[cfg(all(not(bootstrap), debug_assertions))]
-#[unstable(feature = "const_slice_from_raw_parts", issue = "none")]
-#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "none")]
+#[unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
+#[rustc_const_unstable(feature = "const_slice_from_raw_parts", issue = "67456")]
 const fn debug_check_data_len<T>(data: *const T, len: usize) {
     fn rt_check<T>(data: *const T) {
         use crate::intrinsics::is_aligned_and_not_null;


### PR DESCRIPTION
Responses to #90012 seem to allow @rust-lang/wg-const-eval to decide on use of `const_eval_select`, so we can make `core::slice::from_raw_parts[_mut]` const :)

---
This PR marks the following APIs as const:
```rust
// core::slice
pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T];
pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T];
```
---

Resolves #90011
r? @oli-obk 