### PR TITLE
Reduce prominence of item-infos

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -682,7 +682,7 @@ fn short_item_info(
 
     // Render unstable items. But don't render "rustc_private" crates (internal compiler crates).
     // Those crates are permanently unstable so it makes no sense to render "unstable" everywhere.
-    if let Some((StabilityLevel::Unstable { reason, issue, .. }, feature)) = item
+    if let Some((StabilityLevel::Unstable { reason: _, issue, .. }, feature)) = item
         .stability(cx.tcx())
         .as_ref()
         .filter(|stab| stab.feature != sym::rustc_private)
@@ -701,22 +701,6 @@ fn short_item_info(
         }
 
         message.push_str(&format!(" ({})", feature));
-
-        if let Some(unstable_reason) = reason {
-            let mut ids = cx.id_map.borrow_mut();
-            message = format!(
-                "<details><summary>{}</summary>{}</details>",
-                message,
-                MarkdownHtml(
-                    &unstable_reason.as_str(),
-                    &mut ids,
-                    error_codes,
-                    cx.shared.edition(),
-                    &cx.shared.playground,
-                )
-                .into_string()
-            );
-        }
 
         extra_info.push(format!("<div class=\"stab unstable\">{}</div>", message));
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -965,8 +965,6 @@ body.blur > :not(#help) {
 	display: table;
 }
 .stab {
-	border-width: 1px;
-	border-style: solid;
 	padding: 3px;
 	margin-bottom: 5px;
 	font-size: 90%;
@@ -977,7 +975,7 @@ body.blur > :not(#help) {
 }
 
 .stab .emoji {
-	font-size: 1.5em;
+	font-size: 1.2em;
 }
 
 /* Black one-pixel outline around emoji shapes */

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -4,4 +4,4 @@ goto: file://|DOC_PATH|/lib2/struct.Foo.html
 size: (1100, 800)
 // We check that ".item-info" is bigger than its content.
 assert-css: (".item-info", {"width": "807px"})
-assert-css: (".item-info .stab", {"width": "343px"})
+assert-css: (".item-info .stab", {"width": "341px"})

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -1,7 +1,6 @@
 #![feature(staged_api)]
 #![doc(issue_tracker_base_url = "https://issue_url/")]
-
-#![unstable(feature="test", issue = "32374")]
+#![unstable(feature = "test", issue = "32374")]
 
 // @matches issue_32374/index.html '//*[@class="item-left unstable deprecated module-item"]/span[@class="stab deprecated"]' \
 //      'Deprecated'
@@ -23,12 +22,6 @@ pub struct T;
 //      '👎 Deprecated since 1.0.0: deprecated'
 // @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
 //      '🔬 This is a nightly-only experimental API. (test #32374)'
-// @has issue_32374/struct.U.html '//details' \
-//      '🔬 This is a nightly-only experimental API. (test #32374)'
-// @has issue_32374/struct.U.html '//summary' \
-//      '🔬 This is a nightly-only experimental API. (test #32374)'
-// @has issue_32374/struct.U.html '//details/p' \
-//      'unstable'
 #[rustc_deprecated(since = "1.0.0", reason = "deprecated")]
 #[unstable(feature = "test", issue = "32374", reason = "unstable")]
 pub struct U;


### PR DESCRIPTION
Fixes #59853

 - Remove border.
 - Reduce size of emoji slightly.
 - Remove details disclosure for unstable reason. This was inconsistent with our other details disclosures, and the detail revealed was usually better explained by clicking on the issue link.

Demo: https://rustdoc.crud.net/jsha/chill-item-info/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref

Compare vs: https://doc.rust-lang.org/nightly/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref

<img src="https://user-images.githubusercontent.com/220205/142717815-09828c9e-6ff4-445a-8ccc-31e028fd4985.png" width=700>
