### PR TITLE
Fix invalid scrollbar display on source code page

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -305,6 +305,10 @@ nav.sub {
 	overflow-y: scroll;
 }
 
+.rustdoc.source .sidebar {
+	overflow-y: auto;
+}
+
 /* Improve the scrollbar display on firefox */
 * {
 	scrollbar-width: initial;


### PR DESCRIPTION
Fixes bug introduced in #90983:

![Screenshot from 2021-11-25 17-01-08](https://user-images.githubusercontent.com/3050060/143473753-c2e7c43c-ce3f-474d-9d2a-922e63189c51.png)
![Screenshot from 2021-11-25 17-07-08](https://user-images.githubusercontent.com/3050060/143473757-eecaaf2b-f4f0-49e0-a159-ab485e3f7122.png)

To fix it, I simply unset the `overflow-y` on the source code page so it's not displayed anymore.

r? @jsha 