### PR TITLE
Add Range offset

### DIFF
--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -96,6 +96,44 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     }
 }
 
+impl<Idx: Add<Idx> + Copy> Range<Idx> {
+    /// Returns a new `Range` analogous to this range, but moved to the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 0..3;
+    /// assert_eq!(&"Hello"[2..][r], "llo");
+    /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_to(&self, position: Idx) -> Range<Idx> {
+        (position+self.start)..(position+self.end)
+    }
+}
+
+impl<Idx: Sub<Idx> + Copy> Range<Idx> {
+    /// Returns a new `Range` analogous to this range, but moved from the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 2..5;
+    /// assert_eq!(&"Hello"[r], "llo");
+    /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[2..][r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_from(&self, position: Idx) -> Range<Idx> {
+        (self.start-position)..(self.end-position)
+    }
+}
+
 impl<Idx: PartialOrd<Idx>> Range<Idx> {
     /// Returns `true` if `item` is contained in the range.
     ///
@@ -199,6 +237,44 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     }
 }
 
+impl<Idx: Add<Idx> + Copy> RangeFrom<Idx> {
+    /// Returns a new `RangeFrom` analogous to this range, but moved to the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 0..;
+    /// assert_eq!(&"Hello"[2..][r], "llo");
+    /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_to(&self, position: Idx) -> RangeFrom<Idx> {
+        (position+self.start)..
+    }
+}
+
+impl<Idx: Sub<Idx> + Copy> RangeFrom<Idx> {
+    /// Returns a new `RangeFrom` analogous to this range, but moved from the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 2..;
+    /// assert_eq!(&"Hello"[r], "llo");
+    /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[2..][r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_from(&self, position: Idx) -> RangeFrom<Idx> {
+        (self.start-position)..
+    }
+}
+
 impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
     /// Returns `true` if `item` is contained in the range.
     ///
@@ -280,6 +356,44 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     }
 }
 
+impl<Idx: Add<Idx> + Copy> RangeTo<Idx> {
+    /// Returns a new `RangeTo` analogous to this range, but moved to the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = ..3;
+    /// assert_eq!(&"Hello"[2..][r], "llo");
+    /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[r_offset], "Hello");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_to(&self, position: Idx) -> RangeTo<Idx> {
+        ..(position+self.end)
+    }
+}
+
+impl<Idx: Sub<Idx> + Copy> RangeTo<Idx> {
+    /// Returns a new `RangeTo` analogous to this range, but moved from the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = ..5;
+    /// assert_eq!(&"Hello"[r], "Hello");
+    /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[2..][r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_from(&self, position: Idx) -> RangeTo<Idx> {
+        ..(self.end-position)
+    }
+}
+
 impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
     /// Returns `true` if `item` is contained in the range.
     ///
@@ -354,6 +468,52 @@ pub struct RangeInclusive<Idx> {
     //
     // This is required to support PartialEq and Hash without a PartialOrd bound or specialization.
     pub(crate) exhausted: bool,
+}
+
+impl<Idx: Add<Idx> + Copy> RangeInclusive<Idx> {
+    /// Returns a new `RangeInclusive` analogous to this range, but moved to the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 0..=2;
+    /// assert_eq!(&"Hello"[2..][r], "llo");
+    /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_to(&self, position: Idx) -> RangeInclusive<Idx> {
+        Self {
+            start: position+self.start,
+            end: position+self.end,
+            exhausted: self.exhausted,
+        }
+    }
+}
+
+impl<Idx: Sub<Idx> + Copy> RangeInclusive<Idx> {
+    /// Returns a new `RangeInclusive` analogous to this range, but moved from the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = 2..=4;
+    /// assert_eq!(&"Hello"[r], "llo");
+    /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[2..][r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_from(&self, position: Idx) -> RangeInclusive<Idx> {
+        Self {
+            start: self.start-position,
+            end: self.end-position,
+            exhausted: self.exhausted,
+        }
+    }
 }
 
 impl<Idx> RangeInclusive<Idx> {
@@ -595,6 +755,44 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeToInclusive<Idx> {
         write!(fmt, "..=")?;
         self.end.fmt(fmt)?;
         Ok(())
+    }
+}
+
+impl<Idx: Add<Idx> + Copy> RangeToInclusive<Idx> {
+    /// Returns a new `RangeToInclusive` analogous to this range, but moved to the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = ..=2;
+    /// assert_eq!(&"Hello"[2..][r], "llo");
+    /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[r_offset], "Hello");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_to(&self, position: Idx) -> RangeToInclusive<Idx> {
+        ..=position+self.end
+    }
+}
+
+impl<Idx: Sub<Idx> + Copy> RangeToInclusive<Idx> {
+    /// Returns a new `RangeToInclusive` analogous to this range, but moved from the
+    /// given position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(range_offset)]
+    /// let r = ..=4;
+    /// assert_eq!(&"Hello"[r], "Hello");
+    /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[2..][r_offset], "llo");
+    /// ```
+    #[unstable(feature = "range_offset", issue = "none")]
+    pub fn offset_from(&self, position: Idx) -> RangeToInclusive<Idx> {
+        ..=self.end-position
     }
 }
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -113,7 +113,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> Range<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_to(&self, position: Idx) -> Range<Idx> {
-        (position+self.start)..(position+self.end)
+        (position + self.start)..(position + self.end)
     }
 }
 
