### PR TITLE
Perform Sync check on static items in wf-check instead of during const checks

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -1,8 +1,8 @@
 //! The `Visitor` responsible for actually checking a `mir::Body` for invalid operations.
 
 use rustc_errors::{Applicability, Diagnostic, ErrorReported};
+use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{self as hir, HirId, LangItem};
 use rustc_index::bit_set::BitSet;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::{ImplSource, Obligation, ObligationCause};
@@ -14,8 +14,7 @@ use rustc_middle::ty::{self, adjustment::PointerCast, Instance, InstanceDef, Ty,
 use rustc_middle::ty::{Binder, TraitPredicate, TraitRef};
 use rustc_mir_dataflow::{self, Analysis};
 use rustc_span::{sym, Span, Symbol};
-use rustc_trait_selection::traits::error_reporting::InferCtxtExt;
-use rustc_trait_selection::traits::{self, SelectionContext, TraitEngine};
+use rustc_trait_selection::traits::SelectionContext;
 
 use std::mem;
 use std::ops::Deref;
@@ -253,16 +252,6 @@ impl Checker<'mir, 'tcx> {
 
         if !tcx.has_attr(def_id.to_def_id(), sym::rustc_do_not_const_check) {
             self.visit_body(&body);
-        }
-
-        // Ensure that the end result is `Sync` in a non-thread local `static`.
-        let should_check_for_sync = self.const_kind()
-            == hir::ConstContext::Static(hir::Mutability::Not)
-            && !tcx.is_thread_local_static(def_id.to_def_id());
-
-        if should_check_for_sync {
-            let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
-            check_return_ty_is_sync(tcx, &body, hir_id);
         }
 
         // If we got through const-checking without emitting any "primary" errors, emit any
@@ -1052,20 +1041,6 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
             | TerminatorKind::Unreachable => {}
         }
     }
-}
-
-fn check_return_ty_is_sync(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, hir_id: HirId) {
-    let ty = body.return_ty();
-    tcx.infer_ctxt().enter(|infcx| {
-        let cause = traits::ObligationCause::new(body.span, hir_id, traits::SharedStatic);
-        let mut fulfillment_cx = traits::FulfillmentContext::new();
-        let sync_def_id = tcx.require_lang_item(LangItem::Sync, Some(body.span));
-        fulfillment_cx.register_bound(&infcx, ty::ParamEnv::empty(), ty, sync_def_id, cause);
-        let errors = fulfillment_cx.select_all_or_error(&infcx);
-        if !errors.is_empty() {
-            infcx.report_fulfillment_errors(&errors, None, false);
-        }
-    });
 }
 
 fn place_as_reborrow(

--- a/src/test/ui/consts/const-cast-different-types.rs
+++ b/src/test/ui/consts/const-cast-different-types.rs
@@ -1,6 +1,6 @@
-static a: &'static str = "foo";
-static b: *const u8 = a as *const u8; //~ ERROR casting
-static c: *const u8 = &a as *const u8; //~ ERROR casting
+const a: &str = "foo";
+const b: *const u8 = a as *const u8; //~ ERROR casting
+const c: *const u8 = &a as *const u8; //~ ERROR casting
 
 fn main() {
 }

--- a/src/test/ui/consts/const-cast-different-types.stderr
+++ b/src/test/ui/consts/const-cast-different-types.stderr
@@ -1,14 +1,14 @@
 error[E0606]: casting `&'static str` as `*const u8` is invalid
-  --> $DIR/const-cast-different-types.rs:2:23
+  --> $DIR/const-cast-different-types.rs:2:22
    |
-LL | static b: *const u8 = a as *const u8;
-   |                       ^^^^^^^^^^^^^^
+LL | const b: *const u8 = a as *const u8;
+   |                      ^^^^^^^^^^^^^^
 
 error[E0606]: casting `&&'static str` as `*const u8` is invalid
-  --> $DIR/const-cast-different-types.rs:3:23
+  --> $DIR/const-cast-different-types.rs:3:22
    |
-LL | static c: *const u8 = &a as *const u8;
-   |                       ^^^^^^^^^^^^^^^
+LL | const c: *const u8 = &a as *const u8;
+   |                      ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-cast-wrong-type.rs
+++ b/src/test/ui/consts/const-cast-wrong-type.rs
@@ -1,5 +1,5 @@
-static a: [u8; 3] = ['h' as u8, 'i' as u8, 0 as u8];
-static b: *const i8 = &a as *const i8; //~ ERROR mismatched types
+const a: [u8; 3] = ['h' as u8, 'i' as u8, 0 as u8];
+const b: *const i8 = &a as *const i8; //~ ERROR mismatched types
 
 fn main() {
 }

--- a/src/test/ui/consts/const-cast-wrong-type.stderr
+++ b/src/test/ui/consts/const-cast-wrong-type.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/const-cast-wrong-type.rs:2:23
+  --> $DIR/const-cast-wrong-type.rs:2:22
    |
-LL | static b: *const i8 = &a as *const i8;
-   |                       ^^^^^^^^^^^^^^^ expected `u8`, found `i8`
+LL | const b: *const i8 = &a as *const i8;
+   |                      ^^^^^^^^^^^^^^^ expected `u8`, found `i8`
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/issues/issue-86201.rs
+++ b/src/test/ui/impl-trait/issues/issue-86201.rs
@@ -2,9 +2,9 @@
 #![feature(type_alias_impl_trait)]
 
 type FunType = impl Fn<()>;
-//~^ could not find defining uses
+//~^ ERROR could not find defining uses
 static STATIC_FN: FunType = some_fn;
-//~^ mismatched types
+//~^ ERROR mismatched types
 
 fn some_fn() {}
 

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,27 +1,26 @@
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-16538.rs:14:27
+  --> $DIR/issue-16538.rs:15:23
    |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0277]: `*const usize` cannot be shared between threads safely
