### PR TITLE
Fix stack overflow in `usefulness.rs`

### DIFF
--- a/src/test/ui/pattern/usefulness/issue-88747.rs
+++ b/src/test/ui/pattern/usefulness/issue-88747.rs
@@ -1,0 +1,14 @@
+// check-pass: this used to be a stack overflow because of recursion in `usefulness.rs`
+
+macro_rules! long_tuple_arg {
+    ([$($t:tt)*]#$($h:tt)*) => {
+        long_tuple_arg!{[$($t)*$($t)*]$($h)*}
+    };
+    ([$([$t:tt $y:tt])*]) => {
+        pub fn _f(($($t,)*): ($($y,)*)) {}
+    }
+}
+
+long_tuple_arg!{[[_ u8]]########## ###}
+
+fn main() {}


### PR DESCRIPTION
Fix #88747

Applied the suggestion from @nbdd0121, not sure if this has any drawbacks. The first call to `ensure_sufficient_stack` is not needed to fix the test case, but I added it to be safe.