### PR TITLE
Pretty print break and continue without redundant space

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2135,22 +2135,20 @@ impl<'a> State<'a> {
             ast::ExprKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, true),
             ast::ExprKind::Break(opt_label, ref opt_expr) => {
                 self.word("break");
-                self.space();
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident);
                     self.space();
+                    self.print_ident(label.ident);
                 }
                 if let Some(ref expr) = *opt_expr {
-                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                     self.space();
+                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
             ast::ExprKind::Continue(opt_label) => {
                 self.word("continue");
-                self.space();
                 if let Some(label) = opt_label {
+                    self.space();
                     self.print_ident(label.ident);
-                    self.space()
                 }
             }
             ast::ExprKind::Ret(ref result) => {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1543,22 +1543,20 @@ impl<'a> State<'a> {
             hir::ExprKind::Path(ref qpath) => self.print_qpath(qpath, true),
             hir::ExprKind::Break(destination, ref opt_expr) => {
                 self.word("break");
-                self.space();
                 if let Some(label) = destination.label {
-                    self.print_ident(label.ident);
                     self.space();
+                    self.print_ident(label.ident);
                 }
                 if let Some(ref expr) = *opt_expr {
-                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                     self.space();
+                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
             hir::ExprKind::Continue(destination) => {
                 self.word("continue");
-                self.space();
                 if let Some(label) = destination.label {
+                    self.space();
                     self.print_ident(label.ident);
-                    self.space()
                 }
             }
             hir::ExprKind::Ret(ref result) => {

--- a/src/test/pretty/ast-stmt-expr-attr.rs
+++ b/src/test/pretty/ast-stmt-expr-attr.rs
@@ -110,8 +110,8 @@ fn syntax() {
     let _ = #[attr] &mut 0;
     let _ = #[attr] &#[attr] 0;
     let _ = #[attr] &mut #[attr] 0;
-    let _ = #[attr] break ;
-    let _ = #[attr] continue ;
+    let _ = #[attr] break;
+    let _ = #[attr] continue;
     let _ = #[attr] return;
     let _ = #[attr] foo!();
     let _ = #[attr] foo!(#! [attr]);

--- a/src/test/pretty/hir-pretty-loop.pp
+++ b/src/test/pretty/hir-pretty-loop.pp
@@ -6,4 +6,4 @@ extern crate std;
 // pretty-mode:hir
 // pp-exact:hir-pretty-loop.pp
 
-pub fn foo() { loop { break ; } }
+pub fn foo() { loop { break; } }

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -229,9 +229,8 @@ fn _11() {
     let _ = #[rustc_dummy] &mut 0;
     let _ = #[rustc_dummy] &#[rustc_dummy] 0;
     let _ = #[rustc_dummy] &mut #[rustc_dummy] 0;
-    // FIXME: pp bug, extra space after keyword?
-    while false { let _ = #[rustc_dummy] continue ; }
-    while true { let _ = #[rustc_dummy] break ; }
+    while false { let _ = #[rustc_dummy] continue; }
+    while true { let _ = #[rustc_dummy] break; }
     || #[rustc_dummy] return;
     let _ = #[rustc_dummy] expr_mac!();
     let _ = #[rustc_dummy] expr_mac![];


### PR DESCRIPTION
**Repro:**

```rust
macro_rules! m {
    ($e:expr) => { stringify!($e) };
}
fn main() {
    println!("{:?}", m!(loop { break; }));
    println!("{:?}", m!(loop { break 'a; }));
    println!("{:?}", m!(loop { break false; }));
}
```

**Before:**

- `"loop { break ; }"`
- `"loop { break 'a ; }"`
- `"loop { break false ; }"`

**After:**

- `"loop { break; }"`
- `"loop { break 'a; }"`
- `"loop { break false; }"`

<br>

Notice that `return` and `yield` already follow the same approach as this PR of printing the space *before* each additional piece following the keyword, rather than *after* each thing.

https://github.com/rust-lang/rust/blob/772d51f887fa407216860bf8ecf3f1a32fb795b4/compiler/rustc_ast_pretty/src/pprust/state.rs#L2148-L2154

https://github.com/rust-lang/rust/blob/772d51f887fa407216860bf8ecf3f1a32fb795b4/compiler/rustc_ast_pretty/src/pprust/state.rs#L2221-L2228