### PR TITLE
fix getting the discriminant of a zero-variant enum

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2067,7 +2067,9 @@ impl<'tcx> TyS<'tcx> {
     ) -> Option<Discr<'tcx>> {
         match self.kind() {
             TyKind::Adt(adt, _) if adt.variants.is_empty() => {
-                bug!("discriminant_for_variant called on zero variant enum");
+                // This can actually happen during CTFE, see
+                // https://github.com/rust-lang/rust/issues/89765.
+                None
             }
             TyKind::Adt(adt, _) if adt.is_enum() => {
                 Some(adt.discriminant_for_variant(tcx, variant_index))

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -25,6 +25,12 @@ enum SingleVariant {
 
 const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
 
+pub const TEST_VOID: () = {
+    // This is UB, but CTFE does not check validity so it does not detect this.
+    unsafe { std::mem::discriminant(&*(&() as *const () as *const Void)); };
+};
+
+
 fn main() {
     assert_eq!(TEST_A, TEST_A_OTHER);
     assert_eq!(TEST_A, discriminant(black_box(&Test::A(17))));

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -27,6 +27,7 @@ const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
 
 pub const TEST_VOID: () = {
     // This is UB, but CTFE does not check validity so it does not detect this.
+    // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
     unsafe { std::mem::discriminant(&*(&() as *const () as *const Void)); };
 };
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/89765