### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -454,22 +454,20 @@ impl<'a> Resolver<'a> {
                 // edit:
                 // only do this if the const and usage of the non-constant value are on the same line
                 // the further the two are apart, the higher the chance of the suggestion being wrong
-                // also make sure that this line isn't the first one (ICE #90878)
+                // also make sure that the pos for the suggestion is not 0 (ICE #90878)
 
                 let sp =
                     self.session.source_map().span_extend_to_prev_str(ident.span, current, true);
 
-                let is_first_line = self
-                    .session
-                    .source_map()
-                    .lookup_line(sp.lo())
-                    .map(|file_and_line| file_and_line.line == 0)
-                    .unwrap_or(true);
+                let pos_for_suggestion = sp.lo().0.saturating_sub(current.len() as u32);
 
-                if sp.lo().0 == 0 || self.session.source_map().is_multiline(sp) || is_first_line {
+                if sp.lo().0 == 0
+                    || pos_for_suggestion == 0
+                    || self.session.source_map().is_multiline(sp)
+                {
                     err.span_label(ident.span, &format!("this would need to be a `{}`", sugg));
                 } else {
-                    let sp = sp.with_lo(BytePos(sp.lo().0 - current.len() as u32));
+                    let sp = sp.with_lo(BytePos(pos_for_suggestion));
                     err.span_suggestion(
                         sp,
                         &format!("consider using `{}` instead of `{}`", sugg, current),

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1935,6 +1935,7 @@ pub struct Loc {
 #[derive(Debug)]
 pub struct SourceFileAndLine {
     pub sf: Lrc<SourceFile>,
+    /// Index of line, starting from 0.
     pub line: usize,
 }
 #[derive(Debug)]

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -593,14 +593,19 @@ impl SourceMap {
     }
 
     pub fn span_to_margin(&self, sp: Span) -> Option<usize> {
-        match self.span_to_prev_source(sp) {
-            Err(_) => None,
-            Ok(source) => {
-                let last_line = source.rsplit_once('\n').unwrap_or(("", &source)).1;
+        Some(self.indentation_before(sp)?.len())
+    }
 
-                Some(last_line.len() - last_line.trim_start().len())
-            }
-        }
+    pub fn indentation_before(&self, sp: Span) -> Option<String> {
+        self.span_to_source(sp, |src, start_index, _| {
+            let before = &src[..start_index];
+            let last_line = before.rsplit_once('\n').map_or(before, |(_, last)| last);
+            Ok(last_line
+                .split_once(|c: char| !c.is_whitespace())
+                .map_or(last_line, |(indent, _)| indent)
+                .to_string())
+        })
+        .ok()
     }
 
     /// Returns the source snippet as `String` before the given `Span`.

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -199,6 +199,51 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return;
             }
 
+            // If the expression is of type () and it's the return expression of a block,
+            // we suggest adding a separate return expression instead.
+            // (To avoid things like suggesting `Ok(while .. { .. })`.)
+            if expr_ty.is_unit() {
+                if let Some(hir::Node::Block(&hir::Block {
+                    span: block_span, expr: Some(e), ..
+                })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.hir_id))
+                {
+                    if e.hir_id == expr.hir_id {
+                        if let Some(span) = expr.span.find_ancestor_inside(block_span) {
+                            let return_suggestions =
+                                if self.tcx.is_diagnostic_item(sym::Result, expected_adt.did) {
+                                    vec!["Ok(())".to_string()]
+                                } else if self.tcx.is_diagnostic_item(sym::Option, expected_adt.did)
+                                {
+                                    vec!["None".to_string(), "Some(())".to_string()]
+                                } else {
+                                    return;
+                                };
+                            if let Some(indent) =
+                                self.tcx.sess.source_map().indentation_before(span.shrink_to_lo())
+                            {
+                                // Add a semicolon, except after `}`.
+                                let semicolon =
+                                    match self.tcx.sess.source_map().span_to_snippet(span) {
+                                        Ok(s) if s.ends_with('}') => "",
+                                        _ => ";",
+                                    };
+                                err.multipart_suggestions(
+                                    "try adding an expression at the end of the block",
+                                    return_suggestions.into_iter().map(|r| {
+                                        vec![(
+                                            span.shrink_to_hi(),
+                                            format!("{}\n{}{}", semicolon, indent, r),
+                                        )]
+                                    }),
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+
             let mut compatible_variants = expected_adt
                 .variants
                 .iter()

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -227,14 +227,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         Ok(s) if s.ends_with('}') => "",
                                         _ => ";",
                                     };
-                                err.multipart_suggestions(
+                                err.span_suggestions(
+                                    span.shrink_to_hi(),
                                     "try adding an expression at the end of the block",
-                                    return_suggestions.into_iter().map(|r| {
-                                        vec![(
-                                            span.shrink_to_hi(),
-                                            format!("{}\n{}{}", semicolon, indent, r),
-                                        )]
-                                    }),
+                                    return_suggestions
+                                        .into_iter()
+                                        .map(|r| format!("{}\n{}{}", semicolon, indent, r)),
                                     Applicability::MaybeIncorrect,
                                 );
                             }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -303,7 +303,7 @@ nav.sub {
 	left: 0;
 	top: 0;
 	bottom: 0;
-	overflow: auto;
+	overflow-y: scroll;
 }
 
 /* Improve the scrollbar display on firefox */

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -70,11 +70,11 @@ pre, .rustdoc.source .example-wrap {
 
 /* Improve the scrollbar display on firefox */
 * {
-	scrollbar-color: #5c6773 transparent;
+	scrollbar-color: #5c6773 #24292f;
 }
 
 .sidebar {
-	scrollbar-color: #5c6773 transparent;
+	scrollbar-color: #5c6773 #24292f;
 }
 
 /* Improve the scrollbar display on webkit-based browsers */

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -44,7 +44,7 @@ pre, .rustdoc.source .example-wrap {
 	scrollbar-color: rgb(64, 65, 67) #717171;
 }
 .sidebar {
-	scrollbar-color: rgba(32,34,37,.6) transparent;
+	scrollbar-color: rgba(32,34,37,.6) #5a5a5a;
 }
 
 /* Improve the scrollbar display on webkit-based browsers */

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(local_dropped_before_await());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `local_dropped_before_await` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:24:5
    |
@@ -27,7 +27,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:33:20
    |

--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |         take_u32(x.await)

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -25,8 +25,8 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn two() {}
    |                ^ checked the `Output` of this `async fn`, found opaque type
-   = note: expected opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:5:16>)
-              found opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:6:16>)
+   = note: expected opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:5:16>)
+              found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/generator-desc.rs:6:16>)
    = help: consider `await`ing on both `Future`s
    = note: distinct uses of `impl Trait` result in different opaque types
 

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -40,8 +40,8 @@ async fn foo() -> Result<(), ()> {
 
 async fn bar() -> Result<(), ()> {
     foo()?; //~ ERROR the `?` operator can only be applied to values that implement `Try`
-    //~^ NOTE the `?` operator cannot be applied to type `impl Future`
-    //~| HELP the trait `Try` is not implemented for `impl Future`
+    //~^ NOTE the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
+    //~| HELP the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
     //~| NOTE required by `branch`
     //~| HELP consider `await`ing on the `Future`
     //~| NOTE in this expansion of desugaring of operator `?`
@@ -84,7 +84,7 @@ async fn baz() -> Result<(), ()> {
     //~| NOTE field not available in `impl Future`
 
     struct_().method(); //~ ERROR no method named
-    //~^ NOTE method not found in `impl Future`
+    //~^ NOTE method not found in `impl Future<Output = Struct>`
     //~| HELP consider `await`ing on the `Future`
     Ok(())
 }
@@ -93,7 +93,7 @@ async fn match_() {
     match tuple() { //~ HELP consider `await`ing on the `Future`
         Tuple(_) => {} //~ ERROR mismatched types
         //~^ NOTE expected opaque type, found struct `Tuple`
-        //~| NOTE expected opaque type `impl Future`
+        //~| NOTE expected opaque type `impl Future<Output = Tuple>`
     }
 }
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-61076.rs:42:5
    |
 LL |     foo()?;
-   |     ^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |
@@ -32,7 +32,7 @@ help: consider `await`ing on the `Future`
 LL |     t.await?;
    |      ++++++
 
-error[E0609]: no field `0` on type `impl Future`
+error[E0609]: no field `0` on type `impl Future<Output = Tuple>`
   --> $DIR/issue-61076.rs:78:26
    |
 LL |     let _: i32 = tuple().0;
@@ -43,7 +43,7 @@ help: consider `await`ing on the `Future` and access the field of its `Output`
 LL |     let _: i32 = tuple().await.0;
    |                         ++++++
 
-error[E0609]: no field `a` on type `impl Future`
+error[E0609]: no field `a` on type `impl Future<Output = Struct>`
   --> $DIR/issue-61076.rs:82:28
    |
 LL |     let _: i32 = struct_().a;
@@ -54,11 +54,11 @@ help: consider `await`ing on the `Future` and access the field of its `Output`
 LL |     let _: i32 = struct_().await.a;
    |                           ++++++
 
-error[E0599]: no method named `method` found for opaque type `impl Future` in the current scope
+error[E0599]: no method named `method` found for opaque type `impl Future<Output = Struct>` in the current scope
   --> $DIR/issue-61076.rs:86:15
    |
 LL |     struct_().method();
-   |               ^^^^^^ method not found in `impl Future`
+   |               ^^^^^^ method not found in `impl Future<Output = Struct>`
    |
 help: consider `await`ing on the `Future` and calling the method on its `Output`
    |
@@ -76,7 +76,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn tuple() -> Tuple {
    |                     ^^^^^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = Tuple>`
                    found struct `Tuple`
 help: consider `await`ing on the `Future`
    |

--- a/src/test/ui/async-await/issue-64130-1-sync.stderr
+++ b/src/test/ui/async-await/issue-64130-1-sync.stderr
@@ -4,7 +4,7 @@ error: future cannot be shared between threads safely
 LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
-   = help: within `impl Future`, the trait `Sync` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:15:5
    |

--- a/src/test/ui/async-await/issue-64130-2-send.stderr
+++ b/src/test/ui/async-await/issue-64130-2-send.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(bar());
    |             ^^^^^ future returned by `bar` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-2-send.rs:15:5
    |

--- a/src/test/ui/async-await/issue-64130-3-other.rs
+++ b/src/test/ui/async-await/issue-64130-3-other.rs
@@ -5,22 +5,22 @@
 // This tests the the unspecialized async-await-specific error when futures don't implement an
 // auto trait (which is not Send or Sync) due to some type that was captured.
 
-auto trait Qux { }
+auto trait Qux {}
 
 struct Foo;
 
 impl !Qux for Foo {}
 
-fn is_qux<T: Qux>(t: T) { }
+fn is_qux<T: Qux>(t: T) {}
 
 async fn bar() {
     let x = Foo;
     baz().await;
 }
 
-async fn baz() { }
+async fn baz() {}
 
 fn main() {
     is_qux(bar());
-    //~^ ERROR the trait bound `Foo: Qux` is not satisfied in `impl Future`
+    //~^ ERROR the trait bound `Foo: Qux` is not satisfied in `impl Future<Output = ()>`
 }

--- a/src/test/ui/async-await/issue-64130-3-other.stderr
+++ b/src/test/ui/async-await/issue-64130-3-other.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl Future`
+error[E0277]: the trait bound `Foo: Qux` is not satisfied in `impl Future<Output = ()>`
   --> $DIR/issue-64130-3-other.rs:24:12
    |
 LL | async fn bar() {
-   |                - within this `impl Future`
+   |                - within this `impl Future<Output = ()>`
 ...
 LL |     is_qux(bar());
-   |            ^^^^^ within `impl Future`, the trait `Qux` is not implemented for `Foo`
+   |            ^^^^^ within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`
    |
 note: future does not implement `Qux` as this value is used across an await
   --> $DIR/issue-64130-3-other.rs:18:5
@@ -19,7 +19,7 @@ LL | }
 note: required by a bound in `is_qux`
   --> $DIR/issue-64130-3-other.rs:14:14
    |
-LL | fn is_qux<T: Qux>(t: T) { }
+LL | fn is_qux<T: Qux>(t: T) {}
    |              ^^^ required by this bound in `is_qux`
 
 error: aborting due to previous error

--- a/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/src/test/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:5
    |

--- a/src/test/ui/async-await/issue-68112.stderr
+++ b/src/test/ui/async-await/issue-68112.stderr
@@ -9,7 +9,7 @@ note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:31:17
    |
 LL |         let _ = non_send_fut.await;
-   |                 ^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+   |                 ^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:11:25
    |
@@ -27,7 +27,7 @@ note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:40:17
    |
 LL |         let _ = make_non_send_future1().await;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future`, which is not `Send`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `impl Future<Output = Arc<RefCell<i32>>>`, which is not `Send`
 note: required by a bound in `require_send`
   --> $DIR/issue-68112.rs:11:25
    |
@@ -45,9 +45,9 @@ LL |     require_send(send_fut);
    = note: required because it appears within the type `[static generator@$DIR/issue-68112.rs:47:31: 47:36]`
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@$DIR/issue-68112.rs:47:31: 47:36]>`
    = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `impl Future`
-   = note: required because it appears within the type `{ResumeTy, impl Future, (), i32, Ready<i32>}`
+   = note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
+   = note: required because it appears within the type `impl Future<Output = Arc<RefCell<i32>>>`
+   = note: required because it appears within the type `{ResumeTy, impl Future<Output = Arc<RefCell<i32>>>, (), i32, Ready<i32>}`
    = note: required because it appears within the type `[static generator@$DIR/issue-68112.rs:55:26: 59:6]`
    = note: required because it appears within the type `from_generator::GenFuture<[static generator@$DIR/issue-68112.rs:55:26: 59:6]>`
    = note: required because it appears within the type `impl Future`

--- a/src/test/ui/async-await/issue-71137.stderr
+++ b/src/test/ui/async-await/issue-71137.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:5
    |

--- a/src/test/ui/async-await/issue-74497-lifetime-in-opaque.stderr
+++ b/src/test/ui/async-await/issue-74497-lifetime-in-opaque.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL |     let _ = foo(|x| bar(x));
    |                  -- ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                  ||
-   |                  |return type of closure `impl Future` contains a lifetime `'2`
+   |                  |return type of closure `impl Future<Output = ()>` contains a lifetime `'2`
    |                  has type `&'1 u8`
 
 error: aborting due to previous error

--- a/src/test/ui/async-await/issue-84841.stderr
+++ b/src/test/ui/async-await/issue-84841.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-84841.rs:9:5
    |
 LL |     test()?;
-   |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = ()>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = ()>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |

--- a/src/test/ui/async-await/issues/issue-67893.stderr
+++ b/src/test/ui/async-await/issues/issue-67893.stderr
@@ -4,7 +4,7 @@ error: generator cannot be sent between threads safely
 LL |     g(issue_67893::run())
    |       ^^^^^^^^^^^^^^^^^^ generator is not `Send`
    |
-   = help: within `impl Future`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
 note: required by a bound in `g`
   --> $DIR/issue-67893.rs:6:14
    |

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |         take_u32(x.await)

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -10,7 +10,7 @@ note: while checking the return type of the `async fn`
 LL | async fn make_u32() -> u32 {
    |                        ^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `u32`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = u32>`
 help: consider `await`ing on the `Future`
    |
 LL |     take_u32(x.await)
@@ -28,7 +28,7 @@ note: while checking the return type of the `async fn`
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, found opaque type
    = note: expected unit type `()`
-            found opaque type `impl Future`
+            found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |     dummy().await
@@ -53,7 +53,7 @@ LL | |
 LL | |     };
    | |_____- `if` and `else` have incompatible types
    |
-   = note:   expected type `impl Future`
+   = note:   expected type `impl Future<Output = ()>`
            found unit type `()`
 help: consider `await`ing on the `Future`
    |
@@ -66,9 +66,9 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _x = match 0usize {
    |  ______________-
 LL | |         0 => dummy(),
-   | |              ------- this is found to be of type `impl Future`
+   | |              ------- this is found to be of type `impl Future<Output = ()>`
 LL | |         1 => dummy(),
-   | |              ------- this is found to be of type `impl Future`
+   | |              ------- this is found to be of type `impl Future<Output = ()>`
 LL | |         2 => dummy().await,
    | |              ^^^^^^^^^^^^^ expected opaque type, found `()`
 LL | |
@@ -80,7 +80,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
    |
@@ -99,7 +99,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy() {}
    |                  ^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = ()>`
                 found unit type `()`
 help: consider `await`ing on the `Future`
    |

--- a/src/test/ui/consts/issue-90878-2.rs
+++ b/src/test/ui/consts/issue-90878-2.rs
@@ -1,0 +1,12 @@
+ #![l=|x|[b;x ]] //~ ERROR unexpected token: `|x| [b; x]`
+//~^ ERROR cannot find attribute `l` in this scope
+//~^^ ERROR attempt to use a non-constant value in a constant [E0435]
+//~^^^ ERROR cannot find value `b` in this scope [E0425]
+
+// notice the space at the start,
+// we can't attach any attributes to this file because it needs to be at the start
+
+// this example has been slightly modified (adding ]] at the end), so that it actually works here
+// it still produces the same issue though
+
+fn main() {}

--- a/src/test/ui/consts/issue-90878-2.stderr
+++ b/src/test/ui/consts/issue-90878-2.stderr
@@ -1,0 +1,30 @@
+error: unexpected token: `|x| [b; x]`
+  --> $DIR/issue-90878-2.rs:1:7
+   |
+LL |  #![l=|x|[b;x ]]
+   |       ^^^^^^^^^
+
+error: cannot find attribute `l` in this scope
+  --> $DIR/issue-90878-2.rs:1:5
+   |
+LL |  #![l=|x|[b;x ]]
+   |     ^
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/issue-90878-2.rs:1:13
+   |
+LL |  #![l=|x|[b;x ]]
+   |        -    ^
+   |        |
+   |        this would need to be a `const`
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/issue-90878-2.rs:1:11
+   |
+LL |  #![l=|x|[b;x ]]
+   |           ^ help: a local variable with a similar name exists: `x`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0425, E0435.
+For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/consts/issue-90878-3.rs
+++ b/src/test/ui/consts/issue-90878-3.rs
@@ -1,0 +1,6 @@
+
+fn main() {
+    |x: usize| [0; x];  //~ ERROR attempt to use a non-constant value in a constant [E0435]
+    // (note the newline before "fn")
+}
+// ignore-tidy-leading-newlines

--- a/src/test/ui/consts/issue-90878-3.stderr
+++ b/src/test/ui/consts/issue-90878-3.stderr
@@ -1,0 +1,11 @@
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/issue-90878-3.rs:3:20
+   |
+LL |     |x: usize| [0; x];
+   |      -             ^
+   |      |
+   |      this would need to be a `const`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0435`.

--- a/src/test/ui/consts/issue-90878.rs
+++ b/src/test/ui/consts/issue-90878.rs
@@ -1,0 +1,4 @@
+ fn main() {
+    |x: usize| [0; x];  //~ ERROR attempt to use a non-constant value in a constant [E0435]
+    // (note the space before "fn")
+}

--- a/src/test/ui/consts/issue-90878.stderr
+++ b/src/test/ui/consts/issue-90878.stderr
@@ -1,0 +1,11 @@
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/issue-90878.rs:2:20
+   |
+LL |     |x: usize| [0; x];
+   |      -             ^
+   |      |
+   |      this would need to be a `const`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0435`.

--- a/src/test/ui/consts/non-const-value-in-const.rs
+++ b/src/test/ui/consts/non-const-value-in-const.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x = 5;
+    const Y: i32 = x; //~ ERROR attempt to use a non-constant value in a constant [E0435]
+
+    let x = 5;
+    let _ = [0; x]; //~ ERROR attempt to use a non-constant value in a constant [E0435]
+}

--- a/src/test/ui/consts/non-const-value-in-const.stderr
+++ b/src/test/ui/consts/non-const-value-in-const.stderr
@@ -1,0 +1,20 @@
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/non-const-value-in-const.rs:3:20
+   |
+LL |     const Y: i32 = x;
+   |     -------        ^ non-constant value
+   |     |
+   |     help: consider using `let` instead of `const`: `let Y`
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/non-const-value-in-const.rs:6:17
+   |
+LL |     let x = 5;
+   |     ----- help: consider using `const` instead of `let`: `const x`
+...
+LL |     let _ = [0; x];
+   |                 ^ non-constant value
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0435`.

--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -1,0 +1,43 @@
+enum Hey<A, B> {
+    A(A),
+    B(B),
+}
+
+fn f() {}
+
+fn a() -> Option<()> {
+    while false {
+        //~^ ERROR mismatched types
+        f();
+    }
+    //~^ HELP try adding an expression
+}
+
+fn b() -> Result<(), ()> {
+    f()
+    //~^ ERROR mismatched types
+    //~| HELP try adding an expression
+}
+
+fn main() {
+    let _: Option<()> = while false {};
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
+    let _: Option<()> = {
+        while false {}
+        //~^ ERROR mismatched types
+        //~| HELP try adding an expression
+    };
+    let _: Result<i32, i32> = 1;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
+    let _: Option<i32> = 1;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
+    let _: Hey<i32, i32> = 1;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
+    let _: Hey<i32, bool> = false;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
+}

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -1,0 +1,137 @@
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:9:5
+   |
+LL |   fn a() -> Option<()> {
+   |             ---------- expected `Option<()>` because of return type
+LL | /     while false {
+LL | |
+LL | |         f();
+LL | |     }
+   | |_____^ expected enum `Option`, found `()`
+   |
+   = note:   expected enum `Option<()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+LL ~     }
+LL +     None
+   |
+LL ~     }
+LL +     Some(())
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:17:5
+   |
+LL | fn b() -> Result<(), ()> {
+   |           -------------- expected `Result<(), ()>` because of return type
+LL |     f()
+   |     ^^^ expected enum `Result`, found `()`
+   |
+   = note:   expected enum `Result<(), ()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+LL ~     f();
+LL +     Ok(())
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:23:25
+   |
+LL |     let _: Option<()> = while false {};
+   |            ----------   ^^^^^^^^^^^^^^ expected enum `Option`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note:   expected enum `Option<()>`
+           found unit type `()`
+help: try wrapping the expression in `Some`
+   |
+LL |     let _: Option<()> = Some(while false {});
+   |                         +++++              +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:27:9
+   |
+LL |         while false {}
+   |         ^^^^^^^^^^^^^^ expected enum `Option`, found `()`
+   |
+   = note:   expected enum `Option<()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+LL ~         while false {}
+LL +         None
+   |
+LL ~         while false {}
+LL +         Some(())
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:31:31
+   |
+LL |     let _: Result<i32, i32> = 1;
+   |            ----------------   ^ expected enum `Result`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Result<i32, i32>`
+              found type `{integer}`
+help: try wrapping the expression in a variant of `Result`
+   |
+LL |     let _: Result<i32, i32> = Ok(1);
+   |                               +++ +
+LL |     let _: Result<i32, i32> = Err(1);
+   |                               ++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:34:26
+   |
+LL |     let _: Option<i32> = 1;
+   |            -----------   ^ expected enum `Option`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<i32>`
+              found type `{integer}`
+help: try wrapping the expression in `Some`
+   |
+LL |     let _: Option<i32> = Some(1);
+   |                          +++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:37:28
+   |
+LL |     let _: Hey<i32, i32> = 1;
+   |            -------------   ^ expected enum `Hey`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Hey<i32, i32>`
+              found type `{integer}`
+help: try wrapping the expression in a variant of `Hey`
+   |
+LL |     let _: Hey<i32, i32> = Hey::A(1);
+   |                            +++++++ +
+LL |     let _: Hey<i32, i32> = Hey::B(1);
+   |                            +++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:40:29
+   |
+LL |     let _: Hey<i32, bool> = false;
+   |            --------------   ^^^^^ expected enum `Hey`, found `bool`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Hey<i32, bool>`
+              found type `bool`
+help: try wrapping the expression in `Hey::B`
+   |
+LL |     let _: Hey<i32, bool> = Hey::B(false);
+   |                             +++++++     +
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/did_you_mean/issue-42764.rs
+++ b/src/test/ui/did_you_mean/issue-42764.rs
@@ -10,7 +10,7 @@ fn main() {
     let n: usize = 42;
     this_function_expects_a_double_option(n);
     //~^ ERROR mismatched types
-    //~| HELP try using a variant of the expected enum
+    //~| HELP try wrapping the expression in a variant of `DoubleOption`
 }
 
 

--- a/src/test/ui/did_you_mean/issue-42764.stderr
+++ b/src/test/ui/did_you_mean/issue-42764.stderr
@@ -6,12 +6,12 @@ LL |     this_function_expects_a_double_option(n);
    |
    = note: expected enum `DoubleOption<_>`
               found type `usize`
-help: try using a variant of the expected enum
+help: try wrapping the expression in a variant of `DoubleOption`
    |
-LL |     this_function_expects_a_double_option(DoubleOption::AlternativeSome(n));
-   |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     this_function_expects_a_double_option(DoubleOption::FirstSome(n));
-   |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                           ++++++++++++++++++++++++ +
+LL |     this_function_expects_a_double_option(DoubleOption::AlternativeSome(n));
+   |                                           ++++++++++++++++++++++++++++++ +
 
 error[E0308]: mismatched types
   --> $DIR/issue-42764.rs:27:33

--- a/src/test/ui/error-codes/E0365.rs
+++ b/src/test/ui/error-codes/E0365.rs
@@ -3,6 +3,6 @@ mod foo {
 }
 
 pub use foo as foo2;
-//~^ ERROR `foo` is private, and cannot be re-exported [E0365]
+//~^ ERROR `foo` is only public within the crate, and cannot be re-exported outside [E0365]
 
 fn main() {}

--- a/src/test/ui/error-codes/E0365.stderr
+++ b/src/test/ui/error-codes/E0365.stderr
@@ -1,8 +1,8 @@
-error[E0365]: `foo` is private, and cannot be re-exported
+error[E0365]: `foo` is only public within the crate, and cannot be re-exported outside
   --> $DIR/E0365.rs:5:9
    |
 LL | pub use foo as foo2;
-   |         ^^^^^^^^^^^ re-export of private `foo`
+   |         ^^^^^^^^^^^ re-export of crate public `foo`
    |
    = note: consider declaring type or module `foo` with `pub`
 

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
@@ -2,13 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/fully-qualified-type-name1.rs:5:9
    |
 LL |     x = 5;
-   |         ^
-   |         |
-   |         expected enum `Option`, found integer
-   |         help: try using a variant of the expected enum: `Some(5)`
+   |         ^ expected enum `Option`, found integer
    |
    = note: expected enum `Option<usize>`
               found type `{integer}`
+help: try wrapping the expression in `Some`
+   |
+LL |     x = Some(5);
+   |         +++++ +
 
 error: aborting due to previous error
 

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name4.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name4.stderr
@@ -4,13 +4,14 @@ error[E0308]: mismatched types
 LL | fn bar(x: usize) -> Option<usize> {
    |                     ------------- expected `Option<usize>` because of return type
 LL |     return x;
-   |            ^
-   |            |
-   |            expected enum `Option`, found `usize`
-   |            help: try using a variant of the expected enum: `Some(x)`
+   |            ^ expected enum `Option`, found `usize`
    |
    = note: expected enum `Option<usize>`
               found type `usize`
+help: try wrapping the expression in `Some`
+   |
+LL |     return Some(x);
+   |            +++++ +
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/issues/issue-78722.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.stderr
@@ -14,8 +14,8 @@ LL |         let f: F = async { 1 };
 LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
    |                                           ------------------------------- the found opaque type
    |
-   = note: expected opaque type `impl Future` (opaque type at <$DIR/issue-78722.rs:5:10>)
-              found opaque type `impl Future` (opaque type at <$SRC_DIR/core/src/future/mod.rs:LL:COL>)
+   = note: expected opaque type `impl Future<Output = u8>`
+              found opaque type `impl Future`
    = note: distinct uses of `impl Trait` result in different opaque types
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
+++ b/src/test/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
@@ -12,10 +12,10 @@ help: try removing this `?`
 LL -     missing_discourses()?
 LL +     missing_discourses()
    | 
-help: try using a variant of the expected enum
+help: try wrapping the expression in `Ok`
    |
 LL |     Ok(missing_discourses()?)
-   |
+   |     +++                     +
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -26,13 +26,14 @@ error[E0308]: mismatched types
 LL | fn b() -> Option<Foo> {
    |           ----------- expected `Option<Foo>` because of return type
 LL |     Foo { bar: 1 }
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     expected enum `Option`, found struct `Foo`
-   |     help: try using a variant of the expected enum: `Some(Foo { bar: 1 })`
+   |     ^^^^^^^^^^^^^^ expected enum `Option`, found struct `Foo`
    |
    = note: expected enum `Option<Foo>`
             found struct `Foo`
+help: try wrapping the expression in `Some`
+   |
+LL |     Some(Foo { bar: 1 })
+   |     +++++              +
 
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:28:5
@@ -40,13 +41,14 @@ error[E0308]: mismatched types
 LL | fn c() -> Result<Foo, Bar> {
    |           ---------------- expected `Result<Foo, Bar>` because of return type
 LL |     Foo { bar: 1 }
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     expected enum `Result`, found struct `Foo`
-   |     help: try using a variant of the expected enum: `Ok(Foo { bar: 1 })`
+   |     ^^^^^^^^^^^^^^ expected enum `Result`, found struct `Foo`
    |
    = note: expected enum `Result<Foo, Bar>`
             found struct `Foo`
+help: try wrapping the expression in `Ok`
+   |
+LL |     Ok(Foo { bar: 1 })
+   |     +++              +
 
 error[E0308]: mismatched types
   --> $DIR/abridged.rs:39:5

--- a/src/test/ui/modules/issue-56411.rs
+++ b/src/test/ui/modules/issue-56411.rs
@@ -5,7 +5,7 @@ macro_rules! import {
             mod $name;
             pub use self::$name;
             //~^ ERROR the name `issue_56411_aux` is defined multiple times
-            //~| ERROR `issue_56411_aux` is private, and cannot be re-exported
+            //~| ERROR `issue_56411_aux` is only public within the crate, and cannot be re-exported outside
 
         )*
     }

--- a/src/test/ui/modules/issue-56411.stderr
+++ b/src/test/ui/modules/issue-56411.stderr
@@ -15,11 +15,11 @@ LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    = note: `issue_56411_aux` must be defined only once in the type namespace of this module
    = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0365]: `issue_56411_aux` is private, and cannot be re-exported
+error[E0365]: `issue_56411_aux` is only public within the crate, and cannot be re-exported outside
   --> $DIR/issue-56411.rs:6:21
    |
 LL |             pub use self::$name;
-   |                     ^^^^^^^^^^^ re-export of private `issue_56411_aux`
+   |                     ^^^^^^^^^^^ re-export of crate public `issue_56411_aux`
 ...
 LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    | ------------------------------------------------ in this macro invocation

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -194,7 +194,7 @@ LL |         async fn ft1() {}
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
-              found fn pointer `fn() -> impl Future`
+              found fn pointer `fn() -> impl Future<Output = ()>`
 
 error[E0053]: method `ft5` has an incompatible type for trait
   --> $DIR/fn-header-semantic-fail.rs:33:48
@@ -210,7 +210,7 @@ LL |         const async unsafe extern "C" fn ft5() {}
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `unsafe extern "C" fn()`
-              found fn pointer `unsafe extern "C" fn() -> impl Future`
+              found fn pointer `unsafe extern "C" fn() -> impl Future<Output = ()>`
 
 error: aborting due to 20 previous errors
 

--- a/src/test/ui/pattern/pat-type-err-let-stmt.stderr
+++ b/src/test/ui/pattern/pat-type-err-let-stmt.stderr
@@ -2,14 +2,16 @@ error[E0308]: mismatched types
   --> $DIR/pat-type-err-let-stmt.rs:6:29
    |
 LL |     let Ok(0): Option<u8> = 42u8;
-   |                ----------   ^^^^
-   |                |            |
-   |                |            expected enum `Option`, found `u8`
-   |                |            help: try using a variant of the expected enum: `Some(42u8)`
+   |                ----------   ^^^^ expected enum `Option`, found `u8`
+   |                |
    |                expected due to this
    |
    = note: expected enum `Option<u8>`
               found type `u8`
+help: try wrapping the expression in `Some`
+   |
+LL |     let Ok(0): Option<u8> = Some(42u8);
+   |                             +++++    +
 
 error[E0308]: mismatched types
   --> $DIR/pat-type-err-let-stmt.rs:6:9

--- a/src/test/ui/privacy/crate-private-reexport.rs
+++ b/src/test/ui/privacy/crate-private-reexport.rs
@@ -1,0 +1,66 @@
+fn f1() {}
+enum E1 { V }
+struct S1 {
+    #[rustfmt::skip]
+    bar: i32,
+}
+mod m1 {
+    pub use ::f1; //~ ERROR `f1` is only public within the crate, and cannot be re-exported outside
+    pub use ::S1; //~ ERROR `S1` is only public within the crate, and cannot be re-exported outside
+    pub use ::E1; //~ ERROR `E1` is only public within the crate, and cannot be re-exported outside
+    pub use ::E1::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+}
+
+pub(crate) fn f2() {}
+pub(crate) enum E2 {
+    V
+}
+pub(crate) struct S2 {
+    #[rustfmt::skip]
+    bar: i32,
+}
+mod m2 {
+    pub use ::f2; //~ ERROR `f2` is only public within the crate, and cannot be re-exported outside
+    pub use ::S2; //~ ERROR `S2` is only public within the crate, and cannot be re-exported outside
+    pub use ::E2; //~ ERROR `E2` is only public within the crate, and cannot be re-exported outside
+    pub use ::E2::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+}
+
+mod m3 {
+    pub(crate) fn f3() {}
+    pub(crate) enum E3 {
+        V
+    }
+    pub(crate) struct S3 {
+        #[rustfmt::skip]
+        bar: i32,
+    }
+}
+pub use m3::f3; //~ ERROR `f3` is only public within the crate, and cannot be re-exported outside
+pub use m3::S3; //~ ERROR `S3` is only public within the crate, and cannot be re-exported outside
+pub use m3::E3; //~ ERROR `E3` is only public within the crate, and cannot be re-exported outside
+pub use m3::E3::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+
+pub(self) fn f4() {}
+pub use ::f4 as f5; //~ ERROR `f4` is only public within the crate, and cannot be re-exported outside
+
+pub mod m10 {
+    pub mod m {
+        pub(super) fn f6() {}
+        pub(crate) fn f7() {}
+        pub(in crate::m10) fn f8() {}
+    }
+    pub use self::m::f6; //~ ERROR `f6` is private, and cannot be re-exported
+    pub use self::m::f7; //~ ERROR `f7` is only public within the crate, and cannot be re-exported outside
+    pub use self::m::f8; //~ ERROR `f8` is private, and cannot be re-exported
+}
+pub use m10::m::f6; //~ ERROR function `f6` is private
+pub use m10::m::f7; //~ ERROR `f7` is only public within the crate, and cannot be re-exported outside
+pub use m10::m::f8; //~ ERROR function `f8` is private
+
+pub mod m11 {
+    pub(self) fn f9() {}
+}
+pub use m11::f9; //~ ERROR function `f9` is private
+
+fn main() {}

--- a/src/test/ui/privacy/crate-private-reexport.stderr
+++ b/src/test/ui/privacy/crate-private-reexport.stderr
@@ -1,0 +1,220 @@
+error[E0364]: `f1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:8:13
+   |
+LL |     pub use ::f1;
+   |             ^^^^
+   |
+note: consider marking `f1` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:8:13
+   |
+LL |     pub use ::f1;
+   |             ^^^^
+
+error[E0365]: `S1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:9:13
+   |
+LL |     pub use ::S1;
+   |             ^^^^ re-export of crate public `S1`
+   |
+   = note: consider declaring type or module `S1` with `pub`
+
+error[E0365]: `E1` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:10:13
+   |
+LL |     pub use ::E1;
+   |             ^^^^ re-export of crate public `E1`
+   |
+   = note: consider declaring type or module `E1` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:11:13
+   |
+LL |     pub use ::E1::V;
+   |             ^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:11:13
+   |
+LL |     pub use ::E1::V;
+   |             ^^^^^^^
+
+error[E0364]: `f2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:23:13
+   |
+LL |     pub use ::f2;
+   |             ^^^^
+   |
+note: consider marking `f2` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:23:13
+   |
+LL |     pub use ::f2;
+   |             ^^^^
+
+error[E0365]: `S2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:24:13
+   |
+LL |     pub use ::S2;
+   |             ^^^^ re-export of crate public `S2`
+   |
+   = note: consider declaring type or module `S2` with `pub`
+
+error[E0365]: `E2` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:25:13
+   |
+LL |     pub use ::E2;
+   |             ^^^^ re-export of crate public `E2`
+   |
+   = note: consider declaring type or module `E2` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:26:13
+   |
+LL |     pub use ::E2::V;
+   |             ^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:26:13
+   |
+LL |     pub use ::E2::V;
+   |             ^^^^^^^
+
+error[E0364]: `f3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:39:9
+   |
+LL | pub use m3::f3;
+   |         ^^^^^^
+   |
+note: consider marking `f3` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:39:9
+   |
+LL | pub use m3::f3;
+   |         ^^^^^^
+
+error[E0365]: `S3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:40:9
+   |
+LL | pub use m3::S3;
+   |         ^^^^^^ re-export of crate public `S3`
+   |
+   = note: consider declaring type or module `S3` with `pub`
+
+error[E0365]: `E3` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:41:9
+   |
+LL | pub use m3::E3;
+   |         ^^^^^^ re-export of crate public `E3`
+   |
+   = note: consider declaring type or module `E3` with `pub`
+
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:42:9
+   |
+LL | pub use m3::E3::V;
+   |         ^^^^^^^^^
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:42:9
+   |
+LL | pub use m3::E3::V;
+   |         ^^^^^^^^^
+
+error[E0364]: `f4` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:45:9
+   |
+LL | pub use ::f4 as f5;
+   |         ^^^^^^^^^^
+   |
+note: consider marking `f4` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:45:9
+   |
+LL | pub use ::f4 as f5;
+   |         ^^^^^^^^^^
+
+error[E0364]: `f6` is private, and cannot be re-exported
+  --> $DIR/crate-private-reexport.rs:53:13
+   |
+LL |     pub use self::m::f6;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f6` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:53:13
+   |
+LL |     pub use self::m::f6;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f7` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:54:13
+   |
+LL |     pub use self::m::f7;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f7` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:54:13
+   |
+LL |     pub use self::m::f7;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f8` is private, and cannot be re-exported
+  --> $DIR/crate-private-reexport.rs:55:13
+   |
+LL |     pub use self::m::f8;
+   |             ^^^^^^^^^^^
+   |
+note: consider marking `f8` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:55:13
+   |
+LL |     pub use self::m::f8;
+   |             ^^^^^^^^^^^
+
+error[E0364]: `f7` is only public within the crate, and cannot be re-exported outside
+  --> $DIR/crate-private-reexport.rs:58:9
+   |
+LL | pub use m10::m::f7;
+   |         ^^^^^^^^^^
+   |
+note: consider marking `f7` as `pub` in the imported module
+  --> $DIR/crate-private-reexport.rs:58:9
+   |
+LL | pub use m10::m::f7;
+   |         ^^^^^^^^^^
+
+error[E0603]: function `f6` is private
+  --> $DIR/crate-private-reexport.rs:57:17
+   |
+LL | pub use m10::m::f6;
+   |                 ^^ private function
+   |
+note: the function `f6` is defined here
+  --> $DIR/crate-private-reexport.rs:49:9
+   |
+LL |         pub(super) fn f6() {}
+   |         ^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `f8` is private
+  --> $DIR/crate-private-reexport.rs:59:17
+   |
+LL | pub use m10::m::f8;
+   |                 ^^ private function
+   |
+note: the function `f8` is defined here
+  --> $DIR/crate-private-reexport.rs:51:9
+   |
+LL |         pub(in crate::m10) fn f8() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0603]: function `f9` is private
+  --> $DIR/crate-private-reexport.rs:64:14
+   |
+LL | pub use m11::f9;
+   |              ^^ private function
+   |
+note: the function `f9` is defined here
+  --> $DIR/crate-private-reexport.rs:62:5
+   |
+LL |     pub(self) fn f9() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
+
+Some errors have detailed explanations: E0364, E0365, E0603.
+For more information about an error, try `rustc --explain E0364`.

--- a/src/test/ui/privacy/private-variant-reexport.rs
+++ b/src/test/ui/privacy/private-variant-reexport.rs
@@ -1,13 +1,13 @@
 mod m1 {
-    pub use ::E::V; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m2 {
-    pub use ::E::{V}; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::{V}; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ ERROR `V` is private, and cannot be re-exported
+    pub use ::E::V::{self}; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 #[deny(unused_imports)]

--- a/src/test/ui/privacy/private-variant-reexport.stderr
+++ b/src/test/ui/privacy/private-variant-reexport.stderr
@@ -1,4 +1,4 @@
-error[E0364]: `V` is private, and cannot be re-exported
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:2:13
    |
 LL |     pub use ::E::V;
@@ -10,7 +10,7 @@ note: consider marking `V` as `pub` in the imported module
 LL |     pub use ::E::V;
    |             ^^^^^^
 
-error[E0364]: `V` is private, and cannot be re-exported
+error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:6:19
    |
 LL |     pub use ::E::{V};
@@ -22,11 +22,11 @@ note: consider marking `V` as `pub` in the imported module
 LL |     pub use ::E::{V};
    |                   ^
 
-error[E0365]: `V` is private, and cannot be re-exported
+error[E0365]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/private-variant-reexport.rs:10:22
    |
 LL |     pub use ::E::V::{self};
-   |                      ^^^^ re-export of private `V`
+   |                      ^^^^ re-export of crate public `V`
    |
    = note: consider declaring type or module `V` with `pub`
 

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -58,7 +58,7 @@ LL |     async fn associated();
    |
    = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
-              found fn pointer `fn() -> impl Future`
+              found fn pointer `fn() -> impl Future<Output = ()>`
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.rs
@@ -8,7 +8,7 @@ mod m1 {
 
     use legacy_macro as _; // OK
     pub(crate) use legacy_macro as _; // OK
-    pub use legacy_macro as _; //~ ERROR `legacy_macro` is private, and cannot be re-exported
+    pub use legacy_macro as _; //~ ERROR `legacy_macro` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m2 {

--- a/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/macro-rules.stderr
@@ -1,4 +1,4 @@
-error[E0364]: `legacy_macro` is private, and cannot be re-exported
+error[E0364]: `legacy_macro` is only public within the crate, and cannot be re-exported outside
   --> $DIR/macro-rules.rs:11:13
    |
 LL |     pub use legacy_macro as _;

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,15 +1,15 @@
-error[E0277]: `fn() -> impl Future {foo}` is not a future
+error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:9
    |
 LL | async fn foo() {}
    |          --- consider calling this function
 ...
 LL |     bar(foo);
-   |     --- ^^^ `fn() -> impl Future {foo}` is not a future
+   |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `fn() -> impl Future {foo}`
+   = help: the trait `Future` is not implemented for `fn() -> impl Future<Output = ()> {foo}`
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |

--- a/src/test/ui/suggestions/boxed-variant-field.rs
+++ b/src/test/ui/suggestions/boxed-variant-field.rs
@@ -9,7 +9,7 @@ fn foo(x: Ty) -> Ty {
         Ty::List(elem) => foo(elem),
         //~^ ERROR mismatched types
         //~| HELP try dereferencing the `Box`
-        //~| HELP try using a variant of the expected enum
+        //~| HELP try wrapping
     }
 }
 

--- a/src/test/ui/suggestions/boxed-variant-field.stderr
+++ b/src/test/ui/suggestions/boxed-variant-field.stderr
@@ -10,10 +10,10 @@ help: try dereferencing the `Box`
    |
 LL |         Ty::List(elem) => foo(*elem),
    |                               +
-help: try using a variant of the expected enum
+help: try wrapping the expression in `Ty::List`
    |
 LL |         Ty::List(elem) => foo(Ty::List(elem)),
-   |                               ~~~~~~~~~~~~~~
+   |                               +++++++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-72766.stderr
+++ b/src/test/ui/suggestions/issue-72766.stderr
@@ -2,9 +2,9 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
   --> $DIR/issue-72766.rs:14:5
    |
 LL |     SadGirl {}.call()?;
-   |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future`
+   |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future`
+   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 note: required by `branch`
   --> $SRC_DIR/core/src/ops/try_trait.rs:LL:COL
    |

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -20,7 +20,7 @@ note: while checking the return type of the `async fn`
 LL |     pub async fn answer_str(&self, _s: &str) -> Test {
    |                                                 ^^^^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = Test>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -55,7 +55,7 @@ async fn async_different_futures() {
         //~| HELP consider `await`ing on both `Future`s
         false => async_dummy2(), //~ ERROR `match` arms have incompatible types
         //~^ NOTE expected opaque type, found a different opaque type
-        //~| NOTE expected type `impl Future`
+        //~| NOTE expected type `impl Future<Output = ()>`
         //~| NOTE distinct uses of `impl Trait` result in different opaque types
     };
 }

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -21,7 +21,7 @@ note: while checking the return type of the `async fn`
 LL | async fn async_dummy() {}
    |                        ^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |         false => async_dummy().await,
@@ -55,7 +55,7 @@ note: while checking the return type of the `async fn`
 LL | async fn async_dummy2() {}
    |                         ^ checked the `Output` of this `async fn`, found opaque type
    = note:     expected type `()`
-           found opaque type `impl Future`
+           found opaque type `impl Future<Output = ()>`
 help: consider `await`ing on the `Future`
    |
 LL |         false => async_dummy2().await,
@@ -74,7 +74,7 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _ = match true {
    |  _____________-
 LL | |         true => async_dummy(),
-   | |                 ------------- this is found to be of type `impl Future`
+   | |                 ------------- this is found to be of type `impl Future<Output = ()>`
 LL | |
 LL | |         false => async_dummy2(),
    | |                  ^^^^^^^^^^^^^^ expected opaque type, found a different opaque type
@@ -88,8 +88,8 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn async_dummy2() {}
    |                         ^ checked the `Output` of this `async fn`, found opaque type
-   = note:     expected type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
-           found opaque type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:19:25>)
+   = note:     expected type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
+           found opaque type `impl Future<Output = ()>` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:19:25>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |

--- a/src/test/ui/suggestions/opaque-type-error.stderr
+++ b/src/test/ui/suggestions/opaque-type-error.stderr
@@ -13,8 +13,8 @@ LL | |         thing_two()
 LL | |     }.await
    | |_____- `if` and `else` have incompatible types
    |
-   = note:     expected type `impl Future` (opaque type at <$DIR/opaque-type-error.rs:8:19>)
-           found opaque type `impl Future` (opaque type at <$DIR/opaque-type-error.rs:12:19>)
+   = note:     expected type `impl Future<Output = Result<(), ()>>` (opaque type at <$DIR/opaque-type-error.rs:8:19>)
+           found opaque type `impl Future<Output = Result<(), ()>>` (opaque type at <$DIR/opaque-type-error.rs:12:19>)
    = note: distinct uses of `impl Trait` result in different opaque types
 help: consider `await`ing on both `Future`s
    |

--- a/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.stderr
+++ b/src/test/ui/suggestions/suggest-full-enum-variant-for-local-module.stderr
@@ -2,14 +2,16 @@ error[E0308]: mismatched types
   --> $DIR/suggest-full-enum-variant-for-local-module.rs:9:28
    |
 LL |     let _: option::O<()> = ();
-   |            -------------   ^^
-   |            |               |
-   |            |               expected enum `O`, found `()`
-   |            |               help: try using a variant of the expected enum: `option::O::Some(())`
+   |            -------------   ^^ expected enum `O`, found `()`
+   |            |
    |            expected due to this
    |
    = note:   expected enum `O<()>`
            found unit type `()`
+help: try wrapping the expression in `option::O::Some`
+   |
+LL |     let _: option::O<()> = option::O::Some(());
+   |                            ++++++++++++++++  +
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/issue-46112.stderr
+++ b/src/test/ui/typeck/issue-46112.stderr
@@ -2,13 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/issue-46112.rs:9:21
    |
 LL | fn main() { test(Ok(())); }
-   |                     ^^
-   |                     |
-   |                     expected enum `Option`, found `()`
-   |                     help: try using a variant of the expected enum: `Some(())`
+   |                     ^^ expected enum `Option`, found `()`
    |
    = note:   expected enum `Option<()>`
            found unit type `()`
+help: try wrapping the expression in `Some`
+   |
+LL | fn main() { test(Ok(Some(()))); }
+   |                     +++++  +
 
 error: aborting due to previous error
 

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -266,6 +266,8 @@ pub fn check(path: &Path, bad: &mut bool) {
             contains_ignore_directive(can_contain, &contents, "end-whitespace");
         let mut skip_trailing_newlines =
             contains_ignore_directive(can_contain, &contents, "trailing-newlines");
+        let mut skip_leading_newlines =
+            contains_ignore_directive(can_contain, &contents, "leading-newlines");
         let mut skip_copyright = contains_ignore_directive(can_contain, &contents, "copyright");
         let mut leading_new_lines = false;
         let mut trailing_new_lines = 0;
@@ -350,7 +352,10 @@ pub fn check(path: &Path, bad: &mut bool) {
             }
         }
         if leading_new_lines {
-            tidy_error!(bad, "{}: leading newline", file.display());
+            let mut err = |_| {
+                tidy_error!(bad, "{}: leading newline", file.display());
+            };
+            suppressible_tidy_err!(err, skip_leading_newlines, "mising leading newline");
         }
         let mut err = |msg: &str| {
             tidy_error!(bad, "{}: {}", file.display(), msg);
@@ -394,6 +399,9 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
         if let Directive::Ignore(false) = skip_trailing_newlines {
             tidy_error!(bad, "{}: ignoring trailing newlines unnecessarily", file.display());
+        }
+        if let Directive::Ignore(false) = skip_leading_newlines {
+            tidy_error!(bad, "{}: ignoring leading newlines unnecessarily", file.display());
         }
         if let Directive::Ignore(false) = skip_copyright {
             tidy_error!(bad, "{}: ignoring copyright unnecessarily", file.display());


### PR DESCRIPTION
Successful merges:

 - #90575 (Improve suggestions for compatible variants on type mismatch.)
 - #90628 (Clarify error messages caused by re-exporting `pub(crate)` visibility to outside)
 - #90930 (Fix `non-constant value` ICE (#90878))
 - #90983 (Make scrollbar in the sidebar always visible for visual consistency)
 - #91021 (Elaborate `Future::Output` when printing opaque `impl Future` type)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90575,90628,90930,90983,91021)
<!-- homu-ignore:end -->