### PR TITLE
Lint elided lifetimes in path during lifetime resolution.

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1786,7 +1786,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             GenericArg::Lifetime(hir::Lifetime {
                 hir_id: self.next_id(),
                 span: self.lower_span(span),
-                name: hir::LifetimeName::Implicit,
+                name: hir::LifetimeName::Implicit(false),
             })));
         let generic_args = self.arena.alloc_from_iter(generic_args);
 
@@ -1927,8 +1927,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     });
                 let param_name = match lt.name {
                     hir::LifetimeName::Param(param_name) => param_name,
-                    hir::LifetimeName::Implicit
-                    | hir::LifetimeName::ImplicitMissing
+                    hir::LifetimeName::Implicit(_)
                     | hir::LifetimeName::Underscore
                     | hir::LifetimeName::Static => hir::ParamName::Plain(lt.name.ident()),
                     hir::LifetimeName::ImplicitObjectLifetimeDefault => {
@@ -2291,7 +2290,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
             AnonymousLifetimeMode::ReportError => self.new_error_lifetime(None, span),
 
-            AnonymousLifetimeMode::PassThrough => self.new_implicit_lifetime(span),
+            AnonymousLifetimeMode::PassThrough => self.new_implicit_lifetime(span, false),
         }
     }
 
@@ -2344,12 +2343,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             // lifetime. Instead, we simply create an implicit lifetime, which will be checked
             // later, at which point a suitable error will be emitted.
             AnonymousLifetimeMode::PassThrough | AnonymousLifetimeMode::ReportError => {
-                if param_mode == ParamMode::Explicit {
-                    let id = self.resolver.next_node_id();
-                    self.new_named_lifetime(id, span, hir::LifetimeName::ImplicitMissing)
-                } else {
-                    self.new_implicit_lifetime(span)
-                }
+                self.new_implicit_lifetime(span, param_mode == ParamMode::Explicit)
             }
         }
     }
@@ -2392,11 +2386,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         r
     }
 
