### PR TITLE
rustdoc: Add test for mixing doc comments and attrs

### DIFF
--- a/src/test/rustdoc/mixing-doc-comments-and-attrs.rs
+++ b/src/test/rustdoc/mixing-doc-comments-and-attrs.rs
@@ -1,0 +1,26 @@
+#![crate_name = "foo"]
+
+// @has 'foo/struct.S1.html'
+// @count - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]/p' \
+//     1
+// @has - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]/p[1]' \
+//     'Hello world! Goodbye! Hello again!'
+
+#[doc = "Hello world!\n\n"]
+/// Goodbye!
+#[doc = "  Hello again!\n"]
+pub struct S1;
+
+// @has 'foo/struct.S2.html'
+// @count - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]/p' \
+//     2
+// @has - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]/p[1]' \
+//     'Hello world!'
+// @has - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]/p[2]' \
+//     'Goodbye! Hello again!'
+
+/// Hello world!
+///
+#[doc = "Goodbye!"]
+/// Hello again!
+pub struct S2;


### PR DESCRIPTION
This is a step toward adding more test coverage to make it easier to
remove the distinction between collapsed and uncollapsed doc values.