@@ -132,7 +132,7 @@ impl<Idx: Sub<Idx, Output=Idx> + Copy> Range<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_from(&self, position: Idx) -> Range<Idx> {
-        (self.start-position)..(self.end-position)
+        (self.start - position)..(self.end - position)
     }
 }
 
@@ -254,7 +254,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_to(&self, position: Idx) -> RangeFrom<Idx> {
-        (position+self.start)..
+        (position + self.start)..
     }
 }
 
@@ -273,7 +273,7 @@ impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_from(&self, position: Idx) -> RangeFrom<Idx> {
-        (self.start-position)..
+        (self.start - position)..
     }
 }
 
@@ -373,7 +373,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeTo<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_to(&self, position: Idx) -> RangeTo<Idx> {
-        ..(position+self.end)
+        ..(position + self.end)
     }
 }
 
@@ -392,7 +392,7 @@ impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeTo<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_from(&self, position: Idx) -> RangeTo<Idx> {
-        ..(self.end-position)
+        ..(self.end - position)
     }
 }
 
@@ -487,11 +487,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_to(&self, position: Idx) -> RangeInclusive<Idx> {
-        Self {
-            start: position+self.start,
-            end: position+self.end,
-            exhausted: self.exhausted,
-        }
+        Self { start: position + self.start, end: position + self.end, exhausted: self.exhausted }
     }
 }
 
@@ -510,11 +506,7 @@ impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_from(&self, position: Idx) -> RangeInclusive<Idx> {
-        Self {
-            start: self.start-position,
-            end: self.end-position,
-            exhausted: self.exhausted,
-        }
+        Self { start: self.start - position, end: self.end - position, exhausted: self.exhausted }
     }
 }
 
@@ -775,7 +767,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_to(&self, position: Idx) -> RangeToInclusive<Idx> {
-        ..=position+self.end
+        ..=(position + self.end)
     }
 }
 
@@ -794,7 +786,7 @@ impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
     pub fn offset_from(&self, position: Idx) -> RangeToInclusive<Idx> {
-        ..=self.end-position
+        ..=(self.end - position)
     }
 }
 

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -98,7 +98,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     }
 }
 
