### PR TITLE
[perf-check] Revert "Rollup merge of #88789 - the8472:rm-zip-bound, r=JohnTitor"

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -427,9 +427,13 @@ where
     }
 }
 
-// Since SourceIter forwards the left hand side we do the same here
 #[unstable(issue = "none", feature = "inplace_iteration")]
-unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> {}
+// Limited to Item: Copy since interaction between Zip's use of TrustedRandomAccess
+// and Drop implementation of the source is unclear.
+//
+// An additional method returning the number of times the source has been logically advanced
+// (without calling next()) would be needed to properly drop the remainder of the source.
+unsafe impl<A: InPlaceIterable, B: Iterator> InPlaceIterable for Zip<A, B> where A::Item: Copy {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Debug, B: Debug> Debug for Zip<A, B> {


### PR DESCRIPTION
This reverts commit 84fe598f0094c8d6a1dddcdc38ac0fa28df32f44, reversing
changes made to 71fcb72307e2bb9512d291d33f2adace2406e65a.

r? @ghost cc https://github.com/rust-lang/rust/pull/90067#issuecomment-952080100