### PR TITLE
Elaborate `Future::Output` when printing opaque `impl Future` type

### DIFF
--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(local_dropped_before_await());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:24:5
    |
@@ -27,7 +27,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:33:20
    |

--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |         take_u32(x.await)

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -25,8 +25,8 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn two() {}
    |                ^ checked the `Output` of this `async fn`, found opaque type
-   = note: expected opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:5:16>)
-              found opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:6:16>)
+   = note: expected opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:5:16>)
+              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:6:16>)
    = help: consider `await`ing on both `Future`s
    = note: distinct uses of `impl Trait` result in different opaque types
 

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -40,8 +40,8 @@ async fn foo() -> Result<(), ()> {
 
 async fn bar() -> Result<(), ()> {
     foo()?; //~ ERROR the `?` operator can only be applied to values that implement `Try`
-    //~^ NOTE the `?` operator cannot be applied to type `impl Future`
-    //~| HELP the trait `Try` is not implemented for `impl Future`
+    //~^ NOTE the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
+    //~| HELP the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
     //~| NOTE required by `branch`
     //~| HELP consider `await`ing on the `Future`
     //~| NOTE in this expansion of desugaring of operator `?`
@@ -84,7 +84,7 @@ async fn baz() -> Result<(), ()> {
     //~| NOTE field not available in `impl Future`
 
     struct_().method(); //~ ERROR no method named
-    //~^ NOTE method not found in `impl Future`
+    //~^ NOTE method not found in `impl Future<Output = Struct>`
     //~| HELP consider `await`ing on the `Future`
     Ok(())
 }
@@ -93,7 +93,7 @@ async fn match_() {
     match tuple() { //~ HELP consider `await`ing on the `Future`
         Tuple(_) => {} //~ ERROR mismatched types
         //~^ NOTE expected opaque type, found struct `Tuple`
-        //~| NOTE expected opaque type `impl Future`
+        //~| NOTE expected opaque type `impl Future<Output = Tuple>`
     }
 }
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-61076.rs:42:5
    |
 LL |     foo()?;
-   |     ^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |
@@ -32,7 +32,7 @@ help: consider `await`ing on the `Future`
 LL |     t.await?;
    |      ++++++
 
-error[E0609]: no field `0` on type `impl Future`
+error[E0609]: no field `0` on type `impl Future<Output = Tuple>`
   --> $DIR/issue-61076.rs:78:26
    |
 LL |     let _: i32 = tuple().0;
@@ -43,7 +43,7 @@ help: consider `await`ing on the `Future` and access the field of its `Output`
 LL |     let _: i32 = tuple().await.0;
    |                         ++++++
 
-error[E0609]: no field `a` on type `impl Future`
+error[E0609]: no field `a` on type `impl Future<Output = Struct>`
   --> $DIR/issue-61076.rs:82:28
    |
 LL |     let _: i32 = struct_().a;
@@ -54,11 +54,11 @@ help: consider `await`ing on the `Future` and access the field of its `Output`
 LL |     let _: i32 = struct_().await.a;
    |                           ++++++
 
-error[E0599]: no method named `method` found for opaque type `impl Future` in the current scope
+error[E0599]: no method named `method` found for opaque type `impl Future<Output = Struct>` in the current scope
   --> $DIR/issue-61076.rs:86:15
    |
 LL |     struct_().method();
-   |               ^^^^^^ method not found in `impl Future`
+   |               ^^^^^^ method not found in `impl Future<Output = Struct>`
    |
 help: consider `await`ing on the `Future` and calling the method on its `Output`
    |
@@ -76,7 +76,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn tuple() -> Tuple {
    |                     ^^^^^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = Tuple>`
                    found struct `Tuple`
 help: consider `await`ing on the `Future`
    |

--- a/src/test/ui/async-await/issue-64130-1-sync.stderr
+++ b/src/test/ui/async-await/issue-64130-1-sync.stderr
@@ -4,7 +4,7 @@ error: future cannot be shared between threads safely
 LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
-   = help: within `impl Future`, the trait `Sync` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:15:5
    |

--- a/src/test/ui/async-await/issue-64130-2-send.stderr
+++ b/src/test/ui/async-await/issue-64130-2-send.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(bar());
    |             ^^^^^ future returned by `bar` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-2-send.rs:15:5
    |

--- a/src/test/ui/async-await/issue-64130-3-other.rs
+++ b/src/test/ui/async-await/issue-64130-3-other.rs
@@ -5,22 +5,22 @@
 // This tests the the unspecialized async-await-specific error when futures don't implement an
 // auto trait (which is not Send or Sync) due to some type that was captured.
 
-auto trait Qux { }
+auto trait Qux {}
 
 struct Foo;
 
 impl !Qux for Foo {}
 
-fn is_qux<T: Qux>(t: T) { }
+fn is_qux<T: Qux>(t: T) {}
 
 async fn bar() {
     let x = Foo;
     baz().await;
 }
 
-async fn baz() { }
+async fn baz() {}
 
 fn main() {
     is_qux(bar());
-    //~^ ERROR the trait bound `Foo: Qux` is not satisfied in `impl Future`
+    //~^ ERROR the trait bound `Foo: Qux` is not satisfied in `impl Future<Output = ()>`
 }

--- a/src/test/ui/async-await/issue-64130-3-other.stderr
+++ b/src/test/ui/async-await/issue-64130-3-other.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl Future`
+error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl Future<Output = ()>`
   --> $DIR/issue-64130-3-other.rs:24:12
    |
 LL | async fn bar() {
-   |                - within this `impl Future`
+   |                - within this `impl Future<Output = ()>`
 ...
 LL |     is_qux(bar());
-   |            ^^^^^ within `impl Future`, the trait `Qux` is not implemented for `Foo`
+   |            ^^^^^ within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`
    |
 note: future does not implement `Qux` as this value is used across an await
   --> $DIR/issue-64130-3-other.rs:18:5
@@ -19,7 +19,7 @@ LL | }
 note: required by a bound in `is_qux`
   --> $DIR/issue-64130-3-other.rs:14:14
    |
-LL | fn is_qux<T: Qux>(t: T) { }
+LL | fn is_qux<T: Qux>(t: T) {}
    |              ^^^ required by this bound in `is_qux`
 
 error: aborting due to previous error

--- a/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:5
    |

--- a/src/test/ui/async-await/issue-68112.stderr
+++ b/src/test/ui/async-await/issue-68112.stderr
@@ -9,7 +9,7 @@ note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:31:17
    |
 LL |         let _ = non_send_fut.await;
-   |                 ^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+   |                 ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:11:25
    |
@@ -27,7 +27,7 @@ note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:40:17
    |
 LL |         let _ = make_non_send_future1().await;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:11:25
    |
@@ -45,9 +45,9 @@ LL |     require_send(send_fut);
    = note: required because it appears within the type `[static generator@$DIR/issue-68112.rs:47:31: 47:36]`
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@$DIR/issue-68112.rs:47:31: 47:36]>`
    = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `{ResumeTy, impl Future, (), i32, Ready<i32>}`
+   = note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
+   = note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
+   = note: required because it appears within the type `{ResumeTy, impl Future<Output = Arc<RefCell<i32>>>, (), i32, Ready<i32>}`
    = note: required because it appears within the type `[static generator@$DIR/issue-68112.rs:55:26: 59:6]`
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@$DIR/issue-68112.rs:55:26: 59:6]>`
    = note: required because it appears within the type `impl Future`

--- a/src/test/ui/async-await/issue-71137.stderr
+++ b/src/test/ui/async-await/issue-71137.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:5
    |

--- a/src/test/ui/async-await/issue-74497-lifetime-in-opaque.stderr
+++ b/src/test/ui/async-await/issue-74497-lifetime-in-opaque.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL |     let _ = foo(|x| bar(x));
    |                  -- ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                  ||
-   |                  |return type of closure `impl Future` contains a lifetime `'2`
+   |                  |return type of closure `impl Future<Output = ()>` contains a lifetime `'2`
    |                  has type `&'1 u8`
 
 error: aborting due to previous error

--- a/src/test/ui/async-await/issue-84841.stderr
+++ b/src/test/ui/async-await/issue-84841.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-84841.rs:9:5
    |
 LL |     test()?;
-   |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = ()>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = ()>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |

--- a/src/test/ui/async-await/issues/issue-67893.stderr
+++ b/src/test/ui/async-await/issues/issue-67893.stderr
@@ -4,7 +4,7 @@ error: generator cannot be sent between threads safely
 LL |     g(issue_67893::run())
    |       ^^^^^^^^^^^^^^^^^^ generator is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
 note: required by a bound in `g`
   --> $DIR/issue-67893.rs:6:14
    |

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |         take_u32(x.await)

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |     take_u32(x.await)
@@ -28,7 +28,7 @@ note: while checking the return type of the `async fn`
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
-            found opaque type `impl Future`
+            found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |     dummy().await
@@ -53,7 +53,7 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-   = note:   expected type `impl Future`
+   = note:   expected type `impl Future<Output = ()>`
            found unit type `()`
 help: consider `await`ing on the `Future`
    |
@@ -66,9 +66,9 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _x = match 0usize {
    |  ______________-
 LL | |         0 => dummy(),
-   | |              ------- this is found to be of type `impl Future`
+   | |              ------- this is found to be of type `impl Future<Output = ()>`
 LL | |         1 => dummy(),
-   | |              ------- this is found to be of type `impl Future`
+   | |              ------- this is found to be of type `impl Future<Output = ()>`
 LL | |         2 => dummy().await,
    | |              ^^^^^^^^^^^^^ expected opaque type, found `()`
 LL | |
@@ -80,7 +80,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
    |
@@ -99,7 +99,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
    |

--- a/src/test/ui/impl-trait/issues/issue-78722.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.stderr
@@ -14,8 +14,8 @@ LL |         let f: F = async { 1 };
 LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
    |                                           ------------------------------- the found opaque type
    |
-   = note: expected opaque type `impl Future` (opaque type at <$DIR/issue-78722.rs:5:10>)
-              found opaque type `impl Future` (opaque type at <$SRC_DIR/core/src/future/mod.rs:LL:COL>)
+   = note: expected opaque type `impl Future<Output = u8>`
+              found opaque type `impl Future`
    = note: distinct uses of `impl Trait` result in different opaque types
 
 error: aborting due to previous error

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -194,7 +194,7 @@ LL |         async fn ft1() {}
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
-              found fn pointer `fn() -> impl Future`
+              found fn pointer `fn() -> impl Future<Output = ()>`
 
 error[E0053]: method `ft5` has an incompatible type for trait
   --> $DIR/fn-header-semantic-fail.rs:33:48
@@ -210,7 +210,7 @@ LL |         const async unsafe extern "C" fn ft5() {}
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `unsafe extern "C" fn()`
-              found fn pointer `unsafe extern "C" fn() -> impl Future`
+              found fn pointer `unsafe extern "C" fn() -> impl Future<Output = ()>`
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -58,7 +58,7 @@ LL |     async fn associated();
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
-              found fn pointer `fn() -> impl Future`
+              found fn pointer `fn() -> impl Future<Output = ()>`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,15 +1,15 @@
-error[E0277]: `fn() -> impl Future {foo}` is not a future
+error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:9
    |
 LL | async fn foo() {}
    |          --- consider calling this function
 ...
 LL |     bar(foo);
-   |     --- ^^^ `fn() -> impl Future {foo}` is not a future
+   |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `fn() -> impl Future {foo}`
+   = help: the trait `Future` is not implemented for `fn() -> impl Future<Output = ()> {foo}`
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |

--- a/src/test/ui/suggestions/issue-72766.stderr
+++ b/src/test/ui/suggestions/issue-72766.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-72766.rs:14:5
    |
 LL |     SadGirl {}.call()?;
-   |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -20,7 +20,7 @@ note: while checking the return type of the `async fn`
 LL |     pub async fn answer_str(&self, _s: &str) -> Test {
    |                                                 ^^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = Test>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -55,7 +55,7 @@ async fn async_different_futures() {
         //~| HELP consider `await`ing on both `Future`s
         false => async_dummy2(), //~ ERROR `match` arms have incompatible types
         //~^ NOTE expected opaque type, found a different opaque type
-        //~| NOTE expected type `impl Future`
+        //~| NOTE expected type `impl Future<Output = ()>`
         //~| NOTE distinct uses of `impl Trait` result in different opaque types
     };
 }

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -21,7 +21,7 @@ note: while checking the return type of the `async fn`
 LL | async fn async_dummy() {}
    |                        ^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |         false => async_dummy().await,
@@ -55,7 +55,7 @@ note: while checking the return type of the `async fn`
 LL | async fn async_dummy2() {}
    |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |         false => async_dummy2().await,
@@ -74,7 +74,7 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _ = match true {
    |  _____________-
 LL | |         true => async_dummy(),
-   | |                 ------------- this is found to be of type `impl Future`
+   | |                 ------------- this is found to be of type `impl Future<Output = ()>`
 LL | |
 LL | |         false => async_dummy2(),
    | |                  ^^^^^^^^^^^^^^ expected opaque type, found a different opaque type
@@ -88,8 +88,8 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn async_dummy2() {}
    |                         ^ checked the `Output` of this `async fn`, found opaque type
-   = note:     expected type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
-           found opaque type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:19:25>)
+   = note:     expected type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
+           found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:19:25>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |

--- a/src/test/ui/suggestions/opaque-type-error.stderr
+++ b/src/test/ui/suggestions/opaque-type-error.stderr
@@ -13,8 +13,8 @@ LL | |         thing_two()
 LL | |     }.await
    | |_____- `if` and `else` have incompatible types
    |
-   = note:     expected type `impl Future` (opaque type at <$DIR/opaque-type-error.rs:8:19>)
-           found opaque type `impl Future` (opaque type at <$DIR/opaque-type-error.rs:12:19>)
+   = note:     expected type `impl Future<Output = Result<(), ()>>` (opaque type at <$DIR/opaque-type-error.rs:8:19>)
+           found opaque type `impl Future<Output = Result<(), ()>>` (opaque type at <$DIR/opaque-type-error.rs:12:19>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |


### PR DESCRIPTION
I would love to see the `Output =` type when printing type errors involving opaque `impl Future`.

[Test code](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a800b481edd31575fbcaf5771a9c3678)

Before (cut relevant part of output):
```
note: while checking the return type of the `async fn`
 --> /home/michael/test.rs:5:19
  |
5 | async fn bar() -> usize {
  |                   ^^^^^ checked the `Output` of this `async fn`, found opaque type
  = note:     expected type `usize`
          found opaque type `impl Future`
```

After:
```
note: while checking the return type of the `async fn`
 --> /home/michael/test.rs:5:19
  |
5 | async fn bar() -> usize {
  |                   ^^^^^ checked the `Output` of this `async fn`, found opaque type
  = note:     expected type `usize`
          found opaque type `impl Future<Output = usize>`
```

Note the "found opaque type `impl Future<Output = usize>`" in the new output.

----

Questions: 
1. We skip printing the output type when it's a projection, since I have been seeing some types like `impl Future<Output = <[static generator@/home/michael/test.rs:2:11: 2:21] as Generator<ResumeTy>>::Return>` which are not particularly helpful and leak implementation detail. 
    * Am I able to normalize this type within `rustc_middle::ty::print::pretty`? Alternatively, can we normalize it when creating the diagnostic? Otherwise, I'm fine with skipping it and falling back to the old output.
    * Should I suppress any other types? I didn't encounter anything other than this generator projection type.
2. Not sure what the formatting of this should be. Do I include spaces in `Output = `?