### PR TITLE
Fix incorrect stability attributes

### DIFF
--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -628,7 +628,7 @@ macro_rules! saturating_int_impl {
             /// ```
             #[inline]
             #[unstable(feature = "saturating_int_impl", issue = "87920")]
-            #[rustc_const_stable(feature = "const_reverse_bits", since = "1.37.0")]
+            #[rustc_const_unstable(feature = "saturating_int_impl", issue = "87920")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             pub const fn reverse_bits(self) -> Self {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2223,7 +2223,7 @@ macro_rules! uint_impl {
         /// ```
         #[unstable(feature = "wrapping_next_power_of_two", issue = "32463",
                    reason = "needs decision on wrapping behaviour")]
-        #[rustc_const_stable(feature = "const_int_pow", since = "1.50.0")]
+        #[rustc_const_unstable(feature = "wrapping_next_power_of_two", issue = "32463")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         pub const fn wrapping_next_power_of_two(self) -> Self {


### PR DESCRIPTION
These two instances were caught in #90356, but that PR isn't going to be merged. I've extracted these to ensure it's still correct.

@rustbot label: +A-stability +C-cleanup +S-waiting-on-review