### PR TITLE
Ubuntu 20.04 on WSL returns PermissionDenied errors instead of NotFound

### DIFF
--- a/src/test/ui/linkage-attr/issue-10755.rs
+++ b/src/test/ui/linkage-attr/issue-10755.rs
@@ -1,7 +1,7 @@
 // build-fail
 // dont-check-compiler-stderr
 // compile-flags: -C linker=llllll -C linker-flavor=ld
-// error-pattern: linker `llllll` not found
+// error-pattern: linker `llllll`
 
 fn main() {
 }

--- a/src/test/ui/process/process-spawn-nonexistent.rs
+++ b/src/test/ui/process/process-spawn-nonexistent.rs
@@ -6,9 +6,10 @@ use std::io::ErrorKind;
 use std::process::Command;
 
 fn main() {
-    assert_eq!(Command::new("nonexistent")
-                   .spawn()
-                   .unwrap_err()
-                   .kind(),
-               ErrorKind::NotFound);
+    let err = Command::new("nonexistent")
+        .spawn()
+        .unwrap_err()
+        .kind();
+
+    assert!(err == ErrorKind::NotFound || err == ErrorKind::PermissionDenied);
 }


### PR DESCRIPTION
Running the test suite on WSL/Windows 11 (Ubuntu 20.04) has the following two failures (at least for me):

```
failures:

---- [ui] ui/linkage-attr/issue-10755.rs stdout ----

error: error pattern ' linker `llllll` not found' not found!
status: exit status: 1
command: "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc" "/home/jay/other-projects/rust/src/test/ui/linkage-attr/issue-10755.rs" "-Zthreads=1" "--target=x86_64-unknown-linux-gnu" "--error-format" "json" "-Ccodegen-units=1" "-Zui-testing" "-Zdeduplicate-diagnostics=no" "-Zemit-future-incompat-report" "-C" "prefer-dynamic" "--out-dir" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/linkage-attr/issue-10755" "-A" "unused" "-Crpath" "-O" "-Cdebuginfo=0" "-Lnative=/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/native/rust-test-helpers" "-C" "linker=llllll" "-C" "linker-flavor=ld" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/linkage-attr/issue-10755/auxiliary"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
error: could not exec the linker `llllll`
   |
   = note: Permission denied (os error 13)
   = note: "llllll" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/linkage-attr/issue-10755/issue-10755.issue_10755.3d10ea9d-cgu.0.rcgu.o" "--as-needed" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/native/rust-test-helpers" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/linkage-attr/issue-10755/auxiliary" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "--start-group" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-lstd-0683d736407cad97" "--end-group" "-Bstatic" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-0faa288d8e8501c2.rlib" "-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "--eh-frame-hdr" "-znoexecstack" "-L" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/linkage-attr/issue-10755/issue-10755" "--gc-sections" "-pie" "-zrelro" "-znow" "-O1" "-Wl,-rpath,$ORIGIN/../../../../stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,--enable-new-dtags"

error: aborting due to previous error


------------------------------------------


---- [ui] ui/process/process-spawn-nonexistent.rs stdout ----

error: test run failed!
status: exit status: 101
command: "/home/jay/other-projects/rust/build/x86_64-unknown-linux-gnu/test/ui/process/process-spawn-nonexistent/a"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `PermissionDenied`,
 right: `NotFound`', /home/jay/other-projects/rust/src/test/ui/process/process-spawn-nonexistent.rs:9:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

------------------------------------------



failures:
    [ui] ui/linkage-attr/issue-10755.rs
    [ui] ui/process/process-spawn-nonexistent.rs

test result: FAILED. 4 passed; 2 failed; 12409 ignored; 0 measured; 0 filtered out; finished in 0.35s

Some tests failed in compiletest suite=ui mode=ui host=x86_64-unknown-linux-gnu target=x86_64-unknown-linux-gnu
```

Trying to exec non-existent executable through `/usr/bin/env` always returns a permission denied error here:

```
$ /usr/bin/env does-not-exist
/usr/bin/env: ‘does-not-exist’: Permission denied
```

<details><summary>And here it is with <code>strace</code>:</summary>

