### PR TITLE
Allow using $:literal containing integer to index into a tuple

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -452,8 +452,9 @@ impl Token {
     }
 
     // A convenience function for matching on identifiers during parsing.
-    // Turns interpolated identifier (`$i: ident`) or lifetime (`$l: lifetime`) token
-    // into the regular identifier or lifetime token it refers to,
+    // Turns interpolated identifier ($i:ident), lifetime ($l:lifetime), and
+    // integer literal ($l:literal) into the regular identifier or lifetime or
+    // literal token it refers to,
     // otherwise returns the original token.
     pub fn uninterpolate(&self) -> Cow<'_, Token> {
         match &self.kind {
@@ -462,6 +463,11 @@ impl Token {
                     Cow::Owned(Token::new(Ident(ident.name, is_raw), ident.span))
                 }
                 NtLifetime(ident) => Cow::Owned(Token::new(Lifetime(ident.name), ident.span)),
+                NtLiteral(ref literal)
+                    if let ast::ExprKind::Lit(ast::Lit { token, kind: ast::LitKind::Int(..), .. }) = literal.kind =>
+                {
+                    Cow::Owned(Token::new(Literal(token), literal.span))
+                }
                 _ => Cow::Borrowed(self),
             },
             _ => Cow::Borrowed(self),

--- a/src/test/ui/macros/macro-interpolation.rs
+++ b/src/test/ui/macros/macro-interpolation.rs
@@ -24,9 +24,18 @@ macro_rules! qpath {
     };
 }
 
+macro_rules! field {
+    ($var:ident . $field:literal) => {
+        $var . $field
+    };
+}
+
 pub fn main() {
     let _: qpath!(path, <str as ToOwned>::Owned);
     let _: qpath!(ty, <str as ToOwned>::Owned);
+
+    let tuple = ('x',);
+    let _ = field!(tuple.0);
 
     assert!(overly_complicated!(f, x, Option<usize>, { return Some(x); },
                                Some(8), Some(y), y) == 8)


### PR DESCRIPTION
Example of the failure prior to this PR:

```rust
macro_rules! m {
    ($thing:ident . $field:literal) => {
        $thing . $field
    };
}

fn main() {
    let x = ('x',);
    let _ = m!(x.0);
}
```

```console
error: unexpected token: `0`
 --> src/main.rs:3:18
  |
3 |         $thing . $field
  |                  ^^^^^^
...
9 |     let _ = m!(x.0);
  |             ------- in this macro invocation
  |
  = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
```