### PR TITLE
rustdoc: preload fonts

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -7,6 +7,12 @@
     <meta name="description" content="{{page.description}}"> {#- -#}
     <meta name="keywords" content="{{page.keywords}}"> {#- -#}
     <title>{{page.title}}</title> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}SourceSerif4-Regular.ttf.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}FiraSans-Regular.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}FiraSans-Medium.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}SourceCodePro-Regular.ttf.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}SourceSerif4-Bold.ttf.woff2"> {#- -#}
+    <link rel="preload" as="font" type="font/woff2" crossorigin href="{{static_root_path | safe}}SourceCodePro-Semibold.ttf.woff2"> {#- -#}
     <link rel="stylesheet" type="text/css" {# -#}
           href="{{static_root_path | safe}}normalize{{page.resource_suffix}}.css"> {#- -#}
     <link rel="stylesheet" type="text/css" {# -#}


### PR DESCRIPTION
Follow-up from #82315.

I noticed that font loading was so slow that even when loading from local disk, we get a flash of unstyled text (FOUT) followed by a reflow when the fonts load. With this change, we reliably get the appropriate fonts in the first render pass when loading locally, and we get it some of the time when loading from a website.

This only preloads woff2 versions. According to https://caniuse.com/?search=preload and https://caniuse.com/?search=woff2, all browsers that support preload also support woff2, so this is fine; we will never load two copies of a font.

Don't preload italic font faces because they aren't used on all pages.

Demo: https://rustdoc.crud.net/jsha/preload-fonts/std/string/struct.String.html