### PR TITLE
Add unstable feature 'split_rinclusive', adding a right-inclusive version of `str::split_inclusive`

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -25,6 +25,7 @@
 #![feature(const_btree_new)]
 #![feature(const_default_impls)]
 #![feature(const_trait_impl)]
+#![feature(split_rinclusive)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1334,13 +1334,8 @@ fn test_split_char_iterator_rinclusive() {
     assert_eq!(split, ["\nMäry häd ä little lämb", "\nLittle lämb", "\n"]);
 
     let uppercase_separated = "SheepSharkTurtleCat";
-    let mut first_char = true;
     let split: Vec<&str> = uppercase_separated
-        .split_rinclusive(|c: char| {
-            let split = !first_char && c.is_uppercase();
-            first_char = split;
-            split
-        })
+        .split_rinclusive(char::is_uppercase)
         .collect();
     assert_eq!(split, ["Sheep", "Shark", "Turtle", "Cat"]);
 }
@@ -1381,13 +1376,8 @@ fn test_split_char_iterator_rinclusive_rev() {
     // (A different predicate is needed for reverse iterator vs normal iterator.)
     // Not sure if anything can be done though.
     let uppercase_separated = "SheepSharkTurtleCat";
-    let mut term_char = true;
     let split: Vec<&str> = uppercase_separated
-        .split_rinclusive(|c: char| {
-            let split = term_char && c.is_uppercase();
-            term_char = c.is_uppercase();
-            split
-        })
+        .split_rinclusive(char::is_uppercase)
         .rev()
         .collect();
     assert_eq!(split, ["Cat", "Turtle", "Shark", "Sheep"]);

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1325,6 +1325,26 @@ fn test_split_char_iterator_inclusive() {
     assert_eq!(split, ["SheeP", "SharK", "TurtlE", "CaT"]);
 }
 
+
+#[test]
+fn test_split_char_iterator_rinclusive() {
+    let data = "\nMäry häd ä little lämb\nLittle lämb\n";
+
+    let split: Vec<&str> = data.split_rinclusive('\n').collect();
+    assert_eq!(split, ["", "\nMäry häd ä little lämb", "\nLittle lämb", "\n"]);
+
+    let uppercase_separated = "SheepSharkTurtleCat";
+    let mut first_char = true;
+    let split: Vec<&str> = uppercase_separated
+        .split_rinclusive(|c: char| {
+            let split = !first_char && c.is_uppercase();
+            first_char = split;
+            split
+        })
+        .collect();
+    assert_eq!(split, ["Sheep", "Shark", "Turtle", "Cat"]);
+}
+
 #[test]
 fn test_split_char_iterator_inclusive_rev() {
     let data = "\nMäry häd ä little lämb\nLittle lämb\n";
@@ -1347,6 +1367,30 @@ fn test_split_char_iterator_inclusive_rev() {
         .rev()
         .collect();
     assert_eq!(split, ["CaT", "TurtlE", "SharK", "SheeP"]);
+}
+
+#[test]
+fn test_split_char_iterator_rinclusive_rev() {
+    let data = "\nMäry häd ä little lämb\nLittle lämb\n";
+
+    let split: Vec<&str> = data.split_rinclusive('\n').rev().collect();
+    assert_eq!(split, ["\n", "\nLittle lämb", "\nMäry häd ä little lämb", ""]);
+
+    // Note that the predicate is stateful and thus dependent
+    // on the iteration order.
+    // (A different predicate is needed for reverse iterator vs normal iterator.)
+    // Not sure if anything can be done though.
+    let uppercase_separated = "SheepSharkTurtleCat";
+    let mut term_char = true;
+    let split: Vec<&str> = uppercase_separated
+        .split_inclusive(|c: char| {
+            let split = term_char && c.is_uppercase();
+            term_char = c.is_uppercase();
+            split
+        })
+        .rev()
+        .collect();
+    assert_eq!(split, ["Cat", "Turtle", "Shark", "Sheep", ""]);
 }
 
 #[test]

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1383,7 +1383,7 @@ fn test_split_char_iterator_rinclusive_rev() {
     let uppercase_separated = "SheepSharkTurtleCat";
     let mut term_char = true;
     let split: Vec<&str> = uppercase_separated
-        .split_inclusive(|c: char| {
+        .split_rinclusive(|c: char| {
             let split = term_char && c.is_uppercase();
             term_char = c.is_uppercase();
             split

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1371,10 +1371,6 @@ fn test_split_char_iterator_rinclusive_rev() {
     let split: Vec<&str> = data.split_rinclusive('\n').rev().collect();
     assert_eq!(split, ["\n", "\nLittle lämb", "\nMäry häd ä little lämb"]);
 
-    // Note that the predicate is stateful and thus dependent
-    // on the iteration order.
-    // (A different predicate is needed for reverse iterator vs normal iterator.)
-    // Not sure if anything can be done though.
     let uppercase_separated = "SheepSharkTurtleCat";
     let split: Vec<&str> = uppercase_separated
         .split_rinclusive(char::is_uppercase)

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1331,7 +1331,7 @@ fn test_split_char_iterator_rinclusive() {
     let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
     let split: Vec<&str> = data.split_rinclusive('\n').collect();
-    assert_eq!(split, ["", "\nMäry häd ä little lämb", "\nLittle lämb", "\n"]);
+    assert_eq!(split, ["\nMäry häd ä little lämb", "\nLittle lämb", "\n"]);
 
     let uppercase_separated = "SheepSharkTurtleCat";
     let mut first_char = true;
@@ -1374,7 +1374,7 @@ fn test_split_char_iterator_rinclusive_rev() {
     let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
     let split: Vec<&str> = data.split_rinclusive('\n').rev().collect();
-    assert_eq!(split, ["\n", "\nLittle lämb", "\nMäry häd ä little lämb", ""]);
+    assert_eq!(split, ["\n", "\nLittle lämb", "\nMäry häd ä little lämb"]);
 
     // Note that the predicate is stateful and thus dependent
     // on the iteration order.
@@ -1390,7 +1390,7 @@ fn test_split_char_iterator_rinclusive_rev() {
         })
         .rev()
         .collect();
-    assert_eq!(split, ["Cat", "Turtle", "Shark", "Sheep", ""]);
+    assert_eq!(split, ["Cat", "Turtle", "Shark", "Sheep"]);
 }
 
 #[test]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1449,11 +1449,11 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
 /// See its documentation for more.
 ///
 /// [`split_rinclusive`]: str::split_rinclusive
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 #[derive(Clone)]
 pub struct SplitRInclusive<'a, P: Pattern<'a>>(pub(super) SplitInternal<'a, P>);
 
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 impl<'a, P: Pattern<'a>> Iterator for SplitRInclusive<'a, P> {
     type Item = &'a str;
 
@@ -1463,14 +1463,14 @@ impl<'a, P: Pattern<'a>> Iterator for SplitRInclusive<'a, P> {
     }
 }
 
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitRInclusive<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitRInclusive").field("0", &self.0).finish()
     }
 }
 
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     for SplitRInclusive<'a, P>
 {
@@ -1480,7 +1480,7 @@ impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     }
 }
 
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 impl<'a, P: Pattern<'a>> FusedIterator for SplitRInclusive<'a, P> {}
 
 impl<'a, P: Pattern<'a>> SplitRInclusive<'a, P> {
@@ -1498,7 +1498,7 @@ impl<'a, P: Pattern<'a>> SplitRInclusive<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_rinclusive_as_str", issue = "77998")]
+    #[unstable(feature = "split_rinclusive", issue = "none)]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -648,7 +648,7 @@ impl<'a, P: Pattern<'a>> SplitInternal<'a, P> {
             None => self.get_end(),
         }
     }
-    
+
     #[inline]
     fn next_rinclusive(&mut self) -> Option<&'a str> {
         if self.finished {
@@ -760,7 +760,7 @@ impl<'a, P: Pattern<'a>> SplitInternal<'a, P> {
             },
         }
     }
