### PR TITLE
Suggest `extern crate alloc` when using undeclared module `alloc`

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -420,6 +420,10 @@ impl<'a> Resolver<'a> {
                 err.span_label(span, label);
 
                 if let Some((suggestions, msg, applicability)) = suggestion {
+                    if suggestions.is_empty() {
+                        err.help(&msg);
+                        return err;
+                    }
                     err.multipart_suggestion(&msg, suggestions, applicability);
                 }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2527,7 +2527,7 @@ impl<'a> Resolver<'a> {
                                     Some((
                                         vec![],
                                         String::from(
-                                            "add `extern crate alloc` to use the builtin `alloc` module",
+                                            "add `extern crate alloc` to use the `alloc` crate",
                                         ),
                                         Applicability::MaybeIncorrect,
                                     ))

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2523,19 +2523,29 @@ impl<'a> Resolver<'a> {
                         } else {
                             (
                                 format!("use of undeclared crate or module `{}`", ident),
-                                self.find_similarly_named_module_or_crate(
-                                    ident.name,
-                                    &parent_scope.module,
-                                )
-                                .map(|sugg| {
-                                    (
-                                        vec![(ident.span, sugg.to_string())],
+                                if ident.name == sym::alloc {
+                                    Some((
+                                        vec![],
                                         String::from(
-                                            "there is a crate or module with a similar name",
+                                            "add `extern crate alloc` to use the builtin `alloc` module",
                                         ),
                                         Applicability::MaybeIncorrect,
+                                    ))
+                                } else {
+                                    self.find_similarly_named_module_or_crate(
+                                        ident.name,
+                                        &parent_scope.module,
                                     )
-                                }),
+                                    .map(|sugg| {
+                                        (
+                                            vec![(ident.span, sugg.to_string())],
+                                            String::from(
+                                                "there is a crate or module with a similar name",
+                                            ),
+                                            Applicability::MaybeIncorrect,
+                                        )
+                                    })
+                                },
                             )
                         }
                     } else {

--- a/src/test/ui/suggestions/undeclared-module-alloc.rs
+++ b/src/test/ui/suggestions/undeclared-module-alloc.rs
@@ -1,0 +1,5 @@
+// edition:2018
+
+use alloc::rc::Rc; //~ ERROR failed to resolve: use of undeclared crate or module `alloc`
+
+fn main() {}

--- a/src/test/ui/suggestions/undeclared-module-alloc.stderr
+++ b/src/test/ui/suggestions/undeclared-module-alloc.stderr
@@ -4,7 +4,7 @@ error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
 LL | use alloc::rc::Rc;
    |     ^^^^^ use of undeclared crate or module `alloc`
    |
-   = help: add `extern crate alloc` to use the builtin `alloc` module
+   = help: add `extern crate alloc` to use the `alloc` crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/undeclared-module-alloc.stderr
+++ b/src/test/ui/suggestions/undeclared-module-alloc.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
+  --> $DIR/undeclared-module-alloc.rs:3:5
+   |
+LL | use alloc::rc::Rc;
+   |     ^^^^^ use of undeclared crate or module `alloc`
+   |
+   = help: add `extern crate alloc` to use the builtin `alloc` module
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
closes #90136 