### PR TITLE
rustdoc: Skip headers in summaries

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1200,12 +1200,12 @@ fn markdown_summary_with_limit(
             Event::Start(tag) => match tag {
                 Tag::Emphasis => buf.open_tag("em"),
                 Tag::Strong => buf.open_tag("strong"),
-                Tag::CodeBlock(..) => return ControlFlow::BREAK,
+                Tag::Heading(..) | Tag::CodeBlock(..) => return ControlFlow::BREAK,
                 _ => {}
             },
             Event::End(tag) => match tag {
                 Tag::Emphasis | Tag::Strong => buf.close_tag(),
-                Tag::Paragraph | Tag::Heading(..) => return ControlFlow::BREAK,
+                Tag::Paragraph => return ControlFlow::BREAK,
                 _ => {}
             },
             Event::HardBreak | Event::SoftBreak => buf.push(" ")?,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1256,8 +1256,8 @@ crate fn plain_text_summary(md: &str) -> String {
             }
             Event::HardBreak | Event::SoftBreak => s.push(' '),
             Event::Start(Tag::CodeBlock(..)) => break,
+            Event::Start(Tag::Heading(..)) => break,
             Event::End(Tag::Paragraph) => break,
-            Event::End(Tag::Heading(..)) => break,
             _ => (),
         }
     }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -265,6 +265,7 @@ fn test_short_markdown_summary() {
     t("# top header", "");
     t("# top header\n\nfollowed by a paragraph", "");
     t("## header", "");
+    t("some *words*\n# Examples\n```let x = 42;```", "some <em>words</em>");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");
     t("<div>hello</div>", "");
@@ -294,6 +295,7 @@ fn test_plain_text_summary() {
     t("# top header", "");
     t("# top header\n\nfollowed by some text", "");
     t("## header", "");
+    t("some *words*\n# Examples\n```let x = 42;```", "some words");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");
     t("<div>hello</div>", "");

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -262,9 +262,9 @@ fn test_short_markdown_summary() {
          &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; &amp; \
          &amp; &amp; &amp; &amp; &amp; …",
     );
-    t("# top header", "top header");
-    t("# top header\n\nfollowed by a paragraph", "top header");
-    t("## header", "header");
+    t("# top header", "");
+    t("# top header\n\nfollowed by a paragraph", "");
+    t("## header", "");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");
     t("<div>hello</div>", "");

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -291,9 +291,9 @@ fn test_plain_text_summary() {
     t("dud [link]", "dud [link]");
     t("code `let x = i32;` ...", "code `let x = i32;` …");
     t("type `Type<'static>` ...", "type `Type<'static>` …");
-    t("# top header", "top header");
-    t("# top header\n\nfollowed by some text", "top header");
-    t("## header", "header");
+    t("# top header", "");
+    t("# top header\n\nfollowed by some text", "");
+    t("## header", "");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");
     t("<div>hello</div>", "");

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -5,7 +5,7 @@
 //! It should not show up in the description.
 
 // @has 'foo/index.html' '//meta[@name="description"]/@content' \
-//   'Description test crate'
+//   ''
 // @!has - '//meta[@name="description"]/@content' 'should not show up'
 
 // @has 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \


### PR DESCRIPTION
Fixes #91077.

Before, docs like this:

    # Panics

    Panics if ...

would be summarized as this:

    Panics

which is confusing. In general, doc headers don't act as a summary, so
showing just them isn't very useful.

Now, no summary will be shown for the example above.