### PR TITLE
Fix more <a> color

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -218,6 +218,8 @@ a {
 }
 a.srclink,
 a#toggle-all-docs,
+a.anchor,
+.section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -180,6 +180,8 @@ a {
 }
 a.srclink,
 a#toggle-all-docs,
+a.anchor,
+.section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -175,6 +175,8 @@ a {
 }
 a.srclink,
 a#toggle-all-docs,
+a.anchor,
+.section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -1,17 +1,29 @@
+// This test is to ensure that the anchors (`§`) have the expected color.
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+
+// This is needed to ensure that the text color is computed.
+show-text: true
 
 // Set the theme to light.
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("#toggle-all-docs", {"color": "rgba(0, 0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgba(0, 0, 0, 0)"})
-assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgba(0, 0, 0, 0)"})
-assert-css: (".srclink", {"color": "rgba(0, 0, 0, 0)"})
-assert-css: (".srclink", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: ("#toggle-all-docs", {"color": "rgb(0, 0, 0)"})
+assert-css: (".fqn .in-band a:nth-of-type(1)", {"color": "rgb(0, 0, 0)"})
+assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(173, 68, 142)"})
+assert-css: (".srclink", {"color": "rgb(0, 0, 0)"})
+assert-css: (".srclink", {"color": "rgb(0, 0, 0)"})
 
-assert-css: ("#top-doc-prose-title", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
-assert-css: (".sidebar a", {"color": "rgba(0, 0, 0, 0)"})
-assert-css: (".in-band a", {"color": "rgba(0, 0, 0, 0)"})
+assert-css: (".sidebar a", {"color": "rgb(0, 0, 0)"})
+assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
+
+// We move the cursor over the "Implementations" title so the anchor is displayed.
+move-cursor-to: "h2#implementations"
+assert-css: ("h2#implementations a.anchor", {"color": "rgb(0, 0, 0)"})
+
+// Same thing with the impl block title.
+move-cursor-to: "#impl"
+assert-css: ("#impl a.anchor", {"color": "rgb(0, 0, 0)"})

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -17,6 +17,9 @@ assert-css: ("#impl", {"color": "rgb(197, 197, 197)", "background-color": "rgba(
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"}, ALL)
 
+goto: file://|DOC_PATH|/test_docs/index.html
+assert-css: (".section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
+
 // Dark theme
 local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
@@ -29,6 +32,9 @@ assert-css: ("#impl", {"color": "rgb(221, 221, 221)", "background-color": "rgb(7
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/index.html
+assert-css: (".section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
 
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
@@ -44,3 +50,6 @@ assert-css: ("#impl", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 25
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/index.html
+assert-css: (".section-header a", {"color": "rgb(0, 0, 0)"}, ALL)


### PR DESCRIPTION
Fixes #91175.

Another bug I saw is:

![Screenshot from 2021-11-24 11-41-27](https://user-images.githubusercontent.com/3050060/143239845-f173cfeb-8f5c-4215-a5af-b71d4e1bcd84.png)

I fixed it as well.

r? @jsha