### PR TITLE
windows: Return the "Not Found" error when a path is empty

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1439,4 +1439,8 @@ fn create_dir_long_paths() {
     // This will fail if the path isn't converted to verbatim.
     path.push("a");
     fs::create_dir(&path).unwrap();
+
+    // #90940: Ensure an empty path returns the "Not Found" error.
+    let path = Path::new("");
+    assert_eq!(path.canonicalize().unwrap_err().kind(), crate::io::ErrorKind::NotFound);
 }

--- a/library/std/src/sys/windows/path.rs
+++ b/library/std/src/sys/windows/path.rs
@@ -174,8 +174,8 @@ pub(crate) fn maybe_verbatim(path: &Path) -> io::Result<Vec<u16>> {
     const UNC_PREFIX: &[u16] = &[SEP, SEP, QUERY, SEP, U, N, C, SEP];
 
     let mut path = to_u16s(path)?;
-    if path.starts_with(VERBATIM_PREFIX) || path.starts_with(NT_PREFIX) {
-        // Early return for paths that are already verbatim.
+    if path.starts_with(VERBATIM_PREFIX) || path.starts_with(NT_PREFIX) || path == &[0] {
+        // Early return for paths that are already verbatim or empty.
         return Ok(path);
     } else if path.len() < LEGACY_MAX_PATH {
         // Early return if an absolute path is less < 260 UTF-16 code units.

--- a/library/std/src/sys/windows/path/tests.rs
+++ b/library/std/src/sys/windows/path/tests.rs
@@ -91,7 +91,6 @@ fn verbatim() {
     // Make sure opening a drive will work.
     check("Z:", "Z:");
 
-    // An empty path or a path that contains null are not valid paths.
-    assert!(maybe_verbatim(Path::new("")).is_err());
+    // A path that contains null is not a valid path.
     assert!(maybe_verbatim(Path::new("\0")).is_err());
 }


### PR DESCRIPTION
Fixes #90940