### PR TITLE
rustdoc: Fix some unescaped HTML tags in docs

### DIFF
--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -8,13 +8,13 @@ use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
 crate struct ExternalHtml {
-    /// Content that will be included inline in the <head> section of a
+    /// Content that will be included inline in the `<head>` section of a
     /// rendered Markdown file or generated documentation
     crate in_header: String,
-    /// Content that will be included inline between <body> and the content of
+    /// Content that will be included inline between `<body>` and the content of
     /// a rendered Markdown file or generated documentation
     crate before_content: String,
-    /// Content that will be included inline between the content and </body> of
+    /// Content that will be included inline between the content and `</body>` of
     /// a rendered Markdown file or generated documentation
     crate after_content: String,
 }


### PR DESCRIPTION
They were being interpreted literally.