### PR TITLE
Fix bad `NodeId` limit checking.

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1430,12 +1430,9 @@ impl<'a> Resolver<'a> {
     }
 
     pub fn next_node_id(&mut self) -> NodeId {
-        let next = self
-            .next_node_id
-            .as_usize()
-            .checked_add(1)
-            .expect("input too large; ran out of NodeIds");
-        self.next_node_id = ast::NodeId::from_usize(next);
+        let next =
+            self.next_node_id.as_u32().checked_add(1).expect("input too large; ran out of NodeIds");
+        self.next_node_id = ast::NodeId::from_u32(next);
         self.next_node_id
     }
 


### PR DESCRIPTION
`Resolver::next_node_id` converts a `u32` to a `usize` (which is
possibly bigger), does a checked add, and then converts the result back
to a `u32`. The `usize` conversion completely subverts the checked add!

This commit removes the conversion to/from `usize`.