### PR TITLE
Split doc_cfg and doc_auto_cfg features

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -688,6 +688,9 @@ declare_features! (
     /// not changed from prior instances of the same struct (RFC #2528)
     (incomplete, type_changing_struct_update, "1.58.0", Some(86555), None),
 
+    /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.
+    (active, doc_auto_cfg, "1.58.0", Some(43781), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -549,6 +549,7 @@ symbols! {
         div_assign,
         doc,
         doc_alias,
+        doc_auto_cfg,
         doc_cfg,
         doc_cfg_hide,
         doc_keyword,

--- a/src/test/rustdoc/doc-auto-cfg.rs
+++ b/src/test/rustdoc/doc-auto-cfg.rs
@@ -1,0 +1,8 @@
+#![feature(doc_auto_cfg)]
+
+#![crate_name = "foo"]
+
+// @has foo/fn.foo.html
+// @has - '//*[@class="item-info"]/*[@class="stab portability"]' 'non-test'
+#[cfg(not(test))]
+pub fn foo() {}

--- a/src/test/rustdoc/doc-cfg-hide.rs
+++ b/src/test/rustdoc/doc-cfg-hide.rs
@@ -1,5 +1,5 @@
 #![crate_name = "oud"]
-#![feature(doc_cfg, doc_cfg_hide)]
+#![feature(doc_auto_cfg, doc_cfg, doc_cfg_hide)]
 
 #![doc(cfg_hide(feature = "solecism"))]
 

--- a/src/test/rustdoc/doc-cfg-implicit.rs
+++ b/src/test/rustdoc/doc-cfg-implicit.rs
@@ -1,5 +1,5 @@
 #![crate_name = "funambulism"]
-#![feature(doc_cfg)]
+#![feature(doc_auto_cfg, doc_cfg)]
 
 // @has 'funambulism/struct.Disorbed.html'
 // @count   - '//*[@class="stab portability"]' 1

--- a/src/test/rustdoc/feature-gate-doc_auto_cfg.rs
+++ b/src/test/rustdoc/feature-gate-doc_auto_cfg.rs
@@ -1,0 +1,8 @@
+#![feature(doc_cfg)]
+
+#![crate_name = "foo"]
+
+// @has foo/fn.foo.html
+// @count - '//*[@class="item-info"]/*[@class="stab portability"]' 0
+#[cfg(not(test))]
+pub fn foo() {}

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -97,6 +97,7 @@ pub fn check(
             &src_path.join("test/ui"),
             &src_path.join("test/ui-fulldeps"),
             &src_path.join("test/rustdoc-ui"),
+            &src_path.join("test/rustdoc"),
         ],
         &mut |path| super::filter_dirs(path),
         &mut |entry, contents| {


### PR DESCRIPTION
Part of #90497.

With this feature, `doc_cfg` won't pick up items automatically anymore.

cc @Mark-Simulacrum 
r? @jyn514 