### PR TITLE
Set color for <a> in a more straightforward way.

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1079,10 +1079,6 @@ a.test-arrow:hover{
 	text-decoration: none;
 }
 
-.section-header a {
-	color: inherit;
-}
-
 .code-attribute {
 	font-weight: 300;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -214,16 +214,21 @@ nav.main .separator {
 	border: 1px solid #5c6773;
 }
 a {
+	color: #39AFD7;
+}
+a.srclink,
+a#toggle-all-docs,
+#source-sidebar a,
+pre.rust a,
+.sidebar a,
+.in-band a {
 	color: #c5c5c5;
+}
+.search-results a {
+	color: #0096cf;
 }
 body.source .example-wrap pre.rust a {
 	background: #333;
-}
-
-.docblock:not(.item-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
-#help a {
-	color: #39AFD7;
 }
 
 details.rustdoc-toggle > summary.hideme > span,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -174,21 +174,26 @@ nav.main .current {
 nav.main .separator {
 	border-color: #eee;
 }
+
 a {
+	color: #D2991D;
+}
+a.srclink,
+a#toggle-all-docs,
+#source-sidebar a,
+pre.rust a,
+.sidebar a,
+.in-band a {
 	color: #ddd;
+}
+.search-results a {
+	color: #ddd;
+}
+a.test-arrow {
+	color: #dedede;
 }
 body.source .example-wrap pre.rust a {
 	background: #333;
-}
-
-.docblock:not(.item-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
-#help a {
-	color: #D2991D;
-}
-
-a.test-arrow {
-	color: #dedede;
 }
 
 details.rustdoc-toggle > summary.hideme > span,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -169,21 +169,26 @@ nav.main .current {
 nav.main .separator {
 	border: 1px solid #000;
 }
+
 a {
+	color: #3873AD;
+}
+a.srclink,
+a#toggle-all-docs,
+#source-sidebar a,
+pre.rust a,
+.sidebar a,
+.in-band a {
 	color: #000;
+}
+.search-results a {
+	color: initial;
+}
+a.test-arrow {
+	color: #f5f5f5;
 }
 body.source .example-wrap pre.rust a {
 	background: #eee;
-}
-
-.docblock:not(.item-decl) a:not(.srclink):not(.test-arrow),
-.docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
-#help a {
-	color: #3873AD;
-}
-
-a.test-arrow {
-	color: #f5f5f5;
 }
 
 details.rustdoc-toggle > summary.hideme > span,

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -1,0 +1,17 @@
+goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+
+// Set the theme to light.
+local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
+// We reload the page so the local storage settings are being used.
+reload:
+
+assert-css: ("#toggle-all-docs", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".srclink", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".srclink", {"color": "rgba(0, 0, 0, 0)"})
+
+assert-css: ("#top-doc-prose-title", {"color": "rgba(0, 0, 0, 0)"})
+
+assert-css: (".sidebar a", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".in-band a", {"color": "rgba(0, 0, 0, 0)"})

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -194,7 +194,7 @@ async function main(argv) {
             .then(out => {
                 const [output, nb_failures] = out;
                 results[nb_failures === 0 ? "successful" : "failed"].push({
-                    file_name: file_name,
+                    file_name: testPath,
                     output: output,
                 });
                 if (nb_failures > 0) {
@@ -206,7 +206,7 @@ async function main(argv) {
             })
             .catch(err => {
                 results.errored.push({
-                    file_name: file_name,
+                    file_name: testPath + file_name,
                     output: err,
                 });
                 status_bar.erroneous();
@@ -239,7 +239,7 @@ async function main(argv) {
         console.log("");
         results.failed.sort(by_filename);
         results.failed.forEach(r => {
-            console.log(r.output);
+            console.log(r.file_name, r.output);
         });
     }
     if (results.errored.length > 0) {
@@ -247,7 +247,7 @@ async function main(argv) {
         // print run errors on the bottom so developers see them better
         results.errored.sort(by_filename);
         results.errored.forEach(r => {
-            console.error(r.output);
+            console.error(r.file_name, r.output);
         });
     }
 


### PR DESCRIPTION
Previously, we set the default color for <a> tags to black, and then had an override with a bunch of not() clauses to set anchors in
docblocks to blue.

Instead, we should set the default color for <a> to blue (or equivalent in other themes), and override it for places like the sidebar or search results, where we don't want them to be styled as links.

Demo at https://rustdoc.crud.net/jsha/theme-anchor/std/string/struct.String.html. This should result in no visible changes.

r? @GuillaumeGomez 