### PR TITLE
rustdoc: Compute some fields of `clean::Crate` on-demand to reduce size

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -117,7 +117,6 @@ impl From<DefId> for ItemId {
 #[derive(Clone, Debug)]
 crate struct Crate {
     crate name: Symbol,
-    crate src: FileName,
     crate module: Item,
     crate externs: Vec<ExternalCrate>,
     crate primitives: ThinVec<(DefId, PrimitiveType)>,
@@ -128,7 +127,13 @@ crate struct Crate {
 
 // `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Crate, 168);
+rustc_data_structures::static_assert_size!(Crate, 104);
+
+impl Crate {
+    crate fn src(&self, tcx: TyCtxt<'_>) -> FileName {
+        ExternalCrate::LOCAL.src(tcx)
+    }
+}
 
 /// This struct is used to wrap additional information added by rustdoc on a `trait` item.
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -116,7 +116,6 @@ impl From<DefId> for ItemId {
 /// The crate currently being documented.
 #[derive(Clone, Debug)]
 crate struct Crate {
-    crate name: Symbol,
     crate module: Item,
     crate externs: Vec<ExternalCrate>,
     crate primitives: ThinVec<(DefId, PrimitiveType)>,
@@ -130,6 +129,10 @@ crate struct Crate {
 rustc_data_structures::static_assert_size!(Crate, 104);
 
 impl Crate {
+    crate fn name(&self, tcx: TyCtxt<'_>) -> Symbol {
+        ExternalCrate::LOCAL.name(tcx)
+    }
+
     crate fn src(&self, tcx: TyCtxt<'_>) -> FileName {
         ExternalCrate::LOCAL.src(tcx)
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -113,6 +113,7 @@ impl From<DefId> for ItemId {
     }
 }
 
+/// The crate currently being documented.
 #[derive(Clone, Debug)]
 crate struct Crate {
     crate name: Symbol,
@@ -142,6 +143,8 @@ crate struct ExternalCrate {
 }
 
 impl ExternalCrate {
+    const LOCAL: Self = Self { crate_num: LOCAL_CRATE };
+
     #[inline]
     crate fn def_id(&self) -> DefId {
         DefId { krate: self.crate_num, index: CRATE_DEF_INDEX }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -125,6 +125,10 @@ crate struct Crate {
     crate collapsed: bool,
 }
 
+// `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+rustc_data_structures::static_assert_size!(Crate, 168);
+
 /// This struct is used to wrap additional information added by rustdoc on a `trait` item.
 #[derive(Clone, Debug)]
 crate struct TraitWithExtraInfo {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -57,7 +57,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     }
 
     let local_crate = ExternalCrate { crate_num: LOCAL_CRATE };
-    let name = local_crate.name(cx.tcx);
     let primitives = local_crate.primitives(cx.tcx);
     let keywords = local_crate.keywords(cx.tcx);
     {
@@ -79,7 +78,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     }
 
     Crate {
-        name,
         module,
         externs,
         primitives,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -57,7 +57,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     }
 
     let local_crate = ExternalCrate { crate_num: LOCAL_CRATE };
-    let src = local_crate.src(cx.tcx);
     let name = local_crate.name(cx.tcx);
     let primitives = local_crate.primitives(cx.tcx);
     let keywords = local_crate.keywords(cx.tcx);
@@ -81,7 +80,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
 
     Crate {
         name,
-        src,
         module,
         externs,
         primitives,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -29,12 +29,11 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     let module = crate::visit_ast::RustdocVisitor::new(cx).visit();
 
     let mut externs = Vec::new();
-    for &cnum in cx.tcx.crates(()).iter() {
+    for &cnum in cx.tcx.crates(()) {
         externs.push(ExternalCrate { crate_num: cnum });
         // Analyze doc-reachability for extern items
         LibEmbargoVisitor::new(cx).visit_lib(cnum);
     }
-    externs.sort_unstable_by_key(|e| e.crate_num);
 
     // Clean the crate, translating the entire librustc_ast AST to one that is
     // understood by rustdoc.

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -172,7 +172,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
     // Collect the index into a string
     format!(
         r#""{}":{}"#,
-        krate.name,
+        krate.name(tcx),
         serde_json::to_string(&CrateData {
             doc: crate_doc,
             items: crate_items,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -405,7 +405,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             ..
         } = options;
 
-        let src_root = match krate.src {
+        let src_root = match krate.src(tcx) {
             FileName::Real(ref p) => match p.local_path_if_available().parent() {
                 Some(p) => p.to_path_buf(),
                 None => PathBuf::new(),

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -416,14 +416,14 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         let mut playground = None;
         if let Some(url) = playground_url {
             playground =
-                Some(markdown::Playground { crate_name: Some(krate.name.to_string()), url });
+                Some(markdown::Playground { crate_name: Some(krate.name(tcx).to_string()), url });
         }
         let mut layout = layout::Layout {
             logo: String::new(),
             favicon: String::new(),
             external_html,
             default_settings,
-            krate: krate.name.to_string(),
+            krate: krate.name(tcx).to_string(),
             css_file_extension: extension_css,
             generate_search_filter,
             scrape_examples_extension: !call_locations.is_empty(),
@@ -444,7 +444,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 }
                 (sym::html_playground_url, Some(s)) => {
                     playground = Some(markdown::Playground {
-                        crate_name: Some(krate.name.to_string()),
+                        crate_name: Some(krate.name(tcx).to_string()),
                         url: s.to_string(),
                     });
                 }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -455,10 +455,10 @@ pub(super) fn write_shared(
         let dst = cx.dst.join(&format!("source-files{}.js", cx.shared.resource_suffix));
         let make_sources = || {
             let (mut all_sources, _krates) =
-                try_err!(collect(&dst, &krate.name.as_str(), "sourcesIndex"), &dst);
+                try_err!(collect(&dst, &krate.name(cx.tcx()).as_str(), "sourcesIndex"), &dst);
             all_sources.push(format!(
                 "sourcesIndex[\"{}\"] = {};",
-                &krate.name,
+                &krate.name(cx.tcx()),
                 hierarchy.to_json_string()
             ));
             all_sources.sort();
@@ -473,9 +473,10 @@ pub(super) fn write_shared(
 
     // Update the search index and crate list.
     let dst = cx.dst.join(&format!("search-index{}.js", cx.shared.resource_suffix));
-    let (mut all_indexes, mut krates) = try_err!(collect_json(&dst, &krate.name.as_str()), &dst);
+    let (mut all_indexes, mut krates) =
+        try_err!(collect_json(&dst, &krate.name(cx.tcx()).as_str()), &dst);
     all_indexes.push(search_index);
-    krates.push(krate.name.to_string());
+    krates.push(krate.name(cx.tcx()).to_string());
     krates.sort();
 
     // Sort the indexes by crate so the file will be generated identically even
@@ -599,7 +600,7 @@ pub(super) fn write_shared(
 
         let implementors = format!(
             r#"implementors["{}"] = {};"#,
-            krate.name,
+            krate.name(cx.tcx()),
             serde_json::to_string(&implementors).unwrap()
         );
 
@@ -611,7 +612,7 @@ pub(super) fn write_shared(
         mydst.push(&format!("{}.{}.js", remote_item_type, remote_path[remote_path.len() - 1]));
 
         let (mut all_implementors, _) =
-            try_err!(collect(&mydst, &krate.name.as_str(), "implementors"), &mydst);
+            try_err!(collect(&mydst, &krate.name(cx.tcx()).as_str(), "implementors"), &mydst);
         all_implementors.push(implementors);
         // Sort the implementors by crate so the file will be generated
         // identically even with rustdoc running in parallel.

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -18,7 +18,7 @@ use std::path::{Component, Path, PathBuf};
 
 crate fn render(cx: &mut Context<'_>, krate: clean::Crate) -> Result<clean::Crate, Error> {
     info!("emitting source files");
-    let dst = cx.dst.join("src").join(&*krate.name.as_str());
+    let dst = cx.dst.join("src").join(&*krate.name(cx.tcx()).as_str());
     cx.shared.ensure_dir(&dst)?;
     let mut folder = SourceCollector { dst, cx, emitted_local_sources: FxHashSet::default() };
     Ok(folder.fold_crate(krate))


### PR DESCRIPTION
`clean::Crate` is frequently moved by-value -- for example, in `DocFolder`
implementations -- so reducing its size should improve performance.

This PR reduces the size of `clean::Crate` from 168 bytes to 104 bytes.

r? @jyn514
