### PR TITLE
[Perf Experiment] Introduce `NeverShortCircuit` to see if it helps fold-via-try_fold

### DIFF
--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -184,6 +184,8 @@ pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 pub use self::try_trait::{FromResidual, Try};
 
+pub(crate) use self::try_trait::NeverShortCircuit;
+
 #[unstable(feature = "generator_trait", issue = "43122")]
 pub use self::generator::{Generator, GeneratorState};
 

--- a/src/test/ui/issues/issue-3044.stderr
+++ b/src/test/ui/issues/issue-3044.stderr
@@ -11,7 +11,7 @@ LL | |     });
 note: associated function defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
-LL |     fn fold<B, F>(mut self, init: B, mut f: F) -> B
+LL |     fn fold<B, F>(mut self, init: B, f: F) -> B
    |        ^^^^
 
 error: aborting due to previous error


### PR DESCRIPTION
This was removed a while ago for compilation time reasons, but the user experience would be better if implementing just `try_fold` was enough to also get optimized `fold` -- and at the LLVM level that completely works.

Since the removal we've moved to a different `Try` implementation, so this PR tries adding an as-simple-as-possible `repr(transparent)` newtype `NeverShortCircuit` in hopes that will minimize any perf regressions (as it won't need to test `From` impls and such, like it used to back in the try_trait_v1 days).

r? @ghost
