### PR TITLE
Basic block predecessors in mir textual representation

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -351,7 +351,9 @@ where
 
     // Basic block label at the top.
     let cleanup_text = if data.is_cleanup { " (cleanup)" } else { "" };
-    writeln!(w, "{}{:?}{}: {{", INDENT, block, cleanup_text)?;
+    let indented_body = format!("{}{:?}{}: {{", INDENT, block, cleanup_text);
+    let predecessors = &body.predecessors()[block];
+    writeln!(w, "{:A$} // preds: {:?}", indented_body, predecessors, A = ALIGN)?;
 
     // List of statements in the middle.
     let mut current_location = Location { block, statement_index: 0 };

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -6,22 +6,22 @@
       let mut _0: Type;                    // return place in scope 0 at $DIR/76803_regression.rs:10:27: 10:31
       let mut _2: isize;                   // in scope 0 at $DIR/76803_regression.rs:12:9: 12:16
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/76803_regression.rs:11:11: 11:12
           switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/76803_regression.rs:11:5: 11:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = move _1;                    // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
           goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:13:14: 13:15
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
           goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/76803_regression.rs:15:2: 15:2
       }
   }

--- a/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.address_of_reborrow.SimplifyCfg-initial.after.mir
@@ -125,7 +125,7 @@ fn address_of_reborrow() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/address-of.rs:4:9: 4:10
         StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:4:14: 4:21
         _2 = [const 0_i32; 10];          // scope 0 at $DIR/address-of.rs:4:14: 4:21

--- a/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/address_of.borrow_and_cast.SimplifyCfg-initial.after.mir
@@ -19,7 +19,7 @@ fn borrow_and_cast(_1: i32) -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/address-of.rs:42:9: 42:10
         StorageLive(_3);                 // scope 0 at $DIR/address-of.rs:42:13: 42:15
         _3 = &_1;                        // scope 0 at $DIR/address-of.rs:42:13: 42:15

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
         _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
         StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
@@ -42,7 +42,7 @@ fn main() -> () {
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:26: 16:27
         StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
         _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
@@ -51,7 +51,7 @@ fn main() -> () {
         assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:29
         StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
         StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30

--- a/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/array_index_is_temporary.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -23,7 +23,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/array-index-is-temporary.rs:13:9: 13:14
         _1 = [const 42_u32, const 43_u32, const 44_u32]; // scope 0 at $DIR/array-index-is-temporary.rs:13:17: 13:29
         StorageLive(_2);                 // scope 1 at $DIR/array-index-is-temporary.rs:14:9: 14:14
@@ -42,7 +42,7 @@ fn main() -> () {
                                          // + literal: Const { ty: unsafe fn(*mut usize) -> u32 {foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 4 at $DIR/array-index-is-temporary.rs:16:26: 16:27
         StorageLive(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
         _7 = _2;                         // scope 3 at $DIR/array-index-is-temporary.rs:16:7: 16:8
@@ -51,7 +51,7 @@ fn main() -> () {
         assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:9
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         _1[_7] = move _5;                // scope 3 at $DIR/array-index-is-temporary.rs:16:5: 16:29
         StorageDead(_5);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:28: 16:29
         StorageDead(_7);                 // scope 3 at $DIR/array-index-is-temporary.rs:16:29: 16:30

--- a/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/basic_assignment.main.SimplifyCfg-initial.after.mir
@@ -25,7 +25,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
         _1 = const false;                // scope 0 at $DIR/basic_assignment.rs:11:20: 11:25
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/basic_assignment.rs:11:9: 11:17
@@ -44,41 +44,41 @@ fn main() -> () {
         replace(_5 <- move _6) -> [return: bb1, unwind: bb5]; // scope 4 at $DIR/basic_assignment.rs:23:5: 23:11
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         drop(_6) -> [return: bb2, unwind: bb6]; // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_6);                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
         _0 = const ();                   // scope 0 at $DIR/basic_assignment.rs:10:11: 24:2
         drop(_5) -> [return: bb3, unwind: bb7]; // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_5);                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
         drop(_4) -> [return: bb4, unwind: bb8]; // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_4);                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_2);                 // scope 1 at $DIR/basic_assignment.rs:24:1: 24:2
         StorageDead(_1);                 // scope 0 at $DIR/basic_assignment.rs:24:1: 24:2
         return;                          // scope 0 at $DIR/basic_assignment.rs:24:2: 24:2
     }
 
-    bb5 (cleanup): {
+    bb5 (cleanup): {                     // preds: [bb0]
         drop(_6) -> bb6;                 // scope 4 at $DIR/basic_assignment.rs:23:19: 23:20
     }
 
-    bb6 (cleanup): {
+    bb6 (cleanup): {                     // preds: [bb1, bb5]
         drop(_5) -> bb7;                 // scope 3 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb2, bb6]
         drop(_4) -> bb8;                 // scope 2 at $DIR/basic_assignment.rs:24:1: 24:2
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb3, bb7]
         resume;                          // scope 0 at $DIR/basic_assignment.rs:10:1: 24:2
     }
 }

--- a/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt1.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:3:8: 3:17
       let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:3:8: 3:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:3:8: 3:9
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:3:8: 3:9
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:3:8: 3:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:3:20: 3:21
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:3:5: 3:34
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:3:31: 3:32
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:3:5: 3:34
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:3:33: 3:34
           return;                          // scope 0 at $DIR/bool_compare.rs:4:2: 4:2
       }

--- a/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt2.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:8:8: 8:17
       let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:8:16: 8:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:8:16: 8:17
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:8:8: 8:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:8:20: 8:21
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:8:5: 8:34
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:8:31: 8:32
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:8:5: 8:34
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:8:33: 8:34
           return;                          // scope 0 at $DIR/bool_compare.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt3.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:13:8: 13:18
       let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:13:8: 13:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:13:8: 13:9
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:13:8: 13:9
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:13:8: 13:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:13:21: 13:22
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:13:5: 13:35
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:13:32: 13:33
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:13:5: 13:35
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:13:34: 13:35
           return;                          // scope 0 at $DIR/bool_compare.rs:14:2: 14:2
       }

--- a/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
+++ b/src/test/mir-opt/bool_compare.opt4.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/bool_compare.rs:18:8: 18:18
       let mut _3: bool;                    // in scope 0 at $DIR/bool_compare.rs:18:17: 18:18
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
           StorageLive(_3);                 // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
           _3 = _1;                         // scope 0 at $DIR/bool_compare.rs:18:17: 18:18
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/bool_compare.rs:18:8: 18:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/bool_compare.rs:18:21: 18:22
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:18:5: 18:35
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/bool_compare.rs:18:32: 18:33
           goto -> bb3;                     // scope 0 at $DIR/bool_compare.rs:18:5: 18:35
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/bool_compare.rs:18:34: 18:35
           return;                          // scope 0 at $DIR/bool_compare.rs:19:2: 19:2
       }

--- a/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/box_expr.main.ElaborateDrops.before.mir
@@ -15,7 +15,7 @@ fn main() -> () {
     scope 2 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/box_expr.rs:7:9: 7:10
         _2 = SizeOf(S);                  // scope 2 at $DIR/box_expr.rs:7:13: 7:25
         _3 = AlignOf(S);                 // scope 2 at $DIR/box_expr.rs:7:13: 7:25
@@ -25,7 +25,7 @@ fn main() -> () {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_5);                 // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         _5 = ShallowInitBox(move _4, S); // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         (*_5) = S::new() -> [return: bb2, unwind: bb8]; // scope 0 at $DIR/box_expr.rs:7:17: 7:25
@@ -34,12 +34,12 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> S {S::new}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         _1 = move _5;                    // scope 0 at $DIR/box_expr.rs:7:13: 7:25
         drop(_5) -> bb3;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_5);                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
         StorageLive(_6);                 // scope 1 at $DIR/box_expr.rs:8:5: 8:12
         StorageLive(_7);                 // scope 1 at $DIR/box_expr.rs:8:10: 8:11
@@ -50,31 +50,31 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(std::boxed::Box<S>) {std::mem::drop::<std::boxed::Box<S>>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_7);                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
         StorageDead(_6);                 // scope 1 at $DIR/box_expr.rs:8:12: 8:13
         _0 = const ();                   // scope 0 at $DIR/box_expr.rs:6:11: 9:2
         drop(_1) -> bb5;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_1);                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
         return;                          // scope 0 at $DIR/box_expr.rs:9:2: 9:2
     }
 
-    bb6 (cleanup): {
+    bb6 (cleanup): {                     // preds: [bb3]
         drop(_7) -> bb7;                 // scope 1 at $DIR/box_expr.rs:8:11: 8:12
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb6]
         drop(_1) -> bb9;                 // scope 0 at $DIR/box_expr.rs:9:1: 9:2
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb1]
         drop(_5) -> bb9;                 // scope 0 at $DIR/box_expr.rs:7:24: 7:25
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb7, bb8]
         resume;                          // scope 0 at $DIR/box_expr.rs:6:1: 9:2
     }
 }

--- a/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/byte_slice.main.SimplifyCfg-elaborate-drops.after.mir
@@ -11,7 +11,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/byte_slice.rs:5:9: 5:10
         _1 = const b"foo";               // scope 0 at $DIR/byte_slice.rs:5:13: 5:19
                                          // ty::Const

--- a/src/test/mir-opt/combine_array_len.norm2.InstCombine.32bit.diff
+++ b/src/test/mir-opt/combine_array_len.norm2.InstCombine.32bit.diff
@@ -25,7 +25,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
           StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
           _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
@@ -35,7 +35,7 @@
           assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
           StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
           StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
@@ -47,7 +47,7 @@
           assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
           StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:17: 6:18
           StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8

--- a/src/test/mir-opt/combine_array_len.norm2.InstCombine.64bit.diff
+++ b/src/test/mir-opt/combine_array_len.norm2.InstCombine.64bit.diff
@@ -25,7 +25,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/combine_array_len.rs:5:9: 5:10
           StorageLive(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
           _3 = const 0_usize;              // scope 0 at $DIR/combine_array_len.rs:5:15: 5:16
@@ -35,7 +35,7 @@
           assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> bb1; // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _2 = _1[_3];                     // scope 0 at $DIR/combine_array_len.rs:5:13: 5:17
           StorageDead(_3);                 // scope 0 at $DIR/combine_array_len.rs:5:17: 5:18
           StorageLive(_6);                 // scope 1 at $DIR/combine_array_len.rs:6:9: 6:10
@@ -47,7 +47,7 @@
           assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb2; // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _6 = _1[_7];                     // scope 1 at $DIR/combine_array_len.rs:6:13: 6:17
           StorageDead(_7);                 // scope 1 at $DIR/combine_array_len.rs:6:17: 6:18
           StorageLive(_10);                // scope 2 at $DIR/combine_array_len.rs:7:5: 7:8

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.32bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
     let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8

--- a/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation.main.ConstProp.after.64bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
     let mut _2: &&[(std::option::Option<i32>, &[&str])]; // in scope 0 at $DIR/const_allocation.rs:8:5: 8:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation.rs:8:5: 8:8
         _2 = const {alloc1: &&[(Option<i32>, &[&str])]}; // scope 0 at $DIR/const_allocation.rs:8:5: 8:8

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.32bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
     let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8

--- a/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation2.main.ConstProp.after.64bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
     let mut _2: &&[(std::option::Option<i32>, &[&u8])]; // in scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8
         _2 = const {alloc1: &&[(Option<i32>, &[&u8])]}; // scope 0 at $DIR/const_allocation2.rs:5:5: 5:8

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.32bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
     let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8

--- a/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
+++ b/src/test/mir-opt/const_allocation3.main.ConstProp.after.64bit.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     let _1: &Packed;                     // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
     let mut _2: &&Packed;                // in scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         StorageLive(_2);                 // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8
         _2 = const {alloc1: &&Packed};   // scope 0 at $DIR/const_allocation3.rs:5:5: 5:8

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -52,7 +52,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const_debuginfo.rs:9:9: 9:10
           _1 = const 1_u8;                 // scope 0 at $DIR/const_debuginfo.rs:9:13: 9:16
           StorageLive(_2);                 // scope 1 at $DIR/const_debuginfo.rs:10:9: 10:10

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -8,7 +8,7 @@
 -     let mut _3: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
 +     let mut _2: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:17: 12:20
 -         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -16,36 +16,36 @@
 +         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
 +         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0, bb0]
 -         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 -         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb3]
           _0 = const 23_u64;               // scope 0 at $DIR/const_goto.rs:12:41: 12:43
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
 +         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
       }
   
--     bb5: {
+-     bb5: {                               // preds: [bb3]
 -         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: [bb4, bb5]
 -         StorageDead(_2);                 // scope 0 at $DIR/const_goto.rs:12:56: 12:57
-+     bb3: {
++     bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/const_goto.rs:13:2: 13:2
       }
   }

--- a/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
@@ -6,43 +6,43 @@
       let mut _1: bool;                    // in scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
       let mut _2: i32;                     // in scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
           StorageLive(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
           _2 = const A;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
           switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 8:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _1 = const true;                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
           goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0, bb0, bb0]
           _1 = const B;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
 -         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
 +         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
 -         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 12:6
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb3]
           _0 = const 2_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
 +         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
       }
   
