### PR TITLE
Delete duplicated helpers from HIR printer

### DIFF
--- a/compiler/rustc_ast_pretty/src/helpers.rs
+++ b/compiler/rustc_ast_pretty/src/helpers.rs
@@ -35,4 +35,14 @@ impl Printer {
         self.word(w);
         self.nbsp()
     }
+
+    // Synthesizes a comment that was not textually present in the original
+    // source file.
+    pub fn synth_comment(&mut self, text: impl Into<Cow<'static, str>>) {
+        self.word("/*");
+        self.space();
+        self.word(text);
+        self.space();
+        self.word("*/")
+    }
 }


### PR DESCRIPTION
These functions (`cbox`, `nbsp`, `word_nbsp`, `head`, `bopen`, `space_if_not_bol`, `break_offset_if_not_bol`, `synth_comment`, `maybe_print_trailing_comment`, `print_remaining_comments`) are duplicated with identical behavior across the AST printer and HIR printer, but are not specific to AST or HIR data structures.