### PR TITLE
Revert "require full validity when determining the discriminant of a value"

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -265,12 +265,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             sym::discriminant_value => {
                 let place = self.deref_operand(&args[0])?;
-                if M::enforce_validity(self) {
-                    // This is 'using' the value, so make sure the validity invariant is satisfied.
-                    // (Also see https://github.com/rust-lang/rust/pull/89764.)
-                    self.validate_operand(&place.into())?;
-                }
-
                 let discr_val = self.read_discriminant(&place.into())?.0;
                 self.write_scalar(discr_val, dest)?;
             }

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -304,12 +304,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             Discriminant(place) => {
                 let op = self.eval_place_to_op(place, None)?;
-                if M::enforce_validity(self) {
-                    // This is 'using' the value, so make sure the validity invariant is satisfied.
-                    // (Also see https://github.com/rust-lang/rust/pull/89764.)
-                    self.validate_operand(&op)?;
-                }
-
                 let discr_val = self.read_discriminant(&op)?.0;
                 self.write_scalar(discr_val, &dest)?;
             }


### PR DESCRIPTION
This reverts commit 0a2b7d71d96a22126cce57f0dab5890d060f2259, reversing
changes made to 47c1bd1bcc50b25d133f8be3d49825491c1df249.
This caused several unforeseen problems:
- https://github.com/rust-lang/rust/issues/91029
- https://github.com/rust-lang/rust/pull/89764#issuecomment-973588007

So I think it's best to revert for now while we keep discussing the MIR semantics of getting a discriminant.

See https://github.com/rust-lang/rust/issues/91095 for the underlying semantic issue.

r? @oli-obk 