### PR TITLE
Improve 'cannot contain emoji' error.

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -627,6 +627,7 @@ symbols! {
         fdiv_fast,
         feature,
         fence,
+        ferris: "🦀",
         fetch_update,
         ffi,
         ffi_const,

--- a/src/test/ui/parser/emoji-identifiers.rs
+++ b/src/test/ui/parser/emoji-identifiers.rs
@@ -13,4 +13,7 @@ fn main() {
     let _ = i_like_to_😄_a_lot() ➖ 4; //~ ERROR cannot find function `i_like_to_😄_a_lot` in this scope
     //~^ ERROR identifiers cannot contain emoji
     //~| ERROR unknown start of token: \u{2796}
+
+    let 🦀 = 1;//~ ERROR Ferris cannot be used as an identifier
+    dbg!(🦀);
 }

--- a/src/test/ui/parser/emoji-identifiers.stderr
+++ b/src/test/ui/parser/emoji-identifiers.stderr
@@ -18,6 +18,14 @@ LL | fn i_like_to_😅_a_lot() -> 👀 {
 LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
    |             ^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `i_like_to_😅_a_lot`
 
+error: Ferris cannot be used as an identifier
+  --> $DIR/emoji-identifiers.rs:17:9
+   |
+LL |     let 🦀 = 1;
+   |         ^^ help: try using their name instead: `ferris`
+LL |     dbg!(🦀);
+   |          ^^
+
 error: identifiers cannot contain emoji: `ABig👩👩👧👧Family`
   --> $DIR/emoji-identifiers.rs:1:8
    |
@@ -77,7 +85,7 @@ LL |     👀::full_of✨()
    |         function or associated item not found in `👀`
    |         help: there is an associated function with a similar name: `full_of_✨`
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0425, E0599.
 For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Before:

```
error: identifiers cannot contain emoji: `🦀`
 --> src/main.rs:2:9
  |
2 |     let 🦀 = 1;
  |         ^^
```

After:
```
error: Ferris cannot be used as an identifier
 --> src/main.rs:2:9
  |
2 |     let 🦀 = 1;
  |         ^^ help: try using their name instead: `ferris`
```

r? @estebank