### PR TITLE
rustdoc: calculate visibility on-demand

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -112,7 +112,6 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         Some(Item {
             name: None,
             attrs: Default::default(),
-            visibility: Inherited,
             def_id: ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
             kind: box ImplItem(Impl {
                 unsafety: hir::Unsafety::Normal,
@@ -124,6 +123,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                 kind: ImplKind::Auto,
             }),
             cfg: None,
+            inline_stmt_id: None,
         })
     }
 

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -103,7 +103,6 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                 impls.push(Item {
                     name: None,
                     attrs: Default::default(),
-                    visibility: Inherited,
                     def_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
                     kind: box ImplItem(Impl {
                         unsafety: hir::Unsafety::Normal,
@@ -127,6 +126,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         kind: ImplKind::Blanket(box trait_ref.self_ty().clean(self.cx)),
                     }),
                     cfg: None,
+                    inline_stmt_id: None,
                 });
             }
         }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -68,7 +68,7 @@ crate trait DocFolder: Sized {
                 }
                 Variant::CLike => VariantItem(Variant::CLike),
             },
-            ExternCrateItem { src: _ }
+            ExternCrateItem { .. }
             | ImportItem(_)
             | FunctionItem(_)
             | TypedefItem(_, _)

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -771,7 +771,7 @@ fn assoc_const(
         w,
         "{}{}const <a href=\"{}\" class=\"constant\">{}</a>: {}",
         extra,
-        it.visibility.print_with_space(it.def_id, cx),
+        it.visibility(cx.tcx()).print_with_space(it.def_id, cx),
         naive_assoc_href(it, link, cx),
         it.name.as_ref().unwrap(),
         ty.print(cx)
@@ -892,7 +892,7 @@ fn render_assoc_item(
                 }
             }
         };
-        let vis = meth.visibility.print_with_space(meth.def_id, cx).to_string();
+        let vis = meth.visibility(cx.tcx()).print_with_space(meth.def_id, cx).to_string();
         let constness =
             print_constness_with_space(&header.constness, meth.const_stability(cx.tcx()));
         let asyncness = header.asyncness.print_with_space();

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -40,7 +40,8 @@ impl JsonRenderer<'_> {
             .map(rustc_ast_pretty::pprust::attribute_to_string)
             .collect();
         let span = item.span(self.tcx);
-        let clean::Item { name, attrs: _, kind: _, visibility, def_id, cfg: _ } = item;
+        let visibility = item.visibility(self.tcx);
+        let clean::Item { name, attrs: _, kind: _, def_id, cfg: _, inline_stmt_id: _ } = item;
         let inner = match *item.kind {
             clean::StrippedItem(_) => return None,
             _ => from_clean_item(item, self.tcx),
@@ -229,7 +230,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         KeywordItem(_) => {
             panic!("{:?} is not supported for JSON output", item)
         }
-        ExternCrateItem { ref src } => ItemEnum::ExternCrate {
+        ExternCrateItem { ref src, crate_stmt_id: _ } => ItemEnum::ExternCrate {
             name: name.as_ref().unwrap().to_string(),
             rename: src.map(|x| x.to_string()),
         },

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -9,6 +9,6 @@ crate const STRIP_PRIV_IMPORTS: Pass = Pass {
     description: "strips all private import statements (`use`, `extern crate`) from a crate",
 };
 
-crate fn strip_priv_imports(krate: clean::Crate, _: &mut DocContext<'_>) -> clean::Crate {
-    ImportStripper.fold_crate(krate)
+crate fn strip_priv_imports(krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
+    ImportStripper(cx.tcx).fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -22,8 +22,9 @@ crate fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) -> clea
             retained: &mut retained,
             access_levels: &cx.cache.access_levels,
             update_retained: true,
+            tcx: cx.tcx,
         };
-        krate = ImportStripper.fold_crate(stripper.fold_crate(krate));
+        krate = ImportStripper(cx.tcx).fold_crate(stripper.fold_crate(krate));
     }
 
     // strip all impls referencing private items

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -23,7 +23,7 @@ crate trait DocVisitor: Sized {
                 Variant::Tuple(fields) => fields.iter().for_each(|x| self.visit_item(x)),
                 Variant::CLike => {}
             },
-            ExternCrateItem { src: _ }
+            ExternCrateItem { .. }
             | ImportItem(_)
             | FunctionItem(_)
             | TypedefItem(_, _)


### PR DESCRIPTION
`inline_stmt_id` is very hacky and will probably lose all the memory improvements I was hoping for. Maybe we can change inlined items to have the `DefId` of the `use` statement directly instead of storing both?

Helps with https://github.com/rust-lang/rust/issues/90852 (doesn't fix it because I haven't yet switched to `ty::Visibility` directly).

r? @camelid