### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
@@ -2,7 +2,7 @@ use crate::spec::{FramePointer, LinkerFlavor, SanitizerSet, Target, TargetOption
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts("macos");
-    base.cpu = "apple-a12".to_string();
+    base.cpu = "apple-a14".to_string();
     base.max_atomic_width = Some(128);
 
     // FIXME: The leak sanitizer currently fails the tests, see #88132.

--- a/library/std/src/sys/windows/thread_local_dtor.rs
+++ b/library/std/src/sys/windows/thread_local_dtor.rs
@@ -1,4 +1,39 @@
+//! Implements thread-local destructors that are not associated with any
+//! particular data.
+
 #![unstable(feature = "thread_local_internals", issue = "none")]
 #![cfg(target_thread_local)]
+use super::c;
 
-pub use crate::sys_common::thread_local_dtor::register_dtor_fallback as register_dtor;
+// Using a per-thread list avoids the problems in synchronizing global state.
+#[thread_local]
+static mut DESTRUCTORS: Vec<(*mut u8, unsafe extern "C" fn(*mut u8))> = Vec::new();
+
+pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
+    DESTRUCTORS.push((t, dtor));
+}
+
+// See windows/thread_local_keys.rs for an explanation of this callback function.
+// The short version is that all the function pointers in the `.CRT$XL*` array
+// will be called whenever a thread or process starts or ends.
+
+#[link_section = ".CRT$XLD"]
+#[doc(hidden)]
+#[used]
+pub static TLS_CALLBACK: unsafe extern "system" fn(c::LPVOID, c::DWORD, c::LPVOID) = tls_callback;
+
+unsafe extern "system" fn tls_callback(_: c::LPVOID, reason: c::DWORD, _: c::LPVOID) {
+    if reason == c::DLL_THREAD_DETACH || reason == c::DLL_PROCESS_DETACH {
+        // Drop all the destructors.
+        //
+        // Note: While this is potentially an infinite loop, it *should* be
+        // the case that this loop always terminates because we provide the
+        // guarantee that a TLS key cannot be set after it is flagged for
+        // destruction.
+        while let Some((ptr, dtor)) = DESTRUCTORS.pop() {
+            (dtor)(ptr);
+        }
+        // We're done so free the memory.
+        DESTRUCTORS.shrink_to_fit();
+    }
+}

--- a/library/std/src/sys/windows/thread_local_dtor.rs
+++ b/library/std/src/sys/windows/thread_local_dtor.rs
@@ -3,7 +3,6 @@
 
 #![unstable(feature = "thread_local_internals", issue = "none")]
 #![cfg(target_thread_local)]
-use super::c;
 
 // Using a per-thread list avoids the problems in synchronizing global state.
 #[thread_local]
@@ -13,27 +12,17 @@ pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     DESTRUCTORS.push((t, dtor));
 }
 
-// See windows/thread_local_keys.rs for an explanation of this callback function.
-// The short version is that all the function pointers in the `.CRT$XL*` array
-// will be called whenever a thread or process starts or ends.
-
-#[link_section = ".CRT$XLD"]
-#[doc(hidden)]
-#[used]
-pub static TLS_CALLBACK: unsafe extern "system" fn(c::LPVOID, c::DWORD, c::LPVOID) = tls_callback;
-
-unsafe extern "system" fn tls_callback(_: c::LPVOID, reason: c::DWORD, _: c::LPVOID) {
-    if reason == c::DLL_THREAD_DETACH || reason == c::DLL_PROCESS_DETACH {
-        // Drop all the destructors.
-        //
-        // Note: While this is potentially an infinite loop, it *should* be
-        // the case that this loop always terminates because we provide the
-        // guarantee that a TLS key cannot be set after it is flagged for
-        // destruction.
-        while let Some((ptr, dtor)) = DESTRUCTORS.pop() {
-            (dtor)(ptr);
-        }
-        // We're done so free the memory.
-        DESTRUCTORS.shrink_to_fit();
+/// Runs destructors. This should not be called until thread exit.
+pub unsafe fn run_keyless_dtors() {
+    // Drop all the destructors.
+    //
+    // Note: While this is potentially an infinite loop, it *should* be
+    // the case that this loop always terminates because we provide the
+    // guarantee that a TLS key cannot be set after it is flagged for
+    // destruction.
+    while let Some((ptr, dtor)) = DESTRUCTORS.pop() {
+        (dtor)(ptr);
     }
+    // We're done so free the memory.
+    DESTRUCTORS = Vec::new();
 }

--- a/library/std/src/sys/windows/thread_local_key.rs
+++ b/library/std/src/sys/windows/thread_local_key.rs
@@ -196,6 +196,8 @@ pub static p_thread_callback: unsafe extern "system" fn(c::LPVOID, c::DWORD, c::
 unsafe extern "system" fn on_tls_callback(h: c::LPVOID, dwReason: c::DWORD, pv: c::LPVOID) {
     if dwReason == c::DLL_THREAD_DETACH || dwReason == c::DLL_PROCESS_DETACH {
         run_dtors();
+        #[cfg(target_thread_local)]
+        super::thread_local_dtor::run_keyless_dtors();
     }
 
     // See comments above for what this is doing. Note that we don't need this

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -482,6 +482,7 @@ impl<'a> Builder<'a> {
                 doc::RustByExample,
                 doc::RustcBook,
                 doc::CargoBook,
+                doc::Clippy,
                 doc::EmbeddedBook,
                 doc::EditionGuide,
             ),

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -755,6 +755,7 @@ tool_doc!(
     "src/tools/rustfmt",
     ["rustfmt-nightly", "rustfmt-config_proc_macro"],
 );
+tool_doc!(Clippy, "clippy", "src/tools/clippy", ["clippy_utils"]);
 
 #[derive(Ord, PartialOrd, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -257,7 +257,7 @@ unsafe {
 }
 
 println!(
-    "L1 Cache: {}",
+    "L0 Cache: {}",
     ((ebx >> 22) + 1) * (((ebx >> 12) & 0x3ff) + 1) * ((ebx & 0xfff) + 1) * (ecx + 1)
 );
 ```


### PR DESCRIPTION
Successful merges:

 - #90084 (Make printed message match the code comment)
 - #90354 (Document clippy on nightly-rustc)
 - #90442 (Windows thread-local keyless drop)
 - #90478 (Use apple-a14 as target CPU for aarch64-apple-darwin)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90084,90354,90442,90478)
<!-- homu-ignore:end -->