### PR TITLE
Add demonstration test for #91161

### DIFF
--- a/src/test/ui/rfc-2008-non-exhaustive/auxiliary/enums.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/auxiliary/enums.rs
@@ -30,3 +30,15 @@ pub enum VariantNonExhaustive {
 pub enum NonExhaustiveSingleVariant {
     A(bool),
 }
+
+#[repr(u8)]
+pub enum FieldLessWithNonExhaustiveVariant {
+    A,
+    B,
+    #[non_exhaustive]
+    C,
+}
+
+impl Default for FieldLessWithNonExhaustiveVariant {
+    fn default() -> Self { Self::A }
+}

--- a/src/test/ui/rfc-2008-non-exhaustive/enum-as-cast.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum-as-cast.rs
@@ -1,0 +1,17 @@
+// aux-build:enums.rs
+// run-pass
+
+extern crate enums;
+
+use enums::FieldLessWithNonExhaustiveVariant;
+
+fn main() {
+    let e = FieldLessWithNonExhaustiveVariant::default();
+    // FIXME: https://github.com/rust-lang/rust/issues/91161
+    // This `as` cast *should* be an error, since it would fail
+    // if the non-exhaustive variant got fields.  But today it
+    // doesn't.  The fix for that will update this test to
+    // show an error (and not be run-pass any more).
+    let d = e as u8;
+    assert_eq!(d, 0);
+}


### PR DESCRIPTION
Since cross-crate things are hard to demonstrate in playground, here's a test showing that something currently works that shouldn't.

cc https://github.com/rust-lang/rust/issues/91161 that tracks fixing the problem (and updating this test)