### PR TITLE
Remove clean::Function::header and calculate it on-demand

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3273,9 +3273,7 @@ impl<'hir> Node<'hir> {
                 _ => None,
             },
             Node::TraitItem(ti) => match ti.kind {
-                TraitItemKind::Fn(ref sig, TraitFn::Provided(_)) => {
-                    Some(FnKind::Method(ti.ident, sig, None))
-                }
+                TraitItemKind::Fn(ref sig, _) => Some(FnKind::Method(ti.ident, sig, None)),
                 _ => None,
             },
             Node::ImplItem(ii) => match ii.kind {
@@ -3284,6 +3282,10 @@ impl<'hir> Node<'hir> {
             },
             Node::Expr(e) => match e.kind {
                 ExprKind::Closure(..) => Some(FnKind::Closure),
+                _ => None,
+            },
+            Node::ForeignItem(fi) => match fi.kind {
+                ForeignItemKind::Fn(..) => Some(FnKind::ForeignFn(fi.ident)),
                 _ => None,
             },
             _ => None,

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -107,6 +107,9 @@ pub enum FnKind<'a> {
 
     /// `|x, y| {}`
     Closure,
+
+    /// `extern "C" { pub fn foo(); }`
+    ForeignFn(Ident),
 }
 
 impl<'a> FnKind<'a> {
@@ -115,6 +118,7 @@ impl<'a> FnKind<'a> {
             FnKind::ItemFn(_, _, ref header, _) => Some(header),
             FnKind::Method(_, ref sig, _) => Some(&sig.header),
             FnKind::Closure => None,
+            FnKind::ForeignFn(_) => None,
         }
     }
 
@@ -979,7 +983,7 @@ pub fn walk_fn_kind<'v, V: Visitor<'v>>(visitor: &mut V, function_kind: FnKind<'
         FnKind::ItemFn(_, generics, ..) => {
             visitor.visit_generics(generics);
         }
-        FnKind::Method(..) | FnKind::Closure => {}
+        FnKind::Method(..) | FnKind::Closure | FnKind::ForeignFn(_) => {}
     }
 }
 

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -413,7 +413,7 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
                 }
                 self.check_snake_case(cx, "function", ident);
             }
