### PR TITLE
Fix ICE in struct construction with base expression

### DIFF
--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.diverges.set(Diverges::Maybe);
                 match g {
                     hir::Guard::If(e) => {
-                        self.check_expr_has_type_or_error(e, tcx.types.bool, |_| {});
+                        self.check_expr_has_type_or_error(e, tcx.types.bool, |_, _| {});
                     }
                     hir::Guard::IfLet(pat, e) => {
                         let scrutinee_ty = self.demand_scrutinee_type(
@@ -478,7 +478,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 kind: TypeVariableOriginKind::TypeInference,
                 span: scrut.span,
             });
-            self.check_expr_has_type_or_error(scrut, scrut_ty, |_| {});
+            self.check_expr_has_type_or_error(scrut, scrut_ty, |_, _| {});
             scrut_ty
         }
     }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -611,7 +611,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::StmtKind::Item(_) => {}
             hir::StmtKind::Expr(ref expr) => {
                 // Check with expected type of `()`.
-                self.check_expr_has_type_or_error(&expr, self.tcx.mk_unit(), |err| {
+                self.check_expr_has_type_or_error(&expr, self.tcx.mk_unit(), |err, _| {
                     if expr.can_have_side_effects() {
                         self.suggest_semicolon_at_end(expr.span, err);
                     }

--- a/src/test/ui/structs/issue-91502.rs
+++ b/src/test/ui/structs/issue-91502.rs
@@ -1,0 +1,9 @@
+struct Bar {}
+
+fn main() {
+    let old: Option<Bar> = None;
+
+    let b = Bar {
+        ..old.as_ref().unwrap() //~ ERROR E0308
+    };
+}

--- a/src/test/ui/structs/issue-91502.stderr
+++ b/src/test/ui/structs/issue-91502.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-91502.rs:7:11
+   |
+LL |         ..old.as_ref().unwrap()
+   |           ^^^^^^^^^^^^^^^^^^^^^ expected struct `Bar`, found `&Bar`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
For some reason we ICE if we try to `check_expr` within a failing `check_expr_has_type_or_error`. We don't need to do that inner `check_expr`, though, since we've already computed it, so just pass it along to the `extend_err` closure.

Let me know if we should continue investigating the `can't compose [Borrow(Ref('_#0r, Not)) -> &Option<Bar>] and [Borrow(Ref('_#3r, Not)) -> &Option<Bar>]` ICE in `FnCtxt::apply_adjustments` which is the underlying cause for this ICE.

Fixes #91502 