### PR TITLE
Add test for evaluate_obligation: Ok(EvaluatedToOkModuloRegions) ICE

### DIFF
--- a/src/test/incremental/issue-85360-eval-obligation-ice.rs
+++ b/src/test/incremental/issue-85360-eval-obligation-ice.rs
@@ -1,0 +1,117 @@
+// revisions:cfail1 cfail2
+// compile-flags: --crate-type=lib --edition=2021
+// build-pass
+
+use core::any::Any;
+use core::marker::PhantomData;
+
+struct DerefWrap<T>(T);
+
+impl<T> core::ops::Deref for DerefWrap<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct Storage<T, D> {
+    phantom: PhantomData<(T, D)>,
+}
+
+type ReadStorage<T> = Storage<T, DerefWrap<MaskedStorage<T>>>;
+
+pub trait Component {
+    type Storage;
+}
+
+struct VecStorage;
+
+struct Pos;
+
+impl Component for Pos {
+    type Storage = VecStorage;
+}
+
+struct GenericComp<T> {
+    _t: T,
+}
+
+impl<T: 'static> Component for GenericComp<T> {
+    type Storage = VecStorage;
+}
+struct ReadData {
+    pos_interpdata: ReadStorage<GenericComp<Pos>>,
+}
+
+trait System {
+    type SystemData;
+
+    fn run(data: Self::SystemData, any: Box<dyn Any>);
+}
+
+struct Sys;
+
+impl System for Sys {
+    type SystemData = (ReadData, ReadStorage<Pos>);
+
+    fn run((data, pos): Self::SystemData, any: Box<dyn Any>) {
+        <ReadStorage<GenericComp<Pos>> as SystemData>::setup(any);
+
+        ParJoin::par_join((&pos, &data.pos_interpdata));
+    }
+}
+
+trait ParJoin {
+    fn par_join(self)
+    where
+        Self: Sized,
+    {
+    }
+}
+
+impl<'a, T, D> ParJoin for &'a Storage<T, D>
+where
+    T: Component,
+    D: core::ops::Deref<Target = MaskedStorage<T>>,
+    T::Storage: Sync,
+{
+}
+
+impl<A, B> ParJoin for (A, B)
+where
+    A: ParJoin,
+    B: ParJoin,
+{
+}
+
+pub trait SystemData {
+    fn setup(any: Box<dyn Any>);
+}
+
+impl<T: 'static> SystemData for ReadStorage<T>
+where
+    T: Component,
+{
+    fn setup(any: Box<dyn Any>) {
+        let storage: &MaskedStorage<T> = any.downcast_ref().unwrap();
+
+        <dyn Any as CastFrom<MaskedStorage<T>>>::cast(&storage);
+    }
+}
+
+pub struct MaskedStorage<T: Component> {
+    _inner: T::Storage,
+}
+
+pub unsafe trait CastFrom<T> {
+    fn cast(t: &T) -> &Self;
+}
+
+unsafe impl<T> CastFrom<T> for dyn Any
+where
+    T: Any + 'static,
+{
+    fn cast(t: &T) -> &Self {
+        t
+    }
+}

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -9,6 +9,10 @@ fn main() {
     test::<MaskedStorage<GenericComp<Pos>>>(make());
     //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
     //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+
+    test::<MaskedStorage<GenericComp2<Pos>>>(make());
+    //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+    //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
 }
 
 #[rustc_evaluate_where_clauses]
@@ -52,6 +56,15 @@ struct GenericComp<T> {
 impl<T: 'static> Component for GenericComp<T> {
     type Storage = VecStorage;
 }
+
+struct GenericComp2<T> {
+    _t: T,
+}
+
+impl<T: 'static> Component for GenericComp2<T> where for<'a> &'a bool: 'a {
+    type Storage = VecStorage;
+}
+
 struct ReadData {
     pos_interpdata: ReadStorage<GenericComp<Pos>>,
 }

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -1,10 +1,22 @@
-// revisions:cfail1 cfail2
-//[cfail1] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=not-loaded
-//[cfail2] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=loaded
-// build-pass
+// compile-flags: --edition=2021
+
+#![feature(rustc_attrs)]
 
 use core::any::Any;
 use core::marker::PhantomData;
+
+fn main() {
+    test::<MaskedStorage<GenericComp<Pos>>>(make());
+    //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+    //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+}
+
+#[rustc_evaluate_where_clauses]
+fn test<T: Sized>(_: T) {}
+
+fn make<T>() -> T {
+    todo!()
+}
 
 struct DerefWrap<T>(T);
 

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -1,0 +1,20 @@
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
+   |
+LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |         - predicate
+
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
+   |
+LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |            ----- predicate
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -16,5 +16,23 @@ LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
 LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
-error: aborting due to 2 previous errors
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+   |
+LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |         - predicate
+
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+   |
+LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |            ----- predicate
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Adds the minimial repro test case from #85360. The fix for #85360 was
supposed to be #85868 however the repro was resolved in the 2021-07-05
nightly while #85868 didn't land until 2021-09-03. The reason for that
is d34a3a401b4e44f289a4d5bf53da83367cbb6aa7 **also** resolves that
issue.

To test if #85868 actually fixes #85360, I reverted
d34a3a401b4e44f289a4d5bf53da83367cbb6aa7 and found that #85868 does
indeed resolve #85360.

With that question resolved, add a test case to our incremental test
suite for the original Ok(EvaluatedToOkModuloRegions) ICE.

Thanks to @lqd for helping track this down!