### PR TITLE
Improve ManuallyDrop suggestion

### DIFF
--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -13,11 +13,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/feature-gate-untagged_unions.rs:16:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:24:5
@@ -25,11 +24,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/feature-gate-untagged_unions.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -16,7 +16,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:24:5
@@ -27,7 +27,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: A,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/issue-41073.rs:4:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: A,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<A>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -7,7 +7,7 @@ LL |     a: A,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<A>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -7,7 +7,7 @@ LL |     bar: Bar,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     bar: std::mem::ManuallyDrop<Bar>,
-   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |          +++++++++++++++++++++++   +
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     bar: Bar,
    |     ^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-custom-drop.rs:7:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     bar: Bar,
-   |     ^^^^^^^^
+LL |     bar: std::mem::ManuallyDrop<Bar>,
+   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:11:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -16,11 +15,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: S,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:19:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: S,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<S>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -28,11 +26,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
@@ -7,7 +7,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -18,7 +18,7 @@ LL |     a: S,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -29,7 +29,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:11:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -16,11 +15,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: S,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:19:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: S,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<S>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -28,11 +26,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
@@ -7,7 +7,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -18,7 +18,7 @@ LL |     a: S,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -29,7 +29,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
closes https://github.com/rust-lang/rust/issues/90585
* Fixes the recommended change to use ManuallyDrop as per the issue
* Changes the note to a help
* improves the span so it only points at the type.