-    
+
     #[inline]
     fn next_back_rinclusive(&mut self) -> Option<&'a str>
     where
@@ -1456,7 +1456,7 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
 /// An iterator over the substrings of a string,
 /// new substrings beginning when matching to a predicate function.
 /// Unlike `Split`, it contains the matched part as the start
-/// of each subslice - besides the first, which is the contents 
+/// of each subslice - besides the first, which is the contents
 /// up until the first match.
 ///
 /// This struct is created by the [`split_rinclusive`] method on [`str`].

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1449,11 +1449,11 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
 /// See its documentation for more.
 ///
 /// [`split_rinclusive`]: str::split_rinclusive
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 #[derive(Clone)]
 pub struct SplitRInclusive<'a, P: Pattern<'a>>(pub(super) SplitInternal<'a, P>);
 
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 impl<'a, P: Pattern<'a>> Iterator for SplitRInclusive<'a, P> {
     type Item = &'a str;
 
@@ -1463,14 +1463,14 @@ impl<'a, P: Pattern<'a>> Iterator for SplitRInclusive<'a, P> {
     }
 }
 
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitRInclusive<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitRInclusive").field("0", &self.0).finish()
     }
 }
 
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     for SplitRInclusive<'a, P>
 {
@@ -1480,7 +1480,7 @@ impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     }
 }
 
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 impl<'a, P: Pattern<'a>> FusedIterator for SplitRInclusive<'a, P> {}
 
 impl<'a, P: Pattern<'a>> SplitRInclusive<'a, P> {
