### PR TITLE
Shorten Span of unused macro lints

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1194,15 +1194,9 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     // Mark the given macro as unused unless its name starts with `_`.
     // Macro uses will remove items from this set, and the remaining
     // items will be reported as `unused_macros`.
-    fn insert_unused_macro(
-        &mut self,
-        ident: Ident,
-        def_id: LocalDefId,
-        node_id: NodeId,
-        span: Span,
-    ) {
+    fn insert_unused_macro(&mut self, ident: Ident, def_id: LocalDefId, node_id: NodeId) {
         if !ident.as_str().starts_with('_') {
-            self.r.unused_macros.insert(def_id, (node_id, span));
+            self.r.unused_macros.insert(def_id, (node_id, ident));
         }
     }
 
@@ -1246,7 +1240,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 self.r.define(module, ident, MacroNS, (res, vis, span, expansion, IsMacroExport));
             } else {
                 self.r.check_reserved_macro_name(ident, res);
-                self.insert_unused_macro(ident, def_id, item.id, span);
+                self.insert_unused_macro(ident, def_id, item.id);
             }
             self.r.visibilities.insert(def_id, vis);
             self.r.arenas.alloc_macro_rules_scope(MacroRulesScope::Binding(
@@ -1267,7 +1261,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 _ => self.resolve_visibility(&item.vis),
             };
             if vis != ty::Visibility::Public {
-                self.insert_unused_macro(ident, def_id, item.id, span);
+                self.insert_unused_macro(ident, def_id, item.id);
             }
             self.r.define(module, ident, MacroNS, (res, vis, span, expansion));
             self.r.visibilities.insert(def_id, vis);

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -988,7 +988,7 @@ pub struct Resolver<'a> {
     non_macro_attr: Lrc<SyntaxExtension>,
     local_macro_def_scopes: FxHashMap<LocalDefId, Module<'a>>,
     ast_transform_scopes: FxHashMap<LocalExpnId, Module<'a>>,
-    unused_macros: FxHashMap<LocalDefId, (NodeId, Span)>,
+    unused_macros: FxHashMap<LocalDefId, (NodeId, Ident)>,
     proc_macro_stubs: FxHashSet<LocalDefId>,
     /// Traces collected during macro resolution and validated when it's complete.
     single_segment_macro_resolutions:

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -315,8 +315,13 @@ impl<'a> ResolverExpand for Resolver<'a> {
     }
 
     fn check_unused_macros(&mut self) {
-        for (_, &(node_id, span)) in self.unused_macros.iter() {
-            self.lint_buffer.buffer_lint(UNUSED_MACROS, node_id, span, "unused macro definition");
+        for (_, &(node_id, ident)) in self.unused_macros.iter() {
+            self.lint_buffer.buffer_lint(
+                UNUSED_MACROS,
+                node_id,
+                ident.span,
+                &format!("unused macro definition: `{}`", ident.as_str()),
+            );
         }
     }
 

--- a/src/test/ui/lint/unused/issue-70041.stderr
+++ b/src/test/ui/lint/unused/issue-70041.stderr
@@ -1,11 +1,8 @@
-warning: unused macro definition
-  --> $DIR/issue-70041.rs:4:1
+warning: unused macro definition: `regex`
+  --> $DIR/issue-70041.rs:4:14
    |
-LL | / macro_rules! regex {
-LL | |
-LL | |     () => {};
-LL | | }
-   | |_^
+LL | macro_rules! regex {
+   |              ^^^^^
    |
    = note: `#[warn(unused_macros)]` on by default
 

--- a/src/test/ui/lint/unused/unused-macro-rules.stderr
+++ b/src/test/ui/lint/unused/unused-macro-rules.stderr
@@ -1,10 +1,8 @@
-error: unused macro definition
-  --> $DIR/unused-macro-rules.rs:4:1
+error: unused macro definition: `unused`
+  --> $DIR/unused-macro-rules.rs:4:14
    |
-LL | / macro_rules! unused {
-LL | |     () => {};
-LL | | }
-   | |_^
+LL | macro_rules! unused {
+   |              ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-macro-rules.rs:1:9
@@ -12,26 +10,17 @@ note: the lint level is defined here
 LL | #![deny(unused_macros)]
    |         ^^^^^^^^^^^^^
 
-error: unused macro definition
-  --> $DIR/unused-macro-rules.rs:11:9
+error: unused macro definition: `m`
+  --> $DIR/unused-macro-rules.rs:11:22
    |
-LL | /         macro_rules! m {
-LL | |             () => {};
-LL | |         }
-   | |_________^
-...
-LL |   create_macro!();
-   |   --------------- in this macro invocation
-   |
-   = note: this error originates in the macro `create_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |         macro_rules! m {
+   |                      ^
 
-error: unused macro definition
-  --> $DIR/unused-macro-rules.rs:24:5
+error: unused macro definition: `unused`
+  --> $DIR/unused-macro-rules.rs:24:18
    |
-LL | /     macro_rules! unused {
-LL | |         () => {};
-LL | |     }
-   | |_____^
+LL |     macro_rules! unused {
+   |                  ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-macro-rules.rs:23:12

--- a/src/test/ui/lint/unused/unused-macro.stderr
+++ b/src/test/ui/lint/unused/unused-macro.stderr
@@ -1,10 +1,8 @@
-error: unused macro definition
-  --> $DIR/unused-macro.rs:5:1
+error: unused macro definition: `unused`
+  --> $DIR/unused-macro.rs:5:7
    |
-LL | / macro unused {
-LL | |     () => {}
-LL | | }
-   | |_^
+LL | macro unused {
+   |       ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-macro.rs:2:9
@@ -12,13 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unused_macros)]
    |         ^^^^^^^^^^^^^
 
-error: unused macro definition
-  --> $DIR/unused-macro.rs:15:5
+error: unused macro definition: `unused`
+  --> $DIR/unused-macro.rs:15:11
    |
-LL | /     macro unused {
-LL | |         () => {}
-LL | |     }
-   | |_____^
+LL |     macro unused {
+   |           ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-macro.rs:14:12
@@ -26,13 +22,11 @@ note: the lint level is defined here
 LL |     #[deny(unused_macros)]
    |            ^^^^^^^^^^^^^
 
-error: unused macro definition
-  --> $DIR/unused-macro.rs:21:5
+error: unused macro definition: `unused`
+  --> $DIR/unused-macro.rs:21:22
    |
-LL | /     pub(crate) macro unused {
-LL | |         () => {}
-LL | |     }
-   | |_____^
+LL |     pub(crate) macro unused {
+   |                      ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/proc-macro/issue-39889.rs
+++ b/src/test/ui/proc-macro/issue-39889.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-#![allow(dead_code)]
+#![allow(dead_code, unused_macros)]
 // aux-build:issue-39889.rs
 
 extern crate issue_39889;


### PR DESCRIPTION
The span has been reduced to the actual ident of the macro, instead of linting the
*whole* macro.

Closes #90745 

r? @estebank 