### PR TITLE
Add readable rustdoc display for RISC-V target

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -497,6 +497,8 @@ impl<'a> fmt::Display for Display<'a> {
                         "msp430" => "MSP430",
                         "powerpc" => "PowerPC",
                         "powerpc64" => "PowerPC-64",
+                        "riscv32" => "RISC-V RV32",
+                        "riscv64" => "RISC-V RV64",
                         "s390x" => "s390x",
                         "sparc64" => "SPARC64",
                         "wasm32" | "wasm64" => "WebAssembly",


### PR DESCRIPTION
This pull request adds a human readable rustdoc display for RISC-V architecture. Target configuration marked as `#[cfg(target_arch = "riscv32")]` or `#[cfg(target_arch = "riscv64")]` are pretty formatted like `RISC-V RV32` and `RISC-V RV64` in Rust docs.

Before:

![图片](https://user-images.githubusercontent.com/40385009/152681944-58d758ae-ac4f-412b-b70c-1e673a2a071e.png)

After:

![图片](https://user-images.githubusercontent.com/40385009/152681923-91d5fe75-c3b2-4ac2-865c-54eac0aefe8d.png)
