### PR TITLE
Apply adjustments for field expression even if inaccessible

### DIFF
--- a/src/test/ui/typeck/issue-90483-inaccessible-field-adjustment.rs
+++ b/src/test/ui/typeck/issue-90483-inaccessible-field-adjustment.rs
@@ -1,0 +1,14 @@
+// edition:2021
+
+mod m {
+  pub struct S { foo: i32 }
+  impl S {
+    pub fn foo(&self) -> i32 { 42 }
+  }
+}
+
+fn bar(s: &m::S) {
+  || s.foo() + s.foo; //~ ERROR E0616
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-90483-inaccessible-field-adjustment.stderr
+++ b/src/test/ui/typeck/issue-90483-inaccessible-field-adjustment.stderr
@@ -1,0 +1,14 @@
+error[E0616]: field `foo` of struct `S` is private
+  --> $DIR/issue-90483-inaccessible-field-adjustment.rs:11:18
+   |
+LL |   || s.foo() + s.foo;
+   |                  ^^^ private field
+   |
+help: a method `foo` also exists, call it with parentheses
+   |
+LL |   || s.foo() + s.foo();
+   |                     ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0616`.


### PR DESCRIPTION
The adjustments are used later by ExprUseVisitor to build Place projections and without adjustments it can produce invalid result.

Fix #90483

@rustbot label: T-compiler