@@ -1498,7 +1498,7 @@ impl<'a, P: Pattern<'a>> SplitRInclusive<'a, P> {
     /// assert_eq!(split.as_str(), "");
     /// ```
     #[inline]
-    #[unstable(feature = "split_rinclusive", issue = "none)]
+    #[unstable(feature = "split_rinclusive", issue = "none")]
     pub fn as_str(&self) -> &'a str {
         self.0.as_str()
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1464,7 +1464,6 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
 ///
 /// [`split_rinclusive`]: str::split_rinclusive
 #[unstable(feature = "split_rinclusive", issue = "none")]
-#[derive(Clone)]
 pub struct SplitRInclusive<'a, P: Pattern<'a>>(pub(super) SplitInternal<'a, P>);
 
 #[unstable(feature = "split_rinclusive", issue = "none")]
@@ -1481,6 +1480,14 @@ impl<'a, P: Pattern<'a>> Iterator for SplitRInclusive<'a, P> {
 impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitRInclusive<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitRInclusive").field("0", &self.0).finish()
+    }
+}
+
+// FIXME(#26925) Remove in favor of `#[derive(Clone)]`
+#[unstable(feature = "split_rinclusive", issue = "none")]
+impl<'a, P: Pattern<'a, Searcher: Clone>> Clone for SplitRInclusive<'a, P> {
+    fn clone(&self) -> Self {
+        SplitInclusive(self.0.clone())
     }
 }
 

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1487,7 +1487,7 @@ impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitRInclusive<'a
 #[unstable(feature = "split_rinclusive", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: Clone>> Clone for SplitRInclusive<'a, P> {
     fn clone(&self) -> Self {
-        SplitInclusive(self.0.clone())
+        SplitRInclusive(self.0.clone())
     }
 }
 

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -68,6 +68,9 @@ pub use iter::SplitAsciiWhitespace;
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::SplitInclusive;
 
+#[stable(feature = "split_rinclusive", since = "1.51.0")]
+pub use iter::SplitRInclusive;
+
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::{next_code_point, utf8_char_width};
 
@@ -1266,6 +1269,55 @@ impl str {
     #[inline]
     pub fn split_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitInclusive<'a, P> {
         SplitInclusive(SplitInternal {
+            start: 0,
+            end: self.len(),
+            matcher: pat.into_searcher(self),
+            allow_trailing_empty: false,
+            finished: false,
+        })
+    }
+    
+    
+    /// An iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern. Differs from the iterator produced by
+    /// `split` in that `split_rinclusive` leaves the matched part as the
+    /// beginning of the next substring, except possibly the first which is whatever before the first match.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
+    ///     .split_rinclusive('\n').collect();
+    /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb."]);
+    /// ```
+    ///
+    /// If the first element of the string is matched,
+    /// the first substring will be an empty string.
+    ///
+    /// ```
+    /// let v: Vec<&str> = "MaryHadALittleLamb"
+    ///     .split_rinclusive(char::is_uppercase).collect();
+    /// assert_eq!(v, ["", "Mary", "Had", "A", "Little", "Lamb]);
+    /// ```
+    ///
+    /// If the last element of the string is matched,
+    /// that element will be considered the final substring returned by the iterator.
+    ///
+    /// ```
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb.\n"
+    ///     .split_rinclusive('\n').collect();
+    /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
+    /// ```
+    #[stable(feature = "split_rinclusive", since = "1.51.0")]
+    #[inline]
+    pub fn split_rinclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitRInclusive<'a, P> {
+        SplitRInclusive(SplitInternal {
             start: 0,
             end: self.len(),
             matcher: pat.into_searcher(self),

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1233,6 +1233,7 @@ impl str {
             end: self.len(),
             matcher: pat.into_searcher(self),
             allow_trailing_empty: true,
+            allow_leading_empty: true,
             finished: false,
         })
     }
