### PR TITLE
Optimize `impl Hash for ObligationCauseData` by not hashing `ObligationCauseCode` variant fields

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -23,6 +23,7 @@ use smallvec::SmallVec;
 
 use std::borrow::Cow;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 pub use self::select::{EvaluationCache, EvaluationResult, OverflowError, SelectionCache};
@@ -108,7 +109,7 @@ impl Deref for ObligationCause<'tcx> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Lift)]
+#[derive(Clone, Debug, PartialEq, Eq, Lift)]
 pub struct ObligationCauseData<'tcx> {
     pub span: Span,
 
@@ -121,6 +122,14 @@ pub struct ObligationCauseData<'tcx> {
     pub body_id: hir::HirId,
 
     pub code: ObligationCauseCode<'tcx>,
+}
+
+impl Hash for ObligationCauseData<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.body_id.hash(state);
+        self.span.hash(state);
+        std::mem::discriminant(&self.code).hash(state);
+    }
 }
 
 impl<'tcx> ObligationCause<'tcx> {


### PR DESCRIPTION
Split out from #90913 since it's a [clear performance win](https://perf.rust-lang.org/compare.html?start=ad442399756573dccacb314b6bf8079964bcc72a&end=223f5e877fe93b5f437c2d703f883797913cd2b7) and should be easier to review.

It speeds up hashing for `Obligation` [deduplication](https://github.com/rust-lang/rust/blob/c9c4b5d7276297679387189d96a952f2b760e7ad/compiler/rustc_trait_selection/src/traits/select/mod.rs#L2355-L2356) by only hashing the discriminant of the `ObligationCauseCode` enum instead of its contents. That shouldn't affect hash quality much since there are several other fields in `Obligation` which should be unique enough, especially the predicate itself which is hashed as an interned pointer.