### PR TITLE
compiler/rustc_target: make m68k-unknown-linux-gnu use the gnu base

### DIFF
--- a/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::abi::Endian;
 use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
-    let mut base = super::linux_base::opts();
+    let mut base = super::linux_gnu_base::opts();
     base.max_atomic_width = Some(32);
 
     Target {


### PR DESCRIPTION
This makes the m68k arch match the other GNU/Linux based targets by setting the environment to gnu.