### PR TITLE
Fix ICE in `check_must_not_suspend_ty()`

### DIFF
--- a/src/test/ui/typeck/issue-91334.rs
+++ b/src/test/ui/typeck/issue-91334.rs
@@ -1,0 +1,10 @@
+// Regression test for the ICE described in issue #91334.
+
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected one of
+// error-pattern: mismatched closing delimiter
+// error-pattern: mismatched types
+
+#![feature(generators)]
+
+fn f(){||yield(((){),

--- a/src/test/ui/typeck/issue-91334.stderr
+++ b/src/test/ui/typeck/issue-91334.stderr
@@ -1,0 +1,50 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-91334.rs:10:23
+   |
+LL | fn f(){||yield(((){),
+   |       -       -       ^
+   |       |       |
+   |       |       unclosed delimiter
+   |       unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-91334.rs:10:23
+   |
+LL | fn f(){||yield(((){),
+   |       -       -       ^
+   |       |       |
+   |       |       unclosed delimiter
+   |       unclosed delimiter
+
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `{`
+  --> $DIR/issue-91334.rs:10:19
+   |
+LL | fn f(){||yield(((){),
+   |                   ^
+   |                   |
+   |                   expected one of `)`, `,`, `.`, `?`, or an operator
+   |                   help: missing `,`
+
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-91334.rs:10:19
+   |
+LL | fn f(){||yield(((){),
+   |                -  ^^ mismatched closing delimiter
+   |                |  |
+   |                |  unclosed delimiter
+   |                closing delimiter possibly meant for this
+
+error[E0308]: mismatched types
+  --> $DIR/issue-91334.rs:10:8
+   |
+LL | fn f(){||yield(((){),
+   |       -^^^^^^^^^^^^^^^ expected `()`, found generator
+   |       |
+   |       help: try adding a return type: `-> [generator@$DIR/issue-91334.rs:10:8: 10:23]`
+   |
+   = note: expected unit type `()`
+              found generator `[generator@$DIR/issue-91334.rs:10:8: 10:23]`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #91334. I have also used `TyS::tuple_fields()` (instead of the `SubstsRef` directly) to get the tuple fields, because that's what [the documentation](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.TyKind.html#variant.Tuple) says, although it doesn't seem to make a difference in practice (this is not what fixed the ICE).