### PR TITLE
Implement a faster stable sort algorithm

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -955,7 +955,7 @@ where
 /// # Safety
 ///
 /// The two slices must be non-empty and `mid` must be in bounds. Buffer `buf` must be long enough
-/// to hold a copy of the shorter slice. Also, `T` must not be a zero-sized type.
+/// to hold a copy of the shorter slice.
 #[allow(unused_unsafe)]
 #[cfg(not(no_global_oom_handling))]
 unsafe fn merge<T, F>(v: &mut [T], mid: usize, buf: *mut T, is_less: &mut F)
@@ -1088,10 +1088,7 @@ where
     macro_rules! gt {
         ($v: ident, $left: expr, $right: expr, $is_less: ident) => {
             // $is_less(&$v[$right], &$v[$left])
-            {
-                debug_assert!($left < $v.len() && $right < $v.len());
-                $is_less(unsafe { &$v.get_unchecked($right) }, unsafe { &$v.get_unchecked($left) })
-            }
+            $is_less(unsafe { &$v.get_unchecked($right) }, unsafe { &$v.get_unchecked($left) })
         };
     }
 
@@ -1171,7 +1168,9 @@ where
                         return;
                     } else if gt!(v, 0, len - 1, is_less) {
                         // strictly reverse sorted
-                        swap_slices(v, mid, buf_ptr);
+                        unsafe {
+                            swap_slices(v, mid, buf_ptr);
+                        }
                         return;
                     }
                 } else {
@@ -1202,7 +1201,8 @@ where
     ///
     /// `mid` must be <= `v.len()`
     ///   `mid <= v.len()` because `swap_slices` is only called when: `sorted < len && mid == sorted.max(len / 2)`
-    fn swap_slices<T>(v: &mut [T], mid: usize, buf_ptr: *mut T) {
+    #[allow(unused_unsafe)]
+    unsafe fn swap_slices<T>(v: &mut [T], mid: usize, buf_ptr: *mut T) {
         let rlen = v.len() - mid;
         let v_ptr = v.as_mut_ptr();
         unsafe {


### PR DESCRIPTION
Hi everyone, this is my first PR.

This PR replaces slice's [TimSort](https://doc.rust-lang.org/std/primitive.slice.html#method.sort) with a stable two stage merge sort having pre-sorted prefix optimization.  The total running time is O(n * log(n)) worst-case.

**Highlights:**

- Improved performance, especially on random and pre-sorted inputs.
- Improved performance on other patterns such as shuffle and stagger.
- Performs fewer comparisons on random and most other patterns.

**Benchmark:**
The benchmark was run on six OS's / CPUs:

- Ubuntu 20.04.3 LTS / Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
- WIN 10 KVM on Ubuntu / Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
- macOS Big Sur Version 11.6 / MacBook Pro (16-inch, 2019) 2.4 GHz 8-Core Intel Core i9
- Debian Crostini Linux / Google PixelBook Intel(R) 7th Gen Core(TM) i7-7Y75
- Debian Crostini Linux / Asus Chromebook Flip CX5 Intel(R) 11th Gen Core(TM) i5-1130G7
- Debian Crostini Linux / HP Chromebook X2 11 Qualcomm(R) Snapdragon(TM) 7c

For each OS/CPU, the benchmark was run on vecs of `i16`, `i32`, `i64`, `i128`, and `String`. The vecs were of random lengths from 0 to 10,000,000.

The proposed two stage merge sort indicates a speedup of **13.1%** for random unsorted data, with **95%** of sort runs being faster. For random data, including unsorted and forward / reverse sorted variants, the results indicate a speedup of **20.2%**, with **92%** of sort runs being faster. Other data patterns are faster too, except for the sawtooth pattern, which is about the same. The number of comparisons performed is **-2.92%** less over all tests.

**Note:** The above benchmark figures have been corrected since my original post.  The original post did not include sort results for `vecs` of length 0-100.

Full results and benchmark code are at [wpwoodjr/rust-merge-sort](https://github.com/wpwoodjr/rust-merge-sort)

**The new sort**
While not really new, the proposed sort benefits from:

- Top-down recursive depth-first merge, which helps data locality
- Small slices sort using a fast insertion sort, then merge
- Pre-sorted prefix optimization for forward and reverse sorted sub-slices

The new sort builds on existing code wherever possible. 