### PR TITLE
Fix bug where submodules wouldn't be updated when running x.py from a subdirectory

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -493,7 +493,7 @@ impl Build {
 
         // NOTE: The check for the empty directory is here because when running x.py the first time,
         // the submodule won't be checked out. Check it out now so we can build it.
-        if !channel::GitInfo::new(false, relative_path).is_git() && !dir_is_empty(&absolute_path) {
+        if !channel::GitInfo::new(false, &absolute_path).is_git() && !dir_is_empty(&absolute_path) {
             return;
         }
 


### PR DESCRIPTION
Previously, it would concatenate the relative path to the current
subdirectory, which looked at the wrong folder.

I tested this by checking out `1.56.1`, changing the current directory
to `src/`, and running `../x.py build`.

Fixes https://github.com/rust-lang/rust/issues/90481 (cc @pnkfelix).

r? @Mark-Simulacrum