### PR TITLE
Document file path case sensitivity

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -12,6 +12,13 @@
 //! [`PathBuf`]; note that the paths may differ syntactically by the
 //! normalization described in the documentation for the [`components`] method.
 //!
+//! ## Case sensitivity
+//!
+//! Unless otherwise indicated path methods that do not access the filesystem,
+//! such as [`Path::starts_with`] and [`Path::ends_with`], are case sensitive no
+//! matter the platform or filesystem. An exception to this is made for Windows
+//! drive letters.
+//!
 //! ## Simple usage
 //!
 //! Path manipulation includes both parsing components from slices and building


### PR DESCRIPTION
This describes the current behaviour of the standard library's pure path methods.

Fixes #66260.