### PR TITLE
remove pref_align_of intrinsic

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -821,7 +821,7 @@ pub(crate) fn codegen_intrinsic_call<'tcx>(
             dest.write_cvalue(fx, val);
         };
 
-        pref_align_of | needs_drop | type_id | type_name | variant_count, () {
+        needs_drop | type_id | type_name | variant_count, () {
             let const_val =
                 fx.tcx.const_eval_instance(ParamEnv::reveal_all(), instance, None).unwrap();
             let val = crate::constant::codegen_const_value(

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -103,11 +103,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     bx.const_usize(bx.layout_of(tp_ty).align.abi.bytes())
                 }
             }
-            sym::pref_align_of
-            | sym::needs_drop
-            | sym::type_id
-            | sym::type_name
-            | sym::variant_count => {
+            sym::needs_drop | sym::type_id | sym::type_name | sym::variant_count => {
                 let value = bx
                     .tcx()
                     .const_eval_instance(ty::ParamEnv::reveal_all(), instance, None)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -981,7 +981,6 @@ symbols! {
         pre_dash_lto: "pre-lto",
         precise_pointer_size_matching,
         precision,
-        pref_align_of,
         prefetch_read_data,
         prefetch_read_instruction,
         prefetch_write_data,

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -164,7 +164,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::abort => (0, Vec::new(), tcx.types.never),
             sym::unreachable => (0, Vec::new(), tcx.types.never),
             sym::breakpoint => (0, Vec::new(), tcx.mk_unit()),
-            sym::size_of | sym::pref_align_of | sym::min_align_of | sym::variant_count => {
+            sym::size_of | sym::min_align_of | sym::variant_count => {
                 (1, Vec::new(), tcx.types.usize)
             }
             sym::size_of_val | sym::min_align_of_val => {

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -808,11 +808,6 @@ extern "rust-intrinsic" {
     /// The stabilized version of this intrinsic is [`core::mem::align_of`].
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
     pub fn min_align_of<T>() -> usize;
-    /// The preferred alignment of a type.
-    ///
-    /// This intrinsic does not have a stable counterpart.
-    #[rustc_const_unstable(feature = "const_pref_align_of", issue = "none")]
-    pub fn pref_align_of<T>() -> usize;
 
     /// The size of the referenced value in bytes.
     ///

--- a/src/test/ui/intrinsics/intrinsic-alignment.rs
+++ b/src/test/ui/intrinsics/intrinsic-alignment.rs
@@ -5,7 +5,6 @@
 
 mod rusti {
     extern "rust-intrinsic" {
-        pub fn pref_align_of<T>() -> usize;
         pub fn min_align_of<T>() -> usize;
     }
 }
@@ -25,18 +24,12 @@ mod rusti {
 mod m {
     #[cfg(target_arch = "x86")]
     pub fn main() {
-        unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 4);
-        }
+        assert_eq!(::rusti::min_align_of::<u64>(), 4);
     }
 
     #[cfg(not(target_arch = "x86"))]
     pub fn main() {
-        unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
-        }
+        assert_eq!(::rusti::min_align_of::<u64>(), 8);
     }
 }
 
@@ -44,20 +37,14 @@ mod m {
 mod m {
     #[cfg(target_arch = "x86_64")]
     pub fn main() {
-        unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
-        }
+        assert_eq!(::rusti::min_align_of::<u64>(), 8);
     }
 }
 
 #[cfg(target_os = "windows")]
 mod m {
     pub fn main() {
-        unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
-        }
+        assert_eq!(::rusti::min_align_of::<u64>(), 8);
     }
 }
 

--- a/src/test/ui/structs-enums/rec-align-u32.rs
+++ b/src/test/ui/structs-enums/rec-align-u32.rs
@@ -9,7 +9,6 @@ use std::mem;
 
 mod rusti {
     extern "rust-intrinsic" {
-        pub fn pref_align_of<T>() -> usize;
         pub fn min_align_of<T>() -> usize;
     }
 }

--- a/src/test/ui/structs-enums/rec-align-u64.rs
+++ b/src/test/ui/structs-enums/rec-align-u64.rs
@@ -11,7 +11,6 @@ use std::mem;
 
 mod rusti {
     extern "rust-intrinsic" {
-        pub fn pref_align_of<T>() -> usize;
         pub fn min_align_of<T>() -> usize;
     }
 }


### PR DESCRIPTION
This intrinsic has never been stably exposed, and its [existence occasionally causes confusion](https://github.com/rust-lang/rust/pull/88839#discussion_r706793496). Preferred alignment still exists as a concept inside the compiler that it might use e.g. for aligning globals, but there seems to be no good reason to expose it to clients. Also see [this discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/pref_align_of.20intrinsic).