### PR TITLE
Improve rustdoc-gui CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.4.5 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.5.0 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -1,5 +1,6 @@
 // This test is to ensure that the anchors (`§`) have the expected color.
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+show-text: true
 
 // This is needed to ensure that the text color is computed.
 show-text: true

--- a/src/test/rustdoc-gui/search-filter.goml
+++ b/src/test/rustdoc-gui/search-filter.goml
@@ -1,9 +1,11 @@
 goto: file://|DOC_PATH|/test_docs/index.html
+show-text: true
 write: (".search-input", "test")
 // Waiting for the search results to appear...
 wait-for: "#titles"
 assert-text: ("#results .externcrate", "test_docs")
-text: (".search-input", "")
+
+goto: file://|DOC_PATH|/test_docs/index.html
 // We now want to change the crate filter.
 click: "#crate-search"
 // We select "lib2" option then press enter to change the filter.


### PR DESCRIPTION
As commented [here](https://github.com/rust-lang/rust/pull/91179#discussion_r756023009):

When the text isn't displayed, the color returned by puppeteer is always `rgba(0,0,0,0)`, which is definitely not the right value. To prevent this error from happening again, `browser-ui-test` will now fail if a CSS color check is run when the text isn't displayed.

Either this PR or #91179 is merged first, they'll conflict because I made changes to the same test file.

cc @jyn514 
r? @jsha