### PR TITLE
Change output path to {{build-base}} for rustdoc scrape_examples ui test

### DIFF
--- a/src/test/rustdoc-ui/scrape-examples-ice.rs
+++ b/src/test/rustdoc-ui/scrape-examples-ice.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z unstable-options --scrape-examples-output-path t.calls --scrape-examples-target-crate foobar
+// compile-flags: -Z unstable-options --scrape-examples-output-path {{build-base}}/t.calls --scrape-examples-target-crate foobar
 // check-pass
 #![no_std]
 use core as _;


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/90611#issuecomment-981092909

r? @jyn514 

cc @petrochenkov 