### PR TITLE
Relax `A: 'static` bound for boxed `Pin` APIs

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -543,7 +543,7 @@ impl<T, A: Allocator> Box<T, A> {
     #[inline(always)]
     pub const fn pin_in(x: T, alloc: A) -> Pin<Self>
     where
-        A: 'static + ~const Allocator + ~const Drop,
+        A: ~const Allocator + ~const Drop,
     {
         Self::into_pin(Self::new_in(x, alloc))
     }
@@ -1158,10 +1158,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// This is also available via [`From`].
     #[unstable(feature = "box_into_pin", issue = "62370")]
     #[rustc_const_unstable(feature = "const_box", issue = "92521")]
-    pub const fn into_pin(boxed: Self) -> Pin<Self>
-    where
-        A: 'static,
-    {
+    pub const fn into_pin(boxed: Self) -> Pin<Self> {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`,  so it's safe to pin it directly without any
         // additional requirements.
@@ -1382,10 +1379,7 @@ impl<T> From<T> for Box<T> {
 
 #[stable(feature = "pin", since = "1.33.0")]
 #[rustc_const_unstable(feature = "const_box", issue = "92521")]
-impl<T: ?Sized, A: Allocator> const From<Box<T, A>> for Pin<Box<T, A>>
-where
-    A: 'static,
-{
+impl<T: ?Sized, A: Allocator> const From<Box<T, A>> for Pin<Box<T, A>> {
     /// Converts a `Box<T>` into a `Pin<Box<T>>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
@@ -1951,14 +1945,10 @@ impl<T: ?Sized, A: Allocator> AsMut<T> for Box<T, A> {
  *  could have a method to project a Pin<T> from it.
  */
 #[stable(feature = "pin", since = "1.33.0")]
-#[rustc_const_unstable(feature = "const_box", issue = "92521")]
-impl<T: ?Sized, A: Allocator> const Unpin for Box<T, A> where A: 'static {}
+impl<T: ?Sized, A: Allocator> const Unpin for Box<T, A> {}
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator<R> + Unpin, R, A: Allocator> Generator<R> for Box<G, A>
-where
-    A: 'static,
-{
+impl<G: ?Sized + Generator<R> + Unpin, R, A: Allocator> Generator<R> for Box<G, A> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -1968,10 +1958,7 @@ where
 }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator<R>, R, A: Allocator> Generator<R> for Pin<Box<G, A>>
-where
-    A: 'static,
-{
+impl<G: ?Sized + Generator<R>, R, A: Allocator> Generator<R> for Pin<Box<G, A>> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -1981,10 +1968,7 @@ where
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]
-impl<F: ?Sized + Future + Unpin, A: Allocator> Future for Box<F, A>
-where
-    A: 'static,
-{
+impl<F: ?Sized + Future + Unpin, A: Allocator> Future for Box<F, A> {
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
In #79327, the `Pin` APIs for `Box` were restricted to `A: 'static`. This was overly cautious and restricts the `Pin` APIs unnecessarily. The justification for doing this was as follows:

> Allocators has to retain their validity until the instance and all of its clones are dropped. When pinning a value, it must live forever, thus, the allocator requires a 'static lifetime for pinning a value. [Example from reddit](https://www.reddit.com/r/rust/comments/jymzdw/the_story_continues_vec_now_supports_custom/gd7qak2?utm_source=share&utm_medium=web2x&context=3):
>
> ```rust
> let alloc = MyAlloc(/* ... */);
> let pinned = Box::pin_in(42, alloc);
> mem::forget(pinned); // Now `value` must live forever
> // Otherwise `Pin`'s invariants are violated, storage invalidated
> // before Drop was called.
> // borrow of `memory` can end here, there is no value keeping it.
> drop(alloc); // Oh, value doesn't live forever.
> ```

In the comment thread, @TimDiekmann correctly observed that the given code produces a compiler error:

> ```
> error[E0503]: cannot use `memory` because it was mutably borrowed
>     |
>     | let region = Region::new(&mut memory[..]);
>     |              ----------------------------
>     |              |                |
>     |              |                borrow of `memory` occurs here
>     |              argument requires that `memory` is borrowed for `'static`
> ...
>     | drop(memory);
>     |      ^^^^^^ use of borrowed `memory`
> ```

This is a hint that the reasoning may not be correct. Forgetting the box will also forget the allocator, which will prevent the memory from being freed and therefore reused. If you move a clone of `alloc` into the box, you're still covered by the safety conditions for `Allocator`:

> - Memory blocks returned from an allocator must point to valid memory and retain their validity until the instance and all of its clones are dropped,

At least one clone of the allocator must be forgotten along with the pinned box. This is also why `Box::leak` is sound with a restriction of `A: 'a`; the allocator is not dropped when the box is leaked.

It is important to note that naive implementations of non-`'static` allocators cannot fulfill the safety requirements for `Allocator`. The allocator can be forgotten and its allocated memory will still be released at the end of its lifetime, which may cause the memory of undropped pinned values to be reused. The unsoundness is actually in the unsafe `Allocator` impl though, and not the boxed `Pin` APIs.