### PR TITLE
Add needs-unwind to tests that depend on panicking

### DIFF
--- a/src/test/ui/array-slice-vec/box-of-array-of-drop-1.rs
+++ b/src/test/ui/array-slice-vec/box-of-array-of-drop-1.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // Test that we cleanup a fixed size Box<[D; k]> properly when D has a

--- a/src/test/ui/array-slice-vec/box-of-array-of-drop-2.rs
+++ b/src/test/ui/array-slice-vec/box-of-array-of-drop-2.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // Test that we cleanup dynamic sized Box<[D]> properly when D has a

--- a/src/test/ui/array-slice-vec/nested-vec-3.rs
+++ b/src/test/ui/array-slice-vec/nested-vec-3.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // ignore-emscripten no threads support

--- a/src/test/ui/array-slice-vec/slice-panic-1.rs
+++ b/src/test/ui/array-slice-vec/slice-panic-1.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-emscripten no threads support
 

--- a/src/test/ui/array-slice-vec/slice-panic-2.rs
+++ b/src/test/ui/array-slice-vec/slice-panic-2.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-emscripten no threads support
 

--- a/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -2,6 +2,7 @@
 // be talking about `async fn`s instead. Should also test what happens when it panics.
 
 // run-fail
+// needs-unwind
 // error-pattern: thread 'main' panicked at '`async fn` resumed after panicking'
 // edition:2018
 // ignore-wasm no panic or subprocess support

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 

--- a/src/test/ui/builtin-clone-unwind.rs
+++ b/src/test/ui/builtin-clone-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]

--- a/src/test/ui/catch-unwind-bang.rs
+++ b/src/test/ui/catch-unwind-bang.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 fn worker() -> ! {

--- a/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(unused_must_use)]
 #![allow(dead_code)]

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// needs-unwind
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// needs-unwind
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
-  --> $DIR/mir_calls_to_shims.rs:20:38
+  --> $DIR/mir_calls_to_shims.rs:21:38
    |
 LL |     let result = panic::catch_unwind(move || {
    |                                      ^^^^^^^
@@ -11,7 +11,7 @@ LL |         f.0()
    |         --- in Rust 2018, this closure captures all of `f`, but in Rust 2021, it will only capture `f.0`
    |
 note: the lint level is defined here
-  --> $DIR/mir_calls_to_shims.rs:3:9
+  --> $DIR/mir_calls_to_shims.rs:4:9
    |
 LL | #![deny(rust_2021_incompatible_closure_captures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/drop/drop-trait-enum.rs
+++ b/src/test/ui/drop/drop-trait-enum.rs
@@ -3,6 +3,7 @@
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
 // ignore-emscripten no threads support
+// needs-unwind
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -4,6 +4,7 @@
 // * Dropping one of the values panics while dropping the future.
 
 // run-pass
+// needs-unwind
 // edition:2018
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]

--- a/src/test/ui/drop/terminate-in-initializer.rs
+++ b/src/test/ui/drop/terminate-in-initializer.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Issue #787

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 

--- a/src/test/ui/generator/generator-resume-after-panic.rs
+++ b/src/test/ui/generator/generator-resume-after-panic.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:generator resumed after panicking
 // ignore-emscripten no processes
 

--- a/src/test/ui/generator/panic-drops-resume.rs
+++ b/src/test/ui/generator/panic-drops-resume.rs
@@ -1,6 +1,7 @@
 //! Tests that panics inside a generator will correctly drop the initial resume argument.
 
 // run-pass
+// needs-unwind
 // ignore-wasm       no unwind support
 // ignore-emscripten no unwind support
 

--- a/src/test/ui/generator/panic-drops.rs
+++ b/src/test/ui/generator/panic-drops.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/generator/panic-safe.rs
+++ b/src/test/ui/generator/panic-safe.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/generator/resume-after-return.rs
+++ b/src/test/ui/generator/resume-after-return.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // revisions: mir thir
 // [thir]compile-flags: -Zthir-unsafeck

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)

--- a/src/test/ui/issues/issue-25089.rs
+++ b/src/test/ui/issues/issue-25089.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::thread;

--- a/src/test/ui/issues/issue-26655.rs
+++ b/src/test/ui/issues/issue-26655.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Check that the destructors of simple enums are run on unwinding

--- a/src/test/ui/issues/issue-29485.rs
+++ b/src/test/ui/issues/issue-29485.rs
@@ -1,6 +1,7 @@
 // run-pass
 #![allow(unused_attributes)]
 // aux-build:issue-29485.rs
+// needs-unwind
 // ignore-emscripten no threads
 
 #[feature(recover)]

--- a/src/test/ui/issues/issue-29948.rs
+++ b/src/test/ui/issues/issue-29948.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;

--- a/src/test/ui/issues/issue-30018-panic.rs
+++ b/src/test/ui/issues/issue-30018-panic.rs
@@ -4,6 +4,7 @@
 // spawned thread to isolate the expected error result from the
 // SIGTRAP injected by the drop-flag consistency checking.
 
