### PR TITLE
Add `ptr::{str_from_raw_parts, str_from_raw_parts_mut}` functions

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -132,6 +132,7 @@
 #![feature(const_size_of_val)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_slice_ptr_len)]
+#![feature(const_str_from_raw_parts)]
 #![feature(const_str_from_utf8_unchecked_mut)]
 #![feature(const_swap)]
 #![feature(const_trait_impl)]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -292,6 +292,69 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
     from_raw_parts_mut(data.cast(), len)
 }
 
+/// Forms a raw string slice from a pointer and a length.
+///
+/// The `len` argument is the number of **bytes**, not the number of characters.
+///
+/// This function is safe, but actually using the return value is unsafe.
+/// See the documentation of [`slice::from_raw_parts`] for slice safety requirements and [`str::from_utf8`] for string safety requirements.
+///
+/// [`slice::from_raw_parts`]: crate::slice::from_raw_parts
+/// [`str::from_utf8`]: crate::str::from_utf8
+///
+/// # Examples
+///
+/// ```rust
+/// #![feature(str_from_raw_parts)]
+/// use std::ptr;
+///
+/// // create a string slice pointer when starting out with a pointer to the first element
+/// let x = "abc";
+/// let raw_pointer = x.as_ptr();
+/// let str = ptr::str_from_raw_parts(raw_pointer, 3);
+/// assert_eq!(unsafe { &*str }, x);
+/// ```
+#[inline]
+#[unstable(feature = "str_from_raw_parts", issue = "none")]
+#[rustc_const_unstable(feature = "const_str_from_raw_parts", issue = "none")]
+pub const fn str_from_raw_parts(data: *const u8, len: usize) -> *const str {
+    from_raw_parts(data.cast(), len)
+}
+
+/// Performs the same functionality as [`str_from_raw_parts`], except that a
+/// raw mutable string slice is returned, as opposed to a raw immutable string slice.
+///
+/// See the documentation of [`slice_from_raw_parts`] for more details.
+///
+/// This function is safe, but actually using the return value is unsafe.
+/// See the documentation of [`slice::from_raw_parts_mut`] for slice safety requirements and [`str::from_utf8_mut`] for string safety requirements.
+///
+/// [`slice::from_raw_parts_mut`]: crate::slice::from_raw_parts_mut
+/// [`str::from_utf8_mut`]: crate::str::from_utf8_mut
+///
+/// # Examples
+///
+/// ```rust
+/// #![feature(str_from_raw_parts)]
+/// use std::ptr;
+///
+/// let mut x = [b'a', b'b', b'c'];
+/// let raw_pointer = x.as_mut_ptr();
+/// let str = ptr::str_from_raw_parts_mut(raw_pointer, 3);
+///
+/// unsafe {
+///     (*(str as *mut [u8]))[2] = b'z'; // assign a value at an index in the string slice
+/// };
+///
+/// assert_eq!(unsafe { &*str }, "abz");
+/// ```
+#[inline]
+#[unstable(feature = "str_from_raw_parts", issue = "none")]
+#[rustc_const_unstable(feature = "const_str_from_raw_parts", issue = "none")]
+pub const fn str_from_raw_parts_mut(data: *mut u8, len: usize) -> *mut str {
+    from_raw_parts_mut(data.cast(), len)
+}
+
 /// Swaps the values at two mutable locations of the same type, without
 /// deinitializing either.
 ///

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -634,6 +634,42 @@ impl<T> NonNull<[T]> {
     }
 }
 
+impl NonNull<str> {
+    /// Creates a non-null raw string slice from a thin pointer and a length.
+    ///
+    /// The `len` argument is the number of **bytes**, not the number of characters.
+    ///
+    /// This function is safe, but dereferencing the return value is unsafe.
+    /// See the documentation of [`slice::from_raw_parts`] for slice safety
+    /// requirements and [`str::from_utf8`] for string safety requirements.
+    ///
+    /// [`str::from_utf8`]: crate::str::from_utf8
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(nonnull_str_from_raw_parts)]
+    ///
+    /// use std::ptr::NonNull;
+    ///
+    /// // create a string slice pointer when starting out with a pointer to the first byte
+    /// let mut x = [b'a', b'b', b'c'];
+    /// let nonnull_pointer = NonNull::new(x.as_mut_ptr()).unwrap();
+    /// let str = NonNull::str_from_raw_parts(nonnull_pointer, 3);
+    /// assert_eq!(unsafe { str.as_ref() }, "abc");
+    /// ```
+    ///
+    /// (Note that this example artificially demonstrates a use of this method,
+    /// but `let str = NonNull::from(str::from_utf8_unchecked(&x[..]));` would be a better way to write code like this.)
+    #[unstable(feature = "nonnull_str_from_raw_parts", issue = "none")]
+    #[rustc_const_unstable(feature = "const_nonnull_str_from_raw_parts", issue = "none")]
+    #[inline]
+    pub const fn str_from_raw_parts(data: NonNull<u8>, len: usize) -> Self {
+        // SAFETY: `data` is a `NonNull` pointer which is necessarily non-null
+        unsafe { Self::new_unchecked(super::str_from_raw_parts_mut(data.as_ptr(), len)) }
+    }
+}
+
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> Clone for NonNull<T> {
     #[inline]


### PR DESCRIPTION
TL;DR: this PR adds the following API:
```rust
// core::ptr
pub const fn str_from_raw_parts(data: *const u8, len: usize) -> *const str;
pub const fn str_from_raw_parts_mut(data: *mut u8, len: usize) -> *mut str;

impl NonNull<str> {
    pub const fn str_from_raw_parts(data: NonNull<u8>, len: usize) -> Self;
}
```

The functions are under feature gate `str_from_raw_parts` and are similar to
`slice_from_raw_parts`, `slice_from_raw_parts_mut` and `NonNull::slice_from_raw_parts`.

---

These methods were originally proposed as a part of #85816 and there were some [concerns](https://github.com/rust-lang/rust/pull/85816#issuecomment-851395458) about the specific design we should use for `str` pointer construction.

Some alternative designs:

- "Blessed cast"
   ```rust
   // core::ptr
   pub const fn str_from_raw_utf8(raw: *const [u8]) -> *const str;
   pub const fn str_from_raw_utf8_mut(raw: *mut [u8]) -> *mut str;
   // Also NonNull?
   ```
   Pros: similar to already existing `&str` construction (`str::from_utf8`)
   Cons: forces to use 2 functions (`str_from_raw_utf8(slice_from_raw_parts(ptr, len))`) to convert `ptr, len` into `*const str`
-  Add `str::from_raw_parts` too (addition to the current design of this PR)
   ```rust
   // core::str
   pub const unsafe fn from_raw_parts<'a>(ptr: *const u8, len: usize) -> &'a str;
   pub const unsafe fn from_raw_parts_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut str;
   ```
   Pros: similar to slices
   Cons: adds a function to `str` which can be replaced with `slice::from_raw_parts` and `str::from_utf8_unchecked` (in this case having two functions is probably better, as it splits safety conditions into smaller parts)
- Do nothing, use `ptr::from_raw_parts`
  Pros: doesn't add anything new, reuses existing API
  Cons: less clear/longer stabilization path