### PR TITLE
Fix ICE on format string of macro with secondary-label

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -995,8 +995,9 @@ pub fn expand_preparsed_format_args(
             e.note(&note);
         }
         if let Some((label, span)) = err.secondary_label {
-            let sp = fmt_span.from_inner(span);
-            e.span_label(sp, label);
+            if efmt_kind_is_lit {
+                e.span_label(fmt_span.from_inner(span), label);
+            }
         }
         e.emit();
         return DummyResult::raw_expr(sp, true);

--- a/src/test/ui/fmt/issue-91556.rs
+++ b/src/test/ui/fmt/issue-91556.rs
@@ -1,0 +1,8 @@
+fn main() {
+  let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
+  //~^ ERROR: invalid format string: expected `'}'` but string was terminated
+  //~| NOTE: if you intended to print `{`, you can escape it using `{{`
+  //~| NOTE: in this expansion of concat!
+  //~| NOTE: in this expansion of concat!
+  //~| NOTE: expected `'}'` in format string
+}

--- a/src/test/ui/fmt/issue-91556.stderr
+++ b/src/test/ui/fmt/issue-91556.stderr
@@ -1,0 +1,11 @@
+error: invalid format string: expected `'}'` but string was terminated
+  --> $DIR/issue-91556.rs:2:19
+   |
+LL |   let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
+   |                   ^^^^^^^^^^^^^^^^^^^ expected `'}'` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This generalizes the fix #86104 to also correctly skip `Span::from_inner` for the `secondary_label` of a format macro parsing error as well.

We can alternatively skip the `span_label` diagnostic call for the secondary label as well, since that label probably only makes sense when the _proper_ span is computed.

Fixes #91556 