### PR TITLE
Merge `DocContext.{ty,lt,ct}_substs` into one map

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1215,96 +1215,92 @@ fn clean_qpath(hir_ty: &hir::Ty<'_>, cx: &mut DocContext<'_>) -> Type {
 }
 
 fn maybe_expand_private_type_alias(cx: &mut DocContext<'_>, path: &hir::Path<'_>) -> Option<Type> {
-    let mut alias = None;
-    if let Res::Def(DefKind::TyAlias, def_id) = path.res {
-        // Substitute private type aliases
-        if let Some(def_id) = def_id.as_local() {
-            let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id);
-            if !cx.cache.access_levels.is_exported(def_id.to_def_id()) {
-                alias = Some(&cx.tcx.hir().expect_item(hir_id).kind);
-            }
-        }
-    };
-
-    if let Some(&hir::ItemKind::TyAlias(ref ty, ref generics)) = alias {
-        let provided_params = &path.segments.last().expect("segments were empty");
-        let mut ty_substs = FxHashMap::default();
-        let mut lt_substs = FxHashMap::default();
-        let mut ct_substs = FxHashMap::default();
-        let generic_args = provided_params.args();
-        {
-            let mut indices: hir::GenericParamCount = Default::default();
-            for param in generics.params.iter() {
-                match param.kind {
-                    hir::GenericParamKind::Lifetime { .. } => {
-                        let mut j = 0;
-                        let lifetime = generic_args.args.iter().find_map(|arg| match arg {
-                            hir::GenericArg::Lifetime(lt) => {
-                                if indices.lifetimes == j {
-                                    return Some(lt);
-                                }
-                                j += 1;
-                                None
-                            }
-                            _ => None,
-                        });
-                        if let Some(lt) = lifetime.cloned() {
-                            let lt_def_id = cx.tcx.hir().local_def_id(param.hir_id);
-                            let cleaned = if !lt.is_elided() {
-                                lt.clean(cx)
-                            } else {
-                                self::types::Lifetime::elided()
-                            };
-                            lt_substs.insert(lt_def_id.to_def_id(), cleaned);
-                        }
-                        indices.lifetimes += 1;
-                    }
-                    hir::GenericParamKind::Type { ref default, .. } => {
-                        let ty_param_def_id = cx.tcx.hir().local_def_id(param.hir_id);
-                        let mut j = 0;
-                        let type_ = generic_args.args.iter().find_map(|arg| match arg {
-                            hir::GenericArg::Type(ty) => {
-                                if indices.types == j {
-                                    return Some(ty);
-                                }
-                                j += 1;
-                                None
-                            }
-                            _ => None,
-                        });
-                        if let Some(ty) = type_ {
-                            ty_substs.insert(ty_param_def_id.to_def_id(), ty.clean(cx));
-                        } else if let Some(default) = *default {
-                            ty_substs.insert(ty_param_def_id.to_def_id(), default.clean(cx));
-                        }
-                        indices.types += 1;
-                    }
-                    hir::GenericParamKind::Const { .. } => {
-                        let const_param_def_id = cx.tcx.hir().local_def_id(param.hir_id);
-                        let mut j = 0;
-                        let const_ = generic_args.args.iter().find_map(|arg| match arg {
-                            hir::GenericArg::Const(ct) => {
-                                if indices.consts == j {
-                                    return Some(ct);
-                                }
-                                j += 1;
-                                None
-                            }
-                            _ => None,
-                        });
-                        if let Some(ct) = const_ {
-                            ct_substs.insert(const_param_def_id.to_def_id(), ct.clean(cx));
-                        }
-                        // FIXME(const_generics_defaults)
-                        indices.consts += 1;
-                    }
-                }
-            }
-        }
-        Some(cx.enter_alias(ty_substs, lt_substs, ct_substs, |cx| ty.clean(cx)))
+    let Res::Def(DefKind::TyAlias, def_id) = path.res else { return None };
+    // Substitute private type aliases
+    let Some(def_id) = def_id.as_local() else { return None };
+    let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id);
+    let alias = if !cx.cache.access_levels.is_exported(def_id.to_def_id()) {
+        &cx.tcx.hir().expect_item(hir_id).kind
     } else {
-        None
+        return None;
+    };
+    let hir::ItemKind::TyAlias(ty, generics) = alias else { return None };
+
+    let provided_params = &path.segments.last().expect("segments were empty");
+    let mut ty_substs = FxHashMap::default();
+    let mut lt_substs = FxHashMap::default();
+    let mut ct_substs = FxHashMap::default();
+    let generic_args = provided_params.args();
+
+    let mut indices: hir::GenericParamCount = Default::default();
+    for param in generics.params.iter() {
+        match param.kind {
+            hir::GenericParamKind::Lifetime { .. } => {
+                let mut j = 0;
+                let lifetime = generic_args.args.iter().find_map(|arg| match arg {
+                    hir::GenericArg::Lifetime(lt) => {
+                        if indices.lifetimes == j {
+                            return Some(lt);
+                        }
+                        j += 1;
+                        None
+                    }
+                    _ => None,
+                });
+                if let Some(lt) = lifetime.cloned() {
+                    let lt_def_id = cx.tcx.hir().local_def_id(param.hir_id);
+                    let cleaned = if !lt.is_elided() {
+                        lt.clean(cx)
+                    } else {
+                        self::types::Lifetime::elided()
+                    };
+                    lt_substs.insert(lt_def_id.to_def_id(), cleaned);
+                }
+                indices.lifetimes += 1;
+            }
+            hir::GenericParamKind::Type { ref default, .. } => {
+                let ty_param_def_id = cx.tcx.hir().local_def_id(param.hir_id);
+                let mut j = 0;
+                let type_ = generic_args.args.iter().find_map(|arg| match arg {
+                    hir::GenericArg::Type(ty) => {
+                        if indices.types == j {
+                            return Some(ty);
+                        }
+                        j += 1;
+                        None
+                    }
+                    _ => None,
+                });
+                if let Some(ty) = type_ {
+                    ty_substs.insert(ty_param_def_id.to_def_id(), ty.clean(cx));
+                } else if let Some(default) = *default {
+                    ty_substs.insert(ty_param_def_id.to_def_id(), default.clean(cx));
+                }
+                indices.types += 1;
+            }
+            hir::GenericParamKind::Const { .. } => {
+                let const_param_def_id = cx.tcx.hir().local_def_id(param.hir_id);
+                let mut j = 0;
+                let const_ = generic_args.args.iter().find_map(|arg| match arg {
+                    hir::GenericArg::Const(ct) => {
+                        if indices.consts == j {
+                            return Some(ct);
+                        }
+                        j += 1;
+                        None
+                    }
+                    _ => None,
+                });
+                if let Some(ct) = const_ {
+                    ct_substs.insert(const_param_def_id.to_def_id(), ct.clean(cx));
+                }
+                // FIXME(const_generics_defaults)
+                indices.consts += 1;
+            }
+        }
     }
