### PR TITLE
Implement additional `split_inclusive` variants for slices

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -133,7 +133,7 @@
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]
 #![feature(slice_range)]
-#![feature(split_left_inclusive)]
+#![feature(split_inclusive_variants)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
 #![feature(trusted_len)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -133,6 +133,7 @@
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]
 #![feature(slice_range)]
+#![feature(split_left_inclusive)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
 #![feature(trusted_len)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -132,12 +132,17 @@ pub use core::slice::{Iter, IterMut};
 pub use core::slice::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 pub use core::slice::{RSplit, RSplitMut};
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
+pub use core::slice::{
+    RSplitInclusive, RSplitInclusiveMut, RSplitLeftInclusive, RSplitLeftInclusiveMut,
+    RSplitNInclusive, RSplitNInclusiveMut, RSplitNLeftInclusive, RSplitNLeftInclusiveMut,
+    SplitLeftInclusive, SplitLeftInclusiveMut, SplitNInclusive, SplitNInclusiveMut,
+    SplitNLeftInclusive, SplitNLeftInclusiveMut,
+};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{RSplitN, RSplitNMut, SplitN, SplitNMut};
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use core::slice::{SplitInclusive, SplitInclusiveMut};
-#[unstable(feature = "split_left_inclusive", issue = "none")]
-pub use core::slice::{SplitLeftInclusive, SplitLeftInclusiveMut};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Basic slice extension methods

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -136,6 +136,8 @@ pub use core::slice::{RSplit, RSplitMut};
 pub use core::slice::{RSplitN, RSplitNMut, SplitN, SplitNMut};
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use core::slice::{SplitInclusive, SplitInclusiveMut};
+#[unstable(feature = "split_left_inclusive", issue = "none")]
+pub use core::slice::{SplitLeftInclusive, SplitLeftInclusiveMut};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Basic slice extension methods

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -69,8 +69,8 @@ pub use core::str::{Matches, RMatches};
 pub use core::str::{RSplit, Split};
 #[unstable(feature = "split_inclusive_variants", issue = "none")]
 pub use core::str::{
-    RSplitInclusive, RSplitLeftInclusive, RSplitNInclusive, RSplitNLeftInclusive,
-    SplitLeftInclusive, SplitNInclusive, SplitNLeftInclusive,
+    RSplitInclusive, RSplitLeftInclusive, RSplitNInclusive, RSplitNLeftInclusive, SplitEnds,
+    SplitInitiator, SplitLeftInclusive, SplitNInclusive, SplitNLeftInclusive,
 };
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{RSplitN, SplitN};

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -67,6 +67,11 @@ pub use core::str::{MatchIndices, RMatchIndices};
 pub use core::str::{Matches, RMatches};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{RSplit, Split};
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
+pub use core::str::{
+    RSplitInclusive, RSplitLeftInclusive, RSplitNInclusive, RSplitNLeftInclusive,
+    SplitLeftInclusive, SplitNInclusive, SplitNLeftInclusive,
+};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{RSplitN, SplitN};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -42,7 +42,7 @@
 #![feature(bench_black_box)]
 #![feature(strict_provenance)]
 #![feature(once_cell)]
-#![feature(split_left_inclusive)]
+#![feature(split_inclusive_variants)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -42,6 +42,7 @@
 #![feature(bench_black_box)]
 #![feature(strict_provenance)]
 #![feature(once_cell)]
+#![feature(split_left_inclusive)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -943,7 +943,7 @@ fn test_splitator_left_inclusive() {
     assert_eq!(xs.split_left_inclusive(|_| true).collect::<Vec<&[i32]>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_left_inclusive(|x| *x == 5).collect::<Vec<&[i32]>>(), splits);
 }
 