```
$ strace /usr/bin/env does-not-exist
execve("/usr/bin/env", ["/usr/bin/env", "does-not-exist"], 0x7ffd3f9c94d8 /* 46 vars */) = 0
brk(NULL)                               = 0x56533ebcb000
arch_prctl(0x3001 /* ARCH_??? */, 0x7ffeb9e6e880) = -1 EINVAL (Invalid argument)
access("/etc/ld.so.preload", R_OK)      = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 3
fstat(3, {st_mode=S_IFREG|0644, st_size=36389, ...}) = 0
mmap(NULL, 36389, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f9981c71000
close(3)                                = 0
openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC) = 3
read(3, "\177ELF\2\1\1\3\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\360q\2\0\0\0\0\0"..., 832) = 832
pread64(3, "\6\0\0\0\4\0\0\0@\0\0\0\0\0\0\0@\0\0\0\0\0\0\0@\0\0\0\0\0\0\0"..., 784, 64) = 784
pread64(3, "\4\0\0\0\20\0\0\0\5\0\0\0GNU\0\2\0\0\300\4\0\0\0\3\0\0\0\0\0\0\0", 32, 848) = 32
pread64(3, "\4\0\0\0\24\0\0\0\3\0\0\0GNU\0\t\233\222%\274\260\320\31\331\326\10\204\276X>\263"..., 68, 880) = 68
fstat(3, {st_mode=S_IFREG|0755, st_size=2029224, ...}) = 0
mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f9981c6f000
pread64(3, "\6\0\0\0\4\0\0\0@\0\0\0\0\0\0\0@\0\0\0\0\0\0\0@\0\0\0\0\0\0\0"..., 784, 64) = 784
pread64(3, "\4\0\0\0\20\0\0\0\5\0\0\0GNU\0\2\0\0\300\4\0\0\0\3\0\0\0\0\0\0\0", 32, 848) = 32
pread64(3, "\4\0\0\0\24\0\0\0\3\0\0\0GNU\0\t\233\222%\274\260\320\31\331\326\10\204\276X>\263"..., 68, 880) = 68
mmap(NULL, 2036952, PROT_READ, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f9981a7d000
mprotect(0x7f9981aa2000, 1847296, PROT_NONE) = 0
mmap(0x7f9981aa2000, 1540096, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x25000) = 0x7f9981aa2000
mmap(0x7f9981c1a000, 303104, PROT_READ, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x19d000) = 0x7f9981c1a000
mmap(0x7f9981c65000, 24576, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x1e7000) = 0x7f9981c65000
mmap(0x7f9981c6b000, 13528, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f9981c6b000
close(3)                                = 0
arch_prctl(ARCH_SET_FS, 0x7f9981c70580) = 0
mprotect(0x7f9981c65000, 12288, PROT_READ) = 0
mprotect(0x56533e050000, 4096, PROT_READ) = 0
mprotect(0x7f9981ca7000, 4096, PROT_READ) = 0
munmap(0x7f9981c71000, 36389)           = 0
brk(NULL)                               = 0x56533ebcb000
brk(0x56533ebec000)                     = 0x56533ebec000
openat(AT_FDCWD, "/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = 3
fstat(3, {st_mode=S_IFREG|0644, st_size=3035952, ...}) = 0
mmap(NULL, 3035952, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f9981797000
close(3)                                = 0
execve("/home/jay/.local/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/.krew/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/sbin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/.wasme/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/.cargo/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/opt/openssl/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/opt/python/libexec/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/.gem/ruby/2.6.0/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/sbin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/sbin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/sbin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/games/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/games/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/lib/wsl/lib/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files (x86)/Razer/ChromaBroadcast/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/Razer/ChromaBroadcast/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Windows/system32/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Windows/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Windows/System32/Wbem/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Windows/System32/WindowsPowerShell/v1.0//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Windows/System32/OpenSSH//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/system32/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/Wbem/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/OpenSSH//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/Microsoft SQL Server/Client SDK/ODBC/170/Tools/Binn//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 EACCES (Permission denied)
execve("/mnt/c/Program Files/Microsoft SQL Server/130/Tools/Binn//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/program files (x86)/iracing/d3dgear/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/dotnet//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/nodejs//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/system32/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/Wbem/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/WINDOWS/System32/OpenSSH//does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/Git/cmd/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Users/jay/.cargo/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Users/jay/AppData/Local/Microsoft/WindowsApps/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Program Files/CMake/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Users/jay/.dotnet/tools/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/mnt/c/Users/jay/AppData/Roaming/npm/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/snap/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/share/npm/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/home/jay/golang/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
execve("/usr/local/opt/go/libexec/bin/does-not-exist", ["does-not-exist"], 0x7ffeb9e6e970 /* 46 vars */) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/locale.alias", O_RDONLY|O_CLOEXEC) = 3
fstat(3, {st_mode=S_IFREG|0644, st_size=2996, ...}) = 0
read(3, "# Locale name alias data base.\n#"..., 4096) = 2996
read(3, "", 4096)                       = 0
close(3)                                = 0
openat(AT_FDCWD, "/usr/share/locale/en_US.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en_US.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en_US/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
write(2, "/usr/bin/env: ", 14/usr/bin/env: )          = 14
write(2, "\342\200\230does-not-exist\342\200\231", 20‘does-not-exist’) = 20
openat(AT_FDCWD, "/usr/share/locale/en_US.UTF-8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en_US.utf8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en_US/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en.UTF-8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en.utf8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale/en/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US.UTF-8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en_US/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en.UTF-8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en.utf8/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/usr/share/locale-langpack/en/LC_MESSAGES/libc.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
write(2, ": Permission denied", 19: Permission denied)     = 19
write(2, "\n", 1
)                       = 1
close(1)                                = 0
close(2)                                = 0
exit_group(126)                         = ?
+++ exited with 126 +++
```
</details>

This PR accepts `PermissionDenied` and `NotFound` for the process spawn test, and changes the expectation on the linker test to match both error messages. `PermissionDenied` seems like a reasonable return value for commands that do not exist, considering that's what the kernel is giving me.