### PR TITLE
Enable svh tests on msvc

### DIFF
--- a/src/test/ui/svh/changing-crates.rs
+++ b/src/test/ui/svh/changing-crates.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:changing-crates-a1.rs
 // aux-build:changing-crates-b.rs

--- a/src/test/ui/svh/changing-crates.stderr
+++ b/src/test/ui/svh/changing-crates.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/changing-crates.rs:10:1
+  --> $DIR/changing-crates.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-lit.rs
+++ b/src/test/ui/svh/svh-change-lit.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-lit.stderr
+++ b/src/test/ui/svh/svh-change-lit.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-lit.rs:10:1
+  --> $DIR/svh-change-lit.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-significant-cfg.rs
+++ b/src/test/ui/svh/svh-change-significant-cfg.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-significant-cfg.stderr
+++ b/src/test/ui/svh/svh-change-significant-cfg.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-significant-cfg.rs:10:1
+  --> $DIR/svh-change-significant-cfg.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-trait-bound.rs
+++ b/src/test/ui/svh/svh-change-trait-bound.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-trait-bound.stderr
+++ b/src/test/ui/svh/svh-change-trait-bound.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-trait-bound.rs:10:1
+  --> $DIR/svh-change-trait-bound.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-type-arg.rs
+++ b/src/test/ui/svh/svh-change-type-arg.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-type-arg.stderr
+++ b/src/test/ui/svh/svh-change-type-arg.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-type-arg.rs:10:1
+  --> $DIR/svh-change-type-arg.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-type-ret.rs
+++ b/src/test/ui/svh/svh-change-type-ret.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-type-ret.stderr
+++ b/src/test/ui/svh/svh-change-type-ret.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-type-ret.rs:10:1
+  --> $DIR/svh-change-type-ret.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-change-type-static.rs
+++ b/src/test/ui/svh/svh-change-type-static.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/ui/svh/svh-change-type-static.stderr
+++ b/src/test/ui/svh/svh-change-type-static.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `a` which `b` depends on
-  --> $DIR/svh-change-type-static.rs:10:1
+  --> $DIR/svh-change-type-static.rs:8:1
    |
 LL | extern crate b;
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/svh/svh-use-trait.rs
+++ b/src/test/ui/svh/svh-use-trait.rs
@@ -1,5 +1,3 @@
-// ignore-msvc FIXME #31306
-
 // note that these aux-build directives must be in this order
 // aux-build:svh-uta-base.rs
 // aux-build:svh-utb.rs

--- a/src/test/ui/svh/svh-use-trait.stderr
+++ b/src/test/ui/svh/svh-use-trait.stderr
@@ -1,5 +1,5 @@
 error[E0460]: found possibly newer version of crate `uta` which `utb` depends on
-  --> $DIR/svh-use-trait.rs:15:1
+  --> $DIR/svh-use-trait.rs:13:1
    |
 LL | extern crate utb;
    | ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These tests were ignored for msvc in #30778 because of additional notes that were being added for some reason. I'm fairly confident this has been fixed in the intervening years so lets try re-enabling these tests.

Fixes #31306