### PR TITLE
disable portable SIMD tests in Miri

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -402,11 +402,13 @@ pub mod arch {
 #[allow(missing_debug_implementations, dead_code, unsafe_op_in_unsafe_fn, unused_unsafe)]
 #[allow(rustdoc::bare_urls)]
 #[unstable(feature = "portable_simd", issue = "86656")]
+#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
 #[cfg(not(bootstrap))]
 mod core_simd;
 
 #[doc = include_str!("../../portable-simd/crates/core_simd/src/core_simd_docs.md")]
 #[unstable(feature = "portable_simd", issue = "86656")]
+#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
 #[cfg(not(bootstrap))]
 pub mod simd {
     #[unstable(feature = "portable_simd", issue = "86656")]

--- a/library/core/tests/simd.rs
+++ b/library/core/tests/simd.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))] // Miri does not support all SIMD intrinsics
+
 use core::simd::f32x4;
 
 #[test]


### PR DESCRIPTION
Until https://github.com/rust-lang/miri/issues/1912 is resolved, we'll have to skip these tests in Miri.