### PR TITLE
[WIP] Try out alternate CGU merging strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4232,6 +4232,7 @@ dependencies = [
 name = "rustc_monomorphize"
 version = "0.0.0"
 dependencies = [
+ "itertools 0.10.1",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hir",

--- a/compiler/rustc_monomorphize/Cargo.toml
+++ b/compiler/rustc_monomorphize/Cargo.toml
@@ -17,3 +17,4 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
+itertools = "0.10.1"


### PR DESCRIPTION
This implements [largest difference partitioning](https://en.wikipedia.org/wiki/Largest_differencing_method), which has a worse worst-case bound for k partitions (`4/3 + 1/3*k`) compared to the current [greedy number partitioning approach](https://en.wikipedia.org/wiki/Greedy_number_partitioning) (`(4k-1)/3k`) but Wikipedia at least suggests has better performance on average.

Will also test Multifit -- and maybe an exact solution -- but wanted to see what effect, if any, this has on runtimes.

r? @ghost