### PR TITLE
Fix tests using `only-i686` to use the correct `only-x86` directive

### DIFF
--- a/src/test/ui/extern/extern-methods.rs
+++ b/src/test/ui/extern/extern-methods.rs
@@ -1,5 +1,5 @@
 // run-pass
-// only-i686
+// only-x86
 
 trait A {
     extern "fastcall" fn test1(i: i32);

--- a/src/test/ui/extern/extern-thiscall.rs
+++ b/src/test/ui/extern/extern-thiscall.rs
@@ -1,5 +1,5 @@
 // run-pass
-// only-i686
+// only-x86
 
 #![feature(abi_thiscall)]
 

--- a/src/test/ui/extern/extern-vectorcall.rs
+++ b/src/test/ui/extern/extern-vectorcall.rs
@@ -1,7 +1,7 @@
 // run-pass
 // revisions: x64 x32
 // [x64]only-x86_64
-// [x32]only-i686
+// [x32]only-x86
 
 #![feature(abi_vectorcall)]
 

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -168,7 +168,7 @@ fn only_target() {
     let mut config = config();
     config.target = "x86_64-pc-windows-gnu".to_owned();
 
-    assert!(check_ignore(&config, "// only-i686"));
+    assert!(check_ignore(&config, "// only-x86"));
     assert!(check_ignore(&config, "// only-linux"));
     assert!(check_ignore(&config, "// only-msvc"));
     assert!(check_ignore(&config, "// only-32bit"));


### PR DESCRIPTION
We translate `i686` to `x86` which means tests marked as `only-i686`
never ran. Update those tests to use `only-x86`.

We parse the `only-` architecture directive here

https://github.com/rust-lang/rust/blob/27143a9094b55a00d5f440b05b0cb4233b300d33/src/tools/compiletest/src/util.rs#L160-L168

and we translate `i686` to `x86` here

https://github.com/rust-lang/rust/blob/27143a9094b55a00d5f440b05b0cb4233b300d33/src/tools/compiletest/src/util.rs#L56