### PR TITLE
Mention std::io::Error::from(ErrorKind) in Error::new() docs

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -392,6 +392,9 @@ impl Error {
     /// originate from the OS itself. The `error` argument is an arbitrary
     /// payload which will be contained in this [`Error`].
     ///
+    /// If no extra payload is required, use the `From` conversion from
+    /// `ErrorKind`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -402,6 +405,9 @@ impl Error {
     ///
     /// // errors can also be created from other errors
     /// let custom_error2 = Error::new(ErrorKind::Interrupted, custom_error);
+    ///
+    /// // creating an error without payload
+    /// let eof_error = Error::from(ErrorKind::UnexpectedEof);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new<E>(kind: ErrorKind, error: E) -> Error


### PR DESCRIPTION
This conversion is not very discoverable for the cases
where an error is required without extra payload.