### PR TITLE
Clarify error messages caused by re-exporting `pub(crate)` visibility to outside

### DIFF
--- a/src/test/ui/error-codes/E0365.rs
+++ b/src/test/ui/error-codes/E0365.rs
@@ -3,6 +3,6 @@ mod foo {
 }
 
 pub use foo as foo2;
-//~^ ERROR `foo` is private, and cannot be re-exported [E0365]
+//~^ ERROR `foo` is only public within the crate, and cannot be re-exported outside [E0365]
 
 fn main() {}

--- a/src/test/ui/error-codes/E0365.stderr
+++ b/src/test/ui/error-codes/E0365.stderr
@@ -1,8 +1,8 @@
-error[E0365]: `foo` is private, and cannot be re-exported
+error[E0365]: `foo` is only public within the crate, and cannot be re-exported outside
   --> $DIR/E0365.rs:5:9
    |
 LL | pub use foo as foo2;
-   |         ^^^^^^^^^^^ re-export of private `foo`
+   |         ^^^^^^^^^^^ re-export of crate public `foo`
    |
    = note: consider declaring type or module `foo` with `pub`
 

--- a/src/test/ui/modules/issue-56411.rs
+++ b/src/test/ui/modules/issue-56411.rs
@@ -5,7 +5,7 @@ macro_rules! import {
             mod $name;
             pub use self::$name;
             //~^ ERROR the name `issue_56411_aux` is defined multiple times
-            //~| ERROR `issue_56411_aux` is private, and cannot be re-exported
+            //~| ERROR `issue_56411_aux` is only public within the crate, and cannot be re-exported outside
 
         )*
     }

--- a/src/test/ui/modules/issue-56411.stderr
+++ b/src/test/ui/modules/issue-56411.stderr
@@ -15,11 +15,11 @@ LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    = note: `issue_56411_aux` must be defined only once in the type namespace of this module
    = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0365]: `issue_56411_aux` is private, and cannot be re-exported
+error[E0365]: `issue_56411_aux` is only public within the crate, and cannot be re-exported outside
   --> $DIR/issue-56411.rs:6:21
    |
 LL |             pub use self::$name;
-   |                     ^^^^^^^^^^^ re-export of private `issue_56411_aux`
+   |                     ^^^^^^^^^^^ re-export of crate public `issue_56411_aux`
 ...
 LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    | ------------------------------------------------ in this macro invocation

--- a/src/test/ui/privacy/crate-private-reexport.rs
+++ b/src/test/ui/privacy/crate-private-reexport.rs
@@ -1,0 +1,66 @@
+fn f1() {}
+enum E1 { V }
+struct S1 {
+    #[rustfmt::skip]
+    bar: i32,
+}
+mod m1 {
+    pub use ::f1; //~ ERROR `f1` is only public within the crate, and cannot be re-exported outside
+    pub use ::S1; //~ ERROR `S1` is only public within the crate, and cannot be re-exported outside
+    pub use ::E1; //~ ERROR `E1` is only public within the crate, and cannot be re-exported outside
+    pub use ::E1::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+}
+
+pub(crate) fn f2() {}
+pub(crate) enum E2 {
+    V
+}
+pub(crate) struct S2 {
+    #[rustfmt::skip]
+    bar: i32,
+}
+mod m2 {
+    pub use ::f2; //~ ERROR `f2` is only public within the crate, and cannot be re-exported outside
+    pub use ::S2; //~ ERROR `S2` is only public within the crate, and cannot be re-exported outside
+    pub use ::E2; //~ ERROR `E2` is only public within the crate, and cannot be re-exported outside
+    pub use ::E2::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+}
+
+mod m3 {
+    pub(crate) fn f3() {}
+    pub(crate) enum E3 {
+        V
+    }
+    pub(crate) struct S3 {
+        #[rustfmt::skip]
+        bar: i32,
+    }
+}
+pub use m3::f3; //~ ERROR `f3` is only public within the crate, and cannot be re-exported outside
+pub use m3::S3; //~ ERROR `S3` is only public within the crate, and cannot be re-exported outside
+pub use m3::E3; //~ ERROR `E3` is only public within the crate, and cannot be re-exported outside
+pub use m3::E3::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+
+pub(self) fn f4() {}
+pub use ::f4 as f5; //~ ERROR `f4` is only public within the crate, and cannot be re-exported outside
+
+pub mod m10 {
+    pub mod m {
+        pub(super) fn f6() {}
+        pub(crate) fn f7() {}
+        pub(in crate::m10) fn f8() {}
+    }
+    pub use self::m::f6; //~ ERROR `f6` is private, and cannot be re-exported
+    pub use self::m::f7; //~ ERROR `f7` is only public within the crate, and cannot be re-exported outside
+    pub use self::m::f8; //~ ERROR `f8` is private, and cannot be re-exported
+}
+pub use m10::m::f6; //~ ERROR function `f6` is private
+pub use m10::m::f7; //~ ERROR `f7` is only public within the crate, and cannot be re-exported outside
+pub use m10::m::f8; //~ ERROR function `f8` is private
+
+pub mod m11 {
+    pub(self) fn f9() {}
+}
+pub use m11::f9; //~ ERROR function `f9` is private
+
+fn main() {}

