### PR TITLE
Make ptr range iterable

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1,3 +1,5 @@
+mod ptr;
+
 use crate::char;
 use crate::convert::TryFrom;
 use crate::mem;

--- a/library/core/src/iter/range/ptr.rs
+++ b/library/core/src/iter/range/ptr.rs
@@ -58,12 +58,12 @@ macro_rules! impl_iterator_for_ptr_range {
                     None
                 } else {
                     let curr = self.start;
-                    let next = curr.wrapping_add(1);
-                    self.start = if (curr..self.end).contains(&next) {
-                        next
+                    let byte_offset = self.end as usize - curr as usize;
+                    self.start = if byte_offset >= mem::size_of::<T>() {
+                        curr.wrapping_add(1)
                     } else {
-                        // Saturate to self.end if the wrapping_add wrapped or
-                        // landed beyond end.
+                        // Saturate to self.end if the wrapping_add would wrap
+                        // or land beyond end.
                         self.end
                     };
                     Some(curr)

--- a/library/core/src/iter/range/ptr.rs
+++ b/library/core/src/iter/range/ptr.rs
@@ -32,6 +32,20 @@ macro_rules! impl_iterator_for_ptr_range {
         /// start is misaligned, then the pointers in the range are misaligned
         /// as well. The alignedness of the range's end is not relevant.
         ///
+        /// # Optimizability
+        ///
+        /// Iteration being a safe operation imposes some restrictions on the
+        /// kinds of pointer arithmetic operations available to this
+        /// implementation. In code that meets the unsafe requirements of
+        /// [\<\*const T\>::add][add] or
+        /// [\<\*const \[T\]\>::get_unchecked][get_unchecked], it is possible
+        /// that performing the iteration unsafely in terms of those functions
+        /// could yield more optimized code than safely iterating a pointer
+        /// range.
+        ///
+        /// [add]: pointer::add
+        /// [get_unchecked]: pointer::get_unchecked
+        ///
         /// # Example
         ///
         #[doc = example!($mutability)]

--- a/library/core/src/iter/range/ptr.rs
+++ b/library/core/src/iter/range/ptr.rs
@@ -1,0 +1,274 @@
+use crate::cmp::Ordering;
+use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use crate::mem;
+use crate::ops::Range;
+
+macro_rules! impl_iterator_for_ptr_range {
+    ($mutability:ident /* const or mut */) => {
+        /// Iteration of a pointer range, as is common in code that interfaces
+        /// with C++ iterators.
+        ///
+        /// # Safety
+        ///
+        /// Traversing a pointer range is always safe, but **using the resulting
+        /// pointers** is not!
+        ///
+        /// The pointers between the start and end of a range "remember" the
+        /// [allocated object] that they refer into. Pointers resulting from
+        /// pointer arithmetic must not be used to read or write to any other
+        /// allocated object.
+        ///
+        /// As a consequence, pointers from a range traversal are only
+        /// dereferenceable if start and end of the original range both point
+        /// into the same allocated object. Dereferencing a pointer obtained via
+        /// iteration when this is not the case is Undefined Behavior.
+        ///
+        /// [allocated object]: crate::ptr#allocated-object
+        ///
+        /// # Example
+        ///
+        #[doc = example!($mutability)]
+        #[stable(feature = "iterate_ptr_range", since = "1.58.0")]
+        impl<T> Iterator for Range<*$mutability T> {
+            type Item = *$mutability T;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.is_empty() {
+                    None
+                } else {
+                    let curr = self.start;
+                    let next = curr.wrapping_add(1);
+                    self.start = if (curr..self.end).contains(&next) {
+                        next
+                    } else {
+                        // Saturate to self.end if the wrapping_add wrapped or
+                        // landed beyond end.
+                        self.end
+                    };
+                    Some(curr)
+                }
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                if self.is_empty() {
+                    (0, Some(0))
+                } else if mem::size_of::<T>() == 0 {
+                    // T is zero sized so there are infinity of them in the
+                    // nonempty range.
+                    (usize::MAX, None)
+                } else {
+                    // In between self.start and self.end there are some number
+                    // of whole elements of type T, followed by possibly a
+                    // remainder element if T's size doesn't evenly divide the
+                    // byte distance between the endpoints. The remainder
+                    // element still counts as being part of this range, since
+                    // the pointer to it does lie between self.start and
+                    // self.end.
+                    let byte_offset = self.end as usize - self.start as usize;
+                    let number_of_whole_t = byte_offset / mem::size_of::<T>();
+                    let remainder_bytes = byte_offset % mem::size_of::<T>();
+                    let maybe_remainder_t = (remainder_bytes > 0) as usize;
+                    let hint = number_of_whole_t + maybe_remainder_t;
+                    (hint, Some(hint))
+                }
+            }
+
+            fn nth(&mut self, n: usize) -> Option<Self::Item> {
+                let _ = self.advance_by(n);
+                self.next()
+            }
+
+            fn last(mut self) -> Option<Self::Item> {
+                self.next_back()
+            }
+
+            fn min(mut self) -> Option<Self::Item> {
+                self.next()
+            }
+
+            fn max(mut self) -> Option<Self::Item> {
+                self.next_back()
+            }
+
+            fn is_sorted(self) -> bool {
+                true
+            }
+
+            fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+                match self.size_hint().1 {
+                    None => {
+                        // T is zero sized. Advancing does nothing.
+                        Ok(())
+                    }
+                    Some(len) => match n.cmp(&len) {
+                        Ordering::Less => {
+                            // Advance past n number of whole elements.
+                            self.start = self.start.wrapping_add(n);
+                            Ok(())
+                        }
+                        Ordering::Equal => {
+                            // Advance past every single element in the
+                            // iterator, including perhaps the remainder
+                            // element, leaving an empty iterator.
+                            self.start = self.end;
+                            Ok(())
+                        }
+                        Ordering::Greater => {
+                            // Advance too far.
+                            self.start = self.end;
+                            Err(len)
+                        }
+                    }
+                }
+            }
+
+            #[doc(hidden)]
+            unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
+                self.start.wrapping_add(idx)
+            }
+        }
+
+        #[stable(feature = "iterate_ptr_range", since = "1.58.0")]
+        impl<T> DoubleEndedIterator for Range<*$mutability T> {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                match self.size_hint().1 {
+                    None => {
+                        // T is zero sized so the iterator never progresses past
+                        // start, even if going backwards.
+                        Some(self.start)
+                    }
+                    Some(0) => {
+                        None
+                    }
+                    Some(len) => {
+                        self.end = self.start.wrapping_add(len - 1);
+                        Some(self.end)
+                    }
+                }
+            }
+
+            fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+                match self.size_hint().1 {
+                    None => {
+                        // T is zero sized.
+                        Some(self.start)
+                    }
+                    Some(len) => {
+                        if n < len {
+                            self.end = self.start.wrapping_add(len - n - 1);
+                            Some(self.end)
+                        } else {
+                            self.end = self.start;
+                            None
+                        }
+                    }
+                }
+            }
+
+            fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+                match self.size_hint().1 {
+                    None => {
+                        // T is zero sized. Advancing does nothing.
+                        Ok(())
+                    }
+                    Some(len) => match n.cmp(&len) {
+                        Ordering::Less => {
+                            // Advance leaving `len - n` elements in the
+                            // iterator. Careful to preserve the remainder
+                            // element if told to advance by 0.
+                            if n > 0 {
+                                self.end = self.start.wrapping_add(len - n);
+                            }
+                            Ok(())
+                        }
+                        Ordering::Equal => {
+                            // Advance past every single element in the
+                            // iterator, leaving an empty iterator.
+                            self.end = self.start;
+                            Ok(())
+                        }
+                        Ordering::Greater => {
+                            // Advance too far.
+                            self.end = self.start;
+                            Err(len)
+                        }
+                    }
+                }
+            }
+        }
+
+        #[stable(feature = "iterate_ptr_range", since = "1.58.0")]
+        impl<T> FusedIterator for Range<*$mutability T> {}
+
+        #[unstable(feature = "trusted_len", issue = "37572")]
+        unsafe impl<T> TrustedLen for Range<*$mutability T> {}
+
+        #[doc(hidden)]
+        #[unstable(feature = "trusted_random_access", issue = "none")]
+        unsafe impl<T> TrustedRandomAccess for Range<*$mutability T> {}
+
+        #[doc(hidden)]
+        #[unstable(feature = "trusted_random_access", issue = "none")]
+        unsafe impl<T> TrustedRandomAccessNoCoerce for Range<*$mutability T> {
+            const MAY_HAVE_SIDE_EFFECT: bool = false;
+        }
+    };
+}
+
+macro_rules! example {
+    (const) => {
+        doc_comment_to_literal! {
+            /// ```
+            /// // Designed to be called from C++ or C.
+            /// #[no_mangle]
+            /// unsafe extern "C" fn demo(start: *const u16, end: *const u16) {
+            ///     for ptr in start..end {
+            ///         println!("{}", *ptr);
+            ///     }
+            /// }
+            ///
+            /// fn main() {
+            ///     let slice = &[1u16, 2, 3];
+            ///     let range = slice.as_ptr_range();
+            ///     unsafe { demo(range.start, range.end); }
+            /// }
+            /// ```
+        }
+    };
+
+    (mut) => {
+        doc_comment_to_literal! {
+            /// ```
+            /// #![feature(vec_spare_capacity)]
+            ///
+            /// use core::ptr;
+            ///
+            /// // Designed to be called from C++ or C.
+            /// #[no_mangle]
+            /// unsafe extern "C" fn demo(start: *mut u16, end: *mut u16) {
+            ///     for (i, ptr) in (start..end).enumerate() {
+            ///         ptr::write(ptr, i as u16);
+            ///     }
+            /// }
+            ///
+            /// fn main() {
+            ///     let mut vec: Vec<u16> = Vec::with_capacity(100);
+            ///     let range = vec.spare_capacity_mut().as_mut_ptr_range();
+            ///     unsafe {
+            ///         demo(range.start.cast::<u16>(), range.end.cast::<u16>());
+            ///         vec.set_len(100);
+            ///     }
+            /// }
+            /// ```
+        }
+    };
+}
+
+macro_rules! doc_comment_to_literal {
+    ($(#[doc = $example:literal])*) => {
+        concat!($($example, '\n'),*)
+    };
+}
+
+impl_iterator_for_ptr_range!(const);
+impl_iterator_for_ptr_range!(mut);

--- a/library/core/src/iter/range/ptr.rs
+++ b/library/core/src/iter/range/ptr.rs
@@ -25,6 +25,13 @@ macro_rules! impl_iterator_for_ptr_range {
         ///
         /// [allocated object]: crate::ptr#allocated-object
         ///
+        /// # Alignment
+        ///
+        /// All the pointers in the range are at offsets of multiples of
+        /// `size_of::<T>()` bytes from the range's start, so if the range's
+        /// start is misaligned, then the pointers in the range are misaligned
+        /// as well. The alignedness of the range's end is not relevant.
+        ///
         /// # Example
         ///
         #[doc = example!($mutability)]

--- a/library/core/tests/iter/range.rs
+++ b/library/core/tests/iter/range.rs
@@ -632,3 +632,90 @@ fn test_ptr_range_zero_sized() {
     assert_eq!(range.advance_back_by(1), Ok(()));
     assert_eq!(range, start..end);
 }
+
+#[test]
+fn test_ptr_range_reversed() {
+    let start = 2222 as *const i32;
+    let end = 1111 as *const i32;
+    let range = start..end;
+    assert!(range.is_empty());
+    assert_eq!(range.size_hint(), (0, Some(0)));
+    assert_eq!(range.clone().next(), None);
+    assert_eq!(range.clone().nth(0), None);
+    assert_eq!(range.clone().nth(1), None);
+    assert_eq!(range.clone().advance_by(0), Ok(())); // Err(0) would be equally fine
+    assert_eq!(range.clone().advance_by(1), Err(0));
+    assert_eq!(range.clone().next_back(), None);
+    assert_eq!(range.clone().nth_back(0), None);
+    assert_eq!(range.clone().nth_back(1), None);
+    assert_eq!(range.clone().advance_back_by(0), Ok(())); // Err(0) would be equally fine
+    assert_eq!(range.clone().advance_back_by(1), Err(0));
+
+    let start = 2222 as *const ();
+    let end = 1111 as *const ();
+    let range = start..end;
+    assert!(range.is_empty());
+    assert_eq!(range.size_hint(), (0, Some(0)));
+    assert_eq!(range.clone().next(), None);
+    assert_eq!(range.clone().nth(0), None);
+    assert_eq!(range.clone().nth(1), None);
+    assert_eq!(range.clone().advance_by(0), Ok(()));
+    assert_eq!(range.clone().advance_by(1), Err(0));
+    assert_eq!(range.clone().next_back(), None);
+    assert_eq!(range.clone().nth_back(0), None);
+    assert_eq!(range.clone().nth_back(1), None);
+    assert_eq!(range.clone().advance_back_by(0), Ok(()));
+    assert_eq!(range.clone().advance_back_by(1), Err(0));
+}
+
+#[test]
+fn test_ptr_range_underflow() {
+    let start = 1 as *const [u8; 100];
+    let end = 2 as *const [u8; 100];
+
+    let mut range = start..end;
+    assert_eq!(range.next_back(), Some(start));
+    assert_eq!(range, start..start);
+
+    let mut range = start..end;
+    assert_eq!(range.nth_back(0), Some(start));
+    assert_eq!(range, start..start);
+
+    let mut range = start..end;
+    assert_eq!(range.nth_back(1), None);
+    assert_eq!(range, start..start);
+
+    let mut range = start..end;
+    assert_eq!(range.advance_back_by(0), Ok(()));
+    assert_eq!(range, start..end);
+
+    let mut range = start..end;
+    assert_eq!(range.advance_back_by(1), Ok(()));
+    assert_eq!(range, start..start);
+}
+
+#[test]
+fn test_ptr_range_overflow() {
+    let start = (usize::MAX - 2) as *const [u8; 100];
+    let end = usize::MAX as *const [u8; 100];
+
+    let mut range = start..end;
+    assert_eq!(range.next(), Some(start));
+    assert_eq!(range, end..end);
+
+    let mut range = start..end;
+    assert_eq!(range.nth(0), Some(start));
+    assert_eq!(range, end..end);
+
+    let mut range = start..end;
+    assert_eq!(range.nth(1), None);
+    assert_eq!(range, end..end);
+
+    let mut range = start..end;
+    assert_eq!(range.advance_by(0), Ok(()));
+    assert_eq!(range, start..end);
+
+    let mut range = start..end;
+    assert_eq!(range.advance_by(1), Ok(()));
+    assert_eq!(range, end..end);
+}

--- a/library/core/tests/iter/range.rs
+++ b/library/core/tests/iter/range.rs
@@ -643,12 +643,12 @@ fn test_ptr_range_reversed() {
     assert_eq!(range.clone().next(), None);
     assert_eq!(range.clone().nth(0), None);
     assert_eq!(range.clone().nth(1), None);
-    assert_eq!(range.clone().advance_by(0), Ok(())); // Err(0) would be equally fine
+    assert_eq!(range.clone().advance_by(0), Ok(()));
     assert_eq!(range.clone().advance_by(1), Err(0));
     assert_eq!(range.clone().next_back(), None);
     assert_eq!(range.clone().nth_back(0), None);
     assert_eq!(range.clone().nth_back(1), None);
-    assert_eq!(range.clone().advance_back_by(0), Ok(())); // Err(0) would be equally fine
+    assert_eq!(range.clone().advance_back_by(0), Ok(()));
     assert_eq!(range.clone().advance_back_by(1), Err(0));
 
     let start = 2222 as *const ();

--- a/src/test/ui/iterators/ranges.rs
+++ b/src/test/ui/iterators/ranges.rs
@@ -7,3 +7,9 @@ fn main() {
     for _ in 0..=10 {}
     for _ in 0.. {}
 }
+
+fn references_do_not_coerce_to_ptr_range(start: &i32, end: &i32) {
+    // Better not turn into Range<*const i32>.
+    for _ in start..end {}
+    //~^ ERROR E0277
+}

--- a/src/test/ui/iterators/ranges.stderr
+++ b/src/test/ui/iterators/ranges.stderr
@@ -28,6 +28,22 @@ note: required by `into_iter`
 LL |     fn into_iter(self) -> Self::IntoIter;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `&i32: Step` is not satisfied
+  --> $DIR/ranges.rs:13:14
+   |
+LL |     for _ in start..end {}
+   |              ^^^^^^^^^^ the trait `Step` is not implemented for `&i32`
+   |
+   = help: the following implementations were found:
+             <i32 as Step>
+   = note: required because of the requirements on the impl of `Iterator` for `std::ops::Range<&i32>`
+   = note: required because of the requirements on the impl of `IntoIterator` for `std::ops::Range<&i32>`
+note: required by `into_iter`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This PR adds:

```rust
impl<T> Iterator for Range<*const T> { type Item = *const T; }

impl<T> Iterator for Range<*mut T> { type Item = *mut T; }

// and DoubleEndedIterator, FusedIterator, TrustedLen, TrustedRandomAccess
```

enabling iteration over a range of pointers, such as produced by [`<[T]>::as_ptr_range`](https://doc.rust-lang.org/1.56.0/std/primitive.slice.html#method.as_ptr_range) and [`<[T]>::as_mut_ptr_range`](https://doc.rust-lang.org/1.56.0/std/primitive.slice.html#method.as_mut_ptr_range).

## Rationale

It is common for systems interacting with C++ to need to use pointer ranges for iteration, as `begin`/`end` pointer pairs are a design pattern in the C++ standard library.

```rust
// Designed to be called from C++ or C.
#[no_mangle]
unsafe extern "C" fn demo(start: *const u16, end: *const u16) {
    for ptr in start..end {
        println!("{}", *ptr);
    }
}

fn main() {
    let slice = &[1u16, 2, 3];
    let range = slice.as_ptr_range();
    unsafe { demo(range.start, range.end); }
}
```

In pure Rust code such a thing would be done using slices, but in FFI it's not necessarily good to try to turn the ptr pair into a Rust slice at the language boundary &mdash; materializing a reference (to a slice, or even to individual elements) is more prone to UB in Rust than directly working with the foreign pointers as pointers. One basically has to be an expert in Rust aliasing rules, which are not authoritatively written down at this point yet, in order to do it correctly. Whereas someone with basic C++ knowledge can write the pointer-based code and have it be correct.

Compare:

```rust
let start: *mut T = ...;
let end: *mut T = ...;
for ptr in start..end {
    // Only the preconditions of the C++ callee come into play, which a C++ dev
    // is already going to be comfortable reasoning about. Nothing about stacked
    // borrows, concurrency, initializedness, inhabitedness, alignedness, or other
    // Rust-isms is relevant.
    unsafe { cpp(ptr); }
}
```

```rust
let mut slice = std::slice::from_raw_parts_mut(...); // suddenly a pile of extremely subtle
                                                     // invariants in order for this to be allowed
for elem in slice {
    unsafe { cpp(elem as *mut T); } // probably UB
}
```

## Step

Note that the new impls are independent of the previously existing Iterator impl on Range:

https://github.com/rust-lang/rust/blob/003d8d3f56848b6f3833340e859b089a09aea36a/library/core/src/iter/range.rs#L706-L707

That's because the current Step definition has several incompatibilities with the situation of `start`/`end` which are not separated by a multiple of `size_of::<T>()` bytes. For example consider this required invariant on Step::steps_between:

https://github.com/rust-lang/rust/blob/003d8d3f56848b6f3833340e859b089a09aea36a/library/core/src/iter/range.rs#L30-L34

This says that for arbitrary pointers `a` and `b`, which have `n` range elements in between them, we need that `b` be losslessly reconstructible from `a` and `n`. That's not the case for pointers, where e.g. `0x2 as *const u16..0x7 as *const u16` and `0x2 as *const u16..0x8 as *const u16` contain the same sequence of items when iterated, but different `b`.

`Step` is unstable though (#42168). If it were to evolve in a way that accommodates `Range<*const T>` and `Range<*mut T>` then we can switch all this over to `Step` backward compatibly. I don't consider this a goal however.

r? @kennytm