### PR TITLE
Remove unneeded FIXMEs comments in search index generation

### DIFF
--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -377,13 +377,9 @@ crate fn get_all_types<'tcx>(
         if arg.type_.is_self_type() {
             continue;
         }
-        // FIXME: performance wise, it'd be much better to move `args` declaration outside of the
-        // loop and replace this line with `args.clear()`.
         let mut args = Vec::new();
         get_real_types(generics, &arg.type_, tcx, 0, &mut args);
         if !args.is_empty() {
-            // FIXME: once back to performance improvements, replace this line with:
-            // `all_types.extend(args.drain(..));`.
             all_types.extend(args);
         } else {
             if let Some(kind) = arg.type_.def_id_no_primitives().map(|did| tcx.def_kind(did).into())


### PR DESCRIPTION
Original comment:

> Instead of recreating a new `vec` for each arguments, we re-use the same. The impact on performance should be minor but worth a try.

After testing it, we reached the conclusion that the code readability drop wasn't worth the almost unnoticeable performance improvement.

r? @camelid 