### PR TITLE
Fix toggle-click-deadspace rustdoc-gui test

### DIFF
--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -1,6 +1,6 @@
 // This test ensures that clicking on a method summary, but not on the "[-]",
 // doesn't toggle the <details>.
-goto: file://|DOC_PATH|/test_docs/struct.Foo.html
+goto: file://|DOC_PATH|/lib2/struct.Foo.html
 assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
 click: "h4.code-header" // This is the position of "pub" in "pub fn a_method"
 assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})


### PR DESCRIPTION
In #91103 I introduced a rustdoc-gui test for clicks on toggles. I introduced some documentation on a method in lib2/struct.Foo.html so there would be something to toggle, but accidentally left the test checking test_docs/struct.Foo.html. That caused the test to reliably fail.

I'm not sure how that test got past GitHub Actions and bors, but it's manifesting in test failures at https://github.com/rust-lang/rust/pull/91062#issuecomment-977589705 and https://github.com/rust-lang/rust/pull/91170#issuecomment-977636159.

This fixes by pointing at the right file.

r? @GuillaumeGomez 