### PR TITLE
Add unchecked downcast methods

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1482,8 +1482,6 @@ impl<T, const N: usize> TryFrom<Box<[T]>> for Box<[T; N]> {
 }
 
 impl<A: Allocator> Box<dyn Any, A> {
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
     ///
     /// # Examples
@@ -1501,21 +1499,46 @@ impl<A: Allocator> Box<dyn Any, A> {
     /// print_if_string(Box::new(my_string));
     /// print_if_string(Box::new(0i8));
     /// ```
+    #[inline]
+    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
     pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Self> {
-        if self.is::<T>() {
-            unsafe {
-                let (raw, alloc): (*mut dyn Any, _) = Box::into_raw_with_allocator(self);
-                Ok(Box::from_raw_in(raw as *mut T, alloc))
-            }
-        } else {
-            Err(self)
+        if self.is::<T>() { unsafe { Ok(self.downcast_unchecked::<T>()) } } else { Err(self) }
+    }
+
+    /// Downcasts the box to a concrete type.
+    ///
+    /// For a safe alternative see [`downcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(downcast_unchecked)]
+    ///
+    /// use std::any::Any;
+    ///
+    /// let x: Box<dyn Any> = Box::new(1_usize);
+    ///
+    /// unsafe {
+    ///     assert_eq!(*x.downcast_unchecked::<usize>(), 1);
+    /// }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The contained value must be of type `T`. Calling this method
+    /// with the incorrect type is *undefined behavior*.
+    #[inline]
+    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
+        debug_assert!(self.is::<T>());
+        unsafe {
+            let (raw, alloc): (*mut dyn Any, _) = Box::into_raw_with_allocator(self);
+            Box::from_raw_in(raw as *mut T, alloc)
         }
     }
 }
 
 impl<A: Allocator> Box<dyn Any + Send, A> {
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
     ///
     /// # Examples
@@ -1533,21 +1556,46 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
     /// print_if_string(Box::new(my_string));
     /// print_if_string(Box::new(0i8));
     /// ```
+    #[inline]
+    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
     pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Self> {
-        if self.is::<T>() {
-            unsafe {
-                let (raw, alloc): (*mut (dyn Any + Send), _) = Box::into_raw_with_allocator(self);
-                Ok(Box::from_raw_in(raw as *mut T, alloc))
-            }
-        } else {
-            Err(self)
+        if self.is::<T>() { unsafe { Ok(self.downcast_unchecked::<T>()) } } else { Err(self) }
+    }
+
+    /// Downcasts the box to a concrete type.
+    ///
+    /// For a safe alternative see [`downcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(downcast_unchecked)]
+    ///
+    /// use std::any::Any;
+    ///
+    /// let x: Box<dyn Any + Send> = Box::new(1_usize);
+    ///
+    /// unsafe {
+    ///     assert_eq!(*x.downcast_unchecked::<usize>(), 1);
+    /// }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The contained value must be of type `T`. Calling this method
+    /// with the incorrect type is *undefined behavior*.
+    #[inline]
+    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
+        debug_assert!(self.is::<T>());
+        unsafe {
+            let (raw, alloc): (*mut (dyn Any + Send), _) = Box::into_raw_with_allocator(self);
+            Box::from_raw_in(raw as *mut T, alloc)
         }
     }
 }
 
 impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
-    #[inline]
-    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
     /// Attempt to downcast the box to a concrete type.
     ///
     /// # Examples
@@ -1565,15 +1613,42 @@ impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
     /// print_if_string(Box::new(my_string));
     /// print_if_string(Box::new(0i8));
     /// ```
+    #[inline]
+    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
     pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Self> {
-        if self.is::<T>() {
-            unsafe {
-                let (raw, alloc): (*mut (dyn Any + Send + Sync), _) =
-                    Box::into_raw_with_allocator(self);
-                Ok(Box::from_raw_in(raw as *mut T, alloc))
-            }
-        } else {
-            Err(self)
+        if self.is::<T>() { unsafe { Ok(self.downcast_unchecked::<T>()) } } else { Err(self) }
+    }
+
+    /// Downcasts the box to a concrete type.
+    ///
+    /// For a safe alternative see [`downcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(downcast_unchecked)]
+    ///
+    /// use std::any::Any;
+    ///
+    /// let x: Box<dyn Any + Send + Sync> = Box::new(1_usize);
+    ///
+    /// unsafe {
+    ///     assert_eq!(*x.downcast_unchecked::<usize>(), 1);
+    /// }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The contained value must be of type `T`. Calling this method
+    /// with the incorrect type is *undefined behavior*.
+    #[inline]
+    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
+        debug_assert!(self.is::<T>());
+        unsafe {
+            let (raw, alloc): (*mut (dyn Any + Send + Sync), _) =
+                Box::into_raw_with_allocator(self);
+            Box::from_raw_in(raw as *mut T, alloc)
         }
     }
 }

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1528,7 +1528,7 @@ impl<A: Allocator> Box<dyn Any, A> {
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
     #[inline]
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
         debug_assert!(self.is::<T>());
         unsafe {
@@ -1585,7 +1585,7 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
     #[inline]
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
         debug_assert!(self.is::<T>());
         unsafe {
@@ -1642,7 +1642,7 @@ impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
     #[inline]
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
         debug_assert!(self.is::<T>());
         unsafe {

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1500,7 +1500,7 @@ impl<A: Allocator> Box<dyn Any, A> {
     /// print_if_string(Box::new(0i8));
     /// ```
     #[inline]
-    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Self> {
         if self.is::<T>() { unsafe { Ok(self.downcast_unchecked::<T>()) } } else { Err(self) }
     }
@@ -1559,7 +1559,7 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
     /// print_if_string(Box::new(0i8));
     /// ```
     #[inline]
-    #[stable(feature = "box_send_sync_any_downcast", since = "1.51.0")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Self> {
         if self.is::<T>() { unsafe { Ok(self.downcast_unchecked::<T>()) } } else { Err(self) }
     }

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1527,6 +1527,8 @@ impl<A: Allocator> Box<dyn Any, A> {
     ///
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
+    ///
+    /// [`downcast`]: Self::downcast
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
@@ -1584,6 +1586,8 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
     ///
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
+    ///
+    /// [`downcast`]: Self::downcast
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {
@@ -1641,6 +1645,8 @@ impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
     ///
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
+    ///
+    /// [`downcast`]: Self::downcast
     #[inline]
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T: Any>(self) -> Box<T, A> {

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -285,7 +285,7 @@ impl dyn Any {
     ///
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T {
         debug_assert!(self.is::<T>());
@@ -317,7 +317,7 @@ impl dyn Any {
     ///
     /// The contained value must be of type `T`. Calling this method
     /// with the incorrect type is *undefined behavior*.
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T {
         debug_assert!(self.is::<T>());
@@ -422,7 +422,7 @@ impl dyn Any + Send {
     /// # Safety
     ///
     /// Same as the method on the type `dyn Any`.
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T {
         // SAFETY: guaranteed by caller
@@ -450,7 +450,7 @@ impl dyn Any + Send {
     /// # Safety
     ///
     /// Same as the method on the type `dyn Any`.
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T {
         // SAFETY: guaranteed by caller
@@ -550,7 +550,7 @@ impl dyn Any + Send + Sync {
     ///     assert_eq!(*x.downcast_ref_unchecked::<usize>(), 1);
     /// }
     /// ```
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T {
         // SAFETY: guaranteed by caller
@@ -574,7 +574,7 @@ impl dyn Any + Send + Sync {
     ///
     /// assert_eq!(*x.downcast_ref::<usize>().unwrap(), 2);
     /// ```
-    #[unstable(feature = "downcast_unchecked", issue = "none")]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T {
         // SAFETY: guaranteed by caller

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -265,8 +265,6 @@ impl dyn Any {
 
     /// Returns a reference to the inner value as type `dyn T`.
     ///
-    /// For a safe alternative see [`downcast_ref`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -294,8 +292,6 @@ impl dyn Any {
     }
 
     /// Returns a mutable reference to the inner value as type `dyn T`.
-    ///
-    /// For a safe alternative see [`downcast_mut`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
```rust
impl dyn Any (+ Send + Sync) {
    pub unsafe fn downcast_ref_unchecked<T: Any>(&self) -> &T;
    pub unsafe fn downcast_mut_unchecked<T: Any>(&mut self) -> &mut T;
}

impl<A: Allocator> Box<dyn Any (+ Send + Sync), A> {
    pub unsafe fn downcast_unchecked<T: Any>(&self) -> Box<T, A>;
}
```