### PR TITLE
Attach range metadata to alignment loads from vtables

### DIFF
--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -1,3 +1,5 @@
+// compile-flags: -O
+
 #![crate_type = "lib"]
 
 // This test checks that we annotate alignment loads from vtables with nonzero range metadata,

--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -1,0 +1,43 @@
+#![crate_type = "lib"]
+
+// This test checks that we annotate alignment loads from vtables with nonzero range metadata,
+// and that this allows LLVM to eliminate redundant `align >= 1` checks.
+
+pub trait Trait {
+    fn f(&self);
+}
+
+pub struct WrapperWithAlign1<T: ?Sized> { x: u8, y: T }
+
+pub struct WrapperWithAlign2<T: ?Sized> { x: u16, y: T }
+
+pub struct Struct<W: ?Sized> {
+    _field: i8,
+    dst: W,
+}
+
+// CHECK-LABEL: @eliminates_runtime_check_when_align_1
+#[no_mangle]
+pub fn eliminates_runtime_check_when_align_1(
+    x: &Struct<WrapperWithAlign1<dyn Trait>>
+) -> &WrapperWithAlign1<dyn Trait> {
+    // CHECK: load [[USIZE:i[0-9]+]], {{.+}} !range [[RANGE_META:![0-9]+]]
+    // CHECK-NOT: icmp
+    // CHECK-NOT: select
+    // CHECK: ret
+    &x.dst
+}
+
+// CHECK-LABEL: @does_not_eliminate_runtime_check_when_align_2
+#[no_mangle]
+pub fn does_not_eliminate_runtime_check_when_align_2(
+    x: &Struct<WrapperWithAlign2<dyn Trait>>
+) -> &WrapperWithAlign2<dyn Trait> {
+    // CHECK: [[X0:%[0-9]+]] = load [[USIZE]], {{.+}} !range [[RANGE_META]]
+    // CHECK: [[X1:%[0-9]+]] = icmp {{.+}} [[X0]]
+    // CHECK: [[X2:%[0-9]+]] = select {{.+}} [[X1]]
+    // CHECK: ret
+    &x.dst
+}
+
+// CHECK: [[RANGE_META]] = !{[[USIZE]] 1, [[USIZE]] 0}


### PR DESCRIPTION
...because alignment is always nonzero[0].

This helps eliminate redundant runtime alignment checks, when a DST
is a field of a struct whose remaining fields have alignment 1.

Fixes #91438.

---
[0]:

The [reference](https://doc.rust-lang.org/reference/type-layout.html) says that alignment must be at least 1.

And in practice, the alignment field for all vtables is generated here: https://github.com/rust-lang/rust/blob/772d51f887fa407216860bf8ecf3f1a32fb795b4/compiler/rustc_middle/src/ty/vtable.rs#L68-L90 and is nonzero because [`Align::bytes()`](https://github.com/rust-lang/rust/blob/772d51f887fa407216860bf8ecf3f1a32fb795b4/compiler/rustc_target/src/abi/mod.rs#L547-L549) is always nonzero.