### PR TITLE
kmc-solid: Avoid the use of `asm_const`

### DIFF
--- a/library/std/src/sys/solid/abi/mod.rs
+++ b/library/std/src/sys/solid/abi/mod.rs
@@ -4,17 +4,15 @@ mod fs;
 pub mod sockets;
 pub use self::fs::*;
 
-pub const SOLID_BP_PROGRAM_EXITED: usize = 15;
-pub const SOLID_BP_CSABORT: usize = 16;
-
 #[inline(always)]
 pub fn breakpoint_program_exited(tid: usize) {
     unsafe {
         match () {
+            // SOLID_BP_PROGRAM_EXITED = 15
             #[cfg(target_arch = "arm")]
-            () => asm!("bkpt #{}", const SOLID_BP_PROGRAM_EXITED, in("r0") tid),
+            () => asm!("bkpt #15", in("r0") tid),
             #[cfg(target_arch = "aarch64")]
-            () => asm!("hlt #{}", const SOLID_BP_PROGRAM_EXITED, in("x0") tid),
+            () => asm!("hlt #15", in("x0") tid),
         }
     }
 }
@@ -23,10 +21,11 @@ pub fn breakpoint_program_exited(tid: usize) {
 pub fn breakpoint_abort() {
     unsafe {
         match () {
+            // SOLID_BP_CSABORT = 16
             #[cfg(target_arch = "arm")]
-            () => asm!("bkpt #{}", const SOLID_BP_CSABORT),
+            () => asm!("bkpt #16"),
             #[cfg(target_arch = "aarch64")]
-            () => asm!("hlt #{}", const SOLID_BP_CSABORT),
+            () => asm!("hlt #16"),
         }
     }
 }


### PR DESCRIPTION
This PR removes the use of [the now-separated-out `asm_const` compiler feature][1] in `std::sys::solid` to fix the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets.

[1]: https://github.com/rust-lang/rust/pull/90348