### PR TITLE
suppress warning about set_errno being unused on DragonFly

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -97,6 +97,7 @@ pub fn errno() -> i32 {
 }
 
 #[cfg(target_os = "dragonfly")]
+#[allow(dead_code)]
 pub fn set_errno(e: i32) {
     extern "C" {
         #[thread_local]


### PR DESCRIPTION
Other targets allow this function to be unused, DragonFly just misses out due to providing a specialization.

This fixes a build error for DragonFly.