### PR TITLE
Pretty print async block without redundant space

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2068,7 +2068,6 @@ impl<'a> State<'a> {
             ast::ExprKind::Async(capture_clause, _, ref blk) => {
                 self.word_nbsp("async");
                 self.print_capture_clause(capture_clause);
-                self.s.space();
                 // cbox/ibox in analogy to the `ExprKind::Block` arm above
                 self.cbox(INDENT_UNIT);
                 self.ibox(0);

--- a/src/test/pretty/async.rs
+++ b/src/test/pretty/async.rs
@@ -1,0 +1,9 @@
+// pp-exact
+// pretty-compare-only
+// edition:2021
+
+async fn f() {
+    let first = async { 1 };
+    let second = async move { 2 };
+    join(first, second).await
+}

--- a/src/test/ui/async-await/issues/issue-54752-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-54752-async-block.rs
@@ -3,5 +3,5 @@
 // edition:2018
 // pp-exact
 
-fn main() { let _a = (async  { }); }
+fn main() { let _a = (async { }); }
 //~^ WARNING unnecessary parentheses around assigned value

--- a/src/test/ui/async-await/issues/issue-54752-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-54752-async-block.stderr
@@ -1,14 +1,14 @@
 warning: unnecessary parentheses around assigned value
   --> $DIR/issue-54752-async-block.rs:6:22
    |
-LL | fn main() { let _a = (async  { }); }
-   |                      ^          ^
+LL | fn main() { let _a = (async { }); }
+   |                      ^         ^
    |
    = note: `#[warn(unused_parens)]` on by default
 help: remove these parentheses
    |
-LL - fn main() { let _a = (async  { }); }
-LL + fn main() { let _a = async  { }; }
+LL - fn main() { let _a = (async { }); }
+LL + fn main() { let _a = async { }; }
    | 
 
 warning: 1 warning emitted


### PR DESCRIPTION
**Repro:**

```rust
macro_rules! m {
    ($e:expr) => { stringify!($e) };
}
fn main() {
    println!("{:?}", m!(async {}));
}
```

**Before:** <code>"async&nbsp;&nbsp;{}"</code>
**After:** `"async {}"`

<br>

In this function:

https://github.com/rust-lang/rust/blob/65c55bf931a55e6b1e5ed14ad8623814a7386424/compiler/rustc_ast_pretty/src/pprust/state.rs#L2049-L2051

the `print_capture_clause` and `word_nbsp`/`word_space` calls already put a space after the `async` and `move` keywords being printed. The extra `self.s.space()` call removed by this PR resulted in the redundant double space.

https://github.com/rust-lang/rust/blob/65c55bf931a55e6b1e5ed14ad8623814a7386424/compiler/rustc_ast_pretty/src/pprust/state.rs#L2640-L2645

https://github.com/rust-lang/rust/blob/65c55bf931a55e6b1e5ed14ad8623814a7386424/compiler/rustc_ast_pretty/src/helpers.rs#L34-L37

https://github.com/rust-lang/rust/blob/65c55bf931a55e6b1e5ed14ad8623814a7386424/compiler/rustc_ast_pretty/src/helpers.rs#L5-L8