### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -265,12 +265,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             sym::discriminant_value => {
                 let place = self.deref_operand(&args[0])?;
-                if M::enforce_validity(self) {
-                    // This is 'using' the value, so make sure the validity invariant is satisfied.
-                    // (Also see https://github.com/rust-lang/rust/pull/89764.)
-                    self.validate_operand(&place.into())?;
-                }
-
                 let discr_val = self.read_discriminant(&place.into())?.0;
                 self.write_scalar(discr_val, dest)?;
             }

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -304,12 +304,6 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             Discriminant(place) => {
                 let op = self.eval_place_to_op(place, None)?;
-                if M::enforce_validity(self) {
-                    // This is 'using' the value, so make sure the validity invariant is satisfied.
-                    // (Also see https://github.com/rust-lang/rust/pull/89764.)
-                    self.validate_operand(&op)?;
-                }
-
                 let discr_val = self.read_discriminant(&op)?.0;
                 self.write_scalar(discr_val, &dest)?;
             }

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1606,13 +1606,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // encounter a candidate where the test is not relevant; at
         // that point, we stop sorting.
         while let Some(candidate) = candidates.first_mut() {
-            if let Some(idx) = self.sort_candidate(&match_place.clone(), &test, candidate) {
-                let (candidate, rest) = candidates.split_first_mut().unwrap();
-                target_candidates[idx].push(candidate);
-                candidates = rest;
-            } else {
+            let Some(idx) = self.sort_candidate(&match_place.clone(), &test, candidate) else {
                 break;
-            }
+            };
+            let (candidate, rest) = candidates.split_first_mut().unwrap();
+            target_candidates[idx].push(candidate);
+            candidates = rest;
         }
         // at least the first candidate ought to be tested
         assert!(total_candidate_count > candidates.len());

--- a/src/test/ui/async-await/suggest-missing-await.rs
+++ b/src/test/ui/async-await/suggest-missing-await.rs
@@ -54,4 +54,21 @@ async fn suggest_await_on_match_expr() {
     };
 }
 
+async fn dummy_result() -> Result<(), ()> {
+    Ok(())
+}
+
+#[allow(unused)]
+async fn suggest_await_in_generic_pattern() {
+    match dummy_result() {
+        //~^ HELP consider `await`ing on the `Future`
+        //~| HELP consider `await`ing on the `Future`
+        //~| SUGGESTION .await
+        Ok(_) => {}
+        //~^ ERROR mismatched types [E0308]
+        Err(_) => {}
+        //~^ ERROR mismatched types [E0308]
+    }
+}
+
 fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -117,7 +117,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy_result() -> Result<(), ()> {
    |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = Result<(), ()>>`
                      found enum `Result<_, _>`
 help: consider `await`ing on the `Future`
    |
@@ -135,7 +135,7 @@ note: while checking the return type of the `async fn`
    |
 LL | async fn dummy_result() -> Result<(), ()> {
    |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
-   = note: expected opaque type `impl Future`
+   = note: expected opaque type `impl Future<Output = Result<(), ()>>`
                      found enum `Result<_, _>`
 help: consider `await`ing on the `Future`
    |

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -106,6 +106,42 @@ help: consider `await`ing on the `Future`
 LL |     let _x = match dummy().await {
    |                           ++++++
 
-error: aborting due to 5 previous errors
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await.rs:67:9
+   |
+LL |         Ok(_) => {}
+   |         ^^^^^ expected opaque type, found enum `Result`
+   |
+note: while checking the return type of the `async fn`
+  --> $DIR/suggest-missing-await.rs:57:28
+   |
+LL | async fn dummy_result() -> Result<(), ()> {
+   |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
+   = note: expected opaque type `impl Future`
+                     found enum `Result<_, _>`
+help: consider `await`ing on the `Future`
+   |
+LL |     match dummy_result().await {
+   |                         ++++++
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await.rs:69:9
+   |
+LL |         Err(_) => {}
+   |         ^^^^^^ expected opaque type, found enum `Result`
+   |
+note: while checking the return type of the `async fn`
+  --> $DIR/suggest-missing-await.rs:57:28
+   |
+LL | async fn dummy_result() -> Result<(), ()> {
+   |                            ^^^^^^^^^^^^^^ checked the `Output` of this `async fn`, expected opaque type
+   = note: expected opaque type `impl Future`
+                     found enum `Result<_, _>`
+help: consider `await`ing on the `Future`
+   |
+LL |     match dummy_result().await {
+   |                         ++++++
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #89741 (Mark `Arc::from_inner` / `Rc::from_inner` as unsafe)
 - #91018 (Adopt let_else in more places in rustc_mir_build)
 - #91022 (Suggest `await` in more situations where infer types are involved)
 - #91088 (Revert "require full validity when determining the discriminant of a value")

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89741,91018,91022,91088)
<!-- homu-ignore:end -->