### PR TITLE
Use a different server for checking clock drift

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -117,7 +117,7 @@ datecheck() {
   echo -n "  local time: "
   date
   echo -n "  network time: "
-  curl -fs --head http://detectportal.firefox.com/success.txt | grep ^Date: \
+  curl -fs --head http://ci-caches.rust-lang.org | grep ^Date: \
       | sed 's/Date: //g' || true
   echo "== end clock drift check =="
 }


### PR DESCRIPTION
The detectportal.firefox.com server seems to return a random-ish date; for
example I see the following across 5 curl's done consecutively locally, where
the real date is approximately 15 Nov 2021 06:36 UTC.

Date: Mon, 15 Nov 2021 13:34:53 GMT
Date: Mon, 15 Nov 2021 12:20:21 GMT
Date: Mon, 15 Nov 2021 00:06:47 GMT
Date: Mon, 15 Nov 2021 17:14:33 GMT
Date: Mon, 15 Nov 2021 13:33:21 GMT