### PR TITLE
Stabilize `ControlFlow::{is_break, is_continue}`

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -136,7 +136,7 @@ impl<B, C> ControlFlow<B, C> {
     /// assert!(!ControlFlow::<String, i32>::Continue(3).is_break());
     /// ```
     #[inline]
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
     pub fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
@@ -153,7 +153,7 @@ impl<B, C> ControlFlow<B, C> {
     /// assert!(ControlFlow::<String, i32>::Continue(3).is_continue());
     /// ```
     #[inline]
-    #[unstable(feature = "control_flow_enum", reason = "new API", issue = "75744")]
+    #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
     pub fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }


### PR DESCRIPTION
The type itself was stabilized in 1.55, but using it is not ergonomic without these helper functions. Stabilize them.

r? rust-lang/libs-api 