### PR TITLE
Demote metadata load warning to "info".

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -236,7 +236,7 @@ use std::fmt::Write as _;
 use std::io::{Read, Result as IoResult, Write};
 use std::path::{Path, PathBuf};
 use std::{cmp, fmt, fs};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 #[derive(Clone)]
 crate struct CrateLocator<'a> {
@@ -549,7 +549,7 @@ impl<'a> CrateLocator<'a> {
                         }
                     }
                     Err(err) => {
-                        warn!("no metadata found: {}", err);
+                        info!("no metadata found: {}", err);
                         continue;
                     }
                 };


### PR DESCRIPTION
There is a warn log message for whenever the crate loader fails to load metadata from a candidate file. I think this warning is too aggressive, as there are several situations where metadata information might not be found in a candidate file, which is normal. Also, this warning is somewhat confusing, and non-actionable in most cases for a user (most users will not know what it means). 

If the crate loader ultimately does not find a valid crate, then an error will be reported (and hopefully #88368 will improve that error message). 

If a rustc developer wants to debug a loader problem, they can still use `RUSTC_LOG=rustc_metadata=debug` and get the details.

There is more discussion of this particular warning at https://github.com/rust-lang/rust/issues/89795#issuecomment-940798190.

Fixes #90525
