### PR TITLE
Update Clippy dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 name = "clippy"
 version = "0.1.58"
 dependencies = [
- "cargo_metadata 0.12.0",
+ "cargo_metadata 0.14.0",
  "clippy_lints",
  "clippy_utils",
  "compiletest_rs",
@@ -588,7 +588,7 @@ dependencies = [
  "regex",
  "rustc-workspace-hack",
  "rustc_tools_util 0.2.0",
- "semver 0.11.0",
+ "semver 1.0.3",
  "serde",
  "syn",
  "tempfile",
@@ -613,7 +613,7 @@ dependencies = [
 name = "clippy_lints"
 version = "0.1.58"
 dependencies = [
- "cargo_metadata 0.12.0",
+ "cargo_metadata 0.14.0",
  "clippy_utils",
  "if_chain",
  "itertools 0.10.1",
@@ -621,7 +621,7 @@ dependencies = [
  "quine-mc_cluskey",
  "regex-syntax",
  "rustc-semver",
- "semver 0.11.0",
+ "semver 1.0.3",
  "serde",
  "serde_json",
  "toml",

--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -22,12 +22,12 @@ path = "src/driver.rs"
 
 [dependencies]
 clippy_lints = { version = "0.1", path = "clippy_lints" }
-semver = "0.11"
+semver = "1.0"
 rustc_tools_util = { version = "0.2", path = "rustc_tools_util" }
 tempfile = { version = "3.2", optional = true }
 
 [dev-dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.14"
 compiletest_rs = { version = "0.7", features = ["tmp"] }
 tester = "0.9"
 regex = "1.5"

--- a/src/tools/clippy/clippy_lints/Cargo.toml
+++ b/src/tools/clippy/clippy_lints/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2021"
 
 [dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.14"
 clippy_utils = { path = "../clippy_utils" }
 if_chain = "1.0"
 itertools = "0.10"
@@ -21,7 +21,7 @@ serde_json = { version = "1.0", optional = true }
 toml = "0.5"
 unicode-normalization = "0.1"
 unicode-script = { version = "0.5", default-features = false }
-semver = "0.11"
+semver = "1.0"
 rustc-semver = "1.1"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>


### PR DESCRIPTION
Clippy has two outdated dependencies, where one indirect dependency has been flagged by rustsec for dropping a lifetime. See [RUSTSEC-2020-0146](https://rustsec.org/advisories/RUSTSEC-2020-0146). This PR updates these dependencies.

With previous dependency updates, it was tried to prevent duplicates in the `Cargo.lock` file of rust-lang/rust. I've tried to keep this in mind with this update.

* Dependency `semver`
    * Used in `src/tools/cargo/Cargo.toml` as version `1.0.3`
    * Used in `src/tools/rust-analyzer/crates/project_model/Cargo.toml` as version `1`
    * Updated in Clippy from `0.11` to `1.0` (Clippy usually defines the major and minor patch version). The `Cargo.lock` file lists `1.0.3` which is one patch version behind the most recent one but prevents a duplicate with cargo's pinned version. 
* Dependency `cargo_metadata`
    * Used in several tools as `0.14`
    * Used in `src/tools/tidy` and `src/tools/rls` as `0.12`
    * Updated in Clippy from `0.12` to `0.14`

All updates to the `Cargo.lock` have been done automatically by `x.py`.

There are still some tools with these outdated dependencies. Clippy didn't require any changes, and it would be likely that the others could also be updated without any problem. Let me know if I should try to update them as well :upside_down_face:.

Keep up the good work, whoever is reading this :crab: 

---

For Clippy:

changelog: none
