### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -306,8 +306,10 @@ impl<'a> GccLinker<'a> {
         if let Some(path) = &self.sess.opts.debugging_opts.profile_sample_use {
             self.linker_arg(&format!("-plugin-opt=sample-profile={}", path.display()));
         };
-        self.linker_arg(&format!("-plugin-opt={}", opt_level));
-        self.linker_arg(&format!("-plugin-opt=mcpu={}", self.target_cpu));
+        self.linker_args(&[
+            &format!("-plugin-opt={}", opt_level),
+            &format!("-plugin-opt=mcpu={}", self.target_cpu),
+        ]);
     }
 
     fn build_dylib(&mut self, out_filename: &Path) {
@@ -321,10 +323,9 @@ impl<'a> GccLinker<'a> {
             // principled solution at some point to force the compiler to pass
             // the right `-Wl,-install_name` with an `@rpath` in it.
             if self.sess.opts.cg.rpath || self.sess.opts.debugging_opts.osx_rpath_install_name {
-                self.linker_arg("-install_name");
-                let mut v = OsString::from("@rpath/");
-                v.push(out_filename.file_name().unwrap());
-                self.linker_arg(&v);
+                let mut rpath = OsString::from("@rpath/");
+                rpath.push(out_filename.file_name().unwrap());
+                self.linker_args(&[OsString::from("-install_name"), rpath]);
             }
         } else {
             self.cmd.arg("-shared");
@@ -398,8 +399,7 @@ impl<'a> Linker for GccLinker<'a> {
                 self.build_dylib(out_filename);
             }
             LinkOutputKind::WasiReactorExe => {
-                self.linker_arg("--entry");
-                self.linker_arg("_initialize");
+                self.linker_args(&["--entry", "_initialize"]);
             }
         }
         // VxWorks compiler driver introduced `--static-crt` flag specifically for rustc,
@@ -471,8 +471,7 @@ impl<'a> Linker for GccLinker<'a> {
         self.cmd.arg(path);
     }
     fn full_relro(&mut self) {
-        self.linker_arg("-zrelro");
-        self.linker_arg("-znow");
+        self.linker_args(&["-zrelro", "-znow"]);
     }
     fn partial_relro(&mut self) {
         self.linker_arg("-zrelro");
@@ -656,7 +655,6 @@ impl<'a> Linker for GccLinker<'a> {
         }
 
         let is_windows = self.sess.target.is_like_windows;
-        let mut arg = OsString::new();
         let path = tmpdir.join(if is_windows { "list.def" } else { "list" });
 
         debug!("EXPORTED SYMBOLS:");
@@ -708,27 +706,18 @@ impl<'a> Linker for GccLinker<'a> {
         }
 
         if self.sess.target.is_like_osx {
-            if !self.is_ld {
-                arg.push("-Wl,")
-            }
-            arg.push("-exported_symbols_list,");
+            self.linker_args(&[OsString::from("-exported_symbols_list"), path.into()]);
         } else if self.sess.target.is_like_solaris {
-            if !self.is_ld {
-                arg.push("-Wl,")
-            }
-            arg.push("-M,");
+            self.linker_args(&[OsString::from("-M"), path.into()]);
         } else {
-            if !self.is_ld {
-                arg.push("-Wl,")
-            }
-            // Both LD and LLD accept export list in *.def file form, there are no flags required
-            if !is_windows {
-                arg.push("--version-script=")
+            if is_windows {
+                self.linker_arg(path);
+            } else {
+                let mut arg = OsString::from("--version-script=");
+                arg.push(path);
+                self.linker_arg(arg);
             }
         }
-
-        arg.push(&path);
-        self.cmd.arg(arg);
     }
 
     fn subsystem(&mut self, subsystem: &str) {
@@ -786,8 +775,7 @@ impl<'a> Linker for GccLinker<'a> {
             self.linker_arg("--as-needed");
         } else if self.sess.target.is_like_solaris {
             // -z ignore is the Solaris equivalent to the GNU ld --as-needed option
-            self.linker_arg("-z");
-            self.linker_arg("ignore");
+            self.linker_args(&["-z", "ignore"]);
         }
     }
 }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -315,7 +315,10 @@ impl<'a> GccLinker<'a> {
     fn build_dylib(&mut self, out_filename: &Path) {
         // On mac we need to tell the linker to let this library be rpathed
         if self.sess.target.is_like_osx {
-            self.cmd.arg("-dynamiclib");
+            if !self.is_ld {
+                self.cmd.arg("-dynamiclib");
+            }
+
             self.linker_arg("-dylib");
 
             // Note that the `osx_rpath_install_name` option here is a hack

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -118,32 +118,54 @@ macro_rules! newtype_index {
         }
 
         impl $type {
+            /// Maximum value the index can take, as a `u32`.
             $v const MAX_AS_U32: u32 = $max;
 
+            /// Maximum value the index can take.
             $v const MAX: Self = Self::from_u32($max);
 
+            /// Creates a new index from a given `usize`.
+            ///
+            /// # Panics
+            ///
+            /// Will panic if `value` exceeds `MAX`.
             #[inline]
             $v const fn from_usize(value: usize) -> Self {
                 assert!(value <= ($max as usize));
+                // SAFETY: We just checked that `value <= max`.
                 unsafe {
                     Self::from_u32_unchecked(value as u32)
                 }
             }
 
+            /// Creates a new index from a given `u32`.
+            ///
+            /// # Panics
+            ///
+            /// Will panic if `value` exceeds `MAX`.
             #[inline]
             $v const fn from_u32(value: u32) -> Self {
                 assert!(value <= $max);
+                // SAFETY: We just checked that `value <= max`.
                 unsafe {
                     Self::from_u32_unchecked(value)
                 }
             }
 
+            /// Creates a new index from a given `u32`.
+            ///
+            /// # Safety
+            ///
+            /// The provided value must be less than or equal to the maximum value for the newtype.
+            /// Providing a value outside this range is undefined due to layout restrictions.
+            ///
+            /// Prefer using `from_u32`.
             #[inline]
             $v const unsafe fn from_u32_unchecked(value: u32) -> Self {
                 Self { private: value }
             }
 
-            /// Extracts the value of this index as an integer.
+            /// Extracts the value of this index as a `usize`.
             #[inline]
             $v const fn index(self) -> usize {
                 self.as_usize()

--- a/src/test/ui/consts/issue-miri-1910.rs
+++ b/src/test/ui/consts/issue-miri-1910.rs
@@ -1,0 +1,12 @@
+// error-pattern unable to turn pointer into raw bytes
+#![feature(const_ptr_read)]
+#![feature(const_ptr_offset)]
+
+const C: () = unsafe {
+    let foo = Some(&42 as *const i32);
+    let one_and_a_half_pointers = std::mem::size_of::<*const i32>()/2*3;
+    (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
+};
+
+fn main() {
+}

--- a/src/test/ui/consts/issue-miri-1910.stderr
+++ b/src/test/ui/consts/issue-miri-1910.stderr
@@ -1,0 +1,26 @@
+error: any use of this value will cause an error
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |           copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           unable to turn pointer into raw bytes
+   |           inside `std::ptr::read::<u8>` at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |           inside `ptr::const_ptr::<impl *const u8>::read` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |           inside `C` at $DIR/issue-miri-1910.rs:8:5
+   |
+  ::: $DIR/issue-miri-1910.rs:5:1
+   |
+LL | / const C: () = unsafe {
+LL | |     let foo = Some(&42 as *const i32);
+LL | |     let one_and_a_half_pointers = std::mem::size_of::<*const i32>()/2*3;
+LL | |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
+LL | | };
+   | |__-
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to previous error
+

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `C: Copy` is not satisfied
+error[E0277]: the trait bound `B<C>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
 LL |     is_copy(B { a: 1, b: C });
@@ -22,7 +22,7 @@ help: consider borrowing here
 LL |     is_copy(&B { a: 1, b: C });
    |             +
 
-error[E0277]: the trait bound `C: Clone` is not satisfied
+error[E0277]: the trait bound `B<C>: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
 LL |     is_clone(B { a: 1, b: C });
@@ -46,7 +46,7 @@ help: consider borrowing here
 LL |     is_clone(&B { a: 1, b: C });
    |              +
 
-error[E0277]: the trait bound `D: Copy` is not satisfied
+error[E0277]: the trait bound `B<D>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
 LL |     is_copy(B { a: 1, b: D });

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -65,7 +65,7 @@ LL |     is_send(Box::new(TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `dummy2::TestType: Send` is not satisfied
+   = note: the trait bound `Unique<dummy2::TestType>: Send` is not satisfied
    = note: required because of the requirements on the impl of `Send` for `Unique<dummy2::TestType>`
    = note: required because it appears within the type `Box<dummy2::TestType>`
 note: required by a bound in `is_send`
@@ -104,11 +104,11 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
 LL |     is_sync(Outer2(TestType));
-   |     ------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Sync`
+   |     ------- ^^^^^^^^^^^^^^^^ `main::TestType` cannot be sent between threads safely
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `main::TestType: Sync` is not satisfied
+   = help: the trait `Send` is not implemented for `main::TestType`
 note: required because of the requirements on the impl of `Sync` for `Outer2<main::TestType>`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |
@@ -119,12 +119,6 @@ note: required by a bound in `is_sync`
    |
 LL | fn is_sync<T: Sync>(_: T) {}
    |               ^^^^ required by this bound in `is_sync`
-help: consider borrowing here
-   |
-LL |     is_sync(&Outer2(TestType));
-   |             +
-LL |     is_sync(&mut Outer2(TestType));
-   |             ++++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
@@ -1,0 +1,11 @@
+// Do not suggest referencing the parameter to `check`
+
+trait Marker<T> {}
+
+impl<T> Marker<i32> for T {}
+
+pub fn check<T: Marker<u32>>(_: T) {}
+
+pub fn main() {
+    check::<()>(()); //~ ERROR [E0277]
+}

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `(): Marker<u32>` is not satisfied
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:10:17
+   |
+LL |     check::<()>(());
+   |     ----------- ^^ the trait `Marker<u32>` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `check`
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:7:17
+   |
+LL | pub fn check<T: Marker<u32>>(_: T) {}
+   |                 ^^^^^^^^^^^ required by this bound in `check`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #90717 (Fix ld64 flags)
 - #90819 (Fixes incorrect handling of TraitRefs when emitting suggestions.)
 - #90839 (Generate documentation in rustc `rustc_index::newtype_index` macro)
 - #90892 (fix ICE on Miri/CTFE copy of half a pointer)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90717,90819,90839,90892)
<!-- homu-ignore:end -->