### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -316,7 +316,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                     extended_asm.add_input_operand(None, "r", result.llval);
                     extended_asm.add_clobber("memory");
                     extended_asm.set_volatile_flag(true);
-                    
+
                     // We have copied the value to `result` already.
                     return;
                 }
@@ -361,10 +361,6 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
     fn expect(&mut self, cond: Self::Value, _expected: bool) -> Self::Value {
         // TODO(antoyo)
         cond
-    }
-
-    fn sideeffect(&mut self) {
-        // TODO(antoyo)
     }
 
     fn type_test(&mut self, _pointer: Self::Value, _typeid: Self::Value) -> Self::Value {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -597,7 +597,6 @@ impl CodegenCx<'b, 'tcx> {
         ifn!("llvm.trap", fn() -> void);
         ifn!("llvm.debugtrap", fn() -> void);
         ifn!("llvm.frameaddress", fn(t_i32) -> i8p);
-        ifn!("llvm.sideeffect", fn() -> void);
 
         ifn!("llvm.powi.f32", fn(t_f32, t_i32) -> t_f32);
         ifn!("llvm.powi.f64", fn(t_f64, t_i32) -> t_f64);

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -392,15 +392,6 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         self.call_intrinsic("llvm.expect.i1", &[cond, self.const_bool(expected)])
     }
 
-    fn sideeffect(&mut self) {
-        // This kind of check would make a ton of sense in the caller, but currently the only
-        // caller of this function is in `rustc_codegen_ssa`, which is agnostic to whether LLVM
-        // codegen backend being used, and so is unable to check the LLVM version.
-        if unsafe { llvm::LLVMRustVersionMajor() } < 12 {
-            self.call_intrinsic("llvm.sideeffect", &[]);
-        }
-    }
-
     fn type_test(&mut self, pointer: Self::Value, typeid: Self::Value) -> Self::Value {
         // Test the called operand using llvm.type.test intrinsic. The LowerTypeTests link-time
         // optimization pass replaces calls to this intrinsic with code to test type membership.

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -980,17 +980,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::TerminatorKind::Goto { target } => {
-                if bb == target {
-                    // This is an unconditional branch back to this same basic block. That means we
-                    // have something like a `loop {}` statement. LLVM versions before 12.0
-                    // miscompile this because they assume forward progress. For older versions
-                    // try to handle just this specific case which comes up commonly in practice
-                    // (e.g., in embedded code).
-                    //
-                    // NB: the `sideeffect` currently checks for the LLVM version used internally.
-                    bx.sideeffect();
-                }
-
                 helper.funclet_br(self, &mut bx, target);
             }
 

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -20,10 +20,6 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     fn abort(&mut self);
     fn assume(&mut self, val: Self::Value);
     fn expect(&mut self, cond: Self::Value, expected: bool) -> Self::Value;
-    /// Emits a forced side effect.
-    ///
-    /// Currently has any effect only when LLVM versions prior to 12.0 are used as the backend.
-    fn sideeffect(&mut self);
     /// Trait method used to test whether a given pointer is associated with a type identifier.
     fn type_test(&mut self, pointer: Self::Value, typeid: Self::Value) -> Self::Value;
     /// Trait method used to inject `va_start` on the "spoofed" `VaListImpl` in

--- a/compiler/rustc_data_structures/src/sorted_map/index_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map/index_map.rs
@@ -34,39 +34,47 @@ pub struct SortedIndexMultiMap<I: Idx, K, V> {
 }
 
 impl<I: Idx, K: Ord, V> SortedIndexMultiMap<I, K, V> {
+    #[inline]
     pub fn new() -> Self {
         SortedIndexMultiMap { items: IndexVec::new(), idx_sorted_by_item_key: Vec::new() }
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
     /// Returns an iterator over the items in the map in insertion order.
+    #[inline]
     pub fn into_iter(self) -> impl DoubleEndedIterator<Item = (K, V)> {
         self.items.into_iter()
     }
 
     /// Returns an iterator over the items in the map in insertion order along with their indices.
+    #[inline]
     pub fn into_iter_enumerated(self) -> impl DoubleEndedIterator<Item = (I, (K, V))> {
         self.items.into_iter_enumerated()
     }
 
     /// Returns an iterator over the items in the map in insertion order.
+    #[inline]
     pub fn iter(&self) -> impl '_ + DoubleEndedIterator<Item = (&K, &V)> {
         self.items.iter().map(|(ref k, ref v)| (k, v))
     }
 
     /// Returns an iterator over the items in the map in insertion order along with their indices.
+    #[inline]
     pub fn iter_enumerated(&self) -> impl '_ + DoubleEndedIterator<Item = (I, (&K, &V))> {
         self.items.iter_enumerated().map(|(i, (ref k, ref v))| (i, (k, v)))
     }
 
     /// Returns the item in the map with the given index.
+    #[inline]
     pub fn get(&self, idx: I) -> Option<&(K, V)> {
         self.items.get(idx)
     }
@@ -75,6 +83,7 @@ impl<I: Idx, K: Ord, V> SortedIndexMultiMap<I, K, V> {
     ///
     /// If there are multiple items that are equivalent to `key`, they will be yielded in
     /// insertion order.
+    #[inline]
     pub fn get_by_key(&'a self, key: K) -> impl 'a + Iterator<Item = &'a V> {
         self.get_by_key_enumerated(key).map(|(_, v)| v)
     }
@@ -84,6 +93,7 @@ impl<I: Idx, K: Ord, V> SortedIndexMultiMap<I, K, V> {
     ///
     /// If there are multiple items that are equivalent to `key`, they will be yielded in
     /// insertion order.
+    #[inline]
     pub fn get_by_key_enumerated(&'a self, key: K) -> impl '_ + Iterator<Item = (I, &V)> {
         let lower_bound = self.idx_sorted_by_item_key.partition_point(|&i| self.items[i].0 < key);
         self.idx_sorted_by_item_key[lower_bound..].iter().map_while(move |&i| {

--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -34,6 +34,9 @@ declare_features! (
     /// These are used to test this portion of the compiler,
     /// they don't actually mean anything.
     (accepted, test_accepted_feature, "1.0.0", None, None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: for testing purposes
@@ -43,266 +46,269 @@ declare_features! (
     // feature-group-start: accepted features
     // -------------------------------------------------------------------------
 
-    /// Allows using associated `type`s in `trait`s.
-    (accepted, associated_types, "1.0.0", None, None),
-    /// Allows using assigning a default type to type parameters in algebraic data type definitions.
-    (accepted, default_type_params, "1.0.0", None, None),
-    // FIXME: explain `globs`.
-    (accepted, globs, "1.0.0", None, None),
-    /// Allows `macro_rules!` items.
-    (accepted, macro_rules, "1.0.0", None, None),
-    /// Allows use of `&foo[a..b]` as a slicing syntax.
-    (accepted, slicing_syntax, "1.0.0", None, None),
-    /// Allows struct variants `Foo { baz: u8, .. }` in enums (RFC 418).
-    (accepted, struct_variant, "1.0.0", None, None),
-    /// Allows indexing tuples.
-    (accepted, tuple_indexing, "1.0.0", None, None),
-    /// Allows the use of `if let` expressions.
-    (accepted, if_let, "1.0.0", None, None),
-    /// Allows the use of `while let` expressions.
-    (accepted, while_let, "1.0.0", None, None),
-    /// Allows using `#![no_std]`.
-    (accepted, no_std, "1.6.0", None, None),
-    /// Allows overloading augmented assignment operations like `a += b`.
-    (accepted, augmented_assignments, "1.8.0", Some(28235), None),
-    /// Allows empty structs and enum variants with braces.
-    (accepted, braced_empty_structs, "1.8.0", Some(29720), None),
-    /// Allows `#[deprecated]` attribute.
-    (accepted, deprecated, "1.9.0", Some(29935), None),
-    /// Allows macros to appear in the type position.
-    (accepted, type_macros, "1.13.0", Some(27245), None),
-    /// Allows use of the postfix `?` operator in expressions.
-    (accepted, question_mark, "1.13.0", Some(31436), None),
-    /// Allows `..` in tuple (struct) patterns.
-    (accepted, dotdot_in_tuple_patterns, "1.14.0", Some(33627), None),
-    /// Allows some increased flexibility in the name resolution rules,
-    /// especially around globs and shadowing (RFC 1560).
-    (accepted, item_like_imports, "1.15.0", Some(35120), None),
-    /// Allows using `Self` and associated types in struct expressions and patterns.
-    (accepted, more_struct_aliases, "1.16.0", Some(37544), None),
-    /// Allows elision of `'static` lifetimes in `static`s and `const`s.
-    (accepted, static_in_const, "1.17.0", Some(35897), None),
-    /// Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
-    (accepted, field_init_shorthand, "1.17.0", Some(37340), None),
-    /// Allows the definition recursive static items.
-    (accepted, static_recursion, "1.17.0", Some(29719), None),
-    /// Allows `pub(restricted)` visibilities (RFC 1422).
-    (accepted, pub_restricted, "1.18.0", Some(32409), None),
-    /// Allows `#![windows_subsystem]`.
-    (accepted, windows_subsystem, "1.18.0", Some(37499), None),
-    /// Allows `break {expr}` with a value inside `loop`s.
-    (accepted, loop_break_value, "1.19.0", Some(37339), None),
-    /// Allows numeric fields in struct expressions and patterns.
-    (accepted, relaxed_adts, "1.19.0", Some(35626), None),
-    /// Allows coercing non capturing closures to function pointers.
-    (accepted, closure_to_fn_coercion, "1.19.0", Some(39817), None),
-    /// Allows attributes on struct literal fields.
-    (accepted, struct_field_attributes, "1.20.0", Some(38814), None),
-    /// Allows the definition of associated constants in `trait` or `impl` blocks.
-    (accepted, associated_consts, "1.20.0", Some(29646), None),
-    /// Allows usage of the `compile_error!` macro.
-    (accepted, compile_error, "1.20.0", Some(40872), None),
-    /// Allows code like `let x: &'static u32 = &42` to work (RFC 1414).
-    (accepted, rvalue_static_promotion, "1.21.0", Some(38865), None),
-    /// Allows `Drop` types in constants (RFC 1440).
-    (accepted, drop_types_in_const, "1.22.0", Some(33156), None),
     /// Allows the sysV64 ABI to be specified on all platforms
     /// instead of just the platforms on which it is the C ABI.
     (accepted, abi_sysv64, "1.24.0", Some(36167), None),
-    /// Allows `repr(align(16))` struct attribute (RFC 1358).
-    (accepted, repr_align, "1.25.0", Some(33626), None),
-    /// Allows '|' at beginning of match arms (RFC 1925).
-    (accepted, match_beginning_vert, "1.25.0", Some(44101), None),
-    /// Allows nested groups in `use` items (RFC 2128).
-    (accepted, use_nested_groups, "1.25.0", Some(44494), None),
-    /// Allows indexing into constant arrays.
-    (accepted, const_indexing, "1.26.0", Some(29947), None),
-    /// Allows using `a..=b` and `..=b` as inclusive range syntaxes.
-    (accepted, inclusive_range_syntax, "1.26.0", Some(28237), None),
-    /// Allows `..=` in patterns (RFC 1192).
-    (accepted, dotdoteq_in_patterns, "1.26.0", Some(28237), None),
-    /// Allows `fn main()` with return types which implements `Termination` (RFC 1937).
-    (accepted, termination_trait, "1.26.0", Some(43301), None),
-    /// Allows implementing `Clone` for closures where possible (RFC 2132).
-    (accepted, clone_closures, "1.26.0", Some(44490), None),
-    /// Allows implementing `Copy` for closures where possible (RFC 2132).
-    (accepted, copy_closures, "1.26.0", Some(44490), None),
-    /// Allows `impl Trait` in function arguments.
-    (accepted, universal_impl_trait, "1.26.0", Some(34511), None),
-    /// Allows `impl Trait` in function return types.
-    (accepted, conservative_impl_trait, "1.26.0", Some(34511), None),
-    /// Allows using the `u128` and `i128` types.
-    (accepted, i128_type, "1.26.0", Some(35118), None),
-    /// Allows default match binding modes (RFC 2005).
-    (accepted, match_default_bindings, "1.26.0", Some(42640), None),
-    /// Allows `'_` placeholder lifetimes.
-    (accepted, underscore_lifetimes, "1.26.0", Some(44524), None),
-    /// Allows attributes on lifetime/type formal parameters in generics (RFC 1327).
-    (accepted, generic_param_attrs, "1.27.0", Some(48848), None),
-    /// Allows `cfg(target_feature = "...")`.
-    (accepted, cfg_target_feature, "1.27.0", Some(29717), None),
-    /// Allows `#[target_feature(...)]`.
-    (accepted, target_feature, "1.27.0", None, None),
-    /// Allows using `dyn Trait` as a syntax for trait objects.
-    (accepted, dyn_trait, "1.27.0", Some(44662), None),
-    /// Allows `#[must_use]` on functions, and introduces must-use operators (RFC 1940).
-    (accepted, fn_must_use, "1.27.0", Some(43302), None),
-    /// Allows use of the `:lifetime` macro fragment specifier.
-    (accepted, macro_lifetime_matcher, "1.27.0", Some(34303), None),
-    /// Allows `#[test]` functions where the return type implements `Termination` (RFC 1937).
-    (accepted, termination_trait_test, "1.27.0", Some(48854), None),
-    /// Allows the `#[global_allocator]` attribute.
-    (accepted, global_allocator, "1.28.0", Some(27389), None),
-    /// Allows `#[repr(transparent)]` attribute on newtype structs.
-    (accepted, repr_transparent, "1.28.0", Some(43036), None),
-    /// Allows procedural macros in `proc-macro` crates.
-    (accepted, proc_macro, "1.29.0", Some(38356), None),
-    /// Allows `foo.rs` as an alternative to `foo/mod.rs`.
-    (accepted, non_modrs_mods, "1.30.0", Some(44660), None),
-    /// Allows use of the `:vis` macro fragment specifier
-    (accepted, macro_vis_matcher, "1.30.0", Some(41022), None),
-    /// Allows importing and reexporting macros with `use`,
-    /// enables macro modularization in general.
-    (accepted, use_extern_macros, "1.30.0", Some(35896), None),
-    /// Allows keywords to be escaped for use as identifiers.
-    (accepted, raw_identifiers, "1.30.0", Some(48589), None),
-    /// Allows attributes scoped to tools.
-    (accepted, tool_attributes, "1.30.0", Some(44690), None),
-    /// Allows multi-segment paths in attributes and derives.
-    (accepted, proc_macro_path_invoc, "1.30.0", Some(38356), None),
-    /// Allows all literals in attribute lists and values of key-value pairs.
-    (accepted, attr_literals, "1.30.0", Some(34981), None),
-    /// Allows inferring outlives requirements (RFC 2093).
-    (accepted, infer_outlives_requirements, "1.30.0", Some(44493), None),
-    /// Allows annotating functions conforming to `fn(&PanicInfo) -> !` with `#[panic_handler]`.
-    /// This defines the behavior of panics.
-    (accepted, panic_handler, "1.30.0", Some(44489), None),
-    /// Allows `#[used]` to preserve symbols (see llvm.compiler.used).
-    (accepted, used, "1.30.0", Some(40289), None),
-    /// Allows `crate` in paths.
-    (accepted, crate_in_paths, "1.30.0", Some(45477), None),
-    /// Allows resolving absolute paths as paths from other crates.
-    (accepted, extern_absolute_paths, "1.30.0", Some(44660), None),
-    /// Allows access to crate names passed via `--extern` through prelude.
-    (accepted, extern_prelude, "1.30.0", Some(44660), None),
-    /// Allows parentheses in patterns.
-    (accepted, pattern_parentheses, "1.31.0", Some(51087), None),
-    /// Allows the definition of `const fn` functions.
-    (accepted, min_const_fn, "1.31.0", Some(53555), None),
-    /// Allows scoped lints.
-    (accepted, tool_lints, "1.31.0", Some(44690), None),
-    /// Allows lifetime elision in `impl` headers. For example:
-    /// + `impl<I:Iterator> Iterator for &mut Iterator`
-    /// + `impl Debug for Foo<'_>`
-    (accepted, impl_header_lifetime_elision, "1.31.0", Some(15872), None),
-    /// Allows `extern crate foo as bar;`. This puts `bar` into extern prelude.
-    (accepted, extern_crate_item_prelude, "1.31.0", Some(55599), None),
-    /// Allows use of the `:literal` macro fragment specifier (RFC 1576).
-    (accepted, macro_literal_matcher, "1.32.0", Some(35625), None),
-    /// Allows use of `?` as the Kleene "at most one" operator in macros.
-    (accepted, macro_at_most_once_rep, "1.32.0", Some(48075), None),
-    /// Allows `Self` struct constructor (RFC 2302).
-    (accepted, self_struct_ctor, "1.32.0", Some(51994), None),
-    /// Allows `Self` in type definitions (RFC 2300).
-    (accepted, self_in_typedefs, "1.32.0", Some(49303), None),
-    /// Allows `use x::y;` to search `x` in the current scope.
-    (accepted, uniform_paths, "1.32.0", Some(53130), None),
-    /// Allows integer match exhaustiveness checking (RFC 2591).
-    (accepted, exhaustive_integer_patterns, "1.33.0", Some(50907), None),
-    /// Allows `use path as _;` and `extern crate c as _;`.
-    (accepted, underscore_imports, "1.33.0", Some(48216), None),
-    /// Allows `#[repr(packed(N))]` attribute on structs.
-    (accepted, repr_packed, "1.33.0", Some(33158), None),
-    /// Allows irrefutable patterns in `if let` and `while let` statements (RFC 2086).
-    (accepted, irrefutable_let_patterns, "1.33.0", Some(44495), None),
-    /// Allows calling `const unsafe fn` inside `unsafe` blocks in `const fn` functions.
-    (accepted, min_const_unsafe_fn, "1.33.0", Some(55607), None),
-    /// Allows let bindings, assignments and destructuring in `const` functions and constants.
-    /// As long as control flow is not implemented in const eval, `&&` and `||` may not be used
-    /// at the same time as let bindings.
-    (accepted, const_let, "1.33.0", Some(48821), None),
-    /// Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
-    (accepted, cfg_attr_multi, "1.33.0", Some(54881), None),
-    /// Allows top level or-patterns (`p | q`) in `if let` and `while let`.
-    (accepted, if_while_or_patterns, "1.33.0", Some(48215), None),
-    /// Allows `cfg(target_vendor = "...")`.
-    (accepted, cfg_target_vendor, "1.33.0", Some(29718), None),
-    /// Allows `extern crate self as foo;`.
-    /// This puts local crate root into extern prelude under name `foo`.
-    (accepted, extern_crate_self, "1.34.0", Some(56409), None),
-    /// Allows arbitrary delimited token streams in non-macro attributes.
-    (accepted, unrestricted_attribute_tokens, "1.34.0", Some(55208), None),
-    /// Allows paths to enum variants on type aliases including `Self`.
-    (accepted, type_alias_enum_variants, "1.37.0", Some(49683), None),
-    /// Allows using `#[repr(align(X))]` on enums with equivalent semantics
-    /// to wrapping an enum in a wrapper struct with `#[repr(align(X))]`.
-    (accepted, repr_align_enum, "1.37.0", Some(57996), None),
-    /// Allows `const _: TYPE = VALUE`.
-    (accepted, underscore_const_names, "1.37.0", Some(54912), None),
+    /// Allows the definition of associated constants in `trait` or `impl` blocks.
+    (accepted, associated_consts, "1.20.0", Some(29646), None),
+    /// Allows using associated `type`s in `trait`s.
+    (accepted, associated_types, "1.0.0", None, None),
     /// Allows free and inherent `async fn`s, `async` blocks, and `<expr>.await` expressions.
     (accepted, async_await, "1.39.0", Some(50547), None),
+    /// Allows all literals in attribute lists and values of key-value pairs.
+    (accepted, attr_literals, "1.30.0", Some(34981), None),
+    /// Allows overloading augmented assignment operations like `a += b`.
+    (accepted, augmented_assignments, "1.8.0", Some(28235), None),
     /// Allows mixing bind-by-move in patterns and references to those identifiers in guards.
     (accepted, bind_by_move_pattern_guards, "1.39.0", Some(15287), None),
-    /// Allows attributes in formal function parameters.
-    (accepted, param_attrs, "1.39.0", Some(60406), None),
-    /// Allows macro invocations in `extern {}` blocks.
-    (accepted, macros_in_extern, "1.40.0", Some(49476), None),
-    /// Allows future-proofing enums/structs with the `#[non_exhaustive]` attribute (RFC 2008).
-    (accepted, non_exhaustive, "1.40.0", Some(44109), None),
-    /// Allows calling constructor functions in `const fn`.
-    (accepted, const_constructor, "1.40.0", Some(61456), None),
-    /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests.
-    (accepted, cfg_doctest, "1.40.0", Some(62210), None),
-    /// Allows relaxing the coherence rules such that
-    /// `impl<T> ForeignTrait<LocalType> for ForeignType<T>` is permitted.
-    (accepted, re_rebalance_coherence, "1.41.0", Some(55437), None),
-    /// Allows #[repr(transparent)] on univariant enums (RFC 2645).
-    (accepted, transparent_enums, "1.42.0", Some(60405), None),
-    /// Allows using subslice patterns, `[a, .., b]` and `[a, xs @ .., b]`.
-    (accepted, slice_patterns, "1.42.0", Some(62254), None),
-    /// Allows the use of `if` and `match` in constants.
-    (accepted, const_if_match, "1.46.0", Some(49146), None),
-    /// Allows the use of `loop` and `while` in constants.
-    (accepted, const_loop, "1.46.0", Some(52000), None),
-    /// Allows `#[track_caller]` to be used which provides
-    /// accurate caller location reporting during panic (RFC 2091).
-    (accepted, track_caller, "1.46.0", Some(47809), None),
-    /// Allows `#[doc(alias = "...")]`.
-    (accepted, doc_alias, "1.48.0", Some(50146), None),
-    /// Allows patterns with concurrent by-move and by-ref bindings.
-    /// For example, you can write `Foo(a, ref b)` where `a` is by-move and `b` is by-ref.
-    (accepted, move_ref_pattern, "1.49.0", Some(68354), None),
-    /// The smallest useful subset of const generics.
-    (accepted, min_const_generics, "1.51.0", Some(74878), None),
-    /// The `unsafe_op_in_unsafe_fn` lint (allowed by default): no longer treat an unsafe function as an unsafe block.
-    (accepted, unsafe_block_in_unsafe_fn, "1.52.0", Some(71668), None),
-    /// Allows the use of or-patterns (e.g., `0 | 1`).
-    (accepted, or_patterns, "1.53.0", Some(54883), None),
-    /// Allows defining identifiers beyond ASCII.
-    (accepted, non_ascii_idents, "1.53.0", Some(55467), None),
-    /// Allows arbitrary expressions in key-value attributes at parse time.
-    (accepted, extended_key_value_attributes, "1.54.0", Some(78835), None),
-    /// Allows unsizing coercions in `const fn`.
-    (accepted, const_fn_unsize, "1.54.0", Some(64992), None),
-    /// Allows `impl Trait` with multiple unrelated lifetimes.
-    (accepted, member_constraints, "1.54.0", Some(61997), None),
     /// Allows bindings in the subpattern of a binding pattern.
     /// For example, you can write `x @ Some(y)`.
     (accepted, bindings_after_at, "1.56.0", Some(65490), None),
+    /// Allows empty structs and enum variants with braces.
+    (accepted, braced_empty_structs, "1.8.0", Some(29720), None),
+    /// Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
+    (accepted, cfg_attr_multi, "1.33.0", Some(54881), None),
+    /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests.
+    (accepted, cfg_doctest, "1.40.0", Some(62210), None),
+    /// Allows `cfg(target_feature = "...")`.
+    (accepted, cfg_target_feature, "1.27.0", Some(29717), None),
+    /// Allows `cfg(target_vendor = "...")`.
+    (accepted, cfg_target_vendor, "1.33.0", Some(29718), None),
+    /// Allows implementing `Clone` for closures where possible (RFC 2132).
+    (accepted, clone_closures, "1.26.0", Some(44490), None),
+    /// Allows coercing non capturing closures to function pointers.
+    (accepted, closure_to_fn_coercion, "1.19.0", Some(39817), None),
+    /// Allows usage of the `compile_error!` macro.
+    (accepted, compile_error, "1.20.0", Some(40872), None),
+    /// Allows `impl Trait` in function return types.
+    (accepted, conservative_impl_trait, "1.26.0", Some(34511), None),
+    /// Allows calling constructor functions in `const fn`.
+    (accepted, const_constructor, "1.40.0", Some(61456), None),
     /// Allows calling `transmute` in const fn
     (accepted, const_fn_transmute, "1.56.0", Some(53605), None),
     /// Allows accessing fields of unions inside `const` functions.
     (accepted, const_fn_union, "1.56.0", Some(51909), None),
-    /// Allows macro attributes to observe output of `#[derive]`.
-    (accepted, macro_attributes_in_derive_output, "1.57.0", Some(81119), None),
+    /// Allows unsizing coercions in `const fn`.
+    (accepted, const_fn_unsize, "1.54.0", Some(64992), None),
+    /// Allows the use of `if` and `match` in constants.
+    (accepted, const_if_match, "1.46.0", Some(49146), None),
+    /// Allows indexing into constant arrays.
+    (accepted, const_indexing, "1.26.0", Some(29947), None),
+    /// Allows let bindings, assignments and destructuring in `const` functions and constants.
+    /// As long as control flow is not implemented in const eval, `&&` and `||` may not be used
+    /// at the same time as let bindings.
+    (accepted, const_let, "1.33.0", Some(48821), None),
+    /// Allows the use of `loop` and `while` in constants.
+    (accepted, const_loop, "1.46.0", Some(52000), None),
     /// Allows panicking during const eval (producing compile-time errors).
     (accepted, const_panic, "1.57.0", Some(51999), None),
-    /// Lessens the requirements for structs to implement `Unsize`.
-    (accepted, relaxed_struct_unsize, "1.58.0", Some(81793), None),
     /// Allows dereferencing raw pointers during const eval.
     (accepted, const_raw_ptr_deref, "1.58.0", Some(51911), None),
+    /// Allows implementing `Copy` for closures where possible (RFC 2132).
+    (accepted, copy_closures, "1.26.0", Some(44490), None),
+    /// Allows `crate` in paths.
+    (accepted, crate_in_paths, "1.30.0", Some(45477), None),
+    /// Allows using assigning a default type to type parameters in algebraic data type definitions.
+    (accepted, default_type_params, "1.0.0", None, None),
+    /// Allows `#[deprecated]` attribute.
+    (accepted, deprecated, "1.9.0", Some(29935), None),
+    /// Allows `#[doc(alias = "...")]`.
+    (accepted, doc_alias, "1.48.0", Some(50146), None),
+    /// Allows `..` in tuple (struct) patterns.
+    (accepted, dotdot_in_tuple_patterns, "1.14.0", Some(33627), None),
+    /// Allows `..=` in patterns (RFC 1192).
+    (accepted, dotdoteq_in_patterns, "1.26.0", Some(28237), None),
+    /// Allows `Drop` types in constants (RFC 1440).
+    (accepted, drop_types_in_const, "1.22.0", Some(33156), None),
+    /// Allows using `dyn Trait` as a syntax for trait objects.
+    (accepted, dyn_trait, "1.27.0", Some(44662), None),
+    /// Allows integer match exhaustiveness checking (RFC 2591).
+    (accepted, exhaustive_integer_patterns, "1.33.0", Some(50907), None),
+    /// Allows arbitrary expressions in key-value attributes at parse time.
+    (accepted, extended_key_value_attributes, "1.54.0", Some(78835), None),
+    /// Allows resolving absolute paths as paths from other crates.
+    (accepted, extern_absolute_paths, "1.30.0", Some(44660), None),
+    /// Allows `extern crate foo as bar;`. This puts `bar` into extern prelude.
+    (accepted, extern_crate_item_prelude, "1.31.0", Some(55599), None),
+    /// Allows `extern crate self as foo;`.
+    /// This puts local crate root into extern prelude under name `foo`.
+    (accepted, extern_crate_self, "1.34.0", Some(56409), None),
+    /// Allows access to crate names passed via `--extern` through prelude.
+    (accepted, extern_prelude, "1.30.0", Some(44660), None),
+    /// Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
+    (accepted, field_init_shorthand, "1.17.0", Some(37340), None),
+    /// Allows `#[must_use]` on functions, and introduces must-use operators (RFC 1940).
+    (accepted, fn_must_use, "1.27.0", Some(43302), None),
     /// Allows capturing variables in scope using format_args!
     (accepted, format_args_capture, "1.58.0", Some(67984), None),
+    /// Allows attributes on lifetime/type formal parameters in generics (RFC 1327).
+    (accepted, generic_param_attrs, "1.27.0", Some(48848), None),
+    /// Allows the `#[global_allocator]` attribute.
+    (accepted, global_allocator, "1.28.0", Some(27389), None),
+    // FIXME: explain `globs`.
+    (accepted, globs, "1.0.0", None, None),
+    /// Allows using the `u128` and `i128` types.
+    (accepted, i128_type, "1.26.0", Some(35118), None),
+    /// Allows the use of `if let` expressions.
+    (accepted, if_let, "1.0.0", None, None),
+    /// Allows top level or-patterns (`p | q`) in `if let` and `while let`.
+    (accepted, if_while_or_patterns, "1.33.0", Some(48215), None),
+    /// Allows lifetime elision in `impl` headers. For example:
+    /// + `impl<I:Iterator> Iterator for &mut Iterator`
+    /// + `impl Debug for Foo<'_>`
+    (accepted, impl_header_lifetime_elision, "1.31.0", Some(15872), None),
+    /// Allows using `a..=b` and `..=b` as inclusive range syntaxes.
+    (accepted, inclusive_range_syntax, "1.26.0", Some(28237), None),
+    /// Allows inferring outlives requirements (RFC 2093).
+    (accepted, infer_outlives_requirements, "1.30.0", Some(44493), None),
+    /// Allows irrefutable patterns in `if let` and `while let` statements (RFC 2086).
+    (accepted, irrefutable_let_patterns, "1.33.0", Some(44495), None),
+    /// Allows some increased flexibility in the name resolution rules,
+    /// especially around globs and shadowing (RFC 1560).
+    (accepted, item_like_imports, "1.15.0", Some(35120), None),
+    /// Allows `break {expr}` with a value inside `loop`s.
+    (accepted, loop_break_value, "1.19.0", Some(37339), None),
+    /// Allows use of `?` as the Kleene "at most one" operator in macros.
+    (accepted, macro_at_most_once_rep, "1.32.0", Some(48075), None),
+    /// Allows macro attributes to observe output of `#[derive]`.
+    (accepted, macro_attributes_in_derive_output, "1.57.0", Some(81119), None),
+    /// Allows use of the `:lifetime` macro fragment specifier.
+    (accepted, macro_lifetime_matcher, "1.27.0", Some(34303), None),
+    /// Allows use of the `:literal` macro fragment specifier (RFC 1576).
+    (accepted, macro_literal_matcher, "1.32.0", Some(35625), None),
+    /// Allows `macro_rules!` items.
+    (accepted, macro_rules, "1.0.0", None, None),
+    /// Allows use of the `:vis` macro fragment specifier
+    (accepted, macro_vis_matcher, "1.30.0", Some(41022), None),
+    /// Allows macro invocations in `extern {}` blocks.
+    (accepted, macros_in_extern, "1.40.0", Some(49476), None),
+    /// Allows '|' at beginning of match arms (RFC 1925).
+    (accepted, match_beginning_vert, "1.25.0", Some(44101), None),
+    /// Allows default match binding modes (RFC 2005).
+    (accepted, match_default_bindings, "1.26.0", Some(42640), None),
+    /// Allows `impl Trait` with multiple unrelated lifetimes.
+    (accepted, member_constraints, "1.54.0", Some(61997), None),
+    /// Allows the definition of `const fn` functions.
+    (accepted, min_const_fn, "1.31.0", Some(53555), None),
+    /// The smallest useful subset of const generics.
+    (accepted, min_const_generics, "1.51.0", Some(74878), None),
+    /// Allows calling `const unsafe fn` inside `unsafe` blocks in `const fn` functions.
+    (accepted, min_const_unsafe_fn, "1.33.0", Some(55607), None),
+    /// Allows using `Self` and associated types in struct expressions and patterns.
+    (accepted, more_struct_aliases, "1.16.0", Some(37544), None),
+    /// Allows patterns with concurrent by-move and by-ref bindings.
+    /// For example, you can write `Foo(a, ref b)` where `a` is by-move and `b` is by-ref.
+    (accepted, move_ref_pattern, "1.49.0", Some(68354), None),
+    /// Allows using `#![no_std]`.
+    (accepted, no_std, "1.6.0", None, None),
+    /// Allows defining identifiers beyond ASCII.
+    (accepted, non_ascii_idents, "1.53.0", Some(55467), None),
+    /// Allows future-proofing enums/structs with the `#[non_exhaustive]` attribute (RFC 2008).
+    (accepted, non_exhaustive, "1.40.0", Some(44109), None),
+    /// Allows `foo.rs` as an alternative to `foo/mod.rs`.
+    (accepted, non_modrs_mods, "1.30.0", Some(44660), None),
+    /// Allows the use of or-patterns (e.g., `0 | 1`).
+    (accepted, or_patterns, "1.53.0", Some(54883), None),
+    /// Allows annotating functions conforming to `fn(&PanicInfo) -> !` with `#[panic_handler]`.
+    /// This defines the behavior of panics.
+    (accepted, panic_handler, "1.30.0", Some(44489), None),
+    /// Allows attributes in formal function parameters.
+    (accepted, param_attrs, "1.39.0", Some(60406), None),
+    /// Allows parentheses in patterns.
+    (accepted, pattern_parentheses, "1.31.0", Some(51087), None),
+    /// Allows procedural macros in `proc-macro` crates.
+    (accepted, proc_macro, "1.29.0", Some(38356), None),
+    /// Allows multi-segment paths in attributes and derives.
+    (accepted, proc_macro_path_invoc, "1.30.0", Some(38356), None),
+    /// Allows `pub(restricted)` visibilities (RFC 1422).
+    (accepted, pub_restricted, "1.18.0", Some(32409), None),
+    /// Allows use of the postfix `?` operator in expressions.
+    (accepted, question_mark, "1.13.0", Some(31436), None),
+    /// Allows keywords to be escaped for use as identifiers.
+    (accepted, raw_identifiers, "1.30.0", Some(48589), None),
+    /// Allows relaxing the coherence rules such that
+    /// `impl<T> ForeignTrait<LocalType> for ForeignType<T>` is permitted.
+    (accepted, re_rebalance_coherence, "1.41.0", Some(55437), None),
+    /// Allows numeric fields in struct expressions and patterns.
+    (accepted, relaxed_adts, "1.19.0", Some(35626), None),
+    /// Lessens the requirements for structs to implement `Unsize`.
+    (accepted, relaxed_struct_unsize, "1.58.0", Some(81793), None),
+    /// Allows `repr(align(16))` struct attribute (RFC 1358).
+    (accepted, repr_align, "1.25.0", Some(33626), None),
+    /// Allows using `#[repr(align(X))]` on enums with equivalent semantics
+    /// to wrapping an enum in a wrapper struct with `#[repr(align(X))]`.
+    (accepted, repr_align_enum, "1.37.0", Some(57996), None),
+    /// Allows `#[repr(packed(N))]` attribute on structs.
+    (accepted, repr_packed, "1.33.0", Some(33158), None),
+    /// Allows `#[repr(transparent)]` attribute on newtype structs.
+    (accepted, repr_transparent, "1.28.0", Some(43036), None),
+    /// Allows code like `let x: &'static u32 = &42` to work (RFC 1414).
+    (accepted, rvalue_static_promotion, "1.21.0", Some(38865), None),
+    /// Allows `Self` in type definitions (RFC 2300).
+    (accepted, self_in_typedefs, "1.32.0", Some(49303), None),
+    /// Allows `Self` struct constructor (RFC 2302).
+    (accepted, self_struct_ctor, "1.32.0", Some(51994), None),
+    /// Allows using subslice patterns, `[a, .., b]` and `[a, xs @ .., b]`.
+    (accepted, slice_patterns, "1.42.0", Some(62254), None),
+    /// Allows use of `&foo[a..b]` as a slicing syntax.
+    (accepted, slicing_syntax, "1.0.0", None, None),
+    /// Allows elision of `'static` lifetimes in `static`s and `const`s.
+    (accepted, static_in_const, "1.17.0", Some(35897), None),
+    /// Allows the definition recursive static items.
+    (accepted, static_recursion, "1.17.0", Some(29719), None),
+    /// Allows attributes on struct literal fields.
+    (accepted, struct_field_attributes, "1.20.0", Some(38814), None),
+    /// Allows struct variants `Foo { baz: u8, .. }` in enums (RFC 418).
+    (accepted, struct_variant, "1.0.0", None, None),
+    /// Allows `#[target_feature(...)]`.
+    (accepted, target_feature, "1.27.0", None, None),
+    /// Allows `fn main()` with return types which implements `Termination` (RFC 1937).
+    (accepted, termination_trait, "1.26.0", Some(43301), None),
+    /// Allows `#[test]` functions where the return type implements `Termination` (RFC 1937).
+    (accepted, termination_trait_test, "1.27.0", Some(48854), None),
+    /// Allows attributes scoped to tools.
+    (accepted, tool_attributes, "1.30.0", Some(44690), None),
+    /// Allows scoped lints.
+    (accepted, tool_lints, "1.31.0", Some(44690), None),
+    /// Allows `#[track_caller]` to be used which provides
+    /// accurate caller location reporting during panic (RFC 2091).
+    (accepted, track_caller, "1.46.0", Some(47809), None),
+    /// Allows #[repr(transparent)] on univariant enums (RFC 2645).
+    (accepted, transparent_enums, "1.42.0", Some(60405), None),
+    /// Allows indexing tuples.
+    (accepted, tuple_indexing, "1.0.0", None, None),
+    /// Allows paths to enum variants on type aliases including `Self`.
+    (accepted, type_alias_enum_variants, "1.37.0", Some(49683), None),
+    /// Allows macros to appear in the type position.
+    (accepted, type_macros, "1.13.0", Some(27245), None),
+    /// Allows `const _: TYPE = VALUE`.
+    (accepted, underscore_const_names, "1.37.0", Some(54912), None),
+    /// Allows `use path as _;` and `extern crate c as _;`.
+    (accepted, underscore_imports, "1.33.0", Some(48216), None),
+    /// Allows `'_` placeholder lifetimes.
+    (accepted, underscore_lifetimes, "1.26.0", Some(44524), None),
+    /// Allows `use x::y;` to search `x` in the current scope.
+    (accepted, uniform_paths, "1.32.0", Some(53130), None),
+    /// Allows `impl Trait` in function arguments.
+    (accepted, universal_impl_trait, "1.26.0", Some(34511), None),
+    /// Allows arbitrary delimited token streams in non-macro attributes.
+    (accepted, unrestricted_attribute_tokens, "1.34.0", Some(55208), None),
+    /// The `unsafe_op_in_unsafe_fn` lint (allowed by default): no longer treat an unsafe function as an unsafe block.
+    (accepted, unsafe_block_in_unsafe_fn, "1.52.0", Some(71668), None),
+    /// Allows importing and reexporting macros with `use`,
+    /// enables macro modularization in general.
+    (accepted, use_extern_macros, "1.30.0", Some(35896), None),
+    /// Allows nested groups in `use` items (RFC 2128).
+    (accepted, use_nested_groups, "1.25.0", Some(44494), None),
+    /// Allows `#[used]` to preserve symbols (see llvm.compiler.used).
+    (accepted, used, "1.30.0", Some(40289), None),
+    /// Allows the use of `while let` expressions.
+    (accepted, while_let, "1.0.0", None, None),
+    /// Allows `#![windows_subsystem]`.
+    (accepted, windows_subsystem, "1.18.0", Some(37499), None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: accepted features

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -122,130 +122,101 @@ impl Feature {
 #[rustfmt::skip]
 declare_features! (
     // -------------------------------------------------------------------------
-    // feature-group-start: internal feature gates
+    // feature-group-start: internal feature gates (no tracking issue)
     // -------------------------------------------------------------------------
-
     // no-tracking-issue-start
 
-    /// Allows using `rustc_*` attributes (RFC 572).
-    (active, rustc_attrs, "1.0.0", None, None),
-
-    /// Allows using compiler's own crates.
-    (active, rustc_private, "1.0.0", Some(27812), None),
-
-    /// Allows using the `rust-intrinsic`'s "ABI".
-    (active, intrinsics, "1.0.0", None, None),
-
-    /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
-    (active, lang_items, "1.0.0", None, None),
-
-    /// Allows using the `#[stable]` and `#[unstable]` attributes.
-    (active, staged_api, "1.0.0", None, None),
-
-    /// Allows using `#[allow_internal_unstable]`. This is an
-    /// attribute on `macro_rules!` and can't use the attribute handling
-    /// below (it has to be checked before expansion possibly makes
-    /// macros disappear).
-    (active, allow_internal_unstable, "1.0.0", None, None),
-
+    /// Allows using the `thiscall` ABI.
+    (active, abi_thiscall, "1.19.0", None, None),
+    /// Allows using the `unadjusted` ABI; perma-unstable.
+    (active, abi_unadjusted, "1.16.0", None, None),
+    /// Allows using the `vectorcall` ABI.
+    (active, abi_vectorcall, "1.7.0", None, None),
+    /// Allows using `#![needs_allocator]`, an implementation detail of `#[global_allocator]`.
+    (active, allocator_internals, "1.20.0", None, None),
     /// Allows using `#[allow_internal_unsafe]`. This is an
     /// attribute on `macro_rules!` and can't use the attribute handling
     /// below (it has to be checked before expansion possibly makes
     /// macros disappear).
     (active, allow_internal_unsafe, "1.0.0", None, None),
-
-    /// no-tracking-issue-end
-
-    /// Allows using `#[link_name="llvm.*"]`.
-    (active, link_llvm_intrinsics, "1.0.0", Some(29602), None),
-
-    /// Allows using the `box $expr` syntax.
-    (active, box_syntax, "1.0.0", Some(49733), None),
-
-    /// Allows using `#[start]` on a function indicating that it is the program entrypoint.
-    (active, start, "1.0.0", Some(29633), None),
-
-    /// Allows using the `#[fundamental]` attribute.
-    (active, fundamental, "1.0.0", Some(29635), None),
-
-    /// Allows using the `rust-call` ABI.
-    (active, unboxed_closures, "1.0.0", Some(29625), None),
-
-    /// Allows using the `#[linkage = ".."]` attribute.
-    (active, linkage, "1.0.0", Some(29603), None),
-
-    /// Allows using `box` in patterns (RFC 469).
-    (active, box_patterns, "1.0.0", Some(29641), None),
-
-    // no-tracking-issue-start
-
-    /// Allows using `#[prelude_import]` on glob `use` items.
-    (active, prelude_import, "1.2.0", None, None),
-
-    // no-tracking-issue-end
-
-    // no-tracking-issue-start
-
-    /// Allows using `#[omit_gdb_pretty_printer_section]`.
-    (active, omit_gdb_pretty_printer_section, "1.5.0", None, None),
-
-    /// Allows using the `vectorcall` ABI.
-    (active, abi_vectorcall, "1.7.0", None, None),
-
-    // no-tracking-issue-end
-
-    /// Allows using `#[structural_match]` which indicates that a type is structurally matchable.
-    /// FIXME: Subsumed by trait `StructuralPartialEq`, cannot move to removed until a library
-    /// feature with the same name exists.
-    (active, structural_match, "1.8.0", Some(31434), None),
-
-    /// Allows using the `may_dangle` attribute (RFC 1327).
-    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
-
-    /// Allows using the `#![panic_runtime]` attribute.
-    (active, panic_runtime, "1.10.0", Some(32837), None),
-
-    /// Allows declaring with `#![needs_panic_runtime]` that a panic runtime is needed.
-    (active, needs_panic_runtime, "1.10.0", Some(32837), None),
-
-    // no-tracking-issue-start
-
+    /// Allows using `#[allow_internal_unstable]`. This is an
+    /// attribute on `macro_rules!` and can't use the attribute handling
+    /// below (it has to be checked before expansion possibly makes
+    /// macros disappear).
+    (active, allow_internal_unstable, "1.0.0", None, None),
     /// Allows identifying the `compiler_builtins` crate.
     (active, compiler_builtins, "1.13.0", None, None),
-
-    /// Allows using the `unadjusted` ABI; perma-unstable.
-    (active, abi_unadjusted, "1.16.0", None, None),
-
-    /// Used to identify crates that contain the profiler runtime.
-    (active, profiler_runtime, "1.18.0", None, None),
-
-    /// Allows using the `thiscall` ABI.
-    (active, abi_thiscall, "1.19.0", None, None),
-
-    /// Allows using `#![needs_allocator]`, an implementation detail of `#[global_allocator]`.
-    (active, allocator_internals, "1.20.0", None, None),
-
-    /// Added for testing E0705; perma-unstable.
-    (active, test_2018_feature, "1.31.0", None, Some(Edition::Edition2018)),
-
+    /// Allows using the `rust-intrinsic`'s "ABI".
+    (active, intrinsics, "1.0.0", None, None),
+    /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
+    (active, lang_items, "1.0.0", None, None),
     /// Allows `#[repr(no_niche)]` (an implementation detail of `rustc`,
     /// it is not on path for eventual stabilization).
     (active, no_niche, "1.42.0", None, None),
+    /// Allows using `#[omit_gdb_pretty_printer_section]`.
+    (active, omit_gdb_pretty_printer_section, "1.5.0", None, None),
+    /// Allows using `#[prelude_import]` on glob `use` items.
+    (active, prelude_import, "1.2.0", None, None),
+    /// Used to identify crates that contain the profiler runtime.
+    (active, profiler_runtime, "1.18.0", None, None),
+    /// Allows using `rustc_*` attributes (RFC 572).
+    (active, rustc_attrs, "1.0.0", None, None),
+    /// Allows using the `#[stable]` and `#[unstable]` attributes.
+    (active, staged_api, "1.0.0", None, None),
+    /// Added for testing E0705; perma-unstable.
+    (active, test_2018_feature, "1.31.0", None, Some(Edition::Edition2018)),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
-    /// Allows using `#[rustc_allow_const_fn_unstable]`.
-    /// This is an attribute on `const fn` for the same
-    /// purpose as `#[allow_internal_unstable]`.
-    (active, rustc_allow_const_fn_unstable, "1.49.0", Some(69399), None),
+    // no-tracking-issue-end
+    // -------------------------------------------------------------------------
+    // feature-group-end: internal feature gates (no tracking issue)
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // feature-group-start: internal feature gates
+    // -------------------------------------------------------------------------
 
     /// Allows features specific to auto traits.
     /// Renamed from `optin_builtin_traits`.
     (active, auto_traits, "1.50.0", Some(13231), None),
-
+    /// Allows using `box` in patterns (RFC 469).
+    (active, box_patterns, "1.0.0", Some(29641), None),
+    /// Allows using the `box $expr` syntax.
+    (active, box_syntax, "1.0.0", Some(49733), None),
     /// Allows `#[doc(notable_trait)]`.
     /// Renamed from `doc_spotlight`.
     (active, doc_notable_trait, "1.52.0", Some(45040), None),
-
-    // no-tracking-issue-end
+    /// Allows using the `may_dangle` attribute (RFC 1327).
+    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
+    /// Allows using the `#[fundamental]` attribute.
+    (active, fundamental, "1.0.0", Some(29635), None),
+    /// Allows using `#[link_name="llvm.*"]`.
+    (active, link_llvm_intrinsics, "1.0.0", Some(29602), None),
+    /// Allows using the `#[linkage = ".."]` attribute.
+    (active, linkage, "1.0.0", Some(29603), None),
+    /// Allows declaring with `#![needs_panic_runtime]` that a panic runtime is needed.
+    (active, needs_panic_runtime, "1.10.0", Some(32837), None),
+    /// Allows using the `#![panic_runtime]` attribute.
+    (active, panic_runtime, "1.10.0", Some(32837), None),
+    /// Allows using `#[rustc_allow_const_fn_unstable]`.
+    /// This is an attribute on `const fn` for the same
+    /// purpose as `#[allow_internal_unstable]`.
+    (active, rustc_allow_const_fn_unstable, "1.49.0", Some(69399), None),
+    /// Allows using compiler's own crates.
+    (active, rustc_private, "1.0.0", Some(27812), None),
+    /// Allows using `#[start]` on a function indicating that it is the program entrypoint.
+    (active, start, "1.0.0", Some(29633), None),
+    /// Allows using `#[structural_match]` which indicates that a type is structurally matchable.
+    /// FIXME: Subsumed by trait `StructuralPartialEq`, cannot move to removed until a library
+    /// feature with the same name exists.
+    (active, structural_match, "1.8.0", Some(31434), None),
+    /// Allows using the `rust-call` ABI.
+    (active, unboxed_closures, "1.0.0", Some(29625), None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: internal feature gates
@@ -258,23 +229,26 @@ declare_features! (
     // FIXME: Document these and merge with the list below.
 
     // Unstable `#[target_feature]` directives.
-    (active, arm_target_feature, "1.27.0", Some(44839), None),
     (active, aarch64_target_feature, "1.27.0", Some(44839), None),
-    (active, hexagon_target_feature, "1.27.0", Some(44839), None),
-    (active, powerpc_target_feature, "1.27.0", Some(44839), None),
-    (active, mips_target_feature, "1.27.0", Some(44839), None),
+    (active, adx_target_feature, "1.32.0", Some(44839), None),
+    (active, arm_target_feature, "1.27.0", Some(44839), None),
     (active, avx512_target_feature, "1.27.0", Some(44839), None),
+    (active, bpf_target_feature, "1.54.0", Some(44839), None),
+    (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
+    (active, ermsb_target_feature, "1.49.0", Some(44839), None),
+    (active, f16c_target_feature, "1.36.0", Some(44839), None),
+    (active, hexagon_target_feature, "1.27.0", Some(44839), None),
+    (active, mips_target_feature, "1.27.0", Some(44839), None),
+    (active, movbe_target_feature, "1.34.0", Some(44839), None),
+    (active, powerpc_target_feature, "1.27.0", Some(44839), None),
+    (active, riscv_target_feature, "1.45.0", Some(44839), None),
+    (active, rtm_target_feature, "1.35.0", Some(44839), None),
     (active, sse4a_target_feature, "1.27.0", Some(44839), None),
     (active, tbm_target_feature, "1.27.0", Some(44839), None),
     (active, wasm_target_feature, "1.30.0", Some(44839), None),
-    (active, adx_target_feature, "1.32.0", Some(44839), None),
-    (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
-    (active, movbe_target_feature, "1.34.0", Some(44839), None),
-    (active, rtm_target_feature, "1.35.0", Some(44839), None),
-    (active, f16c_target_feature, "1.36.0", Some(44839), None),
-    (active, riscv_target_feature, "1.45.0", Some(44839), None),
-    (active, ermsb_target_feature, "1.49.0", Some(44839), None),
-    (active, bpf_target_feature, "1.54.0", Some(44839), None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates (target features)
@@ -284,65 +258,275 @@ declare_features! (
     // feature-group-start: actual feature gates
     // -------------------------------------------------------------------------
 
-    /// Allows using `#![plugin(myplugin)]`.
-    (active, plugin, "1.0.0", Some(29597), None),
-
-    /// Allows using `#[thread_local]` on `static` items.
-    (active, thread_local, "1.0.0", Some(29594), None),
-
-    /// Allows the use of SIMD types in functions declared in `extern` blocks.
-    (active, simd_ffi, "1.0.0", Some(27731), None),
-
-    /// Allows using non lexical lifetimes (RFC 2094).
-    (active, nll, "1.0.0", Some(43234), None),
-
+    /// Allows using the `amdgpu-kernel` ABI.
+    (active, abi_amdgpu_kernel, "1.29.0", Some(51575), None),
+    /// Allows `extern "avr-interrupt" fn()` and `extern "avr-non-blocking-interrupt" fn()`.
+    (active, abi_avr_interrupt, "1.45.0", Some(69664), None),
+    /// Allows `extern "C-cmse-nonsecure-call" fn()`.
+    (active, abi_c_cmse_nonsecure_call, "1.51.0", Some(81391), None),
+    /// Allows using the `efiapi` ABI.
+    (active, abi_efiapi, "1.40.0", Some(65815), None),
+    /// Allows `extern "msp430-interrupt" fn()`.
+    (active, abi_msp430_interrupt, "1.16.0", Some(38487), None),
+    /// Allows `extern "ptx-*" fn()`.
+    (active, abi_ptx, "1.15.0", Some(38788), None),
+    /// Allows `extern "x86-interrupt" fn()`.
+    (active, abi_x86_interrupt, "1.17.0", Some(40180), None),
+    /// Allows additional const parameter types, such as `&'static str` or user defined types
+    (incomplete, adt_const_params, "1.56.0", Some(44580), None),
+    /// Allows defining an `#[alloc_error_handler]`.
+    (active, alloc_error_handler, "1.29.0", Some(51540), None),
+    /// Allows a test to fail without failing the whole suite.
+    (active, allow_fail, "1.19.0", Some(46488), None),
+    /// Allows explicit discriminants on non-unit enum variants.
+    (active, arbitrary_enum_discriminant, "1.37.0", Some(60553), None),
+    /// Allows trait methods with arbitrary self types.
+    (active, arbitrary_self_types, "1.23.0", Some(44874), None),
+    /// Allows using `const` operands in inline assembly.
+    (active, asm_const, "1.58.0", Some(72016), None),
+    /// Enables experimental inline assembly support for additional architectures.
+    (active, asm_experimental_arch, "1.58.0", Some(72016), None),
+    /// Allows using `sym` operands in inline assembly.
+    (active, asm_sym, "1.58.0", Some(72016), None),
+    /// Allows the user of associated type bounds.
+    (active, associated_type_bounds, "1.34.0", Some(52662), None),
     /// Allows associated type defaults.
     (active, associated_type_defaults, "1.2.0", Some(29661), None),
-
-    /// Allows `#![no_core]`.
-    (active, no_core, "1.3.0", Some(29639), None),
-
-    /// Allows default type parameters to influence type inference.
-    (active, default_type_parameter_fallback, "1.3.0", Some(27336), None),
-
-    /// Allows `repr(simd)` and importing the various simd intrinsics.
-    (active, repr_simd, "1.4.0", Some(27731), None),
-
-    /// Allows `extern "platform-intrinsic" { ... }`.
-    (active, platform_intrinsics, "1.4.0", Some(27731), None),
-
-    /// Allows attributes on expressions and non-item statements.
-    (active, stmt_expr_attributes, "1.6.0", Some(15701), None),
-
-    /// Allows the use of type ascription in expressions.
-    (active, type_ascription, "1.6.0", Some(23416), None),
-
+    /// Allows `async || body` closures.
+    (active, async_closure, "1.37.0", Some(62290), None),
+    /// Allows `extern "C-unwind" fn` to enable unwinding across ABI boundaries.
+    (active, c_unwind, "1.52.0", Some(74990), None),
+    /// Allows using C-variadics.
+    (active, c_variadic, "1.34.0", Some(44930), None),
+    /// Allows capturing disjoint fields in a closure/generator (RFC 2229).
+    (incomplete, capture_disjoint_fields, "1.49.0", Some(53488), None),
+    /// Enables `#[cfg(panic = "...")]` config key.
+    (active, cfg_panic, "1.49.0", Some(77443), None),
+    /// Allows the use of `#[cfg(sanitize = "option")]`; set when -Zsanitizer is used.
+    (active, cfg_sanitize, "1.41.0", Some(39699), None),
+    /// Allows `cfg(target_abi = "...")`.
+    (active, cfg_target_abi, "1.55.0", Some(80970), None),
+    /// Allows `cfg(target_has_atomic = "...")`.
+    (active, cfg_target_has_atomic, "1.9.0", Some(32976), None),
     /// Allows `cfg(target_thread_local)`.
     (active, cfg_target_thread_local, "1.7.0", Some(29594), None),
-
-    /// Allows specialization of implementations (RFC 1210).
-    (incomplete, specialization, "1.7.0", Some(31844), None),
-
+    /// Allow conditional compilation depending on rust version
+    (active, cfg_version, "1.45.0", Some(64796), None),
+    /// Allows `#[track_caller]` on closures and generators.
+    (active, closure_track_caller, "1.57.0", Some(87417), None),
+    /// Allows to use the `#[cmse_nonsecure_entry]` attribute.
+    (active, cmse_nonsecure_entry, "1.48.0", Some(75835), None),
+    /// Allows `async {}` expressions in const contexts.
+    (active, const_async_blocks, "1.53.0", Some(85368), None),
+    // Allows limiting the evaluation steps of const expressions
+    (active, const_eval_limit, "1.43.0", Some(67217), None),
+    /// Allows the definition of `const extern fn` and `const unsafe extern fn`.
+    (active, const_extern_fn, "1.40.0", Some(64926), None),
+    /// Allows basic arithmetic on floating point types in a `const fn`.
+    (active, const_fn_floating_point_arithmetic, "1.48.0", Some(57241), None),
+    /// Allows using and casting function pointers in a `const fn`.
+    (active, const_fn_fn_ptr_basics, "1.48.0", Some(57563), None),
+    /// Allows trait bounds in `const fn`.
+    (active, const_fn_trait_bound, "1.53.0", Some(57563), None),
+    /// Allows `for _ in _` loops in const contexts.
+    (active, const_for, "1.56.0", Some(87575), None),
+    /// Allows const generics to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).
+    (active, const_generics_defaults, "1.51.0", Some(44580), None),
+    /// Allows argument and return position `impl Trait` in a `const fn`.
+    (active, const_impl_trait, "1.48.0", Some(77463), None),
+    /// Allows using `&mut` in constant functions.
+    (active, const_mut_refs, "1.41.0", Some(57349), None),
+    /// Be more precise when looking for live drops in a const context.
+    (active, const_precise_live_drops, "1.46.0", Some(73255), None),
+    /// Allows references to types with interior mutability within constants
+    (active, const_refs_to_cell, "1.51.0", Some(80384), None),
+    /// Allows `impl const Trait for T` syntax.
+    (active, const_trait_impl, "1.42.0", Some(67792), None),
+    /// Allows the `?` operator in const contexts.
+    (active, const_try, "1.56.0", Some(74935), None),
+    /// Allows using `crate` as visibility modifier, synonymous with `pub(crate)`.
+    (active, crate_visibility_modifier, "1.23.0", Some(53120), None),
+    /// Allows non-builtin attributes in inner attribute position.
+    (active, custom_inner_attributes, "1.30.0", Some(54726), None),
+    /// Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
+    (active, custom_test_frameworks, "1.30.0", Some(50297), None),
+    /// Allows declarative macros 2.0 (`macro`).
+    (active, decl_macro, "1.17.0", Some(39412), None),
+    /// Allows rustc to inject a default alloc_error_handler
+    (active, default_alloc_error_handler, "1.48.0", Some(66741), None),
+    /// Allows default type parameters to influence type inference.
+    (active, default_type_parameter_fallback, "1.3.0", Some(27336), None),
+    /// Allows `#[derive(Default)]` and `#[default]` on enums.
+    (active, derive_default_enum, "1.56.0", Some(86985), None),
+    /// Allows the use of destructuring assignments.
+    (active, destructuring_assignment, "1.49.0", Some(71126), None),
+    /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.
+    (active, doc_auto_cfg, "1.58.0", Some(43781), None),
+    /// Allows `#[doc(cfg(...))]`.
+    (active, doc_cfg, "1.21.0", Some(43781), None),
+    /// Allows `#[doc(cfg_hide(...))]`.
+    (active, doc_cfg_hide, "1.57.0", Some(43781), None),
+    /// Allows using `#[doc(keyword = "...")]`.
+    (active, doc_keyword, "1.28.0", Some(51315), None),
+    /// Allows `#[doc(masked)]`.
+    (active, doc_masked, "1.21.0", Some(44027), None),
+    /// Allows using doc(primitive) without a future-incompat warning
+    (active, doc_primitive, "1.56.0", Some(88070), None),
+    /// Allows `X..Y` patterns.
+    (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
+    /// Allows exhaustive pattern matching on types that contain uninhabited types.
+    (active, exhaustive_patterns, "1.13.0", Some(51085), None),
+    /// Allows explicit generic arguments specification with `impl Trait` present.
+    (active, explicit_generic_args_with_impl_trait, "1.56.0", Some(83701), None),
+    /// Allows defining `extern type`s.
+    (active, extern_types, "1.23.0", Some(43467), None),
+    /// Allows the use of `#[ffi_const]` on foreign functions.
+    (active, ffi_const, "1.45.0", Some(58328), None),
+    /// Allows the use of `#[ffi_pure]` on foreign functions.
+    (active, ffi_pure, "1.45.0", Some(58329), None),
+    /// Allows using `#[ffi_returns_twice]` on foreign functions.
+    (active, ffi_returns_twice, "1.34.0", Some(58314), None),
+    /// Allows using `#[repr(align(...))]` on function items
+    (active, fn_align, "1.53.0", Some(82232), None),
+    /// Allows defining generators.
+    (active, generators, "1.21.0", Some(43122), None),
+    /// Infer generic args for both consts and types.
+    (active, generic_arg_infer, "1.55.0", Some(85077), None),
+    /// Allows associated types to be generic, e.g., `type Foo<T>;` (RFC 1598).
+    (active, generic_associated_types, "1.23.0", Some(44265), None),
+    /// Allows non-trivial generic constants which have to have wfness manually propagated to callers
+    (incomplete, generic_const_exprs, "1.56.0", Some(76560), None),
+    /// Allows using `..X`, `..=X`, `...X`, and `X..` as a pattern.
+    (active, half_open_range_patterns, "1.41.0", Some(67264), None),
+    /// Allows `if let` guard in match arms.
+    (active, if_let_guard, "1.47.0", Some(51114), None),
+    /// Allows using imported `main` function
+    (active, imported_main, "1.53.0", Some(28937), None),
+    /// Allows in-band quantification of lifetime bindings (e.g., `fn foo(x: &'a u8) -> &'a u8`).
+    (active, in_band_lifetimes, "1.23.0", Some(44524), None),
+    /// Allows inferring `'static` outlives requirements (RFC 2093).
+    (active, infer_static_outlives_requirements, "1.26.0", Some(54185), None),
+    /// Allows associated types in inherent impls.
+    (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
+    /// Allow anonymous constants from an inline `const` block
+    (incomplete, inline_const, "1.49.0", Some(76001), None),
+    /// Allows using `pointer` and `reference` in intra-doc links
+    (active, intra_doc_pointers, "1.51.0", Some(80896), None),
+    /// Allows `#[instruction_set(_)]` attribute
+    (active, isa_attribute, "1.48.0", Some(74727), None),
+    /// Allows `'a: { break 'a; }`.
+    (active, label_break_value, "1.28.0", Some(48594), None),
+    // Allows setting the threshold for the `large_assignments` lint.
+    (active, large_assignments, "1.52.0", Some(83518), None),
+    /// Allows `if/while p && let q = r && ...` chains.
+    (incomplete, let_chains, "1.37.0", Some(53667), None),
+    /// Allows `let...else` statements.
+    (active, let_else, "1.56.0", Some(87335), None),
+    /// Allows `#[link(..., cfg(..))]`.
+    (active, link_cfg, "1.14.0", Some(37406), None),
+    /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
+    (active, lint_reasons, "1.31.0", Some(54503), None),
+    /// Allows `#[marker]` on certain traits allowing overlapping implementations.
+    (active, marker_trait_attr, "1.30.0", Some(29864), None),
     /// A minimal, sound subset of specialization intended to be used by the
     /// standard library until the soundness issues with specialization
     /// are fixed.
     (active, min_specialization, "1.7.0", Some(31844), None),
-
+    /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
+    (active, more_qualified_paths, "1.54.0", Some(86935), None),
+    /// Allows the `#[must_not_suspend]` attribute.
+    (active, must_not_suspend, "1.57.0", Some(83310), None),
     /// Allows using `#[naked]` on functions.
     (active, naked_functions, "1.9.0", Some(32408), None),
-
-    /// Allows `cfg(target_has_atomic = "...")`.
-    (active, cfg_target_has_atomic, "1.9.0", Some(32976), None),
-
-    /// Allows `X..Y` patterns.
-    (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
-
+    /// Allows specifying modifiers in the link attribute: `#[link(modifiers = "...")]`
+    (active, native_link_modifiers, "1.53.0", Some(81490), None),
+    /// Allows specifying the as-needed link modifier
+    (active, native_link_modifiers_as_needed, "1.53.0", Some(81490), None),
+    /// Allows specifying the bundle link modifier
+    (active, native_link_modifiers_bundle, "1.53.0", Some(81490), None),
+    /// Allows specifying the verbatim link modifier
+    (active, native_link_modifiers_verbatim, "1.53.0", Some(81490), None),
+    /// Allows specifying the whole-archive link modifier
+    (active, native_link_modifiers_whole_archive, "1.53.0", Some(81490), None),
+    /// Allow negative trait implementations.
+    (active, negative_impls, "1.44.0", Some(68318), None),
     /// Allows the `!` type. Does not imply 'exhaustive_patterns' (below) any more.
     (active, never_type, "1.13.0", Some(35121), None),
-
-    /// Allows exhaustive pattern matching on types that contain uninhabited types.
-    (active, exhaustive_patterns, "1.13.0", Some(51085), None),
-
+    /// Allows diverging expressions to fall back to `!` rather than `()`.
+    (active, never_type_fallback, "1.41.0", Some(65992), None),
+    /// Allows using non lexical lifetimes (RFC 2094).
+    (active, nll, "1.0.0", Some(43234), None),
+    /// Allows `#![no_core]`.
+    (active, no_core, "1.3.0", Some(29639), None),
+    /// Allows function attribute `#[no_coverage]`, to bypass coverage
+    /// instrumentation of that function.
+    (active, no_coverage, "1.53.0", Some(84605), None),
+    /// Allows the use of `no_sanitize` attribute.
+    (active, no_sanitize, "1.42.0", Some(39699), None),
+    /// Allows using the `non_exhaustive_omitted_patterns` lint.
+    (active, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554), None),
+    /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
+    /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
+    /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
+    (active, object_safe_for_dispatch, "1.40.0", Some(43561), None),
+    /// Allows using `#[optimize(X)]`.
+    (active, optimize_attribute, "1.34.0", Some(54882), None),
+    /// Allows `extern "platform-intrinsic" { ... }`.
+    (active, platform_intrinsics, "1.4.0", Some(27731), None),
+    /// Allows using `#![plugin(myplugin)]`.
+    (active, plugin, "1.0.0", Some(29597), None),
+    /// Allows exhaustive integer pattern matching on `usize` and `isize`.
+    (active, precise_pointer_size_matching, "1.32.0", Some(56354), None),
+    /// Allows macro attributes on expressions, statements and non-inline modules.
+    (active, proc_macro_hygiene, "1.30.0", Some(54727), None),
+    /// Allows the use of raw-dylibs (RFC 2627).
+    (incomplete, raw_dylib, "1.40.0", Some(58713), None),
+    /// Allows `&raw const $place_expr` and `&raw mut $place_expr` expressions.
+    (active, raw_ref_op, "1.41.0", Some(64490), None),
+    /// Allows using the `#[register_attr]` attribute.
+    (active, register_attr, "1.41.0", Some(66080), None),
+    /// Allows using the `#[register_tool]` attribute.
+    (active, register_tool, "1.41.0", Some(66079), None),
+    /// Allows the `#[repr(i128)]` attribute for enums.
+    (incomplete, repr128, "1.16.0", Some(56071), None),
+    /// Allows `repr(simd)` and importing the various simd intrinsics.
+    (active, repr_simd, "1.4.0", Some(27731), None),
+    /// Allows the use of SIMD types in functions declared in `extern` blocks.
+    (active, simd_ffi, "1.0.0", Some(27731), None),
+    /// Allows specialization of implementations (RFC 1210).
+    (incomplete, specialization, "1.7.0", Some(31844), None),
+    /// Allows `#[link(kind="static-nobundle"...)]`.
+    (active, static_nobundle, "1.16.0", Some(37403), None),
+    /// Allows attributes on expressions and non-item statements.
+    (active, stmt_expr_attributes, "1.6.0", Some(15701), None),
+    /// Allows the use of `#[target_feature]` on safe functions.
+    (active, target_feature_11, "1.45.0", Some(69098), None),
+    /// Allows using `#[thread_local]` on `static` items.
+    (active, thread_local, "1.0.0", Some(29594), None),
+    /// Allows defining `trait X = A + B;` alias items.
+    (active, trait_alias, "1.24.0", Some(41517), None),
+    /// Allows upcasting trait objects via supertraits.
+    /// Trait upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
+    (incomplete, trait_upcasting, "1.56.0", Some(65991), None),
+    /// Allows #[repr(transparent)] on unions (RFC 2645).
+    (active, transparent_unions, "1.37.0", Some(60405), None),
+    /// Allows inconsistent bounds in where clauses.
+    (active, trivial_bounds, "1.28.0", Some(48214), None),
+    /// Allows using `try {...}` expressions.
+    (active, try_blocks, "1.29.0", Some(31436), None),
+    /// Allows `impl Trait` to be used inside type aliases (RFC 2515).
+    (active, type_alias_impl_trait, "1.38.0", Some(63063), None),
+    /// Allows the use of type ascription in expressions.
+    (active, type_ascription, "1.6.0", Some(23416), None),
+    /// Allows creation of instances of a struct by moving fields that have
+    /// not changed from prior instances of the same struct (RFC #2528)
+    (incomplete, type_changing_struct_update, "1.58.0", Some(86555), None),
+    /// Allows unsized fn parameters.
+    (active, unsized_fn_params, "1.49.0", Some(48055), None),
+    /// Allows unsized rvalues at arguments and parameters.
+    (incomplete, unsized_locals, "1.30.0", Some(48055), None),
+    /// Allows unsized tuple coercion.
+    (active, unsized_tuple_coercion, "1.20.0", Some(42877), None),
     /// Allows `union`s to implement `Drop`. Moreover, `union`s may now include fields
     /// that don't implement `Copy` as long as they don't have any drop glue.
     /// This is checked recursively. On encountering type variable where no progress can be made,
@@ -350,350 +534,11 @@ declare_features! (
     ///
     /// NOTE: A limited form of `union U { ... }` was accepted in 1.19.0.
     (active, untagged_unions, "1.13.0", Some(55149), None),
-
-    /// Allows `#[link(..., cfg(..))]`.
-    (active, link_cfg, "1.14.0", Some(37406), None),
-
-    /// Allows `extern "ptx-*" fn()`.
-    (active, abi_ptx, "1.15.0", Some(38788), None),
-
-    /// Allows the `#[repr(i128)]` attribute for enums.
-    (incomplete, repr128, "1.16.0", Some(56071), None),
-
-    /// Allows `#[link(kind="static-nobundle"...)]`.
-    (active, static_nobundle, "1.16.0", Some(37403), None),
-
-    /// Allows `extern "msp430-interrupt" fn()`.
-    (active, abi_msp430_interrupt, "1.16.0", Some(38487), None),
-
-    /// Allows declarative macros 2.0 (`macro`).
-    (active, decl_macro, "1.17.0", Some(39412), None),
-
-    /// Allows `extern "x86-interrupt" fn()`.
-    (active, abi_x86_interrupt, "1.17.0", Some(40180), None),
-
-    /// Allows a test to fail without failing the whole suite.
-    (active, allow_fail, "1.19.0", Some(46488), None),
-
-    /// Allows unsized tuple coercion.
-    (active, unsized_tuple_coercion, "1.20.0", Some(42877), None),
-
-    /// Allows defining generators.
-    (active, generators, "1.21.0", Some(43122), None),
-
-    /// Allows `#[doc(cfg(...))]`.
-    (active, doc_cfg, "1.21.0", Some(43781), None),
-
-    /// Allows `#[doc(masked)]`.
-    (active, doc_masked, "1.21.0", Some(44027), None),
-
-    /// Allows using `crate` as visibility modifier, synonymous with `pub(crate)`.
-    (active, crate_visibility_modifier, "1.23.0", Some(53120), None),
-
-    /// Allows defining `extern type`s.
-    (active, extern_types, "1.23.0", Some(43467), None),
-
-    /// Allows trait methods with arbitrary self types.
-    (active, arbitrary_self_types, "1.23.0", Some(44874), None),
-
-    /// Allows in-band quantification of lifetime bindings (e.g., `fn foo(x: &'a u8) -> &'a u8`).
-    (active, in_band_lifetimes, "1.23.0", Some(44524), None),
-
-    /// Allows associated types to be generic, e.g., `type Foo<T>;` (RFC 1598).
-    (active, generic_associated_types, "1.23.0", Some(44265), None),
-
-    /// Allows defining `trait X = A + B;` alias items.
-    (active, trait_alias, "1.24.0", Some(41517), None),
-
-    /// Allows inferring `'static` outlives requirements (RFC 2093).
-    (active, infer_static_outlives_requirements, "1.26.0", Some(54185), None),
-
-    /// Allows inconsistent bounds in where clauses.
-    (active, trivial_bounds, "1.28.0", Some(48214), None),
-
-    /// Allows `'a: { break 'a; }`.
-    (active, label_break_value, "1.28.0", Some(48594), None),
-
-    /// Allows using `#[doc(keyword = "...")]`.
-    (active, doc_keyword, "1.28.0", Some(51315), None),
-
-    /// Allows using `try {...}` expressions.
-    (active, try_blocks, "1.29.0", Some(31436), None),
-
-    /// Allows defining an `#[alloc_error_handler]`.
-    (active, alloc_error_handler, "1.29.0", Some(51540), None),
-
-    /// Allows using the `amdgpu-kernel` ABI.
-    (active, abi_amdgpu_kernel, "1.29.0", Some(51575), None),
-
-    /// Allows `#[marker]` on certain traits allowing overlapping implementations.
-    (active, marker_trait_attr, "1.30.0", Some(29864), None),
-
-    /// Allows macro attributes on expressions, statements and non-inline modules.
-    (active, proc_macro_hygiene, "1.30.0", Some(54727), None),
-
-    /// Allows unsized rvalues at arguments and parameters.
-    (incomplete, unsized_locals, "1.30.0", Some(48055), None),
-
-    /// Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
-    (active, custom_test_frameworks, "1.30.0", Some(50297), None),
-
-    /// Allows non-builtin attributes in inner attribute position.
-    (active, custom_inner_attributes, "1.30.0", Some(54726), None),
-
-    /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
-    (active, lint_reasons, "1.31.0", Some(54503), None),
-
-    /// Allows exhaustive integer pattern matching on `usize` and `isize`.
-    (active, precise_pointer_size_matching, "1.32.0", Some(56354), None),
-
-    /// Allows using `#[ffi_returns_twice]` on foreign functions.
-    (active, ffi_returns_twice, "1.34.0", Some(58314), None),
-
-    /// Allows using `#[optimize(X)]`.
-    (active, optimize_attribute, "1.34.0", Some(54882), None),
-
-    /// Allows using C-variadics.
-    (active, c_variadic, "1.34.0", Some(44930), None),
-
-    /// Allows the user of associated type bounds.
-    (active, associated_type_bounds, "1.34.0", Some(52662), None),
-
-    /// Allows `if/while p && let q = r && ...` chains.
-    (incomplete, let_chains, "1.37.0", Some(53667), None),
-
-    /// Allows #[repr(transparent)] on unions (RFC 2645).
-    (active, transparent_unions, "1.37.0", Some(60405), None),
-
-    /// Allows explicit discriminants on non-unit enum variants.
-    (active, arbitrary_enum_discriminant, "1.37.0", Some(60553), None),
-
-    /// Allows `async || body` closures.
-    (active, async_closure, "1.37.0", Some(62290), None),
-
-    /// Allows `impl Trait` to be used inside type aliases (RFC 2515).
-    (active, type_alias_impl_trait, "1.38.0", Some(63063), None),
-
-    /// Allows the definition of `const extern fn` and `const unsafe extern fn`.
-    (active, const_extern_fn, "1.40.0", Some(64926), None),
-
-    /// Allows the use of raw-dylibs (RFC 2627).
-    (incomplete, raw_dylib, "1.40.0", Some(58713), None),
-
-    /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
-    /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
-    /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
-    (active, object_safe_for_dispatch, "1.40.0", Some(43561), None),
-
-    /// Allows using the `efiapi` ABI.
-    (active, abi_efiapi, "1.40.0", Some(65815), None),
-
-    /// Allows `&raw const $place_expr` and `&raw mut $place_expr` expressions.
-    (active, raw_ref_op, "1.41.0", Some(64490), None),
-
-    /// Allows diverging expressions to fall back to `!` rather than `()`.
-    (active, never_type_fallback, "1.41.0", Some(65992), None),
-
-    /// Allows using the `#[register_attr]` attribute.
-    (active, register_attr, "1.41.0", Some(66080), None),
-
-    /// Allows using the `#[register_tool]` attribute.
-    (active, register_tool, "1.41.0", Some(66079), None),
-
-    /// Allows the use of `#[cfg(sanitize = "option")]`; set when -Zsanitizer is used.
-    (active, cfg_sanitize, "1.41.0", Some(39699), None),
-
-    /// Allows using `..X`, `..=X`, `...X`, and `X..` as a pattern.
-    (active, half_open_range_patterns, "1.41.0", Some(67264), None),
-
-    /// Allows using `&mut` in constant functions.
-    (active, const_mut_refs, "1.41.0", Some(57349), None),
-
-    /// Allows `impl const Trait for T` syntax.
-    (active, const_trait_impl, "1.42.0", Some(67792), None),
-
-    /// Allows the use of `no_sanitize` attribute.
-    (active, no_sanitize, "1.42.0", Some(39699), None),
-
-    // Allows limiting the evaluation steps of const expressions
-    (active, const_eval_limit, "1.43.0", Some(67217), None),
-
-    /// Allow negative trait implementations.
-    (active, negative_impls, "1.44.0", Some(68318), None),
-
-    /// Allows the use of `#[target_feature]` on safe functions.
-    (active, target_feature_11, "1.45.0", Some(69098), None),
-
-    /// Allow conditional compilation depending on rust version
-    (active, cfg_version, "1.45.0", Some(64796), None),
-
-    /// Allows the use of `#[ffi_pure]` on foreign functions.
-    (active, ffi_pure, "1.45.0", Some(58329), None),
-
-    /// Allows the use of `#[ffi_const]` on foreign functions.
-    (active, ffi_const, "1.45.0", Some(58328), None),
-
-    /// Allows `extern "avr-interrupt" fn()` and `extern "avr-non-blocking-interrupt" fn()`.
-    (active, abi_avr_interrupt, "1.45.0", Some(69664), None),
-
-    /// Be more precise when looking for live drops in a const context.
-    (active, const_precise_live_drops, "1.46.0", Some(73255), None),
-
-    /// Allows `if let` guard in match arms.
-    (active, if_let_guard, "1.47.0", Some(51114), None),
-
-    /// Allows basic arithmetic on floating point types in a `const fn`.
-    (active, const_fn_floating_point_arithmetic, "1.48.0", Some(57241), None),
-
-    /// Allows using and casting function pointers in a `const fn`.
-    (active, const_fn_fn_ptr_basics, "1.48.0", Some(57563), None),
-
-    /// Allows to use the `#[cmse_nonsecure_entry]` attribute.
-    (active, cmse_nonsecure_entry, "1.48.0", Some(75835), None),
-
-    /// Allows rustc to inject a default alloc_error_handler
-    (active, default_alloc_error_handler, "1.48.0", Some(66741), None),
-
-    /// Allows argument and return position `impl Trait` in a `const fn`.
-    (active, const_impl_trait, "1.48.0", Some(77463), None),
-
-    /// Allows `#[instruction_set(_)]` attribute
-    (active, isa_attribute, "1.48.0", Some(74727), None),
-
-    /// Allow anonymous constants from an inline `const` block
-    (incomplete, inline_const, "1.49.0", Some(76001), None),
-
-    /// Allows unsized fn parameters.
-    (active, unsized_fn_params, "1.49.0", Some(48055), None),
-
-    /// Allows the use of destructuring assignments.
-    (active, destructuring_assignment, "1.49.0", Some(71126), None),
-
-    /// Enables `#[cfg(panic = "...")]` config key.
-    (active, cfg_panic, "1.49.0", Some(77443), None),
-
-    /// Allows capturing disjoint fields in a closure/generator (RFC 2229).
-    (incomplete, capture_disjoint_fields, "1.49.0", Some(53488), None),
-
-    /// Allows const generics to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).
-    (active, const_generics_defaults, "1.51.0", Some(44580), None),
-
-    /// Allows references to types with interior mutability within constants
-    (active, const_refs_to_cell, "1.51.0", Some(80384), None),
-
-    /// Allows using `pointer` and `reference` in intra-doc links
-    (active, intra_doc_pointers, "1.51.0", Some(80896), None),
-
-    /// Allows `extern "C-cmse-nonsecure-call" fn()`.
-    (active, abi_c_cmse_nonsecure_call, "1.51.0", Some(81391), None),
-
-    /// Allows associated types in inherent impls.
-    (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
-
-    // Allows setting the threshold for the `large_assignments` lint.
-    (active, large_assignments, "1.52.0", Some(83518), None),
-
-    /// Allows `extern "C-unwind" fn` to enable unwinding across ABI boundaries.
-    (active, c_unwind, "1.52.0", Some(74990), None),
-
-    /// Allows using `#[repr(align(...))]` on function items
-    (active, fn_align, "1.53.0", Some(82232), None),
-
     /// Allows `extern "wasm" fn`
     (active, wasm_abi, "1.53.0", Some(83788), None),
-
-    /// Allows function attribute `#[no_coverage]`, to bypass coverage
-    /// instrumentation of that function.
-    (active, no_coverage, "1.53.0", Some(84605), None),
-
-    /// Allows trait bounds in `const fn`.
-    (active, const_fn_trait_bound, "1.53.0", Some(57563), None),
-
-    /// Allows `async {}` expressions in const contexts.
-    (active, const_async_blocks, "1.53.0", Some(85368), None),
-
-    /// Allows using imported `main` function
-    (active, imported_main, "1.53.0", Some(28937), None),
-
-    /// Allows specifying modifiers in the link attribute: `#[link(modifiers = "...")]`
-    (active, native_link_modifiers, "1.53.0", Some(81490), None),
-
-    /// Allows specifying the bundle link modifier
-    (active, native_link_modifiers_bundle, "1.53.0", Some(81490), None),
-
-    /// Allows specifying the verbatim link modifier
-    (active, native_link_modifiers_verbatim, "1.53.0", Some(81490), None),
-
-    /// Allows specifying the whole-archive link modifier
-    (active, native_link_modifiers_whole_archive, "1.53.0", Some(81490), None),
-
-    /// Allows specifying the as-needed link modifier
-    (active, native_link_modifiers_as_needed, "1.53.0", Some(81490), None),
-
-    /// Allows qualified paths in struct expressions, struct patterns and tuple struct patterns.
-    (active, more_qualified_paths, "1.54.0", Some(86935), None),
-
-    /// Allows `cfg(target_abi = "...")`.
-    (active, cfg_target_abi, "1.55.0", Some(80970), None),
-
-    /// Infer generic args for both consts and types.
-    (active, generic_arg_infer, "1.55.0", Some(85077), None),
-
-    /// Allows `#[derive(Default)]` and `#[default]` on enums.
-    (active, derive_default_enum, "1.56.0", Some(86985), None),
-
-    /// Allows `for _ in _` loops in const contexts.
-    (active, const_for, "1.56.0", Some(87575), None),
-
-    /// Allows the `?` operator in const contexts.
-    (active, const_try, "1.56.0", Some(74935), None),
-
-    /// Allows upcasting trait objects via supertraits.
-    /// Trait upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
-    (incomplete, trait_upcasting, "1.56.0", Some(65991), None),
-
-    /// Allows explicit generic arguments specification with `impl Trait` present.
-    (active, explicit_generic_args_with_impl_trait, "1.56.0", Some(83701), None),
-
-    /// Allows using doc(primitive) without a future-incompat warning
-    (active, doc_primitive, "1.56.0", Some(88070), None),
-
-    /// Allows non-trivial generic constants which have to have wfness manually propagated to callers
-    (incomplete, generic_const_exprs, "1.56.0", Some(76560), None),
-
-    /// Allows additional const parameter types, such as `&'static str` or user defined types
-    (incomplete, adt_const_params, "1.56.0", Some(44580), None),
-
-    /// Allows `let...else` statements.
-    (active, let_else, "1.56.0", Some(87335), None),
-
-    /// Allows the `#[must_not_suspend]` attribute.
-    (active, must_not_suspend, "1.57.0", Some(83310), None),
-
-    /// Allows `#[track_caller]` on closures and generators.
-    (active, closure_track_caller, "1.57.0", Some(87417), None),
-
-    /// Allows `#[doc(cfg_hide(...))]`.
-    (active, doc_cfg_hide, "1.57.0", Some(43781), None),
-
-    /// Allows using the `non_exhaustive_omitted_patterns` lint.
-    (active, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554), None),
-
-    /// Allows creation of instances of a struct by moving fields that have
-    /// not changed from prior instances of the same struct (RFC #2528)
-    (incomplete, type_changing_struct_update, "1.58.0", Some(86555), None),
-
-    /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.
-    (active, doc_auto_cfg, "1.58.0", Some(43781), None),
-
-    /// Allows using `const` operands in inline assembly.
-    (active, asm_const, "1.58.0", Some(72016), None),
-
-    /// Allows using `sym` operands in inline assembly.
-    (active, asm_sym, "1.58.0", Some(72016), None),
-
-    /// Enables experimental inline assembly support for additional architectures.
-    (active, asm_experimental_arch, "1.58.0", Some(72016), None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -45,132 +45,130 @@ declare_features! (
     // feature-group-start: removed features
     // -------------------------------------------------------------------------
 
-    (removed, import_shadowing, "1.0.0", None, None, None),
-    (removed, managed_boxes, "1.0.0", None, None, None),
-    /// Allows use of unary negate on unsigned integers, e.g., -e for e: u8
-    (removed, negate_unsigned, "1.0.0", Some(29645), None, None),
-    (removed, reflect, "1.0.0", Some(27749), None, None),
-    /// A way to temporarily opt out of opt in copy. This will *never* be accepted.
-    (removed, opt_out_copy, "1.0.0", None, None, None),
-    (removed, quad_precision_float, "1.0.0", None, None, None),
-    (removed, struct_inherit, "1.0.0", None, None, None),
-    (removed, test_removed_feature, "1.0.0", None, None, None),
-    (removed, visible_private_types, "1.0.0", None, None, None),
-    (removed, unsafe_no_drop_flag, "1.0.0", None, None, None),
-    /// Allows using items which are missing stability attributes
-    (removed, unmarked_api, "1.0.0", None, None, None),
-    (removed, allocator, "1.0.0", None, None, None),
-    (removed, simd, "1.0.0", Some(27731), None,
-     Some("removed in favor of `#[repr(simd)]`")),
     (removed, advanced_slice_patterns, "1.0.0", Some(62254), None,
      Some("merged into `#![feature(slice_patterns)]`")),
-    (removed, macro_reexport, "1.0.0", Some(29638), None,
-     Some("subsumed by `pub use`")),
-    /// Allows using custom attributes (RFC 572).
-    (removed, custom_attribute, "1.0.0", Some(29642), None,
-     Some("removed in favor of `#![register_tool]` and `#![register_attr]`")),
-    /// Allows features specific to OIBIT (now called auto traits).
-    /// Renamed to `auto_traits`.
-    (removed, optin_builtin_traits, "1.0.0", Some(13231), None,
-     Some("renamed to `auto_traits`")),
-    (removed, pushpop_unsafe, "1.2.0", None, None, None),
-    (removed, needs_allocator, "1.4.0", Some(27389), None,
-     Some("subsumed by `#![feature(allocator_internals)]`")),
-    /// Allows identifying crates that contain sanitizer runtimes.
-    (removed, sanitizer_runtime, "1.17.0", None, None, None),
-    /// Allows `#[doc(spotlight)]`.
-    /// The attribute was renamed to `#[doc(notable_trait)]`
-    /// and the feature to `doc_notable_trait`.
-    (removed, doc_spotlight, "1.22.0", Some(45040), None,
-     Some("renamed to `doc_notable_trait`")),
-    (removed, proc_macro_mod, "1.27.0", Some(54727), None,
-     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
-    (removed, proc_macro_expr, "1.27.0", Some(54727), None,
-     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
-    (removed, proc_macro_non_items, "1.27.0", Some(54727), None,
-     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
-    (removed, proc_macro_gen, "1.27.0", Some(54727), None,
-     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
-    (removed, panic_implementation, "1.28.0", Some(44489), None,
-     Some("subsumed by `#[panic_handler]`")),
-    /// Allows the use of `#[derive(Anything)]` as sugar for `#[derive_Anything]`.
-    (removed, custom_derive, "1.32.0", Some(29644), None,
-     Some("subsumed by `#[proc_macro_derive]`")),
-    /// Paths of the form: `extern::foo::bar`
-    (removed, extern_in_paths, "1.33.0", Some(55600), None,
-     Some("subsumed by `::foo::bar` paths")),
-    (removed, quote, "1.33.0", Some(29601), None, None),
+    (removed, allocator, "1.0.0", None, None, None),
+    (removed, await_macro, "1.38.0", Some(50547), None,
+     Some("subsumed by `.await` syntax")),
+    /// Allows comparing raw pointers during const eval.
+    (removed, const_compare_raw_pointers, "1.46.0", Some(53020), None,
+     Some("cannot be allowed in const eval in any meaningful way")),
+    /// Allows non-trivial generic constants which have to be manually propagated upwards.
+     (removed, const_evaluatable_checked, "1.48.0", Some(76560), None, Some("renamed to `generic_const_exprs`")),
+    /// Allows the definition of `const` functions with some advanced features.
+    (removed, const_fn, "1.54.0", Some(57563), None,
+     Some("split into finer-grained feature gates")),
     /// Allows const generic types (e.g. `struct Foo<const N: usize>(...);`).
     (removed, const_generics, "1.34.0", Some(44580), None,
      Some("removed in favor of `#![feature(adt_const_params)]` and `#![feature(generic_const_exprs)]`")),
     /// Allows `[x; N]` where `x` is a constant (RFC 2203).
     (removed, const_in_array_repeat_expressions,  "1.37.0", Some(49147), None,
      Some("removed due to causing promotable bugs")),
+    /// Allows casting raw pointers to `usize` during const eval.
+    (removed, const_raw_ptr_to_usize_cast, "1.55.0", Some(51910), None,
+     Some("at compile-time, pointers do not have an integer value, so these casts cannot be properly supported")),
+    /// Allows `T: ?const Trait` syntax in bounds.
+    (removed, const_trait_bound_opt_out, "1.42.0", Some(67794), None,
+     Some("Removed in favor of `~const` bound in #![feature(const_trait_impl)]")),
+    /// Allows using custom attributes (RFC 572).
+    (removed, custom_attribute, "1.0.0", Some(29642), None,
+     Some("removed in favor of `#![register_tool]` and `#![register_attr]`")),
+    /// Allows the use of `#[derive(Anything)]` as sugar for `#[derive_Anything]`.
+    (removed, custom_derive, "1.32.0", Some(29644), None,
+     Some("subsumed by `#[proc_macro_derive]`")),
+    /// Allows `#[doc(spotlight)]`.
+    /// The attribute was renamed to `#[doc(notable_trait)]`
+    /// and the feature to `doc_notable_trait`.
+    (removed, doc_spotlight, "1.22.0", Some(45040), None,
+     Some("renamed to `doc_notable_trait`")),
     /// Allows using `#[unsafe_destructor_blind_to_params]` (RFC 1238).
     (removed, dropck_parametricity, "1.38.0", Some(28498), None, None),
-    (removed, await_macro, "1.38.0", Some(50547), None,
-     Some("subsumed by `.await` syntax")),
     /// Allows defining `existential type`s.
     (removed, existential_type, "1.38.0", Some(63063), None,
      Some("removed in favor of `#![feature(type_alias_impl_trait)]`")),
+    /// Paths of the form: `extern::foo::bar`
+    (removed, extern_in_paths, "1.33.0", Some(55600), None,
+     Some("subsumed by `::foo::bar` paths")),
+    /// Allows `#[doc(include = "some-file")]`.
+    (removed, external_doc, "1.54.0", Some(44732), None,
+     Some("use #[doc = include_str!(\"filename\")] instead, which handles macro invocations")),
+    /// Allows `impl Trait` in bindings (`let`, `const`, `static`).
+    (removed, impl_trait_in_bindings, "1.55.0", Some(63065), None,
+     Some("the implementation was not maintainable, the feature may get reintroduced once the current refactorings are done")),
+    (removed, import_shadowing, "1.0.0", None, None, None),
+    /// Lazily evaluate constants. This allows constants to depend on type parameters.
+    (removed, lazy_normalization_consts, "1.46.0", Some(72219), None, Some("superseded by `generic_const_exprs`")),
+    /// Allows using the `#[link_args]` attribute.
+    (removed, link_args, "1.53.0", Some(29596), None,
+     Some("removed in favor of using `-C link-arg=ARG` on command line, \
+           which is available from cargo build scripts with `cargo:rustc-link-arg` now")),
+    (removed, macro_reexport, "1.0.0", Some(29638), None,
+     Some("subsumed by `pub use`")),
+    /// Allows using `#[main]` to replace the entrypoint `#[lang = "start"]` calls.
+    (removed, main, "1.53.0", Some(29634), None, None),
+    (removed, managed_boxes, "1.0.0", None, None, None),
+    /// Allows the use of type alias impl trait in function return positions
+    (removed, min_type_alias_impl_trait, "1.56.0", Some(63063), None,
+     Some("removed in favor of full type_alias_impl_trait")),
+    (removed, needs_allocator, "1.4.0", Some(27389), None,
+     Some("subsumed by `#![feature(allocator_internals)]`")),
+    /// Allows use of unary negate on unsigned integers, e.g., -e for e: u8
+    (removed, negate_unsigned, "1.0.0", Some(29645), None, None),
+    /// Allows `#[no_debug]`.
+    (removed, no_debug, "1.43.0", Some(29721), None, Some("removed due to lack of demand")),
+    /// Allows using `#[on_unimplemented(..)]` on traits.
+    /// (Moved to `rustc_attrs`.)
+    (removed, on_unimplemented, "1.40.0", None, None, None),
+    /// A way to temporarily opt out of opt in copy. This will *never* be accepted.
+    (removed, opt_out_copy, "1.0.0", None, None, None),
+    /// Allows features specific to OIBIT (now called auto traits).
+    /// Renamed to `auto_traits`.
+    (removed, optin_builtin_traits, "1.0.0", Some(13231), None,
+     Some("renamed to `auto_traits`")),
+    /// Allows overlapping impls of marker traits.
+    (removed, overlapping_marker_traits, "1.42.0", Some(29864), None,
+     Some("removed in favor of `#![feature(marker_trait_attr)]`")),
+    (removed, panic_implementation, "1.28.0", Some(44489), None,
+     Some("subsumed by `#[panic_handler]`")),
+    /// Allows using `#[plugin_registrar]` on functions.
+    (removed, plugin_registrar, "1.54.0", Some(29597), None,
+     Some("a __rustc_plugin_registrar symbol must now be defined instead")),
+    (removed, proc_macro_expr, "1.27.0", Some(54727), None,
+     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
+    (removed, proc_macro_gen, "1.27.0", Some(54727), None,
+     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
+    (removed, proc_macro_mod, "1.27.0", Some(54727), None,
+     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
+    (removed, proc_macro_non_items, "1.27.0", Some(54727), None,
+     Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
+    (removed, pub_macro_rules, "1.53.0", Some(78855), None,
+     Some("removed due to being incomplete, in particular it does not work across crates")),
+    (removed, pushpop_unsafe, "1.2.0", None, None, None),
+    (removed, quad_precision_float, "1.0.0", None, None, None),
+    (removed, quote, "1.33.0", Some(29601), None, None),
+    (removed, reflect, "1.0.0", Some(27749), None, None),
     /// Allows using the macros:
     /// + `__diagnostic_used`
     /// + `__register_diagnostic`
     /// +`__build_diagnostic_array`
     (removed, rustc_diagnostic_macros, "1.38.0", None, None, None),
-    /// Allows using `#[on_unimplemented(..)]` on traits.
-    /// (Moved to `rustc_attrs`.)
-    (removed, on_unimplemented, "1.40.0", None, None, None),
-    /// Allows overlapping impls of marker traits.
-    (removed, overlapping_marker_traits, "1.42.0", Some(29864), None,
-     Some("removed in favor of `#![feature(marker_trait_attr)]`")),
-    /// Allows `T: ?const Trait` syntax in bounds.
-    (removed, const_trait_bound_opt_out, "1.42.0", Some(67794), None,
-     Some("Removed in favor of `~const` bound in #![feature(const_trait_impl)]")),
-    /// Allows `#[no_debug]`.
-    (removed, no_debug, "1.43.0", Some(29721), None, Some("removed due to lack of demand")),
-    /// Lazily evaluate constants. This allows constants to depend on type parameters.
-    (removed, lazy_normalization_consts, "1.46.0", Some(72219), None, Some("superseded by `generic_const_exprs`")),
-    /// Allows comparing raw pointers during const eval.
-    (removed, const_compare_raw_pointers, "1.46.0", Some(53020), None,
-     Some("cannot be allowed in const eval in any meaningful way")),
-    /// Allows non-trivial generic constants which have to be manually propagated upwards.
-    (removed, const_evaluatable_checked, "1.48.0", Some(76560), None, Some("renamed to `generic_const_exprs`")),
-    /// Allows using the `#[link_args]` attribute.
-    (removed, link_args, "1.53.0", Some(29596), None,
-     Some("removed in favor of using `-C link-arg=ARG` on command line, \
-           which is available from cargo build scripts with `cargo:rustc-link-arg` now")),
-    /// Allows using `#[main]` to replace the entrypoint `#[lang = "start"]` calls.
-    (removed, main, "1.53.0", Some(29634), None, None),
-    (removed, pub_macro_rules, "1.53.0", Some(78855), None,
-     Some("removed due to being incomplete, in particular it does not work across crates")),
-    /// Allows the definition of `const` functions with some advanced features.
-    (removed, const_fn, "1.54.0", Some(57563), None,
-     Some("split into finer-grained feature gates")),
-    /// Allows using `#[plugin_registrar]` on functions.
-    (removed, plugin_registrar, "1.54.0", Some(29597), None,
-     Some("a __rustc_plugin_registrar symbol must now be defined instead")),
-
-    /// Allows `#[doc(include = "some-file")]`.
-    (removed, external_doc, "1.54.0", Some(44732), None,
-     Some("use #[doc = include_str!(\"filename\")] instead, which handles macro invocations")),
-
-     /// Allows casting raw pointers to `usize` during const eval.
-    (removed, const_raw_ptr_to_usize_cast, "1.55.0", Some(51910), None,
-     Some("at compile-time, pointers do not have an integer value, so these casts cannot be properly supported")),
-
-    /// Allows `impl Trait` in bindings (`let`, `const`, `static`).
-    (removed, impl_trait_in_bindings, "1.55.0", Some(63065), None,
-     Some("the implementation was not maintainable, the feature may get reintroduced once the current refactorings are done")),
-
-    /// Allows the use of type alias impl trait in function return positions
-    (removed, min_type_alias_impl_trait, "1.56.0", Some(63063), None,
-     Some("removed in favor of full type_alias_impl_trait")),
-
+    /// Allows identifying crates that contain sanitizer runtimes.
+    (removed, sanitizer_runtime, "1.17.0", None, None, None),
+    (removed, simd, "1.0.0", Some(27731), None,
+     Some("removed in favor of `#[repr(simd)]`")),
+    (removed, struct_inherit, "1.0.0", None, None, None),
+    (removed, test_removed_feature, "1.0.0", None, None, None),
+    /// Allows using items which are missing stability attributes
+    (removed, unmarked_api, "1.0.0", None, None, None),
+    (removed, unsafe_no_drop_flag, "1.0.0", None, None, None),
     /// Allows `#[unwind(..)]`.
     ///
     /// Permits specifying whether a function should permit unwinding or abort on unwind.
     (removed, unwind_attributes, "1.56.0", Some(58760), None, Some("use the C-unwind ABI instead")),
+    (removed, visible_private_types, "1.0.0", None, None, None),
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
+    // Features are listed in alphabetical order. Tidy will fail if you don't keep it this way.
+    // !!!!    !!!!    !!!!    !!!!   !!!!    !!!!    !!!!    !!!!    !!!!    !!!!    !!!!
 
     // -------------------------------------------------------------------------
     // feature-group-end: removed features

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -5,6 +5,7 @@ use crate::traits::{Obligation, ObligationCause, PredicateObligation};
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_middle::ty::{self, ToPredicate, TyCtxt, WithConstness};
 use rustc_span::symbol::Ident;
+use rustc_span::Span;
 
 pub fn anonymize_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -92,6 +93,22 @@ pub fn elaborate_predicates<'tcx>(
     let obligations = predicates
         .map(|predicate| {
             predicate_obligation(predicate, ty::ParamEnv::empty(), ObligationCause::dummy())
+        })
+        .collect();
+    elaborate_obligations(tcx, obligations)
+}
+
+pub fn elaborate_predicates_with_span<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    predicates: impl Iterator<Item = (ty::Predicate<'tcx>, Span)>,
+) -> Elaborator<'tcx> {
+    let obligations = predicates
+        .map(|(predicate, span)| {
+            predicate_obligation(
+                predicate,
+                ty::ParamEnv::empty(),
+                ObligationCause::dummy_with_span(span),
+            )
         })
         .collect();
     elaborate_obligations(tcx, obligations)

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -7,10 +7,6 @@ use rustc_errors::{pluralize, Applicability, Handler};
 use rustc_lexer::unescape::{EscapeError, Mode};
 use rustc_span::{BytePos, Span};
 
-fn printing(ch: char) -> bool {
-    unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0) != 0 && !ch.is_whitespace()
-}
-
 pub(crate) fn emit_unescape_error(
     handler: &Handler,
     // interior part of the literal, without quotes
@@ -87,7 +83,13 @@ pub(crate) fn emit_unescape_error(
                     );
                 }
             } else {
-                let printable: Vec<char> = lit.chars().filter(|x| printing(*x)).collect();
+                let printable: Vec<char> = lit
+                    .chars()
+                    .filter(|&x| {
+                        unicode_width::UnicodeWidthChar::width(x).unwrap_or(0) != 0
+                            && !x.is_whitespace()
+                    })
+                    .collect();
 
                 if let [ch] = printable.as_slice() {
                     has_help = true;

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -82,6 +82,16 @@ pub(crate) fn emit_unescape_error(
                         Applicability::MachineApplicable,
                     );
                 }
+            } else {
+                if lit.chars().filter(|x| x.is_whitespace() || x.is_control()).count() >= 1 {
+                    handler.span_note(
+                        span,
+                        &format!(
+                            "there are non-printing characters, the full sequence is `{}`",
+                            lit.escape_default(),
+                        ),
+                    );
+                }
             }
 
             if !has_help {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1062,7 +1062,7 @@ impl CheckAttrVisitor<'tcx> {
                     lint.build(
                         "`must_use` attribute on `async` functions \
                               applies to the anonymous `Future` returned by the \
-                              function, not the value within.",
+                              function, not the value within",
                     )
                     .span_label(
                         *span,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -112,6 +112,7 @@ impl CheckAttrVisitor<'tcx> {
                     self.check_default_method_body_is_const(attr, span, target)
                 }
                 sym::must_not_suspend => self.check_must_not_suspend(&attr, span, target),
+                sym::must_use => self.check_must_use(hir_id, &attr, span, target),
                 sym::rustc_const_unstable
                 | sym::rustc_const_stable
                 | sym::unstable
@@ -1044,6 +1045,37 @@ impl CheckAttrVisitor<'tcx> {
         }
 
         is_valid
+    }
+
+    /// Warns against some misuses of `#[must_use]`
+    fn check_must_use(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: &Span,
+        _target: Target,
+    ) -> bool {
+        let node = self.tcx.hir().get(hir_id);
+        if let Some(fn_node) = node.fn_kind() {
+            if let rustc_hir::IsAsync::Async = fn_node.asyncness() {
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build(
+                        "`must_use` attribute on `async` functions \
+                              applies to the anonymous `Future` returned by the \
+                              function, not the value within.",
+                    )
+                    .span_label(
+                        *span,
+                        "this attribute does nothing, the `Future`s \
+                                returned by async functions are already `must_use`",
+                    )
+                    .emit();
+                });
+            }
+        }
+
+        // For now, its always valid
+        true
     }
 
     /// Checks if `#[must_not_suspend]` is applied to a function. Returns `true` if valid.

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -65,7 +65,8 @@ pub use self::specialize::{specialization_graph, translate_substs, OverlapError}
 pub use self::structural_match::search_for_structural_match_violation;
 pub use self::structural_match::NonStructuralMatchTy;
 pub use self::util::{
-    elaborate_obligations, elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs,
+    elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
+    elaborate_trait_ref, elaborate_trait_refs,
 };
 pub use self::util::{expand_trait_aliases, TraitAliasExpander};
 pub use self::util::{

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1445,6 +1445,34 @@ impl<T, A: Allocator> Vec<T, A> {
     where
         F: FnMut(&T) -> bool,
     {
+        self.retain_mut(|elem| f(elem));
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    ///
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(vec_retain_mut)]
+    ///
+    /// let mut vec = vec![1, 2, 3, 4];
+    /// vec.retain_mut(|x| if *x > 3 {
+    ///     false
+    /// } else {
+    ///     *x += 1;
+    ///     true
+    /// });
+    /// assert_eq!(vec, [2, 3, 4]);
+    /// ```
+    #[unstable(feature = "vec_retain_mut", issue = "90829")]
+    pub fn retain_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
         let original_len = self.len();
         // Avoid double drop if the drop guard is not executed,
         // since we may make some holes during the process.
@@ -1496,7 +1524,7 @@ impl<T, A: Allocator> Vec<T, A> {
             g: &mut BackshiftOnDrop<'_, T, A>,
         ) -> bool
         where
-            F: FnMut(&T) -> bool,
+            F: FnMut(&mut T) -> bool,
         {
             // SAFETY: Unchecked element must be valid.
             let cur = unsafe { &mut *g.v.as_mut_ptr().add(g.processed_len) };

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -297,7 +297,7 @@ fn test_interior_nul_in_progname_is_error() {
 
 #[test]
 fn test_interior_nul_in_arg_is_error() {
-    match Command::new("echo").arg("has-some-\0\0s-inside").spawn() {
+    match Command::new("rustc").arg("has-some-\0\0s-inside").spawn() {
         Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
         Ok(_) => panic!(),
     }
@@ -305,7 +305,7 @@ fn test_interior_nul_in_arg_is_error() {
 
 #[test]
 fn test_interior_nul_in_args_is_error() {
-    match Command::new("echo").args(&["has-some-\0\0s-inside"]).spawn() {
+    match Command::new("rustc").args(&["has-some-\0\0s-inside"]).spawn() {
         Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
         Ok(_) => panic!(),
     }
@@ -313,7 +313,7 @@ fn test_interior_nul_in_args_is_error() {
 
 #[test]
 fn test_interior_nul_in_current_dir_is_error() {
-    match Command::new("echo").current_dir("has-some-\0\0s-inside").spawn() {
+    match Command::new("rustc").current_dir("has-some-\0\0s-inside").spawn() {
         Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
         Ok(_) => panic!(),
     }

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -734,6 +734,7 @@ if #[cfg(not(target_vendor = "uwp"))] {
             lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
         ) -> BOOL;
         pub fn SetThreadStackGuarantee(_size: *mut c_ulong) -> BOOL;
+        pub fn GetWindowsDirectoryW(lpBuffer: LPWSTR, uSize: UINT) -> UINT;
     }
 }
 }
@@ -773,6 +774,7 @@ extern "system" {
     pub fn LeaveCriticalSection(CriticalSection: *mut CRITICAL_SECTION);
     pub fn DeleteCriticalSection(CriticalSection: *mut CRITICAL_SECTION);
 
+    pub fn GetSystemDirectoryW(lpBuffer: LPWSTR, uSize: UINT) -> UINT;
     pub fn RemoveDirectoryW(lpPathName: LPCWSTR) -> BOOL;
     pub fn SetFileAttributesW(lpFileName: LPCWSTR, dwFileAttributes: DWORD) -> BOOL;
     pub fn SetLastError(dwErrCode: DWORD);

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -7,24 +7,24 @@ use crate::cmp;
 use crate::collections::BTreeMap;
 use crate::convert::{TryFrom, TryInto};
 use crate::env;
-use crate::env::split_paths;
+use crate::env::consts::{EXE_EXTENSION, EXE_SUFFIX};
 use crate::ffi::{OsStr, OsString};
 use crate::fmt;
-use crate::fs;
 use crate::io::{self, Error, ErrorKind};
 use crate::mem;
 use crate::num::NonZeroI32;
-use crate::os::windows::ffi::OsStrExt;
+use crate::os::windows::ffi::{OsStrExt, OsStringExt};
 use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
-use crate::path::Path;
+use crate::path::{Path, PathBuf};
 use crate::ptr;
 use crate::sys::c;
 use crate::sys::c::NonZeroDWORD;
-use crate::sys::cvt;
 use crate::sys::fs::{File, OpenOptions};
 use crate::sys::handle::Handle;
+use crate::sys::path;
 use crate::sys::pipe::{self, AnonPipe};
 use crate::sys::stdio;
+use crate::sys::{cvt, to_u16s};
 use crate::sys_common::mutex::StaticMutex;
 use crate::sys_common::process::{CommandEnv, CommandEnvs};
 use crate::sys_common::{AsInner, IntoInner};
@@ -258,31 +258,19 @@ impl Command {
         needs_stdin: bool,
     ) -> io::Result<(Process, StdioPipes)> {
         let maybe_env = self.env.capture_if_changed();
-        // To have the spawning semantics of unix/windows stay the same, we need
-        // to read the *child's* PATH if one is provided. See #15149 for more
-        // details.
-        let program = maybe_env.as_ref().and_then(|env| {
-            if let Some(v) = env.get(&EnvKey::new("PATH")) {
-                // Split the value and test each path to see if the
-                // program exists.
-                for path in split_paths(&v) {
-                    let path = path
-                        .join(self.program.to_str().unwrap())
-                        .with_extension(env::consts::EXE_EXTENSION);
-                    if fs::metadata(&path).is_ok() {
-                        return Some(path.into_os_string());
-                    }
-                }
-            }
-            None
-        });
 
         let mut si = zeroed_startupinfo();
         si.cb = mem::size_of::<c::STARTUPINFO>() as c::DWORD;
         si.dwFlags = c::STARTF_USESTDHANDLES;
 
-        let program = program.as_ref().unwrap_or(&self.program);
-        let mut cmd_str = make_command_line(program, &self.args, self.force_quotes_enabled)?;
+        let child_paths = if let Some(env) = maybe_env.as_ref() {
+            env.get(&EnvKey::new("PATH")).map(|s| s.as_os_str())
+        } else {
+            None
+        };
+        let program = resolve_exe(&self.program, child_paths)?;
+        let mut cmd_str =
+            make_command_line(program.as_os_str(), &self.args, self.force_quotes_enabled)?;
         cmd_str.push(0); // add null terminator
 
         // stolen from the libuv code.
@@ -321,9 +309,10 @@ impl Command {
         si.hStdOutput = stdout.as_raw_handle();
         si.hStdError = stderr.as_raw_handle();
 
+        let program = to_u16s(&program)?;
         unsafe {
             cvt(c::CreateProcessW(
-                ptr::null(),
+                program.as_ptr(),
                 cmd_str.as_mut_ptr(),
                 ptr::null_mut(),
                 ptr::null_mut(),
@@ -359,6 +348,132 @@ impl fmt::Debug for Command {
         }
         Ok(())
     }
+}
+
+// Resolve `exe_path` to the executable name.
+//
+// * If the path is simply a file name then use the paths given by `search_paths` to find the executable.
+// * Otherwise use the `exe_path` as given.
+//
+// This function may also append `.exe` to the name. The rationale for doing so is as follows:
+//
+// It is a very strong convention that Windows executables have the `exe` extension.
+// In Rust, it is common to omit this extension.
+// Therefore this functions first assumes `.exe` was intended.
+// It falls back to the plain file name if a full path is given and the extension is omitted
+// or if only a file name is given and it already contains an extension.
+fn resolve_exe<'a>(exe_path: &'a OsStr, child_paths: Option<&OsStr>) -> io::Result<PathBuf> {
+    // Early return if there is no filename.
+    if exe_path.is_empty() || path::has_trailing_slash(exe_path) {
+        return Err(io::Error::new_const(
+            io::ErrorKind::InvalidInput,
+            &"program path has no file name",
+        ));
+    }
+    // Test if the file name has the `exe` extension.
+    // This does a case-insensitive `ends_with`.
+    let has_exe_suffix = if exe_path.len() >= EXE_SUFFIX.len() {
+        exe_path.bytes()[exe_path.len() - EXE_SUFFIX.len()..]
+            .eq_ignore_ascii_case(EXE_SUFFIX.as_bytes())
+    } else {
+        false
+    };
+
+    // If `exe_path` is an absolute path or a sub-path then don't search `PATH` for it.
+    if !path::is_file_name(exe_path) {
+        if has_exe_suffix {
+            // The application name is a path to a `.exe` file.
+            // Let `CreateProcessW` figure out if it exists or not.
+            return Ok(exe_path.into());
+        }
+        let mut path = PathBuf::from(exe_path);
+
+        // Append `.exe` if not already there.
+        path = path::append_suffix(path, EXE_SUFFIX.as_ref());
+        if path.try_exists().unwrap_or(false) {
+            return Ok(path);
+        } else {
+            // It's ok to use `set_extension` here because the intent is to
+            // remove the extension that was just added.
+            path.set_extension("");
+            return Ok(path);
+        }
+    } else {
+        ensure_no_nuls(exe_path)?;
+        // From the `CreateProcessW` docs:
+        // > If the file name does not contain an extension, .exe is appended.
+        // Note that this rule only applies when searching paths.
+        let has_extension = exe_path.bytes().contains(&b'.');
+
+        // Search the directories given by `search_paths`.
+        let result = search_paths(child_paths, |mut path| {
+            path.push(&exe_path);
+            if !has_extension {
+                path.set_extension(EXE_EXTENSION);
+            }
+            if let Ok(true) = path.try_exists() { Some(path) } else { None }
+        });
+        if let Some(path) = result {
+            return Ok(path);
+        }
+    }
+    // If we get here then the executable cannot be found.
+    Err(io::Error::new_const(io::ErrorKind::NotFound, &"program not found"))
+}
+
+// Calls `f` for every path that should be used to find an executable.
+// Returns once `f` returns the path to an executable or all paths have been searched.
+fn search_paths<F>(child_paths: Option<&OsStr>, mut f: F) -> Option<PathBuf>
+where
+    F: FnMut(PathBuf) -> Option<PathBuf>,
+{
+    // 1. Child paths
+    // This is for consistency with Rust's historic behaviour.
+    if let Some(paths) = child_paths {
+        for path in env::split_paths(paths).filter(|p| !p.as_os_str().is_empty()) {
+            if let Some(path) = f(path) {
+                return Some(path);
+            }
+        }
+    }
+
+    // 2. Application path
+    if let Ok(mut app_path) = env::current_exe() {
+        app_path.pop();
+        if let Some(path) = f(app_path) {
+            return Some(path);
+        }
+    }
+
+    // 3 & 4. System paths
+    // SAFETY: This uses `fill_utf16_buf` to safely call the OS functions.
+    unsafe {
+        if let Ok(Some(path)) = super::fill_utf16_buf(
+            |buf, size| c::GetSystemDirectoryW(buf, size),
+            |buf| f(PathBuf::from(OsString::from_wide(buf))),
+        ) {
+            return Some(path);
+        }
+        #[cfg(not(target_vendor = "uwp"))]
+        {
+            if let Ok(Some(path)) = super::fill_utf16_buf(
+                |buf, size| c::GetWindowsDirectoryW(buf, size),
+                |buf| f(PathBuf::from(OsString::from_wide(buf))),
+            ) {
+                return Some(path);
+            }
+        }
+    }
+
+    // 5. Parent paths
+    if let Some(parent_paths) = env::var_os("PATH") {
+        for path in env::split_paths(&parent_paths).filter(|p| !p.as_os_str().is_empty()) {
+            if let Some(path) = f(path) {
+                return Some(path);
+            }
+        }
+    }
+    None
 }
 
 impl Stdio {

--- a/src/test/ui/const-generics/issues/issue-67185-2.rs
+++ b/src/test/ui/const-generics/issues/issue-67185-2.rs
@@ -9,11 +9,10 @@ trait Bar {}
 impl Bar for [u16; 4] {}
 impl Bar for [[u16; 3]; 3] {}
 
-trait Foo  //~ ERROR the trait bound `[u16; 3]: Bar` is not satisfied [E0277]
-           //~^ ERROR the trait bound `[[u16; 3]; 2]: Bar` is not satisfied [E0277]
-    where
-        [<u8 as Baz>::Quaks; 2]: Bar,
-        <u8 as Baz>::Quaks: Bar,
+trait Foo
+where
+    [<u8 as Baz>::Quaks; 2]: Bar, //~ ERROR the trait bound `[[u16; 3]; 2]: Bar` is not satisfied [E0277]
+    <u8 as Baz>::Quaks: Bar,  //~ ERROR the trait bound `[u16; 3]: Bar` is not satisfied [E0277]
 {
 }
 

--- a/src/test/ui/const-generics/issues/issue-67185-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-67185-2.stderr
@@ -1,14 +1,8 @@
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:12:1
+  --> $DIR/issue-67185-2.rs:15:5
    |
-LL | / trait Foo
-LL | |
-LL | |     where
-LL | |         [<u8 as Baz>::Quaks; 2]: Bar,
-LL | |         <u8 as Baz>::Quaks: Bar,
-LL | | {
-LL | | }
-   | |_^ the trait `Bar` is not implemented for `[u16; 3]`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
@@ -17,16 +11,10 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:12:1
+  --> $DIR/issue-67185-2.rs:14:5
    |
-LL | / trait Foo
-LL | |
-LL | |     where
-LL | |         [<u8 as Baz>::Quaks; 2]: Bar,
-LL | |         <u8 as Baz>::Quaks: Bar,
-LL | | {
-LL | | }
-   | |_^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
@@ -35,7 +23,7 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:22:6
+  --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
@@ -44,16 +32,16 @@ LL | impl Foo for FooImpl {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:16:29
+  --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             ^^^ required by this bound in `Foo`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |                         ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:22:6
+  --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
@@ -62,16 +50,16 @@ LL | impl Foo for FooImpl {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:15:34
+  --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
    |       --- required by a bound in this
-...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  ^^^ required by this bound in `Foo`
+LL | where
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |                              ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:14
+  --> $DIR/issue-67185-2.rs:25:14
    |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
@@ -80,16 +68,16 @@ LL | fn f(_: impl Foo) {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:15:34
+  --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
    |       --- required by a bound in this
-...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  ^^^ required by this bound in `Foo`
+LL | where
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |                              ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:14
+  --> $DIR/issue-67185-2.rs:25:14
    |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
@@ -98,13 +86,13 @@ LL | fn f(_: impl Foo) {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:16:29
+  --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             ^^^ required by this bound in `Foo`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |                         ^^^ required by this bound in `Foo`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/cross/cross-fn-cache-hole.rs
+++ b/src/test/ui/cross/cross-fn-cache-hole.rs
@@ -12,8 +12,8 @@ trait Bar<X> { }
 
 // We don't always check where clauses for sanity, but in this case
 // wfcheck does report an error here:
-fn vacuous<A>() //~ ERROR the trait bound `i32: Bar<u32>` is not satisfied
-    where i32: Foo<u32, A>
+fn vacuous<A>()
+    where i32: Foo<u32, A> //~ ERROR the trait bound `i32: Bar<u32>` is not satisfied
 {
     // ... the original intention was to check that we don't use that
     // vacuous where clause (which could never be satisfied) to accept

--- a/src/test/ui/cross/cross-fn-cache-hole.stderr
+++ b/src/test/ui/cross/cross-fn-cache-hole.stderr
@@ -1,14 +1,8 @@
 error[E0277]: the trait bound `i32: Bar<u32>` is not satisfied
-  --> $DIR/cross-fn-cache-hole.rs:15:1
+  --> $DIR/cross-fn-cache-hole.rs:16:11
    |
-LL | / fn vacuous<A>()
-LL | |     where i32: Foo<u32, A>
-LL | | {
-LL | |     // ... the original intention was to check that we don't use that
-...  |
-LL | |     require::<i32, u32>();
-LL | | }
-   | |_^ the trait `Bar<u32>` is not implemented for `i32`
+LL |     where i32: Foo<u32, A>
+   |           ^^^^^^^^^^^^^^^^ the trait `Bar<u32>` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -1,87 +1,71 @@
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:10:1
+  --> $DIR/feature-gate-trivial_bounds.rs:10:14
    |
 LL | enum E where i32: Foo { V }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:12:1
+  --> $DIR/feature-gate-trivial_bounds.rs:12:16
    |
 LL | struct S where i32: Foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |                ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:14:1
+  --> $DIR/feature-gate-trivial_bounds.rs:14:15
    |
 LL | trait T where i32: Foo {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:16:1
+  --> $DIR/feature-gate-trivial_bounds.rs:16:15
    |
 LL | union U where i32: Foo { f: i32 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+  --> $DIR/feature-gate-trivial_bounds.rs:20:23
    |
-LL | / impl Foo for () where i32: Foo {
-LL | |     fn test(&self) {
-LL | |         3i32.test();
-LL | |         Foo::test(&4i32);
-LL | |         generic_function(5i32);
-LL | |     }
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `i32`
+LL | impl Foo for () where i32: Foo {
+   |                       ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:28:1
+  --> $DIR/feature-gate-trivial_bounds.rs:28:14
    |
-LL | / fn f() where i32: Foo
-LL | | {
-LL | |     let s = S;
-LL | |     3i32.test();
-LL | |     Foo::test(&4i32);
-LL | |     generic_function(5i32);
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `i32`
+LL | fn f() where i32: Foo
+   |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `String: Neg` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:36:1
+  --> $DIR/feature-gate-trivial_bounds.rs:36:38
    |
-LL | / fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
-LL | |     -s
-LL | | }
-   | |_^ the trait `Neg` is not implemented for `String`
+LL | fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Neg` is not implemented for `String`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: `i32` is not an iterator
-  --> $DIR/feature-gate-trivial_bounds.rs:40:1
+  --> $DIR/feature-gate-trivial_bounds.rs:40:20
    |
-LL | / fn use_for() where i32: Iterator {
-LL | |     for _ in 2i32 {}
-LL | | }
-   | |_^ `i32` is not an iterator
+LL | fn use_for() where i32: Iterator {
+   |                    ^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
@@ -89,22 +73,20 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:52:1
+  --> $DIR/feature-gate-trivial_bounds.rs:52:32
    |
 LL | struct TwoStrs(str, str) where str: Sized;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:55:1
+  --> $DIR/feature-gate-trivial_bounds.rs:55:26
    |
-LL | / fn unsized_local() where Dst<dyn A>: Sized {
-LL | |     let x: Dst<dyn A> = *(Box::new(Dst { x: 1 }) as Box<Dst<dyn A>>);
-LL | | }
-   | |_^ doesn't have a size known at compile-time
+LL | fn unsized_local() where Dst<dyn A>: Sized {
+   |                          ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Dst<(dyn A + 'static)>`, the trait `Sized` is not implemented for `(dyn A + 'static)`
 note: required because it appears within the type `Dst<(dyn A + 'static)>`
@@ -116,12 +98,10 @@ LL | struct Dst<X: ?Sized> {
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:59:1
+  --> $DIR/feature-gate-trivial_bounds.rs:59:30
    |
-LL | / fn return_str() -> str where str: Sized {
-LL | |     *"Sized".to_string().into_boxed_str()
-LL | | }
-   | |_^ doesn't have a size known at compile-time
+LL | fn return_str() -> str where str: Sized {
+   |                              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214

--- a/src/test/ui/lint/unused/unused-async.rs
+++ b/src/test/ui/lint/unused/unused-async.rs
@@ -1,0 +1,43 @@
+// edition:2018
+// run-pass
+#![allow(dead_code)]
+
+#[must_use]
+//~^ WARNING `must_use`
+async fn test() -> i32 {
+    1
+}
+
+
+struct Wowee {}
+
+impl Wowee {
+    #[must_use]
+    //~^ WARNING `must_use`
+    async fn test_method() -> i32 {
+        1
+    }
+}
+
+/* FIXME(guswynn) update this test when async-fn-in-traits works
+trait Doer {
+    #[must_use]
+    async fn test_trait_method() -> i32;
+    WARNING must_use
+    async fn test_other_trait() -> i32;
+}
+
+impl Doer for Wowee {
+    async fn test_trait_method() -> i32 {
+        1
+    }
+    #[must_use]
+    async fn test_other_trait() -> i32 {
+        WARNING must_use
+        1
+    }
+}
+*/
+
+fn main() {
+}

--- a/src/test/ui/lint/unused/unused-async.stderr
+++ b/src/test/ui/lint/unused/unused-async.stderr
@@ -1,0 +1,26 @@
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+  --> $DIR/unused-async.rs:5:1
+   |
+LL |   #[must_use]
+   |   ^^^^^^^^^^^
+LL |
+LL | / async fn test() -> i32 {
+LL | |     1
+LL | | }
+   | |_- this attribute does nothing, the `Future`s returned by async functions are already `must_use`
+   |
+   = note: `#[warn(unused_attributes)]` on by default
+
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+  --> $DIR/unused-async.rs:15:5
+   |
+LL |       #[must_use]
+   |       ^^^^^^^^^^^
+LL |
+LL | /     async fn test_method() -> i32 {
+LL | |         1
+LL | |     }
+   | |_____- this attribute does nothing, the `Future`s returned by async functions are already `must_use`
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/unused/unused-async.stderr
+++ b/src/test/ui/lint/unused/unused-async.stderr
@@ -1,4 +1,4 @@
-warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within
   --> $DIR/unused-async.rs:5:1
    |
 LL |   #[must_use]
@@ -11,7 +11,7 @@ LL | | }
    |
    = note: `#[warn(unused_attributes)]` on by default
 
-warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within
   --> $DIR/unused-async.rs:15:5
    |
 LL |       #[must_use]

--- a/src/test/ui/parser/char/whitespace-character-literal.rs
+++ b/src/test/ui/parser/char/whitespace-character-literal.rs
@@ -1,0 +1,9 @@
+// This tests that the error generated when a character literal has multiple
+// characters in it contains a note about non-printing characters.
+
+fn main() {
+    // <hair space>x<zero width space>
+    let _hair_space_around = ' x​';
+    //~^ ERROR: character literal may only contain one codepoint
+    //~| NOTE: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+}

--- a/src/test/ui/parser/char/whitespace-character-literal.rs
+++ b/src/test/ui/parser/char/whitespace-character-literal.rs
@@ -2,8 +2,9 @@
 // characters in it contains a note about non-printing characters.
 
 fn main() {
-    // <hair space>x<zero width space>
     let _hair_space_around = ' x​';
     //~^ ERROR: character literal may only contain one codepoint
     //~| NOTE: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+    //~| HELP: consider removing the non-printing characters
+    //~| SUGGESTION: x
 }

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,18 +1,17 @@
+['x']
 error: character literal may only contain one codepoint
-  --> $DIR/whitespace-character-literal.rs:6:30
+  --> $DIR/whitespace-character-literal.rs:5:30
    |
 LL |     let _hair_space_around = ' x​';
-   |                              ^^^^
+   |                              ^--^
+   |                               |
+   |                               help: consider removing the non-printing characters: `x`
    |
 note: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
-  --> $DIR/whitespace-character-literal.rs:6:31
+  --> $DIR/whitespace-character-literal.rs:5:31
    |
 LL |     let _hair_space_around = ' x​';
    |                               ^^
-help: if you meant to write a `str` literal, use double quotes
-   |
-LL |     let _hair_space_around = " x​";
-   |                              ~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,0 +1,18 @@
+error: character literal may only contain one codepoint
+  --> $DIR/whitespace-character-literal.rs:6:30
+   |
+LL |     let _hair_space_around = ' x​';
+   |                              ^^^^
+   |
+note: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+  --> $DIR/whitespace-character-literal.rs:6:31
+   |
+LL |     let _hair_space_around = ' x​';
+   |                               ^^
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _hair_space_around = " x​";
+   |                              ~~~~
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,4 +1,3 @@
-['x']
 error: character literal may only contain one codepoint
   --> $DIR/whitespace-character-literal.rs:5:30
    |

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -258,7 +258,7 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
     let mut next_feature_omits_tracking_issue = false;
 
     let mut in_feature_group = false;
-    let mut prev_name = None;
+    let mut prev_names = vec![];
 
     contents
         .lines()
@@ -291,11 +291,11 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 }
 
                 in_feature_group = true;
-                prev_name = None;
+                prev_names = vec![];
                 return None;
             } else if line.starts_with(FEATURE_GROUP_END_PREFIX) {
                 in_feature_group = false;
-                prev_name = None;
+                prev_names = vec![];
                 return None;
             }
 
@@ -325,16 +325,49 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 }
             };
             if in_feature_group {
-                if prev_name > Some(name) {
+                if prev_names.last() > Some(&name) {
+                    // This assumes the user adds the feature name at the end of the list, as we're
+                    // not looking ahead.
+                    let correct_index = match prev_names.binary_search(&name) {
+                        Ok(_) => {
+                            // This only occurs when the feature name has already been declared.
+                            tidy_error!(
+                                bad,
+                                "{}:{}: duplicate feature {}",
+                                path.display(),
+                                line_number,
+                                name,
+                            );
+                            // skip any additional checks for this line
+                            return None;
+                        }
+                        Err(index) => index,
+                    };
+
+                    let correct_placement = if correct_index == 0 {
+                        "at the beginning of the feature group".to_owned()
+                    } else if correct_index == prev_names.len() {
+                        // I don't believe this is reachable given the above assumption, but it
+                        // doesn't hurt to be safe.
+                        "at the end of the feature group".to_owned()
+                    } else {
+                        format!(
+                            "between {} and {}",
+                            prev_names[correct_index - 1],
+                            prev_names[correct_index],
+                        )
+                    };
+
                     tidy_error!(
                         bad,
-                        "{}:{}: feature {} is not sorted by feature name",
+                        "{}:{}: feature {} is not sorted by feature name (should be {})",
                         path.display(),
                         line_number,
                         name,
+                        correct_placement,
                     );
                 }
-                prev_name = Some(name);
+                prev_names.push(name);
             }
 
             let issue_str = parts.next().unwrap().trim();

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -7,7 +7,7 @@
 //! * Library features have at most one stability level.
 //! * Library features have at most one `since` value.
 //! * All unstable lang features have tests to ensure they are actually unstable.
-//! * Language features in a group are sorted by `since` value.
+//! * Language features in a group are sorted by feature name.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -258,7 +258,7 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
     let mut next_feature_omits_tracking_issue = false;
 
     let mut in_feature_group = false;
-    let mut prev_since = None;
+    let mut prev_name = None;
 
     contents
         .lines()
@@ -291,11 +291,11 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 }
 
                 in_feature_group = true;
-                prev_since = None;
+                prev_name = None;
                 return None;
             } else if line.starts_with(FEATURE_GROUP_END_PREFIX) {
                 in_feature_group = false;
-                prev_since = None;
+                prev_name = None;
                 return None;
             }
 
@@ -325,16 +325,16 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 }
             };
             if in_feature_group {
-                if prev_since > since {
+                if prev_name > Some(name) {
                     tidy_error!(
                         bad,
-                        "{}:{}: feature {} is not sorted by \"since\" (version number)",
+                        "{}:{}: feature {} is not sorted by feature name",
                         path.display(),
                         line_number,
                         name,
                     );
                 }
-                prev_since = since;
+                prev_name = Some(name);
             }
 
             let issue_str = parts.next().unwrap().trim();

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -9,7 +9,7 @@ const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
 const ROOT_ENTRY_LIMIT: usize = 1102;
 const ISSUES_ENTRY_LIMIT: usize = 2310;
-const PARSER_LIMIT: usize = 1004;
+const PARSER_LIMIT: usize = 1005;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
Successful merges:

 - #87704 (Windows: Resolve `process::Command` program without using the current directory)
 - #89610 (warn on must_use use on async fn's)
 - #90772 (Add Vec::retain_mut)
 - #90787 (Add `#[inline]`s to `SortedIndexMultiMap`)
 - #90861 (Print escaped string if char literal has multiple characters, but only one printable character)
 - #90884 (Fix span for non-satisfied trivial trait bounds)
 - #90900 (Remove workaround for the forward progress handling in LLVM)
 - #90920 (:arrow_up: rust-analyzer)
 - #90935 (Alphabetize language features)
 - #90949 (update miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=87704,89610,90772,90787,90861,90884,90900,90920,90935,90949)
<!-- homu-ignore:end -->