### PR TITLE
Improve errors on const mismatches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.60.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.2"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -768,7 +768,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crates-io"
-version = "0.33.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -768,7 +768,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crates-io"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "curl",

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -856,11 +856,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .regions()
             .map(|lifetime| {
                 let s = lifetime.to_string();
-                if s.is_empty() {
-                    "'_".to_string()
-                } else {
-                    s
-                }
+                if s.is_empty() { "'_".to_string() } else { s }
             })
             .collect::<Vec<_>>()
             .join(", ");
@@ -1179,11 +1175,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
                     fn lifetime_display(lifetime: Region<'_>) -> String {
                         let s = lifetime.to_string();
-                        if s.is_empty() {
-                            "'_".to_string()
-                        } else {
-                            s
-                        }
+                        if s.is_empty() { "'_".to_string() } else { s }
                     }
                     // At one point we'd like to elide all lifetimes here, they are irrelevant for
                     // all diagnostics that use this output

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1484,6 +1484,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         self.report_and_explain_type_error(trace, &err)
     }
 
+    #[instrument(skip(self), level = "debug")]
     pub fn report_mismatched_consts(
         &self,
         cause: &ObligationCause<'tcx>,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2328,6 +2328,30 @@ impl BinOp {
         use self::BinOp::*;
         matches!(self, Add | Sub | Mul | Shl | Shr)
     }
+
+    pub fn try_as_string(self) -> Option<String> {
+        use self::BinOp::*;
+
+        match self {
+            Add => Some("+".to_string()),
+            Sub => Some("-".to_string()),
+            Mul => Some("*".to_string()),
+            Div => Some("/".to_string()),
+            Rem => Some("%".to_string()),
+            BitXor => Some("^".to_string()),
+            BitAnd => Some("&".to_string()),
+            BitOr => Some("|".to_string()),
+            Shl => Some("<<".to_string()),
+            Shr => Some(">>".to_string()),
+            Eq => Some("=".to_string()),
+            Lt => Some("<".to_string()),
+            Le => Some("<=".to_string()),
+            Ne => Some("!=".to_string()),
+            Ge => Some(">=".to_string()),
+            Gt => Some(">".to_string()),
+            Offset => None,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]
@@ -2346,6 +2370,15 @@ pub enum UnOp {
     Not,
     /// The `-` operator for negation
     Neg,
+}
+
+impl fmt::Display for UnOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnOp::Not => write!(f, "!"),
+            UnOp::Neg => write!(f, "-"),
+        }
+    }
 }
 
 impl<'tcx> Debug for Rvalue<'tcx> {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2352,6 +2352,30 @@ impl BinOp {
             Offset => None,
         }
     }
