### PR TITLE
rustdoc doctest: detect `fn main` after an unexpected semicolon

### DIFF
--- a/src/test/rustdoc-ui/failed-doctest-extra-semicolon-on-item.rs
+++ b/src/test/rustdoc-ui/failed-doctest-extra-semicolon-on-item.rs
@@ -1,0 +1,18 @@
+// FIXME: if/when the output of the test harness can be tested on its own, this test should be
+// adapted to use that, and that normalize line can go away
+
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// failure-status: 101
+
+/// <https://github.com/rust-lang/rust/issues/91014>
+///
+/// ```rust
+/// struct S {}; // unexpected semicolon after struct def
+///
+/// fn main() {
+///    assert_eq!(0, 1);
+/// }
+/// ```
+mod m {}

--- a/src/test/rustdoc-ui/failed-doctest-extra-semicolon-on-item.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-extra-semicolon-on-item.stdout
@@ -1,0 +1,24 @@
+
+running 1 test
+test $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) ... FAILED
+
+failures:
+
+---- $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) stdout ----
+error: expected item, found `;`
+  --> $DIR/failed-doctest-extra-semicolon-on-item.rs:12:12
+   |
+LL | struct S {}; // unexpected semicolon after struct def
+   |            ^ help: remove this semicolon
+   |
+   = help: braced struct declarations are not followed by a semicolon
+
+error: aborting due to previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes #91014

The basic problem with this is that rustdoc, when hunting for `fn main`, will stop parsing after it reaches a fatal error. This unexpected semicolon was a fatal error, so in `src/test/rustdoc-ui/failed-doctest-extra-semicolon-on-item.rs`, it would wrap the doctest in an implied main function, turning it into this:

    fn main() {
        struct S {};
        fn main() {
            assert_eq!(0, 1);
        }
    }

This, as it turns out, is totally valid, and it executes no assertions, so *it passes,* even though the user wanted it to execute the assertion.

The Rust parser already has the ability to recover from these unexpected semicolons, but to do so, it needs to use the `parse_mod` function, so this PR changes it to do that.