### PR TITLE
Improve error message for `E0659` if the source is not available

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1178,7 +1178,7 @@ impl<'a> Resolver<'a> {
 
     fn binding_description(&self, b: &NameBinding<'_>, ident: Ident, from_prelude: bool) -> String {
         let res = b.res();
-        if b.span.is_dummy() {
+        if b.span.is_dummy() || self.session.source_map().span_to_snippet(b.span).is_err() {
             // These already contain the "built-in" prefix or look bad with it.
             let add_built_in =
                 !matches!(b.res(), Res::NonMacroAttr(..) | Res::PrimTy(..) | Res::ToolMod);


### PR DESCRIPTION
Fixes #91028. The fix is similar to those in #89233 and #87088. With this change, instead of the dangling
```
note: `Option` could also refer to the enum defined here
```
I get
```
note: `Option` could also refer to an enum from prelude
```
If the standard library source code _is_ available, the output does not change.