-  --> $DIR/issue-16538.rs:14:1
-   |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
-   |
-   = help: the trait `Sync` is not implemented for `*const usize`
-   = note: shared static variables must have a type that implements `Sync`
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:14:34
+  --> $DIR/issue-16538.rs:15:30
    |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   |                                  ^^^^ use of extern static
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                              ^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-16538.rs:15:21
+   |
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0015, E0133, E0277.
+Some errors have detailed explanations: E0015, E0133.
 For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,6 +1,7 @@
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
 
+#![feature(const_raw_ptr_deref)]
 mod Y {
     pub type X = usize;
     extern "C" {
@@ -11,8 +12,8 @@ mod Y {
     }
 }
 
-static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-//~^ ERROR `*const usize` cannot be shared between threads safely [E0277]
+static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+//~^ ERROR dereference of raw pointer
 //~| ERROR E0015
 //~| ERROR use of extern static is unsafe and requires
 

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -1,27 +1,26 @@
-error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:14:34
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-16538.rs:15:22
    |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   |                                  ^^^^ use of extern static
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-16538.rs:15:30
+   |
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                              ^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-16538.rs:14:27
+  --> $DIR/issue-16538.rs:15:23
    |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0277]: `*const usize` cannot be shared between threads safely
-  --> $DIR/issue-16538.rs:14:1
-   |
-LL | static foo: *const Y::X = Y::foo(Y::x as *const Y::X);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const usize` cannot be shared between threads safely
-   |
-   = help: the trait `Sync` is not implemented for `*const usize`
-   = note: shared static variables must have a type that implements `Sync`
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0015, E0133, E0277.
+Some errors have detailed explanations: E0015, E0133.
 For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-17718-static-sync.stderr
+++ b/src/test/ui/issues/issue-17718-static-sync.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Foo` cannot be shared between threads safely
-  --> $DIR/issue-17718-static-sync.rs:9:1
+  --> $DIR/issue-17718-static-sync.rs:9:13
    |
 LL | static BAR: Foo = Foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be shared between threads safely
+   |             ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
    = note: shared static variables must have a type that implements `Sync`

