### PR TITLE
Deduplicate obligations in `opt_normalize_projection_type`

### DIFF
--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(box_patterns)]
 #![feature(derive_default_enum)]
 #![feature(extend_one)]
+#![feature(hash_raw_entry)]
 #![feature(let_else)]
 #![feature(never_type)]
 #![feature(control_flow_enum)]

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -8,10 +8,14 @@ mod project;
 mod structural_impls;
 pub mod util;
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{self, Const, Ty, TyCtxt};
 use rustc_span::Span;
+use std::borrow::{Borrow, Cow};
+use std::collections::hash_map::RawEntryMut;
+use std::hash::Hash;
 
 pub use self::FulfillmentErrorCode::*;
 pub use self::ImplSource::*;
@@ -103,6 +107,65 @@ pub enum FulfillmentErrorCode<'tcx> {
     CodeSubtypeError(ExpectedFound<Ty<'tcx>>, TypeError<'tcx>), // always comes from a SubtypePredicate
     CodeConstEquateError(ExpectedFound<&'tcx Const<'tcx>>, TypeError<'tcx>),
     CodeAmbiguity,
+}
+
+pub struct ObligationsDedup<'a, 'tcx, T> {
+    obligations: &'a mut Vec<Obligation<'tcx, T>>,
+}
+
+impl<'a, 'tcx, T: 'tcx> ObligationsDedup<'a, 'tcx, T>
+where
+    T: Clone + Hash + Eq,
+{
+    pub fn from_vec(vec: &'a mut Vec<Obligation<'tcx, T>>) -> Self {
+        ObligationsDedup { obligations: vec }
+    }
+
+    pub fn extend<'b>(&mut self, iter: impl ExactSizeIterator<Item = Cow<'b, Obligation<'tcx, T>>>)
+    where
+        'tcx: 'b,
+    {
+        // obligation tracing has shown that initial batches added to an empty vec do not
+        // contain any duplicates, so there's no need to attempt deduplication
+        if self.obligations.is_empty() {
+            *self.obligations = iter.into_iter().map(Cow::into_owned).collect();
+            return;
+        }
+
+        let initial_size = self.obligations.len();
+        let iter = iter.into_iter();
+        let expected_new = iter.len();
+        let combined_size = initial_size + expected_new;
+
+        if combined_size <= 16 || combined_size < initial_size.next_power_of_two() {
+            // small case/not crossing a power of two. don't bother with dedup
+            self.obligations.extend(iter.map(Cow::into_owned));
+        } else {
+            // crossing power of two threshold. this would incur a vec growth anyway if we didn't do
+            // anything. piggyback a dedup on that
+            let obligations = std::mem::take(self.obligations);
+
+            let mut seen = FxHashMap::default();
+            seen.reserve(initial_size);
+
+            *self.obligations = obligations
+                .into_iter()
+                .map(Cow::Owned)
+                .chain(iter)
+                .filter_map(|obligation| {
+                    match seen.raw_entry_mut().from_key(obligation.borrow()) {
+                        RawEntryMut::Occupied(..) => {
+                            return None;
+                        }
+                        RawEntryMut::Vacant(vacant) => {
+                            vacant.insert(obligation.clone().into_owned(), ());
+                        }
+                    }
+                    Some(obligation.into_owned())
+                })
+                .collect();
+        }
+    }
 }
 
 impl<'tcx, O> Obligation<'tcx, O> {

--- a/compiler/rustc_infer/src/traits/project.rs
+++ b/compiler/rustc_infer/src/traits/project.rs
@@ -173,6 +173,20 @@ impl<'tcx> ProjectionCache<'_, 'tcx> {
         Ok(())
     }
 
+    pub fn try_start_borrowed<'a, T>(
+        &'a mut self,
+        key: ProjectionCacheKey<'tcx>,
+        with: impl FnOnce(&'_ ProjectionCacheEntry<'tcx>) -> T + 'a,
+    ) -> Option<T> {
+        let mut map = self.map();
+        if let Some(entry) = map.get(&key) {
+            return Some(with(entry));
+        }
+
+        map.insert(key, ProjectionCacheEntry::InProgress);
+        None
+    }
+
     /// Indicates that `key` was normalized to `value`.
     pub fn insert_ty(&mut self, key: ProjectionCacheKey<'tcx>, value: NormalizedTy<'tcx>) {
         debug!(

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -904,9 +904,7 @@ fn opt_normalize_projection_type<'a, 'b, 'tcx>(
                         // should ensure that, unless this happens within a snapshot that's
                         // rolled back, fulfillment or evaluation will notice the cycle.
 
-                        if use_cache {
-                            infcx.inner.borrow_mut().projection_cache().recur(cache_key);
-                        }
+                        infcx.inner.borrow_mut().projection_cache().recur(cache_key);
                         Err(InProgress)
                     }
                     ProjectionCacheEntry::Recur => {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2337,6 +2337,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // This code is hot enough that it's worth avoiding the allocation
         // required for the FxHashSet when possible. Special-casing lengths 0,
         // 1 and 2 covers roughly 75-80% of the cases.
+        //
+        // Ideally we would perform deduplication incrementally in the predicates
+        // loop above to prevent excessive Vec growth but that would require
+        // a Vec::range_retain or similar method.
         if obligations.len() <= 1 {
             // No possibility of duplicates.
         } else if obligations.len() == 2 {


### PR DESCRIPTION
This adds a second deduplication site (in addition to the original one at `impl_or_trait_obligations`) in `opt_normalize_projection_type` since that's where the OOMing allocations occured in #74456.

Fixes an OOM and compile time blowup in the reduced test-case on that issue.

Since it only touches one place where obligations are processed it might not fix all of these blowups. If more places need deduplication then either they also need to have the vec locally wrapped in `ObligationsDedup` or we need to start plumbing the deduplication or a sorted set all the way through the APIs that currently use `Vec`.

[perf results](https://perf.rust-lang.org/compare.html?start=7b3cd075bbe309031b418650a9c32baf0b4a3276&end=a5fcd75b334a8bb8bc3e870f0e2c1173c48e0712) from original PR: #90913
The `deep-vector debug incr-unchanged` regression is most likely spurious due to incremental verification noise, so the perf impact is mostly positive.