### PR TITLE
rustdoc: Remove `Crate.primitives`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -118,7 +118,6 @@ impl From<DefId> for ItemId {
 crate struct Crate {
     crate module: Item,
     crate externs: Vec<ExternalCrate>,
-    crate primitives: ThinVec<(DefId, PrimitiveType)>,
     /// Only here so that they can be filtered through the rustdoc passes.
     crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
     crate collapsed: bool,
@@ -126,7 +125,7 @@ crate struct Crate {
 
 // `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Crate, 104);
+rustc_data_structures::static_assert_size!(Crate, 96);
 
 impl Crate {
     crate fn name(&self, tcx: TyCtxt<'_>) -> Symbol {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -76,13 +76,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
         }));
     }
 
-    Crate {
-        module,
-        externs,
-        primitives,
-        external_traits: cx.external_traits.clone(),
-        collapsed: false,
-    }
+    Crate { module, externs, external_traits: cx.external_traits.clone(), collapsed: false }
 }
 
 fn external_generic_args(


### PR DESCRIPTION
This involves no longer filtering out impls on primitive types that
aren't defined with `#[doc(primitive)]` somewhere in the dependency
graph. But, I don't think that filtering is necessary or really has any
effect.
