### PR TITLE
Fixes incorrect handling of TraitRefs when emitting suggestions.

### DIFF
--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `C: Copy` is not satisfied
+error[E0277]: the trait bound `B<C>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
 LL |     is_copy(B { a: 1, b: C });
@@ -22,7 +22,7 @@ help: consider borrowing here
 LL |     is_copy(&B { a: 1, b: C });
    |             +
 
-error[E0277]: the trait bound `C: Clone` is not satisfied
+error[E0277]: the trait bound `B<C>: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
 LL |     is_clone(B { a: 1, b: C });
@@ -46,7 +46,7 @@ help: consider borrowing here
 LL |     is_clone(&B { a: 1, b: C });
    |              +
 
-error[E0277]: the trait bound `D: Copy` is not satisfied
+error[E0277]: the trait bound `B<D>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
 LL |     is_copy(B { a: 1, b: D });

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -65,7 +65,7 @@ LL |     is_send(Box::new(TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `dummy2::TestType: Send` is not satisfied
+   = note: the trait bound `Unique<dummy2::TestType>: Send` is not satisfied
    = note: required because of the requirements on the impl of `Send` for `Unique<dummy2::TestType>`
    = note: required because it appears within the type `Box<dummy2::TestType>`
 note: required by a bound in `is_send`
@@ -104,11 +104,11 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
 LL |     is_sync(Outer2(TestType));
-   |     ------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Sync`
+   |     ------- ^^^^^^^^^^^^^^^^ `main::TestType` cannot be sent between threads safely
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `main::TestType: Sync` is not satisfied
+   = help: the trait `Send` is not implemented for `main::TestType`
 note: required because of the requirements on the impl of `Sync` for `Outer2<main::TestType>`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |
@@ -119,12 +119,6 @@ note: required by a bound in `is_sync`
    |
 LL | fn is_sync<T: Sync>(_: T) {}
    |               ^^^^ required by this bound in `is_sync`
-help: consider borrowing here
-   |
-LL |     is_sync(&Outer2(TestType));
-   |             +
-LL |     is_sync(&mut Outer2(TestType));
-   |             ++++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
@@ -1,0 +1,11 @@
+// Do not suggest referencing the parameter to `check`
+
+trait Marker<T> {}
+
+impl<T> Marker<i32> for T {}
+
+pub fn check<T: Marker<u32>>(_: T) {}
+
+pub fn main() {
+    check::<()>(()); //~ ERROR [E0277]
+}

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `(): Marker<u32>` is not satisfied
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:10:17
+   |
+LL |     check::<()>(());
+   |     ----------- ^^ the trait `Marker<u32>` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `check`
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:7:17
+   |
+LL | pub fn check<T: Marker<u32>>(_: T) {}
+   |                 ^^^^^^^^^^^ required by this bound in `check`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes #90804 , although there were more issues here that were hidden by the thing that caused this ICE.

Underlying problem was that substitutions were being thrown out, which not only leads to an ICE but also incorrect diagnostics. On top of that, in some cases the self types from the root obligations were being mixed in with those from derived obligations.

This makes a couple diagnostics arguable worse ("`B<C>` does not implement `Copy`" instead of "`C` does not implement `Copy`") but the worse diagnostics are at least still correct and that downside is in my opinion clearly outweighed by the benefits of fixing the ICE and unambiguously wrong diagnostics.