### PR TITLE
Restrict liveness of mutable borrow of inner infcx in ConstInferUnifier::consts

### DIFF
--- a/src/test/ui/const-generics/issues/issue-89304.rs
+++ b/src/test/ui/const-generics/issues/issue-89304.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+struct GenericStruct<const T: usize> { val: i64 }
+
+impl<const T: usize> From<GenericStruct<T>> for GenericStruct<{T + 1}> {
+    fn from(other: GenericStruct<T>) -> Self {
+        Self { val: other.val }
+    }
+}
+
+impl<const T: usize> From<GenericStruct<{T + 1}>> for GenericStruct<T> {
+    fn from(other: GenericStruct<{T + 1}>) -> Self {
+        Self { val: other.val }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/89304

r? @oli-obk 