### PR TITLE
update rustc_ast crate descriptions in documentation

### DIFF
--- a/compiler/rustc_ast/README.md
+++ b/compiler/rustc_ast/README.md
@@ -1,6 +1,5 @@
 The `rustc_ast` crate contains those things concerned purely with syntax
-– that is, the AST ("abstract syntax tree"), parser, pretty-printer,
-lexer, macro expander, and utilities for traversing ASTs.
+– that is, the AST ("abstract syntax tree"), along with some definitions for tokens and token streams, data structures/traits for mutating ASTs, and shared definitions for other AST-related parts of the compiler (like the lexer and macro-expansion).
 
 For more information about how these things work in rustc, see the
 rustc dev guide:

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -1,4 +1,4 @@
-//! The Rust parser and macro expander.
+//! The Rust Abstract Syntax Tree (AST).
 //!
 //! # Note
 //!


### PR DESCRIPTION
I noticed this the other day and figured I'd suggest a refresh. It seems like a relic from the days of `libsyntax` that got missed as things were split out into separate crates, since the current documentation text references elements that were moved into their own respective crates (e.g. `rustc_parse`)