### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -14,7 +14,7 @@ impl<'a, 'gcc, 'tcx> AbiBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         // TODO(antoyo)
     }
 
-    fn get_param(&self, index: usize) -> Self::Value {
+    fn get_param(&mut self, index: usize) -> Self::Value {
         self.cx.current_func.borrow().expect("current func")
             .get_param(index as i32)
             .to_rvalue()

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -607,7 +607,7 @@ impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         fn_abi.apply_attrs_callsite(self, callsite)
     }
 
-    fn get_param(&self, index: usize) -> Self::Value {
+    fn get_param(&mut self, index: usize) -> Self::Value {
         llvm::get_param(self.llfn(), index as c_uint)
     }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/abi.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/abi.rs
@@ -4,5 +4,5 @@ use rustc_target::abi::call::FnAbi;
 
 pub trait AbiBuilderMethods<'tcx>: BackendTypes {
     fn apply_attrs_callsite(&mut self, fn_abi: &FnAbi<'tcx, Ty<'tcx>>, callsite: Self::Value);
-    fn get_param(&self, index: usize) -> Self::Value;
+    fn get_param(&mut self, index: usize) -> Self::Value;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -305,6 +305,10 @@ nav.sub {
 	overflow-y: scroll;
 }
 
+.rustdoc.source .sidebar {
+	overflow-y: auto;
+}
+
 /* Improve the scrollbar display on firefox */
 * {
 	scrollbar-width: initial;

--- a/src/test/ui/borrowck/issue-91206.rs
+++ b/src/test/ui/borrowck/issue-91206.rs
@@ -1,0 +1,15 @@
+struct TestClient;
+
+impl TestClient {
+    fn get_inner_ref(&self) -> &Vec<usize> {
+        todo!()
+    }
+}
+
+fn main() {
+    let client = TestClient;
+    let inner = client.get_inner_ref();
+    //~^ HELP consider changing this to be a mutable reference
+    inner.clear();
+    //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
+}

--- a/src/test/ui/borrowck/issue-91206.stderr
+++ b/src/test/ui/borrowck/issue-91206.stderr
@@ -1,0 +1,12 @@
+error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
+  --> $DIR/issue-91206.rs:13:5
+   |
+LL |     let inner = client.get_inner_ref();
+   |         ----- help: consider changing this to be a mutable reference: `&mut Vec<usize>`
+LL |
+LL |     inner.clear();
+   |     ^^^^^^^^^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Successful merges:

 - #91169 (Change cg_ssa's get_param to borrow the builder mutably)
 - #91212 (Fix ICE due to out-of-bounds statement index when reporting borrowck error)
 - #91225 (Fix invalid scrollbar display on source code page)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91169,91212,91225)
<!-- homu-ignore:end -->