### PR TITLE
Normalize both arguments of `equate_normalized_input_or_output`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -893,11 +893,11 @@ struct TypeChecker<'a, 'tcx> {
 }
 
 struct BorrowCheckContext<'a, 'tcx> {
-    universal_regions: &'a UniversalRegions<'tcx>,
+    pub(crate) universal_regions: &'a UniversalRegions<'tcx>,
     location_table: &'a LocationTable,
     all_facts: &'a mut Option<AllFacts>,
     borrow_set: &'a BorrowSet<'tcx>,
-    constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
+    pub(crate) constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
     upvars: &'a [Upvar<'tcx>],
 }
 
@@ -1157,6 +1157,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         self.relate_types(sup, ty::Variance::Contravariant, sub, locations, category)
     }
 
+    #[instrument(skip(self, category), level = "debug")]
     fn eq_types(
         &mut self,
         expected: Ty<'tcx>,

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90612.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90612.rs
@@ -1,0 +1,43 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+use std::marker::PhantomData;
+
+trait Family: Sized {
+    type Item<'a>;
+
+    fn apply_all<F>(&self, f: F)
+    where
+        F: FamilyItemFn<Self> { }
+}
+
+struct Array<T>(PhantomData<T>);
+
+impl<T: 'static> Family for Array<T> {
+    type Item<'a> = &'a T;
+}
+
+trait FamilyItemFn<T: Family> {
+    fn apply(&self, item: T::Item<'_>);
+}
+
+impl<T, F> FamilyItemFn<T> for F
+where
+    T: Family,
+    for<'a> F: Fn(T::Item<'a>)
+{
+    fn apply(&self, item: T::Item<'_>) {
+        (*self)(item);
+    }
+}
+
+fn process<T: 'static>(array: Array<T>) {
+    // Works
+    array.apply_all(|x: &T| { });
+
+    // ICE: NoSolution
+    array.apply_all(|x: <Array<T> as Family>::Item<'_>| { });
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90638.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90638.rs
@@ -1,0 +1,37 @@
+//check-pass
+
+#![feature(generic_associated_types)]
+
+trait Yokeable<'a>: 'static {
+    type Output: 'a;
+}
+
+trait IsCovariant<'a> {}
+
+struct Yoke<Y: for<'a> Yokeable<'a>> {
+    data: Y,
+}
+
+impl<Y: for<'a> Yokeable<'a>> Yoke<Y> {
+    fn project<Y2: for<'a> Yokeable<'a>>(&self, _f: for<'a> fn(<Y as Yokeable<'a>>::Output, &'a ())
+      -> <Y2 as Yokeable<'a>>::Output) -> Yoke<Y2> {
+
+        unimplemented!()
+    }
+}
+
+fn _upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> where
+    Y: for<'a> Yokeable<'a>,
+    for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>
+    {
+    x.project(|data, _| {
+        Box::new(data)
+    })
+}
+
+
+impl<'a> Yokeable<'a> for Box<dyn IsCovariant<'static> + 'static> {
+    type Output = Box<dyn IsCovariant<'a> + 'a>;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/90638
Fixes https://github.com/rust-lang/rust/issues/90612

Temporary fix for a more complex underlying problem stemming from an inability to normalize closure substs during typecheck.

r? @jackh726 