### PR TITLE
[EXPERIMENT] rustdoc: Mark `Context::tcx()` as `#[inline(always)]`

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -151,6 +151,7 @@ impl SharedContext<'_> {
 }
 
 impl<'tcx> Context<'tcx> {
+    #[inline(always)]
     pub(crate) fn tcx(&self) -> TyCtxt<'tcx> {
         self.shared.tcx
     }


### PR DESCRIPTION
I'm wondering if `tcx()` not being inlined could be affecting the perf in #90391.

r? @ghost