--- a/src/test/ui/privacy/crate-private-reexport.stderr
+++ b/src/test/ui/privacy/crate-private-reexport.stderr
@@ -1,0 +1,220 @@
+error[E0364]: `f1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:8:13
+   |
+LL |     pub use ::f1;
+   |             ^^^^
+   |
+note: consider marking `f1` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:8:13
+   |
+LL |     pub use ::f1;
+   |             ^^^^
+
+error[E0365]: `S1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:9:13
+   |
+LL |     pub use ::S1;
+   |             ^^^^ re-export of crate public `S1`
+   |
+   = note: consider declaring type or module `S1` with `pub`
+
+error[E0365]: `E1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:10:13
+   |
+LL |     pub use ::E1;
+   |             ^^^^ re-export of crate public `E1`
+   |
+   = note: consider declaring type or module `E1` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:11:13
+   |
+LL |     pub use ::E1::V;
+   |             ^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:11:13
+   |
+LL |     pub use ::E1::V;
+   |             ^^^^^^^
+
+error[E0364]: `f2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:23:13
+   |
+LL |     pub use ::f2;
+   |             ^^^^
+   |
+note: consider marking `f2` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:23:13
+   |
+LL |     pub use ::f2;
+   |             ^^^^
+
+error[E0365]: `S2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:24:13
+   |
+LL |     pub use ::S2;
+   |             ^^^^ re-export of crate public `S2`
+   |
+   = note: consider declaring type or module `S2` with `pub`
+
+error[E0365]: `E2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:25:13
+   |
+LL |     pub use ::E2;
+   |             ^^^^ re-export of crate public `E2`
+   |
+   = note: consider declaring type or module `E2` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:26:13
+   |
+LL |     pub use ::E2::V;
+   |             ^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:26:13
+   |
+LL |     pub use ::E2::V;
+   |             ^^^^^^^
+
+error[E0364]: `f3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:39:9
+   |
+LL | pub use m3::f3;
+   |         ^^^^^^
+   |
+note: consider marking `f3` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:39:9
+   |
+LL | pub use m3::f3;
+   |         ^^^^^^
+
+error[E0365]: `S3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:40:9
+   |
+LL | pub use m3::S3;
+   |         ^^^^^^ re-export of crate public `S3`
+   |
+   = note: consider declaring type or module `S3` with `pub`
+
+error[E0365]: `E3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:41:9
+   |
+LL | pub use m3::E3;
+   |         ^^^^^^ re-export of crate public `E3`
+   |
+   = note: consider declaring type or module `E3` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:42:9
+   |
+LL | pub use m3::E3::V;
+   |         ^^^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:42:9
+   |
+LL | pub use m3::E3::V;
+   |         ^^^^^^^^^
+
+error[E0364]: `f4` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:45:9
+   |
+LL | pub use ::f4 as f5;
+   |         ^^^^^^^^^^
+   |
+note: consider marking `f4` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:45:9
+   |
+LL | pub use ::f4 as f5;
+   |         ^^^^^^^^^^
+
+error[E0364]: `f6` is private, and cannot be re-exported
+  --> $DIR/crate-private-reexport.rs:53:13
+   |
+LL |     pub use self::m::f6;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f6` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:53:13
+   |
+LL |     pub use self::m::f6;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f7` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:54:13
+   |
+LL |     pub use self::m::f7;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f7` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:54:13
+   |
+LL |     pub use self::m::f7;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f8` is private, and cannot be re-exported
+  --> $DIR/crate-private-reexport.rs:55:13
+   |
+LL |     pub use self::m::f8;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f8` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:55:13
+   |
+LL |     pub use self::m::f8;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f7` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:58:9
+   |
+LL | pub use m10::m::f7;
+   |         ^^^^^^^^^^
+   |
+note: consider marking `f7` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:58:9
+   |
+LL | pub use m10::m::f7;
+   |         ^^^^^^^^^^
+
+error[E0603]: function `f6` is private
+  --> $DIR/crate-private-reexport.rs:57:17
+   |
+LL | pub use m10::m::f6;
+   |                 ^^ private function
+   |
+note: the function `f6` is defined here
+  --> $DIR/crate-private-reexport.rs:49:9
+   |
+LL |         pub(super) fn f6() {}
+   |         ^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `f8` is private
+  --> $DIR/crate-private-reexport.rs:59:17
+   |
+LL | pub use m10::m::f8;
+   |                 ^^ private function
+   |
+note: the function `f8` is defined here
+  --> $DIR/crate-private-reexport.rs:51:9
+   |
+LL |         pub(in crate::m10) fn f8() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `f9` is private
+  --> $DIR/crate-private-reexport.rs:64:14
+   |
+LL | pub use m11::f9;
+   |              ^^ private function
+   |
+note: the function `f9` is defined here
+  --> $DIR/crate-private-reexport.rs:62:5
+   |
+LL |     pub(self) fn f9() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
+
+Some errors have detailed explanations: E0364, E0365, E0603.
+For more information about an error, try `rustc --explain E0364`.

--- a/src/test/ui/privacy/private-variant-reexport.rs
+++ b/src/test/ui/privacy/private-variant-reexport.rs
@@ -1,13 +1,13 @@
 mod m1 {
-    pub use ::E::V; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m2 {
-    pub use ::E::{V}; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::{V}; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::V::{self}; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 #[deny(unused_imports)]

--- a/src/test/ui/privacy/private-variant-reexport.stderr
+++ b/src/test/ui/privacy/private-variant-reexport.stderr
@@ -1,4 +1,4 @@
-error[E0364]: `V` is private, and cannot be re-exported
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:2:13
    |
 LL |     pub use ::E::V;
@@ -10,7 +10,7 @@ note: consider marking `V` as `pub` in the imported module
 LL |     pub use ::E::V;
    |             ^^^^^^
 
-error[E0364]: `V` is private, and cannot be re-exported
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:6:19
    |
 LL |     pub use ::E::{V};
@@ -22,11 +22,11 @@ note: consider marking `V` as `pub` in the imported module
 LL |     pub use ::E::{V};
    |                   ^
 
-error[E0365]: `V` is private, and cannot be re-exported
+error[E0365]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:10:22
    |
 LL |     pub use ::E::V::{self};
-   |                      ^^^^ re-export of private `V`
+   |                      ^^^^ re-export of crate public `V`
    |
    = note: consider declaring type or module `V` with `pub`
 

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
@@ -8,7 +8,7 @@ mod m1 {
 
     use legacy_macro as _; // OK
     pub(crate) use legacy_macro as _; // OK
-    pub use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
+    pub use legacy_macro as _; //~ ERROR `legacy_macro` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m2 {

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
@@ -1,4 +1,4 @@
-error[E0364]: `legacy_macro` is private, and cannot be re-exported
+error[E0364]: `legacy_macro` is only public within the crate, and cannot be re-exported outside
   --> $DIR/macro-rules.rs:11:13
    |
 LL |     pub use legacy_macro as _;


### PR DESCRIPTION
This PR clarifies error messages and suggestions caused by re-exporting pub(crate) visibility outside the crate.

Here is a small example ([Rust Playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=e2cd0bd4422d4f20e6522dcbad167d3b)):

```rust
mod m {
    pub(crate) enum E {}
}
pub use m::E;

fn main() {}
```

This code is compiled to:

```
error[E0365]: `E` is private, and cannot be re-exported
 --> prog.rs:4:9
  |
4 | pub use m::E;
  |         ^^^^ re-export of private `E`
  |
  = note: consider declaring type or module `E` with `pub`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0365`.
```

However, enum `E` is actually public to the crate, not private totally—nevertheless, rustc treats `pub(crate)` and private visibility as the same on the error messages. They are not clear and should be segmented distinctly.

By applying changes in this PR, the error message below will be the following message that would be clearer:

```
error[E0365]: `E` is only public within the crate, and cannot be re-exported outside
 --> prog.rs:4:9
  |
4 | pub use m::E;
  |         ^^^^ re-export of crate public `E`
  |
  = note: consider declaring type or module `E` with `pub`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0365`.
```