### PR TITLE
Bump download-ci-llvm-stamp for LLD inclusion

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/88069
+Last change is for: https://github.com/rust-lang/rust/pull/91229


### PR DESCRIPTION
This will make 'lld' available locally now, instead of
needing to wait for the next LLVM submodule bump.