### PR TITLE
[beta][1.57] Disable outline atomics for aarch64-unknown-linux-musl

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -417,7 +417,10 @@ pub fn llvm_global_features(sess: &Session) -> Vec<String> {
     features.extend(sess.opts.cg.target_feature.split(',').flat_map(&filter));
 
     // FIXME: Move outline-atomics to target definition when earliest supported LLVM is 12.
-    if get_version() >= (12, 0, 0) && sess.target.llvm_target.contains("aarch64-unknown-linux") {
+    if get_version() >= (12, 0, 0)
+        && sess.target.llvm_target.contains("aarch64-unknown-linux")
+        && sess.target.llvm_target != "aarch64-unknown-linux-musl"
+    {
         features.push("+outline-atomics".to_string());
     }
 


### PR DESCRIPTION
This is a functionally equivalent, minimally invasive backport of #90044, which fixes the problem that compiling any binary with the target aarch64-unknown-linux-musl fails unless lld is used for linking (#89626).

I have tested this backport by building aarch64-unknown-linux-gnu, installing the std libraries for the -musl and -gnu variants in rustc-beta-aarch64-unknown-linux-gnu/rustc/lib/rustlib and running helloworld successfully for both targets on arm64 hardware.

cc @workingjubilee @pnkfelix