### PR TITLE
Emit only a single replacement character for WTF-8 surrogates

### DIFF
--- a/library/alloc/tests/string.rs
+++ b/library/alloc/tests/string.rs
@@ -110,10 +110,7 @@ fn test_from_utf8_lossy() {
 
     // surrogates
     let xs = b"\xED\xA0\x80foo\xED\xBF\xBFbar";
-    assert_eq!(
-        String::from_utf8_lossy(xs),
-        String::from("\u{FFFD}\u{FFFD}\u{FFFD}foo\u{FFFD}\u{FFFD}\u{FFFD}bar").into_cow()
-    );
+    assert_eq!(String::from_utf8_lossy(xs), String::from("\u{FFFD}foo\u{FFFD}bar").into_cow());
 }
 
 #[test]

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -85,11 +85,10 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
                         i += 1;
                     }
                     3 => {
-                        match (byte, safe_get(self.source, i)) {
+                        let second = safe_get(self.source, i);
+                        match (byte, second) {
                             (0xE0, 0xA0..=0xBF) => (),
-                            (0xE1..=0xEC, 0x80..=0xBF) => (),
-                            (0xED, 0x80..=0x9F) => (),
-                            (0xEE..=0xEF, 0x80..=0xBF) => (),
+                            (0xE1..=0xEF, 0x80..=0xBF) => (),
                             _ => break,
                         }
                         i += 1;
@@ -97,6 +96,9 @@ impl<'a> Iterator for Utf8LossyChunksIter<'a> {
                             break;
                         }
                         i += 1;
+                        if let (0xED, 0xA0..=0xBF) = (byte, second) {
+                            break;
+                        }
                     }
                     4 => {
                         match (byte, safe_get(self.source, i)) {

--- a/library/core/tests/str_lossy.rs
+++ b/library/core/tests/str_lossy.rs
@@ -55,12 +55,8 @@ fn chunks() {
 
     // surrogates
     let mut iter = Utf8Lossy::from_bytes(b"\xED\xA0\x80foo\xED\xBF\xBFbar").chunks();
-    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\xED" }), iter.next());
-    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\xA0" }), iter.next());
-    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\x80" }), iter.next());
-    assert_eq!(Some(Utf8LossyChunk { valid: "foo", broken: b"\xED" }), iter.next());
-    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\xBF" }), iter.next());
-    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\xBF" }), iter.next());
+    assert_eq!(Some(Utf8LossyChunk { valid: "", broken: b"\xED\xA0\x80" }), iter.next());
+    assert_eq!(Some(Utf8LossyChunk { valid: "foo", broken: b"\xED\xBF\xBF" }), iter.next());
     assert_eq!(Some(Utf8LossyChunk { valid: "bar", broken: b"" }), iter.next());
     assert_eq!(None, iter.next());
 }


### PR DESCRIPTION
### Background:

- Unicode code points are integers in the discontiguous range 0..=D7FF ∪ E000..=10FFFF. The high end of this range is greater than u16::MAX, which is FFFF.

- UTF-16 is an encoding of a sequence of Unicode code points to a sequence of 16-bit integers. Code points in the range 0..=D7FF ∪ E000..=FFFF use the identity mapping, where they use a single u16 to encode the code point with that same integer value. The code points above FFFF are encoded using a **pair** of u16s from the code point "gap" D800..=DFFF, called a surrogate pair.

- UTF-8 is an encoding of a sequence of Unicode code points to a sequence of 8-bit integers.

- Just like there can be sequences of u8 which have no preimage under the UTF-8 encoding (they are not a correct UTF-8 encoding of any sequence of Unicode code points), there can similarly be sequences of u16 which have no preimage under UTF-16. For example if you see a surrogate D800..=DFFF by itself anywhere in the u16 sequence, not next to another surrogate, it's clear from bullet 2 that there is no possible sequence of Unicode code points whose UTF-16 encoding it is. Such an unpaired surrogate is called a lone surrogate.

- These days it's less common for new systems to be designed using UTF-16 (UTF-8 has become dominant) but some extremely widely used legacy systems are stuck with it, for example JavaScript, Java, and Windows's filesystem API. Because type systems are for suckers, often these UTF-16-based systems don't bother enforcing that their "strings" are a correct UTF-16 encoding of some sequence of Unicode code points, in contrast with how Rust's `str` type enforces this about its contents being a correct UTF-8 encoding of some sequence of Unicode code points (i.e. "valid UTF-8"). For example in JavaScript, `"\ud83c"` is a string of u16 of length 1, whose one character is a lone surrogate. Meanwhile `"\u{1f3b5}"` is a string of u16 of length 2, since it contains a single Unicode code point 🎵 greater than FFFF and is thus encoded using a pair of surrogates, but JavaScript is fine with you slicing that string in the middle of the pair, by writing `"\u{1f3b5}".substr(0, 1)` for a string containing just the first surrogate, or `"\u{1f3b5}".substr(1)` for a string containing just the second surrogate. Similarly, Windows filesystem paths can contain lone surrogates.

- Rust supports Windows, so `OsStr`/`OsString` and `Path`/`PathBuf` support filesystem paths containing lone surrogates.

- WTF-8 is an encoding of a sequence of integers 0..=10FFFF to a sequence of 8-bit integers with the property that substrings not containing D800..=DFFF will have the same encoding as they would under UTF-8. This turns out to be a great choice for `PathBuf` because it makes the signature of `Path::to_str` possible: https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str &mdash; we can transmute it to a UTF-8 string when there are no lone surrogates inside.

- The standard library exposes a function `to_string_lossy` to convert a sequence of bytes to UTF-8, keeping substrings that are valid UTF-8, and swapping out invalid bytes with the designated "replacement character" �.

- Lone surrogates happen to be encoded by 3 bytes in WTF-8. So if you're dealing with a JavaScript string or Windows filesystem path containing a lone surrogate, you're gonna get 3 replacement characters: `"ASDF\ud83cJKL"` ⟶ "ASDF���JKL". This leaks an internal detail of the fact that we're storing this stuff as WTF-8 internally, which we are otherwise very careful to avoid; this is why you won't find a public API that turns `&OsStr` into `&[u8]` on cfg(windows).

### This change:

I wonder if we could be less surprising to Windows users by having `to_string_lossy` emit only a single � for surrogates. `"ASDF\ud83cJKL"` ⟶ "ASDF�JKL". As it exists today, there is no way to explain **why** `to_string_lossy` in the Rust standard library turns a valid Windows filesystem path like `ASDF\ud83cJKL` into 3 replacement characters **without** reference to the internal detail that we're internally manipulating it using WTF-8, and WTF-8 uses 3 bytes for lone surrogates. The fact that we use WTF-8 internally is not intended to be publicly exposed, and to some extent WTF-8's choice of using 3 bytes to encode a surrogate is somewhat arbitrary (it could've been a different number and still have the UTF-8 substring property), so emitting a single replacement character for surrogates makes more API sense to me.