--     bb5: {
-+     bb4: {
+-     bb5: {                               // preds: [bb3]
++     bb4: {                               // preds: [bb2]
           _0 = const 1_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
 -         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
 +         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
       }
   
--     bb6: {
-+     bb5: {
+-     bb6: {                               // preds: [bb4, bb5]
++     bb5: {                               // preds: [bb3, bb4]
           StorageDead(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
           StorageDead(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
           return;                          // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:2: 16:2

--- a/src/test/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -6,7 +6,7 @@ promoted[0] in BAR: &[&i32; 1] = {
     let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
     let mut _3: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
 
-    bb0: {
+    bb0: {                               // preds: []
         _3 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -10,7 +10,7 @@
       let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
 +     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
           StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
 -         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
@@ -39,14 +39,14 @@
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
       }
   
-      bb2 (cleanup): {
+      bb2 (cleanup): {                     // preds: [bb0]
           resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
       }
 - }

--- a/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.BOP.mir_map.0.mir
@@ -5,7 +5,7 @@ static BOP: &i32 = {
     let _1: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
     let _2: i32;                         // in scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:16:20: 16:23
         StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23
         _2 = const 13_i32;               // scope 0 at $DIR/const-promotion-extern-static.rs:16:21: 16:23

--- a/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO-promoted[0].SimplifyCfg-elaborate-drops.after.mir
@@ -6,7 +6,7 @@ promoted[0] in FOO: &[&i32; 1] = {
     let mut _2: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
     let mut _3: *const i32;              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
 
-    bb0: {
+    bb0: {                               // preds: []
         _3 = const {alloc3: *const i32}; // scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
                                          // mir::Constant
                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -12,7 +12,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
           StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
 -         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
@@ -41,14 +41,14 @@
                                            // + literal: Const { ty: for<'r> fn(&'r [&i32]) -> *const &i32 {core::slice::<impl [&i32]>::as_ptr}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
 -         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
       }
   
-      bb2 (cleanup): {
+      bb2 (cleanup): {                     // preds: [bb0]
           resume;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
       }
   }

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -10,7 +10,7 @@
           debug x => _1;                   // in scope 1 at $DIR/aggregate.rs:5:9: 5:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
           StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.32bit.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/array_index.rs:5:9: 5:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
           _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
@@ -25,7 +25,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
 +         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
           StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34

--- a/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/array_index.main.ConstProp.64bit.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/array_index.rs:5:9: 5:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/array_index.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/array_index.rs:5:18: 5:30
           _2 = [const 0_u32, const 1_u32, const 2_u32, const 3_u32]; // scope 0 at $DIR/array_index.rs:5:18: 5:30
@@ -25,7 +25,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 4_usize, const 2_usize) -> bb1; // scope 0 at $DIR/array_index.rs:5:18: 5:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = _2[_3];                     // scope 0 at $DIR/array_index.rs:5:18: 5:33
 +         _1 = const 2_u32;                // scope 0 at $DIR/array_index.rs:5:18: 5:33
           StorageDead(_3);                 // scope 0 at $DIR/array_index.rs:5:33: 5:34

--- a/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_div_by_zero.main.ConstProp.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_div_by_zero.rs:4:9: 4:10
           _1 = const 0_i32;                // scope 0 at $DIR/bad_op_div_by_zero.rs:4:13: 4:14
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:9: 5:11
@@ -30,7 +30,7 @@
 +         assert(!const true, "attempt to divide `{}` by zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 -         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 -         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
@@ -41,7 +41,7 @@
 +         assert(!const false, "attempt to compute `{} / {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _2 = Div(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
 +         _2 = Div(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_div_by_zero.rs:5:14: 5:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_div_by_zero.rs:5:18: 5:19

--- a/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/bad_op_mod_by_zero.main.ConstProp.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:9: 4:10
           _1 = const 0_i32;                // scope 0 at $DIR/bad_op_mod_by_zero.rs:4:13: 4:14
           StorageLive(_2);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:9: 5:11
@@ -30,7 +30,7 @@
 +         assert(!const true, "attempt to calculate the remainder of `{}` with a divisor of zero", const 1_i32) -> bb1; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _5 = Eq(_3, const -1_i32);       // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 -         _6 = Eq(const 1_i32, const i32::MIN); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 -         _7 = BitAnd(move _5, move _6);   // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
@@ -41,7 +41,7 @@
 +         assert(!const false, "attempt to compute the remainder of `{} % {}`, which would overflow", const 1_i32, const 0_i32) -> bb2; // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _2 = Rem(const 1_i32, move _3);  // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
 +         _2 = Rem(const 1_i32, const 0_i32); // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:14: 5:19
           StorageDead(_3);                 // scope 1 at $DIR/bad_op_mod_by_zero.rs:5:18: 5:19

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.32bit.diff
@@ -21,7 +21,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
           StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
@@ -47,7 +47,7 @@
 +         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
           nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6

--- a/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/bad_op_unsafe_oob_for_slices.main.ConstProp.64bit.diff
@@ -21,7 +21,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
           StorageLive(_3);                 // scope 0 at $DIR/bad_op_unsafe_oob_for_slices.rs:5:25: 5:35
@@ -47,7 +47,7 @@
 +         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, const 3_usize) -> bb1; // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _5 = (*_1)[_6];                  // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:18: 7:25
           StorageDead(_6);                 // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:7:25: 7:26
           nop;                             // scope 2 at $DIR/bad_op_unsafe_oob_for_slices.rs:6:5: 8:6

--- a/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boolean_identities.test.ConstProp.diff
@@ -10,7 +10,7 @@
       let mut _5: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:18: 5:29
       let mut _6: bool;                    // in scope 0 at $DIR/boolean_identities.rs:5:19: 5:20
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/boolean_identities.rs:5:5: 5:15
           StorageLive(_4);                 // scope 0 at $DIR/boolean_identities.rs:5:6: 5:7
           _4 = _2;                         // scope 0 at $DIR/boolean_identities.rs:5:6: 5:7

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -16,7 +16,7 @@
       scope 2 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/boxes.rs:12:9: 12:10
           StorageLive(_2);                 // scope 0 at $DIR/boxes.rs:12:13: 12:22
           StorageLive(_3);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
@@ -31,7 +31,7 @@
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_7);                 // scope 0 at $DIR/boxes.rs:12:14: 12:22
           _7 = ShallowInitBox(move _6, i32); // scope 0 at $DIR/boxes.rs:12:14: 12:22
           (*_7) = const 42_i32;            // scope 0 at $DIR/boxes.rs:12:19: 12:21
@@ -43,14 +43,14 @@
           drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_3);                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
           nop;                             // scope 0 at $DIR/boxes.rs:11:11: 13:2
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
       }
   
-      bb3 (cleanup): {
+      bb3 (cleanup): {                     // preds: [bb1]
           resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
       }
   }

--- a/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/cast.main.ConstProp.diff
@@ -12,7 +12,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/cast.rs:4:9: 4:10
 -         _1 = const 42_u8 as u32 (Misc);  // scope 0 at $DIR/cast.rs:4:13: 4:24
 +         _1 = const 42_u32;               // scope 0 at $DIR/cast.rs:4:13: 4:24

--- a/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/checked_add.main.ConstProp.diff
@@ -9,7 +9,7 @@
           debug x => _1;                   // in scope 1 at $DIR/checked_add.rs:5:9: 5:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/checked_add.rs:5:9: 5:10
 -         _2 = CheckedAdd(const 1_u32, const 1_u32); // scope 0 at $DIR/checked_add.rs:5:18: 5:23
 -         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
@@ -17,7 +17,7 @@
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 1_u32, const 1_u32) -> bb1; // scope 0 at $DIR/checked_add.rs:5:18: 5:23
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = move (_2.0: u32);           // scope 0 at $DIR/checked_add.rs:5:18: 5:23
 +         _1 = const 2_u32;                // scope 0 at $DIR/checked_add.rs:5:18: 5:23
           nop;                             // scope 0 at $DIR/checked_add.rs:4:11: 6:2

--- a/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/const_prop_fails_gracefully.main.ConstProp.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/const_prop_fails_gracefully.rs:7:9: 7:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:9: 7:10
           StorageLive(_2);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:30
           StorageLive(_3);                 // scope 0 at $DIR/const_prop_fails_gracefully.rs:7:13: 7:16
@@ -36,7 +36,7 @@
                                            // + literal: Const { ty: fn(usize) {read}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_5);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:11: 8:12
           StorageDead(_4);                 // scope 1 at $DIR/const_prop_fails_gracefully.rs:8:12: 8:13
           nop;                             // scope 0 at $DIR/const_prop_fails_gracefully.rs:5:11: 9:2

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -6,7 +6,7 @@
       let mut _1: bool;                    // in scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
       let mut _2: !;                       // in scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
 -         _1 = const <bool as NeedsDrop>::NEEDS; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
 -         switchInt(move _1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
@@ -14,7 +14,7 @@
 +         switchInt(const false) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/control-flow-simplification.rs:12:8: 12:21
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_2);                 // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
           begin_panic::<&str>(const "explicit panic"); // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
@@ -28,7 +28,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           nop;                             // scope 0 at $DIR/control-flow-simplification.rs:14:6: 14:6
           StorageDead(_1);                 // scope 0 at $DIR/control-flow-simplification.rs:14:5: 14:6
           return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.PreCodegen.before.mir
@@ -3,7 +3,7 @@
 fn hello() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/control-flow-simplification.rs:11:14: 11:14
 
-    bb0: {
+    bb0: {                               // preds: []
         return;                          // scope 0 at $DIR/control-flow-simplification.rs:15:2: 15:2
     }
 }

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -11,7 +11,7 @@
           debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:11:9: 11:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
@@ -23,21 +23,21 @@
 +         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1]
           _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -11,7 +11,7 @@
           debug x => _1;                   // in scope 1 at $DIR/discriminant.rs:11:9: 11:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
@@ -23,21 +23,21 @@
 +         switchInt(const 1_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           switchInt(((_3 as Some).0: bool)) -> [false: bb3, otherwise: bb2]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _2 = const 42_i32;               // scope 0 at $DIR/discriminant.rs:11:47: 11:49
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1]
           _2 = const 10_i32;               // scope 0 at $DIR/discriminant.rs:11:59: 11:61
           goto -> bb4;                     // scope 0 at $DIR/discriminant.rs:11:13: 11:64
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/discriminant.rs:11:13: 11:68
           StorageDead(_2);                 // scope 0 at $DIR/discriminant.rs:11:67: 11:68
           StorageDead(_3);                 // scope 0 at $DIR/discriminant.rs:11:68: 11:69

--- a/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/indirect.main.ConstProp.diff
@@ -10,7 +10,7 @@
           debug x => _1;                   // in scope 1 at $DIR/indirect.rs:5:9: 5:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/indirect.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/indirect.rs:5:13: 5:25
 -         _2 = const 2_u32 as u8 (Misc);   // scope 0 at $DIR/indirect.rs:5:13: 5:25
@@ -21,7 +21,7 @@
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u8, const 1_u8) -> bb1; // scope 0 at $DIR/indirect.rs:5:13: 5:29
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = move (_3.0: u8);            // scope 0 at $DIR/indirect.rs:5:13: 5:29
 +         _1 = const 3_u8;                 // scope 0 at $DIR/indirect.rs:5:13: 5:29
           StorageDead(_2);                 // scope 0 at $DIR/indirect.rs:5:28: 5:29

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -18,7 +18,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           discriminant(_2) = 0;            // scope 0 at $DIR/invalid_constant.rs:16:7: 16:11
 -         _4 = discriminant(_2);           // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
 -         switchInt(move _4) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
@@ -26,7 +26,7 @@
 +         switchInt(const 0_isize) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb2, bb3]
 -         _3 = const { Union { int: 0x110001 } }; // scope 0 at $DIR/invalid_constant.rs:22:25: 22:58
 +         _3 = const main::Union { int: 1114113_u32, chr: {transmute(0x00110001): char} }; // scope 0 at $DIR/invalid_constant.rs:22:25: 22:58
                                            // ty::Const
@@ -41,7 +41,7 @@
           return;                          // scope 0 at $DIR/invalid_constant.rs:23:2: 23:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 -         _5 = ((_2 as Some).0: std::option::Option<()>); // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
 -         _1 = _5;                         // scope 3 at $DIR/invalid_constant.rs:16:5: 16:12
 +         _5 = const Scalar(0x02): Option::<()>; // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
@@ -61,7 +61,7 @@
           goto -> bb1;                     // scope 0 at $DIR/invalid_constant.rs:10:20: 10:21
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           discriminant(_1) = 0;            // scope 2 at $DIR/invalid_constant.rs:16:5: 16:12
           goto -> bb1;                     // scope 0 at $DIR/invalid_constant.rs:9:17: 9:21
       }

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -7,7 +7,7 @@
       let mut _2: ((), u8, u8);            // in scope 0 at $DIR/issue-66971.rs:16:12: 16:22
       let mut _3: ();                      // in scope 0 at $DIR/issue-66971.rs:16:13: 16:15
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-66971.rs:16:5: 16:23
           StorageLive(_2);                 // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           StorageLive(_3);                 // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
@@ -21,7 +21,7 @@
                                            // + literal: Const { ty: fn(((), u8, u8)) {encode}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 0 at $DIR/issue-66971.rs:16:22: 16:23
           StorageDead(_1);                 // scope 0 at $DIR/issue-66971.rs:16:23: 16:24
           nop;                             // scope 0 at $DIR/issue-66971.rs:15:11: 17:2

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -7,7 +7,7 @@
       let mut _2: ((u8, u8),);             // in scope 0 at $DIR/issue-67019.rs:11:10: 11:19
       let mut _3: (u8, u8);                // in scope 0 at $DIR/issue-67019.rs:11:11: 11:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
           StorageLive(_2);                 // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
           StorageLive(_3);                 // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
@@ -22,7 +22,7 @@
                                            // + literal: Const { ty: fn(((u8, u8),)) {test}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 0 at $DIR/issue-67019.rs:11:19: 11:20
           StorageDead(_1);                 // scope 0 at $DIR/issue-67019.rs:11:20: 11:21
           nop;                             // scope 0 at $DIR/issue-67019.rs:10:11: 12:2

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.32bit.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:6:9: 6:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
           _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
@@ -25,7 +25,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33

--- a/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/large_array_index.main.ConstProp.64bit.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/large_array_index.rs:6:9: 6:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/large_array_index.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
           _2 = [const 0_u8; 5000];         // scope 0 at $DIR/large_array_index.rs:6:17: 6:29
@@ -25,7 +25,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 5000_usize, const 2_usize) -> bb1; // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _1 = _2[_3];                     // scope 0 at $DIR/large_array_index.rs:6:17: 6:32
           StorageDead(_3);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33
           StorageDead(_2);                 // scope 0 at $DIR/large_array_index.rs:6:32: 6:33

--- a/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mult_by_zero.test.ConstProp.diff
@@ -6,7 +6,7 @@
       let mut _0: i32;                     // return place in scope 0 at $DIR/mult_by_zero.rs:4:21: 4:24
       let mut _2: i32;                     // in scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
           _2 = _1;                         // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:4
 -         _0 = Mul(move _2, const 0_i32);  // scope 0 at $DIR/mult_by_zero.rs:5:3: 5:8

--- a/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable.main.ConstProp.diff
@@ -12,7 +12,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable.rs:5:9: 5:14
           _1 = const 42_i32;               // scope 0 at $DIR/mutable_variable.rs:5:17: 5:19
           _1 = const 99_i32;               // scope 1 at $DIR/mutable_variable.rs:6:5: 6:11

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -12,7 +12,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -16,7 +16,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_partial_read.main.ConstProp.diff
@@ -12,7 +12,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:9: 5:14
           _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_aggregate_partial_read.rs:5:29: 5:34
                                            // mir::Constant
@@ -20,7 +20,7 @@
                                            // + literal: Const { ty: fn() -> (i32, i32) {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:6:5: 6:13
           (_1.0: i32) = const 42_i32;      // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:7:5: 7:13
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_partial_read.rs:8:9: 8:10

--- a/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_no_prop.main.ConstProp.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_no_prop.rs:7:9: 7:14
           _1 = const 42_u32;               // scope 0 at $DIR/mutable_variable_no_prop.rs:7:17: 7:19
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_no_prop.rs:8:5: 10:6

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -21,7 +21,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:9: 5:10
           _1 = foo() -> bb1;               // scope 0 at $DIR/mutable_variable_unprop_assign.rs:5:13: 5:18
                                            // mir::Constant
@@ -29,7 +29,7 @@
                                            // + literal: Const { ty: fn() -> i32 {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
           (_2.0: i32) = const 1_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
           (_2.1: i32) = const 2_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -22,7 +22,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 -         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
@@ -30,7 +30,7 @@
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
@@ -45,7 +45,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
           StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -22,7 +22,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
 -         _2 = CheckedAdd(const 2_i32, const 2_i32); // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 -         assert(!move (_2.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
@@ -30,7 +30,7 @@
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_i32, const 2_i32) -> bb1; // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = move (_2.0: i32);           // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
 +         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
           StorageLive(_3);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10
@@ -45,7 +45,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 6_usize, const 3_usize) -> bb2; // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _3 = _4[_5];                     // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
 +         _3 = const 3_i32;                // scope 1 at $DIR/optimizes_into_variable.rs:13:13: 13:34
           StorageDead(_5);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.32bit.mir
@@ -15,7 +15,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
         StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.SimplifyLocals.after.64bit.mir
@@ -15,7 +15,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/optimizes_into_variable.rs:12:9: 12:10
         _1 = const 4_i32;                // scope 0 at $DIR/optimizes_into_variable.rs:12:13: 12:18
         StorageLive(_2);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:9: 13:10

--- a/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/read_immutable_static.main.ConstProp.diff
@@ -12,7 +12,7 @@
           debug x => _1;                   // in scope 1 at $DIR/read_immutable_static.rs:7:9: 7:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/read_immutable_static.rs:7:9: 7:10
           StorageLive(_2);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16
           StorageLive(_3);                 // scope 0 at $DIR/read_immutable_static.rs:7:13: 7:16

--- a/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.ConstProp.diff
@@ -8,7 +8,7 @@
       let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:8: 5:9
       let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
           _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref.rs:5:6: 5:10

--- a/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref.main.PromoteTemps.diff
@@ -8,7 +8,7 @@
       let _3: i32;                         // in scope 0 at $DIR/ref_deref.rs:5:8: 5:9
 +     let mut _4: &i32;                    // in scope 0 at $DIR/ref_deref.rs:5:6: 5:10
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref.rs:5:5: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref.rs:5:6: 5:10
 -         StorageLive(_3);                 // scope 0 at $DIR/ref_deref.rs:5:8: 5:9

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.ConstProp.diff
@@ -8,7 +8,7 @@
       let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
       let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
           _4 = const main::promoted[0];    // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17

--- a/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
+++ b/src/test/mir-opt/const_prop/ref_deref_project.main.PromoteTemps.diff
@@ -8,7 +8,7 @@
       let _3: (i32, i32);                  // in scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14
 +     let mut _4: &(i32, i32);             // in scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/ref_deref_project.rs:5:5: 5:17
           StorageLive(_2);                 // scope 0 at $DIR/ref_deref_project.rs:5:6: 5:17
 -         StorageLive(_3);                 // scope 0 at $DIR/ref_deref_project.rs:5:8: 5:14

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -9,7 +9,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
           StorageLive(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
           StorageLive(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:17

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.32bit.diff
@@ -13,7 +13,7 @@
           debug x => _1;                   // in scope 1 at $DIR/repeat.rs:6:9: 6:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
           StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
@@ -27,7 +27,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
 -         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
 +         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28

--- a/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/repeat.main.ConstProp.64bit.diff
@@ -13,7 +13,7 @@
           debug x => _1;                   // in scope 1 at $DIR/repeat.rs:6:9: 6:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/repeat.rs:6:9: 6:10
           StorageLive(_2);                 // scope 0 at $DIR/repeat.rs:6:18: 6:28
           StorageLive(_3);                 // scope 0 at $DIR/repeat.rs:6:18: 6:25
@@ -27,7 +27,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 8_usize, const 2_usize) -> bb1; // scope 0 at $DIR/repeat.rs:6:18: 6:28
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _2 = _3[_4];                     // scope 0 at $DIR/repeat.rs:6:18: 6:28
 -         _1 = Add(move _2, const 0_u32);  // scope 0 at $DIR/repeat.rs:6:18: 6:32
 +         _2 = const 42_u32;               // scope 0 at $DIR/repeat.rs:6:18: 6:28

--- a/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/return_place.add.ConstProp.diff
@@ -5,14 +5,14 @@
       let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:5:13: 5:16
       let mut _1: (u32, bool);             // in scope 0 at $DIR/return_place.rs:6:5: 6:10
   
-      bb0: {
+      bb0: {                               // preds: []
 -         _1 = CheckedAdd(const 2_u32, const 2_u32); // scope 0 at $DIR/return_place.rs:6:5: 6:10
 -         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
 +         _1 = const (4_u32, false);       // scope 0 at $DIR/return_place.rs:6:5: 6:10
 +         assert(!const false, "attempt to compute `{} + {}`, which would overflow", const 2_u32, const 2_u32) -> bb1; // scope 0 at $DIR/return_place.rs:6:5: 6:10
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _0 = move (_1.0: u32);           // scope 0 at $DIR/return_place.rs:6:5: 6:10
 +         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
           return;                          // scope 0 at $DIR/return_place.rs:7:2: 7:2

--- a/src/test/mir-opt/const_prop/return_place.add.PreCodegen.before.mir
+++ b/src/test/mir-opt/const_prop/return_place.add.PreCodegen.before.mir
@@ -3,7 +3,7 @@
 fn add() -> u32 {
     let mut _0: u32;                     // return place in scope 0 at $DIR/return_place.rs:5:13: 5:16
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 4_u32;                // scope 0 at $DIR/return_place.rs:6:5: 6:10
         return;                          // scope 0 at $DIR/return_place.rs:7:2: 7:2
     }

--- a/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/scalar_literal_propagation.main.ConstProp.diff
@@ -10,7 +10,7 @@
           debug x => _1;                   // in scope 1 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/scalar_literal_propagation.rs:3:9: 3:10
           _1 = const 1_u32;                // scope 0 at $DIR/scalar_literal_propagation.rs:3:13: 3:14
           StorageLive(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:5: 4:15
@@ -24,7 +24,7 @@
                                            // + literal: Const { ty: fn(u32) {consume}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:14: 4:15
           StorageDead(_2);                 // scope 1 at $DIR/scalar_literal_propagation.rs:4:15: 4:16
           nop;                             // scope 0 at $DIR/scalar_literal_propagation.rs:2:11: 5:2

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.32bit.diff
@@ -14,7 +14,7 @@
       let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
       let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
           StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:30
           StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
@@ -42,7 +42,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
           StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34

--- a/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/slice_len.main.ConstProp.64bit.diff
@@ -14,7 +14,7 @@
       let mut _9: &[u32; 3];               // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
       let mut _10: &[u32; 3];              // in scope 0 at $DIR/slice_len.rs:5:6: 5:19
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:33
           StorageLive(_2);                 // scope 0 at $DIR/slice_len.rs:5:5: 5:30
           StorageLive(_3);                 // scope 0 at $DIR/slice_len.rs:5:6: 5:19
@@ -42,7 +42,7 @@
 +         assert(const true, "index out of bounds: the length is {} but the index is {}", const 3_usize, const 1_usize) -> bb1; // scope 0 at $DIR/slice_len.rs:5:5: 5:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _1 = (*_2)[_6];                  // scope 0 at $DIR/slice_len.rs:5:5: 5:33
 +         _1 = const 2_u32;                // scope 0 at $DIR/slice_len.rs:5:5: 5:33
           StorageDead(_6);                 // scope 0 at $DIR/slice_len.rs:5:33: 5:34

--- a/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.ConstProp.diff
@@ -5,28 +5,28 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:6:11: 6:11
       let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:7:11: 7:12
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
           _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
 -         switchInt(_1) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
 +         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:9:14: 9:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:8:14: 8:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:11:1: 11:2
           return;                          // scope 0 at $DIR/switch_int.rs:11:2: 11:2
       }

--- a/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/const_prop/switch_int.main.SimplifyConstCondition-after-const-prop.diff
@@ -5,28 +5,29 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/switch_int.rs:6:11: 6:11
       let mut _1: i32;                     // in scope 0 at $DIR/switch_int.rs:7:11: 7:12
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/switch_int.rs:7:11: 7:12
           _1 = const 1_i32;                // scope 0 at $DIR/switch_int.rs:7:11: 7:12
 -         switchInt(const 1_i32) -> [1_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/switch_int.rs:7:5: 7:12
 +         goto -> bb2;                     // scope 0 at $DIR/switch_int.rs:7:5: 7:12
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
++     bb1: {                               // preds: []
           _0 = foo(const -1_i32) -> bb3;   // scope 0 at $DIR/switch_int.rs:9:14: 9:21
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:9:14: 9:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = foo(const 0_i32) -> bb3;    // scope 0 at $DIR/switch_int.rs:8:14: 8:20
                                            // mir::Constant
                                            // + span: $DIR/switch_int.rs:8:14: 8:17
                                            // + literal: Const { ty: fn(i32) {foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_1);                 // scope 0 at $DIR/switch_int.rs:11:1: 11:2
           return;                          // scope 0 at $DIR/switch_int.rs:11:2: 11:2
       }

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -10,7 +10,7 @@
           debug x => _1;                   // in scope 1 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
           (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
           (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
@@ -24,7 +24,7 @@
                                            // + literal: Const { ty: fn((u32, u32)) {consume}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:14: 5:15
           StorageDead(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:15: 5:16
           nop;                             // scope 0 at $DIR/tuple_literal_propagation.rs:2:11: 6:2

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:12:9: 12:14
           (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:13:5: 15:6

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -14,7 +14,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:5:9: 5:14
           (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -6,7 +6,7 @@
       let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test.rs:8:21: 8:24
       let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
 -         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -6,7 +6,7 @@
       let mut _0: Baz;                     // return place in scope 0 at $DIR/deaggregator_test_enum.rs:7:21: 7:24
       let mut _2: usize;                   // in scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
 -         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -9,13 +9,13 @@
       let mut _4: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
       let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
           switchInt(move _3) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:8: 10:9
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
           _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
 -         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
@@ -25,7 +25,7 @@
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
           _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
 -         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
@@ -35,7 +35,7 @@
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:14:5: 14:6
           return;                          // scope 0 at $DIR/deaggregator_test_enum_2.rs:15:2: 15:2
       }

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -9,7 +9,7 @@
       let mut _4: Foo;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
       let mut _5: i32;                     // in scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
           StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
           StorageLive(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
           _3 = _1;                         // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
@@ -30,73 +30,76 @@
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&str) -> &[u8] {std::intrinsics::transmute::<&str, &[u8]>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb14]
++     bb1: {                               // preds: [bb12]
           switchInt((*_2)[0 of 4]) -> [47_u8: bb2, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           switchInt((*_2)[1 of 4]) -> [47_u8: bb3, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           switchInt((*_2)[2 of 4]) -> [47_u8: bb4, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
 -         switchInt((*_2)[3 of 4]) -> [47_u8: bb10, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
 +         switchInt((*_2)[3 of 4]) -> [47_u8: bb9, otherwise: bb5]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb5: {
+-     bb5: {                               // preds: [bb1, bb2, bb3, bb4, bb14]
++     bb5: {                               // preds: [bb1, bb2, bb3, bb4, bb12]
           _4 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
           _5 = Ge(move _4, const 3_usize); // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
           switchInt(move _5) -> [false: bb9, otherwise: bb6]; // scope 0 at $DIR/deduplicate_blocks.rs:5:9: 5:31
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb5]
           switchInt((*_2)[0 of 3]) -> [47_u8: bb7, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb6]
           switchInt((*_2)[1 of 3]) -> [47_u8: bb8, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb8: {
+      bb8: {                               // preds: [bb7]
 -         switchInt((*_2)[2 of 3]) -> [47_u8: bb11, 33_u8: bb12, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
 +         switchInt((*_2)[2 of 3]) -> [47_u8: bb10, 33_u8: bb10, otherwise: bb9]; // scope 0 at $DIR/deduplicate_blocks.rs:3:5: 3:23
       }
   
-      bb9: {
+-     bb9: {                               // preds: [bb5, bb6, bb7, bb8]
 -         _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
 -         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:7:14: 7:19
 -     }
 - 
--     bb10: {
+-     bb10: {                              // preds: [bb4]
++     bb9: {                               // preds: [bb4, bb5, bb6, bb7, bb8]
           _0 = const false;                // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
 -         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
 +         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:4:41: 4:46
       }
   
--     bb11: {
+-     bb11: {                              // preds: [bb8]
 -         _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
 -         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:5:35: 5:39
 -     }
 - 
--     bb12: {
-+     bb10: {
+-     bb12: {                              // preds: [bb8]
++     bb10: {                              // preds: [bb8, bb8]
           _0 = const true;                 // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
 -         goto -> bb13;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
 +         goto -> bb11;                    // scope 0 at $DIR/deduplicate_blocks.rs:6:35: 6:39
       }
   
--     bb13: {
-+     bb11: {
+-     bb13: {                              // preds: [bb9, bb10, bb11, bb12]
++     bb11: {                              // preds: [bb9, bb10]
           StorageDead(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/deduplicate_blocks.rs:9:2: 9:2
       }
   
--     bb14: {
-+     bb12: {
+-     bb14: {                              // preds: [bb0]
++     bb12: {                              // preds: [bb0]
           StorageDead(_8);                 // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
           StorageDead(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:22: 3:23
           _6 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37

--- a/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/branch.main.DestinationPropagation.diff
@@ -15,7 +15,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/branch.rs:13:9: 13:10
 -         _1 = val() -> bb1;               // scope 0 at $DIR/branch.rs:13:13: 13:18
 +         nop;                             // scope 0 at $DIR/branch.rs:13:9: 13:10
@@ -25,7 +25,7 @@
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_2);                 // scope 1 at $DIR/branch.rs:15:9: 15:10
 +         nop;                             // scope 1 at $DIR/branch.rs:15:9: 15:10
           StorageLive(_3);                 // scope 1 at $DIR/branch.rs:15:16: 15:22
@@ -35,17 +35,17 @@
                                            // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           switchInt(move _3) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/branch.rs:15:16: 15:22
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
 -         _2 = _1;                         // scope 1 at $DIR/branch.rs:16:9: 16:10
 +         nop;                             // scope 1 at $DIR/branch.rs:16:9: 16:10
           goto -> bb6;                     // scope 1 at $DIR/branch.rs:15:13: 20:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2]
           StorageLive(_4);                 // scope 1 at $DIR/branch.rs:18:9: 18:14
           _4 = val() -> bb5;               // scope 1 at $DIR/branch.rs:18:9: 18:14
                                            // mir::Constant
@@ -53,14 +53,14 @@
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           StorageDead(_4);                 // scope 1 at $DIR/branch.rs:18:14: 18:15
 -         _2 = _1;                         // scope 1 at $DIR/branch.rs:19:9: 19:10
 +         nop;                             // scope 1 at $DIR/branch.rs:19:9: 19:10
           goto -> bb6;                     // scope 1 at $DIR/branch.rs:15:13: 20:6
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb3, bb5]
           StorageDead(_3);                 // scope 1 at $DIR/branch.rs:20:5: 20:6
           nop;                             // scope 0 at $DIR/branch.rs:12:11: 21:2
 -         StorageDead(_2);                 // scope 1 at $DIR/branch.rs:21:1: 21:2

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.arg_src.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.arg_src.DestinationPropagation.diff
@@ -10,7 +10,7 @@
 +         debug y => _0;                   // in scope 1 at $DIR/copy_propagation_arg.rs:28:9: 28:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10
 -         _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:28:13: 28:14
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:28:9: 28:10

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.bar.DestinationPropagation.diff
@@ -7,7 +7,7 @@
       let _2: u8;                          // in scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
       let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:5: 16:13
           StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
           _3 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:16:11: 16:12
@@ -17,7 +17,7 @@
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:12: 16:13
           StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:16:13: 16:14
           _1 = const 5_u8;                 // scope 0 at $DIR/copy_propagation_arg.rs:17:5: 17:10

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.baz.DestinationPropagation.diff
@@ -6,7 +6,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/copy_propagation_arg.rs:21:20: 21:20
       let mut _2: i32;                     // in scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
 -         _2 = _1;                         // scope 0 at $DIR/copy_propagation_arg.rs:23:9: 23:10
 -         _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:23:5: 23:10

--- a/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/copy_propagation_arg.foo.DestinationPropagation.diff
@@ -7,7 +7,7 @@
       let mut _2: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
       let mut _3: u8;                      // in scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
 +         nop;                             // scope 0 at $DIR/copy_propagation_arg.rs:11:9: 11:17
           StorageLive(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:15: 11:16
@@ -19,7 +19,7 @@
                                            // + literal: Const { ty: fn(u8) -> u8 {dummy}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:16: 11:17
 -         _1 = move _2;                    // scope 0 at $DIR/copy_propagation_arg.rs:11:5: 11:17
 -         StorageDead(_2);                 // scope 0 at $DIR/copy_propagation_arg.rs:11:16: 11:17

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -25,7 +25,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:9:9: 9:14
 -         _1 = val() -> bb1;               // scope 0 at $DIR/cycle.rs:9:17: 9:22
 +         nop;                             // scope 0 at $DIR/cycle.rs:9:9: 9:14
@@ -35,7 +35,7 @@
                                            // + literal: Const { ty: fn() -> i32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_2);                 // scope 1 at $DIR/cycle.rs:10:9: 10:10
 -         _2 = _1;                         // scope 1 at $DIR/cycle.rs:10:13: 10:14
 -         StorageLive(_3);                 // scope 2 at $DIR/cycle.rs:11:9: 11:10

--- a/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/simple.nrvo.DestinationPropagation.diff
@@ -13,7 +13,7 @@
           debug buf => _2;                 // in scope 1 at $DIR/simple.rs:5:9: 5:16
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simple.rs:5:9: 5:16
           _2 = [const 0_u8; 1024];         // scope 0 at $DIR/simple.rs:5:19: 5:28
           StorageLive(_3);                 // scope 1 at $DIR/simple.rs:6:5: 6:19
@@ -26,7 +26,7 @@
           _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/simple.rs:6:5: 6:19
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_5);                 // scope 1 at $DIR/simple.rs:6:18: 6:19
           StorageDead(_4);                 // scope 1 at $DIR/simple.rs:6:18: 6:19
           StorageDead(_6);                 // scope 1 at $DIR/simple.rs:6:19: 6:20

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -16,7 +16,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
           StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
           _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
@@ -25,7 +25,7 @@
                                            // + literal: Const { ty: fn() -> u32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
           StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -19,7 +19,7 @@
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:5:24: 5:25
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
@@ -39,19 +39,21 @@
 +         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0, bb2]
++     bb1: {                               // preds: [bb0, bb4]
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
 -         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
 +         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:6:14: 6:15
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
 -         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb4]
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
           _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:5:15: 5:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:5:24: 5:25
@@ -63,13 +65,13 @@
 +         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:5:31: 5:32
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb1, bb3]
++     bb3: {                               // preds: [bb1, bb2]
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:8:2: 8:2
 +     }
 + 
-+     bb4: {
++     bb4: {                               // preds: [bb0]
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
 +         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:4:5: 4:17
       }

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -20,7 +20,7 @@
           debug b => _10;                  // in scope 1 at $DIR/early_otherwise_branch.rs:13:24: 13:25
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
@@ -40,25 +40,26 @@
 +         switchInt(move _12) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
 -         switchInt(move _6) -> [0_isize: bb5, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0, bb1, bb3]
++     bb1: {                               // preds: [bb0, bb5]
 +         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
 -         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:15:14: 15:15
       }
   
--     bb3: {
+-     bb3: {                               // preds: [bb0]
 -         _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
 -         switchInt(move _7) -> [1_isize: bb4, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 -     }
 - 
--     bb4: {
-+     bb2: {
+-     bb4: {                               // preds: [bb3]
++     bb2: {                               // preds: [bb5]
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
           _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:13:15: 13:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch.rs:13:24: 13:25
@@ -70,20 +71,20 @@
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:13:31: 13:32
       }
   
--     bb5: {
-+     bb3: {
+-     bb5: {                               // preds: [bb1]
++     bb3: {                               // preds: [bb5]
           _0 = const 0_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
 -         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:14:25: 14:26
       }
   
--     bb6: {
-+     bb4: {
+-     bb6: {                               // preds: [bb2, bb4, bb5]
++     bb4: {                               // preds: [bb1, bb2, bb3]
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:17:1: 17:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:17:2: 17:2
 +     }
 + 
-+     bb5: {
++     bb5: {                               // preds: [bb0]
 +         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
 +         switchInt(_8) -> [0_isize: bb3, 1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:12:5: 12:17
       }

--- a/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -19,7 +19,7 @@
           debug b => _9;                   // in scope 1 at $DIR/early_otherwise_branch.rs:23:24: 23:25
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
@@ -39,19 +39,21 @@
 +         switchInt(move _11) -> [false: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0, bb2]
++     bb1: {                               // preds: [bb0, bb4]
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
 -         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
 +         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:24:14: 24:15
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _6 = discriminant((_3.1: std::option::Option<bool>)); // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
 -         switchInt(move _6) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb4]
           StorageLive(_8);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:15: 23:16
           _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch.rs:23:15: 23:16
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch.rs:23:24: 23:25
@@ -63,13 +65,13 @@
 +         goto -> bb3;                     // scope 0 at $DIR/early_otherwise_branch.rs:23:31: 23:32
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb1, bb3]
++     bb3: {                               // preds: [bb1, bb2]
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/early_otherwise_branch.rs:26:2: 26:2
 +     }
 + 
-+     bb4: {
++     bb4: {                               // preds: [bb0]
 +         StorageDead(_11);                // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
 +         switchInt(_7) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch.rs:22:5: 22:17
       }

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -26,7 +26,7 @@
           debug c => _13;                  // in scope 1 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:33: 6:34
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
           _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:12: 5:13
@@ -50,7 +50,8 @@
 +         switchInt(move _15) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0, bb2, bb3]
++     bb1: {                               // preds: [bb0, bb2, bb5]
 +         StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
 +         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
@@ -58,19 +59,20 @@
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:7:14: 7:15
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _9 = discriminant((_4.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
 -         switchInt(move _9) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb5]
           _8 = discriminant((_4.2: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
 -         switchInt(move _8) -> [1_isize: bb4, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 +         switchInt(move _8) -> [1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb3]
++     bb3: {                               // preds: [bb2]
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
           _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:15: 6:16
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:24: 6:25
@@ -85,13 +87,13 @@
 +         goto -> bb4;                     // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:6:40: 6:41
       }
   
--     bb5: {
-+     bb4: {
+-     bb5: {                               // preds: [bb1, bb4]
++     bb4: {                               // preds: [bb1, bb3]
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:9:2: 9:2
 +     }
 + 
-+     bb5: {
++     bb5: {                               // preds: [bb0]
 +         StorageDead(_15);                // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
 +         switchInt(_10) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:5: 5:20
       }

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
@@ -63,7 +63,7 @@
 +         debug other => _31;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
 -         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
@@ -90,12 +90,13 @@
 +         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0, bb1, bb3, bb4, bb5]
++     bb1: {                               // preds: [bb0, bb7]
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
@@ -108,7 +109,10 @@
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
-+     bb2: {
+-     bb3: {                               // preds: [bb0]
+-         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++     bb2: {                               // preds: [bb7]
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
 +         _15 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
@@ -127,11 +131,12 @@
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+     }
-+ 
-      bb3: {
--         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+      }
+  
+-     bb4: {                               // preds: [bb0]
+-         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++     bb3: {                               // preds: [bb7]
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 +         _20 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
@@ -152,9 +157,10 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
       }
   
-      bb4: {
--         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+-     bb5: {                               // preds: [bb0]
+-         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
++     bb4: {                               // preds: [bb7]
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 +         _25 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
@@ -175,9 +181,26 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
       }
   
-      bb5: {
--         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
+-     bb6: {                               // preds: [bb1]
+-         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
+-         _12 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
+-         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+-         _13 = (((*(_4.1: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
+-         StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
+-         StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
+-         _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
+-         StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
+-         _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
+-         _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
+-         StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
+-         StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
+-         ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
+-         discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
+-         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
+-         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
+-         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
+-         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
++     bb5: {                               // preds: [bb7]
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 +         _30 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
@@ -198,33 +221,7 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
       }
   
-      bb6: {
--         StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
--         _12 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
--         StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
--         _13 = (((*(_4.1: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
--         StorageLive(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
--         StorageLive(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
--         _15 = _12;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:41
--         StorageLive(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
--         _16 = _13;                       // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:44: 22:49
--         _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
--         StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
--         StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
--         ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
--         discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
--         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
--         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-+         discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
-+         return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
-      }
-  
-      bb7: {
+-     bb7: {                               // preds: [bb3]
 -         StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 -         _17 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
 -         StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
@@ -245,7 +242,7 @@
 -         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
 -     }
 - 
--     bb8: {
+-     bb8: {                               // preds: [bb4]
 -         StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 -         _22 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
 -         StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
@@ -266,7 +263,7 @@
 -         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
 -     }
 - 
--     bb9: {
+-     bb9: {                               // preds: [bb5]
 -         StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 -         _27 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
 -         StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
@@ -287,12 +284,19 @@
 -         goto -> bb10;                    // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
 -     }
 - 
--     bb10: {
+-     bb10: {                              // preds: [bb6, bb7, bb8, bb9]
 -         ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
--         discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
++     bb6: {                               // preds: [bb2, bb3, bb4, bb5]
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
+          discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
 -         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
--         return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
++     }
++ 
++     bb7: {                               // preds: [bb0]
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         switchInt(_11) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -55,7 +55,7 @@
           debug other => _28;              // in scope 4 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
@@ -76,12 +76,13 @@
 +         switchInt(move _35) -> [false: bb7, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _7 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _7) -> [0_isize: bb6, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0, bb1, bb3, bb4, bb5]
++     bb1: {                               // preds: [bb0, bb7]
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
@@ -92,23 +93,23 @@
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
--     bb3: {
+-     bb3: {                               // preds: [bb0]
 -         _8 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _8) -> [1_isize: bb7, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb0]
 -         _9 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _9) -> [2_isize: bb8, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb0]
 -         _10 = discriminant((*(_4.1: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _10) -> [3_isize: bb9, otherwise: bb2]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 -     }
 - 
--     bb6: {
-+     bb2: {
+-     bb6: {                               // preds: [bb1]
++     bb2: {                               // preds: [bb7]
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
           _12 = (((*(_4.0: &ViewportPercentageLength)) as Vw).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:14: 22:17
           StorageLive(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:24: 22:29
@@ -130,8 +131,8 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
       }
   
--     bb7: {
-+     bb3: {
+-     bb7: {                               // preds: [bb3]
++     bb3: {                               // preds: [bb7]
           StorageLive(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
           _17 = (((*(_4.0: &ViewportPercentageLength)) as Vh).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:14: 23:17
           StorageLive(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:24: 23:29
@@ -153,8 +154,8 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
       }
   
--     bb8: {
-+     bb4: {
+-     bb8: {                               // preds: [bb4]
++     bb4: {                               // preds: [bb7]
           StorageLive(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
           _22 = (((*(_4.0: &ViewportPercentageLength)) as Vmin).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:16: 24:19
           StorageLive(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:28: 24:33
@@ -176,8 +177,8 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
       }
   
--     bb9: {
-+     bb5: {
+-     bb9: {                               // preds: [bb5]
++     bb5: {                               // preds: [bb7]
           StorageLive(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
           _27 = (((*(_4.0: &ViewportPercentageLength)) as Vmax).0: f32); // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:16: 25:19
           StorageLive(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:28: 25:33
@@ -199,8 +200,8 @@
 +         goto -> bb6;                     // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
       }
   
--     bb10: {
-+     bb6: {
+-     bb10: {                              // preds: [bb6, bb7, bb8, bb9]
++     bb6: {                               // preds: [bb2, bb3, bb4, bb5]
           ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
@@ -208,7 +209,7 @@
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
 +     }
 + 
-+     bb7: {
++     bb7: {                               // preds: [bb0]
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         switchInt(_11) -> [0_isize: bb2, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
       }

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -26,7 +26,7 @@
           debug b => _12;                  // in scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
@@ -40,22 +40,22 @@
           switchInt(move _8) -> [0_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _6 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           switchInt(move _6) -> [0_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _0 = const 3_u32;                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:12:25: 12:26
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           _7 = discriminant((_3.1: std::option::Option<u32>)); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           switchInt(move _7) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:5: 8:17
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
           StorageLive(_9);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
           _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:15: 9:16
           StorageLive(_10);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:24: 9:25
@@ -66,7 +66,7 @@
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:9:31: 9:32
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3]
           StorageLive(_11);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
           _11 = (((_3.0: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:15: 10:16
           _0 = const 1_u32;                // scope 2 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
@@ -74,7 +74,7 @@
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:10:28: 10:29
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb1]
           StorageLive(_12);                // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
           _12 = (((_3.1: std::option::Option<u32>) as Some).0: u32); // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:21: 11:22
           _0 = const 2_u32;                // scope 3 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
@@ -82,7 +82,7 @@
           goto -> bb7;                     // scope 0 at $DIR/early_otherwise_branch_noopt.rs:11:28: 11:29
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb2, bb4, bb5, bb6]
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:1: 14:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_noopt.rs:14:2: 14:2
       }

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
@@ -12,27 +12,27 @@
           debug v => _5;                   // in scope 1 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           _3 = discriminant(_1);           // scope 0 at $DIR/early_otherwise_branch_soundness.rs:19:11: 19:12
           switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:19:5: 19:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:25:14: 25:15
           return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:25:14: 25:15
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _4 = discriminant((*_2));        // scope 0 at $DIR/early_otherwise_branch_soundness.rs:21:26: 21:28
           switchInt(move _4) -> [1_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:21:20: 21:28
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           _0 = const 0_i32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:23:18: 23:19
           return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:23:18: 23:19
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2]
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
           _5 = (((*_2) as Some).0: i32);   // scope 0 at $DIR/early_otherwise_branch_soundness.rs:22:18: 22:19
           _0 = _5;                         // scope 1 at $DIR/early_otherwise_branch_soundness.rs:22:24: 22:25

--- a/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
@@ -7,22 +7,22 @@
       let mut _2: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:20: 13:30
       let mut _3: isize;                   // in scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
   
-      bb0: {
+      bb0: {                               // preds: []
           _3 = discriminant((*_1));        // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
           switchInt(move _3) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _2 = discriminant((*(((*_1) as Some).0: &E))); // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
           switchInt(move _2) -> [1_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:12: 13:31
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _0 = const 1_u32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:38: 13:39
           return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:5: 13:52
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1]
           _0 = const 2_u32;                // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:49: 13:50
           return;                          // scope 0 at $DIR/early_otherwise_branch_soundness.rs:13:5: 13:52
       }

--- a/src/test/mir-opt/equal_true.opt.InstCombine.diff
+++ b/src/test/mir-opt/equal_true.opt.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:17
       let mut _3: bool;                    // in scope 0 at $DIR/equal_true.rs:4:8: 4:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:17
           StorageLive(_3);                 // scope 0 at $DIR/equal_true.rs:4:8: 4:9
           _3 = _1;                         // scope 0 at $DIR/equal_true.rs:4:8: 4:9
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/equal_true.rs:4:8: 4:17
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_i32;                // scope 0 at $DIR/equal_true.rs:4:20: 4:21
           goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_i32;                // scope 0 at $DIR/equal_true.rs:4:31: 4:32
           goto -> bb3;                     // scope 0 at $DIR/equal_true.rs:4:5: 4:34
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/equal_true.rs:4:33: 4:34
           return;                          // scope 0 at $DIR/equal_true.rs:5:2: 5:2
       }

--- a/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -17,50 +17,50 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
         debug z => _8;                   // in scope 1 at $DIR/exponential-or.rs:6:57: 6:78
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/exponential-or.rs:5:11: 5:12
         switchInt((_1.0: u32)) -> [1_u32: bb2, 4_u32: bb2, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:15: 6:20
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb2, bb3, bb6, bb7, bb8]
         _0 = const 0_u32;                // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
         goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:7:14: 7:15
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0, bb0]
         _2 = discriminant((_1.2: std::option::Option<i32>)); // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
         switchInt(move _2) -> [0_isize: bb4, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1_i32: bb4, 8_i32: bb4, otherwise: bb1]; // scope 0 at $DIR/exponential-or.rs:6:37: 6:55
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2, bb3, bb3]
         _5 = Le(const 6_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
         switchInt(move _5) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         _6 = Le((_1.3: u32), const 9_u32); // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
         switchInt(move _6) -> [false: bb6, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:6:62: 6:67
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb4, bb5]
         _3 = Le(const 13_u32, (_1.3: u32)); // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
         switchInt(move _3) -> [false: bb1, otherwise: bb7]; // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         _4 = Le((_1.3: u32), const 16_u32); // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
         switchInt(move _4) -> [false: bb1, otherwise: bb8]; // scope 0 at $DIR/exponential-or.rs:6:70: 6:77
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb5, bb7]
         falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/exponential-or.rs:6:9: 6:79
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb8]
         StorageLive(_7);                 // scope 0 at $DIR/exponential-or.rs:6:10: 6:21
         _7 = (_1.0: u32);                // scope 0 at $DIR/exponential-or.rs:6:10: 6:21
         StorageLive(_8);                 // scope 0 at $DIR/exponential-or.rs:6:57: 6:78
@@ -77,7 +77,7 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
         goto -> bb10;                    // scope 0 at $DIR/exponential-or.rs:6:87: 6:88
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb1, bb9]
         return;                          // scope 0 at $DIR/exponential-or.rs:9:2: 9:2
     }
 }

--- a/src/test/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
+++ b/src/test/mir-opt/fn_ptr_shim.core.ops-function-Fn-call.AddMovesForPackedDrops.before.mir
@@ -3,11 +3,11 @@
 fn std::ops::Fn::call(_1: *const fn(), _2: ()) -> <fn() as FnOnce<()>>::Output {
     let mut _0: <fn() as std::ops::FnOnce<()>>::Output; // return place in scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = move (*_1)() -> bb1;        // scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         return;                          // scope 0 at $SRC_DIR/core/src/ops/function.rs:LL:COL
     }
 }

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -34,7 +34,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_4);                 // scope 0 at $DIR/funky_arms.rs:15:9: 15:19
           StorageLive(_5);                 // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
           _5 = &(*_1);                     // scope 0 at $DIR/funky_arms.rs:15:22: 15:37
@@ -44,23 +44,23 @@
                                            // + literal: Const { ty: for<'r> fn(&'r std::fmt::Formatter) -> bool {std::fmt::Formatter::sign_plus}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_5);                 // scope 0 at $DIR/funky_arms.rs:15:36: 15:37
           StorageLive(_6);                 // scope 1 at $DIR/funky_arms.rs:19:9: 19:13
           switchInt(_4) -> [false: bb3, otherwise: bb2]; // scope 1 at $DIR/funky_arms.rs:19:16: 19:32
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           discriminant(_6) = 1;            // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
           goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1]
           discriminant(_6) = 0;            // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
           goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageLive(_7);                 // scope 2 at $DIR/funky_arms.rs:24:30: 24:45
           StorageLive(_8);                 // scope 2 at $DIR/funky_arms.rs:24:30: 24:45
           _8 = &(*_1);                     // scope 2 at $DIR/funky_arms.rs:24:30: 24:45
@@ -70,13 +70,13 @@
                                            // + literal: Const { ty: for<'r> fn(&'r std::fmt::Formatter) -> std::option::Option<usize> {std::fmt::Formatter::precision}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           StorageDead(_8);                 // scope 2 at $DIR/funky_arms.rs:24:44: 24:45
           _9 = discriminant(_7);           // scope 2 at $DIR/funky_arms.rs:24:12: 24:27
           switchInt(move _9) -> [1_isize: bb6, otherwise: bb8]; // scope 2 at $DIR/funky_arms.rs:24:12: 24:27
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb5]
           StorageLive(_10);                // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           _10 = ((_7 as Some).0: usize);   // scope 2 at $DIR/funky_arms.rs:24:17: 24:26
           StorageLive(_11);                // scope 2 at $DIR/funky_arms.rs:26:43: 26:46
@@ -101,7 +101,7 @@
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, u32, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_exact::<T>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb6]
           StorageDead(_17);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_14);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
           StorageDead(_13);                // scope 2 at $DIR/funky_arms.rs:26:86: 26:87
@@ -111,7 +111,7 @@
           goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:24:5: 29:6
       }
   
-      bb8: {
+      bb8: {                               // preds: [bb5]
           StorageLive(_18);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
           _18 = &mut (*_1);                // scope 2 at $DIR/funky_arms.rs:28:46: 28:49
           StorageLive(_19);                // scope 2 at $DIR/funky_arms.rs:28:51: 28:54
@@ -126,7 +126,7 @@
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r mut std::fmt::Formatter<'s>, &'t0 T, core::num::flt2dec::Sign, bool) -> std::result::Result<(), std::fmt::Error> {float_to_exponential_common_shortest::<T>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb9: {
+      bb9: {                               // preds: [bb8]
           StorageDead(_21);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
           StorageDead(_20);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
           StorageDead(_19);                // scope 2 at $DIR/funky_arms.rs:28:67: 28:68
@@ -134,7 +134,7 @@
           goto -> bb10;                    // scope 2 at $DIR/funky_arms.rs:24:5: 29:6
       }
   
-      bb10: {
+      bb10: {                              // preds: [bb7, bb9]
           StorageDead(_6);                 // scope 1 at $DIR/funky_arms.rs:30:1: 30:2
           StorageDead(_4);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2
           StorageDead(_7);                 // scope 0 at $DIR/funky_arms.rs:30:1: 30:2

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -27,58 +27,58 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
         debug _s => (((*_1) as variant#3).0: std::string::String); // in scope 1 at $DIR/generator-drop-cleanup.rs:11:13: 11:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb10]
         StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
         StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
         drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
         goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb8]
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb5]
         resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb5 (cleanup): {
+    bb5 (cleanup): {                     // preds: [bb1]
         nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
         goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb9]
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb0]
         goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb2]
         goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb7]
         goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb0]
         StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb11: {
+    bb11: {                              // preds: [bb0]
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -19,7 +19,7 @@ yields ()
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
         (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
         StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
@@ -29,7 +29,7 @@ yields ()
         _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
         StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
         StorageLive(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:9: 26:16
@@ -41,7 +41,7 @@ yields ()
                                          // + literal: Const { ty: fn(Foo) {take::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
         StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
         StorageLive(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:9: 27:16
@@ -53,7 +53,7 @@ yields ()
                                          // + literal: Const { ty: fn(Bar) {take::<Bar>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
         StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
@@ -62,49 +62,49 @@ yields ()
         drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         return;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:6: 28:6
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
         StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         generator_drop;                  // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb2]
         StorageDead(_10);                // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:15: 27:16
         StorageDead(_9);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:27:16: 27:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb1]
         StorageDead(_8);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:15: 26:16
         StorageDead(_7);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:26:16: 26:17
         goto -> bb10;                    // scope 2 at no-location
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb8, bb9]
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb3, bb6, bb10, bb12]
         resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
     }
 
-    bb12 (cleanup): {
+    bb12 (cleanup): {                    // preds: [bb5]
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -26,19 +26,19 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
         debug _d => _3;                  // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _11 = discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]))); // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         switchInt(move _11) -> [0_u32: bb1, 3_u32: bb5, otherwise: bb6]; // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_3);                 // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
         StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
         goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1, bb4]
         StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
@@ -47,7 +47,7 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
         return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb5]
         StorageDead(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:17: 22:18
         StorageDead(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:18: 22:19
         StorageLive(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:13: 23:21
@@ -57,13 +57,13 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
                                          // + literal: Const { ty: fn() {callee}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_8);                 // scope 1 at $DIR/generator-tiny.rs:23:21: 23:22
         _5 = const ();                   // scope 1 at $DIR/generator-tiny.rs:21:14: 24:10
         goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb0]
         StorageLive(_3);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
@@ -72,7 +72,7 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
         goto -> bb3;                     // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb0]
         unreachable;                     // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     }
 }

--- a/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_bool.SimplifyComparisonIntegral.diff
@@ -6,23 +6,23 @@
       let mut _0: u32;                     // return place in scope 0 at $DIR/if-condition-int.rs:16:30: 16:33
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
           _2 = _1;                         // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:17:8: 17:9
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:17:12: 17:13
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:17:5: 17:26
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:17:23: 17:24
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:17:5: 17:26
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:17:25: 17:26
           return;                          // scope 0 at $DIR/if-condition-int.rs:18:2: 18:2
       }

--- a/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_opt_floats.SimplifyComparisonIntegral.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
       let mut _3: f32;                     // in scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:53:8: 53:9
@@ -16,17 +16,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/if-condition-int.rs:53:8: 53:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_i32;                // scope 0 at $DIR/if-condition-int.rs:53:21: 53:22
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:53:5: 53:35
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_i32;                // scope 0 at $DIR/if-condition-int.rs:53:32: 53:33
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:53:5: 53:35
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:53:34: 53:35
           return;                          // scope 0 at $DIR/if-condition-int.rs:54:2: 54:2
       }

--- a/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.dont_remove_comparison.SimplifyComparisonIntegral.diff
@@ -14,7 +14,7 @@
           debug b => _2;                   // in scope 1 at $DIR/if-condition-int.rs:44:9: 44:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:44:9: 44:10
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:44:13: 44:14
@@ -26,7 +26,7 @@
 +         switchInt(move _3) -> [17_i8: bb1, otherwise: bb2]; // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
           StorageLive(_6);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:31
           StorageLive(_7);                 // scope 1 at $DIR/if-condition-int.rs:47:23: 47:24
@@ -38,7 +38,7 @@
           goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:47:30: 47:31
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 1 at $DIR/if-condition-int.rs:45:5: 45:12
           StorageLive(_4);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:31
           StorageLive(_5);                 // scope 1 at $DIR/if-condition-int.rs:46:23: 46:24
@@ -50,7 +50,7 @@
           goto -> bb3;                     // scope 1 at $DIR/if-condition-int.rs:46:30: 46:31
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:49:1: 49:2
           return;                          // scope 0 at $DIR/if-condition-int.rs:49:2: 49:2
       }

--- a/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_char.SimplifyComparisonIntegral.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
       let mut _3: char;                    // in scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:21:8: 21:9
@@ -19,19 +19,19 @@
 +         switchInt(move _3) -> ['x': bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:21:19: 21:20
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:21:8: 21:16
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:21:30: 21:31
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:21:5: 21:33
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:21:32: 21:33
           return;                          // scope 0 at $DIR/if-condition-int.rs:22:2: 22:2
       }

--- a/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_i8.SimplifyComparisonIntegral.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
       let mut _3: i8;                      // in scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:25:8: 25:9
@@ -19,19 +19,19 @@
 +         switchInt(move _3) -> [42_i8: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:25:18: 25:19
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:25:8: 25:15
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:25:29: 25:30
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:25:5: 25:32
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:25:31: 25:32
           return;                          // scope 0 at $DIR/if-condition-int.rs:26:2: 26:2
       }

--- a/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_multiple_ifs.SimplifyComparisonIntegral.diff
@@ -9,7 +9,7 @@
       let mut _4: bool;                    // in scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
       let mut _5: u32;                     // in scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:33:8: 33:9
@@ -21,13 +21,13 @@
 +         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:34:9: 34:10
           goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:33:8: 33:15
           StorageLive(_4);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           StorageLive(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:16
@@ -40,24 +40,24 @@
 +         switchInt(move _5) -> [21_u32: bb4, otherwise: bb3]; // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
 +         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:36:9: 36:10
           goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2]
 +         StorageDead(_5);                 // scope 0 at $DIR/if-condition-int.rs:35:15: 35:22
           _0 = const 2_u32;                // scope 0 at $DIR/if-condition-int.rs:38:9: 38:10
           goto -> bb5;                     // scope 0 at $DIR/if-condition-int.rs:35:12: 39:6
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3, bb4]
           StorageDead(_4);                 // scope 0 at $DIR/if-condition-int.rs:39:5: 39:6
           goto -> bb6;                     // scope 0 at $DIR/if-condition-int.rs:33:5: 39:6
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb1, bb5]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:39:5: 39:6
           return;                          // scope 0 at $DIR/if-condition-int.rs:40:2: 40:2
       }

--- a/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_negative.SimplifyComparisonIntegral.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
       let mut _3: i32;                     // in scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:29:8: 29:9
@@ -19,19 +19,19 @@
 +         switchInt(move _3) -> [-42_i32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:29:19: 29:20
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:29:8: 29:16
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:29:30: 29:31
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:29:5: 29:33
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:29:32: 29:33
           return;                          // scope 0 at $DIR/if-condition-int.rs:30:2: 30:2
       }

--- a/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/if_condition_int.opt_u32.SimplifyComparisonIntegral.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
       let mut _3: u32;                     // in scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
           StorageLive(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
           _3 = _1;                         // scope 0 at $DIR/if-condition-int.rs:12:8: 12:9
@@ -19,19 +19,19 @@
 +         switchInt(move _3) -> [42_u32: bb1, otherwise: bb2]; // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
           _0 = const 0_u32;                // scope 0 at $DIR/if-condition-int.rs:12:18: 12:19
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 +         StorageDead(_3);                 // scope 0 at $DIR/if-condition-int.rs:12:8: 12:15
           _0 = const 1_u32;                // scope 0 at $DIR/if-condition-int.rs:12:29: 12:30
           goto -> bb3;                     // scope 0 at $DIR/if-condition-int.rs:12:5: 12:32
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/if-condition-int.rs:12:31: 12:32
           return;                          // scope 0 at $DIR/if-condition-int.rs:13:2: 13:2
       }

--- a/src/test/mir-opt/inline/cycle.f.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.f.Inline.diff
@@ -8,7 +8,7 @@
       let mut _3: &impl Fn();              // in scope 0 at $DIR/cycle.rs:6:5: 6:6
       let mut _4: ();                      // in scope 0 at $DIR/cycle.rs:6:5: 6:8
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/cycle.rs:6:5: 6:8
           StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:6:5: 6:6
           _3 = &_1;                        // scope 0 at $DIR/cycle.rs:6:5: 6:6
@@ -19,7 +19,7 @@
                                            // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as std::ops::FnOnce<()>>::Output {<impl Fn() as std::ops::Fn<()>>::call}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_4);                 // scope 0 at $DIR/cycle.rs:6:7: 6:8
           StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:6:7: 6:8
           StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:6:8: 6:9
@@ -27,15 +27,15 @@
           drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/cycle.rs:7:1: 7:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           return;                          // scope 0 at $DIR/cycle.rs:7:2: 7:2
       }
   
-      bb3 (cleanup): {
+      bb3 (cleanup): {                     // preds: [bb0]
           drop(_1) -> bb4;                 // scope 0 at $DIR/cycle.rs:7:1: 7:2
       }
   
-      bb4 (cleanup): {
+      bb4 (cleanup): {                     // preds: [bb1, bb3]
           resume;                          // scope 0 at $DIR/cycle.rs:5:1: 7:2
       }
   }

--- a/src/test/mir-opt/inline/cycle.g.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.g.Inline.diff
@@ -5,7 +5,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:11:8: 11:8
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:12:5: 12:12
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:12:5: 12:12
           _1 = f::<fn() {main}>(main) -> bb1; // scope 0 at $DIR/cycle.rs:12:5: 12:12
                                            // mir::Constant
@@ -16,7 +16,7 @@
                                            // + literal: Const { ty: fn() {main}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:12:12: 12:13
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:11:8: 13:2
           return;                          // scope 0 at $DIR/cycle.rs:13:2: 13:2

--- a/src/test/mir-opt/inline/cycle.main.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.main.Inline.diff
@@ -5,7 +5,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/cycle.rs:16:11: 16:11
       let _1: ();                          // in scope 0 at $DIR/cycle.rs:17:5: 17:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/cycle.rs:17:5: 17:9
           _1 = f::<fn() {g}>(g) -> bb1;    // scope 0 at $DIR/cycle.rs:17:5: 17:9
                                            // mir::Constant
@@ -16,7 +16,7 @@
                                            // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/cycle.rs:17:9: 17:10
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:16:11: 18:2
           return;                          // scope 0 at $DIR/cycle.rs:18:2: 18:2

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -16,7 +16,7 @@ fn bar() -> bool {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/inline-any-operand.rs:11:9: 11:10
         _1 = foo;                        // scope 0 at $DIR/inline-any-operand.rs:11:13: 11:16
                                          // mir::Constant

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -19,7 +19,7 @@ fn foo(_1: T, _2: i32) -> i32 {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_3);                 // scope 0 at $DIR/inline-closure.rs:11:9: 11:10
         StorageLive(_4);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:6
         _4 = &_3;                        // scope 1 at $DIR/inline-closure.rs:12:5: 12:6

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -23,7 +23,7 @@ fn foo(_1: T, _2: &i32) -> i32 {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
         StorageLive(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
         _4 = &_3;                        // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -22,7 +22,7 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_3);                 // scope 0 at $DIR/inline-closure-captures.rs:11:9: 11:10
         StorageLive(_4);                 // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         _4 = &_2;                        // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_no_sanitize.Inline.diff
@@ -7,7 +7,7 @@
 +     scope 1 (inlined no_sanitize) {      // at $DIR/inline-compatibility.rs:24:5: 24:18
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:24:5: 24:18
 -         _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:24:5: 24:18
 -                                          // mir::Constant
@@ -15,7 +15,7 @@
 -                                          // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:24:18: 24:19
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:23:37: 25:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:25:2: 25:2

--- a/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.inlined_target_feature.Inline.diff
@@ -7,7 +7,7 @@
 +     scope 1 (inlined target_feature) {   // at $DIR/inline-compatibility.rs:13:5: 13:21
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:13:5: 13:21
 -         _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:13:5: 13:21
 -                                          // mir::Constant
@@ -15,7 +15,7 @@
 -                                          // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:13:21: 13:22
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:12:40: 14:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:14:2: 14:2

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_c_variadic.Inline.diff
@@ -8,7 +8,7 @@
           debug s => _1;                   // in scope 1 at $DIR/inline-compatibility.rs:42:9: 42:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:42:9: 42:10
           _1 = sum(const 4_u32, const 4_u32, const 30_u32, const 200_u32, const 1000_u32) -> bb1; // scope 0 at $DIR/inline-compatibility.rs:42:13: 42:52
                                            // mir::Constant
@@ -16,7 +16,7 @@
                                            // + literal: Const { ty: unsafe extern "C" fn(u32, ...) -> u32 {sum}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:41:40: 43:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:43:1: 43:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:43:2: 43:2

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_no_sanitize.Inline.diff
@@ -5,7 +5,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:28:41: 28:41
       let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
           _1 = no_sanitize() -> bb1;       // scope 0 at $DIR/inline-compatibility.rs:29:5: 29:18
                                            // mir::Constant
@@ -13,7 +13,7 @@
                                            // + literal: Const { ty: unsafe fn() {no_sanitize}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:29:18: 29:19
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:28:41: 30:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:30:2: 30:2

--- a/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
+++ b/src/test/mir-opt/inline/inline_compatibility.not_inlined_target_feature.Inline.diff
@@ -5,7 +5,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-compatibility.rs:17:44: 17:44
       let _1: ();                          // in scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
           _1 = target_feature() -> bb1;    // scope 0 at $DIR/inline-compatibility.rs:18:5: 18:21
                                            // mir::Constant
@@ -13,7 +13,7 @@
                                            // + literal: Const { ty: unsafe fn() {target_feature}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-compatibility.rs:18:21: 18:22
           _0 = const ();                   // scope 0 at $DIR/inline-compatibility.rs:17:44: 19:2
           return;                          // scope 0 at $DIR/inline-compatibility.rs:19:2: 19:2

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -7,7 +7,7 @@
 +     scope 1 (inlined <C as Call>::call) { // at $DIR/inline-cycle.rs:14:5: 14:24
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
 +         _1 = <A<C> as Call>::call() -> bb1; // scope 1 at $DIR/inline-cycle.rs:14:5: 14:24
@@ -18,7 +18,7 @@
 +                                          // + literal: Const { ty: fn() {<A<C> as Call>::call}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:14:24: 14:25
           _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:13:10: 15:2
           return;                          // scope 0 at $DIR/inline-cycle.rs:15:2: 15:2

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -14,7 +14,7 @@
 +         }
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
 -         _1 = call::<fn() {f}>(f) -> bb1; // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
 +         StorageLive(_2);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
@@ -33,7 +33,7 @@
 +         _3 = move _4() -> bb1;           // scope 2 at $DIR/inline-cycle.rs:49:5: 49:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 +         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
 +         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
 +         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -9,7 +9,7 @@
 +         }
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
 +         _1 = <A as Call>::call() -> bb1; // scope 2 at $DIR/inline-cycle-generic.rs:9:5: 9:24
@@ -20,7 +20,7 @@
 +                                          // + literal: Const { ty: fn() {<A as Call>::call}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:9:24: 9:25
           _0 = const ();                   // scope 0 at $DIR/inline-cycle-generic.rs:8:11: 10:2
           return;                          // scope 0 at $DIR/inline-cycle-generic.rs:10:2: 10:2

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -9,7 +9,7 @@
 +     scope 1 (inlined sleep) {            // at $DIR/inline-diverging.rs:8:5: 8:12
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
 -         sleep();                         // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
 -                                          // mir::Constant
@@ -19,7 +19,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/inline-diverging.rs:8:5: 8:12
 +     }
 + 
-+     bb1: {
++     bb1: {                               // preds: [bb0, bb1]
 +         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:8:5: 8:12
       }
   }

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -13,7 +13,7 @@
 +     scope 1 (inlined panic) {            // at $DIR/inline-diverging.rs:16:9: 16:16
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
           StorageLive(_3);                 // scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
           _3 = _1;                         // scope 0 at $DIR/inline-diverging.rs:13:8: 13:9
@@ -22,7 +22,7 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/inline-diverging.rs:13:8: 13:13
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/inline-diverging.rs:14:9: 14:10
           _4 = _1;                         // scope 0 at $DIR/inline-diverging.rs:14:9: 14:10
           _0 = move _4 as u32 (Misc);      // scope 0 at $DIR/inline-diverging.rs:14:9: 14:17
@@ -31,7 +31,7 @@
           return;                          // scope 0 at $DIR/inline-diverging.rs:18:2: 18:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_6);                 // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
 -         panic();                         // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -31,7 +31,7 @@
 +         }
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
 -         _1 = call_twice::<!, fn() -> ! {sleep}>(sleep) -> bb1; // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
 +         StorageLive(_2);                 // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
@@ -50,10 +50,11 @@
 +         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:22:5: 22:22
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
 -         StorageDead(_1);                 // scope 0 at $DIR/inline-diverging.rs:22:22: 22:23
 -         _0 = const ();                   // scope 0 at $DIR/inline-diverging.rs:21:12: 23:2
 -         return;                          // scope 0 at $DIR/inline-diverging.rs:23:2: 23:2
++     bb1: {                               // preds: [bb0, bb1]
 +         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:22:5: 22:22
       }
   }

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -32,7 +32,7 @@
 +         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-generator.rs:9:9: 9:11
           StorageLive(_2);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
           StorageLive(_3);                 // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
@@ -43,7 +43,7 @@
 -                                          // + literal: Const { ty: fn() -> impl std::ops::Generator<bool> {g}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 +         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:9:28: 9:31
           _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
 -         _2 = Pin::<&mut impl Generator<bool>>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
@@ -53,7 +53,7 @@
 -                                          // + literal: Const { ty: fn(&mut impl std::ops::Generator<bool>) -> std::pin::Pin<&mut impl std::ops::Generator<bool>> {std::pin::Pin::<&mut impl std::ops::Generator<bool>>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
 +         StorageLive(_5);                 // scope 4 at $DIR/inline-generator.rs:9:14: 9:32
 +         _5 = move _3;                    // scope 4 at $DIR/inline-generator.rs:9:14: 9:32
 +         StorageLive(_6);                 // scope 5 at $DIR/inline-generator.rs:9:14: 9:32
@@ -75,8 +75,8 @@
 +         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
       }
   
--     bb3: {
-+     bb1: {
+-     bb3: {                               // preds: [bb2]
++     bb1: {                               // preds: [bb6, bb7]
 +         StorageDead(_12);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageDead(_11);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageDead(_10);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
@@ -88,12 +88,12 @@
           return;                          // scope 0 at $DIR/inline-generator.rs:10:2: 10:2
       }
   
--     bb4 (cleanup): {
-+     bb2 (cleanup): {
+-     bb4 (cleanup): {                     // preds: [bb1, bb2]
++     bb2 (cleanup): {                     // preds: [bb8]
           resume;                          // scope 0 at $DIR/inline-generator.rs:8:1: 10:2
 +     }
 + 
-+     bb3: {
++     bb3: {                               // preds: [bb0]
 +         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
@@ -101,17 +101,17 @@
 +         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +     }
 + 
-+     bb4: {
++     bb4: {                               // preds: [bb3]
 +         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +     }
 + 
-+     bb5: {
++     bb5: {                               // preds: [bb3]
 +         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +     }
 + 
-+     bb6: {
++     bb6: {                               // preds: [bb4, bb5]
 +         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
@@ -119,7 +119,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
 +     }
 + 
-+     bb7: {
++     bb7: {                               // preds: [bb0]
 +         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
@@ -129,11 +129,11 @@
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:41: 15:41
 +     }
 + 
-+     bb8: {
++     bb8: {                               // preds: [bb0, bb8]
 +         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +     }
 + 
-+     bb9: {
++     bb9: {                               // preds: [bb0]
 +         unreachable;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
       }
   }

--- a/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.default.Inline.diff
@@ -9,7 +9,7 @@
 +     scope 1 (inlined instruction_set_default) { // at $DIR/inline-instruction-set.rs:53:5: 53:30
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:51:5: 51:26
           _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:51:5: 51:26
                                            // mir::Constant
@@ -17,7 +17,7 @@
                                            // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:51:26: 51:27
           StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:52:5: 52:26
           _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:52:5: 52:26
@@ -26,7 +26,7 @@
                                            // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:52:26: 52:27
           StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:53:5: 53:30
 -         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:53:5: 53:30
@@ -35,7 +35,7 @@
 -                                          // + literal: Const { ty: fn() {instruction_set_default}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb2]
           StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:53:30: 53:31
           _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:50:18: 54:2
           return;                          // scope 0 at $DIR/inline-instruction-set.rs:54:2: 54:2

--- a/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
+++ b/src/test/mir-opt/inline/inline_instruction_set.t32.Inline.diff
@@ -9,7 +9,7 @@
 +     scope 1 (inlined instruction_set_t32) { // at $DIR/inline-instruction-set.rs:43:5: 43:26
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:42:5: 42:26
           _1 = instruction_set_a32() -> bb1; // scope 0 at $DIR/inline-instruction-set.rs:42:5: 42:26
                                            // mir::Constant
@@ -17,7 +17,7 @@
                                            // + literal: Const { ty: fn() {instruction_set_a32}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_1);                 // scope 0 at $DIR/inline-instruction-set.rs:42:26: 42:27
           StorageLive(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:43:5: 43:26
 -         _2 = instruction_set_t32() -> bb2; // scope 0 at $DIR/inline-instruction-set.rs:43:5: 43:26
@@ -26,7 +26,7 @@
 -                                          // + literal: Const { ty: fn() {instruction_set_t32}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
           StorageDead(_2);                 // scope 0 at $DIR/inline-instruction-set.rs:43:26: 43:27
           StorageLive(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
 -         _3 = instruction_set_default() -> bb3; // scope 0 at $DIR/inline-instruction-set.rs:46:5: 46:30
@@ -36,8 +36,8 @@
                                            // + literal: Const { ty: fn() {instruction_set_default}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb3: {
-+     bb2: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb1]
           StorageDead(_3);                 // scope 0 at $DIR/inline-instruction-set.rs:46:30: 46:31
           _0 = const ();                   // scope 0 at $DIR/inline-instruction-set.rs:41:14: 47:2
           return;                          // scope 0 at $DIR/inline-instruction-set.rs:47:2: 47:2

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -18,7 +18,7 @@
 +     scope 3 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
@@ -28,7 +28,7 @@
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
@@ -44,7 +44,7 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
 +                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
@@ -57,18 +57,18 @@
 +         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
-+     bb2: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb1]
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
--     bb4 (cleanup): {
-+     bb3 (cleanup): {
+-     bb4 (cleanup): {                     // preds: [bb2, bb5]
++     bb3 (cleanup): {                     // preds: [bb1]
           resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
--     bb5 (cleanup): {
+-     bb5 (cleanup): {                     // preds: [bb1]
 -         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -18,7 +18,7 @@
 +     scope 3 (inlined Vec::<u32>::new) {  // at $DIR/inline-into-box-place.rs:8:33: 8:43
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:8:9: 8:11
           _2 = SizeOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _3 = AlignOf(std::vec::Vec<u32>); // scope 2 at $DIR/inline-into-box-place.rs:8:29: 8:43
@@ -28,7 +28,7 @@
                                            // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           _5 = ShallowInitBox(move _4, std::vec::Vec<u32>); // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
@@ -44,7 +44,7 @@
 -                                          // + literal: Const { ty: fn() -> std::vec::Vec<u32> {std::vec::Vec::<u32>::new}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
 +                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
@@ -57,18 +57,18 @@
 +         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
--     bb3: {
-+     bb2: {
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb1]
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
       }
   
--     bb4 (cleanup): {
-+     bb3 (cleanup): {
+-     bb4 (cleanup): {                     // preds: [bb2, bb5]
++     bb3 (cleanup): {                     // preds: [bb1]
           resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
--     bb5 (cleanup): {
+-     bb5 (cleanup): {                     // preds: [bb1]
 -         _6 = alloc::alloc::box_free::<Vec<u32>, std::alloc::Global>(move (_5.0: std::ptr::Unique<std::vec::Vec<u32>>), move (_5.1: std::alloc::Global)) -> bb4; // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:42: 8:43

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -10,7 +10,7 @@ fn main() -> () {
         let _5: ();                      // in scope 1 at $DIR/inline-options.rs:10:5: 10:21
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/inline-options.rs:9:5: 9:18
         _1 = not_inlined() -> bb1;       // scope 0 at $DIR/inline-options.rs:9:5: 9:18
                                          // mir::Constant
@@ -18,7 +18,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() {not_inlined}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_1);                 // scope 0 at $DIR/inline-options.rs:9:18: 9:19
         StorageLive(_2);                 // scope 0 at $DIR/inline-options.rs:10:5: 10:21
         StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
@@ -28,7 +28,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
         StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
         _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
@@ -37,7 +37,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
         StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
         _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
@@ -46,7 +46,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
         StorageDead(_2);                 // scope 0 at $DIR/inline-options.rs:10:21: 10:22
         _0 = const ();                   // scope 0 at $DIR/inline-options.rs:8:11: 11:2

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -22,7 +22,7 @@ fn bar() -> bool {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/inline-retag.rs:11:9: 11:10
         _1 = foo;                        // scope 0 at $DIR/inline-retag.rs:11:13: 11:16
                                          // mir::Constant

--- a/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
@@ -8,7 +8,7 @@
 +     scope 1 (inlined <fn(A, B) as Clone>::clone - shim(fn(A, B))) { // at $DIR/inline-shims.rs:6:5: 6:14
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
           _2 = &_1;                        // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
 -         _0 = <fn(A, B) as Clone>::clone(move _2) -> bb1; // scope 0 at $DIR/inline-shims.rs:6:5: 6:14
@@ -17,7 +17,7 @@
 -                                          // + literal: Const { ty: for<'r> fn(&'r fn(A, B)) -> fn(A, B) {<fn(A, B) as std::clone::Clone>::clone}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 +         _0 = (*_2);                      // scope 1 at $DIR/inline-shims.rs:6:5: 6:14
           StorageDead(_2);                 // scope 0 at $DIR/inline-shims.rs:6:13: 6:14
           return;                          // scope 0 at $DIR/inline-shims.rs:7:2: 7:2

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -17,7 +17,7 @@
 +         }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/inline-shims.rs:11:5: 11:42
           StorageLive(_4);                 // scope 1 at $DIR/inline-shims.rs:11:38: 11:39
           _4 = _1;                         // scope 1 at $DIR/inline-shims.rs:11:38: 11:39
@@ -27,7 +27,7 @@
                                            // + literal: Const { ty: unsafe fn(*mut std::vec::Vec<A>) {std::ptr::drop_in_place::<std::vec::Vec<A>>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_4);                 // scope 1 at $DIR/inline-shims.rs:11:39: 11:40
           StorageDead(_3);                 // scope 0 at $DIR/inline-shims.rs:11:41: 11:42
           StorageLive(_5);                 // scope 2 at $DIR/inline-shims.rs:12:38: 12:39
@@ -42,14 +42,15 @@
 +         switchInt(move _6) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb1]
++     bb2: {                               // preds: [bb1, bb3]
 +         StorageDead(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
 +         StorageDead(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
           StorageDead(_5);                 // scope 2 at $DIR/inline-shims.rs:12:39: 12:40
           return;                          // scope 0 at $DIR/inline-shims.rs:13:2: 13:2
 +     }
 + 
-+     bb3: {
++     bb3: {                               // preds: [bb1]
 +         drop((((*_5) as Some).0: B)) -> bb2; // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
       }
   }

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -10,7 +10,7 @@
 +     scope 2 (inlined <Vec<()> as Foo>::bar) { // at $DIR/inline-specialization.rs:5:13: 5:38
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/inline-specialization.rs:5:9: 5:10
 -         _1 = <Vec<()> as Foo>::bar() -> bb1; // scope 0 at $DIR/inline-specialization.rs:5:13: 5:38
 -                                          // mir::Constant
@@ -18,7 +18,7 @@
 -                                          // + literal: Const { ty: fn() -> u32 {<std::vec::Vec<()> as Foo>::bar}, val: Value(Scalar(<ZST>)) }
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 +         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:5:13: 5:38
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:4:11: 6:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:6:1: 6:2

--- a/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method.test.Inline.after.mir
@@ -5,7 +5,7 @@ fn test(_1: &dyn X) -> u32 {
     let mut _0: u32;                     // return place in scope 0 at $DIR/inline-trait-method.rs:8:23: 8:26
     let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
         _2 = &(*_1);                     // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
         _0 = <dyn X as X>::y(move _2) -> bb1; // scope 0 at $DIR/inline-trait-method.rs:9:5: 9:10
@@ -14,7 +14,7 @@ fn test(_1: &dyn X) -> u32 {
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> u32 {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method.rs:9:9: 9:10
         return;                          // scope 0 at $DIR/inline-trait-method.rs:10:2: 10:2
     }

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -10,7 +10,7 @@ fn test2(_1: &dyn X) -> bool {
         let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         StorageLive(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
@@ -24,7 +24,7 @@ fn test2(_1: &dyn X) -> bool {
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:11: 5:12
         return;                          // scope 0 at $DIR/inline-trait-method_2.rs:6:2: 6:2

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -11,7 +11,7 @@ fn a(_1: &mut [T]) -> &mut [T] {
         let mut _5: &mut [T];            // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -12,7 +12,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         let mut _6: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -9,7 +9,7 @@ fn c(_1: &[T]) -> &[T] {
         debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -9,7 +9,7 @@ fn d(_1: &Box<T>) -> &T {
         debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -18,7 +18,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
         _2 = &_1;                        // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -11,7 +11,7 @@
 +     scope 1 (inlined <fn() {foo} as Fn<()>>::call - shim(fn() {foo})) { // at $DIR/issue-78442.rs:11:5: 11:17
 +     }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
           StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
@@ -22,7 +22,7 @@
                                            // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
 -         _2 = <impl Fn() as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
@@ -32,30 +32,32 @@
 +         _2 = move (*_3)() -> [return: bb5, unwind: bb3]; // scope 1 at $DIR/issue-78442.rs:11:5: 11:17
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb1]
 -         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
 -         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
 -         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 -         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 -         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
 -         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
-+         return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
+-     }
+- 
+-     bb3: {                               // preds: [bb2]
++     bb2: {                               // preds: [bb5]
+          return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
       }
   
--     bb3: {
--         return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
-+     bb3 (cleanup): {
+-     bb4 (cleanup): {                     // preds: [bb0, bb1]
+-         drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
++     bb3 (cleanup): {                     // preds: [bb0, bb1]
 +         drop(_1) -> bb4;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
       }
   
-      bb4 (cleanup): {
--         drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
-+         resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
-      }
-  
--     bb5 (cleanup): {
--         resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
-+     bb5: {
+-     bb5 (cleanup): {                     // preds: [bb2, bb4]
++     bb4 (cleanup): {                     // preds: [bb3, bb5]
+          resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
++     }
++ 
++     bb5: {                               // preds: [bb1]
 +         StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
 +         StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
 +         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18

--- a/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
@@ -11,7 +11,7 @@
 +     let _4: fn() {foo};                  // in scope 0 at $DIR/issue-78442.rs:11:5: 11:15
       let mut _5: ();                      // in scope 0 at $DIR/issue-78442.rs:11:5: 11:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
           StorageLive(_3);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_4);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
@@ -21,7 +21,7 @@
                                            // + literal: Const { ty: fn() -> impl Fn() {hide_foo}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
           nop;                             // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
@@ -31,7 +31,7 @@
                                            // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as std::ops::FnOnce<()>>::Output {<impl Fn() as std::ops::Fn<()>>::call}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_5);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
           StorageDead(_3);                 // scope 0 at $DIR/issue-78442.rs:11:16: 11:17
           StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
@@ -40,15 +40,15 @@
           drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
       }
   
-      bb4 (cleanup): {
+      bb4 (cleanup): {                     // preds: [bb0, bb1]
           drop(_1) -> bb5;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
       }
   
-      bb5 (cleanup): {
+      bb5 (cleanup): {                     // preds: [bb2, bb4]
           resume;                          // scope 0 at $DIR/issue-78442.rs:7:1: 12:2
       }
   }

--- a/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/issue_38669.main.SimplifyCfg-initial.after.mir
@@ -11,25 +11,25 @@ fn main() -> () {
         debug should_break => _1;        // in scope 1 at $DIR/issue-38669.rs:5:9: 5:25
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
         _1 = const false;                // scope 0 at $DIR/issue-38669.rs:5:28: 5:33
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/issue-38669.rs:5:9: 5:25
         goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb4]
         falseUnwind -> [real: bb2, cleanup: bb5]; // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageLive(_3);                 // scope 1 at $DIR/issue-38669.rs:7:9: 9:10
         StorageLive(_4);                 // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         _4 = _1;                         // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
         switchInt(move _4) -> [false: bb4, otherwise: bb3]; // scope 1 at $DIR/issue-38669.rs:7:12: 7:24
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         _0 = const ();                   // scope 1 at $DIR/issue-38669.rs:8:13: 8:18
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
@@ -37,7 +37,7 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-38669.rs:12:2: 12:2
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2]
         _3 = const ();                   // scope 1 at $DIR/issue-38669.rs:9:10: 9:10
         StorageDead(_4);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-38669.rs:9:9: 9:10
@@ -46,7 +46,7 @@ fn main() -> () {
         goto -> bb1;                     // scope 1 at $DIR/issue-38669.rs:6:5: 11:6
     }
 
-    bb5 (cleanup): {
+    bb5 (cleanup): {                     // preds: [bb1]
         resume;                          // scope 0 at $DIR/issue-38669.rs:4:1: 12:2
     }
 }

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -11,7 +11,7 @@ fn main() -> () {
         debug x => _1;                   // in scope 1 at $DIR/issue-41110.rs:8:9: 8:10
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
         StorageLive(_2);                 // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
@@ -26,7 +26,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(S) -> S {S::id}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_4);                 // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
         _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/issue-41110.rs:8:13: 8:28
@@ -35,7 +35,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(S, S) {S::other}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_3);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
         StorageDead(_2);                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
@@ -44,27 +44,27 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41110.rs:9:2: 9:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb1]
         goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb0]
         goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:8:26: 8:27
     }
 
-    bb5 (cleanup): {
+    bb5 (cleanup): {                     // preds: [bb3, bb4]
         goto -> bb8;                     // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 
-    bb6 (cleanup): {
+    bb6 (cleanup): {                     // preds: [bb7, bb8]
         resume;                          // scope 0 at $DIR/issue-41110.rs:7:1: 9:2
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb8]
         drop(_2) -> bb6;                 // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb5]
         switchInt(_5) -> [false: bb6, otherwise: bb7]; // scope 0 at $DIR/issue-41110.rs:8:27: 8:28
     }
 }

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -15,7 +15,7 @@ fn test() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _6 = const false;                // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
         _6 = const true;                 // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
@@ -31,7 +31,7 @@ fn test() -> () {
                                          // + literal: Const { ty: fn(S) {std::mem::drop::<S>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_4);                 // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
         StorageDead(_3);                 // scope 2 at $DIR/issue-41110.rs:17:12: 17:13
         StorageLive(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
@@ -40,62 +40,62 @@ fn test() -> () {
         goto -> bb12;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb12]
         goto -> bb3;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_5);                 // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
         _0 = const ();                   // scope 0 at $DIR/issue-41110.rs:14:15: 19:2
         drop(_2) -> [return: bb4, unwind: bb9]; // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_2);                 // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
         goto -> bb5;                     // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         _6 = const false;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
         StorageDead(_1);                 // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
         return;                          // scope 0 at $DIR/issue-41110.rs:19:2: 19:2
     }
 
-    bb6 (cleanup): {
+    bb6 (cleanup): {                     // preds: [bb11]
         goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:18:9: 18:10
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb0]
         goto -> bb8;                     // scope 2 at $DIR/issue-41110.rs:17:11: 17:12
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb6, bb7]
         goto -> bb9;                     // scope 1 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb3, bb8]
         goto -> bb14;                    // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb13, bb14]
         resume;                          // scope 0 at $DIR/issue-41110.rs:14:1: 19:2
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: []
         _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
         goto -> bb6;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
-    bb12: {
+    bb12: {                              // preds: [bb1]
         _2 = move _5;                    // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
         goto -> bb2;                     // scope 2 at $DIR/issue-41110.rs:18:5: 18:6
     }
 
-    bb13 (cleanup): {
+    bb13 (cleanup): {                    // preds: [bb14]
         drop(_1) -> bb10;                // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 
-    bb14 (cleanup): {
+    bb14 (cleanup): {                    // preds: [bb9]
         switchInt(_6) -> [false: bb10, otherwise: bb13]; // scope 0 at $DIR/issue-41110.rs:19:1: 19:2
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.32bit.mir
@@ -4,17 +4,17 @@
     let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
 
-    bb0: {
+    bb0: {                               // preds: []
         _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb0]
         resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
+++ b/src/test/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.64bit.mir
@@ -4,17 +4,17 @@
     let mut _0: usize;                   // return place in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     let mut _1: (usize, bool);           // in scope 0 at $DIR/issue-41697.rs:18:19: 18:22
 
-    bb0: {
+    bb0: {                               // preds: []
         _1 = CheckedAdd(const 1_usize, const 1_usize); // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 1_usize, const 1_usize) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = move (_1.0: usize);         // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
         return;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb0]
         resume;                          // scope 0 at $DIR/issue-41697.rs:18:19: 18:22
     }
 }

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -20,7 +20,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _9 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
@@ -32,11 +32,11 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> bool {cond}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         switchInt(move _2) -> [false: bb7, otherwise: bb2]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
         _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
@@ -45,17 +45,17 @@ fn main() -> () {
         goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb14]
         goto -> bb4;                     // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_3);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         _5 = discriminant(_1);           // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
         switchInt(move _5) -> [0_isize: bb5, otherwise: bb6]; // scope 1 at $DIR/issue-41888.rs:10:16: 10:24
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageLive(_6);                 // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _9 = const false;                // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
         _6 = move ((_1 as F).0: K);      // scope 1 at $DIR/issue-41888.rs:10:21: 10:23
@@ -64,22 +64,22 @@ fn main() -> () {
         goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb4]
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:13:10: 13:10
         goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:10:9: 13:10
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb1]
         _0 = const ();                   // scope 1 at $DIR/issue-41888.rs:14:6: 14:6
         goto -> bb8;                     // scope 1 at $DIR/issue-41888.rs:8:5: 14:6
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb5, bb6, bb7]
         StorageDead(_2);                 // scope 1 at $DIR/issue-41888.rs:14:5: 14:6
         goto -> bb20;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb15]
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         _9 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
@@ -87,19 +87,19 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-41888.rs:15:2: 15:2
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb13]
         goto -> bb11;                    // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb0, bb10]
         goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb12 (cleanup): {
+    bb12 (cleanup): {                    // preds: [bb11, bb16, bb17, bb18, bb22]
         resume;                          // scope 0 at $DIR/issue-41888.rs:6:1: 15:2
     }
 
-    bb13 (cleanup): {
+    bb13 (cleanup): {                    // preds: []
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
@@ -107,7 +107,7 @@ fn main() -> () {
         goto -> bb10;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
-    bb14: {
+    bb14: {                              // preds: [bb2]
         _7 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _8 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
         _9 = const true;                 // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
@@ -115,38 +115,38 @@ fn main() -> () {
         goto -> bb3;                     // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }
 
-    bb15: {
+    bb15: {                              // preds: [bb17, bb19, bb20]
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         goto -> bb9;                     // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb16 (cleanup): {
+    bb16 (cleanup): {                    // preds: [bb21]
         goto -> bb12;                    // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb17: {
+    bb17: {                              // preds: [bb19]
         drop(_1) -> [return: bb15, unwind: bb12]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb18 (cleanup): {
+    bb18 (cleanup): {                    // preds: [bb21]
         drop(_1) -> bb12;                // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb19: {
+    bb19: {                              // preds: [bb20]
         _10 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         switchInt(move _10) -> [0_isize: bb15, otherwise: bb17]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb20: {
+    bb20: {                              // preds: [bb8]
         switchInt(_7) -> [false: bb15, otherwise: bb19]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb21 (cleanup): {
+    bb21 (cleanup): {                    // preds: [bb22]
         _11 = discriminant(_1);          // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
         switchInt(move _11) -> [0_isize: bb16, otherwise: bb18]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 
-    bb22 (cleanup): {
+    bb22 (cleanup): {                    // preds: []
         switchInt(_7) -> [false: bb12, otherwise: bb21]; // scope 0 at $DIR/issue-41888.rs:15:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue_49232.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_49232.main.mir_map.0.mir
@@ -12,15 +12,15 @@ fn main() -> () {
         debug beacon => _2;              // in scope 1 at $DIR/issue-49232.rs:7:13: 7:19
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb9]
         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageLive(_2);                 // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageLive(_3);                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
         _3 = const true;                 // scope 0 at $DIR/issue-49232.rs:8:19: 8:23
@@ -28,29 +28,29 @@ fn main() -> () {
         switchInt(_3) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/issue-49232.rs:8:13: 8:23
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         falseEdge -> [real: bb5, imaginary: bb4]; // scope 0 at $DIR/issue-49232.rs:9:17: 9:22
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2, bb3]
         _0 = const ();                   // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
         goto -> bb10;                    // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb3]
         _2 = const 4_i32;                // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
         goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:9:26: 9:27
     }
 
-    bb6: {
+    bb6: {                               // preds: []
         unreachable;                     // scope 0 at $DIR/issue-49232.rs:10:25: 10:30
     }
 
-    bb7: {
+    bb7: {                               // preds: []
         goto -> bb8;                     // scope 0 at $DIR/issue-49232.rs:11:13: 11:14
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb5, bb7]
         FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-49232.rs:7:13: 7:19
         StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
         StorageLive(_5);                 // scope 1 at $DIR/issue-49232.rs:13:9: 13:22
@@ -62,7 +62,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(&i32) {std::mem::drop::<&i32>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb8]
         StorageDead(_6);                 // scope 1 at $DIR/issue-49232.rs:13:21: 13:22
         StorageDead(_5);                 // scope 1 at $DIR/issue-49232.rs:13:22: 13:23
         _1 = const ();                   // scope 0 at $DIR/issue-49232.rs:6:10: 14:6
@@ -70,13 +70,13 @@ fn main() -> () {
         goto -> bb1;                     // scope 0 at $DIR/issue-49232.rs:6:5: 14:6
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb4]
         StorageDead(_3);                 // scope 0 at $DIR/issue-49232.rs:12:10: 12:11
         StorageDead(_2);                 // scope 0 at $DIR/issue-49232.rs:14:5: 14:6
         return;                          // scope 0 at $DIR/issue-49232.rs:15:2: 15:2
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb1, bb8]
         resume;                          // scope 0 at $DIR/issue-49232.rs:5:1: 15:2
     }
 }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -27,7 +27,7 @@ fn test() -> Option<Box<u32>> {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
         _2 = SizeOf(u32);                // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
         _3 = AlignOf(u32);               // scope 1 at $DIR/issue-62289.rs:9:10: 9:21
@@ -37,7 +37,7 @@ fn test() -> Option<Box<u32>> {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_5);                 // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
         _5 = ShallowInitBox(move _4, u32); // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
         StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
@@ -49,13 +49,13 @@ fn test() -> Option<Box<u32>> {
                                          // + literal: Const { ty: fn(std::option::Option<u32>) -> std::ops::ControlFlow<<std::option::Option<u32> as std::ops::Try>::Residual, <std::option::Option<u32> as std::ops::Try>::Output> {<std::option::Option<u32> as std::ops::Try>::branch}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_7);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _8 = discriminant(_6);           // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         switchInt(move _8) -> [0_isize: bb3, 1_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageLive(_12);                // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         _12 = ((_6 as Continue).0: u32); // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         (*_5) = _12;                     // scope 5 at $DIR/issue-62289.rs:9:15: 9:20
@@ -64,11 +64,11 @@ fn test() -> Option<Box<u32>> {
         drop(_5) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2]
         unreachable;                     // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb2]
         StorageLive(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         _9 = ((_6 as Break).0: std::option::Option<std::convert::Infallible>); // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         StorageLive(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
@@ -79,44 +79,44 @@ fn test() -> Option<Box<u32>> {
                                          // + literal: Const { ty: fn(std::option::Option<std::convert::Infallible>) -> std::option::Option<std::boxed::Box<u32>> {<std::option::Option<std::boxed::Box<u32>> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         StorageDead(_11);                // scope 3 at $DIR/issue-62289.rs:9:19: 9:20
         StorageDead(_9);                 // scope 0 at $DIR/issue-62289.rs:9:19: 9:20
         drop(_5) -> bb9;                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb3]
         StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
         _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
         drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb7]
         StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
         StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
         goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb6]
         StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
         StorageDead(_1);                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
         StorageDead(_6);                 // scope 0 at $DIR/issue-62289.rs:10:1: 10:2
         goto -> bb10;                    // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb8, bb9]
         return;                          // scope 0 at $DIR/issue-62289.rs:10:2: 10:2
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb3]
         drop(_1) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 
-    bb12 (cleanup): {
+    bb12 (cleanup): {                    // preds: [bb1, bb5]
         drop(_5) -> bb13;                // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
     }
 
-    bb13 (cleanup): {
+    bb13 (cleanup): {                    // preds: [bb11, bb12]
         resume;                          // scope 0 at $DIR/issue-62289.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.32bit.mir
@@ -7,7 +7,7 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:19:13: 19:14
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47

--- a/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.bar.mir_map.0.64bit.mir
@@ -7,7 +7,7 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         debug x => _2;                   // in scope 1 at $DIR/issue-72181.rs:19:13: 19:14
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _2 = (_1[0 of 1].1: u32);        // scope 0 at $DIR/issue-72181.rs:19:13: 19:14
         _0 = _2;                         // scope 1 at $DIR/issue-72181.rs:19:46: 19:47

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.32bit.mir
@@ -7,7 +7,7 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
     let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
@@ -15,13 +15,13 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
         assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
         return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb0]
         resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
     }
 }

--- a/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.foo.mir_map.0.64bit.mir
@@ -7,7 +7,7 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
     let mut _3: usize;                   // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     let mut _4: bool;                    // in scope 0 at $DIR/issue-72181.rs:16:40: 16:45
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _2 = const 0_usize;              // scope 0 at $DIR/issue-72181.rs:16:43: 16:44
         _3 = Len(_1);                    // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
@@ -15,13 +15,13 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
         assert(move _4, "index out of bounds: the length is {} but the index is {}", move _3, _2) -> [success: bb1, unwind: bb2]; // scope 0 at $DIR/issue-72181.rs:16:40: 16:45
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = (_1[_2].1: u32);            // scope 0 at $DIR/issue-72181.rs:16:40: 16:47
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181.rs:16:48: 16:49
         return;                          // scope 0 at $DIR/issue-72181.rs:16:49: 16:49
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb0]
         resume;                          // scope 0 at $DIR/issue-72181.rs:16:1: 16:49
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.32bit.mir
@@ -20,7 +20,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
         _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
                                          // mir::Constant
@@ -28,7 +28,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
@@ -47,7 +47,7 @@ fn main() -> () {
         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
@@ -56,7 +56,7 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb0, bb1]
         resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
     }
 }

--- a/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/issue_72181.main.mir_map.0.64bit.mir
@@ -20,7 +20,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
         _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/issue-72181.rs:24:13: 24:34
                                          // mir::Constant
@@ -28,7 +28,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> usize {std::mem::size_of::<Foo>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_1);                 // scope 0 at $DIR/issue-72181.rs:24:34: 24:35
         StorageLive(_2);                 // scope 1 at $DIR/issue-72181.rs:26:9: 26:10
         StorageLive(_3);                 // scope 1 at $DIR/issue-72181.rs:26:14: 26:27
@@ -47,7 +47,7 @@ fn main() -> () {
         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3]; // scope 4 at $DIR/issue-72181.rs:27:22: 27:26
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         _5 = (_2[_6].0: u64);            // scope 4 at $DIR/issue-72181.rs:27:22: 27:28
         StorageDead(_6);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
         StorageDead(_5);                 // scope 2 at $DIR/issue-72181.rs:27:30: 27:31
@@ -56,7 +56,7 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/issue-72181.rs:28:2: 28:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb0, bb1]
         resume;                          // scope 0 at $DIR/issue-72181.rs:23:1: 28:2
     }
 }

--- a/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.f.mir_map.0.mir
@@ -6,23 +6,23 @@ fn f(_1: Void) -> ! {
     let mut _2: !;                       // in scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
     let mut _3: !;                       // in scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
         StorageLive(_3);                 // scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/issue-72181-1.rs:11:11: 11:12
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:11: 11:12
     }
 
-    bb1: {
+    bb1: {                               // preds: []
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:11:5: 11:15
     }
 
-    bb2: {
+    bb2: {                               // preds: []
         StorageDead(_3);                 // scope 0 at $DIR/issue-72181-1.rs:11:14: 11:15
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:10:20: 12:2
     }
 
-    bb3: {
+    bb3: {                               // preds: []
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:12:1: 12:2
         return;                          // scope 0 at $DIR/issue-72181-1.rs:12:2: 12:2
     }

--- a/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
+++ b/src/test/mir-opt/issue_72181_1.main.mir_map.0.mir
@@ -17,7 +17,7 @@ fn main() -> () {
     scope 2 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
         StorageLive(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
         _3 = ();                         // scope 2 at $DIR/issue-72181-1.rs:17:41: 17:43
@@ -27,7 +27,7 @@ fn main() -> () {
                                          // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(()) -> Void {std::intrinsics::transmute::<(), Void>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_3);                 // scope 2 at $DIR/issue-72181-1.rs:17:43: 17:44
         FakeRead(ForLet(None), _2);      // scope 0 at $DIR/issue-72181-1.rs:16:9: 16:10
         AscribeUserType(_2, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/issue-72181-1.rs:16:12: 16:16
@@ -40,18 +40,18 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(Void) -> ! {f}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: []
         StorageDead(_5);                 // scope 1 at $DIR/issue-72181-1.rs:20:8: 20:9
         StorageDead(_4);                 // scope 1 at $DIR/issue-72181-1.rs:20:9: 20:10
         StorageDead(_2);                 // scope 0 at $DIR/issue-72181-1.rs:21:1: 21:2
         unreachable;                     // scope 0 at $DIR/issue-72181-1.rs:15:11: 21:2
     }
 
-    bb3: {
+    bb3: {                               // preds: []
         return;                          // scope 0 at $DIR/issue-72181-1.rs:21:2: 21:2
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb0, bb1]
         resume;                          // scope 0 at $DIR/issue-72181-1.rs:15:1: 21:2
     }
 }

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -40,7 +40,7 @@
           debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -87,7 +87,7 @@
           switchInt(move _11) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -112,7 +112,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -40,7 +40,7 @@
           debug v => _3;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -87,7 +87,7 @@
           switchInt(move _11) -> [false: bb2, otherwise: bb1]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -112,7 +112,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageDead(_11);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_9);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -48,7 +48,7 @@
           debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -57,14 +57,14 @@
           goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
       }
   
-      bb1: {
+      bb1: {                               // preds: []
           nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
@@ -111,7 +111,7 @@
           switchInt(move _15) -> [false: bb4, otherwise: bb3]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -145,7 +145,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2]
           nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -48,7 +48,7 @@
           debug v => _4;                   // in scope 2 at $DIR/issue-73223.rs:3:14: 3:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -57,14 +57,14 @@
           goto -> bb2;                     // scope 0 at $DIR/issue-73223.rs:2:17: 2:30
       }
   
-      bb1: {
+      bb1: {                               // preds: []
           nop;                             // scope 0 at $DIR/issue-73223.rs:4:17: 4:23
           StorageDead(_2);                 // scope 0 at $DIR/issue-73223.rs:5:6: 5:7
           StorageDead(_1);                 // scope 0 at $DIR/issue-73223.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/issue-73223.rs:9:2: 9:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _4 = ((_2 as Some).0: i32);      // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
           _1 = _4;                         // scope 2 at $DIR/issue-73223.rs:3:20: 3:21
@@ -111,7 +111,7 @@
           switchInt(move _15) -> [false: bb4, otherwise: bb3]; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -145,7 +145,7 @@
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2]
           nop;                             // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -35,7 +35,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/issue_76432.rs:7:9: 7:10
           StorageLive(_3);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
           StorageLive(_4);                 // scope 0 at $DIR/issue_76432.rs:7:19: 7:29
@@ -65,7 +65,7 @@
           goto -> bb2;                     // scope 1 at $DIR/issue_76432.rs:9:9: 9:33
       }
   
-      bb1: {
+      bb1: {                               // preds: []
           StorageLive(_22);                // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
           core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/panic.rs:LL:COL
                                            // mir::Constant
@@ -79,7 +79,7 @@
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [105, 110, 116, 101, 114, 110, 97, 108, 32, 101, 114, 114, 111, 114, 58, 32, 101, 110, 116, 101, 114, 101, 100, 32, 117, 110, 114, 101, 97, 99, 104, 97, 98, 108, 101, 32, 99, 111, 100, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1099511627775], len: Size { raw: 40 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 40 }) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_13);                // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
           _13 = &(*_2)[0 of 3];            // scope 1 at $DIR/issue_76432.rs:9:10: 9:16
           StorageLive(_14);                // scope 1 at $DIR/issue_76432.rs:9:18: 9:24

--- a/src/test/mir-opt/issue_78192.f.InstCombine.diff
+++ b/src/test/mir-opt/issue_78192.f.InstCombine.diff
@@ -11,7 +11,7 @@
           debug b => _2;                   // in scope 1 at $DIR/issue-78192.rs:3:9: 3:10
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/issue-78192.rs:3:9: 3:10
           StorageLive(_3);                 // scope 0 at $DIR/issue-78192.rs:3:24: 3:40
           StorageLive(_4);                 // scope 0 at $DIR/issue-78192.rs:3:25: 3:40

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -27,7 +27,7 @@ fn num_to_digit(_1: char) -> u32 {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:11
         _2 = _1;                         // scope 0 at $DIR/issue-59352.rs:14:8: 14:11
         StorageLive(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
@@ -42,7 +42,7 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: fn(char, u32) -> std::option::Option<u32> {std::char::methods::<impl char>::to_digit}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb5]
         StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         StorageLive(_3);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:41
         StorageLive(_4);                 // scope 0 at $DIR/issue-59352.rs:14:26: 14:29
@@ -53,24 +53,24 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: fn(char, u32) -> std::option::Option<u32> {std::char::methods::<impl char>::to_digit}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:14:40: 14:41
         StorageLive(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
         _10 = discriminant(_3);          // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb5]
         StorageDead(_11);                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         _0 = const 0_u32;                // scope 0 at $DIR/issue-59352.rs:14:60: 14:61
         goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3, bb8]
         return;                          // scope 0 at $DIR/issue-59352.rs:15:2: 15:2
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb0]
         _6 = &_7;                        // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
         StorageDead(_8);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
         StorageLive(_9);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
@@ -85,7 +85,7 @@ fn num_to_digit(_1: char) -> u32 {
         switchInt(move _11) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb2]
         core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
                                          // mir::Constant
                                          // + span: $DIR/issue-59352.rs:14:26: 14:50
@@ -98,11 +98,11 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [99, 97, 108, 108, 101, 100, 32, 96, 79, 112, 116, 105, 111, 110, 58, 58, 117, 110, 119, 114, 97, 112, 40, 41, 96, 32, 111, 110, 32, 97, 32, 96, 78, 111, 110, 101, 96, 32, 118, 97, 108, 117, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [8796093022207], len: Size { raw: 43 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 43 }) }
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb2]
         unreachable;                     // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb2]
         _0 = move ((_3 as Some).0: u32); // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
         StorageDead(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
         StorageDead(_3);                 // scope 0 at $DIR/issue-59352.rs:14:49: 14:50

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -20,7 +20,7 @@
       scope 2 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/issue-75439.rs:7:9: 7:15
           StorageLive(_3);                 // scope 2 at $DIR/issue-75439.rs:7:47: 7:52
           _3 = _1;                         // scope 2 at $DIR/issue-75439.rs:7:47: 7:52
@@ -30,20 +30,20 @@
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn([u8; 16]) -> [u32; 4] {std::intrinsics::transmute::<[u8; 16], [u32; 4]>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 2 at $DIR/issue-75439.rs:7:52: 7:53
           switchInt(_2[0 of 4]) -> [0_u32: bb2, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           switchInt(_2[1 of 4]) -> [0_u32: bb3, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           switchInt(_2[2 of 4]) -> [0_u32: bb5, 4294901760_u32: bb6, otherwise: bb8]; // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb5, bb6]
           StorageLive(_5);                 // scope 1 at $DIR/issue-75439.rs:10:14: 10:38
           StorageLive(_6);                 // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
           _6 = _4;                         // scope 4 at $DIR/issue-75439.rs:10:33: 10:35
@@ -53,19 +53,19 @@
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(u32) -> [u8; 4] {std::intrinsics::transmute::<u32, [u8; 4]>}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3]
           StorageLive(_4);                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
           _4 = _2[3 of 4];                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
           goto -> bb4;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb3]
           StorageLive(_4);                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
           _4 = _2[3 of 4];                 // scope 1 at $DIR/issue-75439.rs:9:27: 9:29
           goto -> bb4;                     // scope 1 at $DIR/issue-75439.rs:9:12: 9:30
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb4]
           StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:10:35: 10:36
           ((_0 as Some).0: [u8; 4]) = move _5; // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           discriminant(_0) = 1;            // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
@@ -74,12 +74,12 @@
           goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
       }
   
-      bb8: {
+      bb8: {                               // preds: [bb1, bb2, bb3]
           discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
           goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
       }
   
-      bb9: {
+      bb9: {                               // preds: [bb7, bb8]
           StorageDead(_2);                 // scope 0 at $DIR/issue-75439.rs:14:1: 14:2
           return;                          // scope 0 at $DIR/issue-75439.rs:14:2: 14:2
       }

--- a/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
+++ b/src/test/mir-opt/loop_test.main.SimplifyCfg-promote-consts.after.mir
@@ -12,21 +12,21 @@ fn main() -> () {
         debug x => _6;                   // in scope 1 at $DIR/loop_test.rs:14:13: 14:14
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/loop_test.rs:10:5: 12:6
         StorageLive(_2);                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
         _2 = const true;                 // scope 0 at $DIR/loop_test.rs:10:8: 10:12
         switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/loop_test.rs:10:8: 10:12
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = const ();                   // scope 0 at $DIR/loop_test.rs:11:9: 11:15
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         return;                          // scope 0 at $DIR/loop_test.rs:17:2: 17:2
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         _1 = const ();                   // scope 0 at $DIR/loop_test.rs:12:6: 12:6
         StorageDead(_2);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
         StorageDead(_1);                 // scope 0 at $DIR/loop_test.rs:12:5: 12:6
@@ -34,11 +34,11 @@ fn main() -> () {
         goto -> bb3;                     // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2, bb4]
         falseUnwind -> [real: bb4, cleanup: bb5]; // scope 0 at $DIR/loop_test.rs:13:5: 16:6
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageLive(_6);                 // scope 0 at $DIR/loop_test.rs:14:13: 14:14
         _6 = const 1_i32;                // scope 0 at $DIR/loop_test.rs:14:17: 14:18
         FakeRead(ForLet(None), _6);      // scope 0 at $DIR/loop_test.rs:14:13: 14:14
@@ -46,7 +46,7 @@ fn main() -> () {
         goto -> bb3;                     // scope 0 at no-location
     }
 
-    bb5 (cleanup): {
+    bb5 (cleanup): {                     // preds: [bb3]
         resume;                          // scope 0 at $DIR/loop_test.rs:6:1: 17:2
     }
 }

--- a/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
@@ -15,7 +15,7 @@
       let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
@@ -38,7 +38,7 @@
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
 -         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
@@ -47,18 +47,18 @@
           assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
           StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
       }

--- a/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
@@ -15,7 +15,7 @@
       let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
 +     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
@@ -33,7 +33,7 @@
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
@@ -41,7 +41,7 @@
           switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
           _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
@@ -49,18 +49,18 @@
           assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
           StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1]
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3, bb4]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
       }

--- a/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
@@ -18,7 +18,7 @@
 +     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
 +     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
@@ -39,7 +39,7 @@
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
 -         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
 -         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
@@ -52,7 +52,7 @@
 +         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
 -         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
 +         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
@@ -60,12 +60,12 @@
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:10:9: 10:11
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:11:5: 11:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:12:2: 12:2
       }

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
@@ -18,7 +18,7 @@
       let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
@@ -40,7 +40,7 @@
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
 -         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
@@ -49,13 +49,13 @@
           assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
           StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
           _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
 -         _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
@@ -64,14 +64,14 @@
           assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
           (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
           StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb2, bb4]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
       }

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
@@ -18,7 +18,7 @@
       let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
 +     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
@@ -36,7 +36,7 @@
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
@@ -44,7 +44,7 @@
           switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
           _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
           _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
@@ -52,13 +52,13 @@
           assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
           StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
           goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1]
           StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
           _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
           _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
@@ -66,14 +66,14 @@
           assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb5; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
           StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
           goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb3, bb5]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
       }

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
@@ -24,7 +24,7 @@
 +     let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
 +     let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
@@ -45,7 +45,7 @@
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
 -         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
 -         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
@@ -58,7 +58,7 @@
 +         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
 -         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
 +         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
@@ -66,7 +66,7 @@
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
 -         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
 -         _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
 -         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
@@ -79,7 +79,7 @@
 +         assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
 -         (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
 -         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
 +         (*_2)[_9] = const 42_u8;         // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
@@ -88,7 +88,7 @@
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb2, bb4]
           StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:24:5: 24:6
           return;                          // scope 0 at $DIR/lower_array_len.rs:25:2: 25:2
       }

--- a/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
@@ -8,7 +8,7 @@
       let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
       let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
 -         _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14

--- a/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
@@ -8,7 +8,7 @@
       let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
 +     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
@@ -22,7 +22,7 @@
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
           return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
       }

--- a/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
@@ -8,7 +8,7 @@
 -     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
 -     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
 -         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
 -         _3 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
@@ -8,7 +8,7 @@
       let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
       let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
@@ -8,7 +8,7 @@
       let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
 +     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
@@ -22,7 +22,7 @@
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
           return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
       }

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
@@ -8,7 +8,7 @@
 -     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
 -     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
 -         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
 -         _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14

--- a/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.align_of.LowerIntrinsics.diff
@@ -4,7 +4,7 @@
   fn align_of() -> usize {
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:18:25: 18:30
   
-      bb0: {
+      bb0: {                               // preds: []
 -         _0 = std::intrinsics::min_align_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:19:5: 19:40
@@ -13,11 +13,11 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:19:5: 19:42
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:20:2: 20:2
       }
   
-      bb2 (cleanup): {
+      bb2 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:18:1: 20:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.discriminant.LowerIntrinsics.diff
@@ -23,7 +23,7 @@
       let mut _18: &();                    // in scope 0 at $DIR/lower_intrinsics.rs:76:42: 76:45
       let mut _19: &i32;                   // in scope 0 at $DIR/lower_intrinsics.rs:75:42: 75:44
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
           StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
           StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:42: 74:44
@@ -37,7 +37,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:74:5: 74:45
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:74:44: 74:45
           StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
           StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:74:45: 74:46
@@ -61,7 +61,7 @@
 +         goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:75:5: 75:45
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_6);                 // scope 0 at $DIR/lower_intrinsics.rs:75:44: 75:45
           StorageDead(_7);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
           StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:75:45: 75:46
@@ -85,7 +85,7 @@
 +         goto -> bb3;                     // scope 0 at $DIR/lower_intrinsics.rs:76:5: 76:46
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           StorageDead(_10);                // scope 0 at $DIR/lower_intrinsics.rs:76:45: 76:46
           StorageDead(_11);                // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
           StorageDead(_9);                 // scope 0 at $DIR/lower_intrinsics.rs:76:46: 76:47
@@ -109,7 +109,7 @@
 +         goto -> bb4;                     // scope 0 at $DIR/lower_intrinsics.rs:77:5: 77:48
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
           StorageDead(_14);                // scope 0 at $DIR/lower_intrinsics.rs:77:47: 77:48
           StorageDead(_15);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
           StorageDead(_13);                // scope 0 at $DIR/lower_intrinsics.rs:77:48: 77:49
@@ -117,11 +117,11 @@
           drop(_1) -> bb5;                 // scope 0 at $DIR/lower_intrinsics.rs:78:1: 78:2
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:78:2: 78:2
       }
   
-      bb6 (cleanup): {
+      bb6 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:73:1: 78:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -11,7 +11,7 @@ fn f_u64() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
         _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
         StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
@@ -23,7 +23,7 @@ fn f_u64() -> () {
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
         StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -10,7 +10,7 @@ fn f_unit() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
         StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
         _2 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
@@ -19,7 +19,7 @@ fn f_unit() -> () {
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:18: 34:19
         return;                          // scope 0 at $DIR/lower_intrinsics.rs:35:2: 35:2

--- a/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.forget.LowerIntrinsics.diff
@@ -6,7 +6,7 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:23:24: 23:24
       let mut _2: T;                       // in scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
           _2 = move _1;                    // scope 0 at $DIR/lower_intrinsics.rs:24:30: 24:31
 -         _0 = std::intrinsics::forget::<T>(move _2) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
@@ -17,16 +17,16 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:24:5: 24:32
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:24:31: 24:32
           goto -> bb2;                     // scope 0 at $DIR/lower_intrinsics.rs:25:1: 25:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:25:2: 25:2
       }
   
-      bb3 (cleanup): {
+      bb3 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:23:1: 25:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.non_const.LowerIntrinsics.diff
@@ -9,7 +9,7 @@
           debug size_of_t => _1;           // in scope 1 at $DIR/lower_intrinsics.rs:62:9: 62:18
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:62:9: 62:18
           _1 = std::intrinsics::size_of::<T>; // scope 0 at $DIR/lower_intrinsics.rs:62:21: 62:51
                                            // mir::Constant
@@ -22,13 +22,13 @@
 +         goto -> bb1;                     // scope 1 at $DIR/lower_intrinsics.rs:63:5: 63:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:63:15: 63:16
           StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:64:1: 64:2
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:64:2: 64:2
       }
   
-      bb2 (cleanup): {
+      bb2 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:60:1: 64:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.size_of.LowerIntrinsics.diff
@@ -4,7 +4,7 @@
   fn size_of() -> usize {
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_intrinsics.rs:13:24: 13:29
   
-      bb0: {
+      bb0: {                               // preds: []
 -         _0 = std::intrinsics::size_of::<T>() -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:14:5: 14:37
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:14:5: 14:35
@@ -13,11 +13,11 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:14:5: 14:37
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:15:2: 15:2
       }
   
-      bb2 (cleanup): {
+      bb2 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:13:1: 15:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.unreachable.LowerIntrinsics.diff
@@ -9,7 +9,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/lower_intrinsics.rs:29:5: 29:47
           StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
 -         std::intrinsics::unreachable();  // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
@@ -19,7 +19,7 @@
 +         unreachable;                     // scope 1 at $DIR/lower_intrinsics.rs:29:14: 29:45
       }
   
-      bb1 (cleanup): {
+      bb1 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:28:1: 30:2
       }
   }

--- a/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -24,7 +24,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_intrinsics.rs:7:9: 7:11
           StorageLive(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
           _4 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
@@ -38,7 +38,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:7:49: 7:50
           StorageDead(_4);                 // scope 0 at $DIR/lower_intrinsics.rs:7:49: 7:50
           StorageLive(_6);                 // scope 1 at $DIR/lower_intrinsics.rs:8:9: 8:11
@@ -54,7 +54,7 @@
 +         goto -> bb2;                     // scope 1 at $DIR/lower_intrinsics.rs:8:14: 8:50
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_8);                 // scope 1 at $DIR/lower_intrinsics.rs:8:49: 8:50
           StorageDead(_7);                 // scope 1 at $DIR/lower_intrinsics.rs:8:49: 8:50
           StorageLive(_9);                 // scope 2 at $DIR/lower_intrinsics.rs:9:9: 9:11
@@ -70,7 +70,7 @@
 +         goto -> bb3;                     // scope 2 at $DIR/lower_intrinsics.rs:9:14: 9:50
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           StorageDead(_11);                // scope 2 at $DIR/lower_intrinsics.rs:9:49: 9:50
           StorageDead(_10);                // scope 2 at $DIR/lower_intrinsics.rs:9:49: 9:50
           _0 = const ();                   // scope 0 at $DIR/lower_intrinsics.rs:6:38: 10:2
@@ -80,7 +80,7 @@
           return;                          // scope 0 at $DIR/lower_intrinsics.rs:10:2: 10:2
       }
   
-      bb4 (cleanup): {
+      bb4 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/lower_intrinsics.rs:6:1: 10:2
       }
   }

--- a/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
+++ b/src/test/mir-opt/lower_slice_len.bound.LowerSliceLenCalls.diff
@@ -13,7 +13,7 @@
       let mut _8: usize;                   // in scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
       let mut _9: bool;                    // in scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_3);                 // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:13
           _4 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:13
@@ -28,7 +28,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/lower_slice_len.rs:5:16: 5:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_6);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_slice_len.rs:5:26: 5:27
@@ -36,7 +36,7 @@
           switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_slice_len.rs:5:8: 5:27
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_7);                 // scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
           _7 = _1;                         // scope 0 at $DIR/lower_slice_len.rs:6:15: 6:20
           _8 = Len((*_2));                 // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
@@ -44,18 +44,18 @@
           assert(move _9, "index out of bounds: the length is {} but the index is {}", move _8, _7) -> bb3; // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           _0 = (*_2)[_7];                  // scope 0 at $DIR/lower_slice_len.rs:6:9: 6:21
           StorageDead(_7);                 // scope 0 at $DIR/lower_slice_len.rs:7:5: 7:6
           goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1]
           _0 = const 42_u8;                // scope 0 at $DIR/lower_slice_len.rs:8:9: 8:11
           goto -> bb5;                     // scope 0 at $DIR/lower_slice_len.rs:5:5: 9:6
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3, bb4]
           StorageDead(_3);                 // scope 0 at $DIR/lower_slice_len.rs:9:5: 9:6
           return;                          // scope 0 at $DIR/lower_slice_len.rs:10:2: 10:2
       }

--- a/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/src/test/mir-opt/match_arm_scopes.complicated_match.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -30,35 +30,38 @@
           debug t => _16;                  // in scope 2 at $DIR/match-arm-scopes.rs:16:19: 16:20
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         FakeRead(ForMatchedPlace(None), _2); // scope 0 at $DIR/match-arm-scopes.rs:14:11: 14:16
 -         switchInt((_2.0: bool)) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
 +         switchInt((_2.0: bool)) -> [false: bb5, otherwise: bb1]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
 -         falseEdge -> [real: bb8, imaginary: bb3]; // scope 0 at $DIR/match-arm-scopes.rs:15:9: 15:22
++     bb1: {                               // preds: [bb0, bb9]
 +         switchInt((_2.1: bool)) -> [false: bb10, otherwise: bb2]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0, bb12]
 -         switchInt((_2.1: bool)) -> [false: bb3, otherwise: bb4]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
++     bb2: {                               // preds: [bb1, bb14]
 +         switchInt((_2.0: bool)) -> [false: bb3, otherwise: bb17]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
       }
   
-      bb3: {
+-     bb3: {                               // preds: [bb1, bb2, bb12]
 -         falseEdge -> [real: bb13, imaginary: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:15:25: 15:38
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb2, bb17]
 -         switchInt((_2.0: bool)) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/match-arm-scopes.rs:14:5: 14:16
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb3, bb4, bb17]
 -         falseEdge -> [real: bb20, imaginary: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:16:9: 16:21
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: [bb4, bb5]
++     bb3: {                               // preds: [bb2]
           StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
           _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:32: 16:33
           StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:35: 16:36
@@ -67,15 +70,15 @@
 +         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb7: {
-+     bb4: {
+-     bb7: {                               // preds: [bb11, bb16]
++     bb4: {                               // preds: [bb8, bb13]
           _0 = const 1_i32;                // scope 1 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         drop(_7) -> [return: bb18, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 +         drop(_7) -> [return: bb15, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
       }
   
--     bb8: {
-+     bb5: {
+-     bb8: {                               // preds: [bb1]
++     bb5: {                               // preds: [bb0]
           StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
           _6 = &(_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:17: 15:18
           StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:20: 15:21
@@ -89,8 +92,8 @@
 +         switchInt(move _10) -> [false: bb7, otherwise: bb6]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
       }
   
--     bb9: {
-+     bb6: {
+-     bb9: {                               // preds: [bb8]
++     bb6: {                               // preds: [bb5]
           _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -98,15 +101,15 @@
 +         goto -> bb20;                    // scope 0 at no-location
       }
   
--     bb10: {
-+     bb7: {
+-     bb10: {                              // preds: [bb8]
++     bb7: {                               // preds: [bb5]
           _9 = (*_6);                      // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
 -         switchInt(move _9) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 +         switchInt(move _9) -> [false: bb9, otherwise: bb8]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb11: {
-+     bb8: {
+-     bb11: {                              // preds: [bb10]
++     bb8: {                               // preds: [bb7]
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -121,8 +124,8 @@
 +         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb12: {
-+     bb9: {
+-     bb12: {                              // preds: [bb10]
++     bb9: {                               // preds: [bb7]
           StorageDead(_10);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_9);                 // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
@@ -131,8 +134,8 @@
 +         goto -> bb1;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb13: {
-+     bb10: {
+-     bb13: {                              // preds: [bb3]
++     bb10: {                              // preds: [bb1]
           StorageLive(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
           _6 = &(_2.0: bool);              // scope 0 at $DIR/match-arm-scopes.rs:15:26: 15:27
           StorageLive(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:36: 15:37
@@ -146,8 +149,8 @@
 +         switchInt(move _13) -> [false: bb12, otherwise: bb11]; // scope 0 at $DIR/match-arm-scopes.rs:15:45: 15:49
       }
   
--     bb14: {
-+     bb11: {
+-     bb14: {                              // preds: [bb13]
++     bb11: {                              // preds: [bb10]
           _0 = const 3_i32;                // scope 0 at $DIR/match-arm-scopes.rs:15:59: 15:60
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -155,15 +158,15 @@
 +         goto -> bb20;                    // scope 0 at no-location
       }
   
--     bb15: {
-+     bb12: {
+-     bb15: {                              // preds: [bb13]
++     bb12: {                              // preds: [bb10]
           _12 = (*_6);                     // scope 0 at $DIR/match-arm-scopes.rs:15:70: 15:71
 -         switchInt(move _12) -> [false: bb17, otherwise: bb16]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
 +         switchInt(move _12) -> [false: bb14, otherwise: bb13]; // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb16: {
-+     bb13: {
+-     bb16: {                              // preds: [bb15]
++     bb13: {                              // preds: [bb12]
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
 -         FakeRead(ForMatchGuard, _3);     // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
@@ -178,8 +181,8 @@
 +         goto -> bb4;                     // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb17: {
-+     bb14: {
+-     bb17: {                              // preds: [bb15]
++     bb14: {                              // preds: [bb12]
           StorageDead(_13);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_12);                // scope 0 at $DIR/match-arm-scopes.rs:15:72: 15:73
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
@@ -188,8 +191,8 @@
 +         goto -> bb2;                     // scope 0 at $DIR/match-arm-scopes.rs:15:42: 15:73
       }
   
--     bb18: {
-+     bb15: {
+-     bb18: {                              // preds: [bb7]
++     bb15: {                              // preds: [bb4]
           StorageDead(_7);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_5);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
@@ -198,15 +201,15 @@
 +         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
       }
   
--     bb19: {
-+     bb16: {
+-     bb19: {                              // preds: [bb6, bb20]
++     bb16: {                              // preds: [bb3, bb17]
           _0 = const 2_i32;                // scope 2 at $DIR/match-arm-scopes.rs:16:41: 16:42
 -         drop(_16) -> [return: bb21, unwind: bb25]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
 +         drop(_16) -> [return: bb18, unwind: bb22]; // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
       }
   
--     bb20: {
-+     bb17: {
+-     bb20: {                              // preds: [bb5]
++     bb17: {                              // preds: [bb2]
           StorageLive(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
           _15 = (_2.1: bool);              // scope 0 at $DIR/match-arm-scopes.rs:16:16: 16:17
           StorageLive(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:19: 16:20
@@ -215,57 +218,57 @@
 +         goto -> bb16;                    // scope 0 at $DIR/match-arm-scopes.rs:14:5: 17:6
       }
   
--     bb21: {
-+     bb18: {
+-     bb21: {                              // preds: [bb19]
++     bb18: {                              // preds: [bb16]
           StorageDead(_16);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
           StorageDead(_15);                // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
 -         goto -> bb22;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
 +         goto -> bb19;                    // scope 0 at $DIR/match-arm-scopes.rs:16:41: 16:42
       }
   
--     bb22: {
+-     bb22: {                              // preds: [bb18, bb21]
 -         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     bb19: {
++     bb19: {                              // preds: [bb15, bb18]
 +         goto -> bb26;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
       }
   
--     bb23: {
-+     bb20: {
+-     bb23: {                              // preds: [bb9, bb14]
++     bb20: {                              // preds: [bb6, bb11]
           StorageDead(_8);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
           StorageDead(_6);                 // scope 0 at $DIR/match-arm-scopes.rs:15:77: 15:78
 -         drop(_2) -> [return: bb24, unwind: bb26]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +         drop(_2) -> [return: bb21, unwind: bb23]; // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
       }
   
--     bb24: {
-+     bb21: {
+-     bb24: {                              // preds: [bb22, bb23]
++     bb21: {                              // preds: [bb20, bb24]
           return;                          // scope 0 at $DIR/match-arm-scopes.rs:18:2: 18:2
       }
   
--     bb25 (cleanup): {
+-     bb25 (cleanup): {                    // preds: [bb7, bb19]
 -         drop(_2) -> bb26;                // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
-+     bb22 (cleanup): {
++     bb22 (cleanup): {                    // preds: [bb4, bb16]
 +         goto -> bb27;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
       }
   
--     bb26 (cleanup): {
-+     bb23 (cleanup): {
+-     bb26 (cleanup): {                    // preds: [bb22, bb23, bb25]
++     bb23 (cleanup): {                    // preds: [bb20, bb25, bb27]
           resume;                          // scope 0 at $DIR/match-arm-scopes.rs:13:1: 18:2
 +     }
 + 
-+     bb24: {
++     bb24: {                              // preds: [bb26]
 +         goto -> bb21;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
-+     bb25 (cleanup): {
++     bb25 (cleanup): {                    // preds: []
 +         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
-+     bb26: {
++     bb26: {                              // preds: [bb19]
 +         goto -> bb24;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
 +     }
 + 
-+     bb27 (cleanup): {
++     bb27 (cleanup): {                    // preds: [bb22]
 +         goto -> bb23;                    // scope 0 at $DIR/match-arm-scopes.rs:18:1: 18:2
       }
   }

--- a/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match.PromoteTemps.after.mir
@@ -23,7 +23,7 @@ fn full_tested_match() -> () {
         debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:17:14: 17:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:15:13: 19:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
@@ -32,24 +32,24 @@ fn full_tested_match() -> () {
         switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:15:13: 15:27
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb3]
         _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:18:17: 18:23
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         falseEdge -> [real: bb5, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:16:9: 16:16
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2, bb8]
         falseEdge -> [real: bb9, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:17:9: 17:16
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb0]
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:15:19: 15:27
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb2]
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
         _11 = const full_tested_match::promoted[0]; // scope 0 at $DIR/match_false_edges.rs:16:14: 16:15
                                          // ty::Const
@@ -67,11 +67,11 @@ fn full_tested_match() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
@@ -86,13 +86,13 @@ fn full_tested_match() -> () {
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb6]
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:16:26: 16:27
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:16:36: 16:37
         goto -> bb3;                     // scope 0 at $DIR/match_false_edges.rs:16:20: 16:27
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb3]
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:17:14: 17:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:17:24: 17:25
@@ -103,14 +103,14 @@ fn full_tested_match() -> () {
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:17:25: 17:26
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb1, bb7, bb9]
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:19:6: 19:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:14:28: 20:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:20:2: 20:2
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb5]
         resume;                          // scope 0 at $DIR/match_false_edges.rs:14:1: 20:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.full_tested_match2.PromoteTemps.before.mir
@@ -22,7 +22,7 @@ fn full_tested_match2() -> () {
         debug y => _9;                   // in scope 3 at $DIR/match_false_edges.rs:29:14: 29:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:26:13: 30:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
         _2 = Option::<i32>::Some(const 42_i32); // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
@@ -31,15 +31,15 @@ fn full_tested_match2() -> () {
         switchInt(move _3) -> [0_isize: bb1, 1_isize: bb2, otherwise: bb4]; // scope 0 at $DIR/match_false_edges.rs:26:13: 26:27
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb2, bb8]
         falseEdge -> [real: bb9, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:28:9: 28:13
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:9: 27:16
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1, bb8]
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         _9 = ((_2 as Some).0: i32);      // scope 0 at $DIR/match_false_edges.rs:29:14: 29:15
         StorageLive(_10);                // scope 3 at $DIR/match_false_edges.rs:29:24: 29:25
@@ -50,11 +50,11 @@ fn full_tested_match2() -> () {
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:29:25: 29:26
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb0]
         unreachable;                     // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb2]
         StorageLive(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _6 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:27:14: 27:15
         _4 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:26:19: 26:27
@@ -65,11 +65,11 @@ fn full_tested_match2() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         switchInt(move _7) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         FakeRead(ForGuardBinding, _6);   // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
@@ -84,25 +84,25 @@ fn full_tested_match2() -> () {
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb6]
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:27:26: 27:27
         StorageDead(_6);                 // scope 0 at $DIR/match_false_edges.rs:27:36: 27:37
         falseEdge -> [real: bb3, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:27:20: 27:27
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb1]
         _1 = (const 3_i32, const 3_i32); // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
         goto -> bb10;                    // scope 0 at $DIR/match_false_edges.rs:28:17: 28:23
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb3, bb7, bb9]
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:30:6: 30:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:25:29: 31:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:31:2: 31:2
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb5]
         resume;                          // scope 0 at $DIR/match_false_edges.rs:25:1: 31:2
     }
 }

--- a/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
+++ b/src/test/mir-opt/match_false_edges.main.PromoteTemps.before.mir
@@ -33,7 +33,7 @@ fn main() -> () {
         debug _z => _14;                 // in scope 5 at $DIR/match_false_edges.rs:39:9: 39:11
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/match_false_edges.rs:35:13: 40:6
         StorageLive(_2);                 // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
         _2 = Option::<i32>::Some(const 1_i32); // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
@@ -42,15 +42,15 @@ fn main() -> () {
         switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/match_false_edges.rs:35:13: 35:26
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb2, bb8, bb8]
         falseEdge -> [real: bb9, imaginary: bb4]; // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         falseEdge -> [real: bb5, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:9: 36:17
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb4, bb13, bb13]
         StorageLive(_14);                // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _14 = _2;                        // scope 0 at $DIR/match_false_edges.rs:39:9: 39:11
         _1 = const 4_i32;                // scope 5 at $DIR/match_false_edges.rs:39:15: 39:16
@@ -58,11 +58,11 @@ fn main() -> () {
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:39:15: 39:16
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb1]
         falseEdge -> [real: bb10, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:9: 38:16
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb2]
         StorageLive(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _7 = &((_2 as Some).0: i32);     // scope 0 at $DIR/match_false_edges.rs:36:14: 36:16
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
@@ -73,11 +73,11 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> bool {guard}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         switchInt(move _8) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         FakeRead(ForGuardBinding, _7);   // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
@@ -89,13 +89,13 @@ fn main() -> () {
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb6]
         StorageDead(_8);                 // scope 0 at $DIR/match_false_edges.rs:36:27: 36:28
         StorageDead(_7);                 // scope 0 at $DIR/match_false_edges.rs:36:32: 36:33
         falseEdge -> [real: bb1, imaginary: bb1]; // scope 0 at $DIR/match_false_edges.rs:36:21: 36:28
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb1]
         StorageLive(_9);                 // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _9 = _2;                         // scope 0 at $DIR/match_false_edges.rs:37:9: 37:11
         _1 = const 2_i32;                // scope 3 at $DIR/match_false_edges.rs:37:15: 37:16
@@ -103,7 +103,7 @@ fn main() -> () {
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:37:15: 37:16
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb4]
         StorageLive(_11);                // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _11 = &((_2 as Some).0: i32);    // scope 0 at $DIR/match_false_edges.rs:38:14: 38:15
         _5 = &shallow _2;                // scope 0 at $DIR/match_false_edges.rs:35:19: 35:26
@@ -116,11 +116,11 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(i32) -> bool {guard2}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb11: {
+    bb11: {                              // preds: [bb10]
         switchInt(move _12) -> [false: bb13, otherwise: bb12]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
-    bb12: {
+    bb12: {                              // preds: [bb11]
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
@@ -133,21 +133,21 @@ fn main() -> () {
         goto -> bb14;                    // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
     }
 
-    bb13: {
+    bb13: {                              // preds: [bb11]
         StorageDead(_13);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageDead(_12);                // scope 0 at $DIR/match_false_edges.rs:38:28: 38:29
         StorageDead(_11);                // scope 0 at $DIR/match_false_edges.rs:38:33: 38:34
         falseEdge -> [real: bb3, imaginary: bb3]; // scope 0 at $DIR/match_false_edges.rs:38:20: 38:29
     }
 
-    bb14: {
+    bb14: {                              // preds: [bb3, bb7, bb9, bb12]
         StorageDead(_2);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         StorageDead(_1);                 // scope 0 at $DIR/match_false_edges.rs:40:6: 40:7
         _0 = const ();                   // scope 0 at $DIR/match_false_edges.rs:34:11: 41:2
         return;                          // scope 0 at $DIR/match_false_edges.rs:41:2: 41:2
     }
 
-    bb15 (cleanup): {
+    bb15 (cleanup): {                    // preds: [bb5, bb10]
         resume;                          // scope 0 at $DIR/match_false_edges.rs:34:1: 41:2
     }
 }

--- a/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/src/test/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -18,7 +18,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/match_test.rs:7:9: 7:10
         _1 = const 3_i32;                // scope 0 at $DIR/match_test.rs:7:13: 7:14
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/match_test.rs:7:9: 7:10
@@ -31,72 +31,72 @@ fn main() -> () {
         switchInt(move _6) -> [false: bb4, otherwise: bb1]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _7 = Lt(_1, const 10_i32);       // scope 2 at $DIR/match_test.rs:13:9: 13:14
         switchInt(move _7) -> [false: bb4, otherwise: bb2]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         falseEdge -> [real: bb9, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:9: 13:14
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb7, bb8, bb11]
         _3 = const 3_i32;                // scope 2 at $DIR/match_test.rs:16:14: 16:15
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:16:14: 16:15
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb0, bb1]
         _4 = Le(const 10_i32, _1);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
         switchInt(move _4) -> [false: bb7, otherwise: bb5]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         _5 = Le(_1, const 20_i32);       // scope 2 at $DIR/match_test.rs:14:9: 14:16
         switchInt(move _5) -> [false: bb7, otherwise: bb6]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb2, bb5, bb11]
         falseEdge -> [real: bb12, imaginary: bb8]; // scope 2 at $DIR/match_test.rs:14:9: 14:16
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb4, bb5]
         switchInt(_1) -> [-1_i32: bb8, otherwise: bb3]; // scope 2 at $DIR/match_test.rs:12:5: 12:12
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb6, bb7]
         falseEdge -> [real: bb13, imaginary: bb3]; // scope 2 at $DIR/match_test.rs:15:9: 15:11
     }
 
-    bb9: {
+    bb9: {                               // preds: [bb2]
         _8 = &shallow _1;                // scope 2 at $DIR/match_test.rs:12:11: 12:12
         StorageLive(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _9 = _2;                         // scope 2 at $DIR/match_test.rs:13:18: 13:19
         switchInt(move _9) -> [false: bb11, otherwise: bb10]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
     }
 
-    bb10: {
+    bb10: {                              // preds: [bb9]
         StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
         FakeRead(ForMatchGuard, _8);     // scope 2 at $DIR/match_test.rs:13:18: 13:19
         _3 = const 0_i32;                // scope 2 at $DIR/match_test.rs:13:23: 13:24
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:13:23: 13:24
     }
 
-    bb11: {
+    bb11: {                              // preds: [bb9]
         StorageDead(_9);                 // scope 2 at $DIR/match_test.rs:13:18: 13:19
         falseEdge -> [real: bb3, imaginary: bb6]; // scope 2 at $DIR/match_test.rs:13:18: 13:19
     }
 
-    bb12: {
+    bb12: {                              // preds: [bb6]
         _3 = const 1_i32;                // scope 2 at $DIR/match_test.rs:14:20: 14:21
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:14:20: 14:21
     }
 
-    bb13: {
+    bb13: {                              // preds: [bb8]
         _3 = const 2_i32;                // scope 2 at $DIR/match_test.rs:15:15: 15:16
         goto -> bb14;                    // scope 2 at $DIR/match_test.rs:15:15: 15:16
     }
 
-    bb14: {
+    bb14: {                              // preds: [bb3, bb10, bb12, bb13]
         StorageDead(_3);                 // scope 2 at $DIR/match_test.rs:17:6: 17:7
         _0 = const ();                   // scope 0 at $DIR/match_test.rs:6:11: 18:2
         StorageDead(_2);                 // scope 1 at $DIR/match_test.rs:18:1: 18:2

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -27,7 +27,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
           StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
@@ -36,7 +36,7 @@
 -         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
@@ -44,7 +44,7 @@
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 -         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
 +         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
@@ -56,7 +56,7 @@
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
           StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
           StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -27,7 +27,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
           StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
@@ -36,7 +36,7 @@
 -         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
@@ -44,7 +44,7 @@
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
 -         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
 +         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
@@ -56,7 +56,7 @@
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 19:12
           StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
           StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
@@ -7,20 +7,20 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
 +     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
 -         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
@@ -7,20 +7,20 @@
       let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
 +     let mut _3: isize;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:17: 8:20
 -         switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageLive(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         _3 = move _2;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
 +         StorageDead(_3);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
@@ -4,7 +4,7 @@ fn foo(_1: Option<()>) -> () {
     debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
     let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
 
-    bb0: {
+    bb0: {                               // preds: []
         return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
     }
 }

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
@@ -4,7 +4,7 @@ fn foo(_1: Option<()>) -> () {
     debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
     let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
 
-    bb0: {
+    bb0: {                               // preds: []
         return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
     }
 }

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -14,7 +14,7 @@
           debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
           StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
@@ -23,17 +23,17 @@
 -         switchInt(move _4) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 +         _5 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 +         _3 = Ne(_5, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
@@ -42,17 +42,17 @@
 -         switchInt(move _3) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb3]
 -         _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb3]
 -         _2 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: [bb4, bb5]
 +         StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 +         _6 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 +         _2 = Ne(_6, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
@@ -61,7 +61,7 @@
 -         switchInt(move _2) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb7: {
+-     bb7: {                               // preds: [bb6]
 +         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 +         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
@@ -69,13 +69,13 @@
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
--     bb8: {
+-     bb8: {                               // preds: [bb6]
 -         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
 -         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
--     bb9: {
+-     bb9: {                               // preds: [bb7, bb8]
 +         _1 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 +         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -14,7 +14,7 @@
           debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
           StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
@@ -23,17 +23,17 @@
 -         switchInt(move _4) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
 -         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
 -         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
 +         StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 +         _5 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
 +         _3 = Ne(_5, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
@@ -42,17 +42,17 @@
 -         switchInt(move _3) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb3]
 -         _2 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb3]
 -         _2 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
 -         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: [bb4, bb5]
 +         StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 +         _6 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 +         _2 = Ne(_6, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
@@ -61,7 +61,7 @@
 -         switchInt(move _2) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
--     bb7: {
+-     bb7: {                               // preds: [bb6]
 +         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 +         _7 = move _2;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
@@ -69,13 +69,13 @@
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
 -     }
 - 
--     bb8: {
+-     bb8: {                               // preds: [bb6]
 -         StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
 -         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 -     }
 - 
--     bb9: {
+-     bb9: {                               // preds: [bb7, bb8]
 +         _1 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
 +         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
           _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.32bit.diff
@@ -6,22 +6,22 @@
       let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:11:34: 11:36
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
           switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/matches_u8.rs:16:2: 16:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.64bit.diff
@@ -6,22 +6,22 @@
       let mut _0: u8;                      // return place in scope 0 at $DIR/matches_u8.rs:11:34: 11:36
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:13:9: 13:13
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:12:11: 12:12
           switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:12:5: 12:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 1_u8;                 // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:14:17: 14:18
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 0_u8;                 // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:13:17: 13:18
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/matches_u8.rs:16:2: 16:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.32bit.diff
@@ -6,22 +6,22 @@
       let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:19:37: 19:39
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
           switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/matches_u8.rs:24:2: 24:2
       }
   }

--- a/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.64bit.diff
@@ -6,22 +6,22 @@
       let mut _0: i8;                      // return place in scope 0 at $DIR/matches_u8.rs:19:37: 19:39
       let mut _2: isize;                   // in scope 0 at $DIR/matches_u8.rs:21:9: 21:13
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/matches_u8.rs:20:11: 20:12
           switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_u8.rs:20:5: 20:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 1_i8;                 // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:22:17: 22:18
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 0_i8;                 // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
           goto -> bb3;                     // scope 0 at $DIR/matches_u8.rs:21:17: 21:18
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           return;                          // scope 0 at $DIR/matches_u8.rs:24:2: 24:2
       }
   }

--- a/src/test/mir-opt/multiple_return_terminators.test.MultipleReturnTerminators.diff
+++ b/src/test/mir-opt/multiple_return_terminators.test.MultipleReturnTerminators.diff
@@ -5,7 +5,7 @@
       debug x => _1;                       // in scope 0 at $DIR/multiple_return_terminators.rs:4:9: 4:10
       let mut _0: ();                      // return place in scope 0 at $DIR/multiple_return_terminators.rs:4:18: 4:18
   
-      bb0: {
+      bb0: {                               // preds: []
           return;                          // scope 0 at $DIR/multiple_return_terminators.rs:10:2: 10:2
       }
   }

--- a/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
+++ b/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
@@ -41,7 +41,7 @@ fn use_x(_1: &'_#6r mut i32, _2: &'_#7r u32, _3: &'_#8r u32, _4: &'_#9r u32) -> 
     debug z => _4;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:66: 12:67
     let mut _0: bool;                    // return place in scope 0 at $DIR/named-lifetimes-basic.rs:12:81: 12:85
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const Const(Value(Scalar(0x01)): bool); // bb0[0]: scope 0 at $DIR/named-lifetimes-basic.rs:12:88: 12:92
         return;                          // bb0[1]: scope 0 at $DIR/named-lifetimes-basic.rs:12:94: 12:94
     }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -43,7 +43,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
         _1 = [const Const(Value(Scalar(0x00000001)): usize), const Const(Value(Scalar(0x00000002)): usize), const Const(Value(Scalar(0x00000003)): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:17:17: 17:26
         FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
@@ -55,7 +55,7 @@ fn main() -> () {
         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
         FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
         StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
@@ -66,7 +66,7 @@ fn main() -> () {
         switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
@@ -76,14 +76,14 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
         StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
         goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb1]
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
         _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x00000016)): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // mir::Constant
@@ -91,13 +91,13 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
         goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb3, bb5]
         StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:24:5: 24:6
         StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
         StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
@@ -106,7 +106,7 @@ fn main() -> () {
         return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb0, bb2, bb4]
         resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -43,7 +43,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // bb0[0]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
         _1 = [const Const(Value(Scalar(0x0000000000000001)): usize), const Const(Value(Scalar(0x0000000000000002)): usize), const Const(Value(Scalar(0x0000000000000003)): usize)]; // bb0[1]: scope 0 at $DIR/region-subtyping-basic.rs:17:17: 17:26
         FakeRead(ForLet(None), _1);      // bb0[2]: scope 0 at $DIR/region-subtyping-basic.rs:17:9: 17:14
@@ -55,7 +55,7 @@ fn main() -> () {
         assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, _3) -> [success: bb1, unwind: bb7]; // bb0[8]: scope 1 at $DIR/region-subtyping-basic.rs:18:14: 18:18
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
         FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
         StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
@@ -66,7 +66,7 @@ fn main() -> () {
         switchInt(move _7) -> [Const(Value(Scalar(0x00)): bool): bb4, otherwise: bb2]; // bb1[7]: scope 3 at $DIR/region-subtyping-basic.rs:20:8: 20:12
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageLive(_8);                 // bb2[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:9: 21:18
         StorageLive(_9);                 // bb2[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
         _9 = (*_6);                      // bb2[2]: scope 3 at $DIR/region-subtyping-basic.rs:21:15: 21:17
@@ -76,14 +76,14 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_9);                 // bb3[0]: scope 3 at $DIR/region-subtyping-basic.rs:21:17: 21:18
         StorageDead(_8);                 // bb3[1]: scope 3 at $DIR/region-subtyping-basic.rs:21:18: 21:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb3[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:13: 22:6
         goto -> bb6;                     // bb3[3]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb1]
         StorageLive(_10);                // bb4[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
         _10 = Const(Value(Scalar(<ZST>)): fn(usize) -> bool {use_x})(const Const(Value(Scalar(0x0000000000000016)): usize)) -> [return: bb5, unwind: bb7]; // bb4[1]: scope 3 at $DIR/region-subtyping-basic.rs:23:9: 23:18
                                          // mir::Constant
@@ -91,13 +91,13 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(usize) -> bool {use_x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_10);                // bb5[0]: scope 3 at $DIR/region-subtyping-basic.rs:23:18: 23:19
         _0 = const Const(Value(Scalar(<ZST>)): ()); // bb5[1]: scope 3 at $DIR/region-subtyping-basic.rs:22:12: 24:6
         goto -> bb6;                     // bb5[2]: scope 3 at $DIR/region-subtyping-basic.rs:20:5: 24:6
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb3, bb5]
         StorageDead(_7);                 // bb6[0]: scope 3 at $DIR/region-subtyping-basic.rs:24:5: 24:6
         StorageDead(_6);                 // bb6[1]: scope 2 at $DIR/region-subtyping-basic.rs:25:1: 25:2
         StorageDead(_3);                 // bb6[2]: scope 1 at $DIR/region-subtyping-basic.rs:25:1: 25:2
@@ -106,7 +106,7 @@ fn main() -> () {
         return;                          // bb6[5]: scope 0 at $DIR/region-subtyping-basic.rs:25:2: 25:2
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb0, bb2, bb4]
         resume;                          // bb7[0]: scope 0 at $DIR/region-subtyping-basic.rs:16:1: 25:2
     }
 }

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -13,12 +13,12 @@ fn unwrap(_1: Option<T>) -> T {
         debug x => _3;                   // in scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _2 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:5: 8:14
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_4);                 // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
         begin_panic::<&str>(const "explicit panic") -> bb4; // scope 0 at $SRC_DIR/std/src/panic.rs:LL:COL
                                          // mir::Constant
@@ -32,11 +32,11 @@ fn unwrap(_1: Option<T>) -> T {
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         unreachable;                     // scope 0 at $DIR/no-drop-for-inactive-variant.rs:8:11: 8:14
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb0]
         StorageLive(_3);                 // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _3 = move ((_1 as Some).0: T);   // scope 0 at $DIR/no-drop-for-inactive-variant.rs:9:14: 9:15
         _0 = move _3;                    // scope 1 at $DIR/no-drop-for-inactive-variant.rs:9:20: 9:21
@@ -45,7 +45,7 @@ fn unwrap(_1: Option<T>) -> T {
         return;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:2: 12:2
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb1]
         _7 = discriminant(_1);           // scope 0 at $DIR/no-drop-for-inactive-variant.rs:12:1: 12:2
         resume;                          // scope 0 at $DIR/no-drop-for-inactive-variant.rs:7:1: 12:2
     }

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -7,7 +7,7 @@ fn main() -> () {
     let mut _3: &str;                    // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
     let _4: &str;                        // in scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
         StorageLive(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
         StorageLive(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
@@ -26,7 +26,7 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r> fn(&'r str) -> std::string::String {<str as std::string::ToString>::to_string}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_3);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:33: 9:34
         _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:5: 9:35
                                          // mir::Constant
@@ -34,7 +34,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(std::string::String) {std::mem::drop::<std::string::String>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_2);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
         StorageDead(_4);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
         StorageDead(_1);                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:35: 9:36
@@ -42,11 +42,11 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:10:2: 10:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb1]
         drop(_2) -> bb4;                 // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:34: 9:35
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb3]
         resume;                          // scope 0 at $DIR/no-spurious-drop-after-call.rs:8:1: 10:2
     }
 }

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -7,7 +7,7 @@
       let mut _2: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
       let mut _3: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
           StorageLive(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
           _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
@@ -17,17 +17,17 @@
           switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = const 0_u32;                // scope 0 at $DIR/not_equal_false.rs:4:21: 4:22
           goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = const 1_u32;                // scope 0 at $DIR/not_equal_false.rs:4:32: 4:33
           goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:34: 4:35
           return;                          // scope 0 at $DIR/not_equal_false.rs:5:2: 5:2
       }

--- a/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
+++ b/src/test/mir-opt/nrvo_simple.nrvo.RenameReturnPlace.diff
@@ -15,7 +15,7 @@
 +         debug buf => _0;                 // in scope 1 at $DIR/nrvo-simple.rs:5:9: 5:16
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_2);                 // scope 0 at $DIR/nrvo-simple.rs:5:9: 5:16
 -         _2 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:5:19: 5:28
 +         _0 = [const 0_u8; 1024];         // scope 0 at $DIR/nrvo-simple.rs:5:19: 5:28
@@ -30,7 +30,7 @@
           _3 = move _4(move _5) -> bb1;    // scope 1 at $DIR/nrvo-simple.rs:6:5: 6:19
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageDead(_5);                 // scope 1 at $DIR/nrvo-simple.rs:6:18: 6:19
           StorageDead(_4);                 // scope 1 at $DIR/nrvo-simple.rs:6:18: 6:19
           StorageDead(_6);                 // scope 1 at $DIR/nrvo-simple.rs:6:19: 6:20

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -12,7 +12,7 @@ fn main() -> () {
         debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
@@ -31,21 +31,21 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb4]
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb3, bb4]
         resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb0]
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -12,7 +12,7 @@ fn main() -> () {
         debug x => _1;                   // in scope 1 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
@@ -31,21 +31,21 @@ fn main() -> () {
         drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb4]
         StorageDead(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb3, bb4]
         resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb0]
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb0]
         StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29

--- a/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
+++ b/src/test/mir-opt/receiver_ptr_mutability.main.mir_map.0.mir
@@ -27,7 +27,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
         _1 = null_mut::<Test>() -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/receiver-ptr-mutability.rs:14:26: 14:46
                                          // mir::Constant
@@ -35,7 +35,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() -> *mut Test {std::ptr::null_mut::<Test>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/receiver-ptr-mutability.rs:14:9: 14:12
         AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] }); // scope 0 at $DIR/receiver-ptr-mutability.rs:14:14: 14:23
         StorageLive(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:5: 15:12
@@ -50,7 +50,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_3);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:11: 15:12
         StorageDead(_2);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:15:12: 15:13
         StorageLive(_5);                 // scope 1 at $DIR/receiver-ptr-mutability.rs:18:9: 18:16
@@ -78,7 +78,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn(*const Test) {Test::x}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageDead(_11);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:15: 19:16
         StorageDead(_10);                // scope 2 at $DIR/receiver-ptr-mutability.rs:19:16: 19:17
         _0 = const ();                   // scope 0 at $DIR/receiver-ptr-mutability.rs:13:11: 20:2
@@ -90,7 +90,7 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:20:2: 20:2
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb0, bb1, bb2]
         resume;                          // scope 0 at $DIR/receiver-ptr-mutability.rs:13:1: 20:2
     }
 }

--- a/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
+++ b/src/test/mir-opt/remove_fake_borrows.match_guard.CleanupNonCodegenStatements.diff
@@ -12,27 +12,27 @@
       let mut _7: &i32;                    // in scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
       let mut _8: bool;                    // in scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
   
-      bb0: {
+      bb0: {                               // preds: []
 -         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
 +         nop;                             // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
           _3 = discriminant(_1);           // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
           switchInt(move _3) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0, bb2, bb6]
           _0 = const 1_i32;                // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
           goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:9:14: 9:15
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           switchInt((*(*((_1 as Some).0: &&i32)))) -> [0_i32: bb3, otherwise: bb1]; // scope 0 at $DIR/remove_fake_borrows.rs:7:5: 7:12
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           goto -> bb4;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:9: 8:16
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
 -         _4 = &shallow _1;                // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
 -         _5 = &shallow ((_1 as Some).0: &&i32); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
 -         _6 = &shallow (*((_1 as Some).0: &&i32)); // scope 0 at $DIR/remove_fake_borrows.rs:7:11: 7:12
@@ -46,7 +46,7 @@
           switchInt(move _8) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _4);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
 -         FakeRead(ForMatchGuard, _5);     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
@@ -60,16 +60,16 @@
           goto -> bb7;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:25: 8:26
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb4]
           StorageDead(_8);                 // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
           goto -> bb1;                     // scope 0 at $DIR/remove_fake_borrows.rs:8:20: 8:21
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb1, bb5]
           return;                          // scope 0 at $DIR/remove_fake_borrows.rs:11:2: 11:2
       }
   
-      bb8 (cleanup): {
+      bb8 (cleanup): {                     // preds: []
           resume;                          // scope 0 at $DIR/remove_fake_borrows.rs:6:1: 11:2
       }
   }

--- a/src/test/mir-opt/remove_never_const.no_codegen.PreCodegen.after.mir
+++ b/src/test/mir-opt/remove_never_const.no_codegen.PreCodegen.after.mir
@@ -5,7 +5,7 @@ fn no_codegen() -> () {
     scope 1 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         unreachable;                     // scope 0 at $DIR/remove-never-const.rs:19:13: 19:33
     }
 }

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -33,7 +33,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/remove_storage_markers.rs:7:9: 7:16
           _1 = const 0_i32;                // scope 0 at $DIR/remove_storage_markers.rs:7:19: 7:20
 -         StorageLive(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
@@ -47,7 +47,7 @@
           goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0, bb2]
 -         StorageLive(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
 -         StorageLive(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
 -         StorageLive(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
@@ -62,7 +62,7 @@
                                            // + literal: Const { ty: for<'r> fn(&'r mut std::ops::Range<i32>) -> std::option::Option<<std::ops::Range<i32> as std::iter::range::RangeIteratorImpl>::Item> {<std::ops::Range<i32> as std::iter::range::RangeIteratorImpl>::spec_next}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb4]
 -         StorageLive(_12);                // scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
           _12 = ((_7 as Some).0: i32);     // scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
 -         StorageLive(_13);                // scope 3 at $DIR/remove_storage_markers.rs:9:16: 9:17
@@ -78,7 +78,7 @@
           goto -> bb1;                     // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb4]
           _0 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
 -         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
@@ -89,7 +89,7 @@
           return;                          // scope 0 at $DIR/remove_storage_markers.rs:11:2: 11:2
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1]
 -         StorageDead(_14);                // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
 -         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -10,18 +10,18 @@
           debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       }
   
-      bb1 (cleanup): {
+      bb1 (cleanup): {                     // preds: [bb0]
           resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:20:1: 22:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:11: 21:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:12: 21:13
           nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:20:32: 22:2

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -10,18 +10,18 @@
           debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
           drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       }
   
-      bb1 (cleanup): {
+      bb1 (cleanup): {                     // preds: [bb0]
           resume;                          // scope 0 at $DIR/remove_unneeded_drops.rs:8:1: 10:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:11: 9:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:12: 9:13
           nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:8:27: 10:2

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -10,14 +10,14 @@
           debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
 -         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:11: 4:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:12: 4:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:3:17: 5:2

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -10,14 +10,14 @@
           debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
 -         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
 -     }
 - 
--     bb1: {
+-     bb1: {                               // preds: [bb0]
           StorageDead(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:11: 14:12
           StorageDead(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:12: 14:13
 -         nop;                             // scope 0 at $DIR/remove_unneeded_drops.rs:13:36: 15:2

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
@@ -4,7 +4,7 @@ fn get_union() -> Foo {
     let mut _0: Foo;                     // return place in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:12:19: 12:22
     let mut _1: ();                      // in scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
         (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:5: 13:18
         StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:17: 13:18

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -61,7 +61,7 @@ fn array_casts() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/retag.rs:58:9: 58:14
         _1 = [const 0_usize, const 0_usize]; // scope 0 at $DIR/retag.rs:58:29: 58:35
         StorageLive(_2);                 // scope 1 at $DIR/retag.rs:59:9: 59:10
@@ -84,7 +84,7 @@ fn array_casts() -> () {
                                          // + literal: Const { ty: unsafe fn(*mut usize, usize) -> *mut usize {std::ptr::mut_ptr::<impl *mut usize>::add}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageDead(_7);                 // scope 3 at $DIR/retag.rs:60:22: 60:23
         (*_6) = const 1_usize;           // scope 3 at $DIR/retag.rs:60:14: 60:27
         StorageDead(_6);                 // scope 3 at $DIR/retag.rs:60:27: 60:28
@@ -115,7 +115,7 @@ fn array_casts() -> () {
                                          // + literal: Const { ty: unsafe fn(*const usize, usize) -> *const usize {std::ptr::const_ptr::<impl *const usize>::add}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_17);                // scope 6 at $DIR/retag.rs:64:33: 64:34
         _15 = (*_16);                    // scope 6 at $DIR/retag.rs:64:25: 64:34
         _14 = &_15;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -154,7 +154,7 @@ fn array_casts() -> () {
         switchInt(move _22) -> [false: bb4, otherwise: bb3]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -180,7 +180,7 @@ fn array_casts() -> () {
                                          // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r usize, &'s usize, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2]
         _12 = const ();                  // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
+++ b/src/test/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.mir
@@ -5,7 +5,7 @@ fn std::ptr::drop_in_place(_1: *mut Test) -> () {
     let mut _2: &mut Test;               // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         Retag([raw] _1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = <Test as Drop>::drop(move _2) -> bb1; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -14,7 +14,7 @@ fn std::ptr::drop_in_place(_1: *mut Test) -> () {
                                          // + literal: Const { ty: for<'r> fn(&'r mut Test) {<Test as std::ops::Drop>::drop}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 }

--- a/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main-{closure#0}.SimplifyCfg-elaborate-drops.after.mir
@@ -8,7 +8,7 @@ fn main::{closure#0}(_1: &[closure@main::{closure#0}], _2: &i32) -> &i32 {
         debug _y => _3;                  // in scope 1 at $DIR/retag.rs:41:13: 41:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:40:31: 43:6
         Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:40:31: 43:6
         StorageLive(_3);                 // scope 0 at $DIR/retag.rs:41:13: 41:15

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -55,7 +55,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/retag.rs:30:9: 30:14
         _1 = const 0_i32;                // scope 0 at $DIR/retag.rs:30:17: 30:18
         StorageLive(_2);                 // scope 1 at $DIR/retag.rs:31:5: 37:6
@@ -77,7 +77,7 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x mut i32) -> &'x mut i32 {Test::foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         Retag(_3);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
         StorageDead(_6);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_4);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
@@ -85,7 +85,7 @@ fn main() -> () {
         drop(_5) -> [return: bb2, unwind: bb9]; // scope 1 at $DIR/retag.rs:32:36: 32:37
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_5);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
         StorageLive(_8);                 // scope 2 at $DIR/retag.rs:33:13: 33:14
         StorageLive(_9);                 // scope 2 at $DIR/retag.rs:33:19: 33:20
@@ -134,7 +134,7 @@ fn main() -> () {
         _15 = move _16(move _17) -> bb3; // scope 6 at $DIR/retag.rs:44:14: 44:19
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         Retag(_15);                      // scope 6 at $DIR/retag.rs:44:14: 44:19
         StorageDead(_17);                // scope 6 at $DIR/retag.rs:44:18: 44:19
         StorageDead(_16);                // scope 6 at $DIR/retag.rs:44:18: 44:19
@@ -165,7 +165,7 @@ fn main() -> () {
                                          // + literal: Const { ty: for<'r, 'x> fn(&'r Test, &'x i32) -> &'x i32 {Test::foo_shr}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         Retag(_19);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageDead(_22);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_20);                // scope 7 at $DIR/retag.rs:47:23: 47:24
@@ -173,7 +173,7 @@ fn main() -> () {
         drop(_21) -> [return: bb5, unwind: bb9]; // scope 7 at $DIR/retag.rs:47:24: 47:25
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_21);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageDead(_19);                // scope 7 at $DIR/retag.rs:47:24: 47:25
         StorageLive(_25);                // scope 7 at $DIR/retag.rs:50:9: 50:11
@@ -189,7 +189,7 @@ fn main() -> () {
                                          // + literal: Const { ty: fn() {array_casts}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         StorageDead(_27);                // scope 8 at $DIR/retag.rs:52:18: 52:19
         _0 = const ();                   // scope 0 at $DIR/retag.rs:29:11: 53:2
         StorageDead(_25);                // scope 7 at $DIR/retag.rs:53:1: 53:2
@@ -199,15 +199,15 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/retag.rs:53:2: 53:2
     }
 
-    bb7 (cleanup): {
+    bb7 (cleanup): {                     // preds: [bb3]
         drop(_21) -> bb9;                // scope 7 at $DIR/retag.rs:47:24: 47:25
     }
 
-    bb8 (cleanup): {
+    bb8 (cleanup): {                     // preds: [bb0]
         drop(_5) -> bb9;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb1, bb4, bb7, bb8]
         resume;                          // scope 0 at $DIR/retag.rs:29:1: 53:2
     }
 }

--- a/src/test/mir-opt/retag.{impl#0}-foo.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.{impl#0}-foo.SimplifyCfg-elaborate-drops.after.mir
@@ -6,7 +6,7 @@ fn <impl at $DIR/retag.rs:11:1: 19:2>::foo(_1: &Test, _2: &mut i32) -> &mut i32 
     let mut _0: &mut i32;                // return place in scope 0 at $DIR/retag.rs:13:42: 13:53
     let mut _3: &mut i32;                // in scope 0 at $DIR/retag.rs:14:9: 14:10
 
-    bb0: {
+    bb0: {                               // preds: []
         Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:13:5: 15:6
         Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:13:5: 15:6
         StorageLive(_3);                 // scope 0 at $DIR/retag.rs:14:9: 14:10

--- a/src/test/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.{impl#0}-foo_shr.SimplifyCfg-elaborate-drops.after.mir
@@ -5,7 +5,7 @@ fn <impl at $DIR/retag.rs:11:1: 19:2>::foo_shr(_1: &Test, _2: &i32) -> &i32 {
     debug x => _2;                       // in scope 0 at $DIR/retag.rs:16:27: 16:28
     let mut _0: &i32;                    // return place in scope 0 at $DIR/retag.rs:16:42: 16:49
 
-    bb0: {
+    bb0: {                               // preds: []
         Retag([fn entry] _1);            // scope 0 at $DIR/retag.rs:16:5: 18:6
         Retag([fn entry] _2);            // scope 0 at $DIR/retag.rs:16:5: 18:6
         _0 = _2;                         // scope 0 at $DIR/retag.rs:17:9: 17:10

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -50,7 +50,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
@@ -60,7 +60,7 @@
           switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb3, bb5]
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -72,7 +72,7 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb3, bb5]
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
@@ -95,7 +95,7 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           StorageLive(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           _13 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -116,11 +116,11 @@
 +         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb0]
           unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb0]
           StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -47,7 +47,7 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
@@ -57,7 +57,7 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
         _11 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_12);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -94,11 +94,11 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb0]
         StorageLive(_9);                 // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
         _9 = move ((_4 as Ok).0: i32);   // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_10);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -50,7 +50,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
@@ -61,14 +61,15 @@
 +         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb4, bb6]
 -         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 -         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 -         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
++     bb1: {                               // preds: [bb3, bb5]
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -80,8 +81,8 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
--     bb3: {
-+     bb2: {
+-     bb3: {                               // preds: [bb1]
++     bb2: {                               // preds: [bb3, bb5]
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
@@ -104,8 +105,8 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb0]
++     bb3: {                               // preds: [bb0]
           StorageLive(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           _13 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -125,13 +126,13 @@
 +         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
--     bb5: {
-+     bb4: {
+-     bb5: {                               // preds: [bb0]
++     bb4: {                               // preds: [bb0]
           unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   
--     bb6: {
-+     bb5: {
+-     bb6: {                               // preds: [bb0]
++     bb5: {                               // preds: [bb0]
           StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -27,13 +27,13 @@
           debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
           _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
           switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
@@ -48,7 +48,7 @@
 +         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
@@ -63,7 +63,7 @@
 +         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
@@ -71,7 +71,7 @@
           goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb2]
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
@@ -83,7 +83,7 @@
           goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3, bb4]
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
       }

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -25,13 +25,13 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         debug r => _10;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
         _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
         _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
         StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
@@ -47,7 +47,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
         _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
         StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
@@ -67,7 +67,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1, bb2]
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
     }

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -27,13 +27,13 @@
           debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
           _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
           switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
@@ -47,7 +47,7 @@
 +         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
@@ -59,14 +59,14 @@
 -         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb1, bb2]
           _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
 -         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
 +         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb3]
++     bb3: {                               // preds: [bb1, bb2]
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
@@ -75,8 +75,8 @@
 +         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
       }
   
--     bb5: {
-+     bb4: {
+-     bb5: {                               // preds: [bb3]
++     bb4: {                               // preds: [bb1, bb2]
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
@@ -89,8 +89,8 @@
 +         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
       }
   
--     bb6: {
-+     bb5: {
+-     bb6: {                               // preds: [bb4, bb5]
++     bb5: {                               // preds: [bb3, bb4]
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
       }

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.32bit.mir
@@ -4,26 +4,26 @@ fn match_bool(_1: bool) -> usize {
     debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:5:15: 5:16
     let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:5:27: 5:32
 
-    bb0: {
+    bb0: {                               // preds: []
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
         switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0, bb1]
         _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
         goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1]
         _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
         goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2, bb3]
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/simple_match.match_bool.mir_map.0.64bit.mir
@@ -4,26 +4,26 @@ fn match_bool(_1: bool) -> usize {
     debug x => _1;                       // in scope 0 at $DIR/simple-match.rs:5:15: 5:16
     let mut _0: usize;                   // return place in scope 0 at $DIR/simple-match.rs:5:27: 5:32
 
-    bb0: {
+    bb0: {                               // preds: []
         FakeRead(ForMatchedPlace(None), _1); // scope 0 at $DIR/simple-match.rs:6:11: 6:12
         switchInt(_1) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/simple-match.rs:6:5: 6:12
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         falseEdge -> [real: bb3, imaginary: bb2]; // scope 0 at $DIR/simple-match.rs:7:9: 7:13
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0, bb1]
         _0 = const 20_usize;             // scope 0 at $DIR/simple-match.rs:8:14: 8:16
         goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:8:14: 8:16
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1]
         _0 = const 10_usize;             // scope 0 at $DIR/simple-match.rs:7:17: 7:19
         goto -> bb4;                     // scope 0 at $DIR/simple-match.rs:7:17: 7:19
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb2, bb3]
         return;                          // scope 0 at $DIR/simple-match.rs:10:2: 10:2
     }
 }

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -12,21 +12,21 @@
 +         debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
           switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
 -         _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
 -         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
@@ -39,7 +39,7 @@
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb3]
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -11,29 +11,29 @@
           debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
 -         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb0]
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
       }
   
--     bb4: {
-+     bb2: {
+-     bb4: {                               // preds: [bb1, bb3]
++     bb2: {                               // preds: [bb1]
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -18,12 +18,12 @@
 +         debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
           switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
 -         _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
 -         StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
@@ -36,11 +36,11 @@
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
 -         _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
 -         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
@@ -53,7 +53,7 @@
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb3]
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -16,29 +16,29 @@
           debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
 -         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb0]
 -         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb0]
           _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
       }
   
--     bb4: {
-+     bb2: {
+-     bb4: {                               // preds: [bb1, bb3]
++     bb2: {                               // preds: [bb1]
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -38,7 +38,7 @@
           debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
@@ -49,7 +49,7 @@
           switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
 -         _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
 -         _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
@@ -65,11 +65,11 @@
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
 -         StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
 -         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
 -         StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
@@ -87,7 +87,7 @@
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb3]
           return;                          // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -33,7 +33,7 @@
           debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simplify-arm.rs:36:9: 36:10
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
@@ -45,7 +45,7 @@
 +         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
@@ -53,18 +53,19 @@
 +         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
 -         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb0]
 -         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb1, bb3]
++     bb2: {                               // preds: [bb1]
           return;                          // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   }

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
@@ -26,17 +26,17 @@
           goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
       }
   
-      bb1: {
+      bb1: {                               // preds: []
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
       }
   
-      bb2: {
+      bb2: {                               // preds: []
           unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
@@ -48,7 +48,7 @@
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb3]
           StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
           nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
           StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
@@ -26,17 +26,17 @@
           goto -> bb3;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 19:25
       }
   
-      bb1: {
+      bb1: {                               // preds: []
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
       }
   
-      bb2: {
+      bb2: {                               // preds: []
           unreachable;                     // scope 1 at $DIR/simplify-arm-identity.rs:19:24: 19:25
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           StorageLive(_4);                 // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
@@ -48,7 +48,7 @@
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:20:34: 20:35
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb3]
           StorageDead(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:22:6: 22:7
           nop;                             // scope 0 at $DIR/simplify-arm-identity.rs:17:11: 23:2
           StorageDead(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:23:1: 23:2

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-early-opt.diff
@@ -7,15 +7,16 @@
       let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
   
-      bb0: {
+      bb0: {                               // preds: []
           goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0, bb5]
 -         goto -> bb2;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
 -     }
 - 
--     bb2: {
+-     bb2: {                               // preds: [bb1]
++     bb1: {                               // preds: [bb0, bb4]
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 -         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 +         _2 = bar() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
@@ -24,28 +25,28 @@
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
--     bb3: {
+-     bb3: {                               // preds: [bb2]
 -         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
-+     bb2: {
++     bb2: {                               // preds: [bb1]
 +         switchInt(move _2) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       }
   
--     bb4: {
-+     bb3: {
+-     bb4: {                               // preds: [bb3]
++     bb3: {                               // preds: [bb2]
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
           return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
       }
   
--     bb5: {
-+     bb4: {
+-     bb5: {                               // preds: [bb3]
++     bb4: {                               // preds: [bb2]
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
           goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
--     bb6 (cleanup): {
-+     bb5 (cleanup): {
+-     bb6 (cleanup): {                     // preds: [bb2]
++     bb5 (cleanup): {                     // preds: [bb1]
           resume;                          // scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
       }
   }

--- a/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/src/test/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -7,16 +7,17 @@
       let mut _2: bool;                    // in scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       let mut _3: !;                       // in scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
   
-      bb0: {
+      bb0: {                               // preds: []
           goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0, bb9]
 -         falseUnwind -> [real: bb2, cleanup: bb11]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
++     bb1: {                               // preds: [bb0, bb5]
 +         falseUnwind -> [real: bb2, cleanup: bb6]; // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_2);                 // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 -         _2 = bar() -> [return: bb3, unwind: bb11]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 +         _2 = bar() -> [return: bb3, unwind: bb6]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
@@ -25,46 +26,46 @@
                                            // + literal: Const { ty: fn() -> bool {bar}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
           switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
           _0 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
 -         goto -> bb10;                    // scope 0 at $DIR/simplify_cfg.rs:10:13: 10:18
 +         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
 +         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb3]
 -         goto -> bb8;                     // scope 0 at $DIR/simplify_cfg.rs:9:12: 9:17
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: []
 -         unreachable;                     // scope 0 at $DIR/simplify_cfg.rs:9:18: 11:10
 -     }
 - 
--     bb7: {
+-     bb7: {                               // preds: []
 -         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
 -     }
 - 
--     bb8: {
+-     bb8: {                               // preds: [bb5]
           _1 = const ();                   // scope 0 at $DIR/simplify_cfg.rs:11:10: 11:10
 -         goto -> bb9;                     // scope 0 at $DIR/simplify_cfg.rs:9:9: 11:10
 -     }
 - 
--     bb9: {
+-     bb9: {                               // preds: [bb7, bb8]
           StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
           goto -> bb1;                     // scope 0 at $DIR/simplify_cfg.rs:8:5: 12:6
       }
   
--     bb10: {
+-     bb10: {                              // preds: [bb4]
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify_cfg.rs:11:9: 11:10
 -         return;                          // scope 0 at $DIR/simplify_cfg.rs:13:2: 13:2
 -     }
 - 
--     bb11 (cleanup): {
-+     bb6 (cleanup): {
+-     bb11 (cleanup): {                    // preds: [bb1, bb2]
++     bb6 (cleanup): {                     // preds: [bb1, bb2]
           resume;                          // scope 0 at $DIR/simplify_cfg.rs:7:1: 13:2
       }
   }

--- a/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
+++ b/src/test/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.diff
@@ -6,14 +6,15 @@
       let mut _1: bool;                    // in scope 0 at $DIR/simplify_if.rs:6:8: 6:13
       let _2: ();                          // in scope 0 at $DIR/simplify_if.rs:7:9: 7:15
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
           _1 = const false;                // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
 -         switchInt(const false) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
 +         goto -> bb3;                     // scope 0 at $DIR/simplify_if.rs:6:8: 6:13
       }
   
-      bb1: {
+-     bb1: {                               // preds: [bb0]
++     bb1: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
           _2 = noop() -> bb2;              // scope 0 at $DIR/simplify_if.rs:7:9: 7:15
                                            // mir::Constant
@@ -21,18 +22,18 @@
                                            // + literal: Const { ty: fn() {noop}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageDead(_2);                 // scope 0 at $DIR/simplify_if.rs:7:15: 7:16
           nop;                             // scope 0 at $DIR/simplify_if.rs:6:14: 8:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0]
           nop;                             // scope 0 at $DIR/simplify_if.rs:8:6: 8:6
           goto -> bb4;                     // scope 0 at $DIR/simplify_if.rs:6:5: 8:6
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageDead(_1);                 // scope 0 at $DIR/simplify_if.rs:8:5: 8:6
           return;                          // scope 0 at $DIR/simplify_if.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.c.SimplifyLocals.diff
@@ -13,7 +13,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:14:9: 14:14
           _1 = [const 0_u8; 10];           // scope 0 at $DIR/simplify-locals.rs:14:17: 14:26
 -         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:16:20: 16:26

--- a/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
@@ -7,7 +7,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
 -         discriminant(_1) = 0;            // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:17: 22:18

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -7,7 +7,7 @@
 -     let mut _2: (i32, E);                // in scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
 -     let mut _3: E;                       // in scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -         discriminant(_1) = 1;            // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17

--- a/src/test/mir-opt/simplify_locals.r.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.r.SimplifyLocals.diff
@@ -14,7 +14,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:33:9: 33:14
           _1 = const 1_i32;                // scope 0 at $DIR/simplify-locals.rs:33:17: 33:18
 -         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:35:13: 35:15

--- a/src/test/mir-opt/simplify_locals.t1.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t1.SimplifyLocals.diff
@@ -8,7 +8,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:44:5: 44:17
 -         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:44:14: 44:15
 -         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:44:14: 44:15

--- a/src/test/mir-opt/simplify_locals.t2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t2.SimplifyLocals.diff
@@ -8,7 +8,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:50:5: 50:22
 -         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:50:19: 50:20
 -         _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:50:19: 50:20

--- a/src/test/mir-opt/simplify_locals.t3.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t3.SimplifyLocals.diff
@@ -9,7 +9,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:56:5: 56:23
 -         StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:56:15: 56:21
 -         StorageLive(_3);                 // scope 1 at $DIR/simplify-locals.rs:56:20: 56:21

--- a/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.t4.SimplifyLocals.diff
@@ -8,7 +8,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
           StorageLive(_2);                 // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15
           _2 = &/*tls*/ mut X;             // scope 1 at $DIR/simplify-locals.rs:62:14: 62:15

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -15,7 +15,7 @@
           debug a => _6;                   // in scope 1 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
           discriminant(_2) = 0;            // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
@@ -29,12 +29,12 @@
           switchInt(move _5) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _4 = discriminant((_1.1: std::option::Option<T>)); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
           switchInt(move _4) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:12: 4:27
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_6);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
           _6 = (((_1.0: std::option::Option<u8>) as Some).0: u8); // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:18: 4:19
 -         StorageLive(_7);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:5:12: 5:20
@@ -47,11 +47,11 @@
           goto -> bb3;                     // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:5: 8:6
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1, bb2]
           drop(_1) -> bb4;                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:1: 9:2
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb3]
           StorageDead(_1);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/simplify-locals-fixedpoint.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -19,7 +19,7 @@
       scope 1 {
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:20: 13:28
 -         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:21: 13:23
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-removes-unused-consts.rs:13:25: 13:27
@@ -40,7 +40,7 @@
                                            // + literal: Const { ty: fn(((), ())) {use_zst}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageDead(_5);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:21: 14:22
 -         StorageDead(_4);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:14:22: 14:23
 -         StorageLive(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:5: 16:35
@@ -60,7 +60,7 @@
                                            // + literal: Const { ty: fn(u8) {use_u8}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         StorageDead(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:34: 16:35
 -         StorageDead(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36
 -         StorageDead(_8);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:35: 16:36

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -14,7 +14,7 @@
           debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -14,7 +14,7 @@
           debug x => ((_0 as Some).0: std::boxed::Box<()>); // in scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
 -         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12

--- a/src/test/mir-opt/simplify_match.main.ConstProp.diff
+++ b/src/test/mir-opt/simplify_match.main.ConstProp.diff
@@ -9,7 +9,7 @@
           debug x => _2;                   // in scope 1 at $DIR/simplify_match.rs:6:17: 6:18
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/simplify_match.rs:6:11: 6:31
           StorageLive(_2);                 // scope 0 at $DIR/simplify_match.rs:6:17: 6:18
           _2 = const false;                // scope 0 at $DIR/simplify_match.rs:6:21: 6:26
@@ -20,19 +20,19 @@
 +         switchInt(const false) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_match.rs:6:5: 6:31
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           nop;                             // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
           goto -> bb3;                     // scope 0 at $DIR/simplify_match.rs:8:18: 8:20
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
           _0 = noop() -> bb3;              // scope 0 at $DIR/simplify_match.rs:7:17: 7:23
                                            // mir::Constant
                                            // + span: $DIR/simplify_match.rs:7:17: 7:21
                                            // + literal: Const { ty: fn() {noop}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb1, bb2]
           StorageDead(_1);                 // scope 0 at $DIR/simplify_match.rs:10:1: 10:2
           return;                          // scope 0 at $DIR/simplify_match.rs:10:2: 10:2
       }

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -34,7 +34,7 @@
 +         debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 -         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
@@ -51,7 +51,7 @@
           goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
 +         nop;                             // scope 1 at $DIR/simplify_try.rs:25:5: 25:10

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -38,7 +38,7 @@
           debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
           StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
@@ -49,7 +49,7 @@
           switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
 -         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
 -         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
 -         _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
@@ -65,7 +65,7 @@
           return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb0]
 -         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
 -         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
 -         StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -32,7 +32,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
@@ -43,7 +43,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -22,7 +22,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
         return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
     }

--- a/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.32bit.mir
@@ -17,83 +17,83 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb6, bb12]
         return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb4, bb10]
         resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb4]
         _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb3, bb5]
         _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb6]
         _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5, bb7]
         _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb8]
         _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb15]
         goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb10]
         _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb9, bb11]
         _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb11: {
+    bb11: {                              // preds: [bb12]
         _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb12: {
+    bb12: {                              // preds: [bb11, bb13]
         _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb13: {
+    bb13: {                              // preds: [bb14]
         _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb14: {
+    bb14: {                              // preds: [bb15]
         goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb15: {
+    bb15: {                              // preds: [bb0]
         _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.64bit.mir
@@ -17,83 +17,83 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     let mut _15: *mut [std::string::String]; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb15;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb6, bb12]
         return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb4, bb10]
         resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb3 (cleanup): {
+    bb3 (cleanup): {                     // preds: [bb4]
         _5 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_5)) -> bb4;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb3, bb5]
         _6 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _6) -> [false: bb3, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb6]
         _7 = &raw mut (*_1)[_4];         // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _4 = Add(move _4, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_7)) -> [return: bb6, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5, bb7]
         _8 = Eq(_4, _3);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _8) -> [false: bb5, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb8]
         _4 = const 0_usize;              // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb15]
         goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb10]
         _11 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_11)) -> bb10;            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb9, bb11]
         _12 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _12) -> [false: bb9, otherwise: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb11: {
+    bb11: {                              // preds: [bb12]
         _13 = _9;                        // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = Offset(move _9, const 1_usize); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         drop((*_13)) -> [return: bb12, unwind: bb10]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb12: {
+    bb12: {                              // preds: [bb11, bb13]
         _14 = Eq(_9, _10);               // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _14) -> [false: bb11, otherwise: bb1]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb13: {
+    bb13: {                              // preds: [bb14]
         _15 = &raw mut (*_1);            // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _9 = move _15 as *mut std::string::String (Misc); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _10 = Offset(_9, move _3);       // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         goto -> bb12;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb14: {
+    bb14: {                              // preds: [bb15]
         goto -> bb13;                    // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb15: {
+    bb15: {                              // preds: [bb0]
         _2 = SizeOf(std::string::String); // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = Len((*_1));                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         switchInt(move _2) -> [0_usize: bb8, otherwise: bb14]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -51,7 +51,7 @@ static XXX: &Foo = {
     let mut _47: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:21:17: 21:23
     let mut _48: (u32, u32);             // in scope 0 at $DIR/storage_live_dead_in_statics.rs:21:25: 21:31
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
         StorageLive(_2);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:29: 23:2
         StorageLive(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:7:11: 22:6

--- a/src/test/mir-opt/storage_ranges.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges.main.nll.0.mir
@@ -36,7 +36,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/storage_ranges.rs:4:9: 4:10
         _1 = const 0_i32;                // scope 0 at $DIR/storage_ranges.rs:4:13: 4:14
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/storage_ranges.rs:4:9: 4:10

--- a/src/test/mir-opt/tls_access.main.SimplifyCfg-final.after.mir
+++ b/src/test/mir-opt/tls_access.main.SimplifyCfg-final.after.mir
@@ -11,7 +11,7 @@ fn main() -> () {
         }
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 1 at $DIR/tls-access.rs:8:13: 8:14
         StorageLive(_2);                 // scope 1 at $DIR/tls-access.rs:8:18: 8:21
         _2 = &/*tls*/ mut FOO;           // scope 1 at $DIR/tls-access.rs:8:18: 8:21

--- a/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_by_subslice.mir_map.0.mir
@@ -25,7 +25,7 @@ fn move_out_by_subslice() -> () {
     scope 3 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:11:14: 11:19
@@ -36,7 +36,7 @@ fn move_out_by_subslice() -> () {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:14: 11:19
         (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
@@ -44,7 +44,7 @@ fn move_out_by_subslice() -> () {
         drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:18: 11:19
         StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:11:21: 11:26
@@ -55,7 +55,7 @@ fn move_out_by_subslice() -> () {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:11:21: 11:26
         (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
@@ -63,18 +63,18 @@ fn move_out_by_subslice() -> () {
         drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:11:25: 11:26
         _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:11:13: 11:27
         drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
         drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:11:9: 11:10
         StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:12:10: 12:17
@@ -83,29 +83,29 @@ fn move_out_by_subslice() -> () {
         drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:13:1: 13:2
         drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb7]
         StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
         return;                          // scope 0 at $DIR/uniform_array_move_out.rs:13:2: 13:2
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb6]
         drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:13:1: 13:2
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb3]
         drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb1, bb2, bb4, bb10]
         drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:11:26: 11:27
     }
 
-    bb12 (cleanup): {
+    bb12 (cleanup): {                    // preds: [bb0, bb5, bb7, bb9, bb11]
         resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:10:1: 13:2
     }
 }

--- a/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
+++ b/src/test/mir-opt/uniform_array_move_out.move_out_from_end.mir_map.0.mir
@@ -25,7 +25,7 @@ fn move_out_from_end() -> () {
     scope 3 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
         StorageLive(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         _3 = SizeOf(i32);                // scope 2 at $DIR/uniform_array_move_out.rs:5:14: 5:19
@@ -36,7 +36,7 @@ fn move_out_from_end() -> () {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         _6 = ShallowInitBox(move _5, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:14: 5:19
         (*_6) = const 1_i32;             // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
@@ -44,7 +44,7 @@ fn move_out_from_end() -> () {
         drop(_6) -> [return: bb2, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_6);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:18: 5:19
         StorageLive(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         _8 = SizeOf(i32);                // scope 3 at $DIR/uniform_array_move_out.rs:5:21: 5:26
@@ -55,7 +55,7 @@ fn move_out_from_end() -> () {
                                          // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageLive(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         _11 = ShallowInitBox(move _10, i32); // scope 0 at $DIR/uniform_array_move_out.rs:5:21: 5:26
         (*_11) = const 2_i32;            // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
@@ -63,18 +63,18 @@ fn move_out_from_end() -> () {
         drop(_11) -> [return: bb4, unwind: bb10]; // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_11);                // scope 0 at $DIR/uniform_array_move_out.rs:5:25: 5:26
         _1 = [move _2, move _7];         // scope 0 at $DIR/uniform_array_move_out.rs:5:13: 5:27
         drop(_7) -> [return: bb5, unwind: bb11]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_7);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
         drop(_2) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb5]
         StorageDead(_2);                 // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
         FakeRead(ForLet(None), _1);      // scope 0 at $DIR/uniform_array_move_out.rs:5:9: 5:10
         StorageLive(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:6:14: 6:16
@@ -83,29 +83,29 @@ fn move_out_from_end() -> () {
         drop(_12) -> [return: bb7, unwind: bb9]; // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb6]
         StorageDead(_12);                // scope 1 at $DIR/uniform_array_move_out.rs:7:1: 7:2
         drop(_1) -> [return: bb8, unwind: bb12]; // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb7]
         StorageDead(_1);                 // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
         return;                          // scope 0 at $DIR/uniform_array_move_out.rs:7:2: 7:2
     }
 
-    bb9 (cleanup): {
+    bb9 (cleanup): {                     // preds: [bb6]
         drop(_1) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:7:1: 7:2
     }
 
-    bb10 (cleanup): {
+    bb10 (cleanup): {                    // preds: [bb3]
         drop(_7) -> bb11;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb11 (cleanup): {
+    bb11 (cleanup): {                    // preds: [bb1, bb2, bb4, bb10]
         drop(_2) -> bb12;                // scope 0 at $DIR/uniform_array_move_out.rs:5:26: 5:27
     }
 
-    bb12 (cleanup): {
+    bb12 (cleanup): {                    // preds: [bb0, bb5, bb7, bb9, bb11]
         resume;                          // scope 0 at $DIR/uniform_array_move_out.rs:4:1: 7:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_never.SimplifyLocals.after.mir
@@ -10,7 +10,7 @@ fn process_never(_1: *const !) -> () {
     scope 2 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:8:8: 8:14
         _2 = &(*_1);                     // scope 2 at $DIR/uninhabited-enum.rs:8:26: 8:33
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:9:1: 9:2

--- a/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/uninhabited_enum.process_void.SimplifyLocals.after.mir
@@ -10,7 +10,7 @@ fn process_void(_1: *const Void) -> () {
     scope 2 {
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:14:8: 14:14
         _2 = &(*_1);                     // scope 2 at $DIR/uninhabited-enum.rs:14:26: 14:33
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited-enum.rs:17:1: 17:2

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -12,7 +12,7 @@ fn main() -> () {
     let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
     let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
@@ -36,7 +36,7 @@ fn main() -> () {
         switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
         _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                          // ty::Const
@@ -50,7 +50,7 @@ fn main() -> () {
         goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // ty::Const
                                          // + ty: &str
@@ -61,7 +61,7 @@ fn main() -> () {
         goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1, bb2]
         StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
         StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -13,7 +13,7 @@
       let mut _8: isize;                   // in scope 0 at $DIR/uninhabited_enum_branching.rs:27:9: 27:17
       let _9: &str;                        // in scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
@@ -22,7 +22,7 @@
 +         switchInt(move _3) -> bb1;       // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
           _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                            // ty::Const
@@ -36,7 +36,8 @@
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
++     bb2: {                               // preds: []
           _1 = const "A(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
                                            // ty::Const
                                            // + ty: &str
@@ -47,7 +48,8 @@
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
       }
   
-      bb3: {
+-     bb3: {                               // preds: [bb0]
++     bb3: {                               // preds: []
           StorageLive(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
           _4 = const "B(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
                                            // ty::Const
@@ -61,7 +63,7 @@
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb1, bb2, bb3]
           StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
           StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
@@ -71,7 +73,7 @@
           switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb4]
           StorageLive(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
           _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                            // ty::Const
@@ -85,7 +87,7 @@
           goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb4]
           _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // ty::Const
                                            // + ty: &str
@@ -96,7 +98,7 @@
           goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
       }
   
-      bb7: {
+      bb7: {                               // preds: [bb5, bb6]
           StorageDead(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
           StorageDead(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:29:6: 29:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching.rs:19:11: 30:2

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -19,7 +19,7 @@ fn main() -> () {
         debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
@@ -33,7 +33,7 @@ fn main() -> () {
         switchInt(move _5) -> [2_isize: bb2, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
         _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                          // ty::Const
@@ -47,7 +47,7 @@ fn main() -> () {
         goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb0]
         StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
         _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                          // ty::Const
@@ -61,7 +61,7 @@ fn main() -> () {
         goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb1, bb2]
         StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
         StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
         StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
@@ -69,7 +69,7 @@ fn main() -> () {
         switchInt(move _10) -> [2_isize: bb5, otherwise: bb4]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
         _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                          // ty::Const
@@ -83,7 +83,7 @@ fn main() -> () {
         goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb3]
         StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
         _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                          // ty::Const
@@ -97,7 +97,7 @@ fn main() -> () {
         goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb4, bb5]
         StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:33:6: 33:7
         _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 34:2
         StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:1: 34:2

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -20,7 +20,7 @@
           debug plop => _1;                // in scope 1 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
@@ -35,7 +35,7 @@
 +         switchInt(move _5) -> [2_isize: bb4, otherwise: bb1]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:21:5: 21:22
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           StorageLive(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
           _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                            // ty::Const
@@ -49,7 +49,8 @@
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
       }
   
-      bb2: {
+-     bb2: {                               // preds: [bb0]
++     bb2: {                               // preds: []
           _3 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
                                            // ty::Const
                                            // + ty: &str
@@ -60,7 +61,8 @@
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
       }
   
-      bb3: {
+-     bb3: {                               // preds: [bb0]
++     bb3: {                               // preds: []
           StorageLive(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
           _6 = const "B(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
                                            // ty::Const
@@ -74,7 +76,7 @@
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb0]
           StorageLive(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
           _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                            // ty::Const
@@ -88,7 +90,7 @@
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
       }
   
-      bb5: {
+      bb5: {                               // preds: [bb1, bb2, bb3, bb4]
           StorageDead(_4);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
           StorageDead(_3);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:26:6: 26:7
           StorageLive(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 33:6
@@ -97,7 +99,7 @@
 +         switchInt(move _10) -> [2_isize: bb9, otherwise: bb6]; // scope 1 at $DIR/uninhabited_enum_branching2.rs:28:5: 28:21
       }
   
-      bb6: {
+      bb6: {                               // preds: [bb5]
           StorageLive(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
           _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                            // ty::Const
@@ -111,7 +113,8 @@
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
       }
   
-      bb7: {
+-     bb7: {                               // preds: [bb5]
++     bb7: {                               // preds: []
           _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // ty::Const
                                            // + ty: &str
@@ -122,7 +125,8 @@
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
       }
   
-      bb8: {
+-     bb8: {                               // preds: [bb5]
++     bb8: {                               // preds: []
           StorageLive(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
           _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
                                            // ty::Const
@@ -136,7 +140,7 @@
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
       }
   
-      bb9: {
+      bb9: {                               // preds: [bb5]
           StorageLive(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
           _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                            // ty::Const
@@ -150,7 +154,7 @@
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
       }
   
-      bb10: {
+      bb10: {                              // preds: [bb6, bb7, bb8, bb9]
           StorageDead(_9);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:33:6: 33:7
           _0 = const ();                   // scope 0 at $DIR/uninhabited_enum_branching2.rs:18:11: 34:2
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:34:1: 34:2

--- a/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable.main.UnreachablePropagation.diff
@@ -17,7 +17,7 @@
           debug _y => _4;                  // in scope 2 at $DIR/unreachable.rs:10:13: 10:19
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/unreachable.rs:9:23: 9:30
           _1 = empty() -> bb1;             // scope 0 at $DIR/unreachable.rs:9:23: 9:30
                                            // mir::Constant
@@ -25,13 +25,13 @@
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _2 = discriminant(_1);           // scope 0 at $DIR/unreachable.rs:9:12: 9:20
 -         switchInt(move _2) -> [1_isize: bb2, otherwise: bb6]; // scope 0 at $DIR/unreachable.rs:9:12: 9:20
 +         goto -> bb2;                     // scope 0 at $DIR/unreachable.rs:9:12: 9:20
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
 -         StorageLive(_3);                 // scope 0 at $DIR/unreachable.rs:9:17: 9:19
 -         _3 = move ((_1 as Some).0: Empty); // scope 0 at $DIR/unreachable.rs:9:17: 9:19
 -         StorageLive(_4);                 // scope 0 at $DIR/unreachable.rs:10:13: 10:19
@@ -41,26 +41,26 @@
 -         switchInt(move _6) -> [false: bb4, otherwise: bb3]; // scope 2 at $DIR/unreachable.rs:12:12: 12:16
 -     }
 - 
--     bb3: {
+-     bb3: {                               // preds: [bb2]
 -         _4 = const 21_i32;               // scope 2 at $DIR/unreachable.rs:13:13: 13:20
 -         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:12:17: 14:10
 -         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 
--     bb4: {
+-     bb4: {                               // preds: [bb2]
 -         _4 = const 42_i32;               // scope 2 at $DIR/unreachable.rs:15:13: 15:20
 -         _5 = const ();                   // scope 2 at $DIR/unreachable.rs:14:16: 16:10
 -         goto -> bb5;                     // scope 2 at $DIR/unreachable.rs:12:9: 16:10
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb3, bb4]
 -         StorageDead(_6);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
 -         StorageDead(_5);                 // scope 2 at $DIR/unreachable.rs:16:9: 16:10
 -         StorageLive(_7);                 // scope 2 at $DIR/unreachable.rs:18:9: 18:21
 -         unreachable;                     // scope 2 at $DIR/unreachable.rs:18:15: 18:17
 -     }
 - 
--     bb6: {
+-     bb6: {                               // preds: [bb1]
           _0 = const ();                   // scope 0 at $DIR/unreachable.rs:19:6: 19:6
           StorageDead(_1);                 // scope 0 at $DIR/unreachable.rs:20:1: 20:2
           return;                          // scope 0 at $DIR/unreachable.rs:20:2: 20:2

--- a/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
+++ b/src/test/mir-opt/unreachable_diverging.main.UnreachablePropagation.diff
@@ -17,7 +17,7 @@
           }
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:13:9: 13:10
           _1 = const true;                 // scope 0 at $DIR/unreachable_diverging.rs:13:13: 13:17
           StorageLive(_2);                 // scope 1 at $DIR/unreachable_diverging.rs:14:25: 14:32
@@ -27,13 +27,13 @@
                                            // + literal: Const { ty: fn() -> std::option::Option<Empty> {empty}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           _3 = discriminant(_2);           // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
 -         switchInt(move _3) -> [1_isize: bb2, otherwise: bb6]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
 +         switchInt(move _3) -> [1_isize: bb2, otherwise: bb5]; // scope 1 at $DIR/unreachable_diverging.rs:14:12: 14:22
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           StorageLive(_4);                 // scope 1 at $DIR/unreachable_diverging.rs:14:17: 14:21
           _4 = move ((_2 as Some).0: Empty); // scope 1 at $DIR/unreachable_diverging.rs:14:17: 14:21
           StorageLive(_5);                 // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
@@ -43,7 +43,7 @@
 +         goto -> bb3;                     // scope 1 at $DIR/unreachable_diverging.rs:15:12: 15:13
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb2]
 -         _5 = loop_forever() -> bb5;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
 +         _5 = loop_forever() -> bb4;      // scope 1 at $DIR/unreachable_diverging.rs:16:13: 16:27
                                            // mir::Constant
@@ -51,20 +51,21 @@
                                            // + literal: Const { ty: fn() {loop_forever}, val: Value(Scalar(<ZST>)) }
       }
   
-      bb4: {
+-     bb4: {                               // preds: [bb2]
 -         _5 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:17:10: 17:10
 -         goto -> bb5;                     // scope 1 at $DIR/unreachable_diverging.rs:15:9: 17:10
 -     }
 - 
--     bb5: {
+-     bb5: {                               // preds: [bb3, bb4]
++     bb4: {                               // preds: [bb3]
           StorageDead(_6);                 // scope 1 at $DIR/unreachable_diverging.rs:17:9: 17:10
           StorageDead(_5);                 // scope 1 at $DIR/unreachable_diverging.rs:17:9: 17:10
           StorageLive(_7);                 // scope 1 at $DIR/unreachable_diverging.rs:18:9: 18:22
           unreachable;                     // scope 1 at $DIR/unreachable_diverging.rs:18:15: 18:19
       }
   
--     bb6: {
-+     bb5: {
+-     bb6: {                               // preds: [bb1]
++     bb5: {                               // preds: [bb1]
           _0 = const ();                   // scope 1 at $DIR/unreachable_diverging.rs:19:6: 19:6
           StorageDead(_1);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2
           StorageDead(_2);                 // scope 0 at $DIR/unreachable_diverging.rs:20:1: 20:2

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.32bit.mir
@@ -3,7 +3,7 @@
 E::V::{constant#0}: isize = {
     let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }

--- a/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.E-V-{constant#0}.mir_map.0.64bit.mir
@@ -3,7 +3,7 @@
 E::V::{constant#0}: isize = {
     let mut _0: isize;                   // return place in scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 5_isize;              // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
         return;                          // scope 0 at $DIR/unusual-item-types.rs:22:9: 22:10
     }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -3,7 +3,7 @@
 fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
-    bb0: {
+    bb0: {                               // preds: []
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -3,7 +3,7 @@
 fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
-    bb0: {
+    bb0: {                               // preds: []
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.32bit.mir
@@ -5,31 +5,31 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb3]
         return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb4, bb5]
         resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb5]
         goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb6]
         drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb6]
         drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb0]
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant

--- a/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.64bit.mir
@@ -5,31 +5,31 @@ fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _2: &mut std::vec::Vec<i32>; // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     let mut _3: ();                      // in scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb6;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb3]
         return;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb2 (cleanup): {
+    bb2 (cleanup): {                     // preds: [bb4, bb5]
         resume;                          // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb5]
         goto -> bb1;                     // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb4 (cleanup): {
+    bb4 (cleanup): {                     // preds: [bb6]
         drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> bb2; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb6]
         drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb0]
         _2 = &mut (*_1);                 // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
         _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4]; // scope 0 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
                                          // mir::Constant

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.32bit.mir
@@ -3,7 +3,7 @@
 const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 = {
     let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }

--- a/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.{impl#0}-ASSOCIATED_CONSTANT.mir_map.0.64bit.mir
@@ -3,7 +3,7 @@
 const <impl at $DIR/unusual-item-types.rs:9:1: 11:2>::ASSOCIATED_CONSTANT: i32 = {
     let mut _0: i32;                     // return place in scope 0 at $DIR/unusual-item-types.rs:10:32: 10:35
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 2_i32;                // scope 0 at $DIR/unusual-item-types.rs:10:38: 10:39
         return;                          // scope 0 at $DIR/unusual-item-types.rs:10:5: 10:40
     }

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
@@ -15,7 +15,7 @@
           debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
           _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
@@ -26,24 +26,24 @@
 +         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
           nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1]
           StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           goto -> bb4;                     // scope 1 at no-location
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
           return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
@@ -15,7 +15,7 @@
           debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
       }
   
-      bb0: {
+      bb0: {                               // preds: []
           StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
           _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
@@ -26,24 +26,24 @@
 +         switchInt(const 0_isize) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
-      bb1: {
+      bb1: {                               // preds: [bb0]
           switchInt(((_3 as Some).0: u32)) -> [0_u32: bb2, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
       }
   
-      bb2: {
+      bb2: {                               // preds: [bb1]
           _1 = const 1_i32;                // scope 1 at $DIR/while_let_loops.rs:8:9: 8:15
           nop;                             // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
           goto -> bb4;                     // scope 1 at $DIR/while_let_loops.rs:9:9: 9:14
       }
   
-      bb3: {
+      bb3: {                               // preds: [bb0, bb1]
           StorageLive(_7);                 // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           nop;                             // scope 1 at $DIR/while_let_loops.rs:7:5: 10:6
           StorageDead(_7);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           goto -> bb4;                     // scope 1 at no-location
       }
   
-      bb4: {
+      bb4: {                               // preds: [bb2, bb3]
           StorageDead(_3);                 // scope 1 at $DIR/while_let_loops.rs:10:5: 10:6
           StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2
           return;                          // scope 0 at $DIR/while_let_loops.rs:11:2: 11:2

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.32bit.mir
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.32bit.mir
@@ -7,7 +7,7 @@ fn change_loop_body() -> () {
         debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
         _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
         StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2

--- a/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.64bit.mir
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.PreCodegen.after.64bit.mir
@@ -7,7 +7,7 @@ fn change_loop_body() -> () {
         debug _x => _1;                  // in scope 1 at $DIR/while_let_loops.rs:6:9: 6:15
     }
 
-    bb0: {
+    bb0: {                               // preds: []
         StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
         _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
         StorageDead(_1);                 // scope 0 at $DIR/while_let_loops.rs:11:1: 11:2

--- a/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
+++ b/src/test/mir-opt/while_storage.while_loop.PreCodegen.after.mir
@@ -8,11 +8,11 @@ fn while_loop(_1: bool) -> () {
     let mut _4: bool;                    // in scope 0 at $DIR/while-storage.rs:11:12: 11:23
     let mut _5: bool;                    // in scope 0 at $DIR/while-storage.rs:11:21: 11:22
 
-    bb0: {
+    bb0: {                               // preds: []
         goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0, bb6]
         StorageLive(_2);                 // scope 0 at $DIR/while-storage.rs:10:11: 10:22
         StorageLive(_3);                 // scope 0 at $DIR/while-storage.rs:10:20: 10:21
         _3 = _1;                         // scope 0 at $DIR/while-storage.rs:10:20: 10:21
@@ -22,12 +22,12 @@ fn while_loop(_1: bool) -> () {
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb2: {
+    bb2: {                               // preds: [bb1]
         StorageDead(_3);                 // scope 0 at $DIR/while-storage.rs:10:21: 10:22
         switchInt(move _2) -> [false: bb7, otherwise: bb3]; // scope 0 at $DIR/while-storage.rs:10:11: 10:22
     }
 
-    bb3: {
+    bb3: {                               // preds: [bb2]
         StorageLive(_4);                 // scope 0 at $DIR/while-storage.rs:11:12: 11:23
         StorageLive(_5);                 // scope 0 at $DIR/while-storage.rs:11:21: 11:22
         _5 = _1;                         // scope 0 at $DIR/while-storage.rs:11:21: 11:22
@@ -37,27 +37,27 @@ fn while_loop(_1: bool) -> () {
                                          // + literal: Const { ty: fn(bool) -> bool {get_bool}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb4: {
+    bb4: {                               // preds: [bb3]
         StorageDead(_5);                 // scope 0 at $DIR/while-storage.rs:11:22: 11:23
         switchInt(move _4) -> [false: bb6, otherwise: bb5]; // scope 0 at $DIR/while-storage.rs:11:12: 11:23
     }
 
-    bb5: {
+    bb5: {                               // preds: [bb4]
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
         goto -> bb8;                     // scope 0 at no-location
     }
 
-    bb6: {
+    bb6: {                               // preds: [bb4]
         StorageDead(_4);                 // scope 0 at $DIR/while-storage.rs:13:9: 13:10
         StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
         goto -> bb1;                     // scope 0 at $DIR/while-storage.rs:10:5: 14:6
     }
 
-    bb7: {
+    bb7: {                               // preds: [bb2]
         goto -> bb8;                     // scope 0 at no-location
     }
 
-    bb8: {
+    bb8: {                               // preds: [bb5, bb7]
         StorageDead(_2);                 // scope 0 at $DIR/while-storage.rs:14:5: 14:6
         return;                          // scope 0 at $DIR/while-storage.rs:15:2: 15:2
     }

--- a/src/test/run-make/const_fn_mir/dump.mir
+++ b/src/test/run-make/const_fn_mir/dump.mir
@@ -3,7 +3,7 @@
 fn foo() -> i32 {
     let mut _0: i32;                     // return place in scope 0 at main.rs:4:19: 4:22
 
-    bb0: {
+    bb0: {                               // preds: []
         _0 = const 11_i32;               // scope 0 at main.rs:5:5: 5:10
         return;                          // scope 0 at main.rs:6:2: 6:2
     }
@@ -14,12 +14,12 @@ fn foo() -> i32 {
     let mut _0: i32;                     // return place in scope 0 at main.rs:4:19: 4:22
     let mut _1: (i32, bool);             // in scope 0 at main.rs:5:5: 5:10
 
-    bb0: {
+    bb0: {                               // preds: []
         _1 = CheckedAdd(const 5_i32, const 6_i32); // scope 0 at main.rs:5:5: 5:10
         assert(!move (_1.1: bool), "attempt to compute `{} + {}`, which would overflow", const 5_i32, const 6_i32) -> bb1; // scope 0 at main.rs:5:5: 5:10
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         _0 = move (_1.0: i32);           // scope 0 at main.rs:5:5: 5:10
         return;                          // scope 0 at main.rs:6:2: 6:2
     }
@@ -29,14 +29,14 @@ fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at main.rs:8:11: 8:11
     let _1: i32;                         // in scope 0 at main.rs:9:5: 9:10
 
-    bb0: {
+    bb0: {                               // preds: []
         _1 = foo() -> bb1;               // scope 0 at main.rs:9:5: 9:10
                                          // mir::Constant
                                          // + span: main.rs:9:5: 9:8
                                          // + literal: Const { ty: fn() -> i32 {foo}, val: Value(Scalar(<ZST>)) }
     }
 
-    bb1: {
+    bb1: {                               // preds: [bb0]
         return;                          // scope 0 at main.rs:10:2: 10:2
     }
 }


### PR DESCRIPTION
Similiar to how LLVM-IR includes `; preds = %bb1` in its textual output.
Makes it a bit nicer to read mir dumps.