### PR TITLE
io::ErrorKind: Discuss matching

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -88,6 +88,15 @@ struct Custom {
 /// It is used with the [`io::Error`] type.
 ///
 /// [`io::Error`]: Error
+///
+/// # Handling errors and matching on `ErrorKind`
+///
+/// In application code, use `match` for the `ErrorKind` values you are expecting; use `_` to match
+/// "all other errors".
+///
+/// In comprehensive and thorough tests, you may need to cut-and-paste the current list of
+/// errors from here into your test code.  This seems counterintuitive, but is correct,
+/// as set out in [this blog post](https://diziet.dreamwidth.org/9894.html#diziet-what-to-do).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]


### PR DESCRIPTION
Here I add a cross-reference to a blog post (one of my own).  I have no idea if that is allowed.  (FWIW the URL is stable and I don't expect Dreamwidth do go away.)

I did it like this because this extensive discussion doesn't readily fit into the stdlib docs.  I'm prepared for the possiblity that the suggestion to c&p, or the external reference, might be controversial...

Closes #89175