+
+    pub fn get_precedence(self) -> usize {
+        use self::BinOp::*;
+
+        match self {
+            Add => 7,
+            Sub => 7,
+            Mul => 8,
+            Div => 8,
+            Rem => 8,
+            BitXor => 2,
+            BitAnd => 3,
+            BitOr => 1,
+            Shl => 6,
+            Shr => 6,
+            Eq => 4,
+            Lt => 5,
+            Le => 5,
+            Ne => 4,
+            Ge => 5,
+            Gt => 5,
+            Offset => 0,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -67,6 +67,7 @@ pub enum TypeError<'tcx> {
     ),
     ObjectUnsafeCoercion(DefId),
     ConstMismatch(ExpectedFound<&'tcx ty::Const<'tcx>>),
+    ConstMismatchTooGeneric(ExpectedFound<&'tcx ty::Const<'tcx>>, Option<String>),
 
     IntrinsicCast,
     /// Safe `#[target_feature]` functions are not assignable to safe function pointers.
@@ -201,6 +202,12 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
             ConstMismatch(ref values) => {
                 write!(f, "expected `{}`, found `{}`", values.expected, values.found)
             }
+            ConstMismatchTooGeneric(ref values, ref suggestion) => match suggestion {
+                Some(sugg) => {
+                    write!(f, "expected `{}`, found `{}`", values.expected, sugg)
+                }
+                None => write!(f, "expected `{}`, found `{}`", values.expected, values.found),
+            },
             IntrinsicCast => write!(f, "cannot coerce intrinsics to function pointers"),
             TargetFeatureCast(_) => write!(
                 f,
@@ -233,6 +240,7 @@ impl<'tcx> TypeError<'tcx> {
             | ProjectionMismatched(_)
             | ExistentialMismatch(_)
             | ConstMismatch(_)
+            | ConstMismatchTooGeneric(_, _)
             | IntrinsicCast
             | ObjectUnsafeCoercion(_) => true,
         }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -625,6 +625,9 @@ impl<'a, 'tcx> Lift<'tcx> for ty::error::TypeError<'a> {
             Sorts(x) => return tcx.lift(x).map(Sorts),
             ExistentialMismatch(x) => return tcx.lift(x).map(ExistentialMismatch),
             ConstMismatch(x) => return tcx.lift(x).map(ConstMismatch),
+            ConstMismatchTooGeneric(x, s) => {
+                return tcx.lift(x).map(|x| ConstMismatchTooGeneric(x, s));
+            }
             IntrinsicCast => IntrinsicCast,
             TargetFeatureCast(x) => TargetFeatureCast(x),
             ObjectUnsafeCoercion(x) => return tcx.lift(x).map(ObjectUnsafeCoercion),

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -284,18 +284,22 @@ impl<'tcx> AbstractConst<'tcx> {
                         return Some(PrintStyle::NoBraces(s));
                     }
                 }
-                ty::ConstKind::Value(ConstValue::Scalar(scalar)) => match scalar.to_i64() {
-                    Ok(s) => {
-                        let s = format!("{}", s);
+                ty::ConstKind::Value(ConstValue::Scalar(scalar)) => {
+                    debug!("ct.ty: {:?}", ct.ty);
+                    let test_string = scalar.try_to_string(ct.ty);
+                    debug!(?test_string);
 
-                        if applied_subst {
-                            return Some(PrintStyle::Braces(None, s));
-                        } else {
-                            return Some(PrintStyle::NoBraces(s));
+                    match scalar.try_to_string(ct.ty) {
+                        Some(s) => {
+                            if applied_subst {
+                                return Some(PrintStyle::Braces(None, s));
+                            } else {
+                                return Some(PrintStyle::NoBraces(s));
+                            }
                         }
+                        None => return None,
                     }
-                    Err(_) => return None,
-                },
+                }
                 _ => return None,
             },
             abstract_const::Node::Binop(op, l, r) => {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::infer::error_reporting::{TyCategory, TypeAnnotationNeeded as ErrorCode};
 use crate::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use crate::infer::{self, InferCtxt, TyCtxtInferExt};
+use crate::traits::const_evaluatable::AbstractConst;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder, ErrorReported};
 use rustc_hir as hir;
@@ -19,6 +20,7 @@ use rustc_hir::intravisit::Visitor;
 use rustc_hir::GenericParam;
 use rustc_hir::Item;
 use rustc_hir::Node;
+//use rustc_middle::mir::interpret::ConstValue;
 use rustc_middle::thir::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::fast_reject::{self, SimplifyParams, StripReferences};
@@ -1173,6 +1175,11 @@ trait InferCtxtPrivExt<'hir, 'tcx> {
         obligated_types: &mut Vec<&ty::TyS<'tcx>>,
         cause_code: &ObligationCauseCode<'tcx>,
     ) -> bool;
+
+    fn try_create_suggestion_for_mismatched_const(
+        &self,
+        expected_found: ExpectedFound<&'tcx ty::Const<'tcx>>,
+    ) -> Option<String>;
 }
 
 impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
@@ -1246,6 +1253,11 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 .emit();
             }
             FulfillmentErrorCode::CodeConstEquateError(ref expected_found, ref err) => {
+                debug!(
+                    "expected: {:?}, found: {:?}",
+                    expected_found.expected, expected_found.found
+                );
+
                 self.report_mismatched_consts(
                     &error.obligation.cause,
                     expected_found.expected,
@@ -1486,6 +1498,16 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     self.tcx.impl_trait_ref(def_id)
                 })
                 .collect(),
+        }
+    }
+
+    fn try_create_suggestion_for_mismatched_const(
+        &self,
+        expected_found: ExpectedFound<&'tcx ty::Const<'tcx>>,
+    ) -> Option<String> {
+        match AbstractConst::from_const(self.tcx, expected_found.found) {
+            Ok(Some(f_abstract)) => f_abstract.try_print_with_replacing_substs(self.tcx),
+            _ => None,
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -27,7 +27,6 @@ use super::{FulfillmentError, FulfillmentErrorCode};
 use super::{ObligationCause, PredicateObligation};
 
 use crate::traits::error_reporting::InferCtxtExt as _;
-use crate::traits::error_reporting::InferCtxtPrivExt;
 use crate::traits::project::PolyProjectionObligation;
 use crate::traits::project::ProjectionCacheKeyExt as _;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;

--- a/src/test/ui/const-generics/defaults/generic-expr-default.stderr
+++ b/src/test/ui/const-generics/defaults/generic-expr-default.stderr
@@ -4,7 +4,7 @@ error: unconstrained generic constant
 LL | pub fn needs_evaluatable_bound<const N1: usize>() -> Foo<N1> {
    |                                                      ^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { N + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N1 + 1 }]:`
 
 error: unconstrained generic constant
   --> $DIR/generic-expr-default.rs:14:58

--- a/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.full.stderr
@@ -4,7 +4,7 @@ error: unconstrained generic constant
 LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |                                      ^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); 0 + N]:`
+   = help: try adding a `where` bound using this expression: `where [(); { 0 + N }]:`
 
 error: overly complex generic constant
   --> $DIR/array-size-in-generic-struct-param.rs:19:15

--- a/src/test/ui/const-generics/mismatched-const-errors.rs
+++ b/src/test/ui/const-generics/mismatched-const-errors.rs
@@ -1,0 +1,39 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait Trait {}
+struct HasCastInTraitImpl<const N: usize, const M: usize>;
+impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+pub struct HasTrait<T: Trait>(T);
+
+fn foo1<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 2}, { N }>> {
+    //~^ ERROR mismatched types
+    //~| ERROR unconstrained generic constant
+    loop {}
+}
+
+fn foo2<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N + 1 }>> {
+    //~^ ERROR mismatched types
+    //~| ERROR unconstrained generic constant
+    loop {}
+}
+
+fn foo3<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N - 1}>> {
+    //~^ ERROR mismatched types
+    //~| ERROR unconstrained generic constant
+    loop {}
+}
+
+fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N - 1}, { N }>> {
+    //~^ ERROR mismatched types
+    //~| ERROR unconstrained generic constant
+    loop {}
+}
+
+fn foo5<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + N }, { 2 * N }>> {
+    //~^ ERROR mismatched types
+    //~| ERROR unconstrained generic constant
+    loop {}
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/mismatched-const-errors.stderr
+++ b/src/test/ui/const-generics/mismatched-const-errors.stderr
@@ -4,7 +4,7 @@ error: unconstrained generic constant
 LL | fn foo1<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 2}, { N }>> {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N + 2 + 1 }]:`
 note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 2}, N>`
   --> $DIR/mismatched-const-errors.rs:6:22
    |
