### PR TITLE
Fix bootstrap failing to copy rust-llvm-dwp when cross-compiling rustc

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1161,9 +1161,16 @@ impl Step for Assemble {
             let dst_exe = exe("rust-llvm-dwp", target_compiler.host);
             let llvm_config_bin = builder.ensure(native::Llvm { target: target_compiler.host });
             if !builder.config.dry_run {
-                let llvm_bin_dir = output(Command::new(llvm_config_bin).arg("--bindir"));
-                let llvm_bin_dir = Path::new(llvm_bin_dir.trim());
-                builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+                if target_compiler.host == build_compiler.host {
+                    let llvm_bin_dir = output(Command::new(llvm_config_bin).arg("--bindir"));
+                    let llvm_bin_dir = Path::new(llvm_bin_dir.trim());
+                    builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+                } else {
+                    // if cross-compiling don't copy the llvm directory for the target instead
+                    let llvm_bin_dir = format!("build/{}/llvm/build/bin", target_compiler.host);
+                    let llvm_bin_dir = Path::new(&llvm_bin_dir);
+                    builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+                }
             }
         }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1161,16 +1161,15 @@ impl Step for Assemble {
             let dst_exe = exe("rust-llvm-dwp", target_compiler.host);
             let llvm_config_bin = builder.ensure(native::Llvm { target: target_compiler.host });
             if !builder.config.dry_run {
-                if target_compiler.host == build_compiler.host {
+                let llvm_bin_dir = if target_compiler.host == build_compiler.host {
                     let llvm_bin_dir = output(Command::new(llvm_config_bin).arg("--bindir"));
-                    let llvm_bin_dir = Path::new(llvm_bin_dir.trim());
-                    builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+                    PathBuf::from(llvm_bin_dir.trim())
                 } else {
-                    // if cross-compiling don't copy the llvm directory for the target instead
-                    let llvm_bin_dir = format!("build/{}/llvm/build/bin", target_compiler.host);
-                    let llvm_bin_dir = Path::new(&llvm_bin_dir);
-                    builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
-                }
+                    // if cross-compiling don't copy from the llvm directory for the target instead
+                    PathBuf::from(format!("build/{}/llvm/build/bin", target_compiler.host))
+                };
+
+                builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
             }
         }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1166,7 +1166,7 @@ impl Step for Assemble {
                     PathBuf::from(llvm_bin_dir.trim())
                 } else {
                     // if cross-compiling don't copy from the llvm directory for the target instead
-                    PathBuf::from(format!("build/{}/llvm/build/bin", target_compiler.host))
+                    builder.llvm_out(target_compiler.host).join("build/bin")
                 };
 
                 builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));


### PR DESCRIPTION
Fixes #85593

r? @jyn514