### PR TITLE
Fix false positives in `unreachable_code` lint

### DIFF
--- a/src/test/ui/lint/issue-88393.rs
+++ b/src/test/ui/lint/issue-88393.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #88393.
+
+#![allow(deprecated, invalid_value, unused_must_use)]
+#![forbid(unreachable_code)]
+
+enum Void {}
+
+fn foo() {
+    if false {
+        unsafe { std::mem::uninitialized::<Void>(); }
+    }
+    println!();
+}
+
+fn bar() {
+    let b = false;
+    match b {
+        false => unsafe { std::mem::uninitialized::<Void>(); }
+        _ => unreachable!(),
+    }
+    println!();
+    //~^ ERROR: unreachable expression
+}
+
+fn main() {}

--- a/src/test/ui/lint/issue-88393.stderr
+++ b/src/test/ui/lint/issue-88393.stderr
@@ -1,0 +1,28 @@
+error: unreachable expression
+  --> $DIR/issue-88393.rs:21:5
+   |
+LL | /     match b {
+LL | |         false => unsafe { std::mem::uninitialized::<Void>(); }
+LL | |         _ => unreachable!(),
+LL | |     }
+   | |_____- any code following this expression is unreachable
+LL |       println!();
+   |       ^^^^^^^^^^ unreachable expression
+   |
+note: the lint level is defined here
+  --> $DIR/issue-88393.rs:4:11
+   |
+LL | #![forbid(unreachable_code)]
+   |           ^^^^^^^^^^^^^^^^
+note: all arms of this `match` expression diverge
+  --> $DIR/issue-88393.rs:17:5
+   |
+LL | /     match b {
+LL | |         false => unsafe { std::mem::uninitialized::<Void>(); }
+LL | |         _ => unreachable!(),
+LL | |     }
+   | |_____^
+   = note: this error originates in the macro `$crate::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/unreachable-uninhabited.rs
+++ b/src/test/ui/lint/unreachable-uninhabited.rs
@@ -1,0 +1,51 @@
+// Regression test for #89779.
+
+#![forbid(unreachable_code)]
+//~^ NOTE: the lint level is defined here
+
+fn stop() -> Result<std::convert::Infallible, u64> {
+    Err(5)
+}
+
+fn _foo1() {
+    if false {
+        stop().unwrap();
+    }
+
+    println!("Hello, world!");
+    // no warnings here
+}
+
+fn _foo2() {
+    if false {
+    //~^ NOTE: any code following this expression is unreachable
+    //~| NOTE: both branches of this `if` expression diverge
+        stop().unwrap();
+    } else {
+        stop().unwrap();
+    }
+
+    println!("Hello, world!");
+    //~^ ERROR: unreachable expression
+}
+
+fn _foo3() {
+    match stop() {
+    //~^ NOTE: any code following this expression is unreachable
+    //~| NOTE: all arms of this `match` expression diverge
+        Ok(x) => stop().unwrap(),
+        Err(_) => stop().unwrap(),
+    };
+
+    println!("Hello, world!");
+    //~^ ERROR: unreachable expression
+}
+
+fn bar() -> Result<std::convert::Infallible, u64> {
+    Err(5)
+}
+
+fn main() {
+    match bar().expect("should") {}
+    // no warnings here
+}

--- a/src/test/ui/lint/unreachable-uninhabited.stderr
+++ b/src/test/ui/lint/unreachable-uninhabited.stderr
@@ -1,0 +1,61 @@
+error: unreachable expression
+  --> $DIR/unreachable-uninhabited.rs:28:5
+   |
+LL | /     if false {
+LL | |
+LL | |
+LL | |         stop().unwrap();
+LL | |     } else {
+LL | |         stop().unwrap();
+LL | |     }
+   | |_____- any code following this expression is unreachable
+LL | 
+LL |       println!("Hello, world!");
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable expression
+   |
+note: the lint level is defined here
+  --> $DIR/unreachable-uninhabited.rs:3:11
+   |
+LL | #![forbid(unreachable_code)]
+   |           ^^^^^^^^^^^^^^^^
+note: both branches of this `if` expression diverge
+  --> $DIR/unreachable-uninhabited.rs:20:5
+   |
+LL | /     if false {
+LL | |
+LL | |
+LL | |         stop().unwrap();
+LL | |     } else {
+LL | |         stop().unwrap();
+LL | |     }
+   | |_____^
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unreachable expression
+  --> $DIR/unreachable-uninhabited.rs:40:5
+   |
+LL | /     match stop() {
+LL | |
+LL | |
+LL | |         Ok(x) => stop().unwrap(),
+LL | |         Err(_) => stop().unwrap(),
+LL | |     };
+   | |_____- any code following this expression is unreachable
+LL | 
+LL |       println!("Hello, world!");
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable expression
+   |
+note: all arms of this `match` expression diverge
+  --> $DIR/unreachable-uninhabited.rs:33:5
+   |
+LL | /     match stop() {
+LL | |
+LL | |
+LL | |         Ok(x) => stop().unwrap(),
+LL | |         Err(_) => stop().unwrap(),
+LL | |     };
+   | |_____^
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #89779 (both the false positives as well as the empty `match`) and fixes #88393.

r? @Mark-Simulacrum