### PR TITLE
str::lines and BufRead::lines: document trailing bare cr behaviour

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -899,6 +899,19 @@ impl str {
     ///
     /// assert_eq!(None, lines.next());
     /// ```
+    ///
+    /// Handling of a trailing bare CR is, sadly, anomalous:
+    /// (`std::io::BufRead::lines` handles this case correctly.)
+    ///
+    /// ```
+    /// let text = "foo\nbar\r";
+    /// let mut lines = text.lines();
+    ///
+    /// assert_eq!(Some("foo"), lines.next());
+    /// assert_eq!(Some("bar"), lines.next()); // should really return "bar\r"
+    ///
+    /// assert_eq!(None, lines.next());
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn lines(&self) -> Lines<'_> {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -900,15 +900,14 @@ impl str {
     /// assert_eq!(None, lines.next());
     /// ```
     ///
-    /// Handling of a trailing bare CR is, sadly, anomalous:
-    /// (`std::io::BufRead::lines` handles this case correctly.)
+    /// Unlike [`std::io::BufRead::lines`], trailing bare CR is handled as a newline:
     ///
     /// ```
     /// let text = "foo\nbar\r";
     /// let mut lines = text.lines();
     ///
     /// assert_eq!(Some("foo"), lines.next());
-    /// assert_eq!(Some("bar"), lines.next()); // should really return "bar\r"
+    /// assert_eq!(Some("bar"), lines.next()); // does not return "bar\r"
     ///
     /// assert_eq!(None, lines.next());
     /// ```

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2281,6 +2281,19 @@ pub trait BufRead: Read {
     /// assert_eq!(lines_iter.next(), None);
     /// ```
     ///
+    /// Unlike [`str::lines`], trailing bare CR is handled correctly:
+    ///
+    /// ```
+    /// use std::io::{self, BufRead};
+    ///
+    /// let cursor = io::Cursor::new(b"lorem\nipsum\r");
+    ///
+    /// let mut lines_iter = cursor.lines().map(|l| l.unwrap());
+    /// assert_eq!(lines_iter.next(), Some(String::from("lorem")));
+    /// assert_eq!(lines_iter.next(), Some(String::from("ipsum\r"))); // bare CR is not a newline
+    /// assert_eq!(lines_iter.next(), None);
+    /// ```
+    ///
     /// # Errors
     ///
     /// Each line of the iterator has the same error semantics as [`BufRead::read_line`].

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2281,7 +2281,7 @@ pub trait BufRead: Read {
     /// assert_eq!(lines_iter.next(), None);
     /// ```
     ///
-    /// Unlike [`str::lines`], trailing bare CR is handled correctly:
+    /// Unlike [`str::lines`], trailing bare CR is not handled as a newline:
     ///
     /// ```
     /// use std::io::{self, BufRead};
@@ -2290,7 +2290,7 @@ pub trait BufRead: Read {
     ///
     /// let mut lines_iter = cursor.lines().map(|l| l.unwrap());
     /// assert_eq!(lines_iter.next(), Some(String::from("lorem")));
-    /// assert_eq!(lines_iter.next(), Some(String::from("ipsum\r"))); // bare CR is not a newline
+    /// assert_eq!(lines_iter.next(), Some(String::from("ipsum\r"))); // does not return "ipsum"
     /// assert_eq!(lines_iter.next(), None);
     /// ```
     ///


### PR DESCRIPTION
Apropos discussion here  https://github.com/rust-lang/rust/pull/91047#issuecomment-974321038

Sadly, str::lines gets this wrong.  I think it is probably too late to
fix this, so document it instead.