@@ -1273,6 +1274,7 @@ impl str {
             end: self.len(),
             matcher: pat.into_searcher(self),
             allow_trailing_empty: false,
+            allow_leading_empty: true,
             finished: false,
         })
     }
@@ -1298,12 +1300,12 @@ impl str {
     /// ```
     ///
     /// If the first element of the string is matched,
-    /// the first substring will be an empty string.
+    /// the leading empty string is omitted.
     ///
     /// ```
     /// let v: Vec<&str> = "MaryHadALittleLamb"
     ///     .split_rinclusive(char::is_uppercase).collect();
-    /// assert_eq!(v, ["", "Mary", "Had", "A", "Little", "Lamb]);
+    /// assert_eq!(v, ["Mary", "Had", "A", "Little", "Lamb]);
     /// ```
     ///
     /// If the last element of the string is matched,
@@ -1322,6 +1324,7 @@ impl str {
             end: self.len(),
             matcher: pat.into_searcher(self),
             allow_trailing_empty: false,
+            allow_leading_empty: false,
             finished: false,
         })
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1285,6 +1285,8 @@ impl str {
     /// `split` in that `split_rinclusive` leaves the matched part as the
     /// beginning of the next substring, except possibly the first which is whatever before the first match.
     ///
+    /// Put another way, a match is the start of a new substring.
+    ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -68,7 +68,7 @@ pub use iter::SplitAsciiWhitespace;
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::SplitInclusive;
 
-#[stable(feature = "split_rinclusive", since = "1.51.0")]
+#[unstable(feature = "split_rinclusive", issue = "none)]
 pub use iter::SplitRInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
@@ -1314,7 +1314,7 @@ impl str {
     ///     .split_rinclusive('\n').collect();
     /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
     /// ```
-    #[stable(feature = "split_rinclusive", since = "1.51.0")]
+    #[unstable(feature = "split_rinclusive", issue = "none)]
     #[inline]
     pub fn split_rinclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitRInclusive<'a, P> {
         SplitRInclusive(SplitInternal {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1278,8 +1278,7 @@ impl str {
             finished: false,
         })
     }
-    
-    
+
     /// An iterator over substrings of this string slice, separated by
     /// characters matched by a pattern. Differs from the iterator produced by
     /// `split` in that `split_rinclusive` leaves the matched part as the

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -68,7 +68,7 @@ pub use iter::SplitAsciiWhitespace;
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::SplitInclusive;
 
-#[unstable(feature = "split_rinclusive", issue = "none)]
+#[unstable(feature = "split_rinclusive", issue = "none")]
 pub use iter::SplitRInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
@@ -1314,7 +1314,7 @@ impl str {
     ///     .split_rinclusive('\n').collect();
     /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
     /// ```
-    #[unstable(feature = "split_rinclusive", issue = "none)]
+    #[unstable(feature = "split_rinclusive", issue = "none")]
     #[inline]
     pub fn split_rinclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitRInclusive<'a, P> {
         SplitRInclusive(SplitInternal {


### PR DESCRIPTION
Apologies, no issue associated with this one. If that is necessary for a change this small, please let me know and I'll create an issue or pFCP as needed.

### Motivation

`str::split_inclusive` allows for easily splitting a string and including the `separator` in the substring on the "left".

This change proposes `str::split_rinclusive` which allows to easily split a string but include the `separator` on the "right".

This does not change result order like `rsplit`, so it is not, for example,  a hypothetical `rsplit_inclusive`. Actually, they might be somewhat inverses of each other, but telling people to use `rsplit_inclusive(...).rev()` is less ergonomic and harder to reason about. Either way, neither currently exists.

### Implementation

For the most part, just copying the existing `SplitInternal` impl and changing the matcher indices used. 

We also introduce another param: `allow_leading_empty`, an opposite to the existing `allow_trailing_empty`. This is to mirror the functionality of `split_inclusive` when the final character matches (we do not return a trailing empty substring). Likewise, for this implementation, we do not return a leading empty string if the first character matches. 