### PR TITLE
Improve suggestions for importing out-of-scope traits reexported as `_`

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -17,7 +17,7 @@ use rustc_session::utils::NativeLibKind;
 use rustc_session::{Session, StableCrateId};
 use rustc_span::hygiene::{ExpnHash, ExpnId};
 use rustc_span::source_map::{Span, Spanned};
-use rustc_span::symbol::Symbol;
+use rustc_span::symbol::{kw, Symbol};
 
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
@@ -295,6 +295,10 @@ pub fn provide(providers: &mut Providers) {
             use std::collections::vec_deque::VecDeque;
 
             let mut visible_parent_map: DefIdMap<DefId> = Default::default();
+            // This is a secondary visible_parent_map, storing the DefId of parents that re-export
+            // the child as `_`. Since we prefer parents that don't do this, merge this map at the
+            // end, only if we're missing any keys from the former.
+            let mut fallback_map: DefIdMap<DefId> = Default::default();
 
             // Issue 46112: We want the map to prefer the shortest
             // paths when reporting the path to an item. Therefore we
@@ -317,12 +321,17 @@ pub fn provide(providers: &mut Providers) {
                 bfs_queue.push_back(DefId { krate: cnum, index: CRATE_DEF_INDEX });
             }
 
-            let mut add_child = |bfs_queue: &mut VecDeque<_>, child: &Export, parent: DefId| {
-                if !child.vis.is_public() {
+            let mut add_child = |bfs_queue: &mut VecDeque<_>, export: &Export, parent: DefId| {
+                if !export.vis.is_public() {
                     return;
                 }
 
-                if let Some(child) = child.res.opt_def_id() {
+                if let Some(child) = export.res.opt_def_id() {
+                    if export.ident.name == kw::Underscore {
+                        fallback_map.insert(child, parent);
+                        return;
+                    }
+
                     match visible_parent_map.entry(child) {
                         Entry::Occupied(mut entry) => {
                             // If `child` is defined in crate `cnum`, ensure
@@ -343,6 +352,12 @@ pub fn provide(providers: &mut Providers) {
                 for child in tcx.item_children(def).iter() {
                     add_child(bfs_queue, child, def);
                 }
+            }
+
+            // Fill in any missing entries with the (less preferable) path ending in `::_`.
+            // We still use this path in a diagnostic that suggests importing `::*`.
+            for (child, parent) in fallback_map {
+                visible_parent_map.entry(child).or_insert(parent);
             }
 
             visible_parent_map

--- a/src/test/ui/imports/auxiliary/overlapping_pub_trait_source.rs
+++ b/src/test/ui/imports/auxiliary/overlapping_pub_trait_source.rs
@@ -1,0 +1,13 @@
+/* This crate declares an item as both `prelude::*` and `m::Tr`.
+ * The compiler should always suggest `m::Tr`. */
+
+pub struct S;
+
+pub mod prelude {
+    pub use crate::m::Tr as _;
+}
+
+pub mod m {
+    pub trait Tr { fn method(&self); }
+    impl Tr for crate::S { fn method(&self) {} }
+}

--- a/src/test/ui/imports/auxiliary/unnamed_pub_trait_source.rs
+++ b/src/test/ui/imports/auxiliary/unnamed_pub_trait_source.rs
@@ -1,0 +1,13 @@
+/* This crate declares an item that is unnamed.
+ * Its only public path is through `prelude::*`. */
+
+pub struct S;
+
+mod m {
+    pub trait Tr { fn method(&self); }
+    impl Tr for crate::S { fn method(&self) {} }
+}
+
+pub mod prelude {
+    pub use crate::m::Tr as _;
+}

--- a/src/test/ui/imports/overlapping_pub_trait.rs
+++ b/src/test/ui/imports/overlapping_pub_trait.rs
@@ -1,0 +1,15 @@
+// aux-build:overlapping_pub_trait_source.rs
+
+/*
+ * This crate declares two public paths, `m::Tr` and `prelude::_`. Make sure we prefer the former.
+ */
+extern crate overlapping_pub_trait_source;
+
+fn main() {
+    //~^ HELP the following trait is implemented but not in scope; perhaps add a `use` for it:
+    //~| SUGGESTION overlapping_pub_trait_source::prelude::_
+    use overlapping_pub_trait_source::S;
+    S.method();
+    //~^ ERROR no method named `method` found for struct `S` in the current scope [E0599]
+    //~| HELP items from traits can only be used if the trait is in scope
+}

--- a/src/test/ui/imports/overlapping_pub_trait.rs
+++ b/src/test/ui/imports/overlapping_pub_trait.rs
@@ -7,7 +7,7 @@ extern crate overlapping_pub_trait_source;
 
 fn main() {
     //~^ HELP the following trait is implemented but not in scope; perhaps add a `use` for it:
-    //~| SUGGESTION overlapping_pub_trait_source::prelude::_
+    //~| SUGGESTION overlapping_pub_trait_source::m::Tr
     use overlapping_pub_trait_source::S;
     S.method();
     //~^ ERROR no method named `method` found for struct `S` in the current scope [E0599]

--- a/src/test/ui/imports/overlapping_pub_trait.stderr
+++ b/src/test/ui/imports/overlapping_pub_trait.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no method named `method` found for struct `S` in the current scope
+  --> $DIR/overlapping_pub_trait.rs:12:7
+   |
+LL |     S.method();
+   |       ^^^^^^ method not found in `S`
+   |
+  ::: $DIR/auxiliary/overlapping_pub_trait_source.rs:11:23
+   |
+LL |     pub trait Tr { fn method(&self); }
+   |                       ------ the method is available for `S` here
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use overlapping_pub_trait_source::prelude::_;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/imports/overlapping_pub_trait.stderr
+++ b/src/test/ui/imports/overlapping_pub_trait.stderr
@@ -12,7 +12,7 @@ LL |     pub trait Tr { fn method(&self); }
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-LL | use overlapping_pub_trait_source::prelude::_;
+LL | use overlapping_pub_trait_source::m::Tr;
    |
 
 error: aborting due to previous error

--- a/src/test/ui/imports/unnamed_pub_trait.rs
+++ b/src/test/ui/imports/unnamed_pub_trait.rs
@@ -1,0 +1,16 @@
+// aux-build:unnamed_pub_trait_source.rs
+
+/*
+ * This crate declares an unnameable public path for our item. Make sure we don't suggest
+ * importing it by name, and instead we suggest importing it by glob.
+ */
+extern crate unnamed_pub_trait_source;
+
+fn main() {
+    //~^ HELP the following trait is implemented but not in scope; perhaps add a `use` for it:
+    //~| SUGGESTION unnamed_pub_trait_source::prelude::_
+    use unnamed_pub_trait_source::S;
+    S.method();
+    //~^ ERROR no method named `method` found for struct `S` in the current scope [E0599]
+    //~| HELP items from traits can only be used if the trait is in scope
+}

--- a/src/test/ui/imports/unnamed_pub_trait.rs
+++ b/src/test/ui/imports/unnamed_pub_trait.rs
@@ -8,7 +8,7 @@ extern crate unnamed_pub_trait_source;
 
 fn main() {
     //~^ HELP the following trait is implemented but not in scope; perhaps add a `use` for it:
-    //~| SUGGESTION unnamed_pub_trait_source::prelude::_
+    //~| SUGGESTION unnamed_pub_trait_source::prelude::*; // trait Tr
     use unnamed_pub_trait_source::S;
     S.method();
     //~^ ERROR no method named `method` found for struct `S` in the current scope [E0599]

--- a/src/test/ui/imports/unnamed_pub_trait.stderr
+++ b/src/test/ui/imports/unnamed_pub_trait.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no method named `method` found for struct `S` in the current scope
+  --> $DIR/unnamed_pub_trait.rs:13:7
+   |
+LL |     S.method();
+   |       ^^^^^^ method not found in `S`
+   |
+  ::: $DIR/auxiliary/unnamed_pub_trait_source.rs:7:23
+   |
+LL |     pub trait Tr { fn method(&self); }
+   |                       ------ the method is available for `S` here
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use unnamed_pub_trait_source::prelude::_;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/imports/unnamed_pub_trait.stderr
+++ b/src/test/ui/imports/unnamed_pub_trait.stderr
@@ -12,7 +12,7 @@ LL |     pub trait Tr { fn method(&self); }
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-LL | use unnamed_pub_trait_source::prelude::_;
+LL | use unnamed_pub_trait_source::prelude::*; // trait Tr
    |
 
 error: aborting due to previous error


### PR DESCRIPTION
1. Fix up the `parent_map` query to prefer visible parents that _don't_ export items with the name `_`.
    * I'm not sure if I modified this query properly. Not sure if we want to check for other idents than `kw::Underscore`.
    * This also has the side-effect of not doing BFS on any modules re-exported as `_`, but I think that's desirable here too (or else we get suggestions for paths like `a::_::b` like in [this doctest example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=d9505ea45bb80adf40bb991298f952be)).
2. Bail in `try_print_visible_def_path` if the `def_id` is re-exported as `_`, which will fall back to printing the def-id's real (definition) path.
    * Side-effect of this is that we print paths that are not actually public, but it seems we already sometimes suggest `use`ing paths that are private anyways. See [this doctest example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=bad513ed3241f8ff87579eed8046ad10) for demonstration of current behavior.
3. Suggest a glob-import (for example `my_library::prelude::*`) if the trait in question is only pub-exported as `_`, as a fallback.
    ```
    use foo::bar::prelude::*; // trait MyTrait
    ```
    * I think this is good fallback behavior to suggest instead of doing nothing. Thanks to the original issue filer for suggesting this.

I was somewhat opinionated about behaviors in this PR, and I'm totally open to limiting the impact of my changes or only landing parts of this. Happy to receive feedback if there are better ways to the same end.

Fixes #86035 