### PR TITLE
rustdoc: Remove apparently unnecessary conditional in `doc_value`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1067,9 +1067,6 @@ impl Attributes {
         let mut out = String::new();
         add_doc_fragment(&mut out, ori);
         for new_frag in iter {
-            if new_frag.kind != ori.kind || new_frag.parent_module != ori.parent_module {
-                break;
-            }
             add_doc_fragment(&mut out, new_frag);
         }
         out.pop();


### PR DESCRIPTION
I need to remove this conditional for #91072, but while it seems
unnecessary, we are not certain. So, the plan is to first remove the
conditional and see if any regressions pop up before doing the refactor.
This way, it will be easier to revert if there are subtle regressions.

r? @jyn514 