### PR TITLE
fix(doctest): detect extern crate items in statement doctests

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1121,7 +1121,7 @@ impl<'a> Parser<'a> {
         Ok(P(T::recovered(Some(QSelf { ty, path_span, position: 0 }), path)))
     }
 
-    pub(super) fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
+    pub fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
         if self.eat(&token::Semi) {
             let mut err = self.struct_span_err(self.prev_token.span, "expected item, found `;`");
             err.span_suggestion_short(

--- a/src/test/rustdoc-ui/auxiliary/empty-fn.rs
+++ b/src/test/rustdoc-ui/auxiliary/empty-fn.rs
@@ -1,0 +1,3 @@
+// no-prefer-dynamic
+#![crate_type = "lib"]
+pub fn empty() {}

--- a/src/test/rustdoc-ui/issue-91134.rs
+++ b/src/test/rustdoc-ui/issue-91134.rs
@@ -1,0 +1,14 @@
+// compile-flags: --test --crate-name=empty_fn --extern=empty_fn --test-args=--test-threads=1
+// aux-build:empty-fn.rs
+// check-pass
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// edition:2021
+
+/// <https://github.com/rust-lang/rust/issues/91134>
+///
+/// ```
+/// extern crate empty_fn;
+/// empty_fn::empty();
+/// ```
+pub struct Something;

--- a/src/test/rustdoc-ui/issue-91134.stdout
+++ b/src/test/rustdoc-ui/issue-91134.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/issue-91134.rs - something (line 10) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/src/test/rustdoc-ui/issue-91134.stdout
+++ b/src/test/rustdoc-ui/issue-91134.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/issue-91134.rs - something (line 10) ... ok
+test $DIR/issue-91134.rs - Something (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 


### PR DESCRIPTION
This partially reverts #91026, because rustdoc needs to detect the extern statements, even when they appear inside implicit `main()`. It does not entirely revert it, so the old bug is still fixed, by duplicating some of the logic from `parse_mod` instead of trying to use it directly.

Fixes #91134