### PR TITLE
Add `resize(_with)` and `(try_)repeat(_with)` for arrays

### DIFF
--- a/library/core/src/array/guard.rs
+++ b/library/core/src/array/guard.rs
@@ -1,0 +1,96 @@
+use crate::mem::{forget, replace, MaybeUninit};
+use crate::ptr;
+
+/// The internal-use drop guard for implementing array methods.
+///
+/// This is free to be changed whenever.  Its purpose is not to provide a
+/// beautiful safe interface, but to make the unsafe details of `super`'s
+/// other methods slightly more obvious and have reduced code duplication.
+pub struct Guard<'a, T, const N: usize> {
+    array_mut: &'a mut [MaybeUninit<T>; N],
+    initialized: usize,
+}
+
+impl<'a, T, const N: usize> Guard<'a, T, N> {
+    #[inline]
+    pub fn new(buffer: &'a mut [MaybeUninit<T>; N]) -> Self {
+        Self { array_mut: buffer, initialized: 0 }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.initialized
+    }
+
+    /// Initialize the next item
+    ///
+    /// # Safety
+    ///
+    /// Requires `self.len() < N`.
+    #[inline]
+    pub unsafe fn push_unchecked(&mut self, value: T) {
+        debug_assert!(self.len() < N);
+        // SAFETY: The precondition means we have space
+        unsafe {
+            self.array_mut.get_unchecked_mut(self.initialized).write(value);
+        }
+        self.initialized += 1;
+    }
+
+    /// Initialize the next `CHUNK` item(s)
+    ///
+    /// # Safety
+    ///
+    /// Requires `self.len() + CHUNK <= N`.
+    #[inline]
+    pub unsafe fn push_chunk_unchecked<const CHUNK: usize>(&mut self, chunk: [T; CHUNK]) {
+        assert!(CHUNK <= N);
+        debug_assert!(N - self.len() >= CHUNK);
+        // SAFETY: The precondition means we have space
+        unsafe {
+            // Since we're going to write multiple items, make sure not to do so
+            // via a `&mut MaybeUninit<T>`, as that would violate stacked borrows.
+            let first = self.array_mut.as_mut_ptr();
+            let p = first.add(self.initialized).cast();
+            ptr::write(p, chunk);
+        }
+        self.initialized += CHUNK;
+    }
+
+    /// Read the whole buffer as an initialized array.
+    ///
+    /// This always de-initializes the original buffer -- even if `T: Copy`.
+    ///
+    /// # Safety
+    ///
+    /// Requires `self.len() == N`.
+    #[inline]
+    pub unsafe fn into_array_unchecked(self) -> [T; N] {
+        debug_assert_eq!(self.len(), N);
+
+        // This tells LLVM and MIRI that we don't care about the buffer after,
+        // and the extra `undef` write is trivial for it to optimize away.
+        let buffer = replace(self.array_mut, MaybeUninit::uninit_array());
+
+        // SAFETY: the condition above asserts that all elements are
+        // initialized.
+        let out = unsafe { MaybeUninit::array_assume_init(buffer) };
+
+        forget(self);
+
+        out
+    }
+}
+
+impl<T, const N: usize> Drop for Guard<'_, T, N> {
+    fn drop(&mut self) {
+        debug_assert!(self.initialized <= N);
+
+        // SAFETY: this slice will contain only initialized objects.
+        unsafe {
+            crate::ptr::drop_in_place(MaybeUninit::slice_assume_init_mut(
+                &mut self.array_mut.get_unchecked_mut(..self.initialized),
+            ));
+        }
+    }
+}

--- a/src/test/codegen/array-methods.rs
+++ b/src/test/codegen/array-methods.rs
@@ -1,0 +1,68 @@
+// no-system-llvm
+// compile-flags: -O
+// only-64bit (because the LLVM type of i64 for usize shows up)
+// ignore-debug: all the `debug_assert`s get in the way
+
+#![crate_type = "lib"]
+#![feature(array_repeat)]
+#![feature(array_resize)]
+
+// CHECK-LABEL: @array_repeat_byte
+#[no_mangle]
+pub fn array_repeat_byte() -> [u8; 1234] {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: %1 = getelementptr
+    // CHECK-NEXT: tail call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(1234) %1, i8 42, i64 1234, i1 false)
+    // CHECK-NEXT: ret void
+    std::array::repeat(42)
+}
+
+// CHECK-LABEL: @array_resize_byte_shrink
+#[no_mangle]
+pub fn array_resize_byte_shrink(a: [u8; 300]) -> [u8; 100] {
+    // CHECK-NOT: @llvm.memset
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
+    // CHECK-SAME: dereferenceable(100)
+    // CHECK-SAME: i64 100
+    // CHECK-NOT: @llvm.memset
+    a.resize(42)
+}
+
+// CHECK-LABEL: @array_resize_byte_grow
+#[no_mangle]
+pub fn array_resize_byte_grow(a: [u8; 100]) -> [u8; 300] {
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
+    // CHECK-SAME: dereferenceable(100)
+    // CHECK-SAME: i64 100
+    // CHECK: call void @llvm.memset.p0i8.i64
+    // CHECK-SAME: dereferenceable(200)
+    // CHECK-SAME: i8 42, i64 200
+    a.resize(42)
+}
+
+// CHECK-LABEL: @array_resize_with_byte_grow
+#[no_mangle]
+pub fn array_resize_with_byte_grow(a: [u8; 100]) -> [u8; 300] {
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
+    // CHECK-SAME: dereferenceable(100)
+    // CHECK-SAME: i64 100
+    // CHECK: call void @llvm.memset.p0i8.i64
+    // CHECK-SAME: dereferenceable(200)
+    // CHECK-SAME: i8 42, i64 200
+    a.resize_with(|| 42)
+}
+
+// CHECK-LABEL: @array_resize_string_moves_value
+#[no_mangle]
+pub fn array_resize_string_moves_value(a: [String; 1], b: String) -> [String; 2] {
+    // CHECK-NOT: __rust_dealloc
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
+    // CHECK-SAME: dereferenceable(24)
+    // CHECK-SAME: i64 24
+    // CHECK-NOT: __rust_dealloc
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
+    // CHECK-SAME: dereferenceable(24)
+    // CHECK-SAME: i64 24
+    // CHECK-NOT: __rust_dealloc
+    a.resize(b)
+}


### PR DESCRIPTION
```rust
mod array {
    pub fn repeat<T: Clone, const N: usize>(value: T) -> [T; N];
    pub fn repeat_with<T, const N: usize>(f: impl FnMut() -> T) -> [T; N];
    pub fn try_repeat_with<R: Try, const N: usize>(
        f: impl FnMut() -> R,
    ) -> ChangeOutputType<R, [R::Output; N]>
    where
        R::Residual: Residual<[R::Output; N]>;
}

impl [T; N] {
    pub fn resize<const NEW_LEN: usize>(self, value: T) -> [T; NEW_LEN] where T: Clone;
    pub fn resize_with<const NEW_LEN: usize>(self, mut f: impl FnMut() -> T) -> [T; NEW_LEN];
}
```

I tried to do `resize_with` as just
```rust
collect_into_array(IntoIter::new(self).chain(iter::repeat_with(f)))
```
but unfortunately that optimized very poorly.

As a result there's a bunch of refactoring in here to move the `Guard` struct that was previously private to `try_collect_into_array` over to its own module.  It's still very much internal -- it's visible only to the `core::array` module, with no intention of making it the anointed public thing.  (And thus it basically only has `_unchecked` methods.)

This comes with codegen tests, so preemptively
@bors rollup=iffy