### PR TITLE
Build musl dist artifacts with debuginfo enabled

### DIFF
--- a/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
@@ -8,6 +8,7 @@ RUN sh /scripts/crosstool-ng-1.24.sh
 
 WORKDIR /build
 
+COPY scripts/musl-patch-configure.diff /build/
 COPY scripts/musl-toolchain.sh /build/
 # We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
 RUN CFLAGS="-Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \

--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /build/
 COPY scripts/cmake.sh /scripts/
 RUN /scripts/cmake.sh
 
+COPY scripts/musl-patch-configure.diff /build/
 COPY scripts/musl-toolchain.sh /build/
 # We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
 RUN CFLAGS="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -sL https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz | \
   tar -xJ
 
 WORKDIR /build/
+COPY scripts/musl-patch-configure.diff /build/
 COPY scripts/musl-toolchain.sh /build/
 RUN bash musl-toolchain.sh x86_64 && rm -rf build
 WORKDIR /

--- a/src/ci/docker/scripts/musl-patch-configure.diff
+++ b/src/ci/docker/scripts/musl-patch-configure.diff
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 86801281..ed2f7998 100755
+--- a/configure
++++ b/configure
+@@ -398,7 +398,7 @@ test "$debug" = yes && CFLAGS_AUTO=-g
+ #
+ printf "checking whether we should preprocess assembly to add debugging information... "
+ if fnmatch '-g*|*\ -g*' "$CFLAGS_AUTO $CFLAGS" &&
+-   test -f "tools/add-cfi.$ARCH.awk" &&
++   test -f "$srcdir/tools/add-cfi.$ARCH.awk" &&
+    printf ".file 1 \"srcfile.s\"\n.line 1\n.cfi_startproc\n.cfi_endproc" | $CC -g -x assembler -c -o /dev/null 2>/dev/null -
+ then
+   ADD_CFI=yes

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -38,12 +38,19 @@ shift
 
 # Ancient binutils versions don't understand debug symbols produced by more recent tools.
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
-export CFLAGS="-fPIC $CFLAGS"
+# Enable debug info. If we don't do so, users can't debug into musl code,
+# debuggers can't walk the stack, etc. Fixes #90103.
+export CFLAGS="-fPIC -g1 $CFLAGS"
 
 git clone https://github.com/richfelker/musl-cross-make # -b v0.9.9
 cd musl-cross-make
 # A few commits ahead of v0.9.9 to include the cowpatch fix:
 git checkout a54eb56f33f255dfca60be045f12a5cfaf5a72a9
+
+# Fix the cfi detection script in musl's configure so cfi is generated
+# when debug info is asked for.
+mkdir patches/musl-1.1.24
+cp ../musl-patch-configure.diff patches/musl-1.1.24/0001-fix-cfi-detection.diff
 
 hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE
 hide_output make install TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE OUTPUT=$OUTPUT


### PR DESCRIPTION
Since our musl targets link to a version of musl we build and bundle
with the targets, if users need to debug into musl or generate
backtraces which contain parts of the musl library, they will be unable
to do so unless we enable and ship the debug info.

This patch changes our dist builds so they enabled debug info when
building musl. This patch also includes a fix for CFI detection in
musl's `configure` script which has been [posted upstream](https://www.openwall.com/lists/musl/2021/10/21/2).

The net effect of this is that we now ship debug info for musl in those
targets. This adds ~90kb to those artifacts but running `strip` on
binaries produced removes all of that. For a "hello world" Rust binary
on x86_64, the numbers are:

|                        | debug | release | release + strip |
|           -            |   -   |    -    |        -        |
| without musl debuginfo | 507kb |  495kb  |      410kb      |
| with musl debuginfo    | 595kb | 584kb | 410kb |

Once stripped, the final binaries are the same size (down to the byte).

Fixes #90103

r? @Mark-Simulacrum 