### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3b8db7f3341ddef15786d250106334d4a6c4b0ae4a46cd77082777d9849b9"
+checksum = "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
 dependencies = [
  "curl-sys",
  "libc",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.49+curl-7.79.1"
+version = "0.4.50+curl-7.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483"
+checksum = "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
4 commits in 94ca096afbf25f670e76e07dca754fcfe27134be..2e2a16e983f597da62bc132eb191bc3276d4b1bb
2021-10-29 14:45:06 +0000 to 2021-11-08 15:13:38 +0000
- Fix debug panic on download with redirect body. (rust-lang/cargo#10048)
- no need to clone (rust-lang/cargo#10051)
- Update curl. (rust-lang/cargo#10040)
- Fix --scrape-examples-target-crate using package name (with dashes) instead of crate name (with underscores) (rust-lang/cargo#10037)