### PR TITLE
Stabilize `-Z emit-future-incompat` as `--json future-incompat`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -651,7 +651,6 @@ fn test_debugging_options_tracking_hash() {
     untracked!(dump_mir_dir, String::from("abc"));
     untracked!(dump_mir_exclude_pass_number, true);
     untracked!(dump_mir_graphviz, true);
-    untracked!(emit_future_incompat_report, true);
     untracked!(emit_stack_sizes, true);
     untracked!(future_incompat_test, true);
     untracked!(hir_stats, true);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -746,6 +746,7 @@ impl Default for Options {
             edition: DEFAULT_EDITION,
             json_artifact_notifications: false,
             json_unused_externs: false,
+            json_future_incompat: false,
             pretty: None,
             working_dir: RealFileName::LocalPath(std::env::current_dir().unwrap()),
         }
@@ -1257,6 +1258,7 @@ pub struct JsonConfig {
     pub json_rendered: HumanReadableErrorType,
     pub json_artifact_notifications: bool,
     pub json_unused_externs: bool,
+    pub json_future_incompat: bool,
 }
 
 /// Parse the `--json` flag.
@@ -1269,6 +1271,7 @@ pub fn parse_json(matches: &getopts::Matches) -> JsonConfig {
     let mut json_color = ColorConfig::Never;
     let mut json_artifact_notifications = false;
     let mut json_unused_externs = false;
+    let mut json_future_incompat = false;
     for option in matches.opt_strs("json") {
         // For now conservatively forbid `--color` with `--json` since `--json`
         // won't actually be emitting any colors and anything colorized is
@@ -1286,6 +1289,7 @@ pub fn parse_json(matches: &getopts::Matches) -> JsonConfig {
                 "diagnostic-rendered-ansi" => json_color = ColorConfig::Always,
                 "artifacts" => json_artifact_notifications = true,
                 "unused-externs" => json_unused_externs = true,
+                "future-incompat" => json_future_incompat = true,
                 s => early_error(
                     ErrorOutputType::default(),
                     &format!("unknown `--json` option `{}`", s),
@@ -1298,6 +1302,7 @@ pub fn parse_json(matches: &getopts::Matches) -> JsonConfig {
         json_rendered: json_rendered(json_color),
         json_artifact_notifications,
         json_unused_externs,
+        json_future_incompat,
     }
 }
 
@@ -2011,8 +2016,12 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 
     let edition = parse_crate_edition(matches);
 
-    let JsonConfig { json_rendered, json_artifact_notifications, json_unused_externs } =
-        parse_json(matches);
+    let JsonConfig {
+        json_rendered,
+        json_artifact_notifications,
+        json_unused_externs,
+        json_future_incompat,
+    } = parse_json(matches);
 
     let error_format = parse_error_format(matches, color, json_rendered);
 
@@ -2248,6 +2257,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         edition,
         json_artifact_notifications,
         json_unused_externs,
+        json_future_incompat,
         pretty,
         working_dir,
     }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -205,6 +205,9 @@ top_level_options!(
         /// `true` if we're emitting a JSON blob containing the unused externs
         json_unused_externs: bool [UNTRACKED],
 
+        /// `true` if we're emitting a JSON job containg a future-incompat report for lints
+        json_future_incompat: bool [TRACKED],
+
         pretty: Option<PpMode> [UNTRACKED],
 
         /// The (potentially remapped) working directory
@@ -1124,8 +1127,6 @@ options! {
         computed `block` spans (one span encompassing a block's terminator and \
         all statements). If `-Z instrument-coverage` is also enabled, create \
         an additional `.html` file showing the computed coverage spans."),
-    emit_future_incompat_report: bool = (false, parse_bool, [UNTRACKED],
-        "emits a future-incompatibility report for lints (RFC 2834)"),
     emit_stack_sizes: bool = (false, parse_bool, [UNTRACKED],
         "emit a section containing stack size metadata (default: no)"),
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -280,7 +280,7 @@ impl Session {
     }
 
     fn emit_future_breakage(&self) {
-        if !self.opts.debugging_opts.emit_future_incompat_report {
+        if !self.opts.json_future_incompat {
             return;
         }
 

--- a/src/test/ui/lint/future-incompat-test.rs
+++ b/src/test/ui/lint/future-incompat-test.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zfuture-incompat-test -Zemit-future-incompat-report
+// compile-flags: -Zfuture-incompat-test
 // check-pass
 
 // The `-Zfuture-incompat-test flag causes any normal warning to be included

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1802,6 +1802,7 @@ impl<'test> TestCx<'test> {
                 // patterns still match the raw compiler output.
                 if self.props.error_patterns.is_empty() {
                     rustc.args(&["--error-format", "json"]);
+                    rustc.args(&["--json", "future-incompat"]);
                 }
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
@@ -1809,11 +1810,11 @@ impl<'test> TestCx<'test> {
             Ui => {
                 if !self.props.compile_flags.iter().any(|s| s.starts_with("--error-format")) {
                     rustc.args(&["--error-format", "json"]);
+                    rustc.args(&["--json", "future-incompat"]);
                 }
                 rustc.arg("-Ccodegen-units=1");
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
-                rustc.arg("-Zemit-future-incompat-report");
             }
             MirOpt => {
                 rustc.args(&[


### PR DESCRIPTION
The FCP was completed in https://github.com/rust-lang/rust/issues/71249