### PR TITLE
Extend check for UnsafeCell in consts to cover unions

### DIFF
--- a/src/test/ui/consts/invalid-union.32bit.stderr
+++ b/src/test/ui/consts/invalid-union.32bit.stderr
@@ -1,0 +1,24 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-union.rs:41:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^ type validation failed at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               ╾─alloc7──╼                                     │ ╾──╼
+           }
+
+error: erroneous constant used
+  --> $DIR/invalid-union.rs:42:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^ referenced constant has errors
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.64bit.stderr
+++ b/src/test/ui/consts/invalid-union.64bit.stderr
@@ -1,0 +1,24 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-union.rs:41:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^ type validation failed at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in a `const`
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾───────alloc7────────╼                         │ ╾──────╼
+           }
+
+error: erroneous constant used
+  --> $DIR/invalid-union.rs:42:25
+   |
+LL |     let _: &'static _ = &C;
+   |                         ^^ referenced constant has errors
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/invalid-union.rs
+++ b/src/test/ui/consts/invalid-union.rs
@@ -1,0 +1,44 @@
+// Check that constants with interior mutability inside unions are rejected
+// during validation.
+//
+// Note that this test case relies on undefined behaviour to construct a
+// constant with interior mutability that is "invisible" to the static checks.
+// If for some reason this approach no longer works, it is should be fine to
+// remove the test case.
+//
+// build-fail
+// stderr-per-bitwidth
+#![feature(const_mut_refs)]
+#![feature(const_ptr_offset)]
+#![feature(untagged_unions)]
+use std::cell::Cell;
+
+#[repr(C)]
+struct S {
+    x: u32,
+    y: E,
+}
+
+#[repr(u32)]
+enum E {
+    A,
+    B(U)
+}
+
+union U {
+    cell: Cell<u32>,
+}
+
+const C: S = {
+    let s = S { x: 0, y: E::A };
+    // Go through an &u32 reference which is definitely not allowed to mutate anything.
+    let p = &s.x as *const u32 as *mut u32;
+    // Change enum tag to E::B.
+    unsafe { *p.add(1) = 1 };
+    s
+};
+
+fn main() { //~ ERROR it is undefined behavior to use this value
+    let _: &'static _ = &C; //~ ERROR erroneous constant used
+    //~^ WARN this was previously accepted
+}


### PR DESCRIPTION
A validity companion to changes from #90373.

@rust-lang/wg-const-eval