### PR TITLE
Split inline const to two feature gates and mark expression position inline const complete

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -719,6 +719,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(const_trait_impl, "const trait impls are experimental");
     gate_all!(half_open_range_patterns, "half-open range patterns are unstable");
     gate_all!(inline_const, "inline-const is experimental");
+    gate_all!(inline_const_pat, "inline-const in pattern position is experimental");
     gate_all!(
         const_generics_defaults,
         "default values for const generic parameters are experimental"

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -410,6 +410,8 @@ declare_features! (
     (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
     /// Allow anonymous constants from an inline `const` block
     (incomplete, inline_const, "1.49.0", Some(76001), None),
+    /// Allow anonymous constants from an inline `const` block in pattern position
+    (incomplete, inline_const_pat, "1.58.0", Some(76001), None),
     /// Allows using `pointer` and `reference` in intra-doc links
     (active, intra_doc_pointers, "1.51.0", Some(80896), None),
     /// Allows `#[instruction_set(_)]` attribute

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -409,7 +409,7 @@ declare_features! (
     /// Allows associated types in inherent impls.
     (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
     /// Allow anonymous constants from an inline `const` block
-    (incomplete, inline_const, "1.49.0", Some(76001), None),
+    (active, inline_const, "1.49.0", Some(76001), None),
     /// Allow anonymous constants from an inline `const` block in pattern position
     (incomplete, inline_const_pat, "1.58.0", Some(76001), None),
     /// Allows using `pointer` and `reference` in intra-doc links

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1243,7 +1243,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Unsafe) {
             self.parse_block_expr(None, lo, BlockCheckMode::Unsafe(ast::UserProvided), attrs)
         } else if self.check_inline_const(0) {
-            self.parse_const_block(lo.to(self.token.span))
+            self.parse_const_block(lo.to(self.token.span), false)
         } else if self.is_do_catch_block() {
             self.recover_do_catch(attrs)
         } else if self.is_try_block() {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1095,8 +1095,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses inline const expressions.
-    fn parse_const_block(&mut self, span: Span) -> PResult<'a, P<Expr>> {
-        self.sess.gated_spans.gate(sym::inline_const, span);
+    fn parse_const_block(&mut self, span: Span, pat: bool) -> PResult<'a, P<Expr>> {
+        if pat {
+            self.sess.gated_spans.gate(sym::inline_const_pat, span);
+        } else {
+            self.sess.gated_spans.gate(sym::inline_const, span);
+        }
         self.eat_keyword(kw::Const);
         let blk = self.parse_block()?;
         let anon_const = AnonConst {

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -437,7 +437,7 @@ impl<'a> Parser<'a> {
             PatKind::Box(pat)
         } else if self.check_inline_const(0) {
             // Parse `const pat`
-            let const_expr = self.parse_const_block(lo.to(self.token.span))?;
+            let const_expr = self.parse_const_block(lo.to(self.token.span), true)?;
 
             if let Some(re) = self.parse_range_end() {
                 self.parse_pat_range_begin_with(const_expr, re)?
@@ -884,7 +884,7 @@ impl<'a> Parser<'a> {
 
     fn parse_pat_range_end(&mut self) -> PResult<'a, P<Expr>> {
         if self.check_inline_const(0) {
-            self.parse_const_block(self.token.span)
+            self.parse_const_block(self.token.span, true)
         } else if self.check_path() {
             let lo = self.token.span;
             let (qself, path) = if self.eat_lt() {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -731,6 +731,7 @@ symbols! {
         inlateout,
         inline,
         inline_const,
+        inline_const_pat,
         inout,
         instruction_set,
         intel,

--- a/src/doc/unstable-book/src/language-features/inline-const-pat.md
+++ b/src/doc/unstable-book/src/language-features/inline-const-pat.md
@@ -1,0 +1,24 @@
+# `inline_const_pat`
+
+The tracking issue for this feature is: [#76001]
+
+See also [`inline_const`](inline-const.md)
+
+------
+
+This feature allows you to use inline constant expressions in pattern position:
+
+```rust
+#![feature(inline_const_pat)]
+
+const fn one() -> i32 { 1 }
+
+let some_int = 3;
+match some_int {
+    const { 1 + 2 } => println!("Matched 1 + 2"),
+    const { one() } => println!("Matched const fn returning 1"),
+    _ => println!("Didn't match anything :("),
+}
+```
+
+[#76001]: https://github.com/rust-lang/rust/issues/76001

--- a/src/doc/unstable-book/src/language-features/inline-const.md
+++ b/src/doc/unstable-book/src/language-features/inline-const.md
@@ -2,6 +2,8 @@
 
 The tracking issue for this feature is: [#76001]
 
+See also [`inline_const_pat`](inline-const-pat.md)
+
 ------
 
 This feature allows you to use inline constant expressions. For example, you can
@@ -24,21 +26,6 @@ into this code:
 # fn add_one(x: i32) -> i32 { x + 1 }
 fn main() {
     let x = add_one(const { 1 + 2 * 3 / 4 });
-}
-```
-
-You can also use inline constant expressions in patterns:
-
-```rust
-#![feature(inline_const)]
-
-const fn one() -> i32 { 1 }
-
-let some_int = 3;
-match some_int {
-    const { 1 + 2 } => println!("Matched 1 + 2"),
-    const { one() } => println!("Matched const fn returning 1"),
-    _ => println!("Didn't match anything :("),
 }
 ```
 

--- a/src/test/ui/consts/closure-structural-match-issue-90013.rs
+++ b/src/test/ui/consts/closure-structural-match-issue-90013.rs
@@ -1,6 +1,5 @@
 // Regression test for issue 90013.
 // check-pass
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 fn main() {

--- a/src/test/ui/consts/const-blocks/fn-call-in-const.rs
+++ b/src/test/ui/consts/const-blocks/fn-call-in-const.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(inline_const)]
-#![allow(unused, incomplete_features)]
+#![allow(unused)]
 
 // Some type that is not copyable.
 struct Bar;

--- a/src/test/ui/feature-gates/feature-gate-inline_const_pat.rs
+++ b/src/test/ui/feature-gates/feature-gate-inline_const_pat.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let const { () } = ();
+    //~^ ERROR inline-const in pattern position is experimental [E0658]
+}

--- a/src/test/ui/feature-gates/feature-gate-inline_const_pat.stderr
+++ b/src/test/ui/feature-gates/feature-gate-inline_const_pat.stderr
@@ -1,0 +1,12 @@
+error[E0658]: inline-const in pattern position is experimental
+  --> $DIR/feature-gate-inline_const_pat.rs:2:9
+   |
+LL |     let const { () } = ();
+   |         ^^^^^
+   |
+   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
+   = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions0.rs
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions0.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![feature(exclusive_range_pattern)]
 #![feature(half_open_range_patterns)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 fn main() {
     let mut if_lettable = vec![];

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions3.rs
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions3.rs
@@ -12,7 +12,7 @@ fn main() {
             y @ (0..5 | 6) => or_two.push(y),
             //~^ exclusive range pattern syntax is experimental
             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
-            //~^ inline-const is experimental
+            //~^ inline-const in pattern position is experimental
             //~| exclusive range pattern syntax is experimental
             y @ -5.. => range_from.push(y),
             y @ ..-7 => assert_eq!(y, -8),

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions3.stderr
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions3.stderr
@@ -7,14 +7,14 @@ LL |             y @ ..-7 => assert_eq!(y, -8),
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
-error[E0658]: inline-const is experimental
+error[E0658]: inline-const in pattern position is experimental
   --> $DIR/range_pat_interactions3.rs:14:20
    |
 LL |             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
    |                    ^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
-   = help: add `#![feature(inline_const)]` to the crate attributes to enable
+   = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:10:17

--- a/src/test/ui/inline-const/const-expr-array-init.rs
+++ b/src/test/ui/inline-const/const-expr-array-init.rs
@@ -1,6 +1,5 @@
 // build-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 use std::cell::Cell;

--- a/src/test/ui/inline-const/const-expr-basic.rs
+++ b/src/test/ui/inline-const/const-expr-basic.rs
@@ -1,7 +1,7 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
+
 fn foo() -> i32 {
     const {
         let x = 5 + 10;

--- a/src/test/ui/inline-const/const-expr-inference.rs
+++ b/src/test/ui/inline-const/const-expr-inference.rs
@@ -1,7 +1,6 @@
 // check-pass
 
 #![feature(inline_const)]
-#![allow(incomplete_features)]
 
 pub fn todo<T>() -> T {
     const { todo!() }

--- a/src/test/ui/inline-const/const-expr-lifetime-err.rs
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 

--- a/src/test/ui/inline-const/const-expr-lifetime-err.stderr
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/const-expr-lifetime-err.rs:24:30
+  --> $DIR/const-expr-lifetime-err.rs:23:30
    |
 LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/inline-const/const-expr-lifetime.rs
+++ b/src/test/ui/inline-const/const-expr-lifetime.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 

--- a/src/test/ui/inline-const/const-expr-macro.rs
+++ b/src/test/ui/inline-const/const-expr-macro.rs
@@ -1,7 +1,7 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
+
 macro_rules! do_const_block{
     ($val:block) => { const $val }
 }

--- a/src/test/ui/inline-const/const-expr-reference.rs
+++ b/src/test/ui/inline-const/const-expr-reference.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 const fn bar() -> i32 {

--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 

--- a/src/test/ui/inline-const/const-match-pat-inference.rs
+++ b/src/test/ui/inline-const/const-match-pat-inference.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 #![allow(incomplete_features)]
 
 fn main() {

--- a/src/test/ui/inline-const/const-match-pat-lifetime-err.rs
+++ b/src/test/ui/inline-const/const-match-pat-lifetime-err.rs
@@ -2,7 +2,7 @@
 
 #![allow(incomplete_features)]
 #![feature(const_mut_refs)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/inline-const/const-match-pat-lifetime.rs
+++ b/src/test/ui/inline-const/const-match-pat-lifetime.rs
@@ -3,6 +3,7 @@
 #![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/inline-const/const-match-pat-range.rs
+++ b/src/test/ui/inline-const/const-match-pat-range.rs
@@ -1,7 +1,7 @@
 // build-pass
 
 #![allow(incomplete_features)]
-#![feature(inline_const, half_open_range_patterns, exclusive_range_pattern)]
+#![feature(inline_const_pat, half_open_range_patterns, exclusive_range_pattern)]
 fn main() {
     const N: u32 = 10;
     let x: u32 = 3;

--- a/src/test/ui/inline-const/const-match-pat.rs
+++ b/src/test/ui/inline-const/const-match-pat.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![allow(incomplete_features)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 const MMIO_BIT1: u8 = 4;
 const MMIO_BIT2: u8 = 5;
 

--- a/src/test/ui/lint/dead-code/anon-const-in-pat.rs
+++ b/src/test/ui/lint/dead-code/anon-const-in-pat.rs
@@ -1,5 +1,5 @@
 // check-pass
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 #![allow(incomplete_features)]
 #![deny(dead_code)]
 

--- a/src/test/ui/pattern/non-structural-match-types.rs
+++ b/src/test/ui/pattern/non-structural-match-types.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![allow(unreachable_code)]
 #![feature(const_async_blocks)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 fn main() {
     match loop {} {

--- a/src/test/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/src/test/ui/simd/intrinsic/generic-elements-pass.rs
@@ -2,7 +2,6 @@
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
 
 #![feature(repr_simd, platform_intrinsics)]
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 #[repr(simd)]


### PR DESCRIPTION
This PR splits inline const in pattern position into its own `#![feature(inline_const_pat)]` feature gate, and make the usage in expression position complete.

I think I have resolved most outstanding issues related to `inline_const` with #89561 and other PRs. The only thing left that I am aware of is #90150 and the lack of lifetime checks when inline const is used in pattern position (FIXME in #89561). Implementation-wise when used in pattern position it has to be lowered during MIR building while in expression position it's evaluated only when monomorphizing (just like normal consts), so it makes some sense to separate it into two feature gates so one can progress without being blocked by another.

@rustbot label: T-compiler F-inline_const