### PR TITLE
Apply path remapping to DW_AT_GNU_dwo_name when producing split DWARF

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -901,17 +901,14 @@ pub(crate) unsafe fn codegen(
                     .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &module.name[..]);
 
                 let dwo_out = cgcx.output_filenames.temp_path_dwo(module_name);
-                let dwo_out = match cgcx.split_debuginfo {
-                    // Don't change how DWARF is emitted in single mode (or when disabled).
-                    SplitDebuginfo::Off | SplitDebuginfo::Packed => None,
+                let dwo_out = if cgcx.target_can_use_split_dwarf
+                    && cgcx.split_debuginfo != SplitDebuginfo::Off
+                {
                     // Emit (a subset of the) DWARF into a separate file in split mode.
-                    SplitDebuginfo::Unpacked => {
-                        if cgcx.target_can_use_split_dwarf {
-                            Some(dwo_out.as_path())
-                        } else {
-                            None
-                        }
-                    }
+                    Some(dwo_out.as_path())
+                } else {
+                    // Don't change how DWARF is emitted in single mode (or when disabled).
+                    None
                 };
 
                 with_codegen(tm, llmod, config.no_builtins, |cpm| {
@@ -948,7 +945,7 @@ pub(crate) unsafe fn codegen(
 
     Ok(module.into_compiled_module(
         config.emit_obj != EmitObj::None,
-        cgcx.target_can_use_split_dwarf && cgcx.split_debuginfo == SplitDebuginfo::Unpacked,
+        cgcx.target_can_use_split_dwarf && cgcx.split_debuginfo != SplitDebuginfo::Off,
         config.emit_bc,
         &cgcx.output_filenames,
     ))

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -205,8 +205,11 @@ pub fn target_machine_factory(
     let use_init_array =
         !sess.opts.debugging_opts.use_ctors_section.unwrap_or(sess.target.use_ctors_section);
 
+    let path_mapping = sess.source_map().path_mapping().clone();
+
     Arc::new(move |config: TargetMachineFactoryConfig| {
-        let split_dwarf_file = config.split_dwarf_file.unwrap_or_default();
+        let split_dwarf_file =
+            path_mapping.map_prefix(config.split_dwarf_file.unwrap_or_default()).0;
         let split_dwarf_file = CString::new(split_dwarf_file.to_str().unwrap()).unwrap();
 
         let tm = unsafe {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1057,9 +1057,12 @@ pub fn compile_unit_metadata(
     let output_filenames = tcx.output_filenames(());
     let out_dir = &output_filenames.out_directory;
     let split_name = if tcx.sess.target_can_use_split_dwarf() {
-        output_filenames
-            .split_dwarf_path(tcx.sess.split_debuginfo(), Some(codegen_unit_name))
-            .map(|f| out_dir.join(f))
+        output_filenames.split_dwarf_path(tcx.sess.split_debuginfo(), Some(codegen_unit_name)).map(
+            |f| {
+                let joined = out_dir.join(f);
+                tcx.sess.source_map().path_mapping().map_prefix(joined).0
+            },
+        )
     } else {
         None
     }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1055,14 +1055,11 @@ pub fn compile_unit_metadata(
     let work_dir = tcx.sess.opts.working_dir.to_string_lossy(FileNameDisplayPreference::Remapped);
     let flags = "\0";
     let output_filenames = tcx.output_filenames(());
-    let out_dir = &output_filenames.out_directory;
     let split_name = if tcx.sess.target_can_use_split_dwarf() {
-        output_filenames.split_dwarf_path(tcx.sess.split_debuginfo(), Some(codegen_unit_name)).map(
-            |f| {
-                let joined = out_dir.join(f);
-                tcx.sess.source_map().path_mapping().map_prefix(joined).0
-            },
-        )
+        output_filenames
+            .split_dwarf_path(tcx.sess.split_debuginfo(), Some(codegen_unit_name))
+            // We get a path relative to the working directory from split_dwarf_path
+            .map(|f| tcx.sess.source_map().path_mapping().map_prefix(f).0)
     } else {
         None
     }

--- a/src/test/run-make-fulldeps/split-dwarf/Makefile
+++ b/src/test/run-make-fulldeps/split-dwarf/Makefile
@@ -5,10 +5,10 @@
 all: packed remapped
 
 remapped:
-	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 --remap-path-prefix $$PWD= foo.rs -g
+	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 --remap-path-prefix $$PWD=/a foo.rs -g
 	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
 
-	$(RUSTC) -Z unstable-options -C split-debuginfo=unpacked -C debuginfo=2 --remap-path-prefix $$PWD= foo.rs -g
+	$(RUSTC) -Z unstable-options -C split-debuginfo=unpacked -C debuginfo=2 --remap-path-prefix $$PWD=/a foo.rs -g
 	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
 
 packed:

--- a/src/test/run-make-fulldeps/split-dwarf/Makefile
+++ b/src/test/run-make-fulldeps/split-dwarf/Makefile
@@ -5,11 +5,11 @@
 all: packed remapped
 
 remapped:
-	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 --remap-path-prefix $$PWD=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
+	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 --remap-path-prefix $(TMPDIR)=/a foo.rs -g
+	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
 
-	$(RUSTC) -Z unstable-options -C split-debuginfo=unpacked -C debuginfo=2 --remap-path-prefix $$PWD=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
+	$(RUSTC) -Z unstable-options -C split-debuginfo=unpacked -C debuginfo=2 --remap-path-prefix $(TMPDIR)=/a foo.rs -g
+	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
 
 packed:
 	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 foo.rs -g

--- a/src/test/run-make-fulldeps/split-dwarf/Makefile
+++ b/src/test/run-make-fulldeps/split-dwarf/Makefile
@@ -2,7 +2,16 @@
 
 # only-linux
 
-all:
+all: packed remapped
+
+remapped:
+	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 --remap-path-prefix $$PWD= foo.rs -g
+	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
+
+	$(RUSTC) -Z unstable-options -C split-debuginfo=unpacked -C debuginfo=2 --remap-path-prefix $$PWD= foo.rs -g
+	objdump -Wi $(TMPDIR)/foo | grep $$PWD && exit 1 || exit 0
+
+packed:
 	$(RUSTC) -Z unstable-options -C split-debuginfo=packed -C debuginfo=2 foo.rs -g
 	rm $(TMPDIR)/foo.dwp
 	rm $(TMPDIR)/$(call BIN,foo)


### PR DESCRIPTION
`--remap-path-prefix` doesn't apply to paths to `.o` (in case of packed) or `.dwo` (in case of unpacked) files in `DW_AT_GNU_dwo_name`. GCC also has this bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91888