### PR TITLE
[Experiment] Test rustc perf if compiled for x86-64-v3

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -100,6 +100,8 @@ ENV PGO_HOST=x86_64-unknown-linux-gnu
 
 ENV HOSTS=x86_64-unknown-linux-gnu
 
+ENV RUSTFLAGS="-C target_cpu=x86-64-v3"
+
 ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
       --enable-sanitizers \
@@ -110,6 +112,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
+      --set llvm.cxxflags=-march=x86-64-v3 \
+      --set llvm.cflags=-march=x86-64-v3 \
       --set rust.jemalloc
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \


### PR DESCRIPTION
This can of course not be committed but it might be interesting too see how much perf would be gained (or lost) from AVX2 auto-vectorization and other [x86-64-v3 micro-architecture](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels) optimizations.

r? @ghost