### PR TITLE
rustdoc: Replace where-bounded Clean impl with simple function

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -229,6 +229,7 @@ fn build_external_function(cx: &mut DocContext<'_>, did: DefId) -> clean::Functi
     let asyncness = cx.tcx.asyncness(did);
     let predicates = cx.tcx.predicates_of(did);
     let (generics, decl) = clean::enter_impl_trait(cx, |cx| {
+        // NOTE: generics need to be cleaned before the decl!
         ((cx.tcx.generics_of(did), predicates).clean(cx), (did, sig).clean(cx))
     });
     clean::Function {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -109,7 +109,10 @@ impl Clean<GenericBound> for hir::GenericBound<'_> {
                 };
 
                 GenericBound::TraitBound(
-                    PolyTrait { trait_: (trait_ref, &*bindings).clean(cx), generic_params: vec![] },
+                    PolyTrait {
+                        trait_: (trait_ref, &bindings[..]).clean(cx),
+                        generic_params: vec![],
+                    },
                     hir::TraitBoundModifier::None,
                 )
             }
@@ -764,7 +767,7 @@ impl<'a> Clean<Function> for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::Bo
         let (generics, decl) = enter_impl_trait(cx, |cx| {
             let generics = self.1.clean(cx);
             let args = (self.0.decl.inputs, self.2).clean(cx);
-            let decl = clean_fn_decl_with_args(cx, &*self.0.decl, args);
+            let decl = clean_fn_decl_with_args(cx, self.0.decl, args);
             (generics, decl)
         });
         Function { decl, generics, header: self.0.header }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -765,6 +765,7 @@ fn clean_fn_or_proc_macro(
 impl<'a> Clean<Function> for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::BodyId) {
     fn clean(&self, cx: &mut DocContext<'_>) -> Function {
         let (generics, decl) = enter_impl_trait(cx, |cx| {
+            // NOTE: generics must be cleaned before args
             let generics = self.1.clean(cx);
             let args = (self.0.decl.inputs, self.2).clean(cx);
             let decl = clean_fn_decl_with_args(cx, self.0.decl, args);
@@ -896,6 +897,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
                 }
                 hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Required(names)) => {
                     let (generics, decl) = enter_impl_trait(cx, |cx| {
+                        // NOTE: generics must be cleaned before args
                         let generics = self.generics.clean(cx);
                         let args = (sig.decl.inputs, names).clean(cx);
                         let decl = clean_fn_decl_with_args(cx, sig.decl, args);
@@ -1732,6 +1734,7 @@ impl Clean<PathSegment> for hir::PathSegment<'_> {
 impl Clean<BareFunctionDecl> for hir::BareFnTy<'_> {
     fn clean(&self, cx: &mut DocContext<'_>) -> BareFunctionDecl {
         let (generic_params, decl) = enter_impl_trait(cx, |cx| {
+            // NOTE: generics must be cleaned before args
             let generic_params = self.generic_params.iter().map(|x| x.clean(cx)).collect();
             let args = (self.decl.inputs, self.param_names).clean(cx);
             let decl = clean_fn_decl_with_args(cx, self.decl, args);
@@ -2032,6 +2035,7 @@ impl Clean<Item> for (&hir::ForeignItem<'_>, Option<Symbol>) {
                 hir::ForeignItemKind::Fn(decl, names, ref generics) => {
                     let abi = cx.tcx.hir().get_foreign_abi(item.hir_id());
                     let (generics, decl) = enter_impl_trait(cx, |cx| {
+                        // NOTE: generics must be cleaned before args
                         let generics = generics.clean(cx);
                         let args = (decl.inputs, names).clean(cx);
                         let decl = clean_fn_decl_with_args(cx, decl, args);


### PR DESCRIPTION
This is the first step in removing the Clean impls for tuples. Either way, this
significantly simplifies the code since it reduces the amount of "trait magic".

(To clarify, I'm referring to impls like `impl Clean for (A, B)`, not Clean impls
that work on tuples in the user's program.)

cc @jyn514
