### PR TITLE
Document mpsc Sender/Receiver are only Send if T is Send

### DIFF
--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -315,6 +315,8 @@ mod cache_aligned;
 /// The receiving half of Rust's [`channel`] (or [`sync_channel`]) type.
 /// This half can only be owned by one thread.
 ///
+/// Receiver can only be sent between threads if `T` is [`Send`][`core::marker::Send`]
+///
 /// Messages sent to the channel can be retrieved using [`recv`].
 ///
 /// [`recv`]: Receiver::recv
@@ -463,6 +465,8 @@ pub struct IntoIter<T> {
 
 /// The sending-half of Rust's asynchronous [`channel`] type. This half can only be
 /// owned by one thread, but it can be cloned to send to other threads.
+///
+/// Sender can only be sent between threads if `T` is [`Send`][`core::marker::Send`]
 ///
 /// Messages can be sent through this channel with [`send`].
 ///


### PR DESCRIPTION
Explain that `mpsc::Sender` and `mpsc::Receiver` are only `Send` if `T` is `Send`. This is currently not immediately clear by just looking at the documentation, as the impl does not have a trait bound for `Send`
```rs
impl<T> Sender<T> {
	pub fn send(&self, t: T) -> Result<(), SendError<T>>
}
```
and it can be easy to overlook the `Send` impl
```rs
impl<T: Send> Send for Sender<T>
```