### PR TITLE
Suggestion to wrap inner types using 'allocator_api' in tuple

### DIFF
--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1133,6 +1133,7 @@ impl<'a> Resolver<'a> {
                         feature,
                         reason,
                         issue,
+                        None,
                         is_soft,
                         span,
                         soft_handler,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -308,6 +308,7 @@ symbols! {
         alloc_layout,
         alloc_zeroed,
         allocator,
+        allocator_api,
         allocator_internals,
         allow,
         allow_fail,

--- a/src/test/ui/stability-attribute/suggest-vec-allocator-api.rs
+++ b/src/test/ui/stability-attribute/suggest-vec-allocator-api.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let _: Vec<u8, _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
+    #[rustfmt::skip]
+    let _: Vec<
+        String,
+        _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
+    let _ = Vec::<u16, _>::new(); //~ ERROR use of unstable library feature 'allocator_api'
+    let _boxed: Box<u32, _> = Box::new(10); //~ ERROR use of unstable library feature 'allocator_api'
+}

--- a/src/test/ui/stability-attribute/suggest-vec-allocator-api.stderr
+++ b/src/test/ui/stability-attribute/suggest-vec-allocator-api.stderr
@@ -1,0 +1,49 @@
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:2:20
+   |
+LL |     let _: Vec<u8, _> = vec![];
+   |                ----^
+   |                |
+   |                help: consider wrapping the inner types in tuple: `(u8, _)`
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:6:9
+   |
+LL |         _> = vec![];
+   |         ^
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+help: consider wrapping the inner types in tuple
+   |
+LL ~     let _: Vec<(
+LL +         String,
+LL ~         _)> = vec![];
+   |
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:8:26
+   |
+LL |     let _boxed: Box<u32, _> = Box::new(10);
+   |                          ^
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:7:24
+   |
+LL |     let _ = Vec::<u16, _>::new();
+   |                   -----^
+   |                   |
+   |                   help: consider wrapping the inner types in tuple: `(u16, _)`
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This PR provides a suggestion to wrap the inner types in tuple when being along with 'allocator_api'.

Closes https://github.com/rust-lang/rust/issues/83250

```rust
fn main() {
    let _vec: Vec<u8, _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
}
```

```diff
 error[E0658]: use of unstable library feature 'allocator_api'
   --> $DIR/suggest-vec-allocator-api.rs:2:23
    |
 LL |     let _vec: Vec<u8, _> = vec![];
-   |                       ^
+   |                   ----^
+   |                   |
+   |                   help: consider wrapping the inner types in tuple: `(u8, _)`
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
```