### PR TITLE
Android: -ldl must appear after -lgcc when linking

### DIFF
--- a/library/unwind/build.rs
+++ b/library/unwind/build.rs
@@ -17,6 +17,9 @@ fn main() {
         } else {
             println!("cargo:rustc-link-lib=gcc");
         }
+
+        // Android's unwinding library depends on dl_iterate_phdr in `libdl`.
+        println!("cargo:rustc-link-lib=dl");
     } else if target.contains("freebsd") {
         println!("cargo:rustc-link-lib=gcc_s");
     } else if target.contains("netbsd") {


### PR DESCRIPTION
#90846 accidentally broke Android builds because it causes the standard library to no longer use `dlsym` on Android. This results in `libdl` being ignored by the linker since no symbols are needed from it. However, we later import `libgcc` for unwinding which *does* depend on `libdl` for `dl_iterate_phdr`. Since linkers don't revisit previous libraries when resolving symbols, this causes a linker error due to an undefined reference to `dl_iterate_phdr`.

This is resolved by adding a second `-ldl` after `-lgcc` in the linker command-line.