### PR TITLE
Evaluate inline const pat early and report error if too generic

### DIFF
--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,16 +1,31 @@
 #![allow(incomplete_features)]
 #![feature(inline_const_pat)]
+#![feature(generic_const_exprs)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 
 fn foo<const V: usize>() {
-  match 0 {
-    const { V } => {},
-    //~^ ERROR const parameters cannot be referenced in patterns [E0158]
-    _ => {},
-  }
+    match 0 {
+        const { V } => {},
+        //~^ ERROR const parameters cannot be referenced in patterns [E0158]
+        _ => {},
+    }
+}
+
+const fn f(x: usize) -> usize {
+    x + 1
+}
+
+fn bar<const V: usize>() where [(); f(V)]: {
+    match 0 {
+        const { f(V) } => {},
+        //~^ ERROR constant pattern depends on a generic parameter
+        //~| ERROR constant pattern depends on a generic parameter
+        _ => {},
+    }
 }
 
 fn main() {
     foo::<1>();
+    bar::<1>();
 }

--- a/src/test/ui/inline-const/const-match-pat-generic.stderr
+++ b/src/test/ui/inline-const/const-match-pat-generic.stderr
@@ -1,9 +1,21 @@
 error[E0158]: const parameters cannot be referenced in patterns
-  --> $DIR/const-match-pat-generic.rs:8:11
+  --> $DIR/const-match-pat-generic.rs:9:9
    |
-LL |     const { V } => {},
-   |           ^^^^^
+LL |         const { V } => {},
+   |         ^^^^^^^^^^^
 
-error: aborting due to previous error
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0158`.


### PR DESCRIPTION
Fix #90150

@rustbot label: T-compiler F-inline_const