### PR TITLE
rustdoc: Cleanup two things in `clean::types`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1244,17 +1244,6 @@ impl GenericParamDefKind {
     crate fn is_type(&self) -> bool {
         matches!(self, GenericParamDefKind::Type { .. })
     }
-
-    // FIXME(eddyb) this either returns the default of a type parameter, or the
-    // type of a `const` parameter. It seems that the intention is to *visit*
-    // any embedded types, but `get_type` seems to be the wrong name for that.
-    crate fn get_type(&self) -> Option<Type> {
-        match self {
-            GenericParamDefKind::Type { default, .. } => default.as_deref().cloned(),
-            GenericParamDefKind::Const { ty, .. } => Some((&**ty).clone()),
-            GenericParamDefKind::Lifetime { .. } => None,
-        }
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -1277,10 +1266,6 @@ impl GenericParamDef {
 
     crate fn is_type(&self) -> bool {
         self.kind.is_type()
-    }
-
-    crate fn get_type(&self) -> Option<Type> {
-        self.kind.get_type()
     }
 
     crate fn get_bounds(&self) -> Option<&[GenericBound]> {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1207,10 +1207,6 @@ impl GenericBound {
 crate struct Lifetime(pub Symbol);
 
 impl Lifetime {
-    crate fn get_ref(&self) -> SymbolStr {
-        self.0.as_str()
-    }
-
     crate fn statik() -> Lifetime {
         Lifetime(kw::StaticLifetime)
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -346,7 +346,7 @@ crate fn print_where_clause<'a, 'tcx: 'a>(
 
 impl clean::Lifetime {
     crate fn print(&self) -> impl fmt::Display + '_ {
-        self.get_ref()
+        self.0.as_str()
     }
 }
 

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -347,19 +347,19 @@ crate fn get_real_types<'tcx>(
             let bounds = where_pred.get_bounds().unwrap_or_else(|| &[]);
             for bound in bounds.iter() {
                 if let GenericBound::TraitBound(poly_trait, _) = bound {
-                    for x in poly_trait.generic_params.iter() {
-                        if !x.is_type() {
-                            continue;
-                        }
-                        if let Some(ty) = x.get_type() {
-                            get_real_types(
-                                generics,
-                                &ty,
-                                tcx,
-                                recurse + 1,
-                                &mut ty_generics,
-                                cache,
-                            );
+                    for param_def in poly_trait.generic_params.iter() {
+                        match &param_def.kind {
+                            clean::GenericParamDefKind::Type { default: Some(ty), .. } => {
+                                get_real_types(
+                                    generics,
+                                    ty,
+                                    tcx,
+                                    recurse + 1,
+                                    &mut ty_generics,
+                                    cache,
+                                )
+                            }
+                            _ => {}
                         }
                     }
                 }


### PR DESCRIPTION
Explanations are in the individual commits.