### PR TITLE
Add tests for `normalize-docs` overflow errors

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1337,25 +1337,15 @@ fn normalize(cx: &mut DocContext<'tcx>, ty: Ty<'_>) -> Option<Ty<'tcx>> {
         return None;
     }
 
-    use crate::rustc_trait_selection::infer::TyCtxtInferExt;
-    use crate::rustc_trait_selection::traits::query::normalize::AtExt;
-    use rustc_middle::traits::ObligationCause;
-
     // Try to normalize `<X as Y>::T` to a type
     let lifted = ty.lift_to_tcx(cx.tcx).unwrap();
-    let normalized = cx.tcx.infer_ctxt().enter(|infcx| {
-        infcx
-            .at(&ObligationCause::dummy(), cx.param_env)
-            .normalize(lifted)
-            .map(|resolved| infcx.resolve_vars_if_possible(resolved.value))
-    });
-    match normalized {
+    match cx.tcx.try_normalize_erasing_regions(cx.param_env, lifted) {
         Ok(normalized_value) => {
-            debug!("normalized {:?} to {:?}", ty, normalized_value);
+            trace!("normalized {:?} to {:?}", ty, normalized_value);
             Some(normalized_value)
         }
         Err(err) => {
-            debug!("failed to normalize {:?}: {:?}", ty, err);
+            info!("failed to normalize {:?}: {:?}", ty, err);
             None
         }
     }

--- a/src/test/rustdoc-ui/auxiliary/overflow.rs
+++ b/src/test/rustdoc-ui/auxiliary/overflow.rs
@@ -1,0 +1,20 @@
+pub struct B0;
+pub struct B1;
+use std::ops::Shl;
+use std::ops::Sub;
+pub type Shleft<A, B> = <A as Shl<B>>::Output;
+pub type Sub1<A> = <A as Sub<B1>>::Output;
+pub struct UInt<U, B> {
+    pub(crate) msb: U,
+    pub(crate) lsb: B,
+}
+impl<U, B, Ur, Br> Shl<UInt<Ur, Br>> for UInt<U, B>
+where
+    UInt<Ur, Br>: Sub<B1>,
+    UInt<UInt<U, B>, B0>: Shl<Sub1<UInt<Ur, Br>>>,
+{
+    type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
+    fn shl(self, rhs: UInt<Ur, Br>) -> Self::Output {
+        unimplemented!()
+    }
+}

--- a/src/test/rustdoc-ui/normalize-cycle.rs
+++ b/src/test/rustdoc-ui/normalize-cycle.rs
@@ -1,0 +1,25 @@
+// check-pass
+// Regresion test for <https://github.com/rust-lang/rust/issues/79459>.
+pub trait Query {}
+
+pub trait AsQuery {
+    type Query;
+}
+
+impl<T: Query> AsQuery for T {
+    type Query = T;
+}
+
+pub trait SelectDsl<Selection> {
+    type Output;
+}
+
+impl<T, Selection> SelectDsl<Selection> for T
+where
+    T: AsQuery,
+    T::Query: SelectDsl<Selection>,
+{
+    type Output = <T::Query as SelectDsl<Selection>>::Output;
+}
+
+pub type Select<Source, Selection> = <Source as SelectDsl<Selection>>::Output;

--- a/src/test/rustdoc-ui/normalize-overflow.rs
+++ b/src/test/rustdoc-ui/normalize-overflow.rs
@@ -1,0 +1,3 @@
+// aux-crate:overflow=overflow.rs
+// check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/79506>.


### PR DESCRIPTION
@b-naber do you understand why using `try_normalize_erasing_regions` doesn't silence these cycle errors? Rustdoc isn't emitting them, rustc is aborting before returning an error, even though the function has `try_` in the name.

cc https://github.com/rust-lang/rust/issues/82692, https://github.com/rust-lang/rust/pull/91255