### PR TITLE
Make scrollbar in the sidebar always visible for visual consistency

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -303,7 +303,7 @@ nav.sub {
 	left: 0;
 	top: 0;
 	bottom: 0;
-	overflow: auto;
+	overflow-y: scroll;
 }
 
 /* Improve the scrollbar display on firefox */

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -70,11 +70,11 @@ pre, .rustdoc.source .example-wrap {
 
 /* Improve the scrollbar display on firefox */
 * {
-	scrollbar-color: #5c6773 transparent;
+	scrollbar-color: #5c6773 #24292f;
 }
 
 .sidebar {
-	scrollbar-color: #5c6773 transparent;
+	scrollbar-color: #5c6773 #24292f;
 }
 
 /* Improve the scrollbar display on webkit-based browsers */

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -44,7 +44,7 @@ pre, .rustdoc.source .example-wrap {
 	scrollbar-color: rgb(64, 65, 67) #717171;
 }
 .sidebar {
-	scrollbar-color: rgba(32,34,37,.6) transparent;
+	scrollbar-color: rgba(32,34,37,.6) #5a5a5a;
 }
 
 /* Improve the scrollbar display on webkit-based browsers */


### PR DESCRIPTION
Fixes #90943.

I had to add a background in `dark` and `ayu` themes, otherwise it was looking strange (like an invisible margin). So it looks like this:

![Screenshot from 2021-11-17 14-45-49](https://user-images.githubusercontent.com/3050060/142212476-18892ae0-ba4b-48e3-8c0f-4ca1dd2f851d.png)
![Screenshot from 2021-11-17 14-45-53](https://user-images.githubusercontent.com/3050060/142212482-e97b2fad-68d2-439a-b62e-b56e6ded5345.png)

Sadly, I wasn't able to add a GUI test to ensure that the scrollbar was always displayed because it seems not possible in puppeteer for whatever reason... I used this method: on small pages (like `lib2/sub_mod/index.html`), comparing `.navbar`'s `clientWidth` with `offsetWidth` (the first doesn't include the sidebar in the computed amount). When checking in the browser, it works fine but in puppeteer it almost never works...

In case anyone want to try to solve the bug, here is the puppeteer code:

<details>
More information about this: I tried another approach which was to get the element in `evaluate` directly (by calling it from `page.evaluate(() => { .. });` directly instead of `parseAssertElemProp.evaluate(e => {...});`.

```js
const puppeteer = require('puppeteer');

(async () => {
    const browser = await puppeteer.launch();
    const page = await browser.newPage();
    await page.goto("file:///path/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-gui/doc/lib2/sub_mod/index.html");
    await page.waitFor(".sidebar");
    let parseAssertElemProp = await page.$(".sidebar");
    if (parseAssertElemProp === null) { throw '".sidebar" not found'; }
    await parseAssertElemProp.evaluate(e => {
        const parseAssertElemPropDict = {"clientWidth": "192", "offsetWidth":"200"};
        for (const [parseAssertElemPropKey, parseAssertElemPropValue] of Object.entries(parseAssertElemPropDict)) {
            if (e[parseAssertElemPropKey] === undefined || String(e[parseAssertElemPropKey]) != parseAssertElemPropValue) {
                throw 'expected `' + parseAssertElemPropValue + '` for property `' + parseAssertElemPropKey + '` for selector `.sidebar`, found `' + e[parseAssertElemPropKey] + '`';
            }
        }
    }).catch(e => console.error(e));
    await browser.close();
})();
```

</details>

r? @jsha 