### PR TITLE
tests: Ignore `test/debuginfo/rc_arc.rs` on windows-gnu

### DIFF
--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -1,4 +1,4 @@
-// pretty-printers are not loaded
+// ignore-windows-gnu: pretty-printers are not loaded
 // compile-flags:-g
 
 // min-gdb-version: 8.1


### PR DESCRIPTION
The tests checks some pretty-printer output, but pretty-printers are not embedded on windows-gnu.

Regressed in https://github.com/rust-lang/rust/pull/85448.