### PR TITLE
rustdoc: Remove distinction between "regular" and "collapsed" docs

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -121,12 +121,11 @@ crate struct Crate {
     crate primitives: ThinVec<(DefId, PrimitiveType)>,
     /// Only here so that they can be filtered through the rustdoc passes.
     crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
-    crate collapsed: bool,
 }
 
 // `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Crate, 104);
+rustc_data_structures::static_assert_size!(Crate, 96);
 
 impl Crate {
     crate fn name(&self, tcx: TyCtxt<'_>) -> Symbol {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -411,12 +411,6 @@ impl Item {
         crate::passes::span_of_attrs(&self.attrs).unwrap_or_else(|| self.span(tcx).inner())
     }
 
-    /// Finds the `doc` attribute as a NameValue and returns the corresponding
-    /// value found.
-    crate fn doc_value(&self) -> Option<String> {
-        self.attrs.doc_value()
-    }
-
     /// Convenience wrapper around [`Self::from_def_id_and_parts`] which converts
     /// `hir_id` to a [`DefId`]
     pub fn from_hir_id_and_parts(
@@ -468,8 +462,8 @@ impl Item {
 
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
-    crate fn collapsed_doc_value(&self) -> Option<String> {
-        self.attrs.collapsed_doc_value()
+    crate fn doc_value(&self) -> Option<String> {
+        self.attrs.doc_value()
     }
 
     crate fn links(&self, cx: &Context<'_>) -> Vec<RenderedLink> {
@@ -1074,16 +1068,10 @@ impl Attributes {
         Attributes { doc_strings, other_attrs }
     }
 
-    /// Finds the `doc` attribute as a NameValue and returns the corresponding
-    /// value found.
-    crate fn doc_value(&self) -> Option<String> {
-        self.collapsed_doc_value()
-    }
-
     /// Return the doc-comments on this item, grouped by the module they came from.
     ///
     /// The module can be different if this is a re-export with added documentation.
-    crate fn collapsed_doc_value_by_module_level(&self) -> FxHashMap<Option<DefId>, String> {
+    crate fn doc_value_by_module_level(&self) -> FxHashMap<Option<DefId>, String> {
         let mut ret = FxHashMap::default();
 
         for new_frag in self.doc_strings.iter() {
@@ -1095,7 +1083,7 @@ impl Attributes {
 
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
-    crate fn collapsed_doc_value(&self) -> Option<String> {
+    crate fn doc_value(&self) -> Option<String> {
         if self.doc_strings.is_empty() { None } else { Some(self.doc_strings.iter().collect()) }
     }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1077,18 +1077,7 @@ impl Attributes {
     /// Finds the `doc` attribute as a NameValue and returns the corresponding
     /// value found.
     crate fn doc_value(&self) -> Option<String> {
-        let mut iter = self.doc_strings.iter();
-
-        let ori = iter.next()?;
-        let mut out = String::new();
-        add_doc_fragment(&mut out, ori);
-        for new_frag in iter {
-            if new_frag.kind != ori.kind || new_frag.parent_module != ori.parent_module {
-                break;
-            }
-            add_doc_fragment(&mut out, new_frag);
-        }
-        if out.is_empty() { None } else { Some(out) }
+        self.collapsed_doc_value()
     }
 
     /// Return the doc-comments on this item, grouped by the module they came from.

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -76,13 +76,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
         }));
     }
 
-    Crate {
-        module,
-        externs,
-        primitives,
-        external_traits: cx.external_traits.clone(),
-        collapsed: false,
-    }
+    Crate { module, externs, primitives, external_traits: cx.external_traits.clone() }
 }
 
 fn external_generic_args(

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -512,9 +512,6 @@ crate fn run_global_ctxt(
     let mut cache = ctxt.cache;
     krate = tcx.sess.time("create_format_cache", || cache.populate(krate, tcx, &render_options));
 
-    // The main crate doc comments are always collapsed.
-    krate.collapsed = true;
-
     (krate, render_options, cache)
 }
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1137,8 +1137,6 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
         }
 
         attrs.unindent_doc_comments();
-        // The collapse-docs pass won't combine sugared/raw doc attributes, or included files with
-        // anything else, this will combine them for us.
         if let Some(doc) = attrs.doc_value() {
             // Use the outermost invocation, so that doctest names come from where the docs were written.
             let span = ast_attrs

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1139,7 +1139,7 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
         attrs.unindent_doc_comments();
         // The collapse-docs pass won't combine sugared/raw doc attributes, or included files with
         // anything else, this will combine them for us.
-        if let Some(doc) = attrs.collapsed_doc_value() {
+        if let Some(doc) = attrs.doc_value() {
             // Use the outermost invocation, so that doctest names come from where the docs were written.
             let span = ast_attrs
                 .span()

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -145,7 +145,7 @@ impl SharedContext<'_> {
     /// Returns the `collapsed_doc_value` of the given item if this is the main crate, otherwise
     /// returns the `doc_value`.
     crate fn maybe_collapsed_doc_value<'a>(&self, item: &'a clean::Item) -> Option<String> {
-        if self.collapsed { item.collapsed_doc_value() } else { item.doc_value() }
+        if self.collapsed { item.doc_value() } else { item.doc_value() }
     }
 
     crate fn edition(&self) -> Edition {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -88,8 +88,6 @@ crate struct SharedContext<'tcx> {
     crate local_sources: FxHashMap<PathBuf, String>,
     /// Show the memory layout of types in the docs.
     pub(super) show_type_layout: bool,
-    /// Whether the collapsed pass ran
-    collapsed: bool,
     /// The base-URL of the issue tracker for when an item has been tagged with
     /// an issue number.
     pub(super) issue_tracker_base_url: Option<String>,
@@ -140,12 +138,6 @@ impl SharedContext<'_> {
         }
 
         Ok(())
-    }
-
-    /// Returns the `collapsed_doc_value` of the given item if this is the main crate, otherwise
-    /// returns the `doc_value`.
-    crate fn maybe_collapsed_doc_value<'a>(&self, item: &'a clean::Item) -> Option<String> {
-        if self.collapsed { item.doc_value() } else { item.doc_value() }
     }
 
     crate fn edition(&self) -> Edition {
@@ -472,7 +464,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         let (sender, receiver) = channel();
         let mut scx = SharedContext {
             tcx,
-            collapsed: krate.collapsed,
             src_root,
             local_sources,
             issue_tracker_base_url,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -575,7 +575,7 @@ fn document_full_inner(
     is_collapsible: bool,
     heading_offset: HeadingOffset,
 ) {
-    if let Some(s) = cx.shared.maybe_collapsed_doc_value(item) {
+    if let Some(s) = item.doc_value() {
         debug!("Doc block: =====\n{}\n=====", s);
         if is_collapsible {
             w.write_str(
@@ -1628,7 +1628,7 @@ fn render_impl(
             write!(w, "</summary>")
         }
 
-        if let Some(ref dox) = cx.shared.maybe_collapsed_doc_value(&i.impl_item) {
+        if let Some(ref dox) = i.impl_item.doc_value() {
             let mut ids = cx.id_map.borrow_mut();
             write!(
                 w,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -32,7 +32,7 @@ impl JsonRenderer<'_> {
             .flatten()
             .map(|clean::ItemLink { link, did, .. }| (link.clone(), from_item_id((*did).into())))
             .collect();
-        let docs = item.attrs.collapsed_doc_value();
+        let docs = item.attrs.doc_value();
         let attrs = item
             .attrs
             .other_attrs

--- a/src/librustdoc/passes/bare_urls.rs
+++ b/src/librustdoc/passes/bare_urls.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx> DocVisitor for BareUrlsLinter<'a, 'tcx> {
                 return;
             }
         };
-        let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
+        let dox = item.attrs.doc_value().unwrap_or_default();
         if !dox.is_empty() {
             let report_diag = |cx: &DocContext<'_>, msg: &str, url: &str, range: Range<usize>| {
                 let sp = super::source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs)

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -207,7 +207,7 @@ impl<'a, 'b> DocVisitor for CoverageCalculator<'a, 'b> {
                 let mut tests = Tests { found_tests: 0 };
 
                 find_testable_code(
-                    &i.attrs.collapsed_doc_value().unwrap_or_default(),
+                    &i.attrs.doc_value().unwrap_or_default(),
                     &mut tests,
                     ErrorCodes::No,
                     false,

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -144,7 +144,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
 
 impl<'a, 'tcx> DocVisitor for SyntaxChecker<'a, 'tcx> {
     fn visit_item(&mut self, item: &clean::Item) {
-        if let Some(dox) = &item.attrs.collapsed_doc_value() {
+        if let Some(dox) = &item.attrs.doc_value() {
             let sp = item.attr_span(self.cx.tcx);
             let extra = crate::html::markdown::ExtraInfo::new_did(
                 self.cx.tcx,

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -33,7 +33,7 @@ crate fn check_doc_test_visibility(krate: Crate, cx: &mut DocContext<'_>) -> Cra
 
 impl<'a, 'tcx> DocVisitor for DocTestVisibilityLinter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
-        let dox = item.attrs.collapsed_doc_value().unwrap_or_else(String::new);
+        let dox = item.attrs.doc_value().unwrap_or_else(String::new);
 
         look_for_tests(self.cx, &dox, &item);
 

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -894,7 +894,7 @@ impl<'a, 'tcx> DocVisitor for LinkCollector<'a, 'tcx> {
         // In the presence of re-exports, this is not the same as the module of the item.
         // Rather than merging all documentation into one, resolve it one attribute at a time
         // so we know which module it came from.
-        for (parent_module, doc) in item.attrs.collapsed_doc_value_by_module_level() {
+        for (parent_module, doc) in item.attrs.doc_value_by_module_level() {
             debug!("combined_docs={}", doc);
 
             let (krate, parent_node) = if let Some(id) = parent_module {

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -33,7 +33,7 @@ impl IntraLinkCrateLoader {
 
         // FIXME: this probably needs to consider inlining
         let attrs = crate::clean::Attributes::from_ast(attrs, None);
-        for (parent_module, doc) in attrs.collapsed_doc_value_by_module_level() {
+        for (parent_module, doc) in attrs.doc_value_by_module_level() {
             debug!(?doc);
             for link in markdown_links(doc.as_str()) {
                 debug!(?link.link);

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> DocVisitor for InvalidHtmlTagsLinter<'a, 'tcx> {
                 return;
             }
         };
-        let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
+        let dox = item.attrs.doc_value().unwrap_or_default();
         if !dox.is_empty() {
             let report_diag = |msg: &str, range: &Range<usize>| {
                 let sp = match super::source_span_for_markdown_range(tcx, &dox, range, &item.attrs)

--- a/src/librustdoc/passes/unindent_comments/tests.rs
+++ b/src/librustdoc/passes/unindent_comments/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+use crate::clean::types::collapse_doc_fragments;
+
 use rustc_span::create_default_session_globals_then;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_span::symbol::Symbol;
@@ -19,7 +22,7 @@ fn run_test(input: &str, expected: &str) {
     create_default_session_globals_then(|| {
         let mut s = create_doc_fragment(input);
         unindent_fragments(&mut s);
-        assert_eq!(&s.iter().collect::<String>(), expected);
+        assert_eq!(collapse_doc_fragments(&s), expected);
     });
 }
 


### PR DESCRIPTION
There actually seems to be no difference.

r? @GuillaumeGomez 
cc @jyn514 