### PR TITLE
Skipping verbose diagnostic suggestions when calling .as_ref() on type not implementing AsRef

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1251,6 +1251,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.tcx.lang_items().deref_trait(),
                 self.tcx.lang_items().deref_mut_trait(),
                 self.tcx.lang_items().drop_trait(),
+                self.tcx.get_diagnostic_item(sym::AsRef),
             ];
             // Try alternative arbitrary self types that could fulfill this call.
             // FIXME: probe for all types that *could* be arbitrary self-types, not

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::print::with_crate_prefix;
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt, TypeFoldable, WithConstness};
 use rustc_span::lev_distance;
 use rustc_span::symbol::{kw, sym, Ident};
-use rustc_span::{source_map, FileName, MultiSpan, Span};
+use rustc_span::{source_map, FileName, MultiSpan, Span, Symbol};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt;
 use rustc_trait_selection::traits::{FulfillmentError, Obligation};
 
@@ -1301,7 +1301,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // We don't want to suggest a container type when the missing
                             // method is `.clone()` or `.deref()` otherwise we'd suggest
                             // `Arc::new(foo).clone()`, which is far from what the user wants.
-                            let skip = skippable.contains(&did);
+                            // Explicitly ignore the `Pin::as_ref()` method as `Pin` does not
+                            // implement the `AsRef` trait.
+                            let skip = skippable.contains(&did)
+                                || (("Pin::new" == *pre)
+                                    && (Symbol::intern("as_ref") == item_name.name));
                             // Make sure the method is defined for the *actual* receiver: we don't
                             // want to treat `Box<Self>` as a receiver if it only works because of
                             // an autoderef to `&self`

--- a/src/test/ui/typeck/issue-89806.rs
+++ b/src/test/ui/typeck/issue-89806.rs
@@ -1,0 +1,3 @@
+fn main() {
+    0u8.as_ref(); //~ ERROR no method named `as_ref` found for type `u8` in the current scope
+}

--- a/src/test/ui/typeck/issue-89806.stderr
+++ b/src/test/ui/typeck/issue-89806.stderr
@@ -3,23 +3,6 @@ error[E0599]: no method named `as_ref` found for type `u8` in the current scope
    |
 LL |     0u8.as_ref();
    |         ^^^^^^ method not found in `u8`
-   |
-  ::: $SRC_DIR/core/src/pin.rs:LL:COL
-   |
-LL |     pub fn as_ref(&self) -> Pin<&P::Target> {
-   |            ------
-   |            |
-   |            the method is available for `Pin<&mut u8>` here
-   |            the method is available for `Pin<&u8>` here
-   |
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Pin::new(&mut 0u8).as_ref();
-   |     +++++++++++++    +
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Pin::new(&0u8).as_ref();
-   |     ++++++++++   +
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/issue-89806.stderr
+++ b/src/test/ui/typeck/issue-89806.stderr
@@ -1,0 +1,26 @@
+error[E0599]: no method named `as_ref` found for type `u8` in the current scope
+  --> $DIR/issue-89806.rs:2:9
+   |
+LL |     0u8.as_ref();
+   |         ^^^^^^ method not found in `u8`
+   |
+  ::: $SRC_DIR/core/src/pin.rs:LL:COL
+   |
+LL |     pub fn as_ref(&self) -> Pin<&P::Target> {
+   |            ------
+   |            |
+   |            the method is available for `Pin<&mut u8>` here
+   |            the method is available for `Pin<&u8>` here
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Pin::new(&mut 0u8).as_ref();
+   |     +++++++++++++    +
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Pin::new(&0u8).as_ref();
+   |     ++++++++++   +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Addresses #89806

Skipping suggestions when calling `.as_ref()` for types that do not implement the `AsRef` trait.

r? @estebank