### PR TITLE
Remove `-Z force-overflow-checks`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -726,7 +726,6 @@ fn test_debugging_options_tracking_hash() {
     tracked!(dep_info_omit_d_target, true);
     tracked!(dual_proc_macros, true);
     tracked!(fewer_names, Some(true));
-    tracked!(force_overflow_checks, Some(true));
     tracked!(force_unstable_if_unmarked, true);
     tracked!(fuel, Some(("abc".to_string(), 99)));
     tracked!(function_sections, Some(false));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1131,8 +1131,6 @@ options! {
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \
         (default: no)"),
-    force_overflow_checks: Option<bool> = (None, parse_opt_bool, [TRACKED],
-        "force overflow checks on or off"),
     force_unstable_if_unmarked: bool = (false, parse_bool, [TRACKED],
         "force all crates to be `rustc_private` unstable (default: no)"),
     fuel: Option<(String, u64)> = (None, parse_optimization_fuel, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -678,11 +678,7 @@ impl Session {
         self.opts.debugging_opts.sanitizer.contains(SanitizerSet::CFI)
     }
     pub fn overflow_checks(&self) -> bool {
-        self.opts
-            .cg
-            .overflow_checks
-            .or(self.opts.debugging_opts.force_overflow_checks)
-            .unwrap_or(self.opts.debug_assertions)
+        self.opts.cg.overflow_checks.unwrap_or(self.opts.debug_assertions)
     }
 
     /// Check whether this compile session and crate type use static crt.

--- a/src/test/ui/consts/const-err.rs
+++ b/src/test/ui/consts/const-err.rs
@@ -1,5 +1,5 @@
 // build-fail
-// compile-flags: -Zforce-overflow-checks=on
+// compile-flags: -C overflow-checks=on
 
 #![allow(arithmetic_overflow)]
 #![warn(const_err)]

--- a/src/test/ui/mir/mir_overflow_off.rs
+++ b/src/test/ui/mir/mir_overflow_off.rs
@@ -1,5 +1,5 @@
 // run-pass
-// compile-flags: -Z force-overflow-checks=off
+// compile-flags: -C overflow-checks=off
 
 // Test that with MIR codegen, overflow checks can be
 // turned off, even when they're from core::ops::*.

--- a/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
+++ b/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
@@ -1,5 +1,5 @@
 // run-pass
-// compile-flags: -Z force-overflow-checks=on
+// compile-flags: -C overflow-checks=on
 // ignore-emscripten no threads support
 
 use std::thread;


### PR DESCRIPTION
It was replaced several years ago by the stable option `-C overflow-checks`.
The goal was to delete the `-Z` flag once users had migrated [1].
Now that it's been several years, it makes sense to delete the old flag.

See also the discussion on Zulip [2].

[1]: https://github.com/rust-lang/rust/issues/33134#issuecomment-280484097
[2]: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/overflow.20checks/near/262497224

r? @wesleywiser 
cc @RalfJung 