### PR TITLE
Add spin_loop hint for RISC-V architecture

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -137,6 +137,11 @@ pub fn spin_loop() {
             unsafe { crate::arch::arm::__yield() };
         }
     }
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        crate::arch::riscv::pause();
+    }
 }
 
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what


### PR DESCRIPTION
This commit uses the PAUSE instruction (https://github.com/rust-lang/stdarch/pull/1262) to implement RISC-V spin loop, and updates `stdarch` submodule to use the merged PAUSE instruction.