### PR TITLE
disable tests in Miri that take too long

### DIFF
--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2330,6 +2330,7 @@ macro_rules! empty_max_mut {
     };
 }
 
+#[cfg(not(miri))] // Comparing usize::MAX many elements takes forever in Miri (and in rustc without optimizations)
 take_tests! {
     slice: &[(); usize::MAX], method: take,
     (take_in_bounds_max_range_to, (..usize::MAX), Some(EMPTY_MAX), &[(); 0]),
@@ -2337,6 +2338,7 @@ take_tests! {
     (take_in_bounds_max_range_from, (usize::MAX..), Some(&[] as _), EMPTY_MAX),
 }
 
+#[cfg(not(miri))] // Comparing usize::MAX many elements takes forever in Miri (and in rustc without optimizations)
 take_tests! {
     slice: &mut [(); usize::MAX], method: take_mut,
     (take_mut_in_bounds_max_range_to, (..usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),


### PR DESCRIPTION
Comparing slices of length `usize::MAX` diverges in Miri. In fact these tests even diverge in rustc unless `-O` is passed. I tried this code to check that:
```rust
#![feature(slice_take)]

const EMPTY_MAX: &'static [()] = &[(); usize::MAX];

fn main() {
    let mut slice: &[_] = &[(); usize::MAX];
    println!("1");
    assert_eq!(Some(&[] as _), slice.take(usize::MAX..));
    println!("2");
    let remaining: &[_] = EMPTY_MAX;
    println!("3");
    assert_eq!(remaining, slice);
    println!("4");
}
```
So, disable these tests in Miri for now.