### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/m68k_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::abi::Endian;
 use crate::spec::{Target, TargetOptions};
 
 pub fn target() -> Target {
-    let mut base = super::linux_base::opts();
+    let mut base = super::linux_gnu_base::opts();
     base.max_atomic_width = Some(32);
 
     Target {

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/88069
+Last change is for: https://github.com/rust-lang/rust/pull/91229

--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -359,9 +359,8 @@ are added.
 # fn foo() {}
 ```
 
-`edition2018` tells `rustdoc` that the code sample should be compiled using
-the 2018 edition of Rust. Similarly, you can specify `edition2015` to compile
-the code with the 2015 edition.
+`edition2015`, `edition2018` and `edition2021` tell `rustdoc`
+that the code sample should be compiled using the respective edition of Rust.
 
 ```rust
 /// Only runs on the 2018 edition.

--- a/src/test/ui/typeck/issue-91334.rs
+++ b/src/test/ui/typeck/issue-91334.rs
@@ -1,0 +1,10 @@
+// Regression test for the ICE described in issue #91334.
+
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected one of
+// error-pattern: mismatched closing delimiter
+// error-pattern: mismatched types
+
+#![feature(generators)]
+
+fn f(){||yield(((){),

--- a/src/test/ui/typeck/issue-91334.stderr
+++ b/src/test/ui/typeck/issue-91334.stderr
@@ -1,0 +1,50 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-91334.rs:10:23
+   |
+LL | fn f(){||yield(((){),
+   |       -       -       ^
+   |       |       |
+   |       |       unclosed delimiter
+   |       unclosed delimiter
+
+error: this file contains an unclosed delimiter
+  --> $DIR/issue-91334.rs:10:23
+   |
+LL | fn f(){||yield(((){),
+   |       -       -       ^
+   |       |       |
+   |       |       unclosed delimiter
+   |       unclosed delimiter
+
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `{`
+  --> $DIR/issue-91334.rs:10:19
+   |
+LL | fn f(){||yield(((){),
+   |                   ^
+   |                   |
+   |                   expected one of `)`, `,`, `.`, `?`, or an operator
+   |                   help: missing `,`
+
+error: mismatched closing delimiter: `)`
+  --> $DIR/issue-91334.rs:10:19
+   |
+LL | fn f(){||yield(((){),
+   |                -  ^^ mismatched closing delimiter
+   |                |  |
+   |                |  unclosed delimiter
+   |                closing delimiter possibly meant for this
+
+error[E0308]: mismatched types
+  --> $DIR/issue-91334.rs:10:8
+   |
+LL | fn f(){||yield(((){),
+   |       -^^^^^^^^^^^^^^^ expected `()`, found generator
+   |       |
+   |       help: try adding a return type: `-> [generator@$DIR/issue-91334.rs:10:8: 10:23]`
+   |
+   = note: expected unit type `()`
+              found generator `[generator@$DIR/issue-91334.rs:10:8: 10:23]`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -172,11 +172,16 @@ async function main(argv) {
     }
     files.sort();
 
+    if (no_headless) {
+        opts["jobs"] = 1;
+        console.log("`--no-headless` option is active, disabling concurrency for running tests.");
+    }
+
     console.log(`Running ${files.length} rustdoc-gui (${opts["jobs"]} concurrently) ...`);
 
     if (opts["jobs"] < 1) {
         process.setMaxListeners(files.length + 1);
-    } else {
+    } else if (!no_headless) {
         process.setMaxListeners(opts["jobs"] + 1);
     }
 
@@ -217,9 +222,7 @@ async function main(argv) {
                 tests_queue.splice(tests_queue.indexOf(callback), 1);
             });
         tests_queue.push(callback);
-        if (no_headless) {
-            await tests_queue[i];
-        } else if (opts["jobs"] > 0 && tests_queue.length >= opts["jobs"]) {
+        if (opts["jobs"] > 0 && tests_queue.length >= opts["jobs"]) {
             await Promise.race(tests_queue);
         }
     }


### PR DESCRIPTION
Successful merges:

 - #91367 (Fix ICE in `check_must_not_suspend_ty()`)
 - #91391 (Simplify --no-headless option for rustdoc-gui tester)
 - #91537 (compiler/rustc_target: make m68k-unknown-linux-gnu use the gnu base)
 - #91554 (Update doc about code block edition attributes)
 - #91563 (Bump download-ci-llvm-stamp for LLD inclusion)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91367,91391,91537,91554,91563)
<!-- homu-ignore:end -->