### PR TITLE
rustdoc: Remove `Crate.externs` and compute on-demand instead

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -117,7 +117,6 @@ impl From<DefId> for ItemId {
 #[derive(Clone, Debug)]
 crate struct Crate {
     crate module: Item,
-    crate externs: Vec<ExternalCrate>,
     crate primitives: ThinVec<(DefId, PrimitiveType)>,
     /// Only here so that they can be filtered through the rustdoc passes.
     crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
@@ -126,7 +125,7 @@ crate struct Crate {
 
 // `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Crate, 104);
+rustc_data_structures::static_assert_size!(Crate, 80);
 
 impl Crate {
     crate fn name(&self, tcx: TyCtxt<'_>) -> Symbol {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -7,6 +7,7 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
+use crate::visit_lib::LibEmbargoVisitor;
 
 use rustc_ast as ast;
 use rustc_ast::tokenstream::TokenTree;
@@ -25,6 +26,11 @@ mod tests;
 
 crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     let module = crate::visit_ast::RustdocVisitor::new(cx).visit();
+
+    for &cnum in cx.tcx.crates(()) {
+        // Analyze doc-reachability for extern items
+        LibEmbargoVisitor::new(cx).visit_lib(cnum);
+    }
 
     // Clean the crate, translating the entire librustc_ast AST to one that is
     // understood by rustdoc.

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -24,16 +24,7 @@ use std::mem;
 mod tests;
 
 crate fn krate(cx: &mut DocContext<'_>) -> Crate {
-    use crate::visit_lib::LibEmbargoVisitor;
-
     let module = crate::visit_ast::RustdocVisitor::new(cx).visit();
-
-    let mut externs = Vec::new();
-    for &cnum in cx.tcx.crates(()) {
-        externs.push(ExternalCrate { crate_num: cnum });
-        // Analyze doc-reachability for extern items
-        LibEmbargoVisitor::new(cx).visit_lib(cnum);
-    }
 
     // Clean the crate, translating the entire librustc_ast AST to one that is
     // understood by rustdoc.
@@ -76,13 +67,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
         }));
     }
 
-    Crate {
-        module,
-        externs,
-        primitives,
-        external_traits: cx.external_traits.clone(),
-        collapsed: false,
-    }
+    Crate { module, primitives, external_traits: cx.external_traits.clone(), collapsed: false }
 }
 
 fn external_generic_args(

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -508,14 +508,12 @@ crate fn run_global_ctxt(
         rustc_errors::FatalError.raise();
     }
 
-    let render_options = ctxt.render_options;
-    let mut cache = ctxt.cache;
-    krate = tcx.sess.time("create_format_cache", || cache.populate(krate, tcx, &render_options));
+    krate = tcx.sess.time("create_format_cache", || Cache::populate(&mut ctxt, krate));
 
     // The main crate doc comments are always collapsed.
     krate.collapsed = true;
 
-    (krate, render_options, cache)
+    (krate, ctxt.render_options, ctxt.cache)
 }
 
 /// Due to <https://github.com/rust-lang/rust/pull/73566>,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -14,7 +14,6 @@ use crate::formats::Impl;
 use crate::html::markdown::short_markdown_summary;
 use crate::html::render::cache::{get_index_search_type, ExternalLocation};
 use crate::html::render::IndexItem;
-use crate::visit_lib::LibEmbargoVisitor;
 
 /// This cache is used to store information about the [`clean::Crate`] being
 /// rendered in order to provide more useful documentation. This contains
@@ -148,8 +147,6 @@ impl Cache {
         // FIXME: this part is specific to HTML so it'd be nice to remove it from the common code
         for &crate_num in cx.tcx.crates(()) {
             let e = ExternalCrate { crate_num };
-            // Analyze doc-reachability for extern items
-            LibEmbargoVisitor::new(cx).visit_lib(e.crate_num);
 
             let name = e.name(tcx);
             let render_options = &cx.render_options;


### PR DESCRIPTION
r? @GuillaumeGomez 
cc @jyn514 