### PR TITLE
Distinguish between `ensure` and `get` dependencies in the DepGraph.

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -43,7 +43,9 @@ macro_rules! provide {
                 // doesn't need to do this (and can't, as it would cause a query cycle).
                 use rustc_middle::dep_graph::DepKind;
                 if DepKind::$name != DepKind::crate_hash && $tcx.dep_graph.is_fully_enabled() {
-                    $tcx.ensure().crate_hash($def_id.krate);
+                    // Do not use `ensure` since we want this to be recomputed when the hash
+                    // changes.
+                    let _ = $tcx.crate_hash($def_id.krate);
                 }
 
                 let $cdata = CStore::from_tcx($tcx).get_crate_data($def_id.krate);

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -11,6 +11,7 @@ pub use rustc_query_system::dep_graph::{
     debug::DepNodeFilter, hash_result, DepContext, DepNodeColor, DepNodeIndex,
     SerializedDepNodeIndex, WorkProduct, WorkProductId,
 };
+pub use rustc_query_system::query::QueryMode;
 
 pub use dep_node::{label_strs, DepKind, DepKindStruct, DepNode, DepNodeExt};
 crate use dep_node::{make_compile_codegen_unit, make_compile_mono_item};

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -202,7 +202,7 @@ macro_rules! define_callbacks {
             #[inline(always)]
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) {
                 let key = key.into_query_param();
-                let cached = try_get_cached(self.tcx, &self.tcx.query_caches.$name, &key, noop);
+                let cached = try_get_cached(self.tcx, &self.tcx.query_caches.$name, &key, QueryMode::Ensure, noop);
 
                 let lookup = match cached {
                     Ok(()) => return,
@@ -229,7 +229,7 @@ macro_rules! define_callbacks {
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) -> query_stored::$name<$tcx>
             {
                 let key = key.into_query_param();
-                let cached = try_get_cached(self.tcx, &self.tcx.query_caches.$name, &key, Clone::clone);
+                let cached = try_get_cached(self.tcx, &self.tcx.query_caches.$name, &key, QueryMode::Get, Clone::clone);
 
                 let lookup = match cached {
                     Ok(value) => return value,

--- a/compiler/rustc_query_system/src/cache.rs
+++ b/compiler/rustc_query_system/src/cache.rs
@@ -1,6 +1,7 @@
 //! Cache for candidate selection.
 
 use crate::dep_graph::{DepContext, DepNodeIndex};
+use crate::query::QueryMode;
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lock;
@@ -47,7 +48,7 @@ impl<T: Clone> WithDepNode<T> {
     }
 
     pub fn get<CTX: DepContext>(&self, tcx: CTX) -> T {
-        tcx.dep_graph().read_index(self.dep_node);
+        tcx.dep_graph().read_index(self.dep_node, QueryMode::Get);
         self.cached_value.clone()
     }
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -356,6 +356,7 @@ pub fn try_get_cached<'a, CTX, C, R, OnHit>(
     tcx: CTX,
     cache: &'a QueryCacheStore<C>,
     key: &C::Key,
+    mode: QueryMode,
     // `on_hit` can be called while holding a lock to the query cache
     on_hit: OnHit,
 ) -> Result<R, QueryLookup>
@@ -368,7 +369,7 @@ where
         if unlikely!(tcx.profiler().enabled()) {
             tcx.profiler().query_cache_hit(index.into());
         }
-        tcx.dep_graph().read_index(index);
+        tcx.dep_graph().read_index(index, mode);
         on_hit(value)
     })
 }
@@ -655,7 +656,7 @@ where
             (true, Some(dep_node))
         }
         Some((_, dep_node_index)) => {
-            dep_graph.read_index(dep_node_index);
+            dep_graph.read_index(dep_node_index, QueryMode::Ensure);
             tcx.dep_context().profiler().query_cache_hit(dep_node_index.into());
             (false, None)
         }
@@ -702,7 +703,7 @@ where
         &query,
     );
     if let Some(dep_node_index) = dep_node_index {
-        tcx.dep_context().dep_graph().read_index(dep_node_index)
+        tcx.dep_context().dep_graph().read_index(dep_node_index, mode)
     }
     Some(result)
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -32,7 +32,7 @@ use rustc_errors::ErrorReported;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::LateBoundRegionConversionTime;
-use rustc_middle::dep_graph::{DepKind, DepNodeIndex};
+use rustc_middle::dep_graph::{DepKind, DepNodeIndex, QueryMode};
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::thir::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::fast_reject;
@@ -1121,7 +1121,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     {
         let (result, dep_node) =
             self.tcx().dep_graph.with_anon_task(self.tcx(), DepKind::TraitSelect, || op(self));
-        self.tcx().dep_graph.read_index(dep_node);
+        self.tcx().dep_graph.read_index(dep_node, QueryMode::Get);
         (result, dep_node)
     }
 


### PR DESCRIPTION
When calling `ensure` on a query, we are checking that the query has been
computed, but we do not use the resulting value.  Since we do not have
access to that value, the caller's behavior must not change.

The `QueryMode` is a single bit, and is stored as most-significant bit
of each dependency in the DepGraph.

r? @ghost