### PR TITLE
remove some indirection from proc_macro_server

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1011,6 +1011,7 @@ impl<'a> ExtCtxt<'a> {
     pub fn source_map(&self) -> &'a SourceMap {
         self.sess.parse_sess.source_map()
     }
+    #[inline]
     pub fn parse_sess(&self) -> &'a ParseSess {
         &self.sess.parse_sess
     }

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -377,6 +377,7 @@ impl<'a, 'b> Rustc<'a, 'b> {
         }
     }
 
+    #[inline]
     fn sess(&self) -> &ParseSess {
         self.ecx.parse_sess()
     }


### PR DESCRIPTION
This is a theoretical fix for the performance regression from [#87264](https://github.com/rust-lang/rust/pull/87264#issuecomment-968061499), based on wild guessing about what may have caused the regression. The patch reduces indirections when getting a `ParseSess` and debug-formatting `Span`s in the proc macro server.