### PR TITLE
Visit `param_env` field in Obligation's `TypeFoldable` impl

### DIFF
--- a/compiler/rustc_infer/src/traits/structural_impls.rs
+++ b/compiler/rustc_infer/src/traits/structural_impls.rs
@@ -70,6 +70,7 @@ impl<'tcx, O: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::Obligation<'tcx
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy> {
-        self.predicate.visit_with(visitor)
+        self.predicate.visit_with(visitor)?;
+        self.param_env.visit_with(visitor)
     }
 }

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:11:17
+  --> $DIR/issue-72787.rs:12:17
    |
 LL |     Condition<{ LHS <= RHS }>: True
    |                 ^^^ cannot perform const operation using `LHS`
@@ -8,7 +8,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:11:24
+  --> $DIR/issue-72787.rs:12:24
    |
 LL |     Condition<{ LHS <= RHS }>: True
    |                        ^^^ cannot perform const operation using `RHS`
@@ -17,7 +17,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:25:25
+  --> $DIR/issue-72787.rs:26:25
    |
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                         ^ cannot perform const operation using `I`
@@ -26,7 +26,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-72787.rs:25:36
+  --> $DIR/issue-72787.rs:26:36
    |
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                                    ^ cannot perform const operation using `J`
@@ -35,7 +35,15 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72787.rs:21:26
+  --> $DIR/issue-72787.rs:10:38
+   |
+LL | impl<const LHS: u32, const RHS: u32> True for IsLessOrEqual<LHS, RHS> where
+   |                                      ^^^^ cannot infer type for struct `IsLessOrEqual<LHS, RHS>`
+   |
+   = note: cannot satisfy `IsLessOrEqual<LHS, RHS>: True`
+
+error[E0283]: type annotations needed
+  --> $DIR/issue-72787.rs:22:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
@@ -43,13 +51,13 @@ LL |     IsLessOrEqual<I, 8>: True,
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72787.rs:21:26
+  --> $DIR/issue-72787.rs:22:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
    |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
@@ -8,6 +8,7 @@ pub struct Condition<const CONDITION: bool>;
 pub trait True {}
 
 impl<const LHS: u32, const RHS: u32> True for IsLessOrEqual<LHS, RHS> where
+//[min]~^ ERROR type annotations needed
     Condition<{ LHS <= RHS }>: True
 //[min]~^ Error generic parameters may not be used in const operations
 //[min]~| Error generic parameters may not be used in const operations

--- a/src/test/ui/issues/issue-77919.rs
+++ b/src/test/ui/issues/issue-77919.rs
@@ -10,4 +10,4 @@ struct Multiply<N, M> {
 }
 impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
 //~^ ERROR cannot find type `VAL` in this scope
-//~| ERROR not all trait items implemented, missing: `VAL`
+//~| ERROR type annotations needed

--- a/src/test/ui/issues/issue-77919.stderr
+++ b/src/test/ui/issues/issue-77919.stderr
@@ -17,16 +17,15 @@ LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          |
    |          help: you might be missing a type parameter: `, VAL`
 
-error[E0046]: not all trait items implemented, missing: `VAL`
-  --> $DIR/issue-77919.rs:11:1
+error[E0283]: type annotations needed
+  --> $DIR/issue-77919.rs:11:12
    |
-LL |     const VAL: T;
-   |     ------------- `VAL` from trait
-...
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
+   |            ^^^^^^^^^^^^^^ cannot infer type for struct `Multiply<N, M>`
+   |
+   = note: cannot satisfy `Multiply<N, M>: TypeVal<usize>`
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0412.
-For more information about an error, try `rustc --explain E0046`.
+Some errors have detailed explanations: E0283, E0412.
+For more information about an error, try `rustc --explain E0283`.

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -21,16 +21,15 @@ LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    |          |
    |          help: you might be missing a type parameter: `, VAL`
 
-error[E0046]: not all trait items implemented, missing: `VAL`
-  --> $DIR/ice-6252.rs:10:1
+error[E0283]: type annotations needed
+  --> $DIR/ice-6252.rs:10:12
    |
-LL |     const VAL: T;
-   |     ------------- `VAL` from trait
-...
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
+   |            ^^^^^^^^^^^^^^ cannot infer type for struct `Multiply<N, M>`
+   |
+   = note: cannot satisfy `Multiply<N, M>: TypeVal<usize>`
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0412.
-For more information about an error, try `rustc --explain E0046`.
+Some errors have detailed explanations: E0283, E0412.
+For more information about an error, try `rustc --explain E0283`.


### PR DESCRIPTION
This oversight appears to have gone unnoticed for a long time
without causing issues, but it should still be fixed.