### PR TITLE
Accumulate all values of `-C remark` option

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -833,6 +833,13 @@ impl Passes {
             Passes::All => false,
         }
     }
+
+    pub fn extend(&mut self, passes: impl IntoIterator<Item = String>) {
+        match *self {
+            Passes::Some(ref mut v) => v.extend(passes),
+            Passes::All => {}
+        }
+    }
 }
 
 pub const fn default_lib_output() -> CrateType {

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -567,7 +567,7 @@ mod parse {
             v => {
                 let mut passes = vec![];
                 if parse_list(&mut passes, v) {
-                    *slot = Passes::Some(passes);
+                    slot.extend(passes);
                     true
                 } else {
                     false

--- a/src/test/ui/optimization-remark.rs
+++ b/src/test/ui/optimization-remark.rs
@@ -1,10 +1,19 @@
 // build-pass
 // ignore-pass
 // no-system-llvm
-// revisions: all inline
-//          compile-flags: --crate-type=lib -Cdebuginfo=1 -Copt-level=2
+// revisions: all inline merge1 merge2
+// compile-flags: --crate-type=lib -Cdebuginfo=1 -Copt-level=2
+//
+// Check that remarks can be enabled individually or with "all":
+//
 // [all]    compile-flags: -Cremark=all
 // [inline] compile-flags: -Cremark=inline
+//
+// Check that values of -Cremark flag are accumulated:
+//
+// [merge1] compile-flags: -Cremark=all    -Cremark=giraffe
+// [merge2] compile-flags: -Cremark=inline -Cremark=giraffe
+//
 // error-pattern: inline: f not inlined into g
 // dont-check-compiler-stderr
 


### PR DESCRIPTION
When `-C remark=...` option is specified multiple times,
accumulate all values instead of using only the last one.

r? @nikic