-    fn new_implicit_lifetime(&mut self, span: Span) -> hir::Lifetime {
+    fn new_implicit_lifetime(&mut self, span: Span, missing: bool) -> hir::Lifetime {
         hir::Lifetime {
             hir_id: self.next_id(),
             span: self.lower_span(span),
-            name: hir::LifetimeName::Implicit,
+            name: hir::LifetimeName::Implicit(missing),
         }
     }
 
@@ -2543,9 +2537,7 @@ fn lifetimes_from_impl_trait_bounds(
 
         fn visit_lifetime(&mut self, lifetime: &'v hir::Lifetime) {
             let name = match lifetime.name {
-                hir::LifetimeName::Implicit
-                | hir::LifetimeName::ImplicitMissing
-                | hir::LifetimeName::Underscore => {
+                hir::LifetimeName::Implicit(_) | hir::LifetimeName::Underscore => {
                     if self.collect_elided_lifetimes {
                         // Use `'_` for both implicit and underscore lifetimes in
                         // `type Foo<'_> = impl SomeTrait<'_>;`.

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -584,7 +584,9 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 Some(RegionNameHighlight::MatchedAdtAndSegment(lifetime_span))
             }
 
-            hir::LifetimeName::ImplicitObjectLifetimeDefault | hir::LifetimeName::Implicit => {
+            hir::LifetimeName::ImplicitObjectLifetimeDefault
+            | hir::LifetimeName::Implicit
+            | hir::LifetimeName::ImplicitMissing => {
                 // In this case, the user left off the lifetime; so
                 // they wrote something like:
                 //

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -584,9 +584,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 Some(RegionNameHighlight::MatchedAdtAndSegment(lifetime_span))
             }
 
-            hir::LifetimeName::ImplicitObjectLifetimeDefault
-            | hir::LifetimeName::Implicit
-            | hir::LifetimeName::ImplicitMissing => {
+            hir::LifetimeName::ImplicitObjectLifetimeDefault | hir::LifetimeName::Implicit(_) => {
                 // In this case, the user left off the lifetime; so
                 // they wrote something like:
                 //

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -92,10 +92,9 @@ pub enum LifetimeName {
     Param(ParamName),
 
     /// User wrote nothing (e.g., the lifetime in `&u32`).
-    Implicit,
-
-    /// User wrote nothing, but should have provided something.
-    ImplicitMissing,
+    ///
+    /// The bool indicates whether the user should have written something.
+    Implicit(bool),
 
     /// Implicit lifetime in a context like `dyn Foo`. This is
     /// distinguished from implicit lifetimes elsewhere because the
@@ -125,8 +124,7 @@ impl LifetimeName {
     pub fn ident(&self) -> Ident {
         match *self {
             LifetimeName::ImplicitObjectLifetimeDefault
-            | LifetimeName::Implicit
-            | LifetimeName::ImplicitMissing
+            | LifetimeName::Implicit(_)
             | LifetimeName::Error => Ident::empty(),
             LifetimeName::Underscore => Ident::with_dummy_span(kw::UnderscoreLifetime),
             LifetimeName::Static => Ident::with_dummy_span(kw::StaticLifetime),
@@ -137,8 +135,7 @@ impl LifetimeName {
     pub fn is_elided(&self) -> bool {
         match self {
             LifetimeName::ImplicitObjectLifetimeDefault
-            | LifetimeName::Implicit
-            | LifetimeName::ImplicitMissing
+            | LifetimeName::Implicit(_)
             | LifetimeName::Underscore => true,
 
             // It might seem surprising that `Fresh(_)` counts as
@@ -3303,7 +3300,7 @@ mod size_asserts {
     rustc_data_structures::static_assert_size!(super::Expr<'static>, 64);
     rustc_data_structures::static_assert_size!(super::Pat<'static>, 88);
     rustc_data_structures::static_assert_size!(super::QPath<'static>, 24);
-    rustc_data_structures::static_assert_size!(super::Ty<'static>, 72);
+    rustc_data_structures::static_assert_size!(super::Ty<'static>, 80);
 
     rustc_data_structures::static_assert_size!(super::Item<'static>, 184);
     rustc_data_structures::static_assert_size!(super::TraitItem<'static>, 128);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -94,6 +94,9 @@ pub enum LifetimeName {
     /// User wrote nothing (e.g., the lifetime in `&u32`).
     Implicit,
 
+    /// User wrote nothing, but should have provided something.
+    ImplicitMissing,
+
     /// Implicit lifetime in a context like `dyn Foo`. This is
     /// distinguished from implicit lifetimes elsewhere because the
     /// lifetime that they default to must appear elsewhere within the
@@ -123,6 +126,7 @@ impl LifetimeName {
         match *self {
             LifetimeName::ImplicitObjectLifetimeDefault
             | LifetimeName::Implicit
+            | LifetimeName::ImplicitMissing
             | LifetimeName::Error => Ident::empty(),
             LifetimeName::Underscore => Ident::with_dummy_span(kw::UnderscoreLifetime),
             LifetimeName::Static => Ident::with_dummy_span(kw::StaticLifetime),
@@ -134,6 +138,7 @@ impl LifetimeName {
         match self {
             LifetimeName::ImplicitObjectLifetimeDefault
             | LifetimeName::Implicit
+            | LifetimeName::ImplicitMissing
             | LifetimeName::Underscore => true,
 
             // It might seem surprising that `Fresh(_)` counts as

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -545,8 +545,7 @@ pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime
         | LifetimeName::Param(ParamName::Error)
         | LifetimeName::Static
         | LifetimeName::Error
-        | LifetimeName::Implicit
-        | LifetimeName::ImplicitMissing
+        | LifetimeName::Implicit(_)
         | LifetimeName::ImplicitObjectLifetimeDefault
         | LifetimeName::Underscore => {}
     }

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -546,6 +546,7 @@ pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime
         | LifetimeName::Static
         | LifetimeName::Error
         | LifetimeName::Implicit
+        | LifetimeName::ImplicitMissing
         | LifetimeName::ImplicitObjectLifetimeDefault
         | LifetimeName::Underscore => {}
     }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1871,6 +1871,85 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
         err.emit();
     }
 
+    /// Returns whether to add `'static` lifetime to the suggested lifetime list.
+    crate fn report_elision_failure(
+        &mut self,
+        db: &mut DiagnosticBuilder<'_>,
+        params: &[ElisionFailureInfo],
+    ) -> bool {
+        let mut m = String::new();
+        let len = params.len();
+
+        let elided_params: Vec<_> =
+            params.iter().cloned().filter(|info| info.lifetime_count > 0).collect();
+
+        let elided_len = elided_params.len();
+
+        for (i, info) in elided_params.into_iter().enumerate() {
+            let ElisionFailureInfo { parent, index, lifetime_count: n, have_bound_regions, span } =
+                info;
+
+            db.span_label(span, "");
+            let help_name = if let Some(ident) =
+                parent.and_then(|body| self.tcx.hir().body(body).params[index].pat.simple_ident())
+            {
+                format!("`{}`", ident)
+            } else {
+                format!("argument {}", index + 1)
+            };
+
+            m.push_str(
+                &(if n == 1 {
+                    help_name
+                } else {
+                    format!(
+                        "one of {}'s {} {}lifetimes",
+                        help_name,
+                        n,
+                        if have_bound_regions { "free " } else { "" }
+                    )
+                })[..],
+            );
+
+            if elided_len == 2 && i == 0 {
+                m.push_str(" or ");
+            } else if i + 2 == elided_len {
+                m.push_str(", or ");
+            } else if i != elided_len - 1 {
+                m.push_str(", ");
+            }
+        }
+
+        if len == 0 {
+            db.help(
+                "this function's return type contains a borrowed value, \
+                 but there is no value for it to be borrowed from",
+            );
+            true
+        } else if elided_len == 0 {
+            db.help(
+                "this function's return type contains a borrowed value with \
+                 an elided lifetime, but the lifetime cannot be derived from \
+                 the arguments",
+            );
+            true
+        } else if elided_len == 1 {
+            db.help(&format!(
+                "this function's return type contains a borrowed value, \
+                 but the signature does not say which {} it is borrowed from",
+                m
+            ));
+            false
+        } else {
+            db.help(&format!(
+                "this function's return type contains a borrowed value, \
+                 but the signature does not say whether it is borrowed from {}",
+                m
+            ));
+            false
+        }
+    }
+
     // FIXME(const_generics): This patches over an ICE caused by non-'static lifetimes in const
     // generics. We are disallowing this until we can decide on how we want to handle non-'static
     // lifetimes in const generics. See issue #74052 for discussion.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1952,7 +1952,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
 
     crate fn report_elided_lifetime_in_ty(&self, lifetime_refs: &[&hir::Lifetime]) {
         let Some(missing_lifetime) = lifetime_refs.iter().find(|lt| {
-            lt.name == hir::LifetimeName::ImplicitMissing
+            lt.name == hir::LifetimeName::Implicit(true)
         }) else { return };
 
         let mut spans: Vec<_> = lifetime_refs.iter().map(|lt| lt.span).collect();
@@ -2408,8 +2408,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
         );
         let is_allowed_lifetime = matches!(
             lifetime_ref.name,
-            hir::LifetimeName::Implicit
-                | hir::LifetimeName::ImplicitMissing
+            hir::LifetimeName::Implicit(_)
                 | hir::LifetimeName::Static
                 | hir::LifetimeName::Underscore
         );

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -923,7 +923,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                     }
                 });
                 match lifetime.name {
-                    LifetimeName::Implicit | hir::LifetimeName::ImplicitMissing => {
+                    LifetimeName::Implicit(_) => {
                         // For types like `dyn Foo`, we should
                         // generate a special form of elided.
                         span_bug!(ty.span, "object-lifetime-default expected, not implicit",);
@@ -3282,9 +3282,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                                 ))
                                 .emit();
                         }
-                        hir::LifetimeName::Param(_)
-                        | hir::LifetimeName::Implicit
-                        | hir::LifetimeName::ImplicitMissing => {
+                        hir::LifetimeName::Param(_) | hir::LifetimeName::Implicit(_) => {
                             self.resolve_lifetime_ref(lt);
                         }
                         hir::LifetimeName::ImplicitObjectLifetimeDefault => {

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -5,23 +5,24 @@
 #![deny(elided_lifetimes_in_paths)]
 //~^ NOTE the lint level is defined here
 
-use std::cell::{RefCell, Ref};
+use std::cell::{Ref, RefCell};
 
-
-struct Foo<'a> { x: &'a u32 }
+struct Foo<'a> {
+    x: &'a u32,
+}
 
 fn foo(x: &Foo<'_>) {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
 }
 
 fn bar(x: &Foo<'_>) {}
 
-
 struct Wrapped<'a>(&'a str);
 
 struct WrappedWithBow<'a> {
-    gift: &'a str
+    gift: &'a str,
 }
 
 struct MatchedSet<'a, 'b> {
@@ -31,19 +32,22 @@ struct MatchedSet<'a, 'b> {
 
 fn wrap_gift(gift: &str) -> Wrapped<'_> {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     Wrapped(gift)
 }
 
 fn wrap_gift_with_bow(gift: &str) -> WrappedWithBow<'_> {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     WrappedWithBow { gift }
 }
 
 fn inspect_matched_set(set: MatchedSet<'_, '_>) {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected 2 lifetime parameters
+    //~| HELP consider using the `'_` lifetime
     println!("{} {}", set.one, set.another);
 }
 
@@ -55,7 +59,8 @@ macro_rules! autowrapper {
 
         fn $fn_name(gift: &str) -> $type_name<'_> {
             //~^ ERROR hidden lifetime parameters in types are deprecated
-            //~| HELP indicate the anonymous lifetime
+            //~| NOTE expected named lifetime parameter
+            //~| HELP consider using the `'_` lifetime
             $type_name { gift }
         }
     }
@@ -69,7 +74,8 @@ macro_rules! anytuple_ref_ty {
     ($($types:ty),*) => {
         Ref<'_, ($($types),*)>
         //~^ ERROR hidden lifetime parameters in types are deprecated
-        //~| HELP indicate the anonymous lifetime
+        //~| NOTE expected named lifetime parameter
+        //~| HELP consider using the `'_` lifetime
     }
 }
 
@@ -77,7 +83,8 @@ fn main() {
     let honesty = RefCell::new((4, 'e'));
     let loyalty: Ref<'_, (u32, char)> = honesty.borrow();
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     let generosity = Ref::map(loyalty, |t| &t.0);
 
     let laughter = RefCell::new((true, "magic"));

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -96,6 +96,14 @@ macro_rules! anytuple_ref_ty {
     }
 }
 
+#[allow(elided_lifetimes_in_paths)]
+mod blah {
+    struct Thing<'a>(&'a i32);
+    struct Bar<T>(T);
+
+    fn foo(b: Bar<Thing>) {}
+}
+
 fn main() {
     let honesty = RefCell::new((4, 'e'));
     let loyalty: Ref<'_, (u32, char)> = honesty.borrow();

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.fixed
@@ -51,6 +51,15 @@ fn inspect_matched_set(set: MatchedSet<'_, '_>) {
     println!("{} {}", set.one, set.another);
 }
 
+// Verify that the lint does not fire, because the added `'_` wouldn't be resolved correctly.
+fn match_sets() -> MatchedSet<'static, 'static> {
+    //~^ ERROR missing lifetime specifiers
+    //~| NOTE expected 2 lifetime parameters
+    //~| HELP this function's return type contains a borrowed value
+    //~| HELP consider using the `'static` lifetime
+    MatchedSet { one: "one", another: "another" }
+}
+
 macro_rules! autowrapper {
     ($type_name:ident, $fn_name:ident, $lt:lifetime) => {
         struct $type_name<$lt> {
@@ -61,12 +70,20 @@ macro_rules! autowrapper {
             //~^ ERROR hidden lifetime parameters in types are deprecated
             //~| NOTE expected named lifetime parameter
             //~| HELP consider using the `'_` lifetime
+            //~| ERROR hidden lifetime parameters in types are deprecated
+            //~| NOTE expected named lifetime parameter
+            //~| HELP consider using the `'_` lifetime
             $type_name { gift }
         }
     }
 }
 
 autowrapper!(Autowrapped, autowrap_gift, 'a);
+//~^ NOTE in this expansion of autowrapper!
+//~| NOTE in this expansion of autowrapper!
+
+// Verify that rustfix does not try to apply the fix twice.
+autowrapper!(AutowrappedAgain, autowrap_gift_again, 'a);
 //~^ NOTE in this expansion of autowrapper!
 //~| NOTE in this expansion of autowrapper!
 

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -5,23 +5,24 @@
 #![deny(elided_lifetimes_in_paths)]
 //~^ NOTE the lint level is defined here
 
-use std::cell::{RefCell, Ref};
+use std::cell::{Ref, RefCell};
 
-
-struct Foo<'a> { x: &'a u32 }
+struct Foo<'a> {
+    x: &'a u32,
+}
 
 fn foo(x: &Foo) {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
 }
 
 fn bar(x: &Foo<'_>) {}
 
-
 struct Wrapped<'a>(&'a str);
 
 struct WrappedWithBow<'a> {
-    gift: &'a str
+    gift: &'a str,
 }
 
 struct MatchedSet<'a, 'b> {
@@ -31,19 +32,22 @@ struct MatchedSet<'a, 'b> {
 
 fn wrap_gift(gift: &str) -> Wrapped {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     Wrapped(gift)
 }
 
 fn wrap_gift_with_bow(gift: &str) -> WrappedWithBow {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     WrappedWithBow { gift }
 }
 
 fn inspect_matched_set(set: MatchedSet) {
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected 2 lifetime parameters
+    //~| HELP consider using the `'_` lifetime
     println!("{} {}", set.one, set.another);
 }
 
@@ -55,7 +59,8 @@ macro_rules! autowrapper {
 
         fn $fn_name(gift: &str) -> $type_name {
             //~^ ERROR hidden lifetime parameters in types are deprecated
-            //~| HELP indicate the anonymous lifetime
+            //~| NOTE expected named lifetime parameter
+            //~| HELP consider using the `'_` lifetime
             $type_name { gift }
         }
     }
@@ -69,7 +74,8 @@ macro_rules! anytuple_ref_ty {
     ($($types:ty),*) => {
         Ref<($($types),*)>
         //~^ ERROR hidden lifetime parameters in types are deprecated
-        //~| HELP indicate the anonymous lifetime
+        //~| NOTE expected named lifetime parameter
+        //~| HELP consider using the `'_` lifetime
     }
 }
 
@@ -77,7 +83,8 @@ fn main() {
     let honesty = RefCell::new((4, 'e'));
     let loyalty: Ref<(u32, char)> = honesty.borrow();
     //~^ ERROR hidden lifetime parameters in types are deprecated
-    //~| HELP indicate the anonymous lifetime
+    //~| NOTE expected named lifetime parameter
+    //~| HELP consider using the `'_` lifetime
     let generosity = Ref::map(loyalty, |t| &t.0);
 
     let laughter = RefCell::new((true, "magic"));

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -96,6 +96,14 @@ macro_rules! anytuple_ref_ty {
     }
 }
 
+#[allow(elided_lifetimes_in_paths)]
+mod blah {
+    struct Thing<'a>(&'a i32);
+    struct Bar<T>(T);
+
+    fn foo(b: Bar<Thing>) {}
+}
+
 fn main() {
     let honesty = RefCell::new((4, 'e'));
     let loyalty: Ref<(u32, char)> = honesty.borrow();

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.rs
@@ -51,6 +51,15 @@ fn inspect_matched_set(set: MatchedSet) {
     println!("{} {}", set.one, set.another);
 }
 
+// Verify that the lint does not fire, because the added `'_` wouldn't be resolved correctly.
+fn match_sets() -> MatchedSet {
+    //~^ ERROR missing lifetime specifiers
+    //~| NOTE expected 2 lifetime parameters
+    //~| HELP this function's return type contains a borrowed value
+    //~| HELP consider using the `'static` lifetime
+    MatchedSet { one: "one", another: "another" }
+}
+
 macro_rules! autowrapper {
     ($type_name:ident, $fn_name:ident, $lt:lifetime) => {
         struct $type_name<$lt> {
@@ -61,12 +70,20 @@ macro_rules! autowrapper {
             //~^ ERROR hidden lifetime parameters in types are deprecated
             //~| NOTE expected named lifetime parameter
             //~| HELP consider using the `'_` lifetime
+            //~| ERROR hidden lifetime parameters in types are deprecated
+            //~| NOTE expected named lifetime parameter
+            //~| HELP consider using the `'_` lifetime
             $type_name { gift }
         }
     }
 }
 
 autowrapper!(Autowrapped, autowrap_gift, 'a);
+//~^ NOTE in this expansion of autowrapper!
+//~| NOTE in this expansion of autowrapper!
+
+// Verify that rustfix does not try to apply the fix twice.
+autowrapper!(AutowrappedAgain, autowrap_gift_again, 'a);
 //~^ NOTE in this expansion of autowrapper!
 //~| NOTE in this expansion of autowrapper!
 

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -1,60 +1,92 @@
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:13:12
+  --> $DIR/elided-lifetimes.rs:14:12
    |
 LL | fn foo(x: &Foo) {
-   |            ^^^- help: indicate the anonymous lifetime: `<'_>`
+   |            ^^^ expected named lifetime parameter
    |
 note: the lint level is defined here
   --> $DIR/elided-lifetimes.rs:5:9
    |
 LL | #![deny(elided_lifetimes_in_paths)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider using the `'_` lifetime
+   |
+LL | fn foo(x: &Foo<'_>) {
+   |            ~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:32:29
+  --> $DIR/elided-lifetimes.rs:33:29
    |
 LL | fn wrap_gift(gift: &str) -> Wrapped {
-   |                             ^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
+   |                             ^^^^^^^ expected named lifetime parameter
+   |
+help: consider using the `'_` lifetime
+   |
+LL | fn wrap_gift(gift: &str) -> Wrapped<'_> {
+   |                             ~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:38:38
+  --> $DIR/elided-lifetimes.rs:40:38
    |
 LL | fn wrap_gift_with_bow(gift: &str) -> WrappedWithBow {
-   |                                      ^^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
+   |                                      ^^^^^^^^^^^^^^ expected named lifetime parameter
+   |
+help: consider using the `'_` lifetime
+   |
+LL | fn wrap_gift_with_bow(gift: &str) -> WrappedWithBow<'_> {
+   |                                      ~~~~~~~~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:44:29
+  --> $DIR/elided-lifetimes.rs:47:29
    |
 LL | fn inspect_matched_set(set: MatchedSet) {
-   |                             ^^^^^^^^^^- help: indicate the anonymous lifetimes: `<'_, '_>`
+   |                             ^^^^^^^^^^ expected 2 lifetime parameters
+   |
+help: consider using the `'_` lifetime
+   |
+LL | fn inspect_matched_set(set: MatchedSet<'_, '_>) {
+   |                             ~~~~~~~~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:56:36
+  --> $DIR/elided-lifetimes.rs:60:36
    |
 LL |         fn $fn_name(gift: &str) -> $type_name {
-   |                                    ^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
+   |                                    ^^^^^^^^^^ expected named lifetime parameter
 ...
 LL | autowrapper!(Autowrapped, autowrap_gift, 'a);
    | -------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `autowrapper` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using the `'_` lifetime
+   |
+LL |         fn $fn_name(gift: &str) -> $type_name<'_> {
+   |                                    ~~~~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:78:18
+  --> $DIR/elided-lifetimes.rs:84:22
    |
 LL |     let loyalty: Ref<(u32, char)> = honesty.borrow();
-   |                  ^^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `Ref<'_, (u32, char)>`
+   |                      ^ expected named lifetime parameter
+   |
+help: consider using the `'_` lifetime
+   |
+LL |     let loyalty: Ref<'_, (u32, char)> = honesty.borrow();
+   |                      +++
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:70:9
+  --> $DIR/elided-lifetimes.rs:75:13
    |
 LL |         Ref<($($types),*)>
-   |         ^^^^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `Ref<'_, ($($types),*)>`
+   |             ^ expected named lifetime parameter
 ...
 LL |     let yellow: anytuple_ref_ty!(bool, &str) = laughter.borrow();
    |                 ---------------------------- in this macro invocation
    |
    = note: this error originates in the macro `anytuple_ref_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using the `'_` lifetime
+   |
+LL |         Ref<'_, ($($types),*)>
+   |             +++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -90,7 +90,7 @@ LL |         fn $fn_name(gift: &str) -> $type_name<'_> {
    |                                    ~~~~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:101:22
+  --> $DIR/elided-lifetimes.rs:109:22
    |
 LL |     let loyalty: Ref<(u32, char)> = honesty.borrow();
    |                      ^ expected named lifetime parameter

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -47,8 +47,20 @@ help: consider using the `'_` lifetime
 LL | fn inspect_matched_set(set: MatchedSet<'_, '_>) {
    |                             ~~~~~~~~~~~~~~~~~~
 
+error[E0106]: missing lifetime specifiers
+  --> $DIR/elided-lifetimes.rs:55:20
+   |
+LL | fn match_sets() -> MatchedSet {
+   |                    ^^^^^^^^^^ expected 2 lifetime parameters
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime
+   |
+LL | fn match_sets() -> MatchedSet<'static, 'static> {
+   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:60:36
+  --> $DIR/elided-lifetimes.rs:69:36
    |
 LL |         fn $fn_name(gift: &str) -> $type_name {
    |                                    ^^^^^^^^^^ expected named lifetime parameter
@@ -63,7 +75,22 @@ LL |         fn $fn_name(gift: &str) -> $type_name<'_> {
    |                                    ~~~~~~~~~~~~~~
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:84:22
+  --> $DIR/elided-lifetimes.rs:69:36
+   |
+LL |         fn $fn_name(gift: &str) -> $type_name {
+   |                                    ^^^^^^^^^^ expected named lifetime parameter
+...
+LL | autowrapper!(AutowrappedAgain, autowrap_gift_again, 'a);
+   | ------------------------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `autowrapper` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using the `'_` lifetime
+   |
+LL |         fn $fn_name(gift: &str) -> $type_name<'_> {
+   |                                    ~~~~~~~~~~~~~~
+
+error: hidden lifetime parameters in types are deprecated
+  --> $DIR/elided-lifetimes.rs:101:22
    |
 LL |     let loyalty: Ref<(u32, char)> = honesty.borrow();
    |                      ^ expected named lifetime parameter
@@ -74,7 +101,7 @@ LL |     let loyalty: Ref<'_, (u32, char)> = honesty.borrow();
    |                      +++
 
 error: hidden lifetime parameters in types are deprecated
-  --> $DIR/elided-lifetimes.rs:75:13
+  --> $DIR/elided-lifetimes.rs:92:13
    |
 LL |         Ref<($($types),*)>
    |             ^ expected named lifetime parameter
@@ -88,5 +115,6 @@ help: consider using the `'_` lifetime
 LL |         Ref<'_, ($($types),*)>
    |             +++
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/lint/force-warn/allowed-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-by-default-lint.stderr
@@ -2,9 +2,13 @@ warning: hidden lifetime parameters in types are deprecated
   --> $DIR/allowed-by-default-lint.rs:9:12
    |
 LL | fn foo(x: &Foo) {}
-   |            ^^^- help: indicate the anonymous lifetime: `<'_>`
+   |            ^^^ expected named lifetime parameter
    |
    = note: requested on the command line with `--force-warn elided-lifetimes-in-paths`
+help: consider using the `'_` lifetime
+   |
+LL | fn foo(x: &Foo<'_>) {}
+   |            ~~~~~~~
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/reasons.rs
+++ b/src/test/ui/lint/reasons.rs
@@ -1,7 +1,6 @@
 // check-pass
 
 #![feature(lint_reasons)]
-
 #![warn(elided_lifetimes_in_paths,
         //~^ NOTE the lint level is defined here
         reason = "explicit anonymous lifetimes aid reasoning about ownership")]
@@ -20,8 +19,9 @@ pub struct CheaterDetectionMechanism {}
 impl fmt::Debug for CheaterDetectionMechanism {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         //~^ WARN hidden lifetime parameters in types are deprecated
+        //~| NOTE expected named lifetime parameter
         //~| NOTE explicit anonymous lifetimes aid
-        //~| HELP indicate the anonymous lifetime
+        //~| HELP consider using the `'_` lifetime
         fmt.debug_struct("CheaterDetectionMechanism").finish()
     }
 }

--- a/src/test/ui/lint/reasons.stderr
+++ b/src/test/ui/lint/reasons.stderr
@@ -1,15 +1,19 @@
 warning: hidden lifetime parameters in types are deprecated
-  --> $DIR/reasons.rs:21:29
+  --> $DIR/reasons.rs:20:29
    |
 LL |     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-   |                             ^^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
+   |                             ^^^^^^^^^^^^^^ expected named lifetime parameter
    |
    = note: explicit anonymous lifetimes aid reasoning about ownership
 note: the lint level is defined here
-  --> $DIR/reasons.rs:5:9
+  --> $DIR/reasons.rs:4:9
    |
 LL | #![warn(elided_lifetimes_in_paths,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider using the `'_` lifetime
+   |
+LL |     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+   |                             ~~~~~~~~~~~~~~~~~~
 
 warning: variable `Social_exchange_psychology` should have a snake case name
   --> $DIR/reasons.rs:30:9
@@ -20,7 +24,7 @@ LL |     let Social_exchange_psychology = CheaterDetectionMechanism {};
    = note: people shouldn't have to change their usual style habits
            to contribute to our project
 note: the lint level is defined here
-  --> $DIR/reasons.rs:9:5
+  --> $DIR/reasons.rs:8:5
    |
 LL |     nonstandard_style,
    |     ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The lifetime elision lint is known to be brittle and can be redundant with later lifetime resolution errors. This PR aims to remove the redundancy by performing the lint after lifetime resolution.

This PR proposes to carry the information that an elision should be linted against by using a special `LifetimeName`. I am not certain this is the best solution, but it is certainly the easiest.

Fixes https://github.com/rust-lang/rust/issues/60199
Fixes https://github.com/rust-lang/rust/issues/55768
Fixes https://github.com/rust-lang/rust/issues/63110
Fixes https://github.com/rust-lang/rust/issues/71957