### PR TITLE
Add `drop_while` as doc alias to `Iterator::skip_while`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1023,6 +1023,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
+    #[doc(alias = "drop_while")]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
     where


### PR DESCRIPTION
`skip_while` is commonly referred to as `drop_while` in other languages (clojure/c++/haskell). This recently came up in [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/.E2.9C.94.20DropWhile/near/262203352) as well.

This pull request adds 'drop_while' as a doc-alias for 'skip_while'.

r? @joshtriplett 