### PR TITLE
rustc_llvm: update PassWrapper for recent LLVM

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -897,7 +897,6 @@ LLVMRustOptimizeWithNewPassManager(
             AsanDetectStackUseAfterReturnMode::Runtime,
           };
           MPM.addPass(ModuleAddressSanitizerPass(opts));
-          MPM.addPass(createModuleToFunctionPassAdaptor(AddressSanitizerPass(opts)));
 #else
           MPM.addPass(ModuleAddressSanitizerPass(
               /*CompileKernel=*/false, SanitizerOptions->SanitizeAddressRecover));

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -893,7 +893,7 @@ LLVMRustOptimizeWithNewPassManager(
           AddressSanitizerOptions opts = AddressSanitizerOptions{
             /*CompileKernel=*/false,
             SanitizerOptions->SanitizeAddressRecover,
-            /*UseAfterScope=*/false,
+            /*UseAfterScope=*/true,
             AsanDetectStackUseAfterReturnMode::Runtime,
           };
           MPM.addPass(ModuleAddressSanitizerPass(opts));

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -889,15 +889,18 @@ LLVMRustOptimizeWithNewPassManager(
       OptimizerLastEPCallbacks.push_back(
         [SanitizerOptions](ModulePassManager &MPM, OptimizationLevel Level) {
           MPM.addPass(RequireAnalysisPass<ASanGlobalsMetadataAnalysis, Module>());
-          MPM.addPass(ModuleAddressSanitizerPass(
-              /*CompileKernel=*/false, SanitizerOptions->SanitizeAddressRecover));
 #if LLVM_VERSION_GE(14, 0)
-          AddressSanitizerOptions opts(/*CompileKernel=*/false,
-                                       SanitizerOptions->SanitizeAddressRecover,
-                                       /*UseAfterScope=*/true,
-                                       AsanDetectStackUseAfterReturnMode::Runtime);
+          AddressSanitizerOptions opts = AddressSanitizerOptions{
+            /*CompileKernel=*/false,
+            SanitizerOptions->SanitizeAddressRecover,
+            /*UseAfterScope=*/false,
+            AsanDetectStackUseAfterReturnMode::Runtime,
+          };
+          MPM.addPass(ModuleAddressSanitizerPass(opts));
           MPM.addPass(createModuleToFunctionPassAdaptor(AddressSanitizerPass(opts)));
 #else
+          MPM.addPass(ModuleAddressSanitizerPass(
+              /*CompileKernel=*/false, SanitizerOptions->SanitizeAddressRecover));
           MPM.addPass(createModuleToFunctionPassAdaptor(AddressSanitizerPass(
               /*CompileKernel=*/false, SanitizerOptions->SanitizeAddressRecover,
               /*UseAfterScope=*/true)));


### PR DESCRIPTION
Now AddressSanitizerOptions is a struct, but at least the change was
tiny.

r? @nikic