### PR TITLE
Implement `TryFrom<&'_ mut [T]>` for `[T; N]`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -176,6 +176,18 @@ where
     }
 }
 
+#[stable(feature = "try_from_mut_slice_to_array", since = "1.57.0")]
+impl<T, const N: usize> TryFrom<&mut [T]> for [T; N]
+where
+    T: Copy,
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(slice: &mut [T]) -> Result<[T; N], TryFromSliceError> {
+        <Self>::try_from(slice.as_ref())
+    }
+}
+
 #[stable(feature = "try_from", since = "1.34.0")]
 impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N] {
     type Error = TryFromSliceError;

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -176,7 +176,7 @@ where
     }
 }
 
-#[stable(feature = "try_from_mut_slice_to_array", since = "1.58.0")]
+#[stable(feature = "try_from_mut_slice_to_array", since = "1.59.0")]
 impl<T, const N: usize> TryFrom<&mut [T]> for [T; N]
 where
     T: Copy,

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -184,7 +184,7 @@ where
     type Error = TryFromSliceError;
 
     fn try_from(slice: &mut [T]) -> Result<[T; N], TryFromSliceError> {
-        <Self>::try_from(slice.as_ref())
+        <Self>::try_from(&*slice)
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -176,7 +176,7 @@ where
     }
 }
 
-#[stable(feature = "try_from_mut_slice_to_array", since = "1.57.0")]
+#[stable(feature = "try_from_mut_slice_to_array", since = "1.58.0")]
 impl<T, const N: usize> TryFrom<&mut [T]> for [T; N]
 where
     T: Copy,

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -28,11 +28,22 @@ fn array_try_from() {
         ($($N:expr)+) => {
             $({
                 type Array = [u8; $N];
-                let array: Array = [0; $N];
+                let mut array: Array = [0; $N];
                 let slice: &[u8] = &array[..];
 
                 let result = <&Array>::try_from(slice);
                 assert_eq!(&array, result.unwrap());
+
+                let result = <Array>::try_from(slice);
+                assert_eq!(&array, &result.unwrap());
+
+                let mut_slice: &mut [u8] = &mut array[..];
+                let result = <&mut Array>::try_from(mut_slice);
+                assert_eq!(&[0; $N], result.unwrap());
+
+                let mut_slice: &mut [u8] = &mut array[..];
+                let result = <Array>::try_from(mut_slice);
+                assert_eq!(&array, &result.unwrap());
             })+
         }
     }


### PR DESCRIPTION
Fixes #91085.