### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,14 @@
 Thank you for your interest in contributing to Rust! There are many ways to contribute
 and we appreciate all of them.
 
+The best way to get started is by asking for help in the [#new
+members](https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members)
+Zulip stream. We have lots of docs below of how to get started on your own, but
+the Zulip stream is the best place to *ask* for help.
+
 Documentation for contributing to Rust is located in the [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org/),
 commonly known as the [rustc-dev-guide]. Despite the name, this guide documents
-not just how to develop rustc (the Rust compiler), but also how to contribute to any part
-of the Rust project.
-
-To get started with contributing, please read the [Contributing to Rust] chapter of the guide.
-That chapter explains how to get your development environment set up and how to get help.
+not just how to develop rustc (the Rust compiler), but also how to contribute to the standard library and rustdoc.
 
 ## About the [rustc-dev-guide]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ standard library, and documentation.
 
 **Note: this README is for _users_ rather than _contributors_.
 If you wish to _contribute_ to the compiler, you should read the
-[Getting Started][gettingstarted] section of the rustc-dev-guide instead.**
+[Getting Started][gettingstarted] section of the rustc-dev-guide instead.
+You can ask for help in the [#new members Zulip stream][new-members].**
+
+[new-members]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members
 
 ## Quick Start
 

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -719,6 +719,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
     gate_all!(const_trait_impl, "const trait impls are experimental");
     gate_all!(half_open_range_patterns, "half-open range patterns are unstable");
     gate_all!(inline_const, "inline-const is experimental");
+    gate_all!(inline_const_pat, "inline-const in pattern position is experimental");
     gate_all!(
         const_generics_defaults,
         "default values for const generic parameters are experimental"

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -410,6 +410,8 @@ declare_features! (
     (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
     /// Allow anonymous constants from an inline `const` block
     (incomplete, inline_const, "1.49.0", Some(76001), None),
+    /// Allow anonymous constants from an inline `const` block in pattern position
+    (incomplete, inline_const_pat, "1.58.0", Some(76001), None),
     /// Allows using `pointer` and `reference` in intra-doc links
     (active, intra_doc_pointers, "1.51.0", Some(80896), None),
     /// Allows `#[instruction_set(_)]` attribute

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -409,7 +409,7 @@ declare_features! (
     /// Allows associated types in inherent impls.
     (incomplete, inherent_associated_types, "1.52.0", Some(8995), None),
     /// Allow anonymous constants from an inline `const` block
-    (incomplete, inline_const, "1.49.0", Some(76001), None),
+    (active, inline_const, "1.49.0", Some(76001), None),
     /// Allow anonymous constants from an inline `const` block in pattern position
     (incomplete, inline_const_pat, "1.58.0", Some(76001), None),
     /// Allows using `pointer` and `reference` in intra-doc links

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -95,9 +95,10 @@ pub(crate) type UnificationTable<'a, 'tcx, T> = ut::UnificationTable<
 /// This is used so that the region values inferred by HIR region solving are
 /// not exposed, and so that we can avoid doing work in HIR typeck that MIR
 /// typeck will also do.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub enum RegionckMode {
     /// The default mode: report region errors, don't erase regions.
+    #[default]
     Solve,
     /// Erase the results of region after solving.
     Erase {
@@ -106,12 +107,6 @@ pub enum RegionckMode {
         /// be set to true.
         suppress_errors: bool,
     },
-}
-
-impl Default for RegionckMode {
-    fn default() -> Self {
-        RegionckMode::Solve
-    }
 }
 
 impl RegionckMode {

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -15,6 +15,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
+#![feature(derive_default_enum)]
 #![feature(extend_one)]
 #![feature(iter_zip)]
 #![feature(let_else)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(core_intrinsics)]
+#![feature(derive_default_enum)]
 #![feature(discriminant_kind)]
 #![feature(exhaustive_patterns)]
 #![feature(if_let_guard)]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2263,10 +2263,11 @@ impl<'tcx> TyS<'tcx> {
 /// a miscompilation or unsoundness.
 ///
 /// When in doubt, use `VarianceDiagInfo::default()`
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VarianceDiagInfo<'tcx> {
     /// No additional information - this is the default.
     /// We will not add any additional information to error messages.
+    #[default]
     None,
     /// We switched our variance because a type occurs inside
     /// the generic argument of a mutable reference or pointer
@@ -2299,11 +2300,5 @@ impl<'tcx> VarianceDiagInfo<'tcx> {
             VarianceDiagInfo::None => other,
             VarianceDiagInfo::Mut { .. } => self,
         }
-    }
-}
-
-impl<'tcx> Default for VarianceDiagInfo<'tcx> {
-    fn default() -> Self {
-        Self::None
     }
 }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1243,7 +1243,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Unsafe) {
             self.parse_block_expr(None, lo, BlockCheckMode::Unsafe(ast::UserProvided), attrs)
         } else if self.check_inline_const(0) {
-            self.parse_const_block(lo.to(self.token.span))
+            self.parse_const_block(lo.to(self.token.span), false)
         } else if self.is_do_catch_block() {
             self.recover_do_catch(attrs)
         } else if self.is_try_block() {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1095,8 +1095,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses inline const expressions.
-    fn parse_const_block(&mut self, span: Span) -> PResult<'a, P<Expr>> {
-        self.sess.gated_spans.gate(sym::inline_const, span);
+    fn parse_const_block(&mut self, span: Span, pat: bool) -> PResult<'a, P<Expr>> {
+        if pat {
+            self.sess.gated_spans.gate(sym::inline_const_pat, span);
+        } else {
+            self.sess.gated_spans.gate(sym::inline_const, span);
+        }
         self.eat_keyword(kw::Const);
         let blk = self.parse_block()?;
         let anon_const = AnonConst {

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -437,7 +437,7 @@ impl<'a> Parser<'a> {
             PatKind::Box(pat)
         } else if self.check_inline_const(0) {
             // Parse `const pat`
-            let const_expr = self.parse_const_block(lo.to(self.token.span))?;
+            let const_expr = self.parse_const_block(lo.to(self.token.span), true)?;
 
             if let Some(re) = self.parse_range_end() {
                 self.parse_pat_range_begin_with(const_expr, re)?
@@ -884,7 +884,7 @@ impl<'a> Parser<'a> {
 
     fn parse_pat_range_end(&mut self) -> PResult<'a, P<Expr>> {
         if self.check_inline_const(0) {
-            self.parse_const_block(self.token.span)
+            self.parse_const_block(self.token.span, true)
         } else if self.check_path() {
             let lo = self.token.span;
             let (qself, path) = if self.eat_lt() {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1133,6 +1133,7 @@ impl<'a> Resolver<'a> {
                         feature,
                         reason,
                         issue,
+                        None,
                         is_soft,
                         span,
                         soft_handler,

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -335,20 +335,15 @@ impl Default for ErrorOutputType {
 }
 
 /// Parameter to control path trimming.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum TrimmedDefPaths {
     /// `try_print_trimmed_def_path` never prints a trimmed path and never calls the expensive query
+    #[default]
     Never,
     /// `try_print_trimmed_def_path` calls the expensive query, the query doesn't call `delay_good_path_bug`
     Always,
     /// `try_print_trimmed_def_path` calls the expensive query, the query calls `delay_good_path_bug`
     GoodPath,
-}
-
-impl Default for TrimmedDefPaths {
-    fn default() -> Self {
-        Self::Never
-    }
 }
 
 /// Use tree-based collections to cheaply get a deterministic `Hash` implementation.

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(crate_visibility_modifier)]
+#![feature(derive_default_enum)]
 #![feature(min_specialization)]
 #![feature(once_cell)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -308,6 +308,7 @@ symbols! {
         alloc_layout,
         alloc_zeroed,
         allocator,
+        allocator_api,
         allocator_internals,
         allow,
         allow_fail,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -731,6 +731,7 @@ symbols! {
         inlateout,
         inline,
         inline_const,
+        inline_const_pat,
         inout,
         instruction_set,
         intel,

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(drain_filter)]
+#![feature(derive_default_enum)]
 #![feature(hash_drain_filter)]
 #![feature(in_band_lifetimes)]
 #![feature(iter_zip)]

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -82,24 +82,20 @@ pub use self::chalk_fulfill::FulfillmentContext as ChalkFulfillmentContext;
 pub use rustc_infer::traits::*;
 
 /// Whether to skip the leak check, as part of a future compatibility warning step.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+///
+/// The "default" for skip-leak-check corresponds to the current
+/// behavior (do not skip the leak check) -- not the behavior we are
+/// transitioning into.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum SkipLeakCheck {
     Yes,
+    #[default]
     No,
 }
 
 impl SkipLeakCheck {
     fn is_yes(self) -> bool {
         self == SkipLeakCheck::Yes
-    }
-}
-
-/// The "default" for skip-leak-check corresponds to the current
-/// behavior (do not skip the leak check) -- not the behavior we are
-/// transitioning into.
-impl Default for SkipLeakCheck {
-    fn default() -> Self {
-        SkipLeakCheck::No
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -163,6 +163,7 @@
 #![cfg_attr(bootstrap, feature(const_raw_ptr_deref))]
 #![feature(const_refs_to_cell)]
 #![feature(decl_macro)]
+#![feature(derive_default_enum)]
 #![feature(doc_cfg)]
 #![feature(doc_notable_trait)]
 #![feature(doc_primitive)]

--- a/src/doc/unstable-book/src/language-features/inline-const-pat.md
+++ b/src/doc/unstable-book/src/language-features/inline-const-pat.md
@@ -1,0 +1,24 @@
+# `inline_const_pat`
+
+The tracking issue for this feature is: [#76001]
+
+See also [`inline_const`](inline-const.md)
+
+------
+
+This feature allows you to use inline constant expressions in pattern position:
+
+```rust
+#![feature(inline_const_pat)]
+
+const fn one() -> i32 { 1 }
+
+let some_int = 3;
+match some_int {
+    const { 1 + 2 } => println!("Matched 1 + 2"),
+    const { one() } => println!("Matched const fn returning 1"),
+    _ => println!("Didn't match anything :("),
+}
+```
+
+[#76001]: https://github.com/rust-lang/rust/issues/76001

--- a/src/doc/unstable-book/src/language-features/inline-const.md
+++ b/src/doc/unstable-book/src/language-features/inline-const.md
@@ -2,6 +2,8 @@
 
 The tracking issue for this feature is: [#76001]
 
+See also [`inline_const_pat`](inline-const-pat.md)
+
 ------
 
 This feature allows you to use inline constant expressions. For example, you can
@@ -24,21 +26,6 @@ into this code:
 # fn add_one(x: i32) -> i32 { x + 1 }
 fn main() {
     let x = add_one(const { 1 + 2 * 3 / 4 });
-}
-```
-
-You can also use inline constant expressions in patterns:
-
-```rust
-#![feature(inline_const)]
-
-const fn one() -> i32 { 1 }
-
-let some_int = 3;
-match some_int {
-    const { 1 + 2 } => println!("Matched 1 + 2"),
-    const { one() } => println!("Matched const fn returning 1"),
-    _ => println!("Didn't match anything :("),
 }
 ```
 

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -891,7 +891,7 @@ function hideThemeButtonState() {
             if (e.target.tagName != "SUMMARY") {
                 e.preventDefault();
             }
-        })
+        });
     });
 
     onEachLazy(document.getElementsByClassName("notable-traits"), function(e) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -886,6 +886,14 @@ function hideThemeButtonState() {
         }
     });
 
+    onEachLazy(document.querySelectorAll(".rustdoc-toggle > summary:not(.hideme)"), function(el) {
+        el.addEventListener("click", function(e) {
+            if (e.target.tagName != "SUMMARY") {
+                e.preventDefault();
+            }
+        })
+    });
+
     onEachLazy(document.getElementsByClassName("notable-traits"), function(e) {
         e.onclick = function() {
             this.getElementsByClassName('notable-traits-tooltiptext')[0]

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -22,6 +22,8 @@ pub struct Foo {
 }
 
 impl Foo {
+    /// Some documentation
+    /// # A Heading
     pub fn a_method(&self) {}
 }
 

--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -1,0 +1,8 @@
+// This test ensures that clicking on a method summary, but not on the "[-]",
+// doesn't toggle the <details>.
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
+click: "h4.code-header" // This is the position of "pub" in "pub fn a_method"
+assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
+click: ".impl-items .rustdoc-toggle summary::before" // This is the position of "[-]" next to that pub fn.
+assert-attribute-false: (".impl-items .rustdoc-toggle", {"open": ""})

--- a/src/test/ui/consts/closure-structural-match-issue-90013.rs
+++ b/src/test/ui/consts/closure-structural-match-issue-90013.rs
@@ -1,6 +1,5 @@
 // Regression test for issue 90013.
 // check-pass
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 fn main() {

--- a/src/test/ui/consts/const-blocks/fn-call-in-const.rs
+++ b/src/test/ui/consts/const-blocks/fn-call-in-const.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![feature(inline_const)]
-#![allow(unused, incomplete_features)]
+#![allow(unused)]
 
 // Some type that is not copyable.
 struct Bar;

--- a/src/test/ui/feature-gates/feature-gate-inline_const_pat.rs
+++ b/src/test/ui/feature-gates/feature-gate-inline_const_pat.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let const { () } = ();
+    //~^ ERROR inline-const in pattern position is experimental [E0658]
+}

--- a/src/test/ui/feature-gates/feature-gate-inline_const_pat.stderr
+++ b/src/test/ui/feature-gates/feature-gate-inline_const_pat.stderr
@@ -1,0 +1,12 @@
+error[E0658]: inline-const in pattern position is experimental
+  --> $DIR/feature-gate-inline_const_pat.rs:2:9
+   |
+LL |     let const { () } = ();
+   |         ^^^^^
+   |
+   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
+   = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions0.rs
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions0.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![feature(exclusive_range_pattern)]
 #![feature(half_open_range_patterns)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 fn main() {
     let mut if_lettable = vec![];

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions3.rs
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions3.rs
@@ -12,7 +12,7 @@ fn main() {
             y @ (0..5 | 6) => or_two.push(y),
             //~^ exclusive range pattern syntax is experimental
             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
-            //~^ inline-const is experimental
+            //~^ inline-const in pattern position is experimental
             //~| exclusive range pattern syntax is experimental
             y @ -5.. => range_from.push(y),
             y @ ..-7 => assert_eq!(y, -8),

--- a/src/test/ui/half-open-range-patterns/range_pat_interactions3.stderr
+++ b/src/test/ui/half-open-range-patterns/range_pat_interactions3.stderr
@@ -7,14 +7,14 @@ LL |             y @ ..-7 => assert_eq!(y, -8),
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns)]` to the crate attributes to enable
 
-error[E0658]: inline-const is experimental
+error[E0658]: inline-const in pattern position is experimental
   --> $DIR/range_pat_interactions3.rs:14:20
    |
 LL |             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
    |                    ^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
-   = help: add `#![feature(inline_const)]` to the crate attributes to enable
+   = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:10:17

--- a/src/test/ui/inline-const/const-expr-array-init.rs
+++ b/src/test/ui/inline-const/const-expr-array-init.rs
@@ -1,6 +1,5 @@
 // build-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 use std::cell::Cell;

--- a/src/test/ui/inline-const/const-expr-basic.rs
+++ b/src/test/ui/inline-const/const-expr-basic.rs
@@ -1,7 +1,7 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
+
 fn foo() -> i32 {
     const {
         let x = 5 + 10;

--- a/src/test/ui/inline-const/const-expr-inference.rs
+++ b/src/test/ui/inline-const/const-expr-inference.rs
@@ -1,7 +1,6 @@
 // check-pass
 
 #![feature(inline_const)]
-#![allow(incomplete_features)]
 
 pub fn todo<T>() -> T {
     const { todo!() }

--- a/src/test/ui/inline-const/const-expr-lifetime-err.rs
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 

--- a/src/test/ui/inline-const/const-expr-lifetime-err.stderr
+++ b/src/test/ui/inline-const/const-expr-lifetime-err.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/const-expr-lifetime-err.rs:24:30
+  --> $DIR/const-expr-lifetime-err.rs:23:30
    |
 LL | fn foo<'a>() {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/inline-const/const-expr-lifetime.rs
+++ b/src/test/ui/inline-const/const-expr-lifetime.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 

--- a/src/test/ui/inline-const/const-expr-macro.rs
+++ b/src/test/ui/inline-const/const-expr-macro.rs
@@ -1,7 +1,7 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
+
 macro_rules! do_const_block{
     ($val:block) => { const $val }
 }

--- a/src/test/ui/inline-const/const-expr-reference.rs
+++ b/src/test/ui/inline-const/const-expr-reference.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 const fn bar() -> i32 {

--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 

--- a/src/test/ui/inline-const/const-match-pat-inference.rs
+++ b/src/test/ui/inline-const/const-match-pat-inference.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 #![allow(incomplete_features)]
 
 fn main() {

--- a/src/test/ui/inline-const/const-match-pat-lifetime-err.rs
+++ b/src/test/ui/inline-const/const-match-pat-lifetime-err.rs
@@ -2,7 +2,7 @@
 
 #![allow(incomplete_features)]
 #![feature(const_mut_refs)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/inline-const/const-match-pat-lifetime.rs
+++ b/src/test/ui/inline-const/const-match-pat-lifetime.rs
@@ -3,6 +3,7 @@
 #![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/inline-const/const-match-pat-range.rs
+++ b/src/test/ui/inline-const/const-match-pat-range.rs
@@ -1,7 +1,7 @@
 // build-pass
 
 #![allow(incomplete_features)]
-#![feature(inline_const, half_open_range_patterns, exclusive_range_pattern)]
+#![feature(inline_const_pat, half_open_range_patterns, exclusive_range_pattern)]
 fn main() {
     const N: u32 = 10;
     let x: u32 = 3;

--- a/src/test/ui/inline-const/const-match-pat.rs
+++ b/src/test/ui/inline-const/const-match-pat.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #![allow(incomplete_features)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 const MMIO_BIT1: u8 = 4;
 const MMIO_BIT2: u8 = 5;
 

--- a/src/test/ui/lint/dead-code/anon-const-in-pat.rs
+++ b/src/test/ui/lint/dead-code/anon-const-in-pat.rs
@@ -1,5 +1,5 @@
 // check-pass
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 #![allow(incomplete_features)]
 #![deny(dead_code)]
 

--- a/src/test/ui/pattern/non-structural-match-types.rs
+++ b/src/test/ui/pattern/non-structural-match-types.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features)]
 #![allow(unreachable_code)]
 #![feature(const_async_blocks)]
-#![feature(inline_const)]
+#![feature(inline_const_pat)]
 
 fn main() {
     match loop {} {

--- a/src/test/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/src/test/ui/simd/intrinsic/generic-elements-pass.rs
@@ -2,7 +2,6 @@
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
 
 #![feature(repr_simd, platform_intrinsics)]
-#![allow(incomplete_features)]
 #![feature(inline_const)]
 
 #[repr(simd)]

--- a/src/test/ui/stability-attribute/suggest-vec-allocator-api.rs
+++ b/src/test/ui/stability-attribute/suggest-vec-allocator-api.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let _: Vec<u8, _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
+    #[rustfmt::skip]
+    let _: Vec<
+        String,
+        _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
+    let _ = Vec::<u16, _>::new(); //~ ERROR use of unstable library feature 'allocator_api'
+    let _boxed: Box<u32, _> = Box::new(10); //~ ERROR use of unstable library feature 'allocator_api'
+}

--- a/src/test/ui/stability-attribute/suggest-vec-allocator-api.stderr
+++ b/src/test/ui/stability-attribute/suggest-vec-allocator-api.stderr
@@ -1,0 +1,49 @@
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:2:20
+   |
+LL |     let _: Vec<u8, _> = vec![];
+   |                ----^
+   |                |
+   |                help: consider wrapping the inner types in tuple: `(u8, _)`
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:6:9
+   |
+LL |         _> = vec![];
+   |         ^
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+help: consider wrapping the inner types in tuple
+   |
+LL ~     let _: Vec<(
+LL +         String,
+LL ~         _)> = vec![];
+   |
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:8:26
+   |
+LL |     let _boxed: Box<u32, _> = Box::new(10);
+   |                          ^
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'allocator_api'
+  --> $DIR/suggest-vec-allocator-api.rs:7:24
+   |
+LL |     let _ = Vec::<u16, _>::new();
+   |                   -----^
+   |                   |
+   |                   help: consider wrapping the inner types in tuple: `(u16, _)`
+   |
+   = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
+   = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #90856 (Suggestion to wrap inner types using 'allocator_api' in tuple)
 - #91103 (Inhibit clicks on summary's children)
 - #91137 (Give people a single link they can click in the contributing guide)
 - #91140 (Split inline const to two feature gates and mark expression position inline const complete)
 - #91148 (Use `derive_default_enum` in the compiler)
 - #91153 (kernel_copy: avoid panic on unexpected OS error)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90856,91103,91137,91140,91148,91153)
<!-- homu-ignore:end -->