### PR TITLE
Issue 90702 fix: Stop treating some crate loading failures as fatal errors

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -220,7 +220,7 @@ use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::MetadataRef;
-use rustc_errors::{struct_span_err, DiagnosticBuilder, FatalError};
+use rustc_errors::{struct_span_err, FatalError};
 use rustc_session::config::{self, CrateType};
 use rustc_session::cstore::{CrateSource, MetadataLoader};
 use rustc_session::filesearch::{FileDoesntMatch, FileMatches, FileSearch};
@@ -931,8 +931,8 @@ impl fmt::Display for MetadataError<'_> {
 }
 
 impl CrateError {
-    fn build_diag(self, sess: &Session, span: Span, missing_core: bool) -> DiagnosticBuilder<'_> {
-        match self {
+    crate fn report(self, sess: &Session, span: Span, missing_core: bool) {
+        let mut diag = match self {
             CrateError::NonAsciiName(crate_name) => sess.struct_span_err(
                 span,
                 &format!("cannot load a crate with a non-ascii name `{}`", crate_name),
@@ -1208,10 +1208,8 @@ impl CrateError {
                 "plugin `{}` only found in rlib format, but must be available in dylib format",
                 crate_name,
             ),
-        }
-    }
+        };
 
-    crate fn report(self, sess: &Session, span: Span, missing_core: bool) {
-        self.build_diag(sess, span, missing_core).emit();
+        diag.emit();
     }
 }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -840,57 +840,41 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         let parent_scope = self.parent_scope;
         let expansion = parent_scope.expansion;
 
-        let module = if orig_name.is_none() && ident.name == kw::SelfLower {
+        let (used, module, binding) = if orig_name.is_none() && ident.name == kw::SelfLower {
             self.r
                 .session
                 .struct_span_err(item.span, "`extern crate self;` requires renaming")
                 .span_suggestion(
                     item.span,
-                    "try",
+                    "rename the `self` crate to be able to import it",
                     "extern crate self as name;".into(),
                     Applicability::HasPlaceholders,
                 )
                 .emit();
             return;
         } else if orig_name == Some(kw::SelfLower) {
-            self.r.graph_root
+            Some(self.r.graph_root)
         } else {
-            match self.r.crate_loader.process_extern_crate(item, &self.r.definitions, local_def_id)
-            {
-                Some(crate_id) => {
+            self.r.crate_loader.process_extern_crate(item, &self.r.definitions, local_def_id).map(
+                |crate_id| {
                     self.r.extern_crate_map.insert(local_def_id, crate_id);
                     self.r.expect_module(crate_id.as_def_id())
-                }
-                _ => {
-                    let dummy_import = self.r.arenas.alloc_import(Import {
-                        kind: ImportKind::ExternCrate { source: orig_name, target: ident },
-                        root_id: item.id,
-                        id: item.id,
-                        parent_scope: self.parent_scope,
-                        imported_module: Cell::new(None),
-                        has_attributes: !item.attrs.is_empty(),
-                        use_span_with_attributes: item.span_with_attributes(),
-                        use_span: item.span,
-                        root_span: item.span,
-                        span: item.span,
-                        module_path: Vec::new(),
-                        vis: Cell::new(vis),
-                        used: Cell::new(true),
-                    });
-                    self.r.import_dummy_binding(dummy_import);
-                    return;
-                }
-            }
-        };
-        let used = self.process_macro_use_imports(item, module);
-        let binding =
-            (module, ty::Visibility::Public, sp, expansion).to_name_binding(self.r.arenas);
+                },
+            )
+        }
+        .map(|module| {
+            let used = self.process_macro_use_imports(item, module);
+            let binding =
+                (module, ty::Visibility::Public, sp, expansion).to_name_binding(self.r.arenas);
+            (used, Some(ModuleOrUniformRoot::Module(module)), binding)
+        })
+        .unwrap_or((true, None, self.r.dummy_binding));
         let import = self.r.arenas.alloc_import(Import {
             kind: ImportKind::ExternCrate { source: orig_name, target: ident },
             root_id: item.id,
             id: item.id,
             parent_scope: self.parent_scope,
-            imported_module: Cell::new(Some(ModuleOrUniformRoot::Module(module))),
+            imported_module: Cell::new(module),
             has_attributes: !item.attrs.is_empty(),
             use_span_with_attributes: item.span_with_attributes(),
             use_span: item.span,

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -683,75 +683,16 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             ItemKind::ExternCrate(orig_name) => {
-                let module = if orig_name.is_none() && ident.name == kw::SelfLower {
-                    self.r
-                        .session
-                        .struct_span_err(item.span, "`extern crate self;` requires renaming")
-                        .span_suggestion(
-                            item.span,
-                            "try",
-                            "extern crate self as name;".into(),
-                            Applicability::HasPlaceholders,
-                        )
-                        .emit();
-                    return;
-                } else if orig_name == Some(kw::SelfLower) {
-                    self.r.graph_root
-                } else {
-                    let crate_id = self.r.crate_loader.process_extern_crate(
-                        item,
-                        &self.r.definitions,
-                        local_def_id,
-                    );
-                    self.r.extern_crate_map.insert(local_def_id, crate_id);
-                    self.r.expect_module(crate_id.as_def_id())
-                };
-
-                let used = self.process_macro_use_imports(item, module);
-                let binding =
-                    (module, ty::Visibility::Public, sp, expansion).to_name_binding(self.r.arenas);
-                let import = self.r.arenas.alloc_import(Import {
-                    kind: ImportKind::ExternCrate { source: orig_name, target: ident },
-                    root_id: item.id,
-                    id: item.id,
-                    parent_scope: self.parent_scope,
-                    imported_module: Cell::new(Some(ModuleOrUniformRoot::Module(module))),
-                    has_attributes: !item.attrs.is_empty(),
-                    use_span_with_attributes: item.span_with_attributes(),
-                    use_span: item.span,
-                    root_span: item.span,
-                    span: item.span,
-                    module_path: Vec::new(),
-                    vis: Cell::new(vis),
-                    used: Cell::new(used),
-                });
-                self.r.potentially_unused_imports.push(import);
-                let imported_binding = self.r.import(binding, import);
-                if ptr::eq(parent, self.r.graph_root) {
-                    if let Some(entry) = self.r.extern_prelude.get(&ident.normalize_to_macros_2_0())
-                    {
-                        if expansion != LocalExpnId::ROOT
-                            && orig_name.is_some()
-                            && entry.extern_crate_item.is_none()
-                        {
-                            let msg = "macro-expanded `extern crate` items cannot \
-                                       shadow names passed with `--extern`";
-                            self.r.session.span_err(item.span, msg);
-                        }
-                    }
-                    let entry =
-                        self.r.extern_prelude.entry(ident.normalize_to_macros_2_0()).or_insert(
-                            ExternPreludeEntry {
-                                extern_crate_item: None,
-                                introduced_by_item: true,
-                            },
-                        );
-                    entry.extern_crate_item = Some(imported_binding);
-                    if orig_name.is_some() {
-                        entry.introduced_by_item = true;
-                    }
-                }
-                self.r.define(parent, ident, TypeNS, imported_binding);
+                self.build_reduced_graph_for_extern_crate(
+                    orig_name,
+                    ident,
+                    item,
+                    local_def_id,
+                    sp,
+                    expansion,
+                    vis,
+                    parent,
+                );
             }
 
             ItemKind::Mod(..) => {
@@ -887,6 +828,79 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
 
             ItemKind::MacroDef(..) | ItemKind::MacCall(_) => unreachable!(),
         }
+    }
+
+    fn build_reduced_graph_for_extern_crate(
+        &mut self,
+        orig_name: Option<Symbol>,
+        ident: Ident,
+        item: &Item,
+        local_def_id: LocalDefId,
+        sp: Span,
+        expansion: LocalExpnId,
+        vis: ty::Visibility,
+        parent: Module<'a>,
+    ) {
+        let module = if orig_name.is_none() && ident.name == kw::SelfLower {
+            self.r
+                .session
+                .struct_span_err(item.span, "`extern crate self;` requires renaming")
+                .span_suggestion(
+                    item.span,
+                    "try",
+                    "extern crate self as name;".into(),
+                    Applicability::HasPlaceholders,
+                )
+                .emit();
+            return;
+        } else if orig_name == Some(kw::SelfLower) {
+            self.r.graph_root
+        } else {
+            let crate_id =
+                self.r.crate_loader.process_extern_crate(item, &self.r.definitions, local_def_id);
+            self.r.extern_crate_map.insert(local_def_id, crate_id);
+            self.r.expect_module(crate_id.as_def_id())
+        };
+        let used = self.process_macro_use_imports(item, module);
+        let binding =
+            (module, ty::Visibility::Public, sp, expansion).to_name_binding(self.r.arenas);
+        let import = self.r.arenas.alloc_import(Import {
+            kind: ImportKind::ExternCrate { source: orig_name, target: ident },
+            root_id: item.id,
+            id: item.id,
+            parent_scope: self.parent_scope,
+            imported_module: Cell::new(Some(ModuleOrUniformRoot::Module(module))),
+            has_attributes: !item.attrs.is_empty(),
+            use_span_with_attributes: item.span_with_attributes(),
+            use_span: item.span,
+            root_span: item.span,
+            span: item.span,
+            module_path: Vec::new(),
+            vis: Cell::new(vis),
+            used: Cell::new(used),
+        });
+        self.r.potentially_unused_imports.push(import);
+        let imported_binding = self.r.import(binding, import);
+        if ptr::eq(parent, self.r.graph_root) {
+            if let Some(entry) = self.r.extern_prelude.get(&ident.normalize_to_macros_2_0()) {
+                if expansion != LocalExpnId::ROOT
+                    && orig_name.is_some()
+                    && entry.extern_crate_item.is_none()
+                {
+                    let msg = "macro-expanded `extern crate` items cannot \
+                                       shadow names passed with `--extern`";
+                    self.r.session.span_err(item.span, msg);
+                }
+            }
+            let entry = self.r.extern_prelude.entry(ident.normalize_to_macros_2_0()).or_insert(
+                ExternPreludeEntry { extern_crate_item: None, introduced_by_item: true },
+            );
+            entry.extern_crate_item = Some(imported_binding);
+            if orig_name.is_some() {
+                entry.introduced_by_item = true;
+            }
+        }
+        self.r.define(parent, ident, TypeNS, imported_binding);
     }
 
     /// Constructs the reduced graph for one foreign item.

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -600,8 +600,10 @@ impl<'a> Resolver<'a> {
 
     // Define a "dummy" resolution containing a Res::Err as a placeholder for a
     // failed resolution
-    fn import_dummy_binding(&mut self, import: &'a Import<'a>) {
-        if let ImportKind::Single { target, .. } = import.kind {
+    crate fn import_dummy_binding(&mut self, import: &'a Import<'a>) {
+        if let ImportKind::Single { target, .. } | ImportKind::ExternCrate { target, .. } =
+            import.kind
+        {
             let dummy_binding = self.dummy_binding;
             let dummy_binding = self.import(dummy_binding, import);
             self.per_ns(|this, ns| {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -600,10 +600,8 @@ impl<'a> Resolver<'a> {
 
     // Define a "dummy" resolution containing a Res::Err as a placeholder for a
     // failed resolution
-    crate fn import_dummy_binding(&mut self, import: &'a Import<'a>) {
-        if let ImportKind::Single { target, .. } | ImportKind::ExternCrate { target, .. } =
-            import.kind
-        {
+    fn import_dummy_binding(&mut self, import: &'a Import<'a>) {
+        if let ImportKind::Single { target, .. } = import.kind {
             let dummy_binding = self.dummy_binding;
             let dummy_binding = self.import(dummy_binding, import);
             self.per_ns(|this, ns| {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -3285,7 +3285,9 @@ impl<'a> Resolver<'a> {
                 Some(binding)
             } else {
                 let crate_id = if !speculative {
-                    self.crate_loader.process_path_extern(ident.name, ident.span)
+                    let Some(crate_id) =
+                        self.crate_loader.process_path_extern(ident.name, ident.span) else { return Some(self.dummy_binding); };
+                    crate_id
                 } else {
                     self.crate_loader.maybe_process_path_extern(ident.name)?
                 };

--- a/src/test/ui/crate-loading/invalid-rlib.rs
+++ b/src/test/ui/crate-loading/invalid-rlib.rs
@@ -6,3 +6,5 @@
 #![no_std]
 use ::foo; //~ ERROR invalid metadata files for crate `foo`
 //~| NOTE failed to mmap file
+//~^^ ERROR invalid metadata files for crate `foo`
+//~| NOTE failed to mmap file

--- a/src/test/ui/crate-loading/invalid-rlib.stderr
+++ b/src/test/ui/crate-loading/invalid-rlib.stderr
@@ -6,6 +6,14 @@ LL | use ::foo;
    |
    = note: failed to mmap file 'auxiliary/libfoo.rlib'
 
-error: aborting due to previous error
+error[E0786]: found invalid metadata files for crate `foo`
+  --> $DIR/invalid-rlib.rs:7:7
+   |
+LL | use ::foo;
+   |       ^^^
+   |
+   = note: failed to mmap file 'auxiliary/libfoo.rlib'
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0786`.

--- a/src/test/ui/crate-loading/missing-std.rs
+++ b/src/test/ui/crate-loading/missing-std.rs
@@ -1,6 +1,7 @@
 // compile-flags: --target x86_64-unknown-uefi
 // needs-llvm-components: x86
 // rustc-env:CARGO=/usr/bin/cargo
+#![feature(no_core)]
 #![no_core]
 extern crate core;
 //~^ ERROR can't find crate for `core`

--- a/src/test/ui/crate-loading/missing-std.stderr
+++ b/src/test/ui/crate-loading/missing-std.stderr
@@ -1,5 +1,5 @@
 error[E0463]: can't find crate for `core`
-  --> $DIR/missing-std.rs:5:1
+  --> $DIR/missing-std.rs:6:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ can't find crate
@@ -8,6 +8,8 @@ LL | extern crate core;
    = help: consider downloading the target with `rustup target add x86_64-unknown-uefi`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error: aborting due to previous error
+error: requires `sized` lang_item
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/extern-flag/empty-extern-arg.rs
+++ b/src/test/ui/extern-flag/empty-extern-arg.rs
@@ -1,4 +1,6 @@
 // compile-flags: --extern std=
 // error-pattern: extern location for std does not exist
+// needs-unwind since it affects the error output
+// ignore-emscripten compiled with panic=abort, personality not required
 
 fn main() {}

--- a/src/test/ui/extern-flag/empty-extern-arg.stderr
+++ b/src/test/ui/extern-flag/empty-extern-arg.stderr
@@ -1,4 +1,8 @@
 error: extern location for std does not exist: 
 
-error: aborting due to previous error
+error: language item required, but not found: `eh_personality`
+
+error: `#[panic_handler]` function required, but not found
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/extern/extern-crate-multiple-missing.rs
+++ b/src/test/ui/extern/extern-crate-multiple-missing.rs
@@ -3,6 +3,8 @@ extern crate bar; //~ ERROR can't find crate for `bar`
 extern crate foo; //~ ERROR can't find crate for `foo`
 
 fn main() {
+    // If the crate name introduced by `extern crate` failed to resolve then subsequent
+    // derived paths do not emit additional errors
     foo::something();
     bar::something();
 }

--- a/src/test/ui/extern/extern-crate-multiple-missing.rs
+++ b/src/test/ui/extern/extern-crate-multiple-missing.rs
@@ -1,0 +1,8 @@
+// If multiple `extern crate` resolutions fail each of them should produce an error
+extern crate bar; //~ ERROR can't find crate for `bar`
+extern crate foo; //~ ERROR can't find crate for `foo`
+
+fn main() {
+    foo::something();
+    bar::something();
+}

--- a/src/test/ui/extern/extern-crate-multiple-missing.stderr
+++ b/src/test/ui/extern/extern-crate-multiple-missing.stderr
@@ -1,0 +1,15 @@
+error[E0463]: can't find crate for `bar`
+  --> $DIR/extern-crate-multiple-missing.rs:2:1
+   |
+LL | extern crate bar;
+   | ^^^^^^^^^^^^^^^^^ can't find crate
+
+error[E0463]: can't find crate for `foo`
+  --> $DIR/extern-crate-multiple-missing.rs:3:1
+   |
+LL | extern crate foo;
+   | ^^^^^^^^^^^^^^^^^ can't find crate
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
+++ b/src/test/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
@@ -2,7 +2,12 @@ error: `extern crate self;` requires renaming
   --> $DIR/extern-crate-self-fail.rs:1:1
    |
 LL | extern crate self;
-   | ^^^^^^^^^^^^^^^^^^ help: try: `extern crate self as name;`
+   | ^^^^^^^^^^^^^^^^^^
+   |
+help: rename the `self` crate to be able to import it
+   |
+LL | extern crate self as name;
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: `#[macro_use]` is not supported on `extern crate self`
   --> $DIR/extern-crate-self-fail.rs:3:1

--- a/src/test/ui/issues/issue-37131.stderr
+++ b/src/test/ui/issues/issue-37131.stderr
@@ -4,6 +4,8 @@ error[E0463]: can't find crate for `std`
    = help: consider downloading the target with `rustup target add thumbv6m-none-eabi`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error: aborting due to previous error
+error: requires `sized` lang_item
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/issues/issue-49851/compiler-builtins-error.rs
+++ b/src/test/ui/issues/issue-49851/compiler-builtins-error.rs
@@ -1,4 +1,5 @@
-//~ ERROR 1:1: 1:1: can't find crate for `core` [E0463]
+//~ ERROR can't find crate for `core`
+//~^ ERROR can't find crate for `compiler_builtins`
 
 // compile-flags: --target thumbv7em-none-eabihf
 // needs-llvm-components: arm
@@ -7,3 +8,6 @@
 #![no_std]
 
 extern crate cortex_m;
+//~^ ERROR can't find crate for `cortex_m`
+
+fn main() {}

--- a/src/test/ui/issues/issue-49851/compiler-builtins-error.stderr
+++ b/src/test/ui/issues/issue-49851/compiler-builtins-error.stderr
@@ -4,6 +4,16 @@ error[E0463]: can't find crate for `core`
    = help: consider downloading the target with `rustup target add thumbv7em-none-eabihf`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`
 
-error: aborting due to previous error
+error[E0463]: can't find crate for `compiler_builtins`
+
+error[E0463]: can't find crate for `cortex_m`
+  --> $DIR/compiler-builtins-error.rs:10:1
+   |
+LL | extern crate cortex_m;
+   | ^^^^^^^^^^^^^^^^^^^^^^ can't find crate
+
+error: requires `sized` lang_item
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0463`.

--- a/src/test/ui/rust-2018/uniform-paths/deadlock.rs
+++ b/src/test/ui/rust-2018/uniform-paths/deadlock.rs
@@ -1,7 +1,8 @@
 // edition:2018
 // compile-flags:--extern foo --extern bar
 
+use bar::foo; //~ ERROR can't find crate for `bar`
 use foo::bar; //~ ERROR can't find crate for `foo`
-use bar::foo;
+//~^^ ERROR unresolved imports `bar::foo`, `foo::bar`
 
 fn main() {}

--- a/src/test/ui/rust-2018/uniform-paths/deadlock.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/deadlock.stderr
@@ -1,9 +1,24 @@
-error[E0463]: can't find crate for `foo`
+error[E0463]: can't find crate for `bar`
   --> $DIR/deadlock.rs:4:5
+   |
+LL | use bar::foo;
+   |     ^^^ can't find crate
+
+error[E0463]: can't find crate for `foo`
+  --> $DIR/deadlock.rs:5:5
    |
 LL | use foo::bar;
    |     ^^^ can't find crate
 
-error: aborting due to previous error
+error[E0432]: unresolved imports `bar::foo`, `foo::bar`
+  --> $DIR/deadlock.rs:4:5
+   |
+LL | use bar::foo;
+   |     ^^^^^^^^
+LL | use foo::bar;
+   |     ^^^^^^^^
 
-For more information about this error, try `rustc --explain E0463`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0432, E0463.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
Surface mulitple `extern crate` resolution errors at a time.

This is achieved by creating a dummy crate, instead of aborting directly after the resolution error. The `ExternCrateError` has been added to allow propagating the resolution error from `rustc_metadata` crate to the `rustc_resolve` with a minimal public surface. The `import_extern_crate` function is a block that was factored out from `build_reduced_graph_for_item` for better organization. The only added functionality made to it where the added error handling in the `process_extern_crate` call. The remaining bits in this function are the same as before.

Resolves #90702

r? @petrochenkov 