### PR TITLE
adjust documented inline-asm register constraints

### DIFF
--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -566,8 +566,8 @@ Here is the list of currently supported register classes:
 | ARM (Thumb2) | `reg` | `r[0-12]`, `r14` | `r` |
 | ARM (Thumb1) | `reg` | `r[0-7]` | `r` |
 | ARM (ARM) | `reg_thumb` | `r[0-r12]`, `r14` | `l` |
-| ARM (Thumb2) | `reg_thumb` | `r[0-r7]` | `l` |
-| ARM (Thumb1) | `reg_thumb` | `r[0-r7]` | `l` |
+| ARM (Thumb2) | `reg_thumb` | `r[0-7]` | `l` |
+| ARM (Thumb1) | `reg_thumb` | `r[0-7]` | `l` |
 | ARM | `sreg` | `s[0-31]` | `t` |
 | ARM | `sreg_low16` | `s[0-15]` | `x` |
 | ARM | `dreg` | `d[0-31]` | `w` |

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -562,9 +562,12 @@ Here is the list of currently supported register classes:
 | AArch64 | `vreg` | `v[0-31]` | `w` |
 | AArch64 | `vreg_low16` | `v[0-15]` | `x` |
 | AArch64 | `preg` | `p[0-15]`, `ffr` | Only clobbers |
-| ARM | `reg` | `r[0-12]`, `r14` | `r` |
-| ARM (Thumb) | `reg_thumb` | `r[0-r7]` | `l` |
+| ARM (ARM) | `reg` | `r[0-12]`, `r14` | `r` |
+| ARM (Thumb2) | `reg` | `r[0-12]`, `r14` | `r` |
+| ARM (Thumb1) | `reg` | `r[0-r7]` | `r` |
 | ARM (ARM) | `reg_thumb` | `r[0-r12]`, `r14` | `l` |
+| ARM (Thumb2) | `reg_thumb` | `r[0-r7]` | `l` |
+| ARM (Thumb1) | `reg_thumb` | `r[0-r7]` | `l` |
 | ARM | `sreg` | `s[0-31]` | `t` |
 | ARM | `sreg_low16` | `s[0-15]` | `x` |
 | ARM | `dreg` | `d[0-31]` | `w` |

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -564,7 +564,7 @@ Here is the list of currently supported register classes:
 | AArch64 | `preg` | `p[0-15]`, `ffr` | Only clobbers |
 | ARM (ARM) | `reg` | `r[0-12]`, `r14` | `r` |
 | ARM (Thumb2) | `reg` | `r[0-12]`, `r14` | `r` |
-| ARM (Thumb1) | `reg` | `r[0-r7]` | `r` |
+| ARM (Thumb1) | `reg` | `r[0-7]` | `r` |
 | ARM (ARM) | `reg_thumb` | `r[0-r12]`, `r14` | `l` |
 | ARM (Thumb2) | `reg_thumb` | `r[0-r7]` | `l` |
 | ARM (Thumb1) | `reg_thumb` | `r[0-r7]` | `l` |


### PR DESCRIPTION
This change more clearly specifies how `reg` and `reg_thumb` work with ARM, Thumb2, and Thumb1 code.

Based upon the [llvm documentation](https://llvm.org/docs/LangRef.html#supported-constraint-code-list) for register constraint codes.
To be clear, this just updates the docs to match what already happens with rustc/llvm.
No change in the compiler is required to make it match this new documentation.