### PR TITLE
rustbot allow labels

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,6 +2,7 @@
 allow-unauthenticated = [
     "C-*", "A-*", "E-*", "NLL-*", "O-*", "S-*", "T-*", "WG-*", "F-*",
     "D-*",
+    "relnotes",
     "requires-nightly",
     "regression-*",
     "perf-*",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,6 +2,7 @@
 allow-unauthenticated = [
     "C-*", "A-*", "E-*", "NLL-*", "O-*", "S-*", "T-*", "WG-*", "F-*",
     "D-*",
+    "needs-fcp",
     "relnotes",
     "requires-nightly",
     "regression-*",


### PR DESCRIPTION
`relnotes` was inspired by https://github.com/rust-lang/rust/pull/90521 , and by the various `must_use` PRs; in all of those cases, the submitter of the PR could know that `relnotes` applied, but couldn't apply it themselves.

For `needs-fcp`, I think people should be able to help triage by observing that a change needs an FCP before we can apply it.
