### PR TITLE
Avoid hashing new `Symbol`s twice.

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -16,6 +16,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(crate_visibility_modifier)]
+#![feature(hash_raw_entry)]
 #![feature(if_let_guard)]
 #![feature(negative_impls)]
 #![feature(nll)]


### PR DESCRIPTION
A small win, but an easy one.

r? @Mark-Simulacrum 