-impl<Idx: Add<Idx, Output=Idx> + Copy> Range<Idx> {
+impl<Idx: Add<Idx, Output = Idx> + Copy> Range<Idx> {
     /// Returns a new `Range` analogous to this range, but moved to the
     /// given position.
     ///
@@ -117,7 +117,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> Range<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx, Output=Idx> + Copy> Range<Idx> {
+impl<Idx: Sub<Idx, Output = Idx> + Copy> Range<Idx> {
     /// Returns a new `Range` analogous to this range, but moved from the
     /// given position.
     ///
@@ -239,7 +239,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     }
 }
 
-impl<Idx: Add<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
+impl<Idx: Add<Idx, Output = Idx> + Copy> RangeFrom<Idx> {
     /// Returns a new `RangeFrom` analogous to this range, but moved to the
     /// given position.
     ///
@@ -258,7 +258,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
+impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeFrom<Idx> {
     /// Returns a new `RangeFrom` analogous to this range, but moved from the
     /// given position.
     ///
@@ -358,7 +358,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     }
 }
 
-impl<Idx: Add<Idx, Output=Idx> + Copy> RangeTo<Idx> {
+impl<Idx: Add<Idx, Output = Idx> + Copy> RangeTo<Idx> {
     /// Returns a new `RangeTo` analogous to this range, but moved to the
     /// given position.
     ///
@@ -377,7 +377,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeTo<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeTo<Idx> {
+impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeTo<Idx> {
     /// Returns a new `RangeTo` analogous to this range, but moved from the
     /// given position.
     ///
@@ -472,7 +472,7 @@ pub struct RangeInclusive<Idx> {
     pub(crate) exhausted: bool,
 }
 
-impl<Idx: Add<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
+impl<Idx: Add<Idx, Output = Idx> + Copy> RangeInclusive<Idx> {
     /// Returns a new `RangeInclusive` analogous to this range, but moved to the
     /// given position.
     ///
@@ -491,7 +491,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
+impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeInclusive<Idx> {
     /// Returns a new `RangeInclusive` analogous to this range, but moved from the
     /// given position.
     ///
@@ -752,7 +752,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeToInclusive<Idx> {
     }
 }
 
-impl<Idx: Add<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
+impl<Idx: Add<Idx, Output = Idx> + Copy> RangeToInclusive<Idx> {
     /// Returns a new `RangeToInclusive` analogous to this range, but moved to the
     /// given position.
     ///
@@ -771,7 +771,7 @@ impl<Idx: Add<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
+impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeToInclusive<Idx> {
     /// Returns a new `RangeToInclusive` analogous to this range, but moved from the
     /// given position.
     ///

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -107,8 +107,8 @@ impl<Idx: Add<Idx, Output = Idx> + Copy> Range<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 0..3;
-    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// assert_eq!(&"Hello"[r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -126,8 +126,8 @@ impl<Idx: Sub<Idx, Output = Idx> + Copy> Range<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 2..5;
-    /// assert_eq!(&"Hello"[r], "llo");
     /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[r], "llo");
     /// assert_eq!(&"Hello"[2..][r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -248,8 +248,8 @@ impl<Idx: Add<Idx, Output = Idx> + Copy> RangeFrom<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 0..;
-    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// assert_eq!(&"Hello"[r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -267,8 +267,8 @@ impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeFrom<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 2..;
-    /// assert_eq!(&"Hello"[r], "llo");
     /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[r], "llo");
     /// assert_eq!(&"Hello"[2..][r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -367,8 +367,8 @@ impl<Idx: Add<Idx, Output = Idx> + Copy> RangeTo<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = ..3;
-    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// assert_eq!(&"Hello"[r_offset], "Hello");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -386,8 +386,8 @@ impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeTo<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = ..5;
-    /// assert_eq!(&"Hello"[r], "Hello");
     /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[r], "Hello");
     /// assert_eq!(&"Hello"[2..][r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -481,8 +481,8 @@ impl<Idx: Add<Idx, Output = Idx> + Copy> RangeInclusive<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 0..=2;
-    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// assert_eq!(&"Hello"[r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -500,8 +500,8 @@ impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeInclusive<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = 2..=4;
-    /// assert_eq!(&"Hello"[r], "llo");
     /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[r], "llo");
     /// assert_eq!(&"Hello"[2..][r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -761,8 +761,8 @@ impl<Idx: Add<Idx, Output = Idx> + Copy> RangeToInclusive<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = ..=2;
-    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// let r_offset = r.offset_to(2);
+    /// assert_eq!(&"Hello"[2..][r], "llo");
     /// assert_eq!(&"Hello"[r_offset], "Hello");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]
@@ -780,8 +780,8 @@ impl<Idx: Sub<Idx, Output = Idx> + Copy> RangeToInclusive<Idx> {
     /// ```
     /// #![feature(range_offset)]
     /// let r = ..=4;
-    /// assert_eq!(&"Hello"[r], "Hello");
     /// let r_offset = r.offset_from(2);
+    /// assert_eq!(&"Hello"[r], "Hello");
     /// assert_eq!(&"Hello"[2..][r_offset], "llo");
     /// ```
     #[unstable(feature = "range_offset", issue = "none")]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -1,5 +1,7 @@
 use crate::fmt;
 use crate::hash::Hash;
+use crate::ops::Add;
+use crate::ops::Sub;
 
 /// An unbounded range (`..`).
 ///

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -98,7 +98,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     }
 }
 
-impl<Idx: Add<Idx> + Copy> Range<Idx> {
+impl<Idx: Add<Idx, Output=Idx> + Copy> Range<Idx> {
     /// Returns a new `Range` analogous to this range, but moved to the
     /// given position.
     ///
@@ -117,7 +117,7 @@ impl<Idx: Add<Idx> + Copy> Range<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx> + Copy> Range<Idx> {
+impl<Idx: Sub<Idx, Output=Idx> + Copy> Range<Idx> {
     /// Returns a new `Range` analogous to this range, but moved from the
     /// given position.
     ///
@@ -239,7 +239,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     }
 }
 
-impl<Idx: Add<Idx> + Copy> RangeFrom<Idx> {
+impl<Idx: Add<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
     /// Returns a new `RangeFrom` analogous to this range, but moved to the
     /// given position.
     ///
@@ -258,7 +258,7 @@ impl<Idx: Add<Idx> + Copy> RangeFrom<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx> + Copy> RangeFrom<Idx> {
+impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeFrom<Idx> {
     /// Returns a new `RangeFrom` analogous to this range, but moved from the
     /// given position.
     ///
@@ -358,7 +358,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     }
 }
 
-impl<Idx: Add<Idx> + Copy> RangeTo<Idx> {
+impl<Idx: Add<Idx, Output=Idx> + Copy> RangeTo<Idx> {
     /// Returns a new `RangeTo` analogous to this range, but moved to the
     /// given position.
     ///
@@ -377,7 +377,7 @@ impl<Idx: Add<Idx> + Copy> RangeTo<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx> + Copy> RangeTo<Idx> {
+impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeTo<Idx> {
     /// Returns a new `RangeTo` analogous to this range, but moved from the
     /// given position.
     ///
@@ -472,7 +472,7 @@ pub struct RangeInclusive<Idx> {
     pub(crate) exhausted: bool,
 }
 
-impl<Idx: Add<Idx> + Copy> RangeInclusive<Idx> {
+impl<Idx: Add<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
     /// Returns a new `RangeInclusive` analogous to this range, but moved to the
     /// given position.
     ///
@@ -495,7 +495,7 @@ impl<Idx: Add<Idx> + Copy> RangeInclusive<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx> + Copy> RangeInclusive<Idx> {
+impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeInclusive<Idx> {
     /// Returns a new `RangeInclusive` analogous to this range, but moved from the
     /// given position.
     ///
@@ -760,7 +760,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeToInclusive<Idx> {
     }
 }
 
-impl<Idx: Add<Idx> + Copy> RangeToInclusive<Idx> {
+impl<Idx: Add<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
     /// Returns a new `RangeToInclusive` analogous to this range, but moved to the
     /// given position.
     ///
@@ -779,7 +779,7 @@ impl<Idx: Add<Idx> + Copy> RangeToInclusive<Idx> {
     }
 }
 
-impl<Idx: Sub<Idx> + Copy> RangeToInclusive<Idx> {
+impl<Idx: Sub<Idx, Output=Idx> + Copy> RangeToInclusive<Idx> {
     /// Returns a new `RangeToInclusive` analogous to this range, but moved from the
     /// given position.
     ///


### PR DESCRIPTION
This PR adds `offset_from` and `offset_to` to the various `Range*` types.

The ones for `RangeTo*` are kinda weird but there's not much to be done about those other than leaving them out entirely...

The use-case that prompted this was:

```rust
        input.replace_range(
            (self.range.start-range.start)..(self.range.end-range.start),
            &self.text,
        );
```

which is *very* error-prone. (easy to miss the `self`, easy to use the wrong side of the range, etc.)