@@ -31,7 +31,7 @@ error: unconstrained generic constant
 LL | fn foo2<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N + 1 }>> {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N + 1 + 1 }]:`
 note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 1}, { N + 1 }>`
   --> $DIR/mismatched-const-errors.rs:6:22
    |
@@ -58,7 +58,7 @@ error: unconstrained generic constant
 LL | fn foo3<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N - 1}>> {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N + 1 + 1 }]:`
 note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 1}, { N - 1}>`
   --> $DIR/mismatched-const-errors.rs:6:22
    |
@@ -80,12 +80,12 @@ LL | fn foo3<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N - 1}
               found type `{ N + 1 + 1 }`
 
 error: unconstrained generic constant
-  --> $DIR/mismatched-const-errors.rs:28:44
+  --> $DIR/mismatched-const-errors.rs:27:44
    |
 LL | fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N - 1}, { N }>> {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N - 1 + 1 }]:`
 note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N - 1}, N>`
   --> $DIR/mismatched-const-errors.rs:6:22
    |
@@ -98,7 +98,7 @@ LL | pub struct HasTrait<T: Trait>(T);
    |                        ^^^^^ required by this bound in `HasTrait`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatched-const-errors.rs:28:44
+  --> $DIR/mismatched-const-errors.rs:27:44
    |
 LL | fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N - 1}, { N }>> {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `N`, found `{ N - 1 + 1 }`
@@ -107,12 +107,12 @@ LL | fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N 
               found type `{ N - 1 + 1 }`
 
 error: unconstrained generic constant
-  --> $DIR/mismatched-const-errors.rs:34:30
+  --> $DIR/mismatched-const-errors.rs:33:30
    |
 LL | fn foo5<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + N }, { 2 * N }>> {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+   = help: try adding a `where` bound using this expression: `where [(); { N + N + 1 }]:`
 note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + N }, { 2 * N }>`
   --> $DIR/mismatched-const-errors.rs:6:22
    |
@@ -125,7 +125,7 @@ LL | pub struct HasTrait<T: Trait>(T);
    |                        ^^^^^ required by this bound in `HasTrait`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatched-const-errors.rs:34:30
+  --> $DIR/mismatched-const-errors.rs:33:30
    |
 LL | fn foo5<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + N }, { 2 * N }>> {
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ 2 * N }`, found `{ N + N + 1 }`

