### PR TITLE
Improve `unsafe` diagnostic

### DIFF
--- a/src/test/ui/parser/issues/issue-19398.stderr
+++ b/src/test/ui/parser/issues/issue-19398.stderr
@@ -4,10 +4,15 @@ error: expected `{`, found keyword `unsafe`
 LL | trait T {
    |         - while parsing this item list starting here
 LL |     extern "Rust" unsafe fn foo();
-   |                   ^^^^^^ expected `{`
+   |     --------------^^^^^^
+   |     |             |
+   |     |             expected `{`
+   |     help: `unsafe` must come before `extern "Rust"`: `unsafe extern "Rust"`
 LL |
 LL | }
    | - the item list ends here
+   |
+   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This fixes: https://github.com/rust-lang/rust/issues/90880
I didn't use the exact proposed messages though.