### PR TITLE
Change cg_ssa's get_param to borrow the builder mutably

### DIFF
--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -14,7 +14,7 @@ impl<'a, 'gcc, 'tcx> AbiBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         // TODO(antoyo)
     }
 
-    fn get_param(&self, index: usize) -> Self::Value {
+    fn get_param(&mut self, index: usize) -> Self::Value {
         self.cx.current_func.borrow().expect("current func")
             .get_param(index as i32)
             .to_rvalue()

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -607,7 +607,7 @@ impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         fn_abi.apply_attrs_callsite(self, callsite)
     }
 
-    fn get_param(&self, index: usize) -> Self::Value {
+    fn get_param(&mut self, index: usize) -> Self::Value {
         llvm::get_param(self.llfn(), index as c_uint)
     }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/abi.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/abi.rs
@@ -4,5 +4,5 @@ use rustc_target::abi::call::FnAbi;
 
 pub trait AbiBuilderMethods<'tcx>: BackendTypes {
     fn apply_attrs_callsite(&mut self, fn_abi: &FnAbi<'tcx, Ty<'tcx>>, callsite: Self::Value);
-    fn get_param(&self, index: usize) -> Self::Value;
+    fn get_param(&mut self, index: usize) -> Self::Value;
 }


### PR DESCRIPTION
This is a small change to make `get_param` more flexible for codegens that may need to modify things when retrieving function parameters.

This will currently only be used by [rustc_codegen_nvvm](https://github.com/Rust-GPU/Rust-CUDA) (my own project), but may be useful to more codegens in the future. 

This is needed because cg_nvvm needs to remap certain types to libnvvm-friendly types, such as `i128` -> `<2 x i64>`. Because cg_ssa does not give mutable access to the builder, i resorted to using a mutex:
```rs
    fn get_param(&self, index: usize) -> Self::Value {
        let val = llvm::get_param(self.llfn(), index as c_uint);
        trace!("Get param `{:?}`", val);
        unsafe {
            let llfnty = LLVMRustGetFunctionType(self.llfn());
            let map = self.remapped_integer_args.borrow();
            if let Some((_, key)) = map.get(llfnty) {
                if let Some((_, new_ty)) = key.iter().find(|t| t.0 == index) {
                    trace!("Casting irregular param {:?} to {:?}", val, new_ty);
                    return transmute_llval(
                        *self.llbuilder.lock().unwrap(),
                        &self.cx,
                        val,
                        *new_ty,
                    );
                }
            }
            val
        }
    }
```
However, i predict this is pretty bad for performance, considering how much builders are called during codegen, so i would greatly appreciate having a more flexible API for this.