### PR TITLE
Give people a single link they can click in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,14 @@
 Thank you for your interest in contributing to Rust! There are many ways to contribute
 and we appreciate all of them.
 
+The best way to get started is by asking for help in the [#new
+members](https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members)
+Zulip stream. We have lots of docs below of how to get started on your own, but
+the Zulip stream is the best place to *ask* for help.
+
 Documentation for contributing to Rust is located in the [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org/),
 commonly known as the [rustc-dev-guide]. Despite the name, this guide documents
-not just how to develop rustc (the Rust compiler), but also how to contribute to any part
-of the Rust project.
-
-To get started with contributing, please read the [Contributing to Rust] chapter of the guide.
-That chapter explains how to get your development environment set up and how to get help.
+not just how to develop rustc (the Rust compiler), but also how to contribute to the standard library and rustdoc.
 
 ## About the [rustc-dev-guide]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ standard library, and documentation.
 
 **Note: this README is for _users_ rather than _contributors_.
 If you wish to _contribute_ to the compiler, you should read the
-[Getting Started][gettingstarted] section of the rustc-dev-guide instead.**
+[Getting Started][gettingstarted] section of the rustc-dev-guide instead.
+You can ask for help in the [#new members Zulip stream][new-members].**
+
+[new-members]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members
 
 ## Quick Start
 


### PR DESCRIPTION
Doc Jones mentioned that one of the things making it hard to get started
is that the amount of information is overwhelming, between the
dev-guide, contributing guide, and discussion platforms. This gives
people a single link they can click to ask for help.

cc @doc-jones - is this what you had in mind?