### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
+checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
 dependencies = [
  "curl-sys",
  "libc",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.50+curl-7.79.1"
+version = "0.4.51+curl-7.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
+checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
7 commits in ad50d0d266213e0cc4f6e526a39d96faae9a3842..e1fb17631eb1b3665cdbe45b1c186111577ef512
2021-11-17 18:36:37 +0000 to 2021-11-22 16:53:06 +0000
- re-enable lto_build test on 32-bit MSVC (rust-lang/cargo#10110)
- Fix a couple issues with cyclic features and dev-dependencies (rust-lang/cargo#10103)
- Add --message-format for install command (rust-lang/cargo#10107)
- Update curl dependency, remove M1 macOS build error note (rust-lang/cargo#10106)
- Make clippy happy (rust-lang/cargo#10105)
- Give a hard error if `-Zrustdoc-scrape-examples` is missing a flag (rust-lang/cargo#10043)
- silly fix, pointer to the empty slice (rust-lang/cargo#10097)