### PR TITLE
Optimize Eq and Hash for Path/PathBuf

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1033,12 +1033,11 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
     // the middle of one
     if left.prefix.is_none() && right.prefix.is_none() && left.front == right.front {
         // possible future improvement: a [u8]::first_mismatch simd implementation
-        let first_difference =
-            match left.path.iter().zip(right.path.iter()).position(|(&a, &b)| a != b) {
-                None if left.path.len() == right.path.len() => return cmp::Ordering::Equal,
-                None => left.path.len().min(right.path.len()),
-                Some(diff) => diff,
-            };
+        let first_difference = match left.path.iter().zip(right.path).position(|(&a, &b)| a != b) {
+            None if left.path.len() == right.path.len() => return cmp::Ordering::Equal,
+            None => left.path.len().min(right.path.len()),
+            Some(diff) => diff,
+        };
 
         if let Some(previous_sep) =
             left.path[..first_difference].iter().rposition(|&b| left.is_sep_byte(b))

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2873,9 +2873,35 @@ impl cmp::PartialEq for Path {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Hash for Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
-        for component in self.components() {
-            component.hash(h);
+        let bytes = self.as_u8_slice();
+
+        let mut component_start = 0;
+        let mut bytes_hashed = 0;
+
+        for i in 0..bytes.len() {
+            if is_sep_byte(bytes[i]) {
+                if i > component_start {
+                    let to_hash = &bytes[component_start..i];
+                    h.write(to_hash);
+                    bytes_hashed += to_hash.len();
+                }
+
+                // skip over separator and optionally a following CurDir item
+                // since components() would normalize these away
+                component_start = i + match bytes[i..] {
+                    [_, b'.', b'/', ..] | [_, b'.'] => 2,
+                    _ => 1,
+                };
+            }
         }
+
+        if component_start < bytes.len() {
+            let to_hash = &bytes[component_start..];
+            h.write(to_hash);
+            bytes_hashed += to_hash.len();
+        }
+
+        h.write_usize(bytes_hashed);
     }
 }
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2892,6 +2892,14 @@ impl cmp::PartialEq for Path {
 impl Hash for Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
         let bytes = self.as_u8_slice();
+        let prefix_len = match parse_prefix(&self.inner) {
+            Some(prefix) => {
+                prefix.hash(h);
+                prefix.len()
+            }
+            None => 0,
+        };
+        let bytes = &bytes[prefix_len..];
 
         let mut component_start = 0;
         let mut bytes_hashed = 0;

--- a/library/std/src/sys/unix/path.rs
+++ b/library/std/src/sys/unix/path.rs
@@ -11,6 +11,7 @@ pub fn is_verbatim_sep(b: u8) -> bool {
     b == b'/'
 }
 
+#[inline]
 pub fn parse_prefix(_: &OsStr) -> Option<Prefix<'_>> {
     None
 }


### PR DESCRIPTION

```
# new

test path::tests::bench_hash_path_long                            ... bench:          86 ns/iter (+/- 1)
test path::tests::bench_hash_path_short                           ... bench:          13 ns/iter (+/- 1)
test path::tests::bench_path_hashset                              ... bench:         197 ns/iter (+/- 6)
test path::tests::bench_path_hashset_miss                         ... bench:          94 ns/iter (+/- 4)

# old

test path::tests::bench_hash_path_long                            ... bench:         192 ns/iter (+/- 2)
test path::tests::bench_hash_path_short                           ... bench:          33 ns/iter (+/- 1)
test path::tests::bench_path_hashset                              ... bench:       1,121 ns/iter (+/- 24)
test path::tests::bench_path_hashset_miss                         ... bench:         273 ns/iter (+/- 6)
```