### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -316,7 +316,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                     extended_asm.add_input_operand(None, "r", result.llval);
                     extended_asm.add_clobber("memory");
                     extended_asm.set_volatile_flag(true);
-                    
+
                     // We have copied the value to `result` already.
                     return;
                 }
@@ -361,10 +361,6 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
     fn expect(&mut self, cond: Self::Value, _expected: bool) -> Self::Value {
         // TODO(antoyo)
         cond
-    }
-
-    fn sideeffect(&mut self) {
-        // TODO(antoyo)
     }
 
     fn type_test(&mut self, _pointer: Self::Value, _typeid: Self::Value) -> Self::Value {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -597,7 +597,6 @@ impl CodegenCx<'b, 'tcx> {
         ifn!("llvm.trap", fn() -> void);
         ifn!("llvm.debugtrap", fn() -> void);
         ifn!("llvm.frameaddress", fn(t_i32) -> i8p);
-        ifn!("llvm.sideeffect", fn() -> void);
 
         ifn!("llvm.powi.f32", fn(t_f32, t_i32) -> t_f32);
         ifn!("llvm.powi.f64", fn(t_f64, t_i32) -> t_f64);

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -392,15 +392,6 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         self.call_intrinsic("llvm.expect.i1", &[cond, self.const_bool(expected)])
     }
 
-    fn sideeffect(&mut self) {
-        // This kind of check would make a ton of sense in the caller, but currently the only
-        // caller of this function is in `rustc_codegen_ssa`, which is agnostic to whether LLVM
-        // codegen backend being used, and so is unable to check the LLVM version.
-        if unsafe { llvm::LLVMRustVersionMajor() } < 12 {
-            self.call_intrinsic("llvm.sideeffect", &[]);
-        }
-    }
-
     fn type_test(&mut self, pointer: Self::Value, typeid: Self::Value) -> Self::Value {
         // Test the called operand using llvm.type.test intrinsic. The LowerTypeTests link-time
         // optimization pass replaces calls to this intrinsic with code to test type membership.

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -980,17 +980,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::TerminatorKind::Goto { target } => {
-                if bb == target {
-                    // This is an unconditional branch back to this same basic block. That means we
-                    // have something like a `loop {}` statement. LLVM versions before 12.0
-                    // miscompile this because they assume forward progress. For older versions
-                    // try to handle just this specific case which comes up commonly in practice
-                    // (e.g., in embedded code).
-                    //
-                    // NB: the `sideeffect` currently checks for the LLVM version used internally.
-                    bx.sideeffect();
-                }
-
                 helper.funclet_br(self, &mut bx, target);
             }
 

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -20,10 +20,6 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     fn abort(&mut self);
     fn assume(&mut self, val: Self::Value);
     fn expect(&mut self, cond: Self::Value, expected: bool) -> Self::Value;
-    /// Emits a forced side effect.
-    ///
-    /// Currently has any effect only when LLVM versions prior to 12.0 are used as the backend.
-    fn sideeffect(&mut self);
     /// Trait method used to test whether a given pointer is associated with a type identifier.
     fn type_test(&mut self, pointer: Self::Value, typeid: Self::Value) -> Self::Value;
     /// Trait method used to inject `va_start` on the "spoofed" `VaListImpl` in

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -5,6 +5,7 @@ use crate::traits::{Obligation, ObligationCause, PredicateObligation};
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_middle::ty::{self, ToPredicate, TyCtxt, WithConstness};
 use rustc_span::symbol::Ident;
+use rustc_span::Span;
 
 pub fn anonymize_predicate<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -92,6 +93,22 @@ pub fn elaborate_predicates<'tcx>(
     let obligations = predicates
         .map(|predicate| {
             predicate_obligation(predicate, ty::ParamEnv::empty(), ObligationCause::dummy())
+        })
+        .collect();
+    elaborate_obligations(tcx, obligations)
+}
+
+pub fn elaborate_predicates_with_span<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    predicates: impl Iterator<Item = (ty::Predicate<'tcx>, Span)>,
+) -> Elaborator<'tcx> {
+    let obligations = predicates
+        .map(|(predicate, span)| {
+            predicate_obligation(
+                predicate,
+                ty::ParamEnv::empty(),
+                ObligationCause::dummy_with_span(span),
+            )
         })
         .collect();
     elaborate_obligations(tcx, obligations)

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -7,10 +7,6 @@ use rustc_errors::{pluralize, Applicability, Handler};
 use rustc_lexer::unescape::{EscapeError, Mode};
 use rustc_span::{BytePos, Span};
 
-fn printing(ch: char) -> bool {
-    unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0) != 0 && !ch.is_whitespace()
-}
-
 pub(crate) fn emit_unescape_error(
     handler: &Handler,
     // interior part of the literal, without quotes
@@ -87,7 +83,13 @@ pub(crate) fn emit_unescape_error(
                     );
                 }
             } else {
-                let printable: Vec<char> = lit.chars().filter(|x| printing(*x)).collect();
+                let printable: Vec<char> = lit
+                    .chars()
+                    .filter(|&x| {
+                        unicode_width::UnicodeWidthChar::width(x).unwrap_or(0) != 0
+                            && !x.is_whitespace()
+                    })
+                    .collect();
 
                 if let [ch] = printable.as_slice() {
                     has_help = true;

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -82,6 +82,16 @@ pub(crate) fn emit_unescape_error(
                         Applicability::MachineApplicable,
                     );
                 }
+            } else {
+                if lit.chars().filter(|x| x.is_whitespace() || x.is_control()).count() >= 1 {
+                    handler.span_note(
+                        span,
+                        &format!(
+                            "there are non-printing characters, the full sequence is `{}`",
+                            lit.escape_default(),
+                        ),
+                    );
+                }
             }
 
             if !has_help {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1062,7 +1062,7 @@ impl CheckAttrVisitor<'tcx> {
                     lint.build(
                         "`must_use` attribute on `async` functions \
                               applies to the anonymous `Future` returned by the \
-                              function, not the value within.",
+                              function, not the value within",
                     )
                     .span_label(
                         *span,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -112,6 +112,7 @@ impl CheckAttrVisitor<'tcx> {
                     self.check_default_method_body_is_const(attr, span, target)
                 }
                 sym::must_not_suspend => self.check_must_not_suspend(&attr, span, target),
+                sym::must_use => self.check_must_use(hir_id, &attr, span, target),
                 sym::rustc_const_unstable
                 | sym::rustc_const_stable
                 | sym::unstable
@@ -1044,6 +1045,37 @@ impl CheckAttrVisitor<'tcx> {
         }
 
         is_valid
