### PR TITLE
`i8's` -> `i8s` for proper English

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1359,7 +1359,7 @@ mod impls {
     impl Ord for bool {
         #[inline]
         fn cmp(&self, other: &bool) -> Ordering {
-            // Casting to i8's and converting the difference to an Ordering generates
+            // Casting to i8s and converting the difference to an Ordering generates
             // more optimal assembly.
             // See <https://github.com/rust-lang/rust/issues/66780> for more info.
             match (*self as i8) - (*other as i8) {


### PR DESCRIPTION
A little nit-picky, but I just found this when browsing through the source code's comments and thought I should add it.