### PR TITLE
Do not visit attributes in `ItemLowerer`.

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -40,6 +40,11 @@ impl ItemLowerer<'_, '_, '_> {
 }
 
 impl<'a> Visitor<'a> for ItemLowerer<'a, '_, '_> {
+    fn visit_attribute(&mut self, _: &'a Attribute) {
+        // We do not want to lower expressions that appear in attributes,
+        // as they are not accessible to the rest of the HIR.
+    }
+
     fn visit_item(&mut self, item: &'a Item) {
         let hir_id = self.lctx.with_hir_id_owner(item.id, |lctx| {
             let node = lctx.without_in_scope_lifetime_defs(|lctx| lctx.lower_item(item));

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -431,6 +431,10 @@ struct LateResolutionVisitor<'a, 'b, 'ast> {
 
 /// Walks the whole crate in DFS order, visiting each item, resolving names as it goes.
 impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
+    fn visit_attribute(&mut self, _: &'ast Attribute) {
+        // We do not want to resolve expressions that appear in attributes,
+        // as they do not correspond to actual code.
+    }
     fn visit_item(&mut self, item: &'ast Item) {
         let prev = replace(&mut self.diagnostic_metadata.current_item, Some(item));
         // Always report errors in items we just entered.

--- a/src/test/ui/attributes/issue-90873.rs
+++ b/src/test/ui/attributes/issue-90873.rs
@@ -1,0 +1,5 @@
+#![u=||{static d=||1;}]
+//~^ unexpected token
+//~| cannot find attribute `u` in this scope
+//~| `main` function not found in crate `issue_90873`
+//~| missing type for `static` item

--- a/src/test/ui/attributes/issue-90873.rs
+++ b/src/test/ui/attributes/issue-90873.rs
@@ -3,3 +3,7 @@
 //~| cannot find attribute `u` in this scope
 //~| `main` function not found in crate `issue_90873`
 //~| missing type for `static` item
+
+#![a={impl std::ops::Neg for i8 {}}]
+//~^ ERROR unexpected token
+//~| ERROR cannot find attribute `a` in this scope

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -1,0 +1,30 @@
+error: unexpected token: `||
+           {
+               static d: _ = || 1;
+           }`
+  --> $DIR/issue-90873.rs:1:6
+   |
+LL | #![u=||{static d=||1;}]
+   |      ^^^^^^^^^^^^^^^^^
+
+error: cannot find attribute `u` in this scope
+  --> $DIR/issue-90873.rs:1:4
+   |
+LL | #![u=||{static d=||1;}]
+   |    ^
+
+error[E0601]: `main` function not found in crate `issue_90873`
+  --> $DIR/issue-90873.rs:1:1
+   |
+LL | #![u=||{static d=||1;}]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/issue-90873.rs`
+
+error: missing type for `static` item
+  --> $DIR/issue-90873.rs:1:16
+   |
+LL | #![u=||{static d=||1;}]
+   |                ^ help: provide a type for the item: `d: <type>`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -7,17 +7,37 @@ error: unexpected token: `||
 LL | #![u=||{static d=||1;}]
    |      ^^^^^^^^^^^^^^^^^
 
+error: unexpected token: `{
+           impl std::ops::Neg for i8 { }
+       }`
+  --> $DIR/issue-90873.rs:7:6
+   |
+LL | #![a={impl std::ops::Neg for i8 {}}]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: cannot find attribute `u` in this scope
   --> $DIR/issue-90873.rs:1:4
    |
 LL | #![u=||{static d=||1;}]
    |    ^
 
+error: cannot find attribute `a` in this scope
+  --> $DIR/issue-90873.rs:7:4
+   |
+LL | #![a={impl std::ops::Neg for i8 {}}]
+   |    ^
+
 error[E0601]: `main` function not found in crate `issue_90873`
   --> $DIR/issue-90873.rs:1:1
    |
-LL | #![u=||{static d=||1;}]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/issue-90873.rs`
+LL | / #![u=||{static d=||1;}]
+LL | |
+LL | |
+LL | |
+LL | |
+LL | |
+LL | | #![a={impl std::ops::Neg for i8 {}}]
+   | |____________________________________^ consider adding a `main` function to `$DIR/issue-90873.rs`
 
 error: missing type for `static` item
   --> $DIR/issue-90873.rs:1:16
@@ -25,6 +45,6 @@ error: missing type for `static` item
 LL | #![u=||{static d=||1;}]
    |                ^ help: provide a type for the item: `d: <type>`
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/consts/issue-90878-2.rs
+++ b/src/test/ui/consts/issue-90878-2.rs
@@ -1,7 +1,5 @@
  #![l=|x|[b;x ]] //~ ERROR unexpected token: `|x| [b; x]`
 //~^ ERROR cannot find attribute `l` in this scope
-//~^^ ERROR attempt to use a non-constant value in a constant [E0435]
-//~^^^ ERROR cannot find value `b` in this scope [E0425]
 
 // notice the space at the start,
 // we can't attach any attributes to this file because it needs to be at the start

--- a/src/test/ui/consts/issue-90878-2.stderr
+++ b/src/test/ui/consts/issue-90878-2.stderr
@@ -10,21 +10,5 @@ error: cannot find attribute `l` in this scope
 LL |  #![l=|x|[b;x ]]
    |     ^
 
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/issue-90878-2.rs:1:13
-   |
-LL |  #![l=|x|[b;x ]]
-   |        -    ^
-   |        |
-   |        this would need to be a `const`
+error: aborting due to 2 previous errors
 
-error[E0425]: cannot find value `b` in this scope
-  --> $DIR/issue-90878-2.rs:1:11
-   |
-LL |  #![l=|x|[b;x ]]
-   |           ^ help: a local variable with a similar name exists: `x`
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0425, E0435.
-For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
By default, AST visitors visit expressions that appear in key-value attributes.
Those expressions should not be lowered to HIR, as they do not correspond to actually compiled code.

Since an attribute cannot produce meaningful HIR, just skip them altogether.

Fixes https://github.com/rust-lang/rust/issues/81886
Fixes https://github.com/rust-lang/rust/issues/90873
r? @michaelwoerister 