--- a/src/test/ui/const-generics/mismatched-const-errors.stderr
+++ b/src/test/ui/const-generics/mismatched-const-errors.stderr
@@ -1,0 +1,138 @@
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-errors.rs:9:30
+   |
+LL | fn foo1<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 2}, { N }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 2}, N>`
+  --> $DIR/mismatched-const-errors.rs:6:22
+   |
+LL | impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `HasTrait`
+  --> $DIR/mismatched-const-errors.rs:7:24
+   |
+LL | pub struct HasTrait<T: Trait>(T);
+   |                        ^^^^^ required by this bound in `HasTrait`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-errors.rs:9:30
+   |
+LL | fn foo1<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 2}, { N }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `N`, found `{ N + 2 + 1 }`
+   |
+   = note: expected type `N`
+              found type `{ N + 2 + 1 }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-errors.rs:15:30
+   |
+LL | fn foo2<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N + 1 }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 1}, { N + 1 }>`
+  --> $DIR/mismatched-const-errors.rs:6:22
+   |
+LL | impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `HasTrait`
+  --> $DIR/mismatched-const-errors.rs:7:24
+   |
+LL | pub struct HasTrait<T: Trait>(T);
+   |                        ^^^^^ required by this bound in `HasTrait`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-errors.rs:15:30
+   |
+LL | fn foo2<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N + 1 }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N + 1 }`, found `{ N + 1 + 1 }`
+   |
+   = note: expected type `{ N + 1 }`
+              found type `{ N + 1 + 1 }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-errors.rs:21:30
+   |
+LL | fn foo3<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N - 1}>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + 1}, { N - 1}>`
+  --> $DIR/mismatched-const-errors.rs:6:22
+   |
+LL | impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `HasTrait`
+  --> $DIR/mismatched-const-errors.rs:7:24
+   |
+LL | pub struct HasTrait<T: Trait>(T);
+   |                        ^^^^^ required by this bound in `HasTrait`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-errors.rs:21:30
+   |
+LL | fn foo3<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N - 1}>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N - 1}`, found `{ N + 1 + 1 }`
+   |
+   = note: expected type `{ N - 1}`
+              found type `{ N + 1 + 1 }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-errors.rs:28:44
+   |
+LL | fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N - 1}, { N }>> {
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N - 1}, N>`
+  --> $DIR/mismatched-const-errors.rs:6:22
+   |
+LL | impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `HasTrait`
+  --> $DIR/mismatched-const-errors.rs:7:24
+   |
+LL | pub struct HasTrait<T: Trait>(T);
+   |                        ^^^^^ required by this bound in `HasTrait`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-errors.rs:28:44
+   |
+LL | fn foo4<const N: usize>(c : [usize; N]) -> HasTrait<HasCastInTraitImpl<{ N - 1}, { N }>> {
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `N`, found `{ N - 1 + 1 }`
+   |
+   = note: expected type `N`
+              found type `{ N - 1 + 1 }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-errors.rs:34:30
+   |
+LL | fn foo5<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + N }, { 2 * N }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { M + 1 }]:`
+note: required because of the requirements on the impl of `Trait` for `HasCastInTraitImpl<{ N + N }, { 2 * N }>`
+  --> $DIR/mismatched-const-errors.rs:6:22
+   |
+LL | impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `HasTrait`
+  --> $DIR/mismatched-const-errors.rs:7:24
+   |
+LL | pub struct HasTrait<T: Trait>(T);
+   |                        ^^^^^ required by this bound in `HasTrait`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-errors.rs:34:30
+   |
+LL | fn foo5<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + N }, { 2 * N }>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ 2 * N }`, found `{ N + N + 1 }`
+   |
+   = note: expected type `{ 2 * N }`
+              found type `{ N + N + 1 }`
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/mismatched-const-types-precedence.rs
+++ b/src/test/ui/const-generics/mismatched-const-types-precedence.rs
@@ -1,0 +1,41 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+
+fn bar<const N: usize, const K: usize>(a: [u32; 2 + N], b: [u32; K]) {
+  let _: [u32; 3 * 2 + N + K] = foo::<{ 2 + N }, K>(a, b);
+  //~^ ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR mismatched types
+}
+
+fn foo<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * {M + K}] {}
+//~^ ERROR mismatched types
+
+
+fn bar2<const N: usize, const K: usize>(a: [u32; 2 + N], b: [u32; K]) {
+  let _: [u32; 3 * 2 + N * K] = foo2::<{ 2 + N }, K>(a, b);
+  //~^ ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR mismatched types
+}
+
+fn foo2<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * M * K] {}
+//~^ ERROR mismatched types
+
+
+fn bar3<const N: usize, const K: usize, const L: usize>(a: [u32; 2 + N], b: [u32; K + L]) {
+  let _: [u32; 3 * 2 + N * K + L] = foo3::<{ 2 + N }, K, L>(a, b);
+  //~^ ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR unconstrained generic constant
+  //~| ERROR mismatched types
+}
+
+fn foo3<const M: usize, const K: usize, const L: usize>(a: [u32; M], b: [u32; K + L])
+  -> [u32; 3 * M * {K + L}] {}
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/src/test/ui/const-generics/mismatched-const-types-precedence.stderr
+++ b/src/test/ui/const-generics/mismatched-const-types-precedence.stderr
@@ -1,0 +1,160 @@
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:6:33
+   |
+LL |   let _: [u32; 3 * 2 + N + K] = foo::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N + K } }]:`
+note: required by a bound in `foo`
+  --> $DIR/mismatched-const-types-precedence.rs:13:75
+   |
+LL | fn foo<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * {M + K}] {}
+   |                                                                           ^^^^^^^^^^^ required by this bound in `foo`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:6:10
+   |
+LL |   let _: [u32; 3 * 2 + N + K] = foo::<{ 2 + N }, K>(a, b);
+   |          ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * 2 + N + K }]:`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:6:33
+   |
+LL |   let _: [u32; 3 * 2 + N + K] = foo::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `3 * 2 + N + K`, found `{ 3 * { 2 + N + K } }`
+   |
+   = note: expected type `3 * 2 + N + K`
+              found type `{ 3 * { 2 + N + K } }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:6:33
+   |
+LL |   let _: [u32; 3 * 2 + N + K] = foo::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N + K } }]:`
+note: required by a bound in `foo`
+  --> $DIR/mismatched-const-types-precedence.rs:13:75
+   |
+LL | fn foo<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * {M + K}] {}
+   |                                                                           ^^^^^^^^^^^ required by this bound in `foo`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:13:69
+   |
+LL | fn foo<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * {M + K}] {}
+   |    ---                                                              ^^^^^^^^^^^^^^^^^^ expected array `[u32; _]`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:18:33
+   |
+LL |   let _: [u32; 3 * 2 + N * K] = foo2::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N } * K }]:`
+note: required by a bound in `foo2`
+  --> $DIR/mismatched-const-types-precedence.rs:25:76
+   |
+LL | fn foo2<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * M * K] {}
+   |                                                                            ^^^^^^^^^ required by this bound in `foo2`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:18:10
+   |
+LL |   let _: [u32; 3 * 2 + N * K] = foo2::<{ 2 + N }, K>(a, b);
+   |          ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * 2 + N * K }]:`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:18:33
+   |
+LL |   let _: [u32; 3 * 2 + N * K] = foo2::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `3 * 2 + N * K`, found `{ 3 * { 2 + N } * K }`
+   |
+   = note: expected type `3 * 2 + N * K`
+              found type `{ 3 * { 2 + N } * K }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:18:33
+   |
+LL |   let _: [u32; 3 * 2 + N * K] = foo2::<{ 2 + N }, K>(a, b);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N } * K }]:`
+note: required by a bound in `foo2`
+  --> $DIR/mismatched-const-types-precedence.rs:25:76
+   |
+LL | fn foo2<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * M * K] {}
+   |                                                                            ^^^^^^^^^ required by this bound in `foo2`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:25:70
+   |
+LL | fn foo2<const M: usize, const K: usize>(a: [u32; M], b: [u32; K]) -> [u32; 3 * M * K] {}
+   |    ----                                                              ^^^^^^^^^^^^^^^^ expected array `[u32; _]`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:30:37
+   |
+LL |   let _: [u32; 3 * 2 + N * K + L] = foo3::<{ 2 + N }, K, L>(a, b);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N } * K + L }]:`
+note: required by a bound in `foo3`
+  --> $DIR/mismatched-const-types-precedence.rs:38:12
+   |
+LL | fn foo3<const M: usize, const K: usize, const L: usize>(a: [u32; M], b: [u32; K + L])
+   |    ---- required by a bound in this
+LL |   -> [u32; 3 * M * {K + L}] {}
+   |            ^^^^^^^^^^^^^^^ required by this bound in `foo3`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:30:10
+   |
+LL |   let _: [u32; 3 * 2 + N * K + L] = foo3::<{ 2 + N }, K, L>(a, b);
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * 2 + N * K + L }]:`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:30:37
+   |
+LL |   let _: [u32; 3 * 2 + N * K + L] = foo3::<{ 2 + N }, K, L>(a, b);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `3 * 2 + N * K + L`, found `{ 3 * { 2 + N } * K + L }`
+   |
+   = note: expected type `3 * 2 + N * K + L`
+              found type `{ 3 * { 2 + N } * K + L }`
+
+error: unconstrained generic constant
+  --> $DIR/mismatched-const-types-precedence.rs:30:37
+   |
+LL |   let _: [u32; 3 * 2 + N * K + L] = foo3::<{ 2 + N }, K, L>(a, b);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { 3 * { 2 + N } * K + L }]:`
+note: required by a bound in `foo3`
+  --> $DIR/mismatched-const-types-precedence.rs:38:12
+   |
+LL | fn foo3<const M: usize, const K: usize, const L: usize>(a: [u32; M], b: [u32; K + L])
+   |    ---- required by a bound in this
+LL |   -> [u32; 3 * M * {K + L}] {}
+   |            ^^^^^^^^^^^^^^^ required by this bound in `foo3`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched-const-types-precedence.rs:38:6
+   |
+LL | fn foo3<const M: usize, const K: usize, const L: usize>(a: [u32; M], b: [u32; K + L])
+   |    ---- implicitly returns `()` as its body has no tail or `return` expression
+LL |   -> [u32; 3 * M * {K + L}] {}
+   |      ^^^^^^^^^^^^^^^^^^^^^^ expected array `[u32; _]`, found `()`
+
+error: aborting due to 15 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/86198

This allows us to suggest a correct anonymous constant in case there's a mismatch, e.g. in:

```
trait Trait {}
struct HasCastInTraitImpl<const N: usize, const M: usize>;
impl<const M: usize> Trait for HasCastInTraitImpl<M, { M + 1 }> {}
pub struct HasTrait<T: Trait>(T);
fn foo<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1 }, { N + 1}>> { loop {} }
```

we now get a mismatch const error of the following form:

```
error[E0308]: mismatched types
  --> $DIR/mismatched-const-errors.rs:15:30
   |
LL | fn foo2<const N: usize>() -> HasTrait<HasCastInTraitImpl<{ N + 1}, { N + 1 }>> {
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N + 1 }`, found `{ N + 1 + 1 }`
   |
   = note: expected type `{ N + 1 }`
              found type `{ N + 1 + 1 }`
```

instead of the `found { M + 1 }` constant that was previously output.