### PR TITLE
rustdoc: Unify macro intra-doc link resolution with type and value resolution

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1234,7 +1234,6 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             };
             let binding = (res, vis, span, expansion).to_name_binding(self.r.arenas);
             self.r.set_binding_parent_module(binding, parent_scope.module);
-            self.r.all_macros.insert(ident.name, res);
             if is_macro_export {
                 let module = self.r.graph_root;
                 self.r.define(module, ident, MacroNS, (res, vis, span, expansion, IsMacroExport));

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -981,7 +981,6 @@ pub struct Resolver<'a> {
     registered_attrs: FxHashSet<Ident>,
     registered_tools: FxHashSet<Ident>,
     macro_use_prelude: FxHashMap<Symbol, &'a NameBinding<'a>>,
-    all_macros: FxHashMap<Symbol, Res>,
     macro_map: FxHashMap<DefId, Lrc<SyntaxExtension>>,
     dummy_ext_bang: Lrc<SyntaxExtension>,
     dummy_ext_derive: Lrc<SyntaxExtension>,
@@ -1370,7 +1369,6 @@ impl<'a> Resolver<'a> {
             registered_attrs,
             registered_tools,
             macro_use_prelude: FxHashMap::default(),
-            all_macros: FxHashMap::default(),
             macro_map: FxHashMap::default(),
             dummy_ext_bang: Lrc::new(SyntaxExtension::dummy_bang(session.edition())),
             dummy_ext_derive: Lrc::new(SyntaxExtension::dummy_derive(session.edition())),
@@ -3381,11 +3379,6 @@ impl<'a> Resolver<'a> {
     // For rustdoc.
     pub fn graph_root(&self) -> Module<'a> {
         self.graph_root
-    }
-
-    // For rustdoc.
-    pub fn all_macros(&self) -> &FxHashMap<Symbol, Res> {
-        &self.all_macros
     }
 
     /// Retrieves the span of the given `DefId` if `DefId` is in the local crate.

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -550,7 +550,7 @@ impl<'a> Resolver<'a> {
         Ok((ext, res))
     }
 
-    pub fn resolve_macro_path(
+    crate fn resolve_macro_path(
         &mut self,
         path: &ast::Path,
         kind: Option<MacroKind>,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1292,7 +1292,6 @@ impl LinkCollector<'_, '_> {
     }
 
     /// After parsing the disambiguator, resolve the main part of the link.
-    // FIXME(jynelson): wow this is just so much
     fn resolve_with_disambiguator(
         &mut self,
         key: &ResolutionInfo,
@@ -1354,16 +1353,7 @@ impl LinkCollector<'_, '_> {
                             Res::Def(DefKind::Ctor(..), _) => {
                                 Err(ResolutionFailure::WrongNamespace { res, expected_ns: TypeNS })
                             }
-                            // TODO(jyn514): this looks very wrong
-                            _ => {
-                                match (fragment, extra_fragment.clone()) {
-                                    (Some(fragment), Some(_)) => {
-                                        // Shouldn't happen but who knows?
-                                        Ok((res, Some(fragment)))
-                                    }
-                                    (fragment, None) | (None, fragment) => Ok((res, fragment)),
-                                }
-                            }
+                            _ => Ok((res, fragment)),
                         }
                     }),
                 };

--- a/src/test/rustdoc-ui/intra-doc/private-macro.rs
+++ b/src/test/rustdoc-ui/intra-doc/private-macro.rs
@@ -1,0 +1,14 @@
+// check-pass
+#![deny(rustdoc::broken_intra_doc_links)]
+
+mod bar {
+    macro_rules! str {() => {}}
+}
+
+pub mod foo {
+    pub struct Baz {}
+    impl Baz {
+        /// [str]
+        pub fn foo(&self) {}
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/81633 and also cleans up quite a lot of code.

r? @Manishearth