@@ -963,7 +963,7 @@ fn test_splitator_left_inclusive_reverse() {
     assert_eq!(xs.split_left_inclusive(|_| true).rev().collect::<Vec<_>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_left_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
 }
 
@@ -983,7 +983,7 @@ fn test_splitator_left_inclusive_mut() {
     assert_eq!(xs.split_left_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
 }
 
@@ -1003,7 +1003,7 @@ fn test_splitator_left_inclusive_reverse_mut() {
     assert_eq!(xs.split_left_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
 }
 

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1236,7 +1236,7 @@ fn test_rsplitnator() {
 
 #[test]
 fn test_split_iterators_size_hint() {
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, PartialEq, Eq)]
     enum Bounds {
         Lower,
         Upper,
@@ -1267,8 +1267,9 @@ fn test_split_iterators_size_hint() {
 
         // p: predicate, b: bound selection
         for (p, b) in [
-            // with a predicate always returning false, the split*-iterators
-            // become maximally short, so the size_hint lower bounds are tight
+            // with a predicate always returning false, the non-inclusive
+            // split*-iterators become maximally short, so the size_hint
+            // lower bounds are tight
             ((|_| false) as fn(&_) -> _, Bounds::Lower),
             // with a predicate always returning true, the split*-iterators
             // become maximally long, so the size_hint upper bounds are tight
@@ -1279,8 +1280,10 @@ fn test_split_iterators_size_hint() {
 
             a(v.split(p), b, "split");
             a(v.split_mut(p), b, "split_mut");
-            a(v.split_inclusive(p), b, "split_inclusive");
-            a(v.split_inclusive_mut(p), b, "split_inclusive_mut");
+            if b == Bounds::Upper {
+                a(v.split_inclusive(p), b, "split_inclusive");
+                a(v.split_inclusive_mut(p), b, "split_inclusive_mut");
+            }
             a(v.rsplit(p), b, "rsplit");
             a(v.rsplit_mut(p), b, "rsplit_mut");
 

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1008,6 +1008,166 @@ fn test_splitator_left_inclusive_reverse_mut() {
 }
 
 #[test]
+fn test_rsplitator_inclusive() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[5], &[3, 4], &[1, 2]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[2, 3, 4, 5], &[1]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.rsplit_inclusive(|_| true).collect::<Vec<_>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_inclusive_reverse() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1, 2], &[3, 4], &[5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.rsplit_inclusive(|_| true).rev().collect::<Vec<&[i32]>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.rsplit_inclusive(|x| *x == 5).rev().collect::<Vec<&[i32]>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_mut_inclusive() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[5], &[3, 4], &[1, 2]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[2, 3, 4, 5], &[1]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.rsplit_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_mut_inclusive_reverse() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1, 2], &[3, 4], &[5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.rsplit_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_left_inclusive() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[4, 5], &[2, 3], &[1]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[1, 2, 3, 4]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.rsplit_left_inclusive(|_| true).collect::<Vec<_>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_left_inclusive_reverse() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1], &[2, 3], &[4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4], &[5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.rsplit_left_inclusive(|_| true).rev().collect::<Vec<&[i32]>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[];
+    assert_eq!(xs.rsplit_left_inclusive(|x| *x == 5).rev().collect::<Vec<&[i32]>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_left_inclusive_mut() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[4, 5], &[2, 3], &[1]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[1, 2, 3, 4]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_rsplitator_left_inclusive_reverse_mut() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1], &[2, 3], &[4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4], &[5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.rsplit_left_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+}
+
+#[test]
 fn test_splitnator() {
     let xs = &[1, 2, 3, 4, 5];
 

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -928,6 +928,86 @@ fn test_splitator_mut_inclusive_reverse() {
 }
 
 #[test]
+fn test_splitator_left_inclusive() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1], &[2, 3], &[4, 5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4], &[5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.split_left_inclusive(|_| true).collect::<Vec<&[i32]>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 5).collect::<Vec<&[i32]>>(), splits);
+}
+
+#[test]
+fn test_splitator_left_inclusive_reverse() {
+    let xs = &[1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[4, 5], &[2, 3], &[1]];
+    assert_eq!(xs.split_left_inclusive(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[1, 2, 3, 4]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.split_left_inclusive(|_| true).rev().collect::<Vec<_>>(), splits);
+
+    let xs: &[i32] = &[];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.split_left_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_splitator_left_inclusive_mut() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[1], &[2, 3], &[4, 5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x % 2 == 0).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 1).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4], &[5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 10).collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1], &[2], &[3], &[4], &[5]];
+    assert_eq!(xs.split_left_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
+}
+
+#[test]
+fn test_splitator_left_inclusive_reverse_mut() {
+    let xs = &mut [1, 2, 3, 4, 5];
+
+    let splits: &[&[_]] = &[&[4, 5], &[2, 3], &[1]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x % 2 == 0).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 1).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[1, 2, 3, 4]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[1, 2, 3, 4, 5]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 10).rev().collect::<Vec<_>>(), splits);
+    let splits: &[&[_]] = &[&[5], &[4], &[3], &[2], &[1]];
+    assert_eq!(xs.split_left_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
+
+    let xs: &mut [i32] = &mut [];
+    let splits: &[&[i32]] = &[&[]];
+    assert_eq!(xs.split_left_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
+}
+
+#[test]
 fn test_splitnator() {
     let xs = &[1, 2, 3, 4, 5];
 

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1023,7 +1023,7 @@ fn test_rsplitator_inclusive() {
     assert_eq!(xs.rsplit_inclusive(|_| true).collect::<Vec<_>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.rsplit_inclusive(|x| *x == 5).collect::<Vec<_>>(), splits);
 }
 
@@ -1043,7 +1043,7 @@ fn test_rsplitator_inclusive_reverse() {
     assert_eq!(xs.rsplit_inclusive(|_| true).rev().collect::<Vec<&[i32]>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.rsplit_inclusive(|x| *x == 5).rev().collect::<Vec<&[i32]>>(), splits);
 }
 
@@ -1063,7 +1063,7 @@ fn test_rsplitator_mut_inclusive() {
     assert_eq!(xs.rsplit_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
 }
 
@@ -1083,7 +1083,7 @@ fn test_rsplitator_mut_inclusive_reverse() {
     assert_eq!(xs.rsplit_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.rsplit_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
 }
 

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1439,6 +1439,63 @@ fn test_split_char_iterator_inclusive_rev() {
 }
 
 #[test]
+fn test_split_char_iterator_left_inclusive() {
+    let split: Vec<&str> = "\n\n\n\n".split_left_inclusive('\n').collect();
+    assert_eq!(split, ["\n", "\n", "\n", "\n"]);
+
+    let split: Vec<&str> = "".split_left_inclusive('\n').collect();
+    let rhs: [&str; 0] = [];
+    assert_eq!(split, rhs);
+
+    let data = "\nMäry häd ä little lämb\nLittle lämb\n";
+
+    let split: Vec<&str> = data.split_left_inclusive('\n').collect();
+    assert_eq!(split, ["\nMäry häd ä little lämb", "\nLittle lämb", "\n"]);
+
+    let uppercase_separated = "SheePSharKTurtlECaT";
+    let mut first_char = true;
+    let split: Vec<&str> = uppercase_separated
+        .split_left_inclusive(|c: char| {
+            let split = !first_char && c.is_uppercase();
+            first_char = split;
+            split
+        })
+        .collect();
+    assert_eq!(split, ["Shee", "PShar", "KTurtl", "ECa", "T"]);
+}
+
+#[test]
+fn test_split_char_iterator_left_inclusive_rev() {
+    let split: Vec<&str> = "\n\n\n\n".split_left_inclusive('\n').rev().collect();
+    assert_eq!(split, ["\n", "\n", "\n", "\n"]);
+
+    let split: Vec<&str> = "".split_left_inclusive('\n').rev().collect();
+    let rhs: [&str; 0] = [];
+    assert_eq!(split, rhs);
+
+    let data = "\nMäry häd ä little lämb\nLittle lämb\n";
+
+    let split: Vec<&str> = data.split_left_inclusive('\n').rev().collect();
+    assert_eq!(split, ["\n", "\nLittle lämb", "\nMäry häd ä little lämb"]);
+
+    // Note that the predicate is stateful and thus dependent
+    // on the iteration order.
+    // (A different predicate is needed for reverse iterator vs normal iterator.)
+    // Not sure if anything can be done though.
+    let uppercase_separated = "SheePSharKTurtlECaT";
+    let mut term_char = true;
+    let split: Vec<&str> = uppercase_separated
+        .split_left_inclusive(|c: char| {
+            let split = term_char && c.is_uppercase();
+            term_char = c.is_uppercase();
+            split
+        })
+        .rev()
+        .collect();
+    assert_eq!(split, ["T", "ECa", "KTurtl", "PShar", "Shee",]);
+}
+
+#[test]
 fn test_rsplit() {
     let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -640,6 +640,21 @@ where
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool {}
 
+impl<'a, T, P> SplitIter for SplitInclusive<'a, T, P>
+where
+    P: FnMut(&T) -> bool,
+{
+    #[inline]
+    fn finish(&mut self) -> Option<&'a [T]> {
+        if self.finished {
+            None
+        } else {
+            self.finished = true;
+            Some(self.v)
+        }
+    }
+}
+
 /// An iterator over subslices separated by elements that match a predicate
 /// function. Unlike `Split`, it contains the matched part as an initiator
 /// of the subslice.
@@ -649,7 +664,7 @@ impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool
 /// # Example
 ///
 /// ```
-/// #![feature(split_left_inclusive)]
+/// #![feature(split_inclusive_variants)]
 ///
 /// let slice = [10, 40, 33, 20];
 /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
@@ -657,7 +672,7 @@ impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool
 ///
 /// [`split_left_inclusive`]: slice::split_left_inclusive
 /// [slices]: slice
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 pub struct SplitLeftInclusive<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -675,7 +690,7 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitLeftInclusive<'a, T, P> {
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<T: fmt::Debug, P> fmt::Debug for SplitLeftInclusive<'_, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -689,7 +704,7 @@ where
 }
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<T, P> Clone for SplitLeftInclusive<'_, T, P>
 where
     P: Clone + FnMut(&T) -> bool,
@@ -699,7 +714,7 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, T, P> Iterator for SplitLeftInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -740,7 +755,7 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, T, P> DoubleEndedIterator for SplitLeftInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -761,8 +776,23 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<T, P> FusedIterator for SplitLeftInclusive<'_, T, P> where P: FnMut(&T) -> bool {}
+
+impl<'a, T, P> SplitIter for SplitLeftInclusive<'a, T, P>
+where
+    P: FnMut(&T) -> bool,
+{
+    #[inline]
+    fn finish(&mut self) -> Option<&'a [T]> {
+        if self.finished {
+            None
+        } else {
+            self.finished = true;
+            Some(self.v)
+        }
+    }
+}
 
 /// An iterator over the mutable subslices of the vector which are separated
 /// by elements that match `pred`.
@@ -1018,6 +1048,21 @@ where
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
+impl<'a, T, P> SplitIter for SplitInclusiveMut<'a, T, P>
+where
+    P: FnMut(&T) -> bool,
+{
+    #[inline]
+    fn finish(&mut self) -> Option<&'a mut [T]> {
+        if self.finished {
+            None
+        } else {
+            self.finished = true;
+            Some(mem::replace(&mut self.v, &mut []))
+        }
+    }
+}
+
 /// An iterator over the mutable subslices of the vector which are separated
 /// by elements that match `pred`. Unlike `SplitMut`, it contains the matched
 /// parts in the beginnings of the subslices.
@@ -1028,7 +1073,7 @@ impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> b
 /// # Example
 ///
 /// ```
-/// #![feature(split_left_inclusive)]
+/// #![feature(split_inclusive_variants)]
 ///
 /// let mut v = [10, 40, 30, 20, 60, 50];
 /// let iter = v.split_left_inclusive_mut(|num| *num % 3 == 0);
@@ -1036,7 +1081,7 @@ impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> b
 ///
 /// [`split_left_inclusive_mut`]: slice::split_left_inclusive_mut
 /// [slices]: slice
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 pub struct SplitLeftInclusiveMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1054,7 +1099,7 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitLeftInclusiveMut<'a, T, P> {
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<T: fmt::Debug, P> fmt::Debug for SplitLeftInclusiveMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -1067,7 +1112,7 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, T, P> Iterator for SplitLeftInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -1113,7 +1158,7 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, T, P> DoubleEndedIterator for SplitLeftInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
@@ -1143,196 +1188,150 @@ where
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
-impl<T, P> FusedIterator for SplitLeftInclusiveMut<'_, T, P> where P: FnMut(&T) -> bool {}
-
-/// An iterator over subslices separated by elements that match a predicate
-/// function, starting from the end of the slice.
-///
-/// This struct is created by the [`rsplit`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let slice = [11, 22, 33, 0, 44, 55];
-/// let iter = slice.rsplit(|num| *num == 0);
-/// ```
-///
-/// [`rsplit`]: slice::rsplit
-/// [slices]: slice
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RSplit<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: Split<'a, T, P>,
-}
-
-impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplit<'a, T, P> {
-    #[inline]
-    pub(super) fn new(slice: &'a [T], pred: P) -> Self {
-        Self { inner: Split::new(slice, pred) }
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<T: fmt::Debug, P> fmt::Debug for RSplit<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RSplit")
-            .field("v", &self.inner.v)
-            .field("finished", &self.inner.finished)
-            .finish()
-    }
-}
-
-// FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<T, P> Clone for RSplit<'_, T, P>
-where
-    P: Clone + FnMut(&T) -> bool,
-{
-    fn clone(&self) -> Self {
-        RSplit { inner: self.inner.clone() }
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> Iterator for RSplit<'a, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    type Item = &'a [T];
-
-    #[inline]
-    fn next(&mut self) -> Option<&'a [T]> {
-        self.inner.next_back()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> DoubleEndedIterator for RSplit<'a, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    #[inline]
-    fn next_back(&mut self) -> Option<&'a [T]> {
-        self.inner.next()
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> SplitIter for RSplit<'a, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    #[inline]
-    fn finish(&mut self) -> Option<&'a [T]> {
-        self.inner.finish()
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<T, P> FusedIterator for RSplit<'_, T, P> where P: FnMut(&T) -> bool {}
-
-/// An iterator over the subslices of the vector which are separated
-/// by elements that match `pred`, starting from the end of the slice.
-///
-/// This struct is created by the [`rsplit_mut`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let mut slice = [11, 22, 33, 0, 44, 55];
-/// let iter = slice.rsplit_mut(|num| *num == 0);
-/// ```
-///
-/// [`rsplit_mut`]: slice::rsplit_mut
-/// [slices]: slice
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RSplitMut<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: SplitMut<'a, T, P>,
-}
-
-impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitMut<'a, T, P> {
-    #[inline]
-    pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
-        Self { inner: SplitMut::new(slice, pred) }
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<T: fmt::Debug, P> fmt::Debug for RSplitMut<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RSplitMut")
-            .field("v", &self.inner.v)
-            .field("finished", &self.inner.finished)
-            .finish()
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> SplitIter for RSplitMut<'a, T, P>
+impl<'a, T, P> SplitIter for SplitLeftInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
     fn finish(&mut self) -> Option<&'a mut [T]> {
-        self.inner.finish()
+        if self.finished {
+            None
+        } else {
+            self.finished = true;
+            Some(mem::replace(&mut self.v, &mut []))
+        }
     }
 }
 
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> Iterator for RSplitMut<'a, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    type Item = &'a mut [T];
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
+impl<T, P> FusedIterator for SplitLeftInclusiveMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
-    #[inline]
-    fn next(&mut self) -> Option<&'a mut [T]> {
-        self.inner.next_back()
-    }
+reverse_iter! {
+    #[stable(feature = "slice_rsplit", since = "1.27.0")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, starting from the end of the slice.
+    ///
+    /// This struct is created by the [`rsplit`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let slice = [11, 22, 33, 0, 44, 55];
+    /// let iter = slice.rsplit(|num| *num == 0);
+    /// ```
+    ///
+    /// [`rsplit`]: slice::rsplit
+    /// [slices]: slice
+    pub struct RSplit { "RSplit"; Split }: Clone
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order. Unlike `Split`, it contains the matched part as
+    /// an initiator of the subslice.
+    ///
+    /// This struct is created by the [`rsplit_left_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplit_inclusive(|num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplit_left_inclusive`]: slice::rsplit_inclusive
+    /// [slices]: slice
+    pub struct RSplitInclusive { "RSplitInclusive"; SplitInclusive }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order. Unlike `Split`, it contains the matched part as
+    /// an initiator of the subslice.
+    ///
+    /// This struct is created by the [`rsplit_left_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplit_left_inclusive(|num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplit_left_inclusive`]: slice::rsplit_left_inclusive
+    /// [slices]: slice
+    pub struct RSplitLeftInclusive { "RSplitLeftInclusive"; SplitLeftInclusive }: Clone
+
+    #[stable(feature = "slice_rsplit", since = "1.27.0")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over the subslices of the vector which are separated
+    /// by elements that match `pred`, starting from the end of the slice.
+    ///
+    /// This struct is created by the [`rsplit_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut slice = [11, 22, 33, 0, 44, 55];
+    /// let iter = slice.rsplit_mut(|num| *num == 0);
+    /// ```
+    ///
+    /// [`rsplit_mut`]: slice::rsplit_mut
+    /// [slices]: slice
+    pub struct RSplitMut { "RSplitMut"; SplitMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over the mutable subslices of the vector which are separated
+    /// by elements that match `pred`, in reverse order. Unlike `SplitMut`, it
+    /// contains the matched parts in the ends of the subslices.
+    ///
+    /// This struct is created by the [`rsplit_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    /// let iter = v.rsplit_inclusive_mut(|num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplit_inclusive_mut`]: slice::rsplit_inclusive_mut
+    /// [slices]: slice
+    pub struct RSplitInclusiveMut { "RSplitInclusiveMut" ; SplitInclusiveMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over the mutable subslices of the vector which are separated
+    /// by elements that match `pred`, in reverse order. Unlike `SplitMut`, it
+    /// contains the matched parts in the beginnings of the subslices.
+    ///
+    /// This struct is created by the [`rsplit_left_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    /// let iter = v.rsplit_left_inclusive_mut(|num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplit_left_inclusive_mut`]: slice::rsplit_left_inclusive_mut
+    /// [slices]: slice
+    pub struct RSplitLeftInclusiveMut { "RSplitLeftInclusiveMut" ; SplitLeftInclusiveMut }
 }
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<'a, T, P> DoubleEndedIterator for RSplitMut<'a, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    #[inline]
-    fn next_back(&mut self) -> Option<&'a mut [T]> {
-        self.inner.next()
-    }
-}
-
-#[stable(feature = "slice_rsplit", since = "1.27.0")]
-impl<T, P> FusedIterator for RSplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An private iterator over subslices separated by elements that
 /// match a predicate function, splitting at most a fixed number of
 /// times.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct GenericSplitN<I> {
     iter: I,
     count: usize,
