### PR TITLE
Disable precise_enum_drop_elaboration by default

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1245,10 +1245,10 @@ options! {
         "a single extra argument to prepend the linker invocation (can be used several times)"),
     pre_link_args: Vec<String> = (Vec::new(), parse_list, [UNTRACKED],
         "extra arguments to prepend to the linker invocation (space separated)"),
-    precise_enum_drop_elaboration: bool = (true, parse_bool, [TRACKED],
+    precise_enum_drop_elaboration: bool = (false, parse_bool, [TRACKED],
         "use a more precise version of drop elaboration for matches on enums (default: yes). \
-        This results in better codegen, but has caused miscompilations on some tier 2 platforms. \
-        See #77382 and #74551."),
+        This results in better codegen, but has caused miscompilations. \
+        See #77382, #74551 and 90752."),
     print_fuel: Option<String> = (None, parse_opt_string, [TRACKED],
         "make rustc print the total optimization fuel used by a crate"),
     print_link_args: bool = (false, parse_bool, [UNTRACKED],

--- a/src/test/ui/mir/issue-90752.rs
+++ b/src/test/ui/mir/issue-90752.rs
@@ -1,0 +1,38 @@
+// run-pass
+
+struct V;
+struct S;
+
+impl Drop for S {
+    fn drop(&mut self) {
+        std::process::exit(1);
+    }
+}
+
+enum E {
+    A,
+    B((V, S)),
+}
+
+fn foo(v: &mut E) {
+    *v = E::B((V, S));
+}
+
+fn bar() {
+    let mut v = E::A;
+    match v {
+        E::A => (),
+        _ => unreachable!(),
+    }
+    foo(&mut v);
+    match v {
+        E::B((_x, _)) => {}
+        _ => {}
+    }
+    // v is `E::B((V, S))`, so `S::drop` should be called and this shouldn't return.
+}
+
+pub fn main() {
+    bar();
+    unreachable!();
+}


### PR DESCRIPTION
Temporary fix for #90752.

@rustbot label: +T-compiler +A-mir