### PR TITLE
Suggest tuple-parentheses for enum variants

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -28,6 +28,11 @@ use crate::structured_errors::StructuredDiagnostic;
 use std::iter;
 use std::slice;
 
+enum FnArgsAsTuple<'hir> {
+    Single(&'hir hir::Expr<'hir>),
+    Multi { first: &'hir hir::Expr<'hir>, last: &'hir hir::Expr<'hir> },
+}
+
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(in super::super) fn check_casts(&self) {
         let mut deferred_cast_checks = self.deferred_cast_checks.borrow_mut();
@@ -127,8 +132,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let expected_arg_count = formal_input_tys.len();
 
-        // expected_count, arg_count, error_code, sugg_unit
-        let mut error: Option<(usize, usize, &str, bool)> = None;
+        // expected_count, arg_count, error_code, sugg_unit, sugg_tuple_wrap_args
+        let mut error: Option<(usize, usize, &str, bool, Option<FnArgsAsTuple<'_>>)> = None;
 
         // If the arguments should be wrapped in a tuple (ex: closures), unwrap them here
         let (formal_input_tys, expected_input_tys) = if tuple_arguments == TupleArguments {
@@ -138,7 +143,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ty::Tuple(arg_types) => {
                     // Argument length differs
                     if arg_types.len() != provided_args.len() {
-                        error = Some((arg_types.len(), provided_args.len(), "E0057", false));
+                        error = Some((arg_types.len(), provided_args.len(), "E0057", false, None));
                     }
                     let expected_input_tys = match expected_input_tys.get(0) {
                         Some(&ty) => match ty.kind() {
@@ -169,7 +174,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if supplied_arg_count >= expected_arg_count {
                 (formal_input_tys.to_vec(), expected_input_tys)
             } else {
-                error = Some((expected_arg_count, supplied_arg_count, "E0060", false));
+                error = Some((expected_arg_count, supplied_arg_count, "E0060", false, None));
                 (self.err_args(supplied_arg_count), vec![])
             }
         } else {
@@ -181,7 +186,43 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             } else {
                 false
             };
-            error = Some((expected_arg_count, supplied_arg_count, "E0061", sugg_unit));
+
+            // are we passing elements of a tuple without the tuple parentheses?
+            let chosen_arg_tys = if expected_input_tys.is_empty() {
+                // In most cases we can use expected_arg_tys, but some callers won't have the type
+                // information, in which case we fall back to the types from the input expressions.
+                formal_input_tys
+            } else {
+                &*expected_input_tys
+            };
+
+            let sugg_tuple_wrap_args = chosen_arg_tys
+                .get(0)
+                .cloned()
+                .map(|arg_ty| self.resolve_vars_if_possible(arg_ty))
+                .and_then(|arg_ty| match arg_ty.kind() {
+                    ty::Tuple(tup_elems) => Some(tup_elems),
+                    _ => None,
+                })
+                .and_then(|tup_elems| {
+                    if tup_elems.len() == supplied_arg_count && chosen_arg_tys.len() == 1 {
+                        match provided_args {
+                            [] => None,
+                            [single] => Some(FnArgsAsTuple::Single(single)),
+                            [first, .., last] => Some(FnArgsAsTuple::Multi { first, last }),
+                        }
+                    } else {
+                        None
+                    }
+                });
+
+            error = Some((
+                expected_arg_count,
+                supplied_arg_count,
+                "E0061",
+                sugg_unit,
+                sugg_tuple_wrap_args,
+            ));
             (self.err_args(supplied_arg_count), vec![])
         };
 
@@ -305,7 +346,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         // If there was an error in parameter count, emit that here
-        if let Some((expected_count, arg_count, err_code, sugg_unit)) = error {
+        if let Some((expected_count, arg_count, err_code, sugg_unit, sugg_tuple_wrap_args)) = error
+        {
             let (span, start_span, args, ctor_of) = match &call_expr.kind {
                 hir::ExprKind::Call(
                     hir::Expr {
@@ -406,6 +448,25 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     sugg_span,
                     "expected the unit value `()`; create it with empty parentheses",
                     String::from("()"),
+                    Applicability::MachineApplicable,
+                );
+            } else if let Some(tuple_fn_arg) = sugg_tuple_wrap_args {
+                use FnArgsAsTuple::*;
+
+                let spans = match tuple_fn_arg {
+                    Multi { first, last } => vec![
+                        (first.span.shrink_to_lo(), '('.to_string()),
+                        (last.span.shrink_to_hi(), ')'.to_string()),
+                    ],
+                    Single(single) => vec![
+                        (single.span.shrink_to_lo(), '('.to_string()),
+                        (single.span.shrink_to_hi(), ",)".to_string()),
+                    ],
+                };
+
+                err.multipart_suggestion(
+                    "use parentheses to construct a tuple",
+                    spans,
                     Applicability::MachineApplicable,
                 );
             } else {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -18,7 +18,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{ExprKind, Node, QPath};
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::fold::TypeFoldable;
-use rustc_middle::ty::{self, ParamEnv, Ty};
+use rustc_middle::ty::{self, Ty};
 use rustc_session::Session;
 use rustc_span::symbol::Ident;
 use rustc_span::{self, MultiSpan, Span};
@@ -514,7 +514,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let supplied_types: Vec<_> = provided_args.iter().map(|arg| self.check_expr(arg)).collect();
 
         let all_match = iter::zip(expected_types, supplied_types)
-            .all(|(expected, supplied)| self.can_eq(ParamEnv::empty(), expected, supplied).is_ok());
+            .all(|(expected, supplied)| self.can_eq(self.param_env, expected, supplied).is_ok());
 
         if all_match {
             match provided_args {

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
@@ -1,0 +1,13 @@
+// Ensure we don't suggest tuple-wrapping when we'd end up with a type error
+
+fn main() {
+    // we shouldn't suggest to fix these - `2` isn't a `bool`
+
+    let _: Option<(i32, bool)> = Some(1, 2);
+    //~^ ERROR this enum variant takes 1 argument but 2 arguments were supplied
+    int_bool(1, 2);
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+}
+
+fn int_bool(_: (i32, bool)) {
+}

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
@@ -7,6 +7,9 @@ fn main() {
     //~^ ERROR this enum variant takes 1 argument but 2 arguments were supplied
     int_bool(1, 2);
     //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+
+    let _: Option<(i8,)> = Some();
+    //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 }
 
 fn int_bool(_: (i32, bool)) {

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -1,0 +1,25 @@
+error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple-errors.rs:6:34
+   |
+LL |     let _: Option<(i32, bool)> = Some(1, 2);
+   |                                  ^^^^ -  - supplied 2 arguments
+   |                                  |
+   |                                  expected 1 argument
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple-errors.rs:8:5
+   |
+LL |     int_bool(1, 2);
+   |     ^^^^^^^^ -  - supplied 2 arguments
+   |     |
+   |     expected 1 argument
+   |
+note: function defined here
+  --> $DIR/args-instead-of-tuple-errors.rs:12:4
+   |
+LL | fn int_bool(_: (i32, bool)) {
+   |    ^^^^^^^^ --------------
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -15,11 +15,19 @@ LL |     int_bool(1, 2);
    |     expected 1 argument
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple-errors.rs:12:4
+  --> $DIR/args-instead-of-tuple-errors.rs:15:4
    |
 LL | fn int_bool(_: (i32, bool)) {
    |    ^^^^^^^^ --------------
 
-error: aborting due to 2 previous errors
+error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
+  --> $DIR/args-instead-of-tuple-errors.rs:11:28
+   |
+LL |     let _: Option<(i8,)> = Some();
+   |                            ^^^^-- supplied 0 arguments
+   |                            |
+   |                            expected 1 argument
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/suggestions/args-instead-of-tuple.fixed
+++ b/src/test/ui/suggestions/args-instead-of-tuple.fixed
@@ -11,8 +11,8 @@ fn main() {
     let _: Option<()> = Some(());
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
-    f((1, 2)); //~ ERROR this function takes 1 argument
+    two_ints((1, 2)); //~ ERROR this function takes 1 argument
 }
 
-fn f(_: (i32, i32)) {
+fn two_ints(_: (i32, i32)) {
 }

--- a/src/test/ui/suggestions/args-instead-of-tuple.fixed
+++ b/src/test/ui/suggestions/args-instead-of-tuple.fixed
@@ -1,0 +1,18 @@
+// Test suggesting tuples where bare arguments may have been passed
+// See issue #86481 for details.
+
+// run-rustfix
+
+fn main() {
+    let _: Result<(i32, i8), ()> = Ok((1, 2));
+    //~^ ERROR this enum variant takes 1 argument but 2 arguments were supplied
+    let _: Option<(i32, i8, &'static str)> = Some((1, 2, "hi"));
+    //~^ ERROR this enum variant takes 1 argument but 3 arguments were supplied
+    let _: Option<()> = Some(());
+    //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
+
+    f((1, 2)); //~ ERROR this function takes 1 argument
+}
+
+fn f(_: (i32, i32)) {
+}

--- a/src/test/ui/suggestions/args-instead-of-tuple.fixed
+++ b/src/test/ui/suggestions/args-instead-of-tuple.fixed
@@ -12,7 +12,16 @@ fn main() {
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
     two_ints((1, 2)); //~ ERROR this function takes 1 argument
+
+    with_generic((3, 4)); //~ ERROR this function takes 1 argument
 }
 
 fn two_ints(_: (i32, i32)) {
+}
+
+fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
+    if false {
+        // test generics/bound handling
+        with_generic((a, b)); //~ ERROR this function takes 1 argument
+    }
 }

--- a/src/test/ui/suggestions/args-instead-of-tuple.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple.rs
@@ -12,7 +12,16 @@ fn main() {
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
     two_ints(1, 2); //~ ERROR this function takes 1 argument
+
+    with_generic(3, 4); //~ ERROR this function takes 1 argument
 }
 
 fn two_ints(_: (i32, i32)) {
+}
+
+fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
+    if false {
+        // test generics/bound handling
+        with_generic(a, b); //~ ERROR this function takes 1 argument
+    }
 }

--- a/src/test/ui/suggestions/args-instead-of-tuple.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple.rs
@@ -11,8 +11,8 @@ fn main() {
     let _: Option<()> = Some();
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
-    f(1, 2); //~ ERROR this function takes 1 argument
+    two_ints(1, 2); //~ ERROR this function takes 1 argument
 }
 
-fn f(_: (i32, i32)) {
+fn two_ints(_: (i32, i32)) {
 }

--- a/src/test/ui/suggestions/args-instead-of-tuple.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple.rs
@@ -1,0 +1,18 @@
+// Test suggesting tuples where bare arguments may have been passed
+// See issue #86481 for details.
+
+// run-rustfix
+
+fn main() {
+    let _: Result<(i32, i8), ()> = Ok(1, 2);
+    //~^ ERROR this enum variant takes 1 argument but 2 arguments were supplied
+    let _: Option<(i32, i8, &'static str)> = Some(1, 2, "hi");
+    //~^ ERROR this enum variant takes 1 argument but 3 arguments were supplied
+    let _: Option<()> = Some();
+    //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
+
+    f(1, 2); //~ ERROR this function takes 1 argument
+}
+
+fn f(_: (i32, i32)) {
+}

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -34,18 +34,18 @@ LL |     let _: Option<()> = Some(());
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/args-instead-of-tuple.rs:14:5
    |
-LL |     f(1, 2);
-   |     ^ -  - supplied 2 arguments
+LL |     two_ints(1, 2);
+   |     ^^^^^^^^ -  - supplied 2 arguments
    |
 note: function defined here
   --> $DIR/args-instead-of-tuple.rs:17:4
    |
-LL | fn f(_: (i32, i32)) {
-   |    ^ -------------
+LL | fn two_ints(_: (i32, i32)) {
+   |    ^^^^^^^^ -------------
 help: use parentheses to construct a tuple
    |
-LL |     f((1, 2));
-   |       +    +
+LL |     two_ints((1, 2));
+   |              +    +
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -1,0 +1,52 @@
+error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:7:36
+   |
+LL |     let _: Result<(i32, i8), ()> = Ok(1, 2);
+   |                                    ^^ -  - supplied 2 arguments
+   |
+help: use parentheses to construct a tuple
+   |
+LL |     let _: Result<(i32, i8), ()> = Ok((1, 2));
+   |                                       +    +
+
+error[E0061]: this enum variant takes 1 argument but 3 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:9:46
+   |
+LL |     let _: Option<(i32, i8, &'static str)> = Some(1, 2, "hi");
+   |                                              ^^^^ -  -  ---- supplied 3 arguments
+   |
+help: use parentheses to construct a tuple
+   |
+LL |     let _: Option<(i32, i8, &'static str)> = Some((1, 2, "hi"));
+   |                                                   +          +
+
+error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:11:25
+   |
+LL |     let _: Option<()> = Some();
+   |                         ^^^^-- supplied 0 arguments
+   |
+help: expected the unit value `()`; create it with empty parentheses
+   |
+LL |     let _: Option<()> = Some(());
+   |                              ++
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:14:5
+   |
+LL |     f(1, 2);
+   |     ^ -  - supplied 2 arguments
+   |
+note: function defined here
+  --> $DIR/args-instead-of-tuple.rs:17:4
+   |
+LL | fn f(_: (i32, i32)) {
+   |    ^ -------------
+help: use parentheses to construct a tuple
+   |
+LL |     f((1, 2));
+   |       +    +
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -38,7 +38,7 @@ LL |     two_ints(1, 2);
    |     ^^^^^^^^ -  - supplied 2 arguments
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple.rs:17:4
+  --> $DIR/args-instead-of-tuple.rs:19:4
    |
 LL | fn two_ints(_: (i32, i32)) {
    |    ^^^^^^^^ -------------
@@ -47,6 +47,38 @@ help: use parentheses to construct a tuple
 LL |     two_ints((1, 2));
    |              +    +
 
-error: aborting due to 4 previous errors
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:16:5
+   |
+LL |     with_generic(3, 4);
+   |     ^^^^^^^^^^^^ -  - supplied 2 arguments
+   |
+note: function defined here
+  --> $DIR/args-instead-of-tuple.rs:22:4
+   |
+LL | fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
+   |    ^^^^^^^^^^^^                 ----------------
+help: use parentheses to construct a tuple
+   |
+LL |     with_generic((3, 4));
+   |                  +    +
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/args-instead-of-tuple.rs:25:9
+   |
+LL |         with_generic(a, b);
+   |         ^^^^^^^^^^^^ -  - supplied 2 arguments
+   |
+note: function defined here
+  --> $DIR/args-instead-of-tuple.rs:22:4
+   |
+LL | fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
+   |    ^^^^^^^^^^^^                 ----------------
+help: use parentheses to construct a tuple
+   |
+LL |         with_generic((a, b));
+   |                      +    +
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
This follows on from #86493 / #86481, making the parentheses suggestion. To summarise, given the following code:

```rust
fn f() -> Option<(i32, i8)> {
    Some(1, 2)
}
```

The current output is:

```
error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
 --> b.rs:2:5
  |
2 |     Some(1, 2)
  |     ^^^^ -  - supplied 2 arguments
  |     |
  |     expected 1 argument

error: aborting due to previous error

For more information about this error, try `rustc --explain E0061`.
```

With this change, `rustc` will now suggest parentheses when:
- The callee is expecting a single tuple argument
- The number of arguments passed matches the element count in the above tuple
- The arguments' types match the tuple's fields

```
error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
 --> b.rs:2:5
  |
2 |     Some(1, 2)
  |     ^^^^ -  - supplied 2 arguments
  |
help: use parentheses to construct a tuple
  |
2 |     Some((1, 2))
  |          +    +
```
