### PR TITLE
Add `is_empty()` to Iterator

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -161,6 +161,33 @@ pub trait Iterator {
         (0, None)
     }
 
+    /// Returns whether the iterator has no items left.
+    /// 
+    /// The default implementation returns `true` when [`size_hint()`] returns <code>(0, [Some](0))</code>,
+    /// and `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let a = [1, 2, 3];
+    /// let mut iter = a.iter();
+    ///
+    /// assert!(!iter.is_empty());
+    /// 
+    /// for _ in iter {
+    ///     // consume the iterator, leaving no items left
+    /// }
+    /// 
+    /// assert!(iter.is_empty());
+    /// ```
+    #[inline]
+    #[unstable(feaure = "iter_is_empty", reason = "recently added", issue = "0")]
+    fn is_empty(&self) -> bool {
+        (0, Some(0)) == self.size_hint()
+    }
+
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will call [`next`] repeatedly until [`None`] is encountered,


### PR DESCRIPTION
This is a draft PR as an alternative to #35428.

The original feature was blocked because we felt that it shouldn't be specific to `ExactSizeIterator`, as some iterators can know whether they are empty or not but do not have an exact size e.g. `Filter`.

I didn't see any proposal looking exactly like this. @scottmcm created [an experiment](https://github.com/rust-lang/rust/compare/master...scottmcm:is_empty-alternative?expand=1) that separated it to its own trait, but the implementation seemed too restrictive to me, and adding another trait might not be worth it for a single method: functions using `Iterator`s should not require the iterator to know whether it is empty or not, it should already be able to tell using the size hint.

cc @SimonSapin

*EDIT:* Let's discuss this change before me fixing errors. I could also just remove `ExactSizeIterator::is_empty()` in this PR.