### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -893,11 +893,11 @@ struct TypeChecker<'a, 'tcx> {
 }
 
 struct BorrowCheckContext<'a, 'tcx> {
-    universal_regions: &'a UniversalRegions<'tcx>,
+    pub(crate) universal_regions: &'a UniversalRegions<'tcx>,
     location_table: &'a LocationTable,
     all_facts: &'a mut Option<AllFacts>,
     borrow_set: &'a BorrowSet<'tcx>,
-    constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
+    pub(crate) constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
     upvars: &'a [Upvar<'tcx>],
 }
 
@@ -1157,6 +1157,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         self.relate_types(sup, ty::Variance::Contravariant, sub, locations, category)
     }
 
+    #[instrument(skip(self, category), level = "debug")]
     fn eq_types(
         &mut self,
         expected: Ty<'tcx>,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -647,6 +647,22 @@ pub struct WhereBoundPredicate<'hir> {
     pub bounds: GenericBounds<'hir>,
 }
 
+impl WhereBoundPredicate<'hir> {
+    /// Returns `true` if `param_def_id` matches the `bounded_ty` of this predicate.
+    pub fn is_param_bound(&self, param_def_id: DefId) -> bool {
+        let path = match self.bounded_ty.kind {
+            TyKind::Path(QPath::Resolved(None, path)) => path,
+            _ => return false,
+        };
+        match path.res {
+            Res::Def(DefKind::TyParam, def_id) | Res::SelfTy(Some(def_id), None) => {
+                def_id == param_def_id
+            }
+            _ => false,
+        }
+    }
+}
+
 /// A lifetime predicate (e.g., `'a: 'b + 'c`).
 #[derive(Debug, HashStable_Generic)]
 pub struct WhereRegionPredicate<'hir> {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2067,7 +2067,9 @@ impl<'tcx> TyS<'tcx> {
     ) -> Option<Discr<'tcx>> {
         match self.kind() {
             TyKind::Adt(adt, _) if adt.variants.is_empty() => {
-                bug!("discriminant_for_variant called on zero variant enum");
+                // This can actually happen during CTFE, see
+                // https://github.com/rust-lang/rust/issues/89765.
+                None
             }
             TyKind::Adt(adt, _) if adt.is_enum() => {
                 Some(adt.discriminant_for_variant(tcx, variant_index))

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1762,8 +1762,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> BlockAnd<()> {
         let expr_span = expr.span;
         let expr_place_builder = unpack!(block = self.lower_scrutinee(block, expr, expr_span));
-        let mut guard_candidate = Candidate::new(expr_place_builder.clone(), &pat, false);
         let wildcard = Pat::wildcard_from_ty(pat.ty);
+        let mut guard_candidate = Candidate::new(expr_place_builder.clone(), &pat, false);
         let mut otherwise_candidate = Candidate::new(expr_place_builder.clone(), &wildcard, false);
         let fake_borrow_temps = self.lower_match_tree(
             block,

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -478,6 +478,26 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut label_span_not_found = || {
                     if unsatisfied_predicates.is_empty() {
                         err.span_label(span, format!("{item_kind} not found in `{ty_str}`"));
+                        let is_string_or_ref_str = match actual.kind() {
+                            ty::Ref(_, ty, _) => {
+                                ty.is_str()
+                                    || matches!(
+                                        ty.kind(),
+                                        ty::Adt(adt, _) if self.tcx.is_diagnostic_item(sym::String, adt.did)
+                                    )
+                            }
+                            ty::Adt(adt, _) => self.tcx.is_diagnostic_item(sym::String, adt.did),
+                            _ => false,
+                        };
+                        if is_string_or_ref_str && item_name.name == sym::iter {
+                            err.span_suggestion_verbose(
+                                item_name.span,
+                                "because of the in-memory representation of `&str`, to obtain \
+                                 an `Iterator` over each of its codepoint use method `chars`",
+                                String::from("chars"),
+                                Applicability::MachineApplicable,
+                            );
+                        }
                         if let ty::Adt(adt, _) = rcvr_ty.kind() {
                             let mut inherent_impls_candidate = self
                                 .tcx

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -28,7 +28,7 @@ use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
 use rustc_errors::{struct_span_err, Applicability};
 use rustc_hir as hir;
-use rustc_hir::def::{CtorKind, DefKind, Res};
+use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::weak_lang_items;
@@ -668,6 +668,7 @@ impl ItemCtxt<'tcx> {
             })
             .flat_map(|b| predicates_from_bound(self, ty, b));
 
+        let param_def_id = self.tcx.hir().local_def_id(param_id).to_def_id();
         let from_where_clauses = ast_generics
             .where_clause
             .predicates
@@ -677,7 +678,7 @@ impl ItemCtxt<'tcx> {
                 _ => None,
             })
             .flat_map(|bp| {
-                let bt = if is_param(self.tcx, bp.bounded_ty, param_id) {
+                let bt = if bp.is_param_bound(param_def_id) {
                     Some(ty)
                 } else if !only_self_bounds.0 {
                     Some(self.to_ty(bp.bounded_ty))
@@ -711,23 +712,6 @@ impl ItemCtxt<'tcx> {
             }
             _ => false,
         }
-    }
-}
-
-/// Tests whether this is the AST for a reference to the type
-/// parameter with ID `param_id`. We use this so as to avoid running
-/// `ast_ty_to_ty`, because we want to avoid triggering an all-out
-/// conversion of the type to avoid inducing unnecessary cycles.
-fn is_param(tcx: TyCtxt<'_>, ast_ty: &hir::Ty<'_>, param_id: hir::HirId) -> bool {
-    if let hir::TyKind::Path(hir::QPath::Resolved(None, path)) = ast_ty.kind {
-        match path.res {
-            Res::SelfTy(Some(def_id), None) | Res::Def(DefKind::TyParam, def_id) => {
-                def_id == tcx.hir().local_def_id(param_id).to_def_id()
-            }
-            _ => false,
-        }
-    } else {
-        false
     }
 }
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -117,7 +117,7 @@ datecheck() {
   echo -n "  local time: "
   date
   echo -n "  network time: "
-  curl -fs --head http://detectportal.firefox.com/success.txt | grep ^Date: \
+  curl -fs --head http://ci-caches.rust-lang.org | grep ^Date: \
       | sed 's/Date: //g' || true
   echo "== end clock drift check =="
 }

--- a/src/test/ui/borrowck/issue-80772.rs
+++ b/src/test/ui/borrowck/issue-80772.rs
@@ -1,0 +1,21 @@
+// check-pass
+
+trait SomeTrait {}
+
+pub struct Exhibit {
+    constant: usize,
+    factory: fn(&usize) -> Box<dyn SomeTrait>,
+}
+
+pub const A_CONSTANT: &[Exhibit] = &[
+    Exhibit {
+        constant: 1,
+        factory: |_| unimplemented!(),
+    },
+    Exhibit {
+        constant: "Hello world".len(),
+        factory: |_| unimplemented!(),
+    },
+];
+
+fn main() {}

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -25,6 +25,12 @@ enum SingleVariant {
 
 const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
 
+pub const TEST_VOID: () = {
+    // This is UB, but CTFE does not check validity so it does not detect this.
+    unsafe { std::mem::discriminant(&*(&() as *const () as *const Void)); };
+};
+
+
 fn main() {
     assert_eq!(TEST_A, TEST_A_OTHER);
     assert_eq!(TEST_A, discriminant(black_box(&Test::A(17))));

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -27,6 +27,7 @@ const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
 
 pub const TEST_VOID: () = {
     // This is UB, but CTFE does not check validity so it does not detect this.
+    // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
     unsafe { std::mem::discriminant(&*(&() as *const () as *const Void)); };
 };
 

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `C: Copy` is not satisfied
+error[E0277]: the trait bound `B<C>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:13
    |
 LL |     is_copy(B { a: 1, b: C });
@@ -22,7 +22,7 @@ help: consider borrowing here
 LL |     is_copy(&B { a: 1, b: C });
    |             +
 
-error[E0277]: the trait bound `C: Clone` is not satisfied
+error[E0277]: the trait bound `B<C>: Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:14
    |
 LL |     is_clone(B { a: 1, b: C });
@@ -46,7 +46,7 @@ help: consider borrowing here
 LL |     is_clone(&B { a: 1, b: C });
    |              +
 
-error[E0277]: the trait bound `D: Copy` is not satisfied
+error[E0277]: the trait bound `B<D>: Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:13
    |
 LL |     is_copy(B { a: 1, b: D });

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90612.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90612.rs
@@ -1,0 +1,43 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+use std::marker::PhantomData;
+
+trait Family: Sized {
+    type Item<'a>;
+
+    fn apply_all<F>(&self, f: F)
+    where
+        F: FamilyItemFn<Self> { }
+}
+
+struct Array<T>(PhantomData<T>);
+
+impl<T: 'static> Family for Array<T> {
+    type Item<'a> = &'a T;
+}
+
+trait FamilyItemFn<T: Family> {
+    fn apply(&self, item: T::Item<'_>);
+}
+
+impl<T, F> FamilyItemFn<T> for F
+where
+    T: Family,
+    for<'a> F: Fn(T::Item<'a>)
+{
+    fn apply(&self, item: T::Item<'_>) {
+        (*self)(item);
+    }
+}
+
+fn process<T: 'static>(array: Array<T>) {
+    // Works
+    array.apply_all(|x: &T| { });
+
+    // ICE: NoSolution
+    array.apply_all(|x: <Array<T> as Family>::Item<'_>| { });
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90638.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-90638.rs
@@ -1,0 +1,37 @@
+//check-pass
+
+#![feature(generic_associated_types)]
+
+trait Yokeable<'a>: 'static {
+    type Output: 'a;
+}
+
+trait IsCovariant<'a> {}
+
+struct Yoke<Y: for<'a> Yokeable<'a>> {
+    data: Y,
+}
+
+impl<Y: for<'a> Yokeable<'a>> Yoke<Y> {
+    fn project<Y2: for<'a> Yokeable<'a>>(&self, _f: for<'a> fn(<Y as Yokeable<'a>>::Output, &'a ())
+      -> <Y2 as Yokeable<'a>>::Output) -> Yoke<Y2> {
+
+        unimplemented!()
+    }
+}
+
+fn _upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> where
+    Y: for<'a> Yokeable<'a>,
+    for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>
+    {
+    x.project(|data, _| {
+        Box::new(data)
+    })
+}
+
+
+impl<'a> Yokeable<'a> for Box<dyn IsCovariant<'static> + 'static> {
+    type Output = Box<dyn IsCovariant<'a> + 'a>;
+}
+
+fn main() {}

--- a/src/test/ui/suggest-using-chars.rs
+++ b/src/test/ui/suggest-using-chars.rs
@@ -1,0 +1,7 @@
+pub fn main() {
+    let _ = "foo".iter(); //~ ERROR no method named `iter` found for reference `&'static str` in the current scope
+    let _ = "foo".foo(); //~ ERROR no method named `foo` found for reference `&'static str` in the current scope
+    let _ = String::from("bar").iter(); //~ ERROR no method named `iter` found for struct `String` in the current scope
+    let _ = (&String::from("bar")).iter(); //~ ERROR no method named `iter` found for reference `&String` in the current scope
+    let _ = 0.iter(); //~ ERROR no method named `iter` found for type `{integer}` in the current scope
+}

--- a/src/test/ui/suggest-using-chars.stderr
+++ b/src/test/ui/suggest-using-chars.stderr
@@ -1,0 +1,48 @@
+error[E0599]: no method named `iter` found for reference `&'static str` in the current scope
+  --> $DIR/suggest-using-chars.rs:2:19
+   |
+LL |     let _ = "foo".iter();
+   |                   ^^^^ method not found in `&'static str`
+   |
+help: because of the in-memory representation of `&str`, to obtain an `Iterator` over each of its codepoint use method `chars`
+   |
+LL |     let _ = "foo".chars();
+   |                   ~~~~~
+
+error[E0599]: no method named `foo` found for reference `&'static str` in the current scope
+  --> $DIR/suggest-using-chars.rs:3:19
+   |
+LL |     let _ = "foo".foo();
+   |                   ^^^ method not found in `&'static str`
+
+error[E0599]: no method named `iter` found for struct `String` in the current scope
+  --> $DIR/suggest-using-chars.rs:4:33
+   |
+LL |     let _ = String::from("bar").iter();
+   |                                 ^^^^ method not found in `String`
+   |
+help: because of the in-memory representation of `&str`, to obtain an `Iterator` over each of its codepoint use method `chars`
+   |
+LL |     let _ = String::from("bar").chars();
+   |                                 ~~~~~
+
+error[E0599]: no method named `iter` found for reference `&String` in the current scope
+  --> $DIR/suggest-using-chars.rs:5:36
+   |
+LL |     let _ = (&String::from("bar")).iter();
+   |                                    ^^^^ method not found in `&String`
+   |
+help: because of the in-memory representation of `&str`, to obtain an `Iterator` over each of its codepoint use method `chars`
+   |
+LL |     let _ = (&String::from("bar")).chars();
+   |                                    ~~~~~
+
+error[E0599]: no method named `iter` found for type `{integer}` in the current scope
+  --> $DIR/suggest-using-chars.rs:6:15
+   |
+LL |     let _ = 0.iter();
+   |               ^^^^ method not found in `{integer}`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.rs
+++ b/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.rs
@@ -1,0 +1,8 @@
+// Regression test for #85945: Don't suggest `?Sized` bound if an explicit
+// `Sized` bound is already in a `where` clause.
+fn foo<T>(_: &T) where T: Sized {}
+fn bar() { foo(""); }
+//~^ERROR the size for values of type
+
+pub fn main() {
+}

--- a/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
+++ b/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:4:16
+   |
+LL | fn bar() { foo(""); }
+   |            --- ^^ doesn't have a size known at compile-time
+   |            |
+   |            required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `foo`
+  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:3:8
+   |
+LL | fn foo<T>(_: &T) where T: Sized {}
+   |        ^ required by this bound in `foo`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/src/test/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -65,7 +65,7 @@ LL |     is_send(Box::new(TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `dummy2::TestType: Send` is not satisfied
+   = note: the trait bound `Unique<dummy2::TestType>: Send` is not satisfied
    = note: required because of the requirements on the impl of `Send` for `Unique<dummy2::TestType>`
    = note: required because it appears within the type `Box<dummy2::TestType>`
 note: required by a bound in `is_send`
@@ -104,11 +104,11 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/negated-auto-traits-error.rs:66:13
    |
 LL |     is_sync(Outer2(TestType));
-   |     ------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Sync`
+   |     ------- ^^^^^^^^^^^^^^^^ `main::TestType` cannot be sent between threads safely
    |     |
    |     required by a bound introduced by this call
    |
-   = note: the trait bound `main::TestType: Sync` is not satisfied
+   = help: the trait `Send` is not implemented for `main::TestType`
 note: required because of the requirements on the impl of `Sync` for `Outer2<main::TestType>`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |
@@ -119,12 +119,6 @@ note: required by a bound in `is_sync`
    |
 LL | fn is_sync<T: Sync>(_: T) {}
    |               ^^^^ required by this bound in `is_sync`
-help: consider borrowing here
-   |
-LL |     is_sync(&Outer2(TestType));
-   |             +
-LL |     is_sync(&mut Outer2(TestType));
-   |             ++++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.rs
@@ -1,0 +1,11 @@
+// Do not suggest referencing the parameter to `check`
+
+trait Marker<T> {}
+
+impl<T> Marker<i32> for T {}
+
+pub fn check<T: Marker<u32>>(_: T) {}
+
+pub fn main() {
+    check::<()>(()); //~ ERROR [E0277]
+}

--- a/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
+++ b/src/test/ui/typeck/issue-90804-incorrect-reference-suggestion.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `(): Marker<u32>` is not satisfied
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:10:17
+   |
+LL |     check::<()>(());
+   |     ----------- ^^ the trait `Marker<u32>` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `check`
+  --> $DIR/issue-90804-incorrect-reference-suggestion.rs:7:17
+   |
+LL | pub fn check<T: Marker<u32>>(_: T) {}
+   |                 ^^^^^^^^^^^ required by this bound in `check`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #86455 (check where-clause for explicit `Sized` before suggesting `?Sized`)
 - #90801 (Normalize both arguments of `equate_normalized_input_or_output`)
 - #90803 (Suggest `&str.chars()` on attempt to `&str.iter()`)
 - #90819 (Fixes incorrect handling of TraitRefs when emitting suggestions.)
 - #90910 (fix getting the discriminant of a zero-variant enum)
 - #90925 (rustc_mir_build: reorder bindings)
 - #90928 (Use a different server for checking clock drift)
 - #90936 (Add a regression test for #80772)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=86455,90801,90803,90819,90910,90925,90928,90936)
<!-- homu-ignore:end -->