### PR TITLE
Use a fresh `InferCtxt` when we 'speculatively' evaluate predicates

### DIFF
--- a/src/test/ui/traits/issue-90662-projection-caching.rs
+++ b/src/test/ui/traits/issue-90662-projection-caching.rs
@@ -1,0 +1,34 @@
+// check-pass
+
+// Regression test for issue #90662
+// Tests that projection caching does not cause a spurious error
+
+trait HasProvider<T: ?Sized> {}
+trait Provider<M> {
+    type Interface: ?Sized;
+}
+
+trait Repository {}
+trait Service {}
+
+struct DbConnection;
+impl<M> Provider<M> for DbConnection {
+    type Interface = DbConnection;
+}
+
+struct RepositoryImpl;
+impl<M: HasProvider<DbConnection>> Provider<M> for RepositoryImpl {
+    type Interface = dyn Repository;
+}
+
+struct ServiceImpl;
+impl<M: HasProvider<dyn Repository>> Provider<M> for ServiceImpl {
+    type Interface = dyn Service;
+}
+
+struct TestModule;
+impl HasProvider<<DbConnection as Provider<Self>>::Interface> for TestModule {}
+impl HasProvider<<RepositoryImpl as Provider<Self>>::Interface> for TestModule {}
+impl HasProvider<<ServiceImpl as Provider<Self>>::Interface> for TestModule {}
+
+fn main() {}


### PR DESCRIPTION
The existing `InferCtxt` may already have in-progress projections
for some of the predicates we may (recursively evaluate). This can
cause us to incorrect produce (and cache!) `EvaluatedToRecur`, leading
us to incorrectly mark a predicate as unimplemented.

We now create a fresh `InferCtxt` for each sub-obligation that we
'speculatively' evaluate. This causes us to miss out on some
legitimate caching opportunities, but ensures that our speculative
evaluation cannot pollute any of the caches from the 'real' `InferCtxt`.
The evaluation can still update *global* caches, but our global caches
don't have any notion of 'in progress', so this is fine.

Fixes #90662