### PR TITLE
rustc_mir_build: reorder bindings

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1762,8 +1762,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> BlockAnd<()> {
         let expr_span = expr.span;
         let expr_place_builder = unpack!(block = self.lower_scrutinee(block, expr, expr_span));
-        let mut guard_candidate = Candidate::new(expr_place_builder.clone(), &pat, false);
         let wildcard = Pat::wildcard_from_ty(pat.ty);
+        let mut guard_candidate = Candidate::new(expr_place_builder.clone(), &pat, false);
         let mut otherwise_candidate = Candidate::new(expr_place_builder.clone(), &wildcard, false);
         let fake_borrow_temps = self.lower_match_tree(
             block,


### PR DESCRIPTION
No functional changes intended.

I'm playing around with building compiler components using nightly rust
(2021-11-02) in a non-standard way. I encountered the following error while
trying to build rustc_mir_build:

```
error[E0597]: `wildcard` does not live long enough
    --> rust/src/nightly/compiler/rustc_mir_build/src/build/matches/mod.rs:1767:82
     |
1767 |         let mut otherwise_candidate = Candidate::new(expr_place_builder.clone(), &wildcard, false);
     |                                                                                  ^^^^^^^^^ borrowed value does not live long enough
...
1799 |     }
     |     -
     |     |
     |     `wildcard` dropped here while still borrowed
     |     borrow might be used here, when `guard_candidate` is dropped and runs the destructor for type `Candidate<'_, '_>`
     |
     = note: values in a scope are dropped in the opposite order they are defined
```

I believe this flags an issue that may become an error in the future.
Swapping the order of `wildcard` and `guard_candidate` resolves it.