### PR TITLE
rustdoc: Cleanup `DocFragment`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -906,7 +906,6 @@ impl<I: Iterator<Item = ast::NestedMetaItem> + IntoIterator<Item = ast::NestedMe
 /// kept separate because of issue #42760.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate struct DocFragment {
-    crate line: usize,
     crate span: rustc_span::Span,
     /// The module this doc-comment came from.
     ///
@@ -1027,7 +1026,6 @@ impl Attributes {
         additional_attrs: Option<(&[ast::Attribute], DefId)>,
     ) -> Attributes {
         let mut doc_strings: Vec<DocFragment> = vec![];
-        let mut doc_line = 0;
 
         fn update_need_backline(doc_strings: &mut Vec<DocFragment>) {
             if let Some(prev) = doc_strings.last_mut() {
@@ -1045,10 +1043,7 @@ impl Attributes {
                     DocFragmentKind::RawDoc
                 };
 
-                let line = doc_line;
-                doc_line += value.as_str().lines().count();
                 let frag = DocFragment {
-                    line,
                     span: attr.span,
                     doc: value,
                     kind,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -656,7 +656,7 @@ impl<'a, I> Footnotes<'a, I> {
     }
 
     fn get_entry(&mut self, key: &str) -> &mut (Vec<Event<'a>>, u16) {
-        let new_id = self.footnotes.keys().count() + 1;
+        let new_id = self.footnotes.len() + 1;
         let key = key.to_owned();
         self.footnotes.entry(key).or_insert((Vec::new(), new_id as u16))
     }

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -1,5 +1,7 @@
 use std::cmp;
 
+use rustc_span::symbol::kw;
+
 use crate::clean::{self, DocFragment, DocFragmentKind, Item};
 use crate::core::DocContext;
 use crate::fold::{self, DocFolder};
@@ -87,7 +89,7 @@ fn unindent_fragments(docs: &mut Vec<DocFragment>) {
     };
 
     for fragment in docs {
-        if fragment.doc.as_str().lines().next().is_none() {
+        if fragment.doc == kw::Empty {
             continue;
         }
 

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -87,7 +87,7 @@ fn unindent_fragments(docs: &mut Vec<DocFragment>) {
     };
 
     for fragment in docs {
-        if fragment.doc.as_str().lines().count() == 0 {
+        if fragment.doc.as_str().lines().next().is_none() {
             continue;
         }
 

--- a/src/librustdoc/passes/unindent_comments/tests.rs
+++ b/src/librustdoc/passes/unindent_comments/tests.rs
@@ -5,7 +5,6 @@ use rustc_span::symbol::Symbol;
 
 fn create_doc_fragment(s: &str) -> Vec<DocFragment> {
     vec![DocFragment {
-        line: 0,
         span: DUMMY_SP,
         parent_module: None,
         doc: Symbol::intern(s),


### PR DESCRIPTION
- Remove unused `DocFragment.line` field
- Avoid using `Iterator::count()` where possible