### PR TITLE
Remove weird edge case for "Type::inner_def_id"

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1538,7 +1538,6 @@ impl Type {
             ResolvedPath { did, .. } => return Some(did),
             DynTrait(ref bounds, _) => return Some(bounds[0].trait_.def_id()),
             Primitive(p) => return cache.and_then(|c| c.primitive_locations.get(&p).cloned()),
-            BorrowedRef { type_: box Generic(..), .. } => PrimitiveType::Reference,
             BorrowedRef { ref type_, .. } => return type_.inner_def_id(cache),
             Tuple(ref tys) => {
                 if tys.is_empty() {


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/90385.

In this case, the generic is not considered as a generic because it is behind a reference. I'm surprised we had this for so long going unnoticed...

Extra explanations: we discovered it #90385 because since `Primitive::Reference` needs the `cache`, we simply ignored it before because `def_id_no_primitives` returned `None`. But since we're now using it everywhere, it is not discarded anymore, which allowed us to uncover this bug.

cc @jyn514 
r? @camelid 