### PR TITLE
Skip reborrows in AbstractConstBuilder

### DIFF
--- a/src/test/ui/const-generics/generic_const_exprs/closures.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/closures.stderr
@@ -4,7 +4,7 @@ error: overly complex generic constant
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    |                                   ^^^^-------^^
    |                                       |
-   |                                       dereferencing is not supported in generic constants
+   |                                       borrowing is not supported in generic constants
    |
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future

--- a/src/test/ui/const-generics/issues/issue-90455.rs
+++ b/src/test/ui/const-generics/issues/issue-90455.rs
@@ -1,0 +1,12 @@
+#![feature(generic_const_exprs, adt_const_params)]
+#![allow(incomplete_features)]
+
+struct FieldElement<const N: &'static str> {
+    n: [u64; num_limbs(N)],
+    //~^ ERROR unconstrained generic constant
+}
+const fn num_limbs(_: &str) -> usize {
+    0
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-90455.stderr
+++ b/src/test/ui/const-generics/issues/issue-90455.stderr
@@ -1,0 +1,10 @@
+error: unconstrained generic constant
+  --> $DIR/issue-90455.rs:5:8
+   |
+LL |     n: [u64; num_limbs(N)],
+   |        ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); num_limbs(N)]:`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/90455

Temporary fix to prevent confusing diagnostics that refer to implicit borrows and derefs until we allow borrows and derefs on constant expressions.

r? @oli-obk 