### PR TITLE
Make `path::Display` output user-style paths instead of verbatim

### DIFF
--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1090,6 +1090,20 @@ pub fn test_decompositions_windows() {
     file_prefix: Some(".x")
     );
 }
+#[test]
+#[cfg(windows)]
+pub fn windows_display_user_paths() {
+    fn check(path: &str, expected: &str) {
+        assert_eq!(&Path::new(path).display().to_string(), expected);
+    }
+    check(r"\\?\UNC\server\share", r"\\server\share");
+    check(r"\\?\C:\path", r"C:\path");
+    check(r"\\?\C:\", r"C:\");
+
+    // This should not change.
+    // `\\?\C:` is an absolute path while `C:` is a "drive relative" path.
+    check(r"\\?\C:", r"\\?\C:");
+}
 
 #[test]
 pub fn test_stem_ext() {

--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1153,9 +1153,6 @@ pub fn windows_display_user_paths() {
 
     // ...but two dots won't be. Don't ask.
     check(r"\\?\C:\path\to..\file", r"C:\path\to..\file");
-    check(r"\\?\C:\path\to..\file", r"C:\path\to..\file");
-
-    check(r"\\?\UNC\server\share\path\to..\file", r"\\server\share\path\to..\file");
     check(r"\\?\UNC\server\share\path\to..\file", r"\\server\share\path\to..\file");
 
     // Dots elsewhere are fine.


### PR DESCRIPTION
Fixes #31789

Windows verbatim paths are essentially an API hack to allow smuggling NT kernel paths through the Win32 API. This allows bypassing certain historic limits of the Win32 APIs. Most users do not normally encounter them and can find it confusing if they do. However some APIs, most notably the one used by `canonicalize`, will return verbatim paths.

This PR changes `Path::Display` so that it will prefer to display user-style paths instead of verbatim. Examples of the transformations that are applied are:

|Verbatim|User|
|--|--|
|`\\?\C:\directory\file.txt`|`C:\directory\file.txt`|
|`\\?\UNC\server\share\file.txt`|`\\server\share\file.txt`|

This will not affect verbatim device paths. I think, from a user perspective, `\\?\PIPE\name` and `\\.\PIPE\name` are equally strange and rarely encountered.