### PR TITLE
Add suggestion to diagnostic when user has array but trait wants slice.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -498,7 +498,14 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         } else if !have_alt_message {
                             // Can't show anything else useful, try to find similar impls.
                             let impl_candidates = self.find_similar_impl_candidates(trait_ref);
-                            self.report_similar_impl_candidates(impl_candidates, &mut err);
+                            self.report_similar_impl_candidates(&impl_candidates, &mut err);
+
+                            self.maybe_suggest_convert_to_slice(
+                                &mut err,
+                                trait_ref,
+                                &impl_candidates,
+                                span,
+                            );
                         }
 
                         // Changing mutability doesn't make a difference to whether we have
@@ -1091,7 +1098,7 @@ trait InferCtxtPrivExt<'tcx> {
 
     fn report_similar_impl_candidates(
         &self,
-        impl_candidates: Vec<ty::TraitRef<'tcx>>,
+        impl_candidates: &[ty::TraitRef<'tcx>],
         err: &mut DiagnosticBuilder<'_>,
     );
 
@@ -1432,7 +1439,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
 
     fn report_similar_impl_candidates(
         &self,
-        impl_candidates: Vec<ty::TraitRef<'tcx>>,
+        impl_candidates: &[ty::TraitRef<'tcx>],
         err: &mut DiagnosticBuilder<'_>,
     ) {
         if impl_candidates.is_empty() {

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-1.rs
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-1.rs
@@ -1,0 +1,28 @@
+// Issue #90528: provide helpful suggestions when a trait bound is unsatisfied
+// due to a missed unsizing coercion.
+//
+// This test exercises array literals and a trait implemented on immutable slices.
+
+trait Read {}
+
+impl Read for &[u8] {}
+
+fn wants_read(_: impl Read) {}
+
+fn main() {
+    wants_read([0u8]);
+    //~^ ERROR the trait bound `[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &[0u8][..]
+    wants_read(&[0u8]);
+    //~^ ERROR the trait bound `&[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &[0u8][..]
+    wants_read(&[0u8][..]);
+
+    wants_read(&mut [0u8]);
+    //~^ ERROR the trait bound `&mut [u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+}

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-1.stderr
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-1.stderr
@@ -1,0 +1,55 @@
+error[E0277]: the trait bound `[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:13:16
+   |
+LL |     wants_read([0u8]);
+   |     ---------- ^^^^^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&[0u8][..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `&[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:18:16
+   |
+LL |     wants_read(&[0u8]);
+   |     ---------- ^^^^^^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `&[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&[0u8][..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `&mut [u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:25:16
+   |
+LL |     wants_read(&mut [0u8]);
+   |     ---------- ^^^^^^^^^^ the trait `Read` is not implemented for `&mut [u8; 1]`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-1.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-2.rs
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-2.rs
@@ -1,0 +1,42 @@
+// Issue #90528: provide helpful suggestions when a trait bound is unsatisfied
+// due to a missed unsizing coercion.
+//
+// This test exercises array variables and a trait implemented on immmutable slices.
+
+trait Read {}
+
+impl Read for &[u8] {}
+
+fn wants_read(_: impl Read) {}
+
+fn main() {
+    let x = [0u8];
+    wants_read(x);
+    //~^ ERROR the trait bound `[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &x[..]
+    wants_read(&x);
+    //~^ ERROR the trait bound `&[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &x[..]
+    wants_read(&x[..]);
+
+    let x = &[0u8];
+    wants_read(x);
+    //~^ ERROR the trait bound `&[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &x[..]
+    wants_read(&x);
+    //~^ ERROR the trait bound `&&[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    wants_read(*x);
+    //~^ ERROR the trait bound `[u8; 1]: Read` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &*x[..]
+    //              ^^^^^^^ bad suggestion
+    wants_read(&x[..]);
+}

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-2.stderr
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-2.stderr
@@ -1,0 +1,91 @@
+error[E0277]: the trait bound `[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:14:16
+   |
+LL |     wants_read(x);
+   |     ---------- ^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `&[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:19:16
+   |
+LL |     wants_read(&x);
+   |     ---------- ^^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `&[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `&[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:27:16
+   |
+LL |     wants_read(x);
+   |     ---------- ^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `&[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `&&[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:32:16
+   |
+LL |     wants_read(&x);
+   |     ---------- ^^ the trait `Read` is not implemented for `&&[u8; 1]`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error[E0277]: the trait bound `[u8; 1]: Read` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:35:16
+   |
+LL |     wants_read(*x);
+   |     ---------- ^^
+   |     |          |
+   |     |          the trait `Read` is not implemented for `[u8; 1]`
+   |     |          help: convert the array to a `&[u8]` slice instead: `&*x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&[u8] as Read>
+note: required by a bound in `wants_read`
+  --> $DIR/issue-90528-unsizing-suggestion-2.rs:10:23
+   |
+LL | fn wants_read(_: impl Read) {}
+   |                       ^^^^ required by this bound in `wants_read`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-3.rs
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-3.rs
@@ -1,0 +1,33 @@
+// Issue #90528: provide helpful suggestions when a trait bound is unsatisfied
+// due to a missed unsizing coercion.
+//
+// This test exercises array literals and a trait implemented on mutable slices.
+
+trait Write {}
+
+impl Write for & mut [u8] {}
+
+fn wants_write(_: impl Write) {}
+
+fn main() {
+    wants_write([0u8]);
+    //~^ ERROR the trait bound `[u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut [0u8][..]
+    wants_write(&mut [0u8]);
+    //~^ ERROR the trait bound `&mut [u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut [0u8][..]
+    wants_write(&mut [0u8][..]);
+
+    wants_write(&[0u8]);
+    //~^ ERROR the trait bound `&[u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+
+    wants_write(&[0u8][..]);
+    //~^ ERROR the trait bound `&[u8]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP consider changing this borrow's mutability
+}

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-3.stderr
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-3.stderr
@@ -1,0 +1,75 @@
+error[E0277]: the trait bound `[u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:13:17
+   |
+LL |     wants_write([0u8]);
+   |     ----------- ^^^^^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `[u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut [0u8][..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `&mut [u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:18:17
+   |
+LL |     wants_write(&mut [0u8]);
+   |     ----------- ^^^^^^^^^^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `&mut [u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut [0u8][..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `&[u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:25:17
+   |
+LL |     wants_write(&[0u8]);
+   |     ----------- ^^^^^^ the trait `Write` is not implemented for `&[u8; 1]`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `&[u8]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:29:17
+   |
+LL |     wants_write(&[0u8][..]);
+   |     ----------- ^^^^^^^^^^ the trait `Write` is not implemented for `&[u8]`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-3.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+help: consider changing this borrow's mutability
+   |
+LL |     wants_write(&mut [0u8][..]);
+   |                 ~~~~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-4.rs
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-4.rs
@@ -1,0 +1,39 @@
+// Issue #90528: provide helpful suggestions when a trait bound is unsatisfied
+// due to a missed unsizing coercion.
+//
+// This test exercises array variables and a trait implemented on mutable slices.
+
+trait Write {}
+
+impl Write for & mut [u8] {}
+
+fn wants_write(_: impl Write) {}
+
+fn main() {
+    let mut x = [0u8];
+    wants_write(x);
+    //~^ ERROR the trait bound `[u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut x[..]
+    wants_write(&mut x);
+    //~^ ERROR the trait bound `&mut [u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut x[..]
+    wants_write(&mut x[..]);
+
+    let x = &mut [0u8];
+    wants_write(x);
+    //~^ ERROR the trait bound `&mut [u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut x[..]
+    wants_write(*x);
+    //~^ ERROR the trait bound `[u8; 1]: Write` is not satisfied
+    //~| HELP the following implementations were found
+    //~| HELP convert the array
+    //~| SUGGESTION &mut *x[..]
+    //              ^^^^^^^ bad suggestion
+    wants_write(&mut x[..]);
+}

--- a/src/test/ui/dst/issue-90528-unsizing-suggestion-4.stderr
+++ b/src/test/ui/dst/issue-90528-unsizing-suggestion-4.stderr
@@ -1,0 +1,75 @@
+error[E0277]: the trait bound `[u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:14:17
+   |
+LL |     wants_write(x);
+   |     ----------- ^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `[u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `&mut [u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:19:17
+   |
+LL |     wants_write(&mut x);
+   |     ----------- ^^^^^^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `&mut [u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `&mut [u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:27:17
+   |
+LL |     wants_write(x);
+   |     ----------- ^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `&mut [u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error[E0277]: the trait bound `[u8; 1]: Write` is not satisfied
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:32:17
+   |
+LL |     wants_write(*x);
+   |     ----------- ^^
+   |     |           |
+   |     |           the trait `Write` is not implemented for `[u8; 1]`
+   |     |           help: convert the array to a `&mut [u8]` slice instead: `&mut *x[..]`
+   |     required by a bound introduced by this call
+   |
+   = help: the following implementations were found:
+             <&mut [u8] as Write>
+note: required by a bound in `wants_write`
+  --> $DIR/issue-90528-unsizing-suggestion-4.rs:10:24
+   |
+LL | fn wants_write(_: impl Write) {}
+   |                        ^^^^^ required by this bound in `wants_write`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Resolves #90528.

Before:

<img width="629" alt="image" src="https://user-images.githubusercontent.com/13339928/143768111-5d9bbfe1-2725-4afe-a496-8dc43ca3e65a.png">

After:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/13339928/143768259-1ce98f09-0996-46d3-af2c-4c31edb31c70.png">

Alternatively, I could make it look like this:

<img width="630" alt="image" src="https://user-images.githubusercontent.com/13339928/143768047-40521428-40ba-405d-8281-0e786f678030.png">

The latter more closely mirrors other suggestions like "consider changing this borrow's mutability," but the former kinda looks better. I'm open to other ideas as well.

The code ended up being a little more complicated than I had hoped. Had to account for different mutabilities and variables vs. literals. See the tests.

Since I found it impractical to provide a machine applicable suggestion, is it maybe not worth bothering with the complicated mutability logic?

cc @binajmen
