### PR TITLE
[crater experiment] do the opposite of what zip side-effect documentation currently guarantees

### DIFF
--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1925,7 +1925,8 @@ impl<T: Clone> Clone for LinkedList<T> {
         if self.len() > other.len() {
             self.split_off(other.len());
         }
-        for (elem, elem_other) in self.iter_mut().zip(&mut iter_other) {
+        let len = self.len();
+        for (elem, elem_other) in self.iter_mut().zip((&mut iter_other).take(len)) {
             elem.clone_from(elem_other);
         }
         if !iter_other.is_empty() {

--- a/library/core/tests/iter/adapters/cloned.rs
+++ b/library/core/tests/iter/adapters/cloned.rs
@@ -31,7 +31,7 @@ fn test_cloned_side_effects() {
             .zip(&[1]);
         for _ in iter {}
     }
-    assert_eq!(count, 2);
+    assert_eq!(count, 1);
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -108,7 +108,7 @@ fn test_zip_next_back_side_effects_exhausted() {
     iter.next();
     iter.next();
     assert_eq!(iter.next_back(), None);
-    assert_eq!(a, vec![1, 2, 3, 4, 6, 5]);
+    assert_eq!(a, vec![1, 2, 3, 6, 5, 4]);
     assert_eq!(b, vec![200, 300, 400]);
 }
 
@@ -119,7 +119,7 @@ fn test_zip_cloned_sideffectful() {
 
     for _ in xs.iter().cloned().zip(ys.iter().cloned()) {}
 
-    assert_eq!(&xs, &[1, 1, 1, 0][..]);
+    assert_eq!(&xs, &[1, 1, 0, 0][..]);
     assert_eq!(&ys, &[1, 1][..]);
 
     let xs = [CountClone::new(), CountClone::new()];
@@ -128,7 +128,7 @@ fn test_zip_cloned_sideffectful() {
     for _ in xs.iter().cloned().zip(ys.iter().cloned()) {}
 
     assert_eq!(&xs, &[1, 1][..]);
-    assert_eq!(&ys, &[1, 1, 0, 0][..]);
+    assert_eq!(&ys, &[1, 1, 1, 0][..]);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn test_zip_map_sideffectful() {
 
     for _ in xs.iter_mut().map(|x| *x += 1).zip(ys.iter_mut().map(|y| *y += 1)) {}
 
-    assert_eq!(&xs, &[1, 1, 1, 1, 1, 0]);
+    assert_eq!(&xs, &[1, 1, 1, 1, 0, 0]);
     assert_eq!(&ys, &[1, 1, 1, 1]);
 
     let mut xs = [0; 4];
@@ -147,7 +147,7 @@ fn test_zip_map_sideffectful() {
     for _ in xs.iter_mut().map(|x| *x += 1).zip(ys.iter_mut().map(|y| *y += 1)) {}
 
     assert_eq!(&xs, &[1, 1, 1, 1]);
-    assert_eq!(&ys, &[1, 1, 1, 1, 0, 0]);
+    assert_eq!(&ys, &[1, 1, 1, 1, 1, 0]);
 }
 
 #[test]
@@ -176,15 +176,15 @@ fn test_zip_map_rev_sideffectful() {
 
 #[test]
 fn test_zip_nested_sideffectful() {
-    let mut xs = [0; 6];
-    let ys = [0; 4];
+    let xs = [0; 4];
+    let mut ys = [0; 6];
 
     {
         // test that it has the side effect nested inside enumerate
-        let it = xs.iter_mut().map(|x| *x = 1).enumerate().zip(&ys);
+        let it = xs.iter().enumerate().zip(ys.iter_mut().map(|x| *x = 1));
         it.count();
     }
-    assert_eq!(&xs, &[1, 1, 1, 1, 1, 0]);
+    assert_eq!(&ys, &[1, 1, 1, 1, 1, 0]);
 }
 
 #[test]
@@ -208,7 +208,7 @@ fn test_zip_nth_back_side_effects_exhausted() {
     iter.next();
     iter.next();
     assert_eq!(iter.nth_back(0), None);
-    assert_eq!(a, vec![1, 2, 3, 4, 6, 5]);
+    assert_eq!(a, vec![1, 2, 3, 6, 5, 4]);
     assert_eq!(b, vec![200, 300, 400]);
 }
 
@@ -227,8 +227,7 @@ fn test_zip_trusted_random_access_composition() {
     assert_eq!(z1.next().unwrap(), (0, 0));
 
     let mut z2 = z1.zip(c);
-    fn assert_trusted_random_access<T: TrustedRandomAccess>(_a: &T) {}
-    assert_trusted_random_access(&z2);
+
     assert_eq!(z2.next().unwrap(), ((1, 1), 1));
 }
 


### PR DESCRIPTION
Improved crater experiment to elucidate the possibility of completely removing the guarantee that was added in #52279, suggested by @steffahn in https://github.com/rust-lang/rust/pull/83791#issuecomment-892791462

That it was already used in linkedlist doesn't bode well. 😢

r? @ghost