### PR TITLE
Const `Option::cloned`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1497,8 +1497,12 @@ impl<T: Clone> Option<&T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn cloned(self) -> Option<T> {
-        self.map(|t| t.clone())
+    #[rustc_const_unstable(feature = "option_const_cloned", issue = "none")]
+    pub const fn cloned(self) -> Option<T> where T: ~const Clone {
+        match self {
+            Some(t) => Some(t.clone()),
+            None => None,
+        }
     }
 }
 
@@ -1515,9 +1519,14 @@ impl<T: Clone> Option<&mut T> {
     /// let cloned = opt_x.cloned();
     /// assert_eq!(cloned, Some(12));
     /// ```
+    #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(since = "1.26.0", feature = "option_ref_mut_cloned")]
-    pub fn cloned(self) -> Option<T> {
-        self.map(|t| t.clone())
+    #[rustc_const_unstable(feature = "option_const_cloned", issue = "none")]
+    pub const fn cloned(self) -> Option<T> where T: ~const Clone {
+        match self {
+            Some(t) => Some(t.clone()),
+            None => None,
+        }
     }
 }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1498,7 +1498,10 @@ impl<T: Clone> Option<&T> {
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
-    pub const fn cloned(self) -> Option<T> where T: ~const Clone {
+    pub const fn cloned(self) -> Option<T>
+    where
+        T: ~const Clone,
+    {
         match self {
             Some(t) => Some(t.clone()),
             None => None,
@@ -1522,7 +1525,10 @@ impl<T: Clone> Option<&mut T> {
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(since = "1.26.0", feature = "option_ref_mut_cloned")]
     #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
-    pub const fn cloned(self) -> Option<T> where T: ~const Clone {
+    pub const fn cloned(self) -> Option<T>
+    where
+        T: ~const Clone,
+    {
         match self {
             Some(t) => Some(t.clone()),
             None => None,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1497,7 +1497,7 @@ impl<T: Clone> Option<&T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "option_const_cloned", issue = "none")]
+    #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
     pub const fn cloned(self) -> Option<T> where T: ~const Clone {
         match self {
             Some(t) => Some(t.clone()),
@@ -1521,7 +1521,7 @@ impl<T: Clone> Option<&mut T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(since = "1.26.0", feature = "option_ref_mut_cloned")]
-    #[rustc_const_unstable(feature = "option_const_cloned", issue = "none")]
+    #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
     pub const fn cloned(self) -> Option<T> where T: ~const Clone {
         match self {
             Some(t) => Some(t.clone()),

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1497,7 +1497,7 @@ impl<T: Clone> Option<&T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
+    #[rustc_const_unstable(feature = "const_option_cloned", issue = "91582")]
     pub const fn cloned(self) -> Option<T>
     where
         T: ~const Clone,
@@ -1524,7 +1524,7 @@ impl<T: Clone> Option<&mut T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(since = "1.26.0", feature = "option_ref_mut_cloned")]
-    #[rustc_const_unstable(feature = "const_option_cloned", issue = "none")]
+    #[rustc_const_unstable(feature = "const_option_cloned", issue = "91582")]
     pub const fn cloned(self) -> Option<T>
     where
         T: ~const Clone,


### PR DESCRIPTION
This constifies the two `Option::cloned` functions, bounded on `~const Clone`.