### PR TITLE
Fix ICE when lowering `trait A where for<'a> Self: 'a`

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -666,7 +666,7 @@ impl ItemCtxt<'tcx> {
                 Some(assoc_name) => self.bound_defines_assoc_item(b, assoc_name),
                 None => true,
             })
-            .flat_map(|b| predicates_from_bound(self, ty, b));
+            .flat_map(|b| predicates_from_bound(self, ty, b, ty::List::empty()));
 
         let param_def_id = self.tcx.hir().local_def_id(param_id).to_def_id();
         let from_where_clauses = ast_generics
@@ -685,15 +685,17 @@ impl ItemCtxt<'tcx> {
                 } else {
                     None
                 };
+                let bvars = self.tcx.late_bound_vars(bp.bounded_ty.hir_id);
+
                 bp.bounds
                     .iter()
                     .filter(|b| match assoc_name {
                         Some(assoc_name) => self.bound_defines_assoc_item(b, assoc_name),
                         None => true,
                     })
-                    .filter_map(move |b| bt.map(|bt| (bt, b)))
+                    .filter_map(move |b| bt.map(|bt| (bt, b, bvars)))
             })
-            .flat_map(|(bt, b)| predicates_from_bound(self, bt, b));
+            .flat_map(|(bt, b, bvars)| predicates_from_bound(self, bt, b, bvars));
 
         from_ty_params.chain(from_where_clauses).collect()
     }
@@ -2433,14 +2435,10 @@ fn predicates_from_bound<'tcx>(
     astconv: &dyn AstConv<'tcx>,
     param_ty: Ty<'tcx>,
     bound: &'tcx hir::GenericBound<'tcx>,
+    bound_vars: &'tcx ty::List<ty::BoundVariableKind>,
 ) -> Vec<(ty::Predicate<'tcx>, Span)> {
     let mut bounds = Bounds::default();
-    astconv.add_bounds(
-        param_ty,
-        std::array::IntoIter::new([bound]),
-        &mut bounds,
-        ty::List::empty(),
-    );
+    astconv.add_bounds(param_ty, std::array::IntoIter::new([bound]), &mut bounds, bound_vars);
     bounds.predicates(astconv.tcx(), param_ty)
 }
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2438,7 +2438,7 @@ fn predicates_from_bound<'tcx>(
     bound_vars: &'tcx ty::List<ty::BoundVariableKind>,
 ) -> Vec<(ty::Predicate<'tcx>, Span)> {
     let mut bounds = Bounds::default();
-    astconv.add_bounds(param_ty, std::array::IntoIter::new([bound]), &mut bounds, bound_vars);
+    astconv.add_bounds(param_ty, [bound].into_iter(), &mut bounds, bound_vars);
     bounds.predicates(astconv.tcx(), param_ty)
 }
 

--- a/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.rs
@@ -1,0 +1,11 @@
+// Regression test for #88586: a higher-ranked outlives bound on Self in a trait
+// definition caused an ICE when debug_assertions were enabled.
+//
+// The error output is incidentally unhelpful; this should be improved.
+
+trait A where for<'a> Self: 'a
+//~^ ERROR the parameter type `Self` may not live long enough
+{
+}
+
+fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.rs
+++ b/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.rs
@@ -1,7 +1,7 @@
 // Regression test for #88586: a higher-ranked outlives bound on Self in a trait
 // definition caused an ICE when debug_assertions were enabled.
 //
-// The error output is incidentally unhelpful; this should be improved.
+// FIXME: The error output in the absence of the ICE is unhelpful; this should be improved.
 
 trait A where for<'a> Self: 'a
 //~^ ERROR the parameter type `Self` may not live long enough

--- a/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/issue-88586-hr-self-outlives-in-trait-def.stderr
@@ -1,0 +1,19 @@
+error[E0311]: the parameter type `Self` may not live long enough
+  --> $DIR/issue-88586-hr-self-outlives-in-trait-def.rs:6:1
+   |
+LL | / trait A where for<'a> Self: 'a
+LL | |
+LL | | {
+LL | | }
+   | |_^
+   |
+   = help: consider adding an explicit lifetime bound `Self: 'a`...
+   = note: ...so that the type `Self` will meet its required lifetime bounds...
+note: ...that is required by this bound
+  --> $DIR/issue-88586-hr-self-outlives-in-trait-def.rs:6:29
+   |
+LL | trait A where for<'a> Self: 'a
+   |                             ^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #88586.

r? @jackh726 

Jack, this fix is much smaller in scope than what I think you were proposing in the issue. Let me know if you had a vision for a larger refactor here.

cc @JohnTitor 