### PR TITLE
Make rustdoc headings black, and markdown blue

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -296,7 +296,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
             let (short, name) = item_ty_to_strs(myty.unwrap());
             write!(
                 w,
-                "<h2 id=\"{id}\" class=\"section-header\">\
+                "<h2 id=\"{id}\" class=\"small-section-header\">\
                     <a href=\"#{id}\">{name}</a>\
                  </h2>\n{}",
                 ITEM_TABLE_OPEN,

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -219,7 +219,7 @@ a {
 a.srclink,
 a#toggle-all-docs,
 a.anchor,
-.section-header a,
+.small-section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -181,7 +181,7 @@ a {
 a.srclink,
 a#toggle-all-docs,
 a.anchor,
-.section-header a,
+.small-section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -176,7 +176,7 @@ a {
 a.srclink,
 a#toggle-all-docs,
 a.anchor,
-.section-header a,
+.small-section-header a,
 #source-sidebar a,
 pre.rust a,
 .sidebar a,

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -18,7 +18,10 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".small-section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+assert-css: (".section-header a", {"color": "rgb(57, 175, 215)"}, ALL)
 
 // Dark theme
 local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
@@ -34,7 +37,10 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".small-section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+assert-css: (".section-header a", {"color": "rgb(210, 153, 29)"}, ALL)
 
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
@@ -52,4 +58,7 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
 assert-css: ("#method\.must_use", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".section-header a", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".small-section-header a", {"color": "rgb(0, 0, 0)"}, ALL)
+
+goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
+assert-css: (".section-header a", {"color": "rgb(56, 115, 173)"}, ALL)


### PR DESCRIPTION
Demo:

https://rustdoc.crud.net/jsha/heading-color/std/string/index.html#structs
https://rustdoc.crud.net/jsha/heading-color/std/string/struct.String.html#examples

Fixes #91304

r? @camelid /cc @GuillaumeGomez

(Note: we may want to make rustdoc headings and markdown headings the same color -- #90245 -- but we would want to do that intentionally; this is fixing up a change that did so accidentally)