### PR TITLE
Inhibit clicks on summary's children

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -891,7 +891,7 @@ function hideThemeButtonState() {
             if (e.target.tagName != "SUMMARY") {
                 e.preventDefault();
             }
-        })
+        });
     });
 
     onEachLazy(document.getElementsByClassName("notable-traits"), function(e) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -886,6 +886,14 @@ function hideThemeButtonState() {
         }
     });
 
+    onEachLazy(document.querySelectorAll(".rustdoc-toggle > summary:not(.hideme)"), function(el) {
+        el.addEventListener("click", function(e) {
+            if (e.target.tagName != "SUMMARY") {
+                e.preventDefault();
+            }
+        })
+    });
+
     onEachLazy(document.getElementsByClassName("notable-traits"), function(e) {
         e.onclick = function() {
             this.getElementsByClassName('notable-traits-tooltiptext')[0]

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -22,6 +22,8 @@ pub struct Foo {
 }
 
 impl Foo {
+    /// Some documentation
+    /// # A Heading
     pub fn a_method(&self) {}
 }
 

--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -1,0 +1,8 @@
+// This test ensures that clicking on a method summary, but not on the "[-]",
+// doesn't toggle the <details>.
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
+click: "h4.code-header" // This is the position of "pub" in "pub fn a_method"
+assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
+click: ".impl-items .rustdoc-toggle summary::before" // This is the position of "[-]" next to that pub fn.
+assert-attribute-false: (".impl-items .rustdoc-toggle", {"open": ""})


### PR DESCRIPTION
A byproduct of using `<details>` and `<summary>` to show/hide detailed documentation was that clicking any part of a method heading (or impl heading) would show or hide the documentation. This was not super noticeable because clicking a link inside the method heading would navigate to that link. But clicking any unlinked black text in a method heading would trigger the behavior.

That behavior was somewhat unexpected, and means that if you try to click a type name in a method heading, but miss by a few pixels, you get a confusing surprise.

This change inhibits that behavior by putting an event listener on most summaries that cancels the event unless the event target was the summary itself. In practice, that means it cancels the event unless the target was the "[+]" / "[-]", because the rest of the heading is wrapped inside a `<div>`, which is the target for anything that doesn't have a more specific target.

r? @Manishearth 