+
+    Some(cx.enter_alias(ty_substs, lt_substs, ct_substs, |cx| ty.clean(cx)))
 }
 
 impl Clean<Type> for hir::Ty<'_> {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2247,3 +2247,32 @@ impl TypeBinding {
         }
     }
 }
+
+/// The type, lifetime, or constant that a private type alias's parameter should be
+/// replaced with when expanding a use of that type alias.
+///
+/// For example:
+///
+/// ```
+/// type PrivAlias<T> = Vec<T>;
+///
+/// pub fn public_fn() -> PrivAlias<i32> { vec![] }
+/// ```
+///
+/// `public_fn`'s docs will show it as returning `Vec<i32>`, since `PrivAlias` is private.
+/// [`SubstParam`] is used to record that `T` should be mapped to `i32`.
+crate enum SubstParam {
+    Type(Type),
+    Lifetime(Lifetime),
+    Constant(Constant),
+}
+
+impl SubstParam {
+    crate fn as_ty(&self) -> Option<&Type> {
+        if let Self::Type(ty) = self { Some(ty) } else { None }
+    }
+
+    crate fn as_lt(&self) -> Option<&Lifetime> {
+        if let Self::Lifetime(lt) = self { Some(lt) } else { None }
+    }
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -9,6 +9,7 @@
 #![feature(control_flow_enum)]
 #![feature(box_syntax)]
 #![feature(in_band_lifetimes)]
+#![feature(let_else)]
 #![feature(nll)]
 #![feature(test)]
 #![feature(crate_visibility_modifier)]


### PR DESCRIPTION
It should be impossible to have more than one entry with a particular
key across the three maps, so they should be one map. In addition to
making it impossible for multiple entries to exist, this should improve
memory usage since now only one map is allocated on the stack and heap.

r? @GuillaumeGomez