+// needs-unwind
 // ignore-emscripten no threads support
 
 struct Foo;

--- a/src/test/ui/issues/issue-43853.rs
+++ b/src/test/ui/issues/issue-43853.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -1,6 +1,7 @@
 // run-pass
 // compile-flags:--test -O
 
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #[test]

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 

--- a/src/test/ui/iterators/iter-step-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-step-overflow-debug.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 

--- a/src/test/ui/iterators/iter-sum-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 

--- a/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C overflow-checks
 

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(unused_imports)]
 // Ideally, any macro call with a trailing comma should behave
 // identically to a call without the comma.

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]

--- a/src/test/ui/mir/mir_drop_order.rs
+++ b/src/test/ui/mir/mir_drop_order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::cell::RefCell;

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:panic 1
 // error-pattern:drop 2
 // ignore-emscripten no processes

--- a/src/test/ui/mir/mir_dynamic_drops_3.rs
+++ b/src/test/ui/mir/mir_dynamic_drops_3.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:unwind happens
 // error-pattern:drop 3
 // error-pattern:drop 2

--- a/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
+++ b/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
@@ -1,6 +1,7 @@
 // run-pass
 // compile-flags: -C overflow-checks=on
 // ignore-emscripten no threads support
+// needs-unwind
 
 use std::thread;
 

--- a/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
+++ b/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // compile-flags: -C debug_assertions=yes
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten dies with an LLVM error
 

--- a/src/test/ui/panics/panic-handler-chain.rs
+++ b/src/test/ui/panics/panic-handler-chain.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(stable_features)]
 
 // ignore-emscripten no threads support

--- a/src/test/ui/panics/panic-handler-flail-wildly.rs
+++ b/src/test/ui/panics/panic-handler-flail-wildly.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(stable_features)]
 #![allow(unused_must_use)]

--- a/src/test/ui/panics/panic-handler-set-twice.rs
+++ b/src/test/ui/panics/panic-handler-set-twice.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(unused_variables)]
 #![allow(stable_features)]
 

--- a/src/test/ui/panics/panic-in-dtor-drops-fields.rs
+++ b/src/test/ui/panics/panic-in-dtor-drops-fields.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/ui/panics/panic-recover-propagate.rs
+++ b/src/test/ui/panics/panic-recover-propagate.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/test/ui/privacy/reachable-unnameable-items.rs
+++ b/src/test/ui/privacy/reachable-unnameable-items.rs
@@ -1,5 +1,6 @@
 // run-pass
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 // aux-build:reachable-unnameable-items.rs
 
 extern crate reachable_unnameable_items;

--- a/src/test/ui/proc-macro/expand-with-a-macro.rs
+++ b/src/test/ui/proc-macro/expand-with-a-macro.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // aux-build:expand-with-a-macro.rs
 
 // ignore-wasm32-bare compiled with panic=abort by default

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -1,5 +1,6 @@
 // compile-flags: --test
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4

--- a/src/test/ui/rfcs/rfc1857-drop-order.rs
+++ b/src/test/ui/rfcs/rfc1857-drop-order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(dead_code, unreachable_code)]

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-wasm32-bare no unwinding panic

--- a/src/test/ui/sepcomp/sepcomp-unwind.rs
+++ b/src/test/ui/sepcomp/sepcomp-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(dead_code)]
 // compile-flags: -C codegen-units=3
 // ignore-emscripten no threads support

--- a/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
+++ b/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Make sure the destructor is run for unit-like structs.

--- a/src/test/ui/test-attrs/test-should-fail-good-message.rs
+++ b/src/test/ui/test-attrs/test-should-fail-good-message.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: --test
 #[test]

--- a/src/test/ui/threads-sendsync/task-stderr.rs
+++ b/src/test/ui/threads-sendsync/task-stderr.rs
@@ -1,5 +1,6 @@
 // run-pass
 // ignore-emscripten no threads support
+// needs-unwind
 
 #![feature(internal_output_capture)]
 

--- a/src/test/ui/threads-sendsync/unwind-resource.rs
+++ b/src/test/ui/threads-sendsync/unwind-resource.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(non_camel_case_types)]
 // ignore-emscripten no threads support

--- a/src/test/ui/unwind-unique.rs
+++ b/src/test/ui/unwind-unique.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::thread;


### PR DESCRIPTION
These tests were found by running the test suite on fuchsia which compiles with `panic=abort` by default, then picking through the failures manually to locate the tests that require unwinding support.

Most of these tests are already opted-out on platforms that compile with `panic=abort` by default. This just generalizes it a bit more so that fuchsia tests can be run properly. Currently, the `needs-unwind` directive needs to be manually passed to compiletest (e.g. via `--test-args '--target-panic=abort'`). Eventually, I would like `x.py` or compiletest to determine whether the directive should be used automatically based on the target panic settings.