### PR TITLE
Fix headings indent

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1129,13 +1129,15 @@ h3.variant {
 	margin-top: 3px;
 }
 
-.docblock > .section-header:first-child {
+.top-doc .docblock > .section-header:first-child {
 	margin-left: 15px;
-	margin-top: 0;
+}
+.top-doc .docblock > .section-header:first-child:hover > a:before {
+	left: -10px;
 }
 
-.docblock > .section-header:first-child:hover > a:before {
-	left: -10px;
+.docblock > .section-header:first-child {
+	margin-top: 0;
 }
 
 :target > code, :target > .code-header {

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -1,4 +1,4 @@
-// This test is to ensure that the anchors (`§`) have the expected color.
+// This test is to ensure that the anchors (`§`) have the expected color and position.
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 show-text: true
 
@@ -28,3 +28,47 @@ assert-css: ("h2#implementations a.anchor", {"color": "rgb(0, 0, 0)"})
 // Same thing with the impl block title.
 move-cursor-to: "#impl"
 assert-css: ("#impl a.anchor", {"color": "rgb(0, 0, 0)"})
+
+// Now we check the positions: only the first heading of the top doc comment should
+// have a different position.
+move-cursor-to: ".top-doc .docblock .section-header:first-child"
+assert-css: (
+    ".top-doc .docblock .section-header:first-child > a::before",
+    {"left": "-10px", "padding-right": "10px"}
+)
+// We also check that the heading itself has a different indent.
+assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "15px"})
+
+move-cursor-to: ".top-doc .docblock .section-header:not(:first-child)"
+assert-css: (
+    ".top-doc .docblock .section-header:not(:first-child) > a::before",
+    {"left": "-25px", "padding-right": "10px"}
+)
+assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-left": "0px"})
+
+// Now let's check some other docblock headings...
+// First the impl block docs.
+move-cursor-to: "#title-for-struct-impl-doc"
+assert-css: (
+    "#title-for-struct-impl-doc > a::before",
+    {"left": "-25px", "padding-right": "10px"}
+)
+assert-css: ("#title-for-struct-impl-doc", {"margin-left": "0px"})
+// Now a method docs.
+move-cursor-to: "#title-for-struct-impl-item-doc"
+assert-css: (
+    "#title-for-struct-impl-item-doc > a::before",
+    {"left": "-25px", "padding-right": "10px"}
+)
+assert-css: ("#title-for-struct-impl-item-doc", {"margin-left": "0px"})
+
+// Finally, we want to ensure that if the first element of the doc block isn't a heading,
+// if there is a heading afterwards, it won't have the indent.
+goto: file://|DOC_PATH|/test_docs/enum.WhoLetTheDogOut.html
+
+move-cursor-to: ".top-doc .docblock .section-header"
+assert-css: (
+    ".top-doc .docblock .section-header > a::before",
+    {"left": "-25px", "padding-right": "10px"}
+)
+assert-css: (".top-doc .docblock .section-header", {"margin-left": "0px"})

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -47,6 +47,8 @@ impl AsRef<str> for Foo {
 }
 
 /// Just a normal enum.
+///
+/// # title!
 #[doc(alias = "ThisIsAnAlias")]
 pub enum WhoLetTheDogOut {
     /// Woof!


### PR DESCRIPTION
Fixes #91200.

Screenshots with the fix:

![Screenshot from 2021-11-25 15-32-35](https://user-images.githubusercontent.com/3050060/143462481-f7e9ea13-72d5-46fe-90e0-9527e74599e3.png)
![Screenshot from 2021-11-25 15-32-49](https://user-images.githubusercontent.com/3050060/143462485-c010716a-0276-421b-a777-afff19c81c96.png)

If the first element of a top docblock is a heading, we still need to keep the indent, but only on this one (I added a test to check it). We need it because otherwise the anchor will go over the `[-]` toggle.

cc @camelid 
r? @jsha

