### PR TITLE
Update to fix regression 90319 and correctly emit overflow errors when not inside an error reporting context

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -85,6 +85,9 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
             Ok(result) => result,
             Err(OverflowError::Canonical) => {
                 let mut selcx = SelectionContext::with_query_mode(&self, TraitQueryMode::Standard);
+                if self.is_tainted_by_errors() {
+                    selcx.is_suggestion(true)
+                }
                 selcx.evaluate_root_obligation(obligation).unwrap_or_else(|r| match r {
                     OverflowError::Canonical => {
                         span_bug!(

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -135,6 +135,10 @@ pub struct SelectionContext<'cx, 'tcx> {
     /// policy. In essence, canonicalized queries need their errors propagated
     /// rather than immediately reported because we do not have accurate spans.
     query_mode: TraitQueryMode,
+
+    /// Are we in a selection context to try to make a suggestion for error reporting
+    /// and we don't want to emit errors until we are complete (Overflow)
+    is_suggestion: bool,
 }
 
 // A stack that walks back up the stack frame.
@@ -224,6 +228,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             allow_negative_impls: false,
             is_in_const_context: false,
             query_mode: TraitQueryMode::Standard,
+            is_suggestion: false,
         }
     }
 
@@ -236,6 +241,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             allow_negative_impls: false,
             is_in_const_context: false,
             query_mode: TraitQueryMode::Standard,
+            is_suggestion: false,
         }
     }
 
@@ -252,6 +258,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             allow_negative_impls,
             is_in_const_context: false,
             query_mode: TraitQueryMode::Standard,
+            is_suggestion: false,
         }
     }
 
@@ -268,6 +275,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             allow_negative_impls: false,
             is_in_const_context: false,
             query_mode,
+            is_suggestion: false,
         }
     }
 
@@ -283,9 +291,31 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             allow_negative_impls: false,
             is_in_const_context: matches!(constness, hir::Constness::Const),
             query_mode: TraitQueryMode::Standard,
+            is_suggestion: false,
         }
     }
 
+    pub fn with_suggestion(
+        infcx: &'cx InferCtxt<'cx, 'tcx>,
+        suggestion: bool,
+    ) -> SelectionContext<'cx, 'tcx> {
+        SelectionContext {
+            infcx,
+            freshener: infcx.freshener_keep_static(),
+            intercrate: false,
+            intercrate_ambiguity_causes: None,
+            allow_negative_impls: false,
+            is_in_const_context: false,
+            query_mode: TraitQueryMode::Standard,
+            is_suggestion: suggestion,
+        }
+    }
+
+    /// Enable suggestion mode for use during error reporting selection contexts
+    /// to prevent reporting overflow errors during method suggestions
+    pub fn is_suggestion(&mut self, suggestion: bool) {
+        self.is_suggestion = suggestion;
+    }
     /// Enables tracking of intercrate ambiguity causes. These are
     /// used in coherence to give improved diagnostics. We don't do
     /// this until we detect a coherence error because it can lead to
@@ -1093,7 +1123,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         if !self.infcx.tcx.recursion_limit().value_within_limit(depth) {
             match self.query_mode {
                 TraitQueryMode::Standard => {
-                    if self.infcx.is_tainted_by_errors() {
+                    if self.is_suggestion {
                         return Err(OverflowError::ErrorReporting);
                     }
                     self.infcx.report_overflow_error(error_obligation, true);

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -143,7 +143,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Err(e) => e,
         };
 
-        self.set_tainted_by_errors();
         let expr = expr.peel_drop_temps();
         let cause = self.misc(expr.span);
         let expr_ty = self.resolve_vars_with_obligations(checked_ty);

--- a/src/test/ui/typeck/issue-90319.rs
+++ b/src/test/ui/typeck/issue-90319.rs
@@ -1,0 +1,17 @@
+struct Wrapper<T>(T);
+
+trait Trait {
+    fn method(&self) {}
+}
+
+impl<'a, T> Trait for Wrapper<&'a T> where Wrapper<T>: Trait {}
+
+fn get<T>() -> T {
+    unimplemented!()
+}
+
+fn main() {
+    let thing = get::<Thing>();//~ERROR 14:23: 14:28: cannot find type `Thing` in this scope [E0412]
+    let wrapper = Wrapper(thing);
+    Trait::method(&wrapper);//~ERROR 16:5: 16:18: overflow evaluating the requirement `_: Sized` [E0275]
+}

--- a/src/test/ui/typeck/issue-90319.stderr
+++ b/src/test/ui/typeck/issue-90319.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `Thing` in this scope
+  --> $DIR/issue-90319.rs:14:23
+   |
+LL |     let thing = get::<Thing>();
+   |                       ^^^^^ not found in this scope
+
+error[E0275]: overflow evaluating the requirement `_: Sized`
+  --> $DIR/issue-90319.rs:16:5
+   |
+LL |     Trait::method(&wrapper);
+   |     ^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_90319`)
+note: required because of the requirements on the impl of `Trait` for `Wrapper<&_>`
+  --> $DIR/issue-90319.rs:7:13
+   |
+LL | impl<'a, T> Trait for Wrapper<&'a T> where Wrapper<T>: Trait {}
+   |             ^^^^^     ^^^^^^^^^^^^^^
+   = note: 128 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Trait` for `Wrapper<&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&_>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0275, E0412.
+For more information about an error, try `rustc --explain E0275`.


### PR DESCRIPTION
This fixes #90319 to correctly report overflow errors instead of an ICE while also keeping the functionality of not reporting excess overflow errors during error reporting and method suggestions.

cc: @Mark-Simulacrum @estebank @dtolnay 