### PR TITLE
Fix ICE due to out-of-bounds statement index when reporting borrowck error

### DIFF
--- a/src/test/ui/borrowck/issue-91206.rs
+++ b/src/test/ui/borrowck/issue-91206.rs
@@ -1,0 +1,15 @@
+struct TestClient;
+
+impl TestClient {
+    fn get_inner_ref(&self) -> &Vec<usize> {
+        todo!()
+    }
+}
+
+fn main() {
+    let client = TestClient;
+    let inner = client.get_inner_ref();
+    //~^ HELP consider changing this to be a mutable reference
+    inner.clear();
+    //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
+}

--- a/src/test/ui/borrowck/issue-91206.stderr
+++ b/src/test/ui/borrowck/issue-91206.stderr
@@ -1,0 +1,12 @@
+error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
+  --> $DIR/issue-91206.rs:13:5
+   |
+LL |     let inner = client.get_inner_ref();
+   |         ----- help: consider changing this to be a mutable reference: `&mut Vec<usize>`
+LL |
+LL |     inner.clear();
+   |     ^^^^^^^^^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Replace an `[index]` with a `.get` when `statement_index` points to a basic-block terminator (and is therefore out-of-bounds in the statements list).

Fixes #91206 
Cc @camsteffen 
r? @oli-obk