### PR TITLE
Permit const panics in stable const contexts in stdlib

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -36,6 +36,7 @@ use crate::panic::{Location, PanicInfo};
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[track_caller]
+#[rustc_const_unstable(feature = "core_panic", issue = "none")]
 #[lang = "panic"] // needed by codegen for panic on overflow and other `Assert` MIR terminators
 pub const fn panic(expr: &'static str) -> ! {
     // Use Arguments::new_v1 instead of format_args!("{}", expr) to potentially

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -727,7 +727,7 @@ impl Duration {
     pub const fn from_secs_f64(secs: f64) -> Duration {
         match Duration::try_from_secs_f64(secs) {
             Ok(v) => v,
-            Err(e) => crate::panicking::panic(e.description()),
+            Err(e) => panic!("{}", e.description()),
         }
     }
 
@@ -788,7 +788,7 @@ impl Duration {
     pub const fn from_secs_f32(secs: f32) -> Duration {
         match Duration::try_from_secs_f32(secs) {
             Ok(v) => v,
-            Err(e) => crate::panicking::panic(e.description()),
+            Err(e) => panic!("{}", e.description()),
         }
     }
 

--- a/src/test/ui/consts/const-eval/const_panic_stability.e2018.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_stability.e2018.stderr
@@ -1,0 +1,16 @@
+warning: panic message is not a string literal
+  --> $DIR/const_panic_stability.rs:14:12
+   |
+LL |     panic!({ "foo" });
+   |            ^^^^^^^^^
+   |
+   = note: `#[warn(non_fmt_panics)]` on by default
+   = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+help: add a "{}" format string to Display the message
+   |
+LL |     panic!("{}", { "foo" });
+   |            +++++
+
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/const-eval/const_panic_stability.e2021.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_stability.e2021.stderr
@@ -1,0 +1,13 @@
+error: format argument must be a string literal
+  --> $DIR/const_panic_stability.rs:14:12
+   |
+LL |     panic!({ "foo" });
+   |            ^^^^^^^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     panic!("{}", { "foo" });
+   |            +++++
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-eval/const_panic_stability.rs
+++ b/src/test/ui/consts/const-eval/const_panic_stability.rs
@@ -1,0 +1,17 @@
+// revisions: e2018 e2021
+//[e2018] edition:2018
+//[e2021] edition:2021
+//[e2018] check-pass
+#![crate_type = "lib"]
+#![stable(feature = "foo", since = "1.0.0")]
+#![feature(staged_api)]
+
+#[stable(feature = "foo", since = "1.0.0")]
+#[rustc_const_stable(feature = "foo", since = "1.0.0")]
+const fn foo() {
+    assert!(false);
+    assert!(false, "foo");
+    panic!({ "foo" });
+    //[e2018]~^ WARNING panic message is not a string literal
+    //[e2021]~^^ ERROR format argument must be a string literal
+}


### PR DESCRIPTION
Without this change, it is not possible to use `panic!` and similar (including `assert!`) in stable const contexts inside of stdlib. See #89542 for a real-world case that currently fails for this reason. This does _not_ affect any user code.

For example, this snippet currently fails to compile:

```rust
#[stable(feature = "foo", since = "1.0.0")]
#[rustc_const_stable(feature = "foo", since = "1.0.0")]
const fn foo() {
    assert!(false);
    assert!(false, "foo");
}
```

With the addition of `#[rustc_const_unstable]` to `core::panicking::panic`, the error no longer occurs. This snippet has been added verbatim in this PR as a UI test.

To avoid needing to add `#![feature(core_panic)]` to libcore, the two instances of direct calls to `core::panicking::panic` have been switched to use the `panic!` macro.

I am requesting prioritization because this is holding up other stabilizations such as #89542 (which is otherwise ready to merge and succeeds with this change)