### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/dropck.rs
+++ b/compiler/rustc_typeck/src/check/dropck.rs
@@ -240,8 +240,12 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
                     ty::PredicateKind::ConstEvaluatable(a),
                     ty::PredicateKind::ConstEvaluatable(b),
                 ) => tcx.try_unify_abstract_consts((a, b)),
-                (ty::PredicateKind::TypeOutlives(a), ty::PredicateKind::TypeOutlives(b)) => {
-                    relator.relate(predicate.rebind(a.0), p.rebind(b.0)).is_ok()
+                (
+                    ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(ty_a, lt_a)),
+                    ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(ty_b, lt_b)),
+                ) => {
+                    relator.relate(predicate.rebind(ty_a), p.rebind(ty_b)).is_ok()
+                        && relator.relate(predicate.rebind(lt_a), p.rebind(lt_b)).is_ok()
                 }
                 _ => predicate == p,
             }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -952,7 +952,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let mut err = rustc_errors::struct_span_err!(
                         self.sess(),
                         self_ty.span,
-                        E0783,
+                        E0782,
                         "{}",
                         msg,
                     );

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -204,7 +204,6 @@ crate fn get_index_search_type<'tcx>(
 
     inputs.retain(|a| a.ty.name.is_some());
     output.retain(|a| a.ty.name.is_some());
-    let output = if output.is_empty() { None } else { Some(output) };
 
     Some(IndexItemFunctionType { inputs, output })
 }

--- a/src/test/ui/dropck/relate_lt_in_type_outlives_bound.rs
+++ b/src/test/ui/dropck/relate_lt_in_type_outlives_bound.rs
@@ -1,0 +1,13 @@
+struct Wrapper<'a, T>(&'a T)
+where
+    T: 'a;
+
+impl<'a, T> Drop for Wrapper<'a, T>
+where
+    T: 'static,
+    //~^ error: `Drop` impl requires `T: 'static` but the struct it is implemented for does not
+{
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/ui/dropck/relate_lt_in_type_outlives_bound.stderr
+++ b/src/test/ui/dropck/relate_lt_in_type_outlives_bound.stderr
@@ -1,0 +1,17 @@
+error[E0367]: `Drop` impl requires `T: 'static` but the struct it is implemented for does not
+  --> $DIR/relate_lt_in_type_outlives_bound.rs:7:8
+   |
+LL |     T: 'static,
+   |        ^^^^^^^
+   |
+note: the implementor must specify the same requirement
+  --> $DIR/relate_lt_in_type_outlives_bound.rs:1:1
+   |
+LL | / struct Wrapper<'a, T>(&'a T)
+LL | | where
+LL | |     T: 'a;
+   | |__________^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0367`.

--- a/src/test/ui/editions/dyn-trait-sugg-2021.stderr
+++ b/src/test/ui/editions/dyn-trait-sugg-2021.stderr
@@ -1,4 +1,4 @@
-error[E0783]: trait objects without an explicit `dyn` are deprecated
+error[E0782]: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-trait-sugg-2021.rs:10:5
    |
 LL |     Foo::hi(123);
@@ -6,4 +6,4 @@ LL |     Foo::hi(123);
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0783`.
+For more information about this error, try `rustc --explain E0782`.


### PR DESCRIPTION
Successful merges:

 - #90771 (Fix trait object error code)
 - #90840 (relate lifetime in `TypeOutlives` bounds on drop impls)
 - #90853 (rustdoc: Use an empty Vec instead of Option<Vec>)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90771,90840,90853)
<!-- homu-ignore:end -->