### PR TITLE
Use apple-a14 as target CPU for aarch64-apple-darwin

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
@@ -2,7 +2,7 @@ use crate::spec::{FramePointer, LinkerFlavor, SanitizerSet, Target, TargetOption
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts("macos");
-    base.cpu = "apple-a12".to_string();
+    base.cpu = "apple-a14".to_string();
     base.max_atomic_width = Some(128);
 
     // FIXME: The leak sanitizer currently fails the tests, see #88132.


### PR DESCRIPTION
After updating the minimum required LLVM version to 12 (#90175) we can use `apple-a14` as target CPU, because that CPU is similar in features to the Apple M1 (see [LLVM 13 source](https://github.com/llvm/llvm-project/blob/b8016b626ec7095c7d57ebfffb2135dc5c3077b8/llvm/lib/Target/AArch64/AArch64.td#L1127)). Once the minimum required LLVM version is updated to 13 we can use `apple-m1` here.