-            FnKind::Closure => (),
+            FnKind::Closure | FnKind::ForeignFn(_) => (),
         }
     }
 

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -47,9 +47,9 @@ impl<'tcx> Visitor<'tcx> for CheckNakedFunctions<'tcx> {
         let fn_header;
 
         match fk {
-            FnKind::Closure => {
-                // Closures with a naked attribute are rejected during attribute
-                // check. Don't validate them any further.
+            FnKind::Closure | FnKind::ForeignFn(_) => {
+                // Closures and Foreign Functions with a naked attribute are
+                // rejected during attribute check. Don't validate them any further.
                 return;
             }
             FnKind::ItemFn(ident, _, ref header, ..) => {

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -692,15 +692,16 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             intravisit::FnKind::ItemFn(id, _, _, _) => id.as_str(),
             intravisit::FnKind::Method(id, _, _) => id.as_str(),
             intravisit::FnKind::Closure => Symbol::intern("closure").as_str(),
+            intravisit::FnKind::ForeignFn(id) => id.as_str(),
         };
         let name: &str = &name;
         let span = span!(Level::DEBUG, "visit_fn", name);
         let _enter = span.enter();
         match fk {
             // Any `Binders` are handled elsewhere
-            intravisit::FnKind::ItemFn(..) | intravisit::FnKind::Method(..) => {
-                intravisit::walk_fn(self, fk, fd, b, s, hir_id)
-            }
+            intravisit::FnKind::ItemFn(..)
+            | intravisit::FnKind::Method(..)
+            | intravisit::FnKind::ForeignFn(..) => intravisit::walk_fn(self, fk, fd, b, s, hir_id),
             intravisit::FnKind::Closure => {
                 self.map.late_bound_vars.insert(hir_id, vec![]);
                 let scope = Scope::Binder {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -223,20 +223,12 @@ crate fn build_external_trait(cx: &mut DocContext<'_>, did: DefId) -> clean::Tra
 
 fn build_external_function(cx: &mut DocContext<'_>, did: DefId) -> clean::Function {
     let sig = cx.tcx.fn_sig(did);
-
-    let constness =
-        if cx.tcx.is_const_fn_raw(did) { hir::Constness::Const } else { hir::Constness::NotConst };
-    let asyncness = cx.tcx.asyncness(did);
     let predicates = cx.tcx.predicates_of(did);
     let (generics, decl) = clean::enter_impl_trait(cx, |cx| {
         // NOTE: generics need to be cleaned before the decl!
         ((cx.tcx.generics_of(did), predicates).clean(cx), (did, sig).clean(cx))
     });
-    clean::Function {
-        decl,
-        generics,
-        header: hir::FnHeader { unsafety: sig.unsafety(), abi: sig.abi(), constness, asyncness },
-    }
+    clean::Function { decl, generics }
 }
 
 fn build_enum(cx: &mut DocContext<'_>, did: DefId) -> clean::Enum {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1303,7 +1303,6 @@ crate struct Generics {
 crate struct Function {
     crate decl: FnDecl,
     crate generics: Generics,
-    crate header: hir::FnHeader,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -313,19 +313,6 @@ crate fn from_function(function: clean::Function, did: DefId, tcx: TyCtxt<'_>) -
     }
 }
 
-// impl FromWithTcx<clean::Function> for Function {
-//     fn from_tcx(function: clean::Function, tcx: TyCtxt<'_>) -> Self {
-//         let clean::Function { decl, generics } = function;
-//         let header = hir::FnHeader { unsafety: sig.unsafety(), abi: sig.abi(), constness, asyncness }
-//         Function {
-//             decl: decl.into_tcx(tcx),
-//             generics: generics.into_tcx(tcx),
-//             header: from_fn_header(&header),
-//             abi: header.abi.to_string(),
-//         }
-//     }
-// }
-
 impl FromWithTcx<clean::Generics> for Generics {
     fn from_tcx(generics: clean::Generics, tcx: TyCtxt<'_>) -> Self {
         Generics {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -35,7 +35,6 @@ extern crate rustc_ast;
 extern crate rustc_ast_lowering;
 extern crate rustc_ast_pretty;
 extern crate rustc_attr;
-extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;

--- a/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
+++ b/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
@@ -82,7 +82,7 @@ impl CognitiveComplexity {
 
         if rust_cc > self.limit.limit() {
             let fn_span = match kind {
-                FnKind::ItemFn(ident, _, _, _) | FnKind::Method(ident, _, _) => ident.span,
+                FnKind::ItemFn(ident, _, _, _) | FnKind::Method(ident, _, _) | FnKind::ForeignFn(ident) => ident.span,
                 FnKind::Closure => {
                     let header_span = body_span.with_hi(decl.output.span().lo());
                     let pos = snippet_opt(cx, header_span).and_then(|snip| {

--- a/src/tools/clippy/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
@@ -20,6 +20,7 @@ pub(super) fn check_fn(
         intravisit::FnKind::ItemFn(_, _, hir::FnHeader { unsafety, .. }, _) => unsafety,
         intravisit::FnKind::Method(_, sig, _) => sig.header.unsafety,
         intravisit::FnKind::Closure => return,
+        intravisit::FnKind::ForeignFn(_) => return,
     };
 
     check_raw_ptr(cx, unsafety, decl, body, cx.tcx.hir().local_def_id(hir_id));

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -128,6 +128,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
                 }
             },
             FnKind::Closure => return,
+            FnKind::ForeignFn(_) => return,
         }
 
         let mir = cx.tcx.optimized_mir(def_id);

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -92,6 +92,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
             },
             FnKind::Method(..) => (),
             FnKind::Closure => return,
+            FnKind::ForeignFn(_) => return,
         }
 
         // Exclude non-inherent impls

--- a/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
@@ -266,6 +266,7 @@ impl<'tcx> LateLintPass<'tcx> for PassByRefOrValue {
             },
             FnKind::Method(..) => (),
             FnKind::Closure => return,
+            FnKind::ForeignFn(_) => return,
         }
 
         // Exclude non-inherent impls

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -147,6 +147,7 @@ impl<'tcx> LateLintPass<'tcx> for Return {
                     check_block_return(cx, block);
                 }
             },
+            FnKind::ForeignFn(_) => (),
         }
     }
 }

--- a/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
@@ -87,6 +87,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
                 }
             },
             FnKind::Closure => return,
+            FnKind::ForeignFn(_) => return,
         }
 
         // Abort if the method is implementing a trait or of it a trait method.


### PR DESCRIPTION
Addresses #89673

Remove `clean::Function::header` and calculate it on-demand based on the `DefId`.

r? @jyn514