--- a/src/test/ui/issues/issue-24446.rs
+++ b/src/test/ui/issues/issue-24446.rs
@@ -1,6 +1,7 @@
 fn main() {
     static foo: dyn Fn() -> u32 = || -> u32 {
         //~^ ERROR the size for values of type
+        //~| ERROR cannot be shared between threads safely
         0
     };
 }

--- a/src/test/ui/issues/issue-24446.stderr
+++ b/src/test/ui/issues/issue-24446.stderr
@@ -6,6 +6,15 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
 
-error: aborting due to previous error
+error[E0277]: `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
+  --> $DIR/issue-24446.rs:2:17
+   |
+LL |     static foo: dyn Fn() -> u32 = || -> u32 {
+   |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
+   |
+   = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = note: shared static variables must have a type that implements `Sync`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-5216.rs
+++ b/src/test/ui/issues/issue-5216.rs
@@ -1,10 +1,10 @@
 fn f() { }
-struct S(Box<dyn FnMut()>);
+struct S(Box<dyn FnMut() + Sync>);
 pub static C: S = S(f); //~ ERROR mismatched types
 
 
 fn g() { }
-type T = Box<dyn FnMut()>;
+type T = Box<dyn FnMut() + Sync>;
 pub static D: T = g; //~ ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/issues/issue-5216.stderr
+++ b/src/test/ui/issues/issue-5216.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub static C: S = S(f);
    |                     ^ expected struct `Box`, found fn item
    |
-   = note: expected struct `Box<(dyn FnMut() + 'static)>`
+   = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
              found fn item `fn() {f}`
 
 error[E0308]: mismatched types
@@ -13,7 +13,7 @@ error[E0308]: mismatched types
 LL | pub static D: T = g;
    |                   ^ expected struct `Box`, found fn item
    |
-   = note: expected struct `Box<(dyn FnMut() + 'static)>`
+   = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
              found fn item `fn() {g}`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-7364.rs
+++ b/src/test/ui/issues/issue-7364.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
-//~^ ERROR allocations are not allowed in statics
-//~| ERROR `RefCell<isize>` cannot be shared between threads safely [E0277]
+//~^ ERROR `RefCell<isize>` cannot be shared between threads safely [E0277]
 
 fn main() { }

--- a/src/test/ui/issues/issue-7364.stderr
+++ b/src/test/ui/issues/issue-7364.stderr
@@ -1,21 +1,14 @@
-error[E0010]: allocations are not allowed in statics
-  --> $DIR/issue-7364.rs:6:37
-   |
-LL | static boxed: Box<RefCell<isize>> = box RefCell::new(0);
-   |                                     ^^^^^^^^^^^^^^^^^^^ allocation not allowed in statics
-
 error[E0277]: `RefCell<isize>` cannot be shared between threads safely
-  --> $DIR/issue-7364.rs:6:1
+  --> $DIR/issue-7364.rs:6:15
    |
 LL | static boxed: Box<RefCell<isize>> = box RefCell::new(0);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
+   |               ^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<isize>`
    = note: required because of the requirements on the impl of `Sync` for `Unique<RefCell<isize>>`
    = note: required because it appears within the type `Box<RefCell<isize>>`
    = note: shared static variables must have a type that implements `Sync`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0010, E0277.
-For more information about an error, try `rustc --explain E0010`.
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc1623.nll.stderr
+++ b/src/test/ui/rfc1623.nll.stderr
@@ -1,26 +1,5 @@
-error[E0277]: `dyn for<'a, 'b> Fn(&'a Foo<'b>) -> &'a Foo<'b>` cannot be shared between threads safely
-  --> $DIR/rfc1623.rs:21:1
-   |
-LL | / static SOME_STRUCT: &SomeStruct = &SomeStruct {
-LL | |     foo: &Foo { bools: &[false, true] },
-LL | |     bar: &Bar { bools: &[true, true] },
-LL | |     f: &id,
-LL | |
-LL | | };
-   | |__^ `dyn for<'a, 'b> Fn(&'a Foo<'b>) -> &'a Foo<'b>` cannot be shared between threads safely
-   |
-   = help: within `&SomeStruct`, the trait `Sync` is not implemented for `dyn for<'a, 'b> Fn(&'a Foo<'b>) -> &'a Foo<'b>`
-   = note: required because it appears within the type `&dyn for<'a, 'b> Fn(&'a Foo<'b>) -> &'a Foo<'b>`
-note: required because it appears within the type `SomeStruct`
-  --> $DIR/rfc1623.rs:11:8
-   |
-LL | struct SomeStruct<'x, 'y, 'z: 'x> {
-   |        ^^^^^^^^^^
-   = note: required because it appears within the type `&SomeStruct`
-   = note: shared static variables must have a type that implements `Sync`
-
 error[E0308]: mismatched types
-  --> $DIR/rfc1623.rs:21:35
+  --> $DIR/rfc1623.rs:25:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
@@ -35,7 +14,7 @@ LL | | };
               found type `Fn<(&Foo<'_>,)>`
 
 error[E0308]: mismatched types
-  --> $DIR/rfc1623.rs:21:35
+  --> $DIR/rfc1623.rs:25:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
@@ -50,7 +29,7 @@ LL | | };
               found type `Fn<(&Foo<'_>,)>`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:21:35
+  --> $DIR/rfc1623.rs:25:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
@@ -65,7 +44,7 @@ LL | | };
    = note: ...but it actually implements `FnOnce<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:21:35
+  --> $DIR/rfc1623.rs:25:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
@@ -79,7 +58,6 @@ LL | | };
    = note: `fn(&Foo<'2>) -> &Foo<'2> {id::<&Foo<'2>>}` must implement `FnOnce<(&'a Foo<'1>,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&Foo<'2>,)>`, for some specific lifetime `'2`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/rfc1623.rs
+++ b/src/test/ui/rfc1623.rs
@@ -14,6 +14,10 @@ struct SomeStruct<'x, 'y, 'z: 'x> {
     f: &'y dyn for<'a, 'b> Fn(&'a Foo<'b>) -> &'a Foo<'b>,
 }
 
+// Without this, the wf-check will fail early so we'll never see the
+// error in SOME_STRUCT's body.
+unsafe impl<'x, 'y, 'z: 'x> Sync for SomeStruct<'x, 'y, 'z> {}
+
 fn id<T>(t: T) -> T {
     t
 }

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:24:8
+  --> $DIR/rfc1623.rs:28:8
    |
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/type-alias-impl-trait/static-const-types.rs
+++ b/src/test/ui/type-alias-impl-trait/static-const-types.rs
@@ -5,12 +5,9 @@
 
 use std::fmt::Debug;
 
-type Foo = impl Debug;
-//~^ ERROR: could not find defining uses
+type Foo = impl Debug; //~ ERROR could not find defining uses
 
-static FOO1: Foo = 22_u32;
-//~^ ERROR: mismatched types [E0308]
-const FOO2: Foo = 22_u32;
-//~^ ERROR: mismatched types [E0308]
+static FOO1: Foo = 22_u32; //~ ERROR mismatched types
+const FOO2: Foo = 22_u32; //~ ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/type-alias-impl-trait/static-const-types.stderr
+++ b/src/test/ui/type-alias-impl-trait/static-const-types.stderr
@@ -1,9 +1,9 @@
 error[E0308]: mismatched types
-  --> $DIR/static-const-types.rs:11:20
+  --> $DIR/static-const-types.rs:10:20
    |
 LL | type Foo = impl Debug;
    |            ---------- the expected opaque type
-...
+LL | 
 LL | static FOO1: Foo = 22_u32;
    |                    ^^^^^^ expected opaque type, found `u32`
    |
@@ -11,7 +11,7 @@ LL | static FOO1: Foo = 22_u32;
                      found type `u32`
 
 error[E0308]: mismatched types
-  --> $DIR/static-const-types.rs:13:19
+  --> $DIR/static-const-types.rs:11:19
    |
 LL | type Foo = impl Debug;
    |            ---------- the expected opaque type


### PR DESCRIPTION
r? @RalfJung

This check is solely happening on the signature of the static item and not on its body, therefor it belongs into wf-checking instead of const checking.