### PR TITLE
[EXPERIMENT] What if we make ?-on-Err be #[cold]?

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1896,9 +1896,14 @@ impl<T, E> ops::Try for Result<T, E> {
 
     #[inline]
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+        #[cold]
+        fn cold_err<E>(e: E) -> Result<convert::Infallible, E> {
+            Err(e)
+        }
+
         match self {
             Ok(v) => ControlFlow::Continue(v),
-            Err(e) => ControlFlow::Break(Err(e)),
+            Err(e) => ControlFlow::Break(cold_err(e)),
         }
     }
 }


### PR DESCRIPTION
I don't know if we'd actually *want* to do this, but I'm curious what happens.  This would only affect checks inside `?` on specifically `Result`, so wouldn't impact `?`-on-`Option` nor `?`-on-`ControlFlow`.

r? @ghost 