@@ -1366,172 +1365,261 @@ impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
     }
 }
 
-/// An iterator over subslices separated by elements that match a predicate
-/// function, limited to a given number of splits.
-///
-/// This struct is created by the [`splitn`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let slice = [10, 40, 30, 20, 60, 50];
-/// let iter = slice.splitn(2, |num| *num % 3 == 0);
-/// ```
-///
-/// [`splitn`]: slice::splitn
-/// [slices]: slice
-#[stable(feature = "rust1", since = "1.0.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct SplitN<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: GenericSplitN<Split<'a, T, P>>,
-}
+iter_n! {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[fused(stable(feature = "fused", since = "1.26.0"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a given number of splits.
+    ///
+    /// This struct is created by the [`splitn`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let slice = [10, 40, 30, 20, 60, 50];
+    /// let iter = slice.splitn(2, |num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn`]: slice::splitn
+    /// [slices]: slice
+    pub struct SplitN {"SplitN"; Split }: Clone
 
-impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitN<'a, T, P> {
-    #[inline]
-    pub(super) fn new(s: Split<'a, T, P>, n: usize) -> Self {
-        Self { inner: GenericSplitN { iter: s, count: n } }
-    }
-}
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[fused(stable(feature = "fused", since = "1.26.0"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a
+    /// predicate function, limited to a given number of splits, starting
+    /// from the end of the slice.
+    ///
+    /// This struct is created by the [`rsplitn`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let slice = [10, 40, 30, 20, 60, 50];
+    /// let iter = slice.rsplitn(2, |num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn`]: slice::rsplitn
+    /// [slices]: slice
+    pub struct RSplitN {"RSplitN"; RSplit }: Clone
 
-#[stable(feature = "core_impl_debug", since = "1.9.0")]
-impl<T: fmt::Debug, P> fmt::Debug for SplitN<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SplitN").field("inner", &self.inner).finish()
-    }
-}
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[fused(stable(feature = "fused", since = "1.26.0"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a given number of splits.
+    ///
+    /// This struct is created by the [`splitn_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut slice = [10, 40, 30, 20, 60, 50];
+    /// let iter = slice.splitn_mut(2, |num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn_mut`]: slice::splitn_mut
+    /// [slices]: slice
+    pub struct SplitNMut {"SplitNMut"; SplitMut }
 
-/// An iterator over subslices separated by elements that match a
-/// predicate function, limited to a given number of splits, starting
-/// from the end of the slice.
-///
-/// This struct is created by the [`rsplitn`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let slice = [10, 40, 30, 20, 60, 50];
-/// let iter = slice.rsplitn(2, |num| *num % 3 == 0);
-/// ```
-///
-/// [`rsplitn`]: slice::rsplitn
-/// [slices]: slice
-#[stable(feature = "rust1", since = "1.0.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RSplitN<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: GenericSplitN<RSplit<'a, T, P>>,
-}
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[fused(stable(feature = "fused", since = "1.26.0"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a
+    /// predicate function, limited to a given number of splits, starting
+    /// from the end of the slice.
+    ///
+    /// This struct is created by the [`rsplitn_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut slice = [10, 40, 30, 20, 60, 50];
+    /// let iter = slice.rsplitn_mut(2, |num| *num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn_mut`]: slice::rsplitn_mut
+    /// [slices]: slice
+    pub struct RSplitNMut {"RSplitNMut"; RSplitMut }
 
-impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitN<'a, T, P> {
-    #[inline]
-    pub(super) fn new(s: RSplit<'a, T, P>, n: usize) -> Self {
-        Self { inner: GenericSplitN { iter: s, count: n } }
-    }
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a certain number of elements. Unlike `SplitN`, it
+    /// contains the matched part as a terminator of the subslice.
+    ///
+    /// This struct is created by the [`splitn_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.splitn_inclusive(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn_inclusive`]: slice::splitn_inclusive
+    /// [slices]: slice
+    pub struct SplitNInclusive {"SplitNInclusive"; SplitInclusive}: Clone
 
-#[stable(feature = "core_impl_debug", since = "1.9.0")]
-impl<T: fmt::Debug, P> fmt::Debug for RSplitN<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RSplitN").field("inner", &self.inner).finish()
-    }
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a certain number of elements. Unlike `SplitN`, it
+    /// contains the matched part as an initiator of the subslice.
+    ///
+    /// This struct is created by the [`splitn_left_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.splitn_left_inclusive(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn_left_inclusive`]: slice::splitn_left_inclusive
+    /// [slices]: slice
+    pub struct SplitNLeftInclusive {"SplitNLeftInclusive"; SplitLeftInclusive}: Clone
 
-/// An iterator over subslices separated by elements that match a predicate
-/// function, limited to a given number of splits.
-///
-/// This struct is created by the [`splitn_mut`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let mut slice = [10, 40, 30, 20, 60, 50];
-/// let iter = slice.splitn_mut(2, |num| *num % 3 == 0);
-/// ```
-///
-/// [`splitn_mut`]: slice::splitn_mut
-/// [slices]: slice
-#[stable(feature = "rust1", since = "1.0.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct SplitNMut<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: GenericSplitN<SplitMut<'a, T, P>>,
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order, limited to a certain number of elements. Unlike
+    /// `RSplitN`, it contains the matched part as a terminator of the subslice.
+    ///
+    /// This struct is created by the [`rsplitn_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_inclusive(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn_inclusive`]: slice::rsplitn_inclusive
+    /// [slices]: slice
+    pub struct RSplitNInclusive {"RSplitNInclusive"; RSplitInclusive}: Clone
 
-impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitNMut<'a, T, P> {
-    #[inline]
-    pub(super) fn new(s: SplitMut<'a, T, P>, n: usize) -> Self {
-        Self { inner: GenericSplitN { iter: s, count: n } }
-    }
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order, limited to a certain number of elements. Unlike
+    /// `RSplitN`, it contains the matched part as an initiator of the subslice.
+    ///
+    /// This struct is created by the [`rsplitn_left_inclusive`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_left_inclusive(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn_left_inclusive`]: slice::rsplitn_left_inclusive
+    /// [slices]: slice
+    pub struct RSplitNLeftInclusive {"RSplitNLeftInclusive"; RSplitLeftInclusive}: Clone
 
-#[stable(feature = "core_impl_debug", since = "1.9.0")]
-impl<T: fmt::Debug, P> fmt::Debug for SplitNMut<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SplitNMut").field("inner", &self.inner).finish()
-    }
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a certain number of elements. Unlike `SplitNMut`, it
+    /// contains the matched part as a terminator of the subslice.
+    ///
+    /// This struct is created by the [`splitn_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut slice = [10, 40, 33, 20];
+    /// let mut iter = slice.splitn_inclusive_mut(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn_inclusive_mut`]: slice::splitn_inclusive_mut
+    /// [slices]: slice
+    pub struct SplitNInclusiveMut {"SplitNInclusiveMut"; SplitInclusiveMut}
 
-/// An iterator over subslices separated by elements that match a
-/// predicate function, limited to a given number of splits, starting
-/// from the end of the slice.
-///
-/// This struct is created by the [`rsplitn_mut`] method on [slices].
-///
-/// # Example
-///
-/// ```
-/// let mut slice = [10, 40, 30, 20, 60, 50];
-/// let iter = slice.rsplitn_mut(2, |num| *num % 3 == 0);
-/// ```
-///
-/// [`rsplitn_mut`]: slice::rsplitn_mut
-/// [slices]: slice
-#[stable(feature = "rust1", since = "1.0.0")]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct RSplitNMut<'a, T: 'a, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    inner: GenericSplitN<RSplitMut<'a, T, P>>,
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, limited to a certain number of elements. Unlike `SplitNMut`, it
+    /// contains the matched part as an initiator of the subslice.
+    ///
+    /// This struct is created by the [`splitn_left_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut slice = [10, 40, 33, 20];
+    /// let mut iter = slice.splitn_left_inclusive_mut(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`splitn_left_inclusive_mut`]: slice::splitn_left_inclusive_mut
+    /// [slices]: slice
+    pub struct SplitNLeftInclusiveMut {"SplitNLeftInclusiveMut"; SplitLeftInclusiveMut}
 
-impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitNMut<'a, T, P> {
-    #[inline]
-    pub(super) fn new(s: RSplitMut<'a, T, P>, n: usize) -> Self {
-        Self { inner: GenericSplitN { iter: s, count: n } }
-    }
-}
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order, limited to a certain number of elements. Unlike
+    /// `RSplitN`, it contains the matched part as a terminator of the subslice.
+    ///
+    /// This struct is created by the [`rsplitn_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_inclusive_mut(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn_inclusive_mut`]: slice::rsplitn_inclusive_mut
+    /// [slices]: slice
+    pub struct RSplitNInclusiveMut {"RSplitNInclusiveMut"; RSplitInclusiveMut}
 
-#[stable(feature = "core_impl_debug", since = "1.9.0")]
-impl<T: fmt::Debug, P> fmt::Debug for RSplitNMut<'_, T, P>
-where
-    P: FnMut(&T) -> bool,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RSplitNMut").field("inner", &self.inner).finish()
-    }
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
+    /// An iterator over subslices separated by elements that match a predicate
+    /// function, in reverse order, limited to a certain number of elements. Unlike
+    /// `RSplitN`, it contains the matched part as an initiator of the subslice.
+    ///
+    /// This struct is created by the [`rsplitn_left_inclusive_mut`] method on [slices].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_left_inclusive_mut(2, |num| num % 3 == 0);
+    /// ```
+    ///
+    /// [`rsplitn_left_inclusive_mut`]: slice::rsplitn_left_inclusive_mut
+    /// [slices]: slice
+    pub struct RSplitNLeftInclusiveMut {"RSplitNLeftInclusiveMut"; RSplitLeftInclusiveMut}
 }
-
-forward_iterator! { SplitN: T, &'a [T] }
-forward_iterator! { RSplitN: T, &'a [T] }
-forward_iterator! { SplitNMut: T, &'a mut [T] }
-forward_iterator! { RSplitNMut: T, &'a mut [T] }
 
 /// An iterator over overlapping subslices of length `size`.
 ///

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -376,6 +376,7 @@ pub(super) trait SplitIter: DoubleEndedIterator {
 
 split_iter! {
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[debug(stable(feature = "core_impl_debug", since = "1.9.0"))]
     #[fused(stable(feature = "fused", since = "1.26.0"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over subslices separated by elements that match a predicate
@@ -393,12 +394,16 @@ split_iter! {
     /// [`split`]: slice::split
     /// [slices]: slice
     struct Split<shared_ref: &'a> {
-        #[stable(feature = "core_impl_debug", since = "1.9.0")]
-        debug: "Split",
         include_leading: false,
         include_trailing: false,
     }
+}
 
+impl<'a, T, P> Split<'a, T, P>
+where
+    T: 'a,
+    P: FnMut(&T) -> bool,
+{
     /// Returns a slice which contains items not yet handled by split.
     /// # Example
     ///
@@ -417,6 +422,7 @@ split_iter! {
 
 split_iter! {
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[debug(stable(feature = "core_impl_debug", since = "1.9.0"))]
     #[fused(stable(feature = "fused", since = "1.26.0"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over the mutable subslices of the vector which are separated
@@ -434,8 +440,6 @@ split_iter! {
     /// [`split_mut`]: slice::split_mut
     /// [slices]: slice
     struct SplitMut<mut_ref: &'a> {
-        #[stable(feature = "core_impl_debug", since = "1.9.0")]
-        debug: "SplitMut",
         include_leading: false,
         include_trailing: false,
     }
@@ -443,6 +447,7 @@ split_iter! {
 
 split_iter! {
     #[stable(feature = "split_inclusive", since = "1.51.0")]
+    #[debug(stable(feature = "core_impl_debug", since = "1.9.0"))]
     #[fused(stable(feature = "split_inclusive", since = "1.51.0"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over subslices separated by elements that match a predicate
@@ -461,8 +466,6 @@ split_iter! {
     /// [`split_inclusive`]: slice::split_inclusive
     /// [slices]: slice
     struct SplitInclusive<shared_ref: &'a> {
-        #[stable(feature = "split_inclusive", since = "1.51.0")]
-        debug: "SplitInclusive",
         include_leading: false,
         include_trailing: true,
     }
@@ -470,6 +473,7 @@ split_iter! {
 
 split_iter! {
     #[stable(feature = "split_inclusive", since = "1.51.0")]
+    #[debug(stable(feature = "split_inclusive", since = "1.51.0"))]
     #[fused(stable(feature = "split_inclusive", since = "1.51.0"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over the mutable subslices of the vector which are separated
@@ -488,8 +492,6 @@ split_iter! {
     /// [`split_inclusive_mut`]: slice::split_inclusive_mut
     /// [slices]: slice
     struct SplitInclusiveMut<mut_ref: &'a> {
-        #[stable(feature = "split_inclusive", since = "1.51.0")]
-        debug: "SplitInclusiveMut",
         include_leading: false,
         include_trailing: true,
     }
@@ -497,6 +499,7 @@ split_iter! {
 
 split_iter! {
     #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[debug(stable(feature = "split_inclusive", since = "1.51.0"))]
     #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over subslices separated by elements that match a predicate
@@ -517,8 +520,6 @@ split_iter! {
     /// [`split_left_inclusive`]: slice::split_left_inclusive
     /// [slices]: slice
     struct SplitLeftInclusive<shared_ref: &'a> {
-        #[unstable(feature = "split_inclusive_variants", issue = "none")]
-        debug: "SplitLeftInclusive",
         include_leading: true,
         include_trailing: false,
     }
@@ -526,6 +527,7 @@ split_iter! {
 
 split_iter! {
     #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[debug(unstable(feature = "split_inclusive_variants", issue = "none"))]
     #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
     #[must_use = "iterators are lazy and do nothing unless consumed"]
     /// An iterator over the mutable subslices of the vector which are separated
@@ -547,8 +549,6 @@ split_iter! {
     /// [`split_left_inclusive_mut`]: slice::split_left_inclusive_mut
     /// [slices]: slice
     struct SplitLeftInclusiveMut<mut_ref: &'a> {
-        #[unstable(feature = "split_inclusive_variants", issue = "none")]
-        debug: "SplitLeftInclusiveMut",
         include_leading: true,
         include_trailing: false,
     }
@@ -571,7 +571,7 @@ reverse_iter! {
     ///
     /// [`rsplit`]: slice::rsplit
     /// [slices]: slice
-    pub struct RSplit { "RSplit"; Split }: Clone
+    pub struct RSplit { inner: Split }: Clone
 }
 
 reverse_iter! {
@@ -594,7 +594,7 @@ reverse_iter! {
     ///
     /// [`rsplit_left_inclusive`]: slice::rsplit_inclusive
     /// [slices]: slice
-    pub struct RSplitInclusive { "RSplitInclusive"; SplitInclusive }: Clone
+    pub struct RSplitInclusive { inner: SplitInclusive }: Clone
 }
 
 reverse_iter! {
@@ -617,7 +617,7 @@ reverse_iter! {
     ///
     /// [`rsplit_left_inclusive`]: slice::rsplit_left_inclusive
     /// [slices]: slice
-    pub struct RSplitLeftInclusive { "RSplitLeftInclusive"; SplitLeftInclusive }: Clone
+    pub struct RSplitLeftInclusive { inner: SplitLeftInclusive }: Clone
 }
 
 reverse_iter! {
@@ -637,7 +637,7 @@ reverse_iter! {
     ///
     /// [`rsplit_mut`]: slice::rsplit_mut
     /// [slices]: slice
-    pub struct RSplitMut { "RSplitMut"; SplitMut }
+    pub struct RSplitMut { inner: SplitMut }
 }
 
 reverse_iter! {
@@ -660,7 +660,7 @@ reverse_iter! {
     ///
     /// [`rsplit_inclusive_mut`]: slice::rsplit_inclusive_mut
     /// [slices]: slice
-    pub struct RSplitInclusiveMut { "RSplitInclusiveMut" ; SplitInclusiveMut }
+    pub struct RSplitInclusiveMut { inner: SplitInclusiveMut }
 }
 
 reverse_iter! {
@@ -683,7 +683,7 @@ reverse_iter! {
     ///
     /// [`rsplit_left_inclusive_mut`]: slice::rsplit_left_inclusive_mut
     /// [slices]: slice
-    pub struct RSplitLeftInclusiveMut { "RSplitLeftInclusiveMut" ; SplitLeftInclusiveMut }
+    pub struct RSplitLeftInclusiveMut { inner: SplitLeftInclusiveMut }
 }
 
 /// An private iterator over subslices separated by elements that
@@ -741,7 +741,10 @@ iter_n! {
     ///
     /// [`splitn`]: slice::splitn
     /// [slices]: slice
-    pub struct SplitN {"SplitN"; Split }: Clone
+    pub struct SplitN { inner:  Split }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -763,7 +766,10 @@ iter_n! {
     ///
     /// [`rsplitn`]: slice::rsplitn
     /// [slices]: slice
-    pub struct RSplitN {"RSplitN"; RSplit }: Clone
+    pub struct RSplitN { inner: RSplit }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -784,7 +790,10 @@ iter_n! {
     ///
     /// [`splitn_mut`]: slice::splitn_mut
     /// [slices]: slice
-    pub struct SplitNMut {"SplitNMut"; SplitMut }
+    pub struct SplitNMut { inner: SplitMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -806,7 +815,10 @@ iter_n! {
     ///
     /// [`rsplitn_mut`]: slice::rsplitn_mut
     /// [slices]: slice
-    pub struct RSplitNMut {"RSplitNMut"; RSplitMut }
+    pub struct RSplitNMut { inner: RSplitMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -830,7 +842,10 @@ iter_n! {
     ///
     /// [`splitn_inclusive`]: slice::splitn_inclusive
     /// [slices]: slice
-    pub struct SplitNInclusive {"SplitNInclusive"; SplitInclusive}: Clone
+    pub struct SplitNInclusive { inner: SplitInclusive }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -854,7 +869,10 @@ iter_n! {
     ///
     /// [`splitn_left_inclusive`]: slice::splitn_left_inclusive
     /// [slices]: slice
-    pub struct SplitNLeftInclusive {"SplitNLeftInclusive"; SplitLeftInclusive}: Clone
+    pub struct SplitNLeftInclusive { inner: SplitLeftInclusive }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -878,7 +896,10 @@ iter_n! {
     ///
     /// [`rsplitn_inclusive`]: slice::rsplitn_inclusive
     /// [slices]: slice
-    pub struct RSplitNInclusive {"RSplitNInclusive"; RSplitInclusive}: Clone
+    pub struct RSplitNInclusive { inner: RSplitInclusive }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -902,7 +923,10 @@ iter_n! {
     ///
     /// [`rsplitn_left_inclusive`]: slice::rsplitn_left_inclusive
     /// [slices]: slice
-    pub struct RSplitNLeftInclusive {"RSplitNLeftInclusive"; RSplitLeftInclusive}: Clone
+    pub struct RSplitNLeftInclusive { inner: RSplitLeftInclusive }: Clone
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -926,7 +950,10 @@ iter_n! {
     ///
     /// [`splitn_inclusive_mut`]: slice::splitn_inclusive_mut
     /// [slices]: slice
-    pub struct SplitNInclusiveMut {"SplitNInclusiveMut"; SplitInclusiveMut}
+    pub struct SplitNInclusiveMut { inner: SplitInclusiveMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -950,7 +977,10 @@ iter_n! {
     ///
     /// [`splitn_left_inclusive_mut`]: slice::splitn_left_inclusive_mut
     /// [slices]: slice
-    pub struct SplitNLeftInclusiveMut {"SplitNLeftInclusiveMut"; SplitLeftInclusiveMut}
+    pub struct SplitNLeftInclusiveMut { inner: SplitLeftInclusiveMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -974,7 +1004,10 @@ iter_n! {
     ///
     /// [`rsplitn_inclusive_mut`]: slice::rsplitn_inclusive_mut
     /// [slices]: slice
-    pub struct RSplitNInclusiveMut {"RSplitNInclusiveMut"; RSplitInclusiveMut}
+    pub struct RSplitNInclusiveMut { inner: RSplitInclusiveMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 iter_n! {
@@ -998,7 +1031,10 @@ iter_n! {
     ///
     /// [`rsplitn_left_inclusive_mut`]: slice::rsplitn_left_inclusive_mut
     /// [slices]: slice
-    pub struct RSplitNLeftInclusiveMut {"RSplitNLeftInclusiveMut"; RSplitLeftInclusiveMut}
+    pub struct RSplitNLeftInclusiveMut { inner: RSplitLeftInclusiveMut }
+
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    fn max_items;
 }
 
 /// An iterator over overlapping subslices of length `size`.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -670,7 +670,8 @@ where
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitLeftInclusive<'a, T, P> {
     #[inline]
     pub(super) fn new(slice: &'a [T], pred: P) -> Self {
-        Self { v: slice, pred, finished: false }
+        let finished = slice.is_empty();
+        Self { v: slice, pred, finished }
     }
 }
 
@@ -1048,7 +1049,8 @@ where
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitLeftInclusiveMut<'a, T, P> {
     #[inline]
     pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
-        Self { v: slice, pred, finished: false }
+        let finished = slice.is_empty();
+        Self { v: slice, pred, finished }
     }
 }
 

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -776,8 +776,7 @@ macro_rules! iter_n {
         #[$stability]
         impl<'a, T: 'a, P> $clone for $iter_n<'a, T, P>
         where
-            P: FnMut(&T) -> bool,
-            $inner<'a, T, P>: Clone,
+            P: Clone + FnMut(&T) -> bool,
         {
             fn clone(&self) -> Self {
                 Self { inner: self.inner.clone() }
@@ -788,7 +787,7 @@ macro_rules! iter_n {
         #[$stability]
         impl<T: fmt::Debug, P> fmt::Debug for $iter_n<'_, T, P>
         where
-            P: Clone + FnMut(&T) -> bool,
+            P: FnMut(&T) -> bool,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct($str).field("inner", &self.inner).finish()

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -65,6 +65,9 @@ pub use iter::{GroupBy, GroupByMut};
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::{SplitInclusive, SplitInclusiveMut};
 
+#[unstable(feature = "split_left_inclusive", issue = "none")]
+pub use iter::{SplitLeftInclusive, SplitLeftInclusiveMut};
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use raw::{from_raw_parts, from_raw_parts_mut};
 
@@ -1967,6 +1970,71 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         SplitInclusiveMut::new(self, pred)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the start of the next
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_left_inclusive)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33, 20]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    ///
+    /// If the last element of the slice is matched,
+    /// that element will be considered the initiator of a new slice.
+    /// That slice will be the last item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_left_inclusive)]
+    ///
+    /// let slice = [3, 10, 40, 33];
+    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[3, 10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_left_inclusive", issue = "none")]
+    #[inline]
+    pub fn split_left_inclusive<F>(&self, pred: F) -> SplitLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitLeftInclusive::new(self, pred)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the next
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_left_inclusive)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.split_left_inclusive_mut(|num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 1, 20, 1, 50]);
+    /// ```
+    #[unstable(feature = "split_left_inclusive", issue = "none")]
+    #[inline]
+    pub fn split_left_inclusive_mut<F>(&mut self, pred: F) -> SplitLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitLeftInclusiveMut::new(self, pred)
     }
 
     /// Returns an iterator over subslices separated by elements that match

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -65,8 +65,13 @@ pub use iter::{GroupBy, GroupByMut};
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::{SplitInclusive, SplitInclusiveMut};
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
-pub use iter::{SplitLeftInclusive, SplitLeftInclusiveMut};
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
+pub use iter::{
+    RSplitInclusive, RSplitInclusiveMut, RSplitLeftInclusive, RSplitLeftInclusiveMut,
+    RSplitNInclusive, RSplitNInclusiveMut, RSplitNLeftInclusive, RSplitNLeftInclusiveMut,
+    SplitLeftInclusive, SplitLeftInclusiveMut, SplitNInclusive, SplitNInclusiveMut,
+    SplitNLeftInclusive, SplitNLeftInclusiveMut,
+};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use raw::{from_raw_parts, from_raw_parts_mut};
@@ -1955,6 +1960,8 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
     /// let mut v = [10, 40, 30, 20, 60, 50];
     ///
     /// for group in v.split_inclusive_mut(|num| *num % 3 == 0) {
@@ -1973,13 +1980,13 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over subslices separated by elements that match
-    /// `pred`. The matched element is contained in the start of the next
+    /// `pred`. The matched element is contained in the start of the following
     /// subslice as an initiator.
     ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     ///
     /// let slice = [10, 40, 33, 20];
     /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
@@ -1994,7 +2001,7 @@ impl<T> [T] {
     /// That slice will be the last item returned by the iterator.
     ///
     /// ```
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     ///
     /// let slice = [3, 10, 40, 33];
     /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
@@ -2003,7 +2010,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next().unwrap(), &[33]);
     /// assert!(iter.next().is_none());
     /// ```
-    #[unstable(feature = "split_left_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
     #[inline]
     pub fn split_left_inclusive<F>(&self, pred: F) -> SplitLeftInclusive<'_, T, F>
     where
@@ -2013,13 +2020,13 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over mutable subslices separated by elements that
-    /// match `pred`. The matched element is contained in the next
+    /// match `pred`. The matched element is contained in the following
     /// subslice as an initiator.
     ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     ///
     /// let mut v = [10, 40, 30, 20, 60, 50];
     ///
@@ -2028,7 +2035,7 @@ impl<T> [T] {
     /// }
     /// assert_eq!(v, [1, 40, 1, 20, 1, 50]);
     /// ```
-    #[unstable(feature = "split_left_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
     #[inline]
     pub fn split_left_inclusive_mut<F>(&mut self, pred: F) -> SplitLeftInclusiveMut<'_, T, F>
     where
@@ -2097,6 +2104,137 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         RSplitMut::new(self, pred)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`, in reverse order. The matched element is contained in the end
+    /// of the previous subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplit_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[20]);
+    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    ///
+    /// If the last element of the slice is matched,
+    /// that element will be considered the terminator of the preceding slice.
+    /// That slice will be the first item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [3, 10, 40, 33];
+    /// let mut iter = slice.rsplit_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
+    /// assert_eq!(iter.next().unwrap(), &[3]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_inclusive<F>(&self, pred: F) -> RSplitInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitInclusive::new(self, pred)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`, in reverse order. The matched element is contained in the
+    /// previous subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.split_inclusive_mut(|num| *num % 3 == 0) {
+    ///     let terminator_idx = group.len()-1;
+    ///     group[terminator_idx] = 1;
+    /// }
+    /// assert_eq!(v, [10, 40, 1, 20, 1, 1]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_inclusive_mut<F>(&mut self, pred: F) -> RSplitInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitInclusiveMut::new(self, pred)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`, in reverse order. The matched element is contained in the start
+    /// of the following subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.rsplit_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[33, 20]);
+    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    ///
+    /// If the last element of the slice is matched,
+    /// that element will be considered the initiator of a new slice.
+    /// That slice will be the first item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [3, 10, 40, 33];
+    /// let mut iter = slice.rsplit_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[33]);
+    /// assert_eq!(iter.next().unwrap(), &[3, 10, 40]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_left_inclusive<F>(&self, pred: F) -> RSplitLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitLeftInclusive::new(self, pred)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`, in reverse order. The matched element is contained in the
+    /// following subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.rsplit_left_inclusive_mut(|num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 1, 20, 1, 50]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_left_inclusive_mut<F>(&mut self, pred: F) -> RSplitLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitLeftInclusiveMut::new(self, pred)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2207,6 +2345,220 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         RSplitNMut::new(self.rsplit_mut(pred), n)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the end of the previous
+    /// subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20, 30];
+    /// let mut iter = slice.splitn_inclusive(2, |num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
+    /// assert_eq!(iter.next().unwrap(), &[20, 30]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_inclusive<F>(&self, n: usize, pred: F) -> SplitNInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNInclusive::new(self.split_inclusive(pred), n)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the previous
+    /// subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.splitn_inclusive_mut(2, |num| *num % 3 == 0) {
+    ///     let terminator_idx = group.len()-1;
+    ///     group[terminator_idx] = 1;
+    /// }
+    /// assert_eq!(v, [10, 40, 1, 20, 60, 1]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_inclusive_mut<F>(&mut self, n: usize, pred: F) -> SplitNInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNInclusiveMut::new(self.split_inclusive_mut(pred), n)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the start of the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20, 9];
+    /// let mut iter = slice.splitn_left_inclusive(2, |num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33, 20, 9]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_left_inclusive<F>(&self, n: usize, pred: F) -> SplitNLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNLeftInclusive::new(self.split_left_inclusive(pred), n)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50, 90];
+    ///
+    /// for group in v.splitn_left_inclusive_mut(2, |num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 1, 20, 60, 50, 90]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_left_inclusive_mut<F>(
+        &mut self,
+        n: usize,
+        pred: F,
+    ) -> SplitNLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNLeftInclusiveMut::new(self.split_left_inclusive_mut(pred), n)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`, in reverse order, limited to returning at most `n` items. The
+    /// matched element is contained in the end of the previous subslice as a
+    /// terminator.
+    ///
+    /// The last element returned, if any, will contain the remainder of the
+    /// slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [20, 60, 10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_inclusive(2, |num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[20]);
+    /// assert_eq!(iter.next().unwrap(), &[20, 60, 10, 40, 33]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_inclusive<F>(&self, n: usize, pred: F) -> RSplitNInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitNInclusive::new(self.rsplit_inclusive(pred), n)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`, in reverse order. The matched element is contained in the
+    /// previous subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.rsplitn_inclusive_mut(2, |num| *num % 3 == 0) {
+    ///     let terminator_idx = group.len()-1;
+    ///     group[terminator_idx] = 1;
+    /// }
+    /// assert_eq!(v, [10, 40, 30, 20, 1, 1]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_inclusive_mut<F>(&mut self, n: usize, pred: F) -> RSplitNInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitNInclusiveMut::new(self.rsplit_inclusive_mut(pred), n)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`, in reverse order. The matched element is contained in the start
+    /// of the following subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [3, 9, 10, 40, 33, 20];
+    /// let mut iter = slice.rsplitn_left_inclusive(2, |num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[33, 20]);
+    /// assert_eq!(iter.next().unwrap(), &[3, 9, 10, 40]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_left_inclusive<F>(&self, n: usize, pred: F) -> RSplitNLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitNLeftInclusive::new(self.rsplit_left_inclusive(pred), n)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`, in reverse order. The matched element is contained in the
+    /// following subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.rsplitn_left_inclusive_mut(2, |num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 30, 20, 1, 50]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_left_inclusive_mut<F>(
+        &mut self,
+        n: usize,
+        pred: F,
+    ) -> RSplitNLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        RSplitNLeftInclusiveMut::new(self.rsplit_left_inclusive_mut(pred), n)
     }
 
     /// Returns `true` if the slice contains an element with the given value.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2262,7 +2262,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        SplitN::new(self.split(pred), n)
+        self.split(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2288,7 +2288,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        SplitNMut::new(self.split_mut(pred), n)
+        self.split_mut(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2317,7 +2317,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        RSplitN::new(self.rsplit(pred), n)
+        self.rsplit(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2344,7 +2344,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        RSplitNMut::new(self.rsplit_mut(pred), n)
+        self.rsplit_mut(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2369,7 +2369,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        SplitNInclusive::new(self.split_inclusive(pred), n)
+        self.split_inclusive(pred).max_items(n)
     }
 
     /// Returns an iterator over mutable subslices separated by elements that
@@ -2395,7 +2395,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        SplitNInclusiveMut::new(self.split_inclusive_mut(pred), n)
+        self.split_inclusive_mut(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2424,7 +2424,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        RSplitNInclusive::new(self.rsplit_inclusive(pred), n)
+        self.rsplit_inclusive(pred).max_items(n)
     }
 
     /// Returns an iterator over mutable subslices separated by elements that
@@ -2450,7 +2450,7 @@ impl<T> [T] {
     where
         F: FnMut(&T) -> bool,
     {
-        RSplitNInclusiveMut::new(self.rsplit_inclusive_mut(pred), n)
+        self.rsplit_inclusive_mut(pred).max_items(n)
     }
 
     /// Returns an iterator over subslices separated by elements that match

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1918,133 +1918,6 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over subslices separated by elements that match
-    /// `pred`. The matched element is contained in the end of the previous
-    /// subslice as a terminator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let slice = [10, 40, 33, 20];
-    /// let mut iter = slice.split_inclusive(|num| num % 3 == 0);
-    ///
-    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
-    /// assert_eq!(iter.next().unwrap(), &[20]);
-    /// assert!(iter.next().is_none());
-    /// ```
-    ///
-    /// If the last element of the slice is matched,
-    /// that element will be considered the terminator of the preceding slice.
-    /// That slice will be the last item returned by the iterator.
-    ///
-    /// ```
-    /// let slice = [3, 10, 40, 33];
-    /// let mut iter = slice.split_inclusive(|num| num % 3 == 0);
-    ///
-    /// assert_eq!(iter.next().unwrap(), &[3]);
-    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
-    /// assert!(iter.next().is_none());
-    /// ```
-    #[stable(feature = "split_inclusive", since = "1.51.0")]
-    #[inline]
-    pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitInclusive::new(self, pred)
-    }
-
-    /// Returns an iterator over mutable subslices separated by elements that
-    /// match `pred`. The matched element is contained in the previous
-    /// subslice as a terminator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let mut v = [10, 40, 30, 20, 60, 50];
-    ///
-    /// for group in v.split_inclusive_mut(|num| *num % 3 == 0) {
-    ///     let terminator_idx = group.len()-1;
-    ///     group[terminator_idx] = 1;
-    /// }
-    /// assert_eq!(v, [10, 40, 1, 20, 1, 1]);
-    /// ```
-    #[stable(feature = "split_inclusive", since = "1.51.0")]
-    #[inline]
-    pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitInclusiveMut::new(self, pred)
-    }
-
-    /// Returns an iterator over subslices separated by elements that match
-    /// `pred`. The matched element is contained in the start of the following
-    /// subslice as an initiator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let slice = [10, 40, 33, 20];
-    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
-    ///
-    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
-    /// assert_eq!(iter.next().unwrap(), &[33, 20]);
-    /// assert!(iter.next().is_none());
-    /// ```
-    ///
-    /// If the last element of the slice is matched,
-    /// that element will be considered the initiator of a new slice.
-    /// That slice will be the last item returned by the iterator.
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let slice = [3, 10, 40, 33];
-    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
-    ///
-    /// assert_eq!(iter.next().unwrap(), &[3, 10, 40]);
-    /// assert_eq!(iter.next().unwrap(), &[33]);
-    /// assert!(iter.next().is_none());
-    /// ```
-    #[unstable(feature = "split_inclusive_variants", issue = "none")]
-    #[inline]
-    pub fn split_left_inclusive<F>(&self, pred: F) -> SplitLeftInclusive<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitLeftInclusive::new(self, pred)
-    }
-
-    /// Returns an iterator over mutable subslices separated by elements that
-    /// match `pred`. The matched element is contained in the following
-    /// subslice as an initiator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let mut v = [10, 40, 30, 20, 60, 50];
-    ///
-    /// for group in v.split_left_inclusive_mut(|num| *num % 3 == 0) {
-    ///     group[0] = 1;
-    /// }
-    /// assert_eq!(v, [1, 40, 1, 20, 1, 50]);
-    /// ```
-    #[unstable(feature = "split_inclusive_variants", issue = "none")]
-    #[inline]
-    pub fn split_left_inclusive_mut<F>(&mut self, pred: F) -> SplitLeftInclusiveMut<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitLeftInclusiveMut::new(self, pred)
-    }
-
-    /// Returns an iterator over subslices separated by elements that match
     /// `pred`, starting at the end of the slice and working backwards.
     /// The matched element is not contained in the subslices.
     ///
@@ -2104,6 +1977,68 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         RSplitMut::new(self, pred)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the end of the previous
+    /// subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.split_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
+    /// assert_eq!(iter.next().unwrap(), &[20]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    ///
+    /// If the last element of the slice is matched,
+    /// that element will be considered the terminator of the preceding slice.
+    /// That slice will be the last item returned by the iterator.
+    ///
+    /// ```
+    /// let slice = [3, 10, 40, 33];
+    /// let mut iter = slice.split_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[3]);
+    /// assert_eq!(iter.next().unwrap(), &[10, 40, 33]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[stable(feature = "split_inclusive", since = "1.51.0")]
+    #[inline]
+    pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitInclusive::new(self, pred)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the previous
+    /// subslice as a terminator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.split_inclusive_mut(|num| *num % 3 == 0) {
+    ///     let terminator_idx = group.len()-1;
+    ///     group[terminator_idx] = 1;
+    /// }
+    /// assert_eq!(v, [10, 40, 1, 20, 1, 1]);
+    /// ```
+    #[stable(feature = "split_inclusive", since = "1.51.0")]
+    #[inline]
+    pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitInclusiveMut::new(self, pred)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2170,6 +2105,71 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         RSplitInclusiveMut::new(self, pred)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the start of the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20];
+    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33, 20]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    ///
+    /// If the last element of the slice is matched,
+    /// that element will be considered the initiator of a new slice.
+    /// That slice will be the last item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [3, 10, 40, 33];
+    /// let mut iter = slice.split_left_inclusive(|num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[3, 10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn split_left_inclusive<F>(&self, pred: F) -> SplitLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitLeftInclusive::new(self, pred)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50];
+    ///
+    /// for group in v.split_left_inclusive_mut(|num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 1, 20, 1, 50]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn split_left_inclusive_mut<F>(&mut self, pred: F) -> SplitLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitLeftInclusiveMut::new(self, pred)
     }
 
     /// Returns an iterator over subslices separated by elements that match
@@ -2399,60 +2399,6 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over subslices separated by elements that match
-    /// `pred`. The matched element is contained in the start of the following
-    /// subslice as an initiator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let slice = [10, 40, 33, 20, 9];
-    /// let mut iter = slice.splitn_left_inclusive(2, |num| num % 3 == 0);
-    ///
-    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
-    /// assert_eq!(iter.next().unwrap(), &[33, 20, 9]);
-    /// assert!(iter.next().is_none());
-    /// ```
-    #[unstable(feature = "split_inclusive_variants", issue = "none")]
-    #[inline]
-    pub fn splitn_left_inclusive<F>(&self, n: usize, pred: F) -> SplitNLeftInclusive<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitNLeftInclusive::new(self.split_left_inclusive(pred), n)
-    }
-
-    /// Returns an iterator over mutable subslices separated by elements that
-    /// match `pred`. The matched element is contained in the following
-    /// subslice as an initiator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    ///
-    /// let mut v = [10, 40, 30, 20, 60, 50, 90];
-    ///
-    /// for group in v.splitn_left_inclusive_mut(2, |num| *num % 3 == 0) {
-    ///     group[0] = 1;
-    /// }
-    /// assert_eq!(v, [1, 40, 1, 20, 60, 50, 90]);
-    /// ```
-    #[unstable(feature = "split_inclusive_variants", issue = "none")]
-    #[inline]
-    pub fn splitn_left_inclusive_mut<F>(
-        &mut self,
-        n: usize,
-        pred: F,
-    ) -> SplitNLeftInclusiveMut<'_, T, F>
-    where
-        F: FnMut(&T) -> bool,
-    {
-        SplitNLeftInclusiveMut::new(self.split_left_inclusive_mut(pred), n)
-    }
-
-    /// Returns an iterator over subslices separated by elements that match
     /// `pred`, in reverse order, limited to returning at most `n` items. The
     /// matched element is contained in the end of the previous subslice as a
     /// terminator.
@@ -2505,6 +2451,60 @@ impl<T> [T] {
         F: FnMut(&T) -> bool,
     {
         RSplitNInclusiveMut::new(self.rsplit_inclusive_mut(pred), n)
+    }
+
+    /// Returns an iterator over subslices separated by elements that match
+    /// `pred`. The matched element is contained in the start of the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let slice = [10, 40, 33, 20, 9];
+    /// let mut iter = slice.splitn_left_inclusive(2, |num| num % 3 == 0);
+    ///
+    /// assert_eq!(iter.next().unwrap(), &[10, 40]);
+    /// assert_eq!(iter.next().unwrap(), &[33, 20, 9]);
+    /// assert!(iter.next().is_none());
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_left_inclusive<F>(&self, n: usize, pred: F) -> SplitNLeftInclusive<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNLeftInclusive::new(self.split_left_inclusive(pred), n)
+    }
+
+    /// Returns an iterator over mutable subslices separated by elements that
+    /// match `pred`. The matched element is contained in the following
+    /// subslice as an initiator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let mut v = [10, 40, 30, 20, 60, 50, 90];
+    ///
+    /// for group in v.splitn_left_inclusive_mut(2, |num| *num % 3 == 0) {
+    ///     group[0] = 1;
+    /// }
+    /// assert_eq!(v, [1, 40, 1, 20, 60, 50, 90]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_left_inclusive_mut<F>(
+        &mut self,
+        n: usize,
+        pred: F,
+    ) -> SplitNLeftInclusiveMut<'_, T, F>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        SplitNLeftInclusiveMut::new(self.split_left_inclusive_mut(pred), n)
     }
 
     /// Returns an iterator over subslices separated by elements that match

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -872,6 +872,35 @@ generate_pattern_iterators! {
 }
 
 split_internal! {
+    SplitInitiatorInternal {
+        debug: "SplitInitiatorInternal",
+        skip_leading_empty: skip_leading_empty,
+        include_leading: false,
+        include_trailing: false,
+    }
+}
+
+generate_pattern_iterators! {
+    forward:
+        #[unstable(feature = "split_inclusive_variants", issue = "none")]
+        #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+        /// Created with the method [`split_initiator`].
+        ///
+        /// [`split_initiator`]: str::split_initiator
+        struct SplitInitiator;
+    reverse:
+        #[unstable(feature = "split_inclusive_variants", issue = "none")]
+        #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+        /// Created with the method [`rsplit_initiator`].
+        ///
+        /// [`rsplit_initiator`]: str::rsplit_initiator
+        struct RSplitInitiator;
+    internal:
+        SplitInitiatorInternal yielding (&'a str);
+    delegate double ended;
+}
+
+split_internal! {
     SplitTerminatorInternal {
         debug: "SplitTerminatorInternal",
         skip_trailing_empty: skip_trailing_empty,
@@ -897,6 +926,36 @@ generate_pattern_iterators! {
         struct RSplitTerminator;
     internal:
         SplitTerminatorInternal yielding (&'a str);
+    delegate double ended;
+}
+
+split_internal! {
+    SplitEndsInternal {
+        debug: "SplitEndsInternal",
+        skip_leading_empty: skip_leading_empty,
+        skip_trailing_empty: skip_trailing_empty,
+        include_leading: false,
+        include_trailing: false,
+    }
+}
+
+generate_pattern_iterators! {
+    forward:
+        #[unstable(feature = "split_inclusive_variants", issue = "none")]
+        #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+        /// Created with the method [`split_ends`].
+        ///
+        /// [`split_ends`]: str::split_ends
+        struct SplitEnds;
+    reverse:
+        #[unstable(feature = "split_inclusive_variants", issue = "none")]
+        #[fused(unstable(feature = "split_inclusive_variants", issue = "none"))]
+        /// Created with the method [`rsplit_ends`].
+        ///
+        /// [`rsplit_ends`]: str::rsplit_ends
+        struct RSplitEnds;
+    internal:
+        SplitEndsInternal yielding (&'a str);
     delegate double ended;
 }
 

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -573,7 +573,7 @@ trait SplitIterInternal<'a, P: Pattern<'a>> {
     where
         P::Searcher: ReverseSearcher<'a>;
 
-    fn get_end(&mut self) -> Option<&'a str>;
+    fn finish(&mut self) -> Option<&'a str>;
 
     fn as_str(&self) -> &'a str;
 }
@@ -711,7 +711,7 @@ macro_rules! split_internal {
             }
 
             #[inline]
-            fn get_end(&mut self) -> Option<&'a str> {
+            fn finish(&mut self) -> Option<&'a str> {
                 if self.finished {
                     None
                 } else {
@@ -731,7 +731,7 @@ macro_rules! split_internal {
 
             #[inline]
             fn as_str(&self) -> &'a str {
-                // `Self::get_end` doesn't change `self.start`
+                // `Self::finish` doesn't change `self.start`
                 if self.finished {
                     ""
                 } else {
@@ -823,7 +823,6 @@ split_internal! {
 }
 
 generate_pattern_iterators! {
-
     forward:
         #[stable(feature = "split_inclusive", since = "1.51.0")]
         #[fused(stable(feature = "split_inclusive", since = "1.51.0"))]
@@ -980,7 +979,7 @@ macro_rules! splitn_internal {
                     0 => None,
                     1 => {
                         self.count = 0;
-                        self.iter.get_end()
+                        self.iter.finish()
                     }
                     _ => {
                         self.count -= 1;
@@ -1006,7 +1005,7 @@ macro_rules! splitn_internal {
                     0 => None,
                     1 => {
                         self.count = 0;
-                        self.iter.get_end()
+                        self.iter.finish()
                     }
                     _ => {
                         self.count -= 1;

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1453,10 +1453,10 @@ impl<'a, P: Pattern<'a>> SplitInclusive<'a, P> {
 /// See its documentation for more.
 ///
 /// [`split_left_inclusive`]: str::split_left_inclusive
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 pub struct SplitLeftInclusive<'a, P: Pattern<'a>>(pub(super) SplitInternal<'a, P>);
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, P: Pattern<'a>> Iterator for SplitLeftInclusive<'a, P> {
     type Item = &'a str;
 
@@ -1466,7 +1466,7 @@ impl<'a, P: Pattern<'a>> Iterator for SplitLeftInclusive<'a, P> {
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitLeftInclusive<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitLeftInclusive").field("0", &self.0).finish()
@@ -1474,14 +1474,14 @@ impl<'a, P: Pattern<'a, Searcher: fmt::Debug>> fmt::Debug for SplitLeftInclusive
 }
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: Clone>> Clone for SplitLeftInclusive<'a, P> {
     fn clone(&self) -> Self {
         SplitLeftInclusive(self.0.clone())
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     for SplitLeftInclusive<'a, P>
 {
@@ -1491,7 +1491,7 @@ impl<'a, P: Pattern<'a, Searcher: ReverseSearcher<'a>>> DoubleEndedIterator
     }
 }
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 impl<'a, P: Pattern<'a>> FusedIterator for SplitLeftInclusive<'a, P> {}
 
 impl<'a, P: Pattern<'a>> SplitLeftInclusive<'a, P> {
@@ -1501,7 +1501,7 @@ impl<'a, P: Pattern<'a>> SplitLeftInclusive<'a, P> {
     ///
     /// ```
     /// #![feature(str_split_inclusive_as_str)]
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     /// let mut split = "Mary had a little lamb".split_left_inclusive(' ');
     /// assert_eq!(split.as_str(), "Mary had a little lamb");
     /// split.next();

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -13,7 +13,10 @@ mod iter;
 mod traits;
 mod validations;
 
-use self::iter::{SplitInclusiveInternal, SplitLeftInclusiveInternal, SplitTerminatorInternal};
+use self::iter::{
+    SplitInclusiveInternal, SplitLeftInclusiveInternal, SplitNInclusiveInternal,
+    SplitNLeftInclusiveInternal, SplitTerminatorInternal,
+};
 use self::pattern::{DoubleEndedSearcher, Pattern, ReverseSearcher, Searcher};
 
 use crate::char::{self, EscapeDebugExtArgs};
@@ -1332,76 +1335,6 @@ impl str {
         Split(SplitInternal::new(self, pat))
     }
 
-    /// An iterator over substrings of this string slice, separated by
-    /// characters matched by a pattern. Differs from the iterator produced by
-    /// `split` in that `split_inclusive` leaves the matched part as the
-    /// terminator of the substring.
-    ///
-    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
-    /// function or closure that determines if a character matches.
-    ///
-    /// [`char`]: prim@char
-    /// [pattern]: self::pattern
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
-    ///     .split_inclusive('\n').collect();
-    /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb."]);
-    /// ```
-    ///
-    /// If the last element of the string is matched,
-    /// that element will be considered the terminator of the preceding substring.
-    /// That substring will be the last item returned by the iterator.
-    ///
-    /// ```
-    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb.\n"
-    ///     .split_inclusive('\n').collect();
-    /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb.\n"]);
-    /// ```
-    #[stable(feature = "split_inclusive", since = "1.51.0")]
-    #[inline]
-    pub fn split_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitInclusive<'a, P> {
-        SplitInclusive(SplitInclusiveInternal::new(self, pat))
-    }
-
-    /// An iterator over substrings of this string slice, separated by
-    /// characters matched by a pattern. Differs from the iterator produced by
-    /// `split` in that `split_left_inclusive` leaves the matched part as the
-    /// initiator of the substring.
-    ///
-    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
-    /// function or closure that determines if a character matches.
-    ///
-    /// [`char`]: prim@char
-    /// [pattern]: self::pattern
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
-    ///     .split_left_inclusive('\n').collect();
-    /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb."]);
-    /// ```
-    ///
-    /// If the last element of the string is matched,
-    /// that element will be considered the initiator of a new substring.
-    /// That substring will be the last item returned by the iterator.
-    ///
-    /// ```
-    /// #![feature(split_inclusive_variants)]
-    /// let v: Vec<&str> = "\nMary had a little lamb\nlittle lamb\nlittle lamb.\n"
-    ///     .split_left_inclusive('\n').collect();
-    /// assert_eq!(v, ["\nMary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
-    /// ```
-    #[unstable(feature = "split_inclusive_variants", issue = "none")]
-    #[inline]
-    pub fn split_left_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitLeftInclusive<'a, P> {
-        SplitLeftInclusive(SplitLeftInclusiveInternal::new(self, pat))
-    }
-
     /// An iterator over substrings of the given string slice, separated by
     /// characters matched by a pattern and yielded in reverse order.
     ///
@@ -1452,6 +1385,182 @@ impl str {
         P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplit(self.split(pat).0)
+    }
+
+    /// An iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern. Differs from the iterator produced by
+    /// `split` in that `split_inclusive` leaves the matched part as the
+    /// terminator of the substring.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
+    ///     .split_inclusive('\n').collect();
+    /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb."]);
+    /// ```
+    ///
+    /// If the last element of the string is matched,
+    /// that element will be considered the terminator of the preceding substring.
+    /// That substring will be the last item returned by the iterator.
+    ///
+    /// ```
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb.\n"
+    ///     .split_inclusive('\n').collect();
+    /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb.\n"]);
+    /// ```
+    ///
+    /// If the string is empty, the iterator returns [`None`].
+    ///
+    /// ```
+    /// let v: Vec<&str> = "".split_inclusive('\n').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    #[stable(feature = "split_inclusive", since = "1.51.0")]
+    #[inline]
+    pub fn split_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitInclusive<'a, P> {
+        SplitInclusive(SplitInclusiveInternal::new(self, pat))
+    }
+
+    /// An iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern and yielded in reverse order. Differs
+    /// from the iterator produced by `rsplit` in that `rsplit_inclusive` leaves
+    /// the matched part as the terminator of the substring.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
+    ///     .rsplit_inclusive('\n').collect();
+    /// assert_eq!(v, ["little lamb.", "little lamb\n", "Mary had a little lamb\n"]);
+    /// ```
+    ///
+    /// If the last element of the string is matched,
+    /// that element will be considered the terminator of the preceding substring.
+    /// That substring will be the first item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb.\n"
+    ///     .rsplit_inclusive('\n').collect();
+    /// assert_eq!(v, ["little lamb.\n", "little lamb\n", "Mary had a little lamb\n"]);
+    /// ```
+    ///
+    /// If the string is empty, the iterator returns [`None`].
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "".rsplit_inclusive('\n').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> RSplitInclusive<'a, P> {
+        RSplitInclusive(self.split_inclusive(pat).0)
+    }
+
+    /// An iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern. Differs from the iterator produced by
+    /// `split` in that `split_left_inclusive` leaves the matched part as the
+    /// initiator of the substring.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
+    ///     .split_left_inclusive('\n').collect();
+    /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb."]);
+    /// ```
+    ///
+    /// If the last element of the string is matched,
+    /// that element will be considered the initiator of a new substring.
+    /// That substring will be the last item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "\nMary had a little lamb\nlittle lamb\nlittle lamb.\n"
+    ///     .split_left_inclusive('\n').collect();
+    /// assert_eq!(v, ["\nMary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
+    /// ```
+    ///
+    /// If the string is empty, the iterator returns [`None`].
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "".split_left_inclusive('\n').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn split_left_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitLeftInclusive<'a, P> {
+        SplitLeftInclusive(SplitLeftInclusiveInternal::new(self, pat))
+    }
+
+    /// An iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern and yielded in reverse order. Differs
+    /// from the iterator produced by `rsplit` in that `rsplit_left_inclusive`
+    /// leaves the matched part as the initiator of the substring.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
+    ///     .rsplit_left_inclusive('\n').collect();
+    /// assert_eq!(v, ["\nlittle lamb.", "\nlittle lamb", "Mary had a little lamb"]);
+    /// ```
+    ///
+    /// If the last element of the string is matched,
+    /// that element will be considered the terminator of the preceding substring.
+    /// That substring will be the first item returned by the iterator.
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let v: Vec<&str> = "\nMary had a little lamb\nlittle lamb\nlittle lamb.\n"
+    ///     .rsplit_left_inclusive('\n').collect();
+    /// assert_eq!(v, ["\n", "\nlittle lamb.", "\nlittle lamb", "\nMary had a little lamb"]);
+    /// ```
+    ///
+    /// If the string is empty, the iterator returns [`None`].
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    /// let o = "".rsplit_left_inclusive('\n').next();
+    /// assert_eq!(o, None);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplit_left_inclusive<'a, P: Pattern<'a>>(
+        &'a self,
+        pat: P,
+    ) -> RSplitLeftInclusive<'a, P> {
+        RSplitLeftInclusive(self.split_left_inclusive(pat).0)
     }
 
     /// An iterator over substrings of the given string slice, separated by
@@ -1653,6 +1762,251 @@ impl str {
         P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplitN(self.splitn(n, pat).0)
+    }
+
+    /// An iterator over substrings of the given string slice, separated by a
+    /// pattern, leaving the matched part as the terminator of the substring,
+    /// restricted to returning at most `n` items.
+    ///
+    /// If `n` substrings are returned, the last substring (the `n`th substring)
+    /// will contain the remainder of the string.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Iterator behavior
+    ///
+    /// The returned iterator will not be double ended, because it is
+    /// not efficient to support.
+    ///
+    /// If the pattern allows a reverse search, the [`rsplitn_inclusive`] method can be
+    /// used.
+    ///
+    /// [`rsplitn_inclusive`]: str::rsplitn_inclusive
+    ///
+    /// # Examples
+    ///
+    /// Simple patterns:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "Mary had a little lambda".splitn_inclusive(3, ' ').collect();
+    /// assert_eq!(v, ["Mary ", "had ", "a little lambda"]);
+    ///
+    /// let v: Vec<&str> = "lionXXtigerXleopard".splitn_inclusive(3, "X").collect();
+    /// assert_eq!(v, ["lionX", "X", "tigerXleopard"]);
+    ///
+    /// let v: Vec<&str> = "abcXdef".splitn_inclusive(1, 'X').collect();
+    /// assert_eq!(v, ["abcXdef"]);
+    ///
+    /// let v: Vec<&str> = "".splitn_inclusive(1, 'X').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    ///
+    /// A more complex pattern, using a closure:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "abc1defXghi".splitn_inclusive(2, |c| c == '1' || c == 'X').collect();
+    /// assert_eq!(v, ["abc1", "defXghi"]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_inclusive<'a, P: Pattern<'a>>(
+        &'a self,
+        n: usize,
+        pat: P,
+    ) -> SplitNInclusive<'a, P> {
+        SplitNInclusive(SplitNInclusiveInternal { iter: self.split_inclusive(pat).0, count: n })
+    }
+
+    /// An iterator over substrings of this string slice, separated by a
+    /// pattern, starting from the end of the string, leaving the matched part
+    /// as the terminator of the substring, restricted to returning at most `n`
+    /// items.
+    ///
+    /// If `n` substrings are returned, the last substring (the `n`th substring)
+    /// will contain the remainder of the string.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Iterator behavior
+    ///
+    /// The returned iterator will not be double ended, because it is not
+    /// efficient to support.
+    ///
+    /// For splitting from the front, the [`splitn_inclusive`] method can be used.
+    ///
+    /// [`splitn_inclusive`]: str::splitn_inclusive
+    ///
+    /// # Examples
+    ///
+    /// Simple patterns:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "Mary had a little lamb".rsplitn_inclusive(3, ' ').collect();
+    /// assert_eq!(v, ["lamb", "little ", "Mary had a "]);
+    ///
+    /// let v: Vec<&str> = "lionXXtigerXleopard".rsplitn_inclusive(3, 'X').collect();
+    /// assert_eq!(v, ["leopard", "tigerX", "lionXX"]);
+    ///
+    /// let v: Vec<&str> = "lion::tiger::leopard".rsplitn_inclusive(2, "::").collect();
+    /// assert_eq!(v, ["leopard", "lion::tiger::"]);
+    ///
+    /// let v: Vec<&str> = "".rsplitn_inclusive(1, 'X').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    ///
+    /// A more complex pattern, using a closure:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "abc1defXghi".rsplitn_inclusive(2, |c| c == '1' || c == 'X').collect();
+    /// assert_eq!(v, ["ghi", "abc1defX"]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_inclusive<'a, P>(&'a self, n: usize, pat: P) -> RSplitNInclusive<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
+    {
+        RSplitNInclusive(self.splitn_inclusive(n, pat).0)
+    }
+
+    /// An iterator over substrings of the given string slice, separated by a
+    /// pattern, leaving the matched part as the initiator of the substring,
+    /// restricted to returning at most `n` items.
+    ///
+    /// If `n` substrings are returned, the last substring (the `n`th substring)
+    /// will contain the remainder of the string.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Iterator behavior
+    ///
+    /// The returned iterator will not be double ended, because it is
+    /// not efficient to support.
+    ///
+    /// If the pattern allows a reverse search, the [`rsplitn_left_inclusive`] method can be
+    /// used.
+    ///
+    /// [`rsplitn_left_inclusive`]: str::rsplitn_left_inclusive
+    ///
+    /// # Examples
+    ///
+    /// Simple patterns:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "Mary had a little lambda".splitn_left_inclusive(3, ' ').collect();
+    /// assert_eq!(v, ["Mary", " had", " a little lambda"]);
+    ///
+    /// let v: Vec<&str> = "lionXXtigerXleopard".splitn_left_inclusive(3, "X").collect();
+    /// assert_eq!(v, ["lion", "X", "XtigerXleopard"]);
+    ///
+    /// let v: Vec<&str> = "abcXdef".splitn_left_inclusive(1, 'X').collect();
+    /// assert_eq!(v, ["abcXdef"]);
+    ///
+    /// let v: Vec<&str> = "".splitn_left_inclusive(1, 'X').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    ///
+    /// A more complex pattern, using a closure:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "abc1defXghi".splitn_left_inclusive(2, |c| c == '1' || c == 'X').collect();
+    /// assert_eq!(v, ["abc", "1defXghi"]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn splitn_left_inclusive<'a, P: Pattern<'a>>(
+        &'a self,
+        n: usize,
+        pat: P,
+    ) -> SplitNLeftInclusive<'a, P> {
+        SplitNLeftInclusive(SplitNLeftInclusiveInternal {
+            iter: self.split_left_inclusive(pat).0,
+            count: n,
+        })
+    }
+
+    /// An iterator over substrings of this string slice, separated by a
+    /// pattern, starting from the end of the string, leaving the matched part
+    /// as the terminator of the substring, restricted to returning at most `n`
+    /// items.
+    ///
+    /// If `n` substrings are returned, the last substring (the `n`th substring)
+    /// will contain the remainder of the string.
+    ///
+    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    ///
+    /// [`char`]: prim@char
+    /// [pattern]: self::pattern
+    ///
+    /// # Iterator behavior
+    ///
+    /// The returned iterator will not be double ended, because it is not
+    /// efficient to support.
+    ///
+    /// For splitting from the front, the [`splitn_left_inclusive`] method can be used.
+    ///
+    /// [`splitn_left_inclusive`]: str::splitn_left_inclusive
+    ///
+    /// # Examples
+    ///
+    /// Simple patterns:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "Mary had a little lamb".rsplitn_left_inclusive(3, ' ').collect();
+    /// assert_eq!(v, [" lamb", " little", "Mary had a"]);
+    ///
+    /// let v: Vec<&str> = "lionXXtigerXleopard".rsplitn_left_inclusive(3, 'X').collect();
+    /// assert_eq!(v, ["Xleopard", "Xtiger", "lionX"]);
+    ///
+    /// let v: Vec<&str> = "lion::tiger::leopard".rsplitn_left_inclusive(2, "::").collect();
+    /// assert_eq!(v, ["::leopard", "lion::tiger"]);
+    ///
+    /// let v: Vec<&str> = "".rsplitn_left_inclusive(1, 'X').collect();
+    /// assert_eq!(v.len(), 0);
+    /// ```
+    ///
+    /// A more complex pattern, using a closure:
+    ///
+    /// ```
+    /// #![feature(split_inclusive_variants)]
+    ///
+    /// let v: Vec<&str> = "abc1defXghi".rsplitn_left_inclusive(2, |c| c == '1' || c == 'X').collect();
+    /// assert_eq!(v, ["Xghi", "abc1def"]);
+    /// ```
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
+    #[inline]
+    pub fn rsplitn_left_inclusive<'a, P>(&'a self, n: usize, pat: P) -> RSplitNLeftInclusive<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
+    {
+        RSplitNLeftInclusive(self.splitn_left_inclusive(n, pat).0)
     }
 
     /// Splits the string on the first occurrence of the specified delimiter and

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -69,7 +69,7 @@ pub use iter::SplitAsciiWhitespace;
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::SplitInclusive;
 
-#[unstable(feature = "split_left_inclusive", issue = "none")]
+#[unstable(feature = "split_inclusive_variants", issue = "none")]
 pub use iter::SplitLeftInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
@@ -1389,7 +1389,7 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     /// let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb."
     ///     .split_left_inclusive('\n').collect();
     /// assert_eq!(v, ["Mary had a little lamb", "\nlittle lamb", "\nlittle lamb."]);
@@ -1400,12 +1400,12 @@ impl str {
     /// That substring will be the last item returned by the iterator.
     ///
     /// ```
-    /// #![feature(split_left_inclusive)]
+    /// #![feature(split_inclusive_variants)]
     /// let v: Vec<&str> = "\nMary had a little lamb\nlittle lamb\nlittle lamb.\n"
     ///     .split_left_inclusive('\n').collect();
     /// assert_eq!(v, ["\nMary had a little lamb", "\nlittle lamb", "\nlittle lamb.", "\n"]);
     /// ```
-    #[unstable(feature = "split_left_inclusive", issue = "none")]
+    #[unstable(feature = "split_inclusive_variants", issue = "none")]
     #[inline]
     pub fn split_left_inclusive<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitLeftInclusive<'a, P> {
         SplitLeftInclusive(SplitInternal {


### PR DESCRIPTION
Implements additional variants of the `split` iterator methods for strings and slices.

### Methods implemented:

- **`slice::{r}split{n}{left}_inclusive{_mut}()`, `str::{r}split{n}{left}_inclusive()`, and `str::split_once{_left}_inclusive`:** The `inclusive` variants include the separator at the end of the returned elements, while the `left_inclusive` variants include it at the beginning.
- **`str::{r}split_initiator`, and `str::{r}split_ends`:** Variants of `split_terminator` that skip empty subslices at the beginning of the string, and at both ends of the string respectively.

In addition, this PR implements `Clone` when appropriate for the `splitn` iterators, and changes the return value of `size_hint` in a few cases.

### Unresolved questions

This adds a lot of new methods because of all the possible permutations. The implementations are unified via macros, but it's a lot of choices to sort through in the documentation. Maybe some variants should be omitted, or a more generic interface should be provided?

One possibility to limit the combinatorial explosion, which I'm currently implementing, is to not have the additional "`n`" variant methods be defined directly on `str`/`slice`, but on their base iterator.

-----
Interacts with #77998 (I haven't yet implemented `as_str` for all the new iterators)