+    }
+
+    /// Warns against some misuses of `#[must_use]`
+    fn check_must_use(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: &Span,
+        _target: Target,
+    ) -> bool {
+        let node = self.tcx.hir().get(hir_id);
+        if let Some(fn_node) = node.fn_kind() {
+            if let rustc_hir::IsAsync::Async = fn_node.asyncness() {
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build(
+                        "`must_use` attribute on `async` functions \
+                              applies to the anonymous `Future` returned by the \
+                              function, not the value within.",
+                    )
+                    .span_label(
+                        *span,
+                        "this attribute does nothing, the `Future`s \
+                                returned by async functions are already `must_use`",
+                    )
+                    .emit();
+                });
+            }
+        }
+
+        // For now, its always valid
+        true
     }
 
     /// Checks if `#[must_not_suspend]` is applied to a function. Returns `true` if valid.

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -65,7 +65,8 @@ pub use self::specialize::{specialization_graph, translate_substs, OverlapError}
 pub use self::structural_match::search_for_structural_match_violation;
 pub use self::structural_match::NonStructuralMatchTy;
 pub use self::util::{
-    elaborate_obligations, elaborate_predicates, elaborate_trait_ref, elaborate_trait_refs,
+    elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
+    elaborate_trait_ref, elaborate_trait_refs,
 };
 pub use self::util::{expand_trait_aliases, TraitAliasExpander};
 pub use self::util::{

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1445,6 +1445,34 @@ impl<T, A: Allocator> Vec<T, A> {
     where
         F: FnMut(&T) -> bool,
     {
+        self.retain_mut(|elem| f(elem));
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    ///
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(vec_retain_mut)]
+    ///
+    /// let mut vec = vec![1, 2, 3, 4];
+    /// vec.retain_mut(|x| if *x > 3 {
+    ///     false
+    /// } else {
+    ///     *x += 1;
+    ///     true
+    /// });
+    /// assert_eq!(vec, [2, 3, 4]);
+    /// ```
+    #[unstable(feature = "vec_retain_mut", issue = "90829")]
+    pub fn retain_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
         let original_len = self.len();
         // Avoid double drop if the drop guard is not executed,
         // since we may make some holes during the process.
@@ -1496,7 +1524,7 @@ impl<T, A: Allocator> Vec<T, A> {
             g: &mut BackshiftOnDrop<'_, T, A>,
         ) -> bool
         where
-            F: FnMut(&T) -> bool,
+            F: FnMut(&mut T) -> bool,
         {
             // SAFETY: Unchecked element must be valid.
             let cur = unsafe { &mut *g.v.as_mut_ptr().add(g.processed_len) };

--- a/src/test/ui/const-generics/issues/issue-67185-2.rs
+++ b/src/test/ui/const-generics/issues/issue-67185-2.rs
@@ -9,11 +9,10 @@ trait Bar {}
 impl Bar for [u16; 4] {}
 impl Bar for [[u16; 3]; 3] {}
 
-trait Foo  //~ ERROR the trait bound `[u16; 3]: Bar` is not satisfied [E0277]
-           //~^ ERROR the trait bound `[[u16; 3]; 2]: Bar` is not satisfied [E0277]
-    where
-        [<u8 as Baz>::Quaks; 2]: Bar,
-        <u8 as Baz>::Quaks: Bar,
+trait Foo
+where
+    [<u8 as Baz>::Quaks; 2]: Bar, //~ ERROR the trait bound `[[u16; 3]; 2]: Bar` is not satisfied [E0277]
+    <u8 as Baz>::Quaks: Bar,  //~ ERROR the trait bound `[u16; 3]: Bar` is not satisfied [E0277]
 {
 }
 

--- a/src/test/ui/const-generics/issues/issue-67185-2.stderr
+++ b/src/test/ui/const-generics/issues/issue-67185-2.stderr
@@ -1,14 +1,8 @@
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:12:1
+  --> $DIR/issue-67185-2.rs:15:5
    |
-LL | / trait Foo
-LL | |
-LL | |     where
-LL | |         [<u8 as Baz>::Quaks; 2]: Bar,
-LL | |         <u8 as Baz>::Quaks: Bar,
-LL | | {
-LL | | }
-   | |_^ the trait `Bar` is not implemented for `[u16; 3]`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[u16; 3]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
@@ -17,16 +11,10 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:12:1
+  --> $DIR/issue-67185-2.rs:14:5
    |
-LL | / trait Foo
-LL | |
-LL | |     where
-LL | |         [<u8 as Baz>::Quaks; 2]: Bar,
-LL | |         <u8 as Baz>::Quaks: Bar,
-LL | | {
-LL | | }
-   | |_^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
    |
    = help: the following implementations were found:
              <[[u16; 3]; 3] as Bar>
@@ -35,7 +23,7 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:22:6
+  --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
@@ -44,16 +32,16 @@ LL | impl Foo for FooImpl {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:16:29
+  --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             ^^^ required by this bound in `Foo`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |                         ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:22:6
+  --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
    |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
@@ -62,16 +50,16 @@ LL | impl Foo for FooImpl {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:15:34
+  --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
    |       --- required by a bound in this
-...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  ^^^ required by this bound in `Foo`
+LL | where
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |                              ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:14
+  --> $DIR/issue-67185-2.rs:25:14
    |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
@@ -80,16 +68,16 @@ LL | fn f(_: impl Foo) {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:15:34
+  --> $DIR/issue-67185-2.rs:14:30
    |
 LL | trait Foo
    |       --- required by a bound in this
-...
-LL |         [<u8 as Baz>::Quaks; 2]: Bar,
-   |                                  ^^^ required by this bound in `Foo`
+LL | where
+LL |     [<u8 as Baz>::Quaks; 2]: Bar,
+   |                              ^^^ required by this bound in `Foo`
 
 error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
-  --> $DIR/issue-67185-2.rs:26:14
+  --> $DIR/issue-67185-2.rs:25:14
    |
 LL | fn f(_: impl Foo) {}
    |              ^^^ the trait `Bar` is not implemented for `[u16; 3]`
@@ -98,13 +86,13 @@ LL | fn f(_: impl Foo) {}
              <[[u16; 3]; 3] as Bar>
              <[u16; 4] as Bar>
 note: required by a bound in `Foo`
-  --> $DIR/issue-67185-2.rs:16:29
+  --> $DIR/issue-67185-2.rs:15:25
    |
 LL | trait Foo
    |       --- required by a bound in this
 ...
-LL |         <u8 as Baz>::Quaks: Bar,
-   |                             ^^^ required by this bound in `Foo`
+LL |     <u8 as Baz>::Quaks: Bar,
+   |                         ^^^ required by this bound in `Foo`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/cross/cross-fn-cache-hole.rs
+++ b/src/test/ui/cross/cross-fn-cache-hole.rs
@@ -12,8 +12,8 @@ trait Bar<X> { }
 
 // We don't always check where clauses for sanity, but in this case
 // wfcheck does report an error here:
-fn vacuous<A>() //~ ERROR the trait bound `i32: Bar<u32>` is not satisfied
-    where i32: Foo<u32, A>
+fn vacuous<A>()
+    where i32: Foo<u32, A> //~ ERROR the trait bound `i32: Bar<u32>` is not satisfied
 {
     // ... the original intention was to check that we don't use that
     // vacuous where clause (which could never be satisfied) to accept

--- a/src/test/ui/cross/cross-fn-cache-hole.stderr
+++ b/src/test/ui/cross/cross-fn-cache-hole.stderr
@@ -1,14 +1,8 @@
 error[E0277]: the trait bound `i32: Bar<u32>` is not satisfied
-  --> $DIR/cross-fn-cache-hole.rs:15:1
+  --> $DIR/cross-fn-cache-hole.rs:16:11
    |
-LL | / fn vacuous<A>()
-LL | |     where i32: Foo<u32, A>
-LL | | {
-LL | |     // ... the original intention was to check that we don't use that
-...  |
-LL | |     require::<i32, u32>();
-LL | | }
-   | |_^ the trait `Bar<u32>` is not implemented for `i32`
+LL |     where i32: Foo<u32, A>
+   |           ^^^^^^^^^^^^^^^^ the trait `Bar<u32>` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -1,87 +1,71 @@
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:10:1
+  --> $DIR/feature-gate-trivial_bounds.rs:10:14
    |
 LL | enum E where i32: Foo { V }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:12:1
+  --> $DIR/feature-gate-trivial_bounds.rs:12:16
    |
 LL | struct S where i32: Foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |                ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:14:1
+  --> $DIR/feature-gate-trivial_bounds.rs:14:15
    |
 LL | trait T where i32: Foo {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:16:1
+  --> $DIR/feature-gate-trivial_bounds.rs:16:15
    |
 LL | union U where i32: Foo { f: i32 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:20:1
+  --> $DIR/feature-gate-trivial_bounds.rs:20:23
    |
-LL | / impl Foo for () where i32: Foo {
-LL | |     fn test(&self) {
-LL | |         3i32.test();
-LL | |         Foo::test(&4i32);
-LL | |         generic_function(5i32);
-LL | |     }
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `i32`
+LL | impl Foo for () where i32: Foo {
+   |                       ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:28:1
+  --> $DIR/feature-gate-trivial_bounds.rs:28:14
    |
-LL | / fn f() where i32: Foo
-LL | | {
-LL | |     let s = S;
-LL | |     3i32.test();
-LL | |     Foo::test(&4i32);
-LL | |     generic_function(5i32);
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `i32`
+LL | fn f() where i32: Foo
+   |              ^^^^^^^^ the trait `Foo` is not implemented for `i32`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `String: Neg` is not satisfied
-  --> $DIR/feature-gate-trivial_bounds.rs:36:1
+  --> $DIR/feature-gate-trivial_bounds.rs:36:38
    |
-LL | / fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
-LL | |     -s
-LL | | }
-   | |_^ the trait `Neg` is not implemented for `String`
+LL | fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Neg` is not implemented for `String`
    |
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: `i32` is not an iterator
-  --> $DIR/feature-gate-trivial_bounds.rs:40:1
+  --> $DIR/feature-gate-trivial_bounds.rs:40:20
    |
-LL | / fn use_for() where i32: Iterator {
-LL | |     for _ in 2i32 {}
-LL | | }
-   | |_^ `i32` is not an iterator
+LL | fn use_for() where i32: Iterator {
+   |                    ^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
@@ -89,22 +73,20 @@ LL | | }
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:52:1
+  --> $DIR/feature-gate-trivial_bounds.rs:52:32
    |
 LL | struct TwoStrs(str, str) where str: Sized;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:55:1
+  --> $DIR/feature-gate-trivial_bounds.rs:55:26
    |
-LL | / fn unsized_local() where Dst<dyn A>: Sized {
-LL | |     let x: Dst<dyn A> = *(Box::new(Dst { x: 1 }) as Box<Dst<dyn A>>);
-LL | | }
-   | |_^ doesn't have a size known at compile-time
+LL | fn unsized_local() where Dst<dyn A>: Sized {
+   |                          ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Dst<(dyn A + 'static)>`, the trait `Sized` is not implemented for `(dyn A + 'static)`
 note: required because it appears within the type `Dst<(dyn A + 'static)>`
@@ -116,12 +98,10 @@ LL | struct Dst<X: ?Sized> {
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/feature-gate-trivial_bounds.rs:59:1
+  --> $DIR/feature-gate-trivial_bounds.rs:59:30
    |
-LL | / fn return_str() -> str where str: Sized {
-LL | |     *"Sized".to_string().into_boxed_str()
-LL | | }
-   | |_^ doesn't have a size known at compile-time
+LL | fn return_str() -> str where str: Sized {
+   |                              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -13,11 +13,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/feature-gate-untagged_unions.rs:16:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:24:5
@@ -25,11 +24,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/feature-gate-untagged_unions.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -16,7 +16,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/feature-gate-untagged_unions.rs:24:5
@@ -27,7 +27,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/unused/unused-async.rs
+++ b/src/test/ui/lint/unused/unused-async.rs
@@ -1,0 +1,43 @@
+// edition:2018
+// run-pass
+#![allow(dead_code)]
+
+#[must_use]
+//~^ WARNING `must_use`
+async fn test() -> i32 {
+    1
+}
+
+
+struct Wowee {}
+
+impl Wowee {
+    #[must_use]
+    //~^ WARNING `must_use`
+    async fn test_method() -> i32 {
+        1
+    }
+}
+
+/* FIXME(guswynn) update this test when async-fn-in-traits works
+trait Doer {
+    #[must_use]
+    async fn test_trait_method() -> i32;
+    WARNING must_use
+    async fn test_other_trait() -> i32;
+}
+
+impl Doer for Wowee {
+    async fn test_trait_method() -> i32 {
+        1
+    }
+    #[must_use]
+    async fn test_other_trait() -> i32 {
+        WARNING must_use
+        1
+    }
+}
+*/
+
+fn main() {
+}

--- a/src/test/ui/lint/unused/unused-async.stderr
+++ b/src/test/ui/lint/unused/unused-async.stderr
@@ -1,0 +1,26 @@
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+  --> $DIR/unused-async.rs:5:1
+   |
+LL |   #[must_use]
+   |   ^^^^^^^^^^^
+LL |
+LL | / async fn test() -> i32 {
+LL | |     1
+LL | | }
+   | |_- this attribute does nothing, the `Future`s returned by async functions are already `must_use`
+   |
+   = note: `#[warn(unused_attributes)]` on by default
+
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+  --> $DIR/unused-async.rs:15:5
+   |
+LL |       #[must_use]
+   |       ^^^^^^^^^^^
+LL |
+LL | /     async fn test_method() -> i32 {
+LL | |         1
+LL | |     }
+   | |_____- this attribute does nothing, the `Future`s returned by async functions are already `must_use`
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/lint/unused/unused-async.stderr
+++ b/src/test/ui/lint/unused/unused-async.stderr
@@ -1,4 +1,4 @@
-warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within
   --> $DIR/unused-async.rs:5:1
    |
 LL |   #[must_use]
@@ -11,7 +11,7 @@ LL | | }
    |
    = note: `#[warn(unused_attributes)]` on by default
 
-warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within.
+warning: `must_use` attribute on `async` functions applies to the anonymous `Future` returned by the function, not the value within
   --> $DIR/unused-async.rs:15:5
    |
 LL |       #[must_use]

--- a/src/test/ui/parser/char/whitespace-character-literal.rs
+++ b/src/test/ui/parser/char/whitespace-character-literal.rs
@@ -1,0 +1,9 @@
+// This tests that the error generated when a character literal has multiple
+// characters in it contains a note about non-printing characters.
+
+fn main() {
+    // <hair space>x<zero width space>
+    let _hair_space_around = ' x​';
+    //~^ ERROR: character literal may only contain one codepoint
+    //~| NOTE: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+}

--- a/src/test/ui/parser/char/whitespace-character-literal.rs
+++ b/src/test/ui/parser/char/whitespace-character-literal.rs
@@ -2,8 +2,9 @@
 // characters in it contains a note about non-printing characters.
 
 fn main() {
-    // <hair space>x<zero width space>
     let _hair_space_around = ' x​';
     //~^ ERROR: character literal may only contain one codepoint
     //~| NOTE: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+    //~| HELP: consider removing the non-printing characters
+    //~| SUGGESTION: x
 }

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,18 +1,17 @@
+['x']
 error: character literal may only contain one codepoint
-  --> $DIR/whitespace-character-literal.rs:6:30
+  --> $DIR/whitespace-character-literal.rs:5:30
    |
 LL |     let _hair_space_around = ' x​';
-   |                              ^^^^
+   |                              ^--^
+   |                               |
+   |                               help: consider removing the non-printing characters: `x`
    |
 note: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
-  --> $DIR/whitespace-character-literal.rs:6:31
+  --> $DIR/whitespace-character-literal.rs:5:31
    |
 LL |     let _hair_space_around = ' x​';
    |                               ^^
-help: if you meant to write a `str` literal, use double quotes
-   |
-LL |     let _hair_space_around = " x​";
-   |                              ~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,0 +1,18 @@
+error: character literal may only contain one codepoint
+  --> $DIR/whitespace-character-literal.rs:6:30
+   |
+LL |     let _hair_space_around = ' x​';
+   |                              ^^^^
+   |
+note: there are non-printing characters, the full sequence is `\u{200a}x\u{200b}`
+  --> $DIR/whitespace-character-literal.rs:6:31
+   |
+LL |     let _hair_space_around = ' x​';
+   |                               ^^
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _hair_space_around = " x​";
+   |                              ~~~~
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/char/whitespace-character-literal.stderr
+++ b/src/test/ui/parser/char/whitespace-character-literal.stderr
@@ -1,4 +1,3 @@
-['x']
 error: character literal may only contain one codepoint
   --> $DIR/whitespace-character-literal.rs:5:30
    |

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: A,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/issue-41073.rs:4:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: A,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<A>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -7,7 +7,7 @@ LL |     a: A,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<A>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -7,7 +7,7 @@ LL |     bar: Bar,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     bar: std::mem::ManuallyDrop<Bar>,
-   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |          +++++++++++++++++++++++   +
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     bar: Bar,
    |     ^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-custom-drop.rs:7:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     bar: Bar,
-   |     ^^^^^^^^
+LL |     bar: std::mem::ManuallyDrop<Bar>,
+   |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:11:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -16,11 +15,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: S,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:19:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: S,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<S>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -28,11 +26,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
@@ -7,7 +7,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -18,7 +18,7 @@ LL |     a: S,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -29,7 +29,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
@@ -4,11 +4,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: String,
    |     ^^^^^^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:11:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: String,
-   |     ^^^^^^^^^
+LL |     a: std::mem::ManuallyDrop<String>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -16,11 +15,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: S,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:19:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: S,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<S>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -28,11 +26,10 @@ error[E0740]: unions may not contain fields that need dropping
 LL |     a: T,
    |     ^^^^
    |
-note: `std::mem::ManuallyDrop` can be used to wrap the type
-  --> $DIR/union-with-drop-fields.rs:24:5
+help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
-LL |     a: T,
-   |     ^^^^
+LL |     a: std::mem::ManuallyDrop<T>,
+   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
@@ -7,7 +7,7 @@ LL |     a: String,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++      +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
@@ -18,7 +18,7 @@ LL |     a: S,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error[E0740]: unions may not contain fields that need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
@@ -29,7 +29,7 @@ LL |     a: T,
 help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
-   |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |        +++++++++++++++++++++++ +
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -9,7 +9,7 @@ const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
 const ROOT_ENTRY_LIMIT: usize = 1102;
 const ISSUES_ENTRY_LIMIT: usize = 2310;
-const PARSER_LIMIT: usize = 1004;
+const PARSER_LIMIT: usize = 1005;
 
 fn check_entries(path: &Path, bad: &mut bool) {
     let dirs = walkdir::WalkDir::new(&path.join("test/ui"))


### PR DESCRIPTION
Successful merges:

 - #89610 (warn on must_use use on async fn's)
 - #90772 (Add Vec::retain_mut)
 - #90774 (std: Tweak expansion of thread-local const)
 - #90861 (Print escaped string if char literal has multiple characters, but only one printable character)
 - #90884 (Fix span for non-satisfied trivial trait bounds)
 - #90900 (Remove workaround for the forward progress handling in LLVM)
 - #90901 (Improve ManuallyDrop suggestion)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89610,90772,90774,90861,90884,90900,90901)
<!-- homu-ignore:end -->