### PR TITLE
Improve typo suggestions

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -526,6 +526,25 @@ impl Diagnostic {
         self
     }
 
+    /// Prints out a message for a suggestion without showing the suggested code if
+    /// the message is shown inline.
+    pub fn span_suggestion_hide_inline(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestion: String,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestion_with_style(
+            sp,
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::HideCodeInline,
+        );
+        self
+    }
+
     /// Prints out a message for a suggestion without showing the suggested code.
     ///
     /// This is intended to be used for suggestions that are obvious in what the changes need to

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -360,6 +360,21 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    /// See [`Diagnostic::span_suggestion_hide_inline()`].
+    pub fn span_suggestion_hide_inline(
+        &mut self,
+        sp: Span,
+        msg: &str,
+        suggestion: String,
+        applicability: Applicability,
+    ) -> &mut Self {
+        if !self.0.allow_suggestions {
+            return self;
+        }
+        self.0.diagnostic.span_suggestion_hide_inline(sp, msg, suggestion, applicability);
+        self
+    }
+
     /// See [`Diagnostic::span_suggestion_hidden()`].
     pub fn span_suggestion_hidden(
         &mut self,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -571,9 +571,12 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                                 ..
                             })) = source
                             {
-                                err.span_suggestion(
+                                err.span_suggestion_hide_inline(
                                     span,
-                                    "use the similarly named label",
+                                    &format!(
+                                        "did you mean `{}`? (a similarly named label)",
+                                        label_ident
+                                    ),
                                     label_ident.name.to_string(),
                                     Applicability::MaybeIncorrect,
                                 );

--- a/compiler/rustc_typeck/src/astconv/errors.rs
+++ b/compiler/rustc_typeck/src/astconv/errors.rs
@@ -184,9 +184,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             find_best_match_for_name(&all_candidate_names, assoc_name.name, None),
             assoc_name.span != DUMMY_SP,
         ) {
-            err.span_suggestion(
+            err.span_suggestion_hide_inline(
                 assoc_name.span,
-                "there is an associated type with a similar name",
+                &format!("did you mean `{}`? (a similarly named associated type)", suggested_name),
                 suggested_name.to_string(),
                 Applicability::MaybeIncorrect,
             );

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1811,9 +1811,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         assoc_ident.name,
                         None,
                     ) {
-                        err.span_suggestion(
+                        err.span_suggestion_hide_inline(
                             assoc_ident.span,
-                            "there is a variant with a similar name",
+                            &format!(
+                                "did you mean `{}`? (a similarly named variant)",
+                                suggested_name
+                            ),
                             suggested_name.to_string(),
                             Applicability::MaybeIncorrect,
                         );

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1729,9 +1729,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let Some(field_name) =
                     Self::suggest_field_name(variant, field.ident.name, skip_fields.collect())
                 {
-                    err.span_suggestion(
+                    err.span_suggestion_hide_inline(
                         field.ident.span,
-                        "a field with a similar name exists",
+                        &format!("did you mean `{}`? (a similarly named field)", field_name),
                         field_name.to_string(),
                         Applicability::MaybeIncorrect,
                     );
@@ -2125,9 +2125,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let Some(suggested_field_name) =
             Self::suggest_field_name(def.non_enum_variant(), field.name, vec![])
         {
-            err.span_suggestion(
+            err.span_suggestion_hide_inline(
                 field.span,
-                "a field with a similar name exists",
+                &format!("did you mean `{}`? (a similarly named field)", suggested_field_name),
                 suggested_field_name.to_string(),
                 Applicability::MaybeIncorrect,
             );

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -981,9 +981,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         item_name.name,
                         None,
                     ) {
-                        err.span_suggestion(
+                        err.span_suggestion_hide_inline(
                             span,
-                            "there is a variant with a similar name",
+                            &format!("did you mean `{}`? (a similarly named variant)", suggestion),
                             suggestion.to_string(),
                             Applicability::MaybeIncorrect,
                         );
@@ -1014,11 +1014,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // that had unsatisfied trait bounds
                     if unsatisfied_predicates.is_empty() {
                         let def_kind = lev_candidate.kind.as_def_kind();
-                        err.span_suggestion(
+                        err.span_suggestion_hide_inline(
                             span,
                             &format!(
-                                "there is {} {} with a similar name",
-                                def_kind.article(),
+                                "did you mean `{}`? (a similarly named {})",
+                                lev_candidate.ident,
                                 def_kind.descr(lev_candidate.def_id),
                             ),
                             lev_candidate.ident.to_string(),

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1489,9 +1489,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     unmentioned_fields.iter().map(|(_, field)| field.name).collect::<Vec<_>>();
                 let suggested_name = find_best_match_for_name(&input, ident.name, None);
                 if let Some(suggested_name) = suggested_name {
-                    err.span_suggestion(
+                    err.span_suggestion_hide_inline(
                         ident.span,
-                        "a field with a similar name exists",
+                        &format!("did you mean `{}`? (a similarly named field)", suggested_name),
                         suggested_name.to_string(),
                         Applicability::MaybeIncorrect,
                     );

--- a/src/test/ui/associated-item/associated-item-enum.stderr
+++ b/src/test/ui/associated-item/associated-item-enum.stderr
@@ -8,7 +8,7 @@ LL |     Enum::mispellable();
    |           ^^^^^^^^^^^
    |           |
    |           variant or associated item not found in `Enum`
-   |           help: there is an associated function with a similar name: `misspellable`
+   |           help: did you mean `misspellable`? (a similarly named associated function)
 
 error[E0599]: no variant or associated item named `mispellable_trait` found for enum `Enum` in the current scope
   --> $DIR/associated-item-enum.rs:18:11
@@ -29,7 +29,7 @@ LL |     Enum::MISPELLABLE;
    |           ^^^^^^^^^^^
    |           |
    |           variant or associated item not found in `Enum`
-   |           help: there is an associated constant with a similar name: `MISSPELLABLE`
+   |           help: did you mean `MISSPELLABLE`? (a similarly named associated constant)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/associated-types-eq-1.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-1.stderr
@@ -6,7 +6,7 @@ LL | fn foo2<I: Foo>(x: I) {
 LL |     let _: A = x.boo();
    |            ^
    |
-help: a type parameter with a similar name exists
+help: did you mean `I`? (a similarly named type parameter)
    |
 LL |     let _: I = x.boo();
    |            ~

--- a/src/test/ui/async-await/suggest-switching-edition-on-await.rs
+++ b/src/test/ui/async-await/suggest-switching-edition-on-await.rs
@@ -21,7 +21,7 @@ fn await_on_struct_similar() {
     let x = S { awai: 42 };
     x.await;
     //~^ ERROR no field `await` on type
-    //~| HELP a field with a similar name exists
+    //~| HELP did you mean `awai`?
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
     //~| HELP set `edition = "2021"` in `Cargo.toml`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide

--- a/src/test/ui/async-await/suggest-switching-edition-on-await.stderr
+++ b/src/test/ui/async-await/suggest-switching-edition-on-await.stderr
@@ -12,7 +12,7 @@ error[E0609]: no field `await` on type `await_on_struct_similar::S`
   --> $DIR/suggest-switching-edition-on-await.rs:22:7
    |
 LL |     x.await;
-   |       ^^^^^ help: a field with a similar name exists: `awai`
+   |       ^^^^^ help: did you mean `awai`? (a similarly named field)
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
    = help: set `edition = "2021"` in `Cargo.toml`

--- a/src/test/ui/auto-ref-slice-plus-ref.stderr
+++ b/src/test/ui/auto-ref-slice-plus-ref.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `test_mut` found for struct `Vec<{integer}>` in th
   --> $DIR/auto-ref-slice-plus-ref.rs:7:7
    |
 LL |     a.test_mut();
-   |       ^^^^^^^^ help: there is an associated function with a similar name: `get_mut`
+   |       ^^^^^^^^ help: did you mean `get_mut`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `MyIter` defines an item `test_mut`, perhaps you need to implement it

--- a/src/test/ui/block-result/issue-3563.stderr
+++ b/src/test/ui/block-result/issue-3563.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `b` found for reference `&Self` in the current sco
   --> $DIR/issue-3563.rs:3:17
    |
 LL |         || self.b()
-   |                 ^ help: there is an associated function with a similar name: `a`
+   |                 ^ help: did you mean `a`? (a similarly named associated function)
 
 error: aborting due to previous error
 

--- a/src/test/ui/c-variadic/issue-86053-1.stderr
+++ b/src/test/ui/c-variadic/issue-86053-1.stderr
@@ -69,7 +69,7 @@ LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize
 LL | pub trait Fn<Args>: FnMut<Args> {
    | ------------------------------- similarly named trait `Fn` defined here
    |
-help: a trait with a similar name exists
+help: did you mean `Fn`? (a similarly named trait)
    |
 LL |     self , ... ,   self ,   self , ... ) where Fn : FnOnce ( & 'a & 'b usize ) {
    |                                                ~~

--- a/src/test/ui/closures/issue-78720.stderr
+++ b/src/test/ui/closures/issue-78720.stderr
@@ -15,7 +15,7 @@ LL |     _func: F,
 LL | pub trait Fn<Args>: FnMut<Args> {
    | ------------------------------- similarly named trait `Fn` defined here
    |
-help: a trait with a similar name exists
+help: did you mean `Fn`? (a similarly named trait)
    |
 LL |     _func: Fn,
    |            ~~

--- a/src/test/ui/const-generics/early/invalid-const-arguments.stderr
+++ b/src/test/ui/const-generics/early/invalid-const-arguments.stderr
@@ -7,7 +7,7 @@ LL | trait Foo {}
 LL | impl Foo for A<N> {}
    |                ^
    |
-help: a struct with a similar name exists
+help: did you mean `A`? (a similarly named struct)
    |
 LL | impl Foo for A<A> {}
    |                ~
@@ -25,7 +25,7 @@ LL | struct A<const N: u8>;
 LL | impl<const N: u8> Foo for C<N, T> {}
    |                                ^
    |
-help: a struct with a similar name exists
+help: did you mean `A`? (a similarly named struct)
    |
 LL | impl<const N: u8> Foo for C<N, A> {}
    |                                ~

--- a/src/test/ui/derived-errors/issue-30580.stderr
+++ b/src/test/ui/derived-errors/issue-30580.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `c` on type `&Foo`
   --> $DIR/issue-30580.rs:12:11
    |
 LL |         b.c;
-   |           ^ help: a field with a similar name exists: `a`
+   |           ^ help: did you mean `a`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/src/test/ui/derives/deriving-meta-unknown-trait.stderr
@@ -2,7 +2,7 @@ error: cannot find derive macro `Eqr` in this scope
   --> $DIR/deriving-meta-unknown-trait.rs:1:10
    |
 LL | #[derive(Eqr)]
-   |          ^^^ help: a derive macro with a similar name exists: `Eq`
+   |          ^^^ help: did you mean `Eq`? (a similarly named derive macro)
    |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
@@ -13,7 +13,7 @@ error: cannot find derive macro `Eqr` in this scope
   --> $DIR/deriving-meta-unknown-trait.rs:1:10
    |
 LL | #[derive(Eqr)]
-   |          ^^^ help: a derive macro with a similar name exists: `Eq`
+   |          ^^^ help: did you mean `Eq`? (a similarly named derive macro)
    |
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |

--- a/src/test/ui/did_you_mean/issue-36798.stderr
+++ b/src/test/ui/did_you_mean/issue-36798.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `baz` on type `Foo`
   --> $DIR/issue-36798.rs:7:7
    |
 LL |     f.baz;
-   |       ^^^ help: a field with a similar name exists: `bar`
+   |       ^^^ help: did you mean `bar`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/did_you_mean/issue-42599_available_fields_note.stderr
+++ b/src/test/ui/did_you_mean/issue-42599_available_fields_note.stderr
@@ -2,7 +2,7 @@ error[E0560]: struct `Demo` has no field named `inocently_mispellable`
   --> $DIR/issue-42599_available_fields_note.rs:16:39
    |
 LL |             Self { secret_integer: 2, inocently_mispellable: () }
-   |                                       ^^^^^^^^^^^^^^^^^^^^^ help: a field with a similar name exists: `innocently_misspellable`
+   |                                       ^^^^^^^^^^^^^^^^^^^^^ help: did you mean `innocently_misspellable`? (a similarly named field)
 
 error[E0560]: struct `Demo` has no field named `egregiously_nonexistent_field`
   --> $DIR/issue-42599_available_fields_note.rs:21:39
@@ -16,7 +16,7 @@ error[E0609]: no field `inocently_mispellable` on type `Demo`
   --> $DIR/issue-42599_available_fields_note.rs:32:41
    |
 LL |     let innocent_field_misaccess = demo.inocently_mispellable;
-   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: a field with a similar name exists: `innocently_misspellable`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: did you mean `innocently_misspellable`? (a similarly named field)
 
 error[E0609]: no field `egregiously_nonexistent_field` on type `Demo`
   --> $DIR/issue-42599_available_fields_note.rs:35:42

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -16,7 +16,7 @@ help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
    |              ~~~~~~~~~
-help: a unit struct with a similar name exists
+help: did you mean `XEmpty2`? (a similarly named unit struct)
    |
 LL |     let e1 = XEmpty2;
    |              ~~~~~~~
@@ -39,7 +39,7 @@ help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
    |              ~~~~~~~~~
-help: a unit struct with a similar name exists
+help: did you mean `XEmpty2`? (a similarly named unit struct)
    |
 LL |     let e1 = XEmpty2();
    |              ~~~~~~~
@@ -79,7 +79,7 @@ help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
    |               ~~~~~~~~~~
-help: a unit struct with a similar name exists
+help: did you mean `XEmpty2`? (a similarly named unit struct)
    |
 LL |     let xe1 = XEmpty2;
    |               ~~~~~~~
@@ -101,7 +101,7 @@ help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
    |               ~~~~~~~~~~
-help: a unit struct with a similar name exists
+help: did you mean `XEmpty2`? (a similarly named unit struct)
    |
 LL |     let xe1 = XEmpty2();
    |               ~~~~~~~
@@ -113,7 +113,7 @@ LL |     let xe3 = XE::Empty3;
    |                   ^^^^^^
    |                   |
    |                   variant or associated item not found in `empty_struct::XE`
-   |                   help: there is a variant with a similar name: `XEmpty3`
+   |                   help: did you mean `XEmpty3`? (a similarly named variant)
 
 error[E0599]: no variant or associated item named `Empty3` found for enum `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:26:19
@@ -122,13 +122,13 @@ LL |     let xe3 = XE::Empty3();
    |                   ^^^^^^
    |                   |
    |                   variant or associated item not found in `empty_struct::XE`
-   |                   help: there is a variant with a similar name: `XEmpty3`
+   |                   help: did you mean `XEmpty3`? (a similarly named variant)
 
 error[E0599]: no variant named `Empty1` found for enum `empty_struct::XE`
   --> $DIR/empty-struct-braces-expr.rs:28:9
    |
 LL |     XE::Empty1 {};
-   |         ^^^^^^ help: there is a variant with a similar name: `XEmpty3`
+   |         ^^^^^^ help: did you mean `XEmpty3`? (a similarly named variant)
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/empty/empty-struct-braces-pat-1.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-1.stderr
@@ -24,7 +24,7 @@ help: use struct pattern syntax instead
    |
 LL |         XE::XEmpty3 { /* fields */ } => ()
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: a unit variant with a similar name exists
+help: did you mean `XEmpty4`? (a similarly named unit variant)
    |
 LL |         XE::XEmpty4 => ()
    |             ~~~~~~~

--- a/src/test/ui/empty/empty-struct-braces-pat-2.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-2.stderr
@@ -16,7 +16,7 @@ help: use struct pattern syntax instead
    |
 LL |         Empty1 {} => ()
    |         ~~~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6() => ()
    |         ~~~~~~~
@@ -39,7 +39,7 @@ help: use struct pattern syntax instead
    |
 LL |         XEmpty1 {} => ()
    |         ~~~~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6() => ()
    |         ~~~~~~~
@@ -62,7 +62,7 @@ help: use struct pattern syntax instead
    |
 LL |         Empty1 {} => ()
    |         ~~~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6(..) => ()
    |         ~~~~~~~
@@ -85,7 +85,7 @@ help: use struct pattern syntax instead
    |
 LL |         XEmpty1 {} => ()
    |         ~~~~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6(..) => ()
    |         ~~~~~~~

--- a/src/test/ui/empty/empty-struct-braces-pat-3.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-3.stderr
@@ -25,7 +25,7 @@ help: use struct pattern syntax instead
    |
 LL |         XE::XEmpty3 { /* fields */ } => ()
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `XEmpty5`? (a similarly named tuple variant)
    |
 LL |         XE::XEmpty5() => ()
    |             ~~~~~~~
@@ -57,7 +57,7 @@ help: use struct pattern syntax instead
    |
 LL |         XE::XEmpty3 { /* fields */ } => ()
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `XEmpty5`? (a similarly named tuple variant)
    |
 LL |         XE::XEmpty5(..) => ()
    |             ~~~~~~~

--- a/src/test/ui/empty/empty-struct-tuple-pat.stderr
+++ b/src/test/ui/empty/empty-struct-tuple-pat.stderr
@@ -42,7 +42,7 @@ help: use the tuple variant pattern syntax instead
    |
 LL |         XE::XEmpty5(/* fields */) => (),
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~
-help: a unit variant with a similar name exists
+help: did you mean `XEmpty4`? (a similarly named unit variant)
    |
 LL |         XE::XEmpty4 => (),
    |             ~~~~~~~

--- a/src/test/ui/empty/empty-struct-unit-pat.stderr
+++ b/src/test/ui/empty/empty-struct-unit-pat.stderr
@@ -16,7 +16,7 @@ help: use this syntax instead
    |
 LL |         Empty2 => ()
    |         ~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6() => ()
    |         ~~~~~~~
@@ -38,7 +38,7 @@ help: use this syntax instead
    |
 LL |         XEmpty2 => ()
    |         ~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6() => ()
    |         ~~~~~~~
@@ -61,7 +61,7 @@ help: use this syntax instead
    |
 LL |         Empty2 => ()
    |         ~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6(..) => ()
    |         ~~~~~~~
@@ -83,7 +83,7 @@ help: use this syntax instead
    |
 LL |         XEmpty2 => ()
    |         ~~~~~~~
-help: a tuple struct with a similar name exists
+help: did you mean `XEmpty6`? (a similarly named tuple struct)
    |
 LL |         XEmpty6(..) => ()
    |         ~~~~~~~
@@ -114,7 +114,7 @@ help: use this syntax instead
    |
 LL |         XE::XEmpty4 => (),
    |         ~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `XEmpty5`? (a similarly named tuple variant)
    |
 LL |         XE::XEmpty5() => (),
    |             ~~~~~~~
@@ -145,7 +145,7 @@ help: use this syntax instead
    |
 LL |         XE::XEmpty4 => (),
    |         ~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `XEmpty5`? (a similarly named tuple variant)
    |
 LL |         XE::XEmpty5(..) => (),
    |             ~~~~~~~

--- a/src/test/ui/error-codes/E0407.stderr
+++ b/src/test/ui/error-codes/E0407.stderr
@@ -4,7 +4,7 @@ error[E0407]: method `b` is not a member of trait `Foo`
 LL |     fn b() {}
    |     ^^^-^^^^^
    |     |  |
-   |     |  help: there is an associated function with a similar name: `a`
+   |     |  help: did you mean `a`? (a similarly named associated function)
    |     not a member of trait `Foo`
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -42,7 +42,7 @@ help: use struct literal syntax instead
    |
 LL |     let f = Foo { a: val };
    |             ~~~~~~~~~~~~~~
-help: a function with a similar name exists
+help: did you mean `foo`? (a similarly named function)
    |
 LL |     let f = foo();
    |             ~~~

--- a/src/test/ui/error-codes/ex-E0612.stderr
+++ b/src/test/ui/error-codes/ex-E0612.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `1` on type `Foo`
   --> $DIR/ex-E0612.rs:5:6
    |
 LL |    y.1;
-   |      ^ help: a field with a similar name exists: `0`
+   |      ^ help: did you mean `0`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-festival.stderr
+++ b/src/test/ui/error-festival.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/error-festival.rs:14:5
    |
 LL |     y = 2;
-   |     ^ help: a local variable with a similar name exists: `x`
+   |     ^ help: did you mean `x`? (a similarly named local variable)
 
 error[E0603]: constant `FOO` is private
   --> $DIR/error-festival.rs:22:10

--- a/src/test/ui/hygiene/assoc_item_ctxt.stderr
+++ b/src/test/ui/hygiene/assoc_item_ctxt.stderr
@@ -4,7 +4,7 @@ error[E0407]: method `method` is not a member of trait `Tr`
 LL |             fn method() {}
    |             ^^^------^^^^^
    |             |  |
-   |             |  help: there is an associated function with a similar name: `method`
+   |             |  help: did you mean `method`? (a similarly named associated function)
    |             not a member of trait `Tr`
 ...
 LL |     mac_trait_impl!();

--- a/src/test/ui/hygiene/rustc-macro-transparency.stderr
+++ b/src/test/ui/hygiene/rustc-macro-transparency.stderr
@@ -17,7 +17,7 @@ help: use `!` to invoke the macro
    |
 LL |     semitransparent!;
    |                    +
-help: a unit struct with a similar name exists
+help: did you mean `SemiTransparent`? (a similarly named unit struct)
    |
 LL |     SemiTransparent;
    |     ~~~~~~~~~~~~~~~
@@ -35,7 +35,7 @@ help: use `!` to invoke the macro
    |
 LL |     opaque!;
    |           +
-help: a unit struct with a similar name exists
+help: did you mean `Opaque`? (a similarly named unit struct)
    |
 LL |     Opaque;
    |     ~~~~~~

--- a/src/test/ui/imports/glob-resolve1.stderr
+++ b/src/test/ui/imports/glob-resolve1.stderr
@@ -70,7 +70,7 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<A>();
-   |           ^ help: an enum with a similar name exists: `B`
+   |           ^ help: did you mean `B`? (a similarly named enum)
    |
 note: enum `bar::A` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:11:5
@@ -85,7 +85,7 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<C>();
-   |           ^ help: an enum with a similar name exists: `B`
+   |           ^ help: did you mean `B`? (a similarly named enum)
    |
 note: struct `bar::C` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:18:5
@@ -100,7 +100,7 @@ LL |     pub enum B {
    |     ---------- similarly named enum `B` defined here
 ...
 LL |     foo::<D>();
-   |           ^ help: an enum with a similar name exists: `B`
+   |           ^ help: did you mean `B`? (a similarly named enum)
    |
 note: type alias `bar::D` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:20:5

--- a/src/test/ui/issues/issue-17546.stderr
+++ b/src/test/ui/issues/issue-17546.stderr
@@ -13,7 +13,7 @@ help: try using the variant's enum
    |
 LL |     fn new() -> foo::MyEnum {
    |                 ~~~~~~~~~~~
-help: an enum with a similar name exists
+help: did you mean `Result`? (a similarly named enum)
    |
 LL |     fn new() -> Result<MyEnum, String> {
    |                 ~~~~~~
@@ -67,7 +67,7 @@ help: try using the variant's enum
    |
 LL | fn newer() -> foo::MyEnum {
    |               ~~~~~~~~~~~
-help: an enum with a similar name exists
+help: did you mean `Result`? (a similarly named enum)
    |
 LL | fn newer() -> Result<foo::MyEnum, String> {
    |               ~~~~~~

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -8,7 +8,7 @@ LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
    |                                                       ^^^
    |                                                       |
    |                                                       variant or associated item not found in `Delicious`
-   |                                                       help: there is a variant with a similar name: `Pie`
+   |                                                       help: did you mean `Pie`? (a similarly named variant)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -7,7 +7,7 @@ LL |     B = SomeEnum::A,
    |                   ^
    |                   |
    |                   variant or associated item not found in `SomeEnum`
-   |                   help: there is a variant with a similar name: `B`
+   |                   help: did you mean `B`? (a similarly named variant)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28344.stderr
+++ b/src/test/ui/issues/issue-28344.stderr
@@ -11,7 +11,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                         ^^^^^
    |                         |
    |                         function or associated item not found in `dyn BitXor<_>`
-   |                         help: there is an associated function with a similar name: `bitxor`
+   |                         help: did you mean `bitxor`? (a similarly named associated function)
 
 error[E0191]: the value of the associated type `Output` (from trait `BitXor`) must be specified
   --> $DIR/issue-28344.rs:8:13
@@ -26,7 +26,7 @@ LL |     let g = BitXor::bitor;
    |                     ^^^^^
    |                     |
    |                     function or associated item not found in `dyn BitXor<_>`
-   |                     help: there is an associated function with a similar name: `bitxor`
+   |                     help: did you mean `bitxor`? (a similarly named associated function)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -8,7 +8,7 @@ LL |             Foo::Baz(..) => (),
    |                  ^^^
    |                  |
    |                  variant or associated item not found in `Foo`
-   |                  help: there is a variant with a similar name: `Bar`
+   |                  help: did you mean `Bar`? (a similarly named variant)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32004.stderr
+++ b/src/test/ui/issues/issue-32004.stderr
@@ -13,7 +13,7 @@ help: use the tuple variant pattern syntax instead
    |
 LL |         Foo::Bar(_) => {}
    |         ~~~~~~~~~~~
-help: a unit variant with a similar name exists
+help: did you mean `Baz`? (a similarly named unit variant)
    |
 LL |         Foo::Baz => {}
    |              ~~~

--- a/src/test/ui/issues/issue-32086.stderr
+++ b/src/test/ui/issues/issue-32086.stderr
@@ -5,7 +5,7 @@ LL | struct S(u8);
    | ------------- similarly named tuple struct `S` defined here
 ...
 LL |     let C(a) = S(11);
-   |         ^ help: a tuple struct with a similar name exists: `S`
+   |         ^ help: did you mean `S`? (a similarly named tuple struct)
 
 error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/issue-32086.rs:6:9
@@ -14,7 +14,7 @@ LL | struct S(u8);
    | ------------- similarly named tuple struct `S` defined here
 ...
 LL |     let C(..) = S(11);
-   |         ^ help: a tuple struct with a similar name exists: `S`
+   |         ^ help: did you mean `S`? (a similarly named tuple struct)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-34209.stderr
+++ b/src/test/ui/issues/issue-34209.stderr
@@ -5,7 +5,7 @@ LL | enum S {
    | ------ variant `B` not found here
 ...
 LL |         S::B {} => {},
-   |            ^ help: there is a variant with a similar name: `A`
+   |            ^ help: did you mean `A`? (a similarly named variant)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-46332.stderr
+++ b/src/test/ui/issues/issue-46332.stderr
@@ -5,7 +5,7 @@ LL | struct TyUint {}
    | ------------- similarly named struct `TyUint` defined here
 ...
 LL |     TyUInt {};
-   |     ^^^^^^ help: a struct with a similar name exists (notice the capitalization): `TyUint`
+   |     ^^^^^^ help: did you mean `TyUint`? (a similarly named struct)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47073-zero-padded-tuple-struct-indices.stderr
+++ b/src/test/ui/issues/issue-47073-zero-padded-tuple-struct-indices.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `00` on type `Verdict`
   --> $DIR/issue-47073-zero-padded-tuple-struct-indices.rs:8:30
    |
 LL |     let _condemned = justice.00;
-   |                              ^^ help: a field with a similar name exists: `0`
+   |                              ^^ help: did you mean `0`? (a similarly named field)
 
 error[E0609]: no field `001` on type `Verdict`
   --> $DIR/issue-47073-zero-padded-tuple-struct-indices.rs:10:31

--- a/src/test/ui/issues/issue-50480.stderr
+++ b/src/test/ui/issues/issue-50480.stderr
@@ -36,7 +36,7 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |            |
    |            similarly named type parameter `T` defined here
    |
-help: a type parameter with a similar name exists
+help: did you mean `T`? (a similarly named type parameter)
    |
 LL | struct Bar<T>(T, T, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                  ~

--- a/src/test/ui/issues/issue-52717.stderr
+++ b/src/test/ui/issues/issue-52717.stderr
@@ -5,7 +5,7 @@ LL |     A::A { fob } => { println!("{}", fob); }
    |            ^^^
    |            |
    |            variant `A::A` does not have this field
-   |            help: a field with a similar name exists: `foo`
+   |            help: did you mean `foo`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7607-1.stderr
+++ b/src/test/ui/issues/issue-7607-1.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `Fo` in this scope
   --> $DIR/issue-7607-1.rs:5:6
    |
 LL | impl Fo {
-   |      ^^ help: a trait with a similar name exists: `Fn`
+   |      ^^ help: did you mean `Fn`? (a similarly named trait)
    |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -43,7 +43,7 @@ LL |         break LOOP;
    |               ^^^^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'LOOP`
+   |               help: did you mean `'LOOP`? (a similarly named label)
 
 error[E0425]: cannot find value `while_loop` in this scope
   --> $DIR/label_misspelled.rs:32:15
@@ -54,7 +54,7 @@ LL |         break while_loop;
    |               ^^^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'while_loop`
+   |               help: did you mean `'while_loop`? (a similarly named label)
 
 error[E0425]: cannot find value `while_let` in this scope
   --> $DIR/label_misspelled.rs:36:15
@@ -65,7 +65,7 @@ LL |         break while_let;
    |               ^^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'while_let`
+   |               help: did you mean `'while_let`? (a similarly named label)
 
 error[E0425]: cannot find value `for_loop` in this scope
   --> $DIR/label_misspelled.rs:40:15
@@ -76,7 +76,7 @@ LL |         break for_loop;
    |               ^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'for_loop`
+   |               help: did you mean `'for_loop`? (a similarly named label)
 
 warning: unused label
   --> $DIR/label_misspelled.rs:4:5

--- a/src/test/ui/label/label_misspelled_2.stderr
+++ b/src/test/ui/label/label_misspelled_2.stderr
@@ -19,7 +19,7 @@ LL |         break b;
    |               ^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'b`
+   |               help: did you mean `'b`? (a similarly named label)
 
 error[E0425]: cannot find value `d` in this scope
   --> $DIR/label_misspelled_2.rs:14:15
@@ -30,7 +30,7 @@ LL |         break d;
    |               ^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'d`
+   |               help: did you mean `'d`? (a similarly named label)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -7,7 +7,7 @@ LL |         break LOOP;
    |               ^^^^
    |               |
    |               not found in this scope
-   |               help: use the similarly named label: `'LOOP`
+   |               help: did you mean `'LOOP`? (a similarly named label)
 
 warning: denote infinite loops with `loop { ... }`
   --> $DIR/loop-break-value.rs:26:5

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -46,7 +46,7 @@ error[E0412]: cannot find type `i` in this scope
   --> $DIR/macro-context.rs:3:13
    |
 LL |     () => ( i ; typeof );
-   |             ^ help: a builtin type with a similar name exists: `i8`
+   |             ^ help: did you mean `i8`? (a similarly named builtin type)
 ...
 LL |     let a: m!();
    |            ---- in this macro invocation
@@ -57,7 +57,7 @@ error[E0425]: cannot find value `i` in this scope
   --> $DIR/macro-context.rs:3:13
    |
 LL |     () => ( i ; typeof );
-   |             ^ help: a local variable with a similar name exists: `a`
+   |             ^ help: did you mean `a`? (a similarly named local variable)
 ...
 LL |     let i = m!();
    |             ---- in this macro invocation

--- a/src/test/ui/macros/macro-name-typo.stderr
+++ b/src/test/ui/macros/macro-name-typo.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `printlx` in this scope
   --> $DIR/macro-name-typo.rs:2:5
    |
 LL |     printlx!("oh noes!");
-   |     ^^^^^^^ help: a macro with a similar name exists: `println`
+   |     ^^^^^^^ help: did you mean `println`? (a similarly named macro)
    |
   ::: $SRC_DIR/std/src/macros.rs:LL:COL
    |

--- a/src/test/ui/macros/macro-path-prelude-fail-3.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-3.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `inline` in this scope
   --> $DIR/macro-path-prelude-fail-3.rs:2:5
    |
 LL |     inline!();
-   |     ^^^^^^ help: a macro with a similar name exists: `line`
+   |     ^^^^^^ help: did you mean `line`? (a similarly named macro)
    |
   ::: $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -10,7 +10,7 @@ error: cannot find attribute `macro_reexport` in this scope
   --> $DIR/macro-reexport-removed.rs:5:3
    |
 LL | #[macro_reexport(macro_one)]
-   |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`
+   |   ^^^^^^^^^^^^^^ help: did you mean `macro_export`? (a similarly named built-in attribute)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-use-wrong-name.stderr
+++ b/src/test/ui/macros/macro-use-wrong-name.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `macro_two` in this scope
   --> $DIR/macro-use-wrong-name.rs:7:5
    |
 LL |     macro_two!();
-   |     ^^^^^^^^^ help: a macro with a similar name exists: `macro_one`
+   |     ^^^^^^^^^ help: did you mean `macro_one`? (a similarly named macro)
    |
   ::: $DIR/auxiliary/two_macros.rs:2:1
    |

--- a/src/test/ui/macros/macro_undefined.stderr
+++ b/src/test/ui/macros/macro_undefined.stderr
@@ -5,7 +5,7 @@ LL |     macro_rules! kl {
    |     --------------- similarly named macro `kl` defined here
 ...
 LL |     k!();
-   |     ^ help: a macro with a similar name exists: `kl`
+   |     ^ help: did you mean `kl`? (a similarly named macro)
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -7,7 +7,7 @@ LL |
 LL | impl X<N> {}
    |        ^
    |
-help: a struct with a similar name exists
+help: did you mean `X`? (a similarly named struct)
    |
 LL | impl X<X> {}
    |        ~
@@ -24,7 +24,7 @@ LL | impl<T, const A: u8 = 2> X<N> {}
    |      |
    |      similarly named type parameter `T` defined here
    |
-help: a type parameter with a similar name exists
+help: did you mean `T`? (a similarly named type parameter)
    |
 LL | impl<T, const A: u8 = 2> X<T> {}
    |                            ~
@@ -42,7 +42,7 @@ LL | struct X<const N: u8>();
 LL | fn foo(_: T) where T: Send {}
    |                    ^
    |
-help: a struct with a similar name exists
+help: did you mean `X`? (a similarly named struct)
    |
 LL | fn foo(_: T) where X: Send {}
    |                    ~
@@ -60,7 +60,7 @@ LL | struct X<const N: u8>();
 LL | fn foo(_: T) where T: Send {}
    |           ^
    |
-help: a struct with a similar name exists
+help: did you mean `X`? (a similarly named struct)
    |
 LL | fn foo(_: X) where T: Send {}
    |           ~
@@ -78,7 +78,7 @@ LL | struct X<const N: u8>();
 LL | fn bar<const N: u8>(_: A) {}
    |                        ^
    |
-help: a struct with a similar name exists
+help: did you mean `X`? (a similarly named struct)
    |
 LL | fn bar<const N: u8>(_: X) {}
    |                        ~

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -8,7 +8,7 @@ LL |     check(m1::S);
    |           ^^^^^
    |
    = note: can't use a type alias as a constructor
-help: a tuple struct with a similar name exists
+help: did you mean `TS`? (a similarly named tuple struct)
    |
 LL |     check(m1::TS);
    |               ~~
@@ -31,7 +31,7 @@ LL |     pub struct TS();
    |     ---------------- similarly named tuple struct `TS` defined here
    |
    = note: can't use a type alias as a constructor
-help: a tuple struct with a similar name exists
+help: did you mean `TS`? (a similarly named tuple struct)
    |
 LL |     check(xm1::TS);
    |                ~~
@@ -57,7 +57,7 @@ help: use struct literal syntax instead
    |
 LL |     check(m7::V {});
    |           ~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `TV`? (a similarly named tuple variant)
    |
 LL |     check(m7::TV);
    |               ~~
@@ -85,7 +85,7 @@ help: use struct literal syntax instead
    |
 LL |     check(xm7::V { /* fields */ });
    |           ~~~~~~~~~~~~~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `TV`? (a similarly named tuple variant)
    |
 LL |     check(xm7::TV);
    |                ~~

--- a/src/test/ui/parser/emoji-identifiers.stderr
+++ b/src/test/ui/parser/emoji-identifiers.stderr
@@ -16,7 +16,7 @@ LL | fn i_like_to_😅_a_lot() -> 👀 {
    | ----------------------------- similarly named function `i_like_to_😅_a_lot` defined here
 ...
 LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
-   |             ^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `i_like_to_😅_a_lot`
+   |             ^^^^^^^^^^^^^^^^^^ help: did you mean `i_like_to_😅_a_lot`? (a similarly named function)
 
 error: identifiers cannot contain emoji: `ABig👩👩👧👧Family`
   --> $DIR/emoji-identifiers.rs:1:8
@@ -75,7 +75,7 @@ LL |     👀::full_of✨()
    |         ^^^^^^^^^
    |         |
    |         function or associated item not found in `👀`
-   |         help: there is an associated function with a similar name: `full_of_✨`
+   |         help: did you mean `full_of_✨`? (a similarly named associated function)
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/parser/issues/issue-62895.stderr
+++ b/src/test/ui/parser/issues/issue-62895.stderr
@@ -31,7 +31,7 @@ error[E0412]: cannot find type `isizee` in this scope
   --> $DIR/issue-62895.rs:5:15
    |
 LL | pub fn g() -> isizee {
-   |               ^^^^^^ help: a builtin type with a similar name exists: `isize`
+   |               ^^^^^^ help: did you mean `isize`? (a similarly named builtin type)
 
 error[E0308]: mismatched types
   --> $DIR/issue-62895.rs:3:11

--- a/src/test/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/src/test/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -24,7 +24,7 @@ help: use this syntax instead
    |
 LL |         Z0 => {}
    |         ~~
-help: a tuple struct with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple struct)
    |
 LL |         Z1() => {}
    |         ~~
@@ -46,7 +46,7 @@ help: use this syntax instead
    |
 LL |         Z0 => {}
    |         ~~
-help: a tuple struct with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple struct)
    |
 LL |         Z1(x) => {}
    |         ~~
@@ -68,7 +68,7 @@ help: use this syntax instead
    |
 LL |         E1::Z0 => {}
    |         ~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple variant)
    |
 LL |         E1::Z1() => {}
    |             ~~
@@ -90,7 +90,7 @@ help: use this syntax instead
    |
 LL |         E1::Z0 => {}
    |         ~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple variant)
    |
 LL |         E1::Z1(x) => {}
    |             ~~
@@ -112,7 +112,7 @@ help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1(/* fields */) => {}
    |         ~~~~~~~~~~~~~~~~~~~~
-help: a unit variant with a similar name exists
+help: did you mean `Z0`? (a similarly named unit variant)
    |
 LL |         E1::Z0 => {}
    |             ~~

--- a/src/test/ui/pattern/pat-tuple-overfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-overfield.stderr
@@ -22,7 +22,7 @@ help: use this syntax instead
    |
 LL |         Z0 => {}
    |         ~~
-help: a tuple struct with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple struct)
    |
 LL |         Z1() => {}
    |         ~~
@@ -42,7 +42,7 @@ help: use this syntax instead
    |
 LL |         Z0 => {}
    |         ~~
-help: a tuple struct with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple struct)
    |
 LL |         Z1(_) => {}
    |         ~~
@@ -62,7 +62,7 @@ help: use this syntax instead
    |
 LL |         Z0 => {}
    |         ~~
-help: a tuple struct with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple struct)
    |
 LL |         Z1(_, _) => {}
    |         ~~
@@ -82,7 +82,7 @@ help: use this syntax instead
    |
 LL |         E1::Z0 => {}
    |         ~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple variant)
    |
 LL |         E1::Z1() => {}
    |             ~~
@@ -102,7 +102,7 @@ help: use this syntax instead
    |
 LL |         E1::Z0 => {}
    |         ~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple variant)
    |
 LL |         E1::Z1(_) => {}
    |             ~~
@@ -122,7 +122,7 @@ help: use this syntax instead
    |
 LL |         E1::Z0 => {}
    |         ~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `Z1`? (a similarly named tuple variant)
    |
 LL |         E1::Z1(_, _) => {}
    |             ~~
@@ -142,7 +142,7 @@ help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}
    |         ~~~~~~~~
-help: a unit variant with a similar name exists
+help: did you mean `Z0`? (a similarly named unit variant)
    |
 LL |         E1::Z0 => {}
    |             ~~

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -20,7 +20,7 @@ help: use this syntax instead
    |
 LL |         A::D => (),
    |         ~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `B`? (a similarly named tuple variant)
    |
 LL |         A::B(_) => (),
    |            ~

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -7,7 +7,7 @@ LL |     pub struct Baz;
 LL |     Bar();
    |     ^^^
    |
-help: a unit struct with a similar name exists
+help: did you mean `Baz`? (a similarly named unit struct)
    |
 LL |     Baz();
    |     ~~~
@@ -25,7 +25,7 @@ LL |     pub struct Baz;
 LL |     Bar();
    |     ^^^
    |
-help: a unit struct with a similar name exists
+help: did you mean `Baz`? (a similarly named unit struct)
    |
 LL |     Baz();
    |     ~~~
@@ -43,7 +43,7 @@ LL |     pub struct Baz;
 LL |     let _x: Box<Bar>;
    |                 ^^^
    |
-help: a struct with a similar name exists
+help: did you mean `Baz`? (a similarly named struct)
    |
 LL |     let _x: Box<Baz>;
    |                 ~~~

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -18,7 +18,7 @@ LL |     pub struct Baz;
 LL |     Bar();
    |     ^^^
    |
-help: a unit struct with a similar name exists
+help: did you mean `Baz`? (a similarly named unit struct)
    |
 LL |     Baz();
    |     ~~~

--- a/src/test/ui/proc-macro/lints_in_proc_macros.rs
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.rs
@@ -8,7 +8,7 @@ fn main() {
     let foobar = 42;
     bang_proc_macro2!();
     //~^ ERROR cannot find value `foobar2` in this scope
-    //~| HELP a local variable with a similar name exists
+    //~| HELP did you mean `foobar`?
     //~| SUGGESTION foobar
     println!("{}", x);
 }

--- a/src/test/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `foobar2` in this scope
   --> $DIR/lints_in_proc_macros.rs:9:5
    |
 LL |     bang_proc_macro2!();
-   |     ^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `foobar`
+   |     ^^^^^^^^^^^^^^^^^^^ help: did you mean `foobar`? (a similarly named local variable)
    |
    = note: this error originates in the macro `bang_proc_macro2` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -140,7 +140,7 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean `Ok`? (a similarly named tuple variant)
 ...
 LL |     one!("hello", "world");
    |     ---------------------- in this macro invocation
@@ -156,7 +156,7 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean `Ok`? (a similarly named tuple variant)
 ...
 LL |     two!("yay", "rust");
    |     ------------------- in this macro invocation
@@ -172,7 +172,7 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean `Ok`? (a similarly named tuple variant)
 ...
 LL |     three!("hip", "hop");
    |     -------------------- in this macro invocation

--- a/src/test/ui/proc-macro/proc-macro-attributes.stderr
+++ b/src/test/ui/proc-macro/proc-macro-attributes.stderr
@@ -2,7 +2,12 @@ error: cannot find attribute `C` in this scope
   --> $DIR/proc-macro-attributes.rs:9:3
    |
 LL | #[C]
-   |   ^ help: a derive helper attribute with a similar name exists: `B`
+   |   ^
+   |
+help: did you mean `B`? (a similarly named derive helper attribute)
+   |
+LL | #[B]
+   |   ~
 
 error[E0659]: `B` is ambiguous
   --> $DIR/proc-macro-attributes.rs:6:3

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `bang_proc_macrp` in this scope
   --> $DIR/resolve-error.rs:60:5
    |
 LL |     bang_proc_macrp!();
-   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `bang_proc_macro`
+   |     ^^^^^^^^^^^^^^^ help: did you mean `bang_proc_macro`? (a similarly named macro)
    |
   ::: $DIR/auxiliary/test-macros.rs:15:1
    |
@@ -22,7 +22,7 @@ LL | macro_rules! attr_proc_mac {
    | -------------------------- similarly named macro `attr_proc_mac` defined here
 ...
 LL |     attr_proc_macra!();
-   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `attr_proc_mac`
+   |     ^^^^^^^^^^^^^^^ help: did you mean `attr_proc_mac`? (a similarly named macro)
 
 error: cannot find macro `FooWithLongNama` in this scope
   --> $DIR/resolve-error.rs:51:5
@@ -31,7 +31,7 @@ LL | macro_rules! FooWithLongNam {
    | --------------------------- similarly named macro `FooWithLongNam` defined here
 ...
 LL |     FooWithLongNama!();
-   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `FooWithLongNam`
+   |     ^^^^^^^^^^^^^^^ help: did you mean `FooWithLongNam`? (a similarly named macro)
 
 error: cannot find derive macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:45:10
@@ -49,7 +49,7 @@ error: cannot find derive macro `Dlona` in this scope
   --> $DIR/resolve-error.rs:40:10
    |
 LL | #[derive(Dlona)]
-   |          ^^^^^ help: a derive macro with a similar name exists: `Clona`
+   |          ^^^^^ help: did you mean `Clona`? (a similarly named derive macro)
    |
   ::: $DIR/auxiliary/derive-clona.rs:11:1
    |
@@ -60,7 +60,7 @@ error: cannot find derive macro `Dlona` in this scope
   --> $DIR/resolve-error.rs:40:10
    |
 LL | #[derive(Dlona)]
-   |          ^^^^^ help: a derive macro with a similar name exists: `Clona`
+   |          ^^^^^ help: did you mean `Clona`? (a similarly named derive macro)
    |
   ::: $DIR/auxiliary/derive-clona.rs:11:1
    |
@@ -71,7 +71,7 @@ error: cannot find derive macro `Dlone` in this scope
   --> $DIR/resolve-error.rs:35:10
    |
 LL | #[derive(Dlone)]
-   |          ^^^^^ help: a derive macro with a similar name exists: `Clone`
+   |          ^^^^^ help: did you mean `Clone`? (a similarly named derive macro)
    |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -82,7 +82,7 @@ error: cannot find derive macro `Dlone` in this scope
   --> $DIR/resolve-error.rs:35:10
    |
 LL | #[derive(Dlone)]
-   |          ^^^^^ help: a derive macro with a similar name exists: `Clone`
+   |          ^^^^^ help: did you mean `Clone`? (a similarly named derive macro)
    |
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -99,7 +99,7 @@ error: cannot find attribute `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:28:3
    |
 LL | #[attr_proc_macra]
-   |   ^^^^^^^^^^^^^^^ help: an attribute macro with a similar name exists: `attr_proc_macro`
+   |   ^^^^^^^^^^^^^^^ help: did you mean `attr_proc_macro`? (a similarly named attribute macro)
    |
   ::: $DIR/auxiliary/test-macros.rs:20:1
    |
@@ -110,7 +110,7 @@ error: cannot find derive macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:22:10
    |
 LL | #[derive(FooWithLongNan)]
-   |          ^^^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FooWithLongName`
+   |          ^^^^^^^^^^^^^^ help: did you mean `FooWithLongName`? (a similarly named derive macro)
    |
   ::: $DIR/auxiliary/derive-foo.rs:11:1
    |
@@ -121,7 +121,7 @@ error: cannot find derive macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:22:10
    |
 LL | #[derive(FooWithLongNan)]
-   |          ^^^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FooWithLongName`
+   |          ^^^^^^^^^^^^^^ help: did you mean `FooWithLongName`? (a similarly named derive macro)
    |
   ::: $DIR/auxiliary/derive-foo.rs:11:1
    |

--- a/src/test/ui/resolve/issue-10200.stderr
+++ b/src/test/ui/resolve/issue-10200.stderr
@@ -5,7 +5,7 @@ LL | struct Foo(bool);
    | ----------------- similarly named tuple struct `Foo` defined here
 ...
 LL |         foo(x)
-   |         ^^^ help: a tuple struct with a similar name exists (notice the capitalization): `Foo`
+   |         ^^^ help: did you mean `Foo`? (a similarly named tuple struct)
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-39226.stderr
+++ b/src/test/ui/resolve/issue-39226.stderr
@@ -11,7 +11,7 @@ help: use struct literal syntax instead
    |
 LL |         handle: Handle {}
    |                 ~~~~~~~~~
-help: a local variable with a similar name exists
+help: did you mean `handle`? (a similarly named local variable)
    |
 LL |         handle: handle
    |                 ~~~~~~

--- a/src/test/ui/resolve/issue-49074.stderr
+++ b/src/test/ui/resolve/issue-49074.stderr
@@ -10,7 +10,7 @@ error: cannot find attribute `marco_use` in this scope
   --> $DIR/issue-49074.rs:3:3
    |
 LL | #[marco_use] // typo
-   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_use`
+   |   ^^^^^^^^^ help: did you mean `macro_use`? (a similarly named built-in attribute)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/issue-5035.stderr
+++ b/src/test/ui/resolve/issue-5035.stderr
@@ -17,7 +17,7 @@ help: you might have meant to use `#![feature(trait_alias)]` instead of a `type`
    |
 LL | trait K = dyn I;
    |
-help: a trait with a similar name exists
+help: did you mean `I`? (a similarly named trait)
    |
 LL | impl I for isize {}
    |      ~

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `esize` in this scope
   --> $DIR/levenshtein.rs:5:11
    |
 LL | fn foo(c: esize) {} // Misspelled primitive type name.
-   |           ^^^^^ help: a builtin type with a similar name exists: `isize`
+   |           ^^^^^ help: did you mean `isize`? (a similarly named builtin type)
 
 error[E0412]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10
@@ -11,13 +11,13 @@ LL | enum Bar { }
    | -------- similarly named enum `Bar` defined here
 LL | 
 LL | type A = Baz; // Misspelled type name.
-   |          ^^^ help: an enum with a similar name exists: `Bar`
+   |          ^^^ help: did you mean `Bar`? (a similarly named enum)
 
 error[E0412]: cannot find type `Opiton` in this scope
   --> $DIR/levenshtein.rs:12:10
    |
 LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
-   |          ^^^^^^ help: an enum with a similar name exists: `Option`
+   |          ^^^^^^ help: did you mean `Option`? (a similarly named enum)
    |
   ::: $SRC_DIR/core/src/option.rs:LL:COL
    |
@@ -37,7 +37,7 @@ LL | const MAX_ITEM: usize = 10;
    | --------------------------- similarly named constant `MAX_ITEM` defined here
 ...
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
-   |                    ^^^^^^^ help: a constant with a similar name exists: `MAX_ITEM`
+   |                    ^^^^^^^ help: did you mean `MAX_ITEM`? (a similarly named constant)
 
 error[E0425]: cannot find function `foobar` in this scope
   --> $DIR/levenshtein.rs:26:5
@@ -46,7 +46,7 @@ LL | fn foo_bar() {}
    | ------------ similarly named function `foo_bar` defined here
 ...
 LL |     foobar(); // Misspelled function name.
-   |     ^^^^^^ help: a function with a similar name exists: `foo_bar`
+   |     ^^^^^^ help: did you mean `foo_bar`? (a similarly named function)
 
 error[E0412]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
@@ -55,7 +55,7 @@ LL |     pub struct First;
    |     ----------------- similarly named struct `First` defined here
 ...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |               ^^^^^ help: a struct with a similar name exists (notice the capitalization): `First`
+   |               ^^^^^ help: did you mean `First`? (a similarly named struct)
 
 error[E0425]: cannot find value `second` in module `m`
   --> $DIR/levenshtein.rs:28:26
@@ -64,7 +64,7 @@ LL |     pub struct Second;
    |     ------------------ similarly named unit struct `Second` defined here
 ...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |                          ^^^^^^ help: a unit struct with a similar name exists (notice the capitalization): `Second`
+   |                          ^^^^^^ help: did you mean `Second`? (a similarly named unit struct)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -95,7 +95,7 @@ LL |     let _: E = (E::Fn(/* fields */));
    |                ~~~~~~~~~~~~~~~~~~~~~
 LL |     let _: E = (E::Struct { /* fields */ });
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: a function with a similar name exists
+help: did you mean `f`? (a similarly named function)
    |
 LL |     let _: E = m::f;
    |                   ~
@@ -169,7 +169,7 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z;
-   |            ^ help: an enum with a similar name exists: `E`
+   |            ^ help: did you mean `E`? (a similarly named enum)
    |
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -212,7 +212,7 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Fn;
-   |            ^ help: an enum with a similar name exists: `E`
+   |            ^ help: did you mean `E`? (a similarly named enum)
    |
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -227,7 +227,7 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Struct;
-   |            ^ help: an enum with a similar name exists: `E`
+   |            ^ help: did you mean `E`? (a similarly named enum)
    |
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:11:9
@@ -253,7 +253,7 @@ LL |     pub enum E {
    |     ---------- similarly named enum `E` defined here
 ...
 LL |     let _: Z = m::n::Z::Unit {};
-   |            ^ help: an enum with a similar name exists: `E`
+   |            ^ help: did you mean `E`? (a similarly named enum)
    |
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:11:9

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -8,7 +8,7 @@ LL |         Z;
    |         ^
    |         |
    |         constructor is not visible here due to private fields
-   |         help: a tuple struct with a similar name exists: `S`
+   |         help: did you mean `S`? (a similarly named tuple struct)
 
 error[E0423]: expected value, found struct `S`
   --> $DIR/privacy-struct-ctor.rs:33:5

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -35,7 +35,7 @@ help: use the path separator to refer to an item
    |
 LL |     a::b::J
    |
-help: a constant with a similar name exists
+help: did you mean `I`? (a similarly named constant)
    |
 LL |     a::I.J
    |        ~
@@ -57,7 +57,7 @@ LL |     pub const I: i32 = 1;
 LL |     v.push(a::b);
    |            ^^^-
    |               |
-   |               help: a constant with a similar name exists: `I`
+   |               help: did you mean `I`? (a similarly named constant)
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:45:5
@@ -72,7 +72,7 @@ help: use the path separator to refer to an item
    |
 LL |     a::b::f()
    |     ~~~~~~~
-help: a constant with a similar name exists
+help: did you mean `I`? (a similarly named constant)
    |
 LL |     a::I.f()
    |        ~
@@ -86,7 +86,7 @@ LL |     pub const I: i32 = 1;
 LL |     a::b
    |     ^^^-
    |        |
-   |        help: a constant with a similar name exists: `I`
+   |        help: did you mean `I`? (a similarly named constant)
 
 error[E0423]: expected function, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:55:5
@@ -97,7 +97,7 @@ LL |     pub const I: i32 = 1;
 LL |     a::b()
    |     ^^^-
    |        |
-   |        help: a constant with a similar name exists: `I`
+   |        help: did you mean `I`? (a similarly named constant)
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/resolve/tuple-struct-alias.stderr
+++ b/src/test/ui/resolve/tuple-struct-alias.stderr
@@ -5,7 +5,7 @@ LL | struct S(u8, u16);
    | ------------------ similarly named tuple struct `S` defined here
 ...
 LL |     let s = A(0, 1);
-   |             ^ help: a tuple struct with a similar name exists: `S`
+   |             ^ help: did you mean `S`? (a similarly named tuple struct)
    |
    = note: can't use a type alias as a constructor
 
@@ -16,7 +16,7 @@ LL | struct S(u8, u16);
    | ------------------ similarly named tuple struct `S` defined here
 ...
 LL |         A(..) => {}
-   |         ^ help: a tuple struct with a similar name exists: `S`
+   |         ^ help: did you mean `S`? (a similarly named tuple struct)
    |
    = note: can't use a type alias as a constructor
 

--- a/src/test/ui/rmeta/rmeta_meta_main.stderr
+++ b/src/test/ui/rmeta/rmeta_meta_main.stderr
@@ -2,7 +2,7 @@ error[E0560]: struct `Foo` has no field named `field2`
   --> $DIR/rmeta_meta_main.rs:13:19
    |
 LL |     let _ = Foo { field2: 42 };
-   |                   ^^^^^^ help: a field with a similar name exists: `field`
+   |                   ^^^^^^ help: did you mean `field`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/type-binding.stderr
+++ b/src/test/ui/span/type-binding.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Trget` not found for `Deref`
   --> $DIR/type-binding.rs:6:20
    |
 LL | fn homura<T: Deref<Trget = i32>>(_: T) {}
-   |                    ^^^^^ help: there is an associated type with a similar name: `Target`
+   |                    ^^^^^ help: did you mean `Target`? (a similarly named associated type)
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/typo-suggestion.stderr
+++ b/src/test/ui/span/typo-suggestion.stderr
@@ -8,7 +8,7 @@ error[E0425]: cannot find value `fob` in this scope
   --> $DIR/typo-suggestion.rs:8:26
    |
 LL |     println!("Hello {}", fob);
-   |                          ^^^ help: a local variable with a similar name exists: `foo`
+   |                          ^^^ help: did you mean `foo`? (a similarly named local variable)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/structs/struct-fields-hints-no-dupe.stderr
+++ b/src/test/ui/structs/struct-fields-hints-no-dupe.stderr
@@ -2,7 +2,7 @@ error[E0560]: struct `A` has no field named `bar`
   --> $DIR/struct-fields-hints-no-dupe.rs:10:9
    |
 LL |         bar : 42,
-   |         ^^^ help: a field with a similar name exists: `barr`
+   |         ^^^ help: did you mean `barr`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-fields-hints.stderr
+++ b/src/test/ui/structs/struct-fields-hints.stderr
@@ -2,7 +2,7 @@ error[E0560]: struct `A` has no field named `bar`
   --> $DIR/struct-fields-hints.rs:10:9
    |
 LL |         bar : 42,
-   |         ^^^ help: a field with a similar name exists: `car`
+   |         ^^^ help: did you mean `car`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-fields-shorthand-unresolved.stderr
+++ b/src/test/ui/structs/struct-fields-shorthand-unresolved.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/struct-fields-shorthand-unresolved.rs:10:9
    |
 LL |         y
-   |         ^ help: a local variable with a similar name exists: `x`
+   |         ^ help: did you mean `x`? (a similarly named local variable)
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-fields-typo.rs
+++ b/src/test/ui/structs/struct-fields-typo.rs
@@ -9,7 +9,7 @@ fn main() {
         bar: 0.5,
     };
     let x = foo.baa; //~ ERROR no field `baa` on type `BuildData`
-                     //~| HELP a field with a similar name exists
+                     //~| HELP did you mean `bar`?
                      //~| SUGGESTION bar
     println!("{}", x);
 }

--- a/src/test/ui/structs/struct-fields-typo.stderr
+++ b/src/test/ui/structs/struct-fields-typo.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `baa` on type `BuildData`
   --> $DIR/struct-fields-typo.rs:11:17
    |
 LL |     let x = foo.baa;
-   |                 ^^^ help: a field with a similar name exists: `bar`
+   |                 ^^^ help: did you mean `bar`? (a similarly named field)
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-pat-derived-error.stderr
+++ b/src/test/ui/structs/struct-pat-derived-error.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `d` on type `&A`
   --> $DIR/struct-pat-derived-error.rs:8:31
    |
 LL |         let A { x, y } = self.d;
-   |                               ^ help: a field with a similar name exists: `b`
+   |                               ^ help: did you mean `b`? (a similarly named field)
 
 error[E0026]: struct `A` does not have fields named `x`, `y`
   --> $DIR/struct-pat-derived-error.rs:8:17

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -8,13 +8,13 @@ error: cannot find attribute `rustc_err` in this scope
   --> $DIR/attribute-typos.rs:7:3
    |
 LL | #[rustc_err]
-   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `rustc_error`
+   |   ^^^^^^^^^ help: did you mean `rustc_error`? (a similarly named built-in attribute)
 
 error: cannot find attribute `tests` in this scope
   --> $DIR/attribute-typos.rs:4:3
    |
 LL | #[tests]
-   |   ^^^^^ help: an attribute macro with a similar name exists: `test`
+   |   ^^^^^ help: did you mean `test`? (a similarly named attribute macro)
    |
   ::: $SRC_DIR/core/src/macros/mod.rs:LL:COL
    |
@@ -25,7 +25,7 @@ error: cannot find attribute `deprcated` in this scope
   --> $DIR/attribute-typos.rs:1:3
    |
 LL | #[deprcated]
-   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `deprecated`
+   |   ^^^^^^^^^ help: did you mean `deprecated`? (a similarly named built-in attribute)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
+++ b/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
@@ -2,7 +2,7 @@ error[E0573]: expected type, found module `result`
   --> $DIR/do-not-attempt-to-add-suggestions-with-no-changes.rs:2:6
    |
 LL | impl result {
-   |      ^^^^^^ help: an enum with a similar name exists: `Result`
+   |      ^^^^^^ help: did you mean `Result`? (a similarly named enum)
    |
   ::: $SRC_DIR/core/src/result.rs:LL:COL
    |

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -13,7 +13,7 @@ help: use struct literal syntax instead
    |
 LL |     let _: E = E::B { a: val };
    |                ~~~~~~~~~~~~~~~
-help: a tuple variant with a similar name exists
+help: did you mean `A`? (a similarly named tuple variant)
    |
 LL |     let _: E = E::A;
    |                   ~

--- a/src/test/ui/suggestions/issue-66968-suggest-sorted-words.stderr
+++ b/src/test/ui/suggestions/issue-66968-suggest-sorted-words.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `a_variable_longer_name` in this scope
   --> $DIR/issue-66968-suggest-sorted-words.rs:3:20
    |
 LL |     println!("{}", a_variable_longer_name);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `a_longer_variable_name`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ help: did you mean `a_longer_variable_name`? (a similarly named local variable)
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/suggest-labels.stderr
+++ b/src/test/ui/suggestions/suggest-labels.stderr
@@ -7,7 +7,7 @@ LL |         break 'fo;
    |               ^^^
    |               |
    |               undeclared label `'fo`
-   |               help: try using similarly named label: `'foo`
+   |               help: did you mean `'foo`? (a similarly named label)
 
 error[E0426]: use of undeclared label `'bor`
   --> $DIR/suggest-labels.rs:8:18
@@ -18,7 +18,7 @@ LL |         continue 'bor;
    |                  ^^^^
    |                  |
    |                  undeclared label `'bor`
-   |                  help: try using similarly named label: `'bar`
+   |                  help: did you mean `'bar`? (a similarly named label)
 
 error[E0426]: use of undeclared label `'longlable`
   --> $DIR/suggest-labels.rs:13:19
@@ -29,7 +29,7 @@ LL |             break 'longlable;
    |                   ^^^^^^^^^^
    |                   |
    |                   undeclared label `'longlable`
-   |                   help: try using similarly named label: `'longlabel1`
+   |                   help: did you mean `'longlabel1`? (a similarly named label)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -5,19 +5,19 @@ LL | struct Foo;
    | ----------- method `bat` not found for this
 ...
 LL |     f.bat(1.0);
-   |       ^^^ help: there is an associated function with a similar name: `bar`
+   |       ^^^ help: did you mean `bar`? (a similarly named associated function)
 
 error[E0599]: no method named `is_emtpy` found for struct `String` in the current scope
   --> $DIR/suggest-methods.rs:21:15
    |
 LL |     let _ = s.is_emtpy();
-   |               ^^^^^^^^ help: there is an associated function with a similar name: `is_empty`
+   |               ^^^^^^^^ help: did you mean `is_empty`? (a similarly named associated function)
 
 error[E0599]: no method named `count_eos` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:25:19
    |
 LL |     let _ = 63u32.count_eos();
-   |                   ^^^^^^^^^ help: there is an associated function with a similar name: `count_zeros`
+   |                   ^^^^^^^^^ help: did you mean `count_zeros`? (a similarly named associated function)
 
 error[E0599]: no method named `count_o` found for type `u32` in the current scope
   --> $DIR/suggest-methods.rs:28:19

--- a/src/test/ui/suggestions/suggest-private-fields.stderr
+++ b/src/test/ui/suggestions/suggest-private-fields.stderr
@@ -2,7 +2,7 @@ error[E0560]: struct `B` has no field named `aa`
   --> $DIR/suggest-private-fields.rs:15:9
    |
 LL |         aa: 20,
-   |         ^^ help: a field with a similar name exists: `a`
+   |         ^^ help: did you mean `a`? (a similarly named field)
 
 error[E0560]: struct `B` has no field named `bb`
   --> $DIR/suggest-private-fields.rs:17:9
@@ -16,13 +16,13 @@ error[E0560]: struct `A` has no field named `aa`
   --> $DIR/suggest-private-fields.rs:22:9
    |
 LL |         aa: 20,
-   |         ^^ help: a field with a similar name exists: `a`
+   |         ^^ help: did you mean `a`? (a similarly named field)
 
 error[E0560]: struct `A` has no field named `bb`
   --> $DIR/suggest-private-fields.rs:24:9
    |
 LL |         bb: 20,
-   |         ^^ help: a field with a similar name exists: `b`
+   |         ^^ help: did you mean `b`? (a similarly named field)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/suggest-trait-items.rs
+++ b/src/test/ui/suggestions/suggest-trait-items.rs
@@ -12,19 +12,19 @@ impl Foo for A {
 //~^ ERROR not all trait items implemented
     type Typ = ();
     //~^ ERROR type `Typ` is not a member of trait
-    //~| HELP there is an associated type with a similar name
+    //~| HELP did you mean `Type`?
 
     fn fooo() {}
     //~^ ERROR method `fooo` is not a member of trait
-    //~| HELP there is an associated function with a similar name
+    //~| HELP did you mean `foo`?
 
     fn barr() {}
     //~^ ERROR method `barr` is not a member of trait
-    //~| HELP there is an associated function with a similar name
+    //~| HELP did you mean `bar`?
 
     fn quux() {}
     //~^ ERROR method `quux` is not a member of trait
-    //~| HELP there is an associated function with a similar name
+    //~| HELP did you mean `qux`?
 }
 //~^ HELP implement the missing item
 //~| HELP implement the missing item
@@ -41,7 +41,7 @@ impl Bar for B {
 //~^ ERROR not all trait items implemented
     const Cnst: i32 = 0;
     //~^ ERROR const `Cnst` is not a member of trait
-    //~| HELP there is an associated constant with a similar name
+    //~| HELP did you mean `Const`?
 }
 //~^ HELP implement the missing item
 

--- a/src/test/ui/suggestions/suggest-trait-items.stderr
+++ b/src/test/ui/suggestions/suggest-trait-items.stderr
@@ -4,7 +4,7 @@ error[E0437]: type `Typ` is not a member of trait `Foo`
 LL |     type Typ = ();
    |     ^^^^^---^^^^^^
    |     |    |
-   |     |    help: there is an associated type with a similar name: `Type`
+   |     |    help: did you mean `Type`? (a similarly named associated type)
    |     not a member of trait `Foo`
 
 error[E0407]: method `fooo` is not a member of trait `Foo`
@@ -13,7 +13,7 @@ error[E0407]: method `fooo` is not a member of trait `Foo`
 LL |     fn fooo() {}
    |     ^^^----^^^^^
    |     |  |
-   |     |  help: there is an associated function with a similar name: `foo`
+   |     |  help: did you mean `foo`? (a similarly named associated function)
    |     not a member of trait `Foo`
 
 error[E0407]: method `barr` is not a member of trait `Foo`
@@ -22,7 +22,7 @@ error[E0407]: method `barr` is not a member of trait `Foo`
 LL |     fn barr() {}
    |     ^^^----^^^^^
    |     |  |
-   |     |  help: there is an associated function with a similar name: `bar`
+   |     |  help: did you mean `bar`? (a similarly named associated function)
    |     not a member of trait `Foo`
 
 error[E0407]: method `quux` is not a member of trait `Foo`
@@ -31,7 +31,7 @@ error[E0407]: method `quux` is not a member of trait `Foo`
 LL |     fn quux() {}
    |     ^^^----^^^^^
    |     |  |
-   |     |  help: there is an associated function with a similar name: `qux`
+   |     |  help: did you mean `qux`? (a similarly named associated function)
    |     not a member of trait `Foo`
 
 error[E0438]: const `Cnst` is not a member of trait `Bar`
@@ -40,7 +40,7 @@ error[E0438]: const `Cnst` is not a member of trait `Bar`
 LL |     const Cnst: i32 = 0;
    |     ^^^^^^----^^^^^^^^^^
    |     |     |
-   |     |     help: there is an associated constant with a similar name: `Const`
+   |     |     help: did you mean `Const`? (a similarly named associated constant)
    |     not a member of trait `Bar`
 
 error[E0046]: not all trait items implemented, missing: `Type`, `foo`, `bar`, `qux`

--- a/src/test/ui/suggestions/suggest-tryinto-edition-change.stderr
+++ b/src/test/ui/suggestions/suggest-tryinto-edition-change.stderr
@@ -41,7 +41,7 @@ LL | pub trait IntoIterator {
    |
    = note: 'std::iter::FromIterator' is included in the prelude starting in Edition 2021
    = note: 'core::iter::FromIterator' is included in the prelude starting in Edition 2021
-help: a trait with a similar name exists
+help: did you mean `IntoIterator`? (a similarly named trait)
    |
 LL |     let _v: Vec<_> = IntoIterator::from_iter(&[1]);
    |                      ~~~~~~~~~~~~

--- a/src/test/ui/suggestions/suggest-variants.stderr
+++ b/src/test/ui/suggestions/suggest-variants.stderr
@@ -5,7 +5,7 @@ LL | enum Shape {
    | ---------- variant `Squareee` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Squareee { size: 5});
-   |                                         ^^^^^^^^ help: there is a variant with a similar name: `Square`
+   |                                         ^^^^^^^^ help: did you mean `Square`? (a similarly named variant)
 
 error[E0599]: no variant named `Circl` found for enum `Shape`
   --> $DIR/suggest-variants.rs:13:41
@@ -14,7 +14,7 @@ LL | enum Shape {
    | ---------- variant `Circl` not found here
 ...
 LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
-   |                                         ^^^^^ help: there is a variant with a similar name: `Circle`
+   |                                         ^^^^^ help: did you mean `Circle`? (a similarly named variant)
 
 error[E0599]: no variant named `Rombus` found for enum `Shape`
   --> $DIR/suggest-variants.rs:14:41
@@ -35,7 +35,7 @@ LL |     Shape::Squareee;
    |            ^^^^^^^^
    |            |
    |            variant or associated item not found in `Shape`
-   |            help: there is a variant with a similar name: `Square`
+   |            help: did you mean `Square`? (a similarly named variant)
 
 error[E0599]: no variant or associated item named `Circl` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:16:12
@@ -47,7 +47,7 @@ LL |     Shape::Circl;
    |            ^^^^^
    |            |
    |            variant or associated item not found in `Shape`
-   |            help: there is a variant with a similar name: `Circle`
+   |            help: did you mean `Circle`? (a similarly named variant)
 
 error[E0599]: no variant or associated item named `Rombus` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:17:12

--- a/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
+++ b/src/test/ui/suggestions/type-mismatch-struct-field-shorthand-2.stderr
@@ -24,7 +24,7 @@ error[E0560]: struct `RGB` has no field named `c`
   --> $DIR/type-mismatch-struct-field-shorthand-2.rs:5:25
    |
 LL |     let _ = RGB { r, g, c };
-   |                         ^ help: a field with a similar name exists: `b`
+   |                         ^ help: did you mean `b`? (a similarly named field)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/src/test/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -13,7 +13,7 @@ help: constrain the associated type to `String`
    |
 LL | struct Foo<T> where T: Bar, T: Bar<Baz = String> {
    |                             ~~~~~~~~~~~~~~~~~~~~
-help: a trait with a similar name exists
+help: did you mean `ToString`? (a similarly named trait)
    |
 LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: ToString {
    |                                              ~~~~~~~~
@@ -33,7 +33,7 @@ help: constrain the associated type to `String`
    |
 LL | struct Qux<'a, T> where T: Bar, &'a T: Bar<Baz = String> {
    |                                 ~~~~~~~~~~~~~~~~~~~~~~~~
-help: a trait with a similar name exists
+help: did you mean `ToString`? (a similarly named trait)
    |
 LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: ToString {
    |                                                      ~~~~~~~~
@@ -53,7 +53,7 @@ help: constrain the associated type to `String`
    |
 LL | fn foo<T: Bar>(_: T) where T: Bar<Baz = String> {
    |                            ~~~~~~~~~~~~~~~~~~~~
-help: a trait with a similar name exists
+help: did you mean `ToString`? (a similarly named trait)
    |
 LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: ToString {
    |                                             ~~~~~~~~
@@ -73,7 +73,7 @@ help: constrain the associated type to `String`
    |
 LL | fn qux<'a, T: Bar>(_: &'a T) where &'a T: Bar<Baz = String> {
    |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
-help: a trait with a similar name exists
+help: did you mean `ToString`? (a similarly named trait)
    |
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: ToString {
    |                                                         ~~~~~~~~

--- a/src/test/ui/traits/bound/not-on-struct.stderr
+++ b/src/test/ui/traits/bound/not-on-struct.stderr
@@ -164,7 +164,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
 LL - fn g() -> Traitor + 'static {
 LL + fn g() -> Traitor {
    | 
-help: a trait with a similar name exists
+help: did you mean `Trait`? (a similarly named trait)
    |
 LL | fn g() -> Trait + 'static {
    |           ~~~~~

--- a/src/test/ui/traits/impl-for-module.stderr
+++ b/src/test/ui/traits/impl-for-module.stderr
@@ -5,7 +5,7 @@ LL | trait A {
    | ------- similarly named trait `A` defined here
 ...
 LL | impl A for a {
-   |            ^ help: a trait with a similar name exists: `A`
+   |            ^ help: did you mean `A`? (a similarly named trait)
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-78372.stderr
+++ b/src/test/ui/traits/issue-78372.stderr
@@ -17,7 +17,7 @@ LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
    |      |
    |      similarly named type parameter `T` defined here
    |
-help: a type parameter with a similar name exists
+help: did you mean `T`? (a similarly named type parameter)
    |
 LL | impl<T> DispatchFromDyn<Smaht<T, MISC>> for T {}
    |                               ~

--- a/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
+++ b/src/test/ui/traits/trait-upcasting/subtrait-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `c` found for reference `&dyn Bar` in the current 
   --> $DIR/subtrait-method.rs:56:9
    |
 LL |     bar.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: did you mean `a`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
@@ -15,7 +15,7 @@ error[E0599]: no method named `b` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:60:9
    |
 LL |     foo.b();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: did you mean `a`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
@@ -28,7 +28,7 @@ error[E0599]: no method named `c` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:62:9
    |
 LL |     foo.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: did you mean `a`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it
@@ -41,7 +41,7 @@ error[E0599]: no method named `b` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:66:9
    |
 LL |     foo.b();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: did you mean `a`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `b`, perhaps you need to implement it
@@ -54,7 +54,7 @@ error[E0599]: no method named `c` found for reference `&dyn Foo` in the current 
   --> $DIR/subtrait-method.rs:68:9
    |
 LL |     foo.c();
-   |         ^ help: there is an associated function with a similar name: `a`
+   |         ^ help: did you mean `a`? (a similarly named associated function)
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Baz` defines an item `c`, perhaps you need to implement it

--- a/src/test/ui/tuple/tuple-index-not-tuple.stderr
+++ b/src/test/ui/tuple/tuple-index-not-tuple.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `0` on type `Point`
   --> $DIR/tuple-index-not-tuple.rs:6:12
    |
 LL |     origin.0;
-   |            ^ help: a field with a similar name exists: `x`
+   |            ^ help: did you mean `x`? (a similarly named field)
 
 error[E0609]: no field `0` on type `Empty`
   --> $DIR/tuple-index-not-tuple.rs:8:11

--- a/src/test/ui/tuple/tuple-index-out-of-bounds.stderr
+++ b/src/test/ui/tuple/tuple-index-out-of-bounds.stderr
@@ -2,7 +2,7 @@ error[E0609]: no field `2` on type `Point`
   --> $DIR/tuple-index-out-of-bounds.rs:7:12
    |
 LL |     origin.2;
-   |            ^ help: a field with a similar name exists: `0`
+   |            ^ help: did you mean `0`? (a similarly named field)
 
 error[E0609]: no field `2` on type `({integer}, {integer})`
   --> $DIR/tuple-index-out-of-bounds.rs:12:11

--- a/src/test/ui/typeck/issue-83693.stderr
+++ b/src/test/ui/typeck/issue-83693.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `F` in this scope
   --> $DIR/issue-83693.rs:6:6
    |
 LL | impl F {
-   |      ^ help: a trait with a similar name exists: `Fn`
+   |      ^ help: did you mean `Fn`? (a similarly named trait)
    |
   ::: $SRC_DIR/core/src/ops/function.rs:LL:COL
    |

--- a/src/test/ui/typeck/issue-88844.rs
+++ b/src/test/ui/typeck/issue-88844.rs
@@ -5,7 +5,7 @@ struct Struct { value: i32 }
 
 impl Stuct {
 //~^ ERROR: cannot find type `Stuct` in this scope [E0412]
-//~| HELP: a struct with a similar name exists
+//~| HELP: did you mean `Struct`?
     fn new() -> Self {
         Self { value: 42 }
     }

--- a/src/test/ui/typeck/issue-88844.stderr
+++ b/src/test/ui/typeck/issue-88844.stderr
@@ -5,7 +5,7 @@ LL | struct Struct { value: i32 }
    | ------------- similarly named struct `Struct` defined here
 ...
 LL | impl Stuct {
-   |      ^^^^^ help: a struct with a similar name exists: `Struct`
+   |      ^^^^^ help: did you mean `Struct`? (a similarly named struct)
 
 error: aborting due to previous error
 

--- a/src/test/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.stderr
@@ -17,7 +17,7 @@ LL |     type Y = u16;
    |     ------------- similarly named associated type `Y` defined here
 ...
 LL |     let _: <u8 as Tr>::N;
-   |                        ^ help: an associated type with a similar name exists: `Y`
+   |                        ^ help: did you mean `Y`? (a similarly named associated type)
 
 error[E0576]: cannot find associated type `N` in enum `E`
   --> $DIR/ufcs-partially-resolved.rs:20:23
@@ -38,7 +38,7 @@ LL |     fn Y() {}
    |     ------ similarly named associated function `Y` defined here
 ...
 LL |     <u8 as Tr>::N;
-   |                 ^ help: an associated function with a similar name exists: `Y`
+   |                 ^ help: did you mean `Y`? (a similarly named associated function)
 
 error[E0576]: cannot find method or associated constant `N` in enum `E`
   --> $DIR/ufcs-partially-resolved.rs:23:16
@@ -71,7 +71,7 @@ LL |     type Y = u16;
    |     ------------- similarly named associated type `Y` defined here
 ...
 LL |     let _: <u8 as Tr>::N::NN;
-   |                        ^ help: an associated type with a similar name exists: `Y`
+   |                        ^ help: did you mean `Y`? (a similarly named associated type)
 
 error[E0576]: cannot find associated type `N` in enum `E`
   --> $DIR/ufcs-partially-resolved.rs:31:23
@@ -92,7 +92,7 @@ LL |     type Y = u16;
    |     ------------- similarly named associated type `Y` defined here
 ...
 LL |     <u8 as Tr>::N::NN;
-   |                 ^ help: an associated type with a similar name exists: `Y`
+   |                 ^ help: did you mean `Y`? (a similarly named associated type)
 
 error[E0576]: cannot find associated type `N` in enum `E`
   --> $DIR/ufcs-partially-resolved.rs:34:16
@@ -175,7 +175,7 @@ LL |     type X = u16;
 LL |     let _: <u8 as Dr>::Z;
    |            ^^^^^^^^^^^^-
    |                        |
-   |                        help: an associated type with a similar name exists: `X`
+   |                        help: did you mean `X`? (a similarly named associated type)
 
 error[E0575]: expected method or associated constant, found associated type `Dr::X`
   --> $DIR/ufcs-partially-resolved.rs:53:5
@@ -186,7 +186,7 @@ LL |     fn Z() {}
 LL |     <u8 as Dr>::X;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: an associated function with a similar name exists: `Z`
+   |                 help: did you mean `Z`? (a similarly named associated function)
    |
    = note: can't use a type alias as a constructor
 
@@ -199,7 +199,7 @@ LL |     type X = u16;
 LL |     let _: <u8 as Dr>::Z::N;
    |            ^^^^^^^^^^^^-^^^
    |                        |
-   |                        help: an associated type with a similar name exists: `X`
+   |                        help: did you mean `X`? (a similarly named associated type)
 
 error[E0223]: ambiguous associated type
   --> $DIR/ufcs-partially-resolved.rs:36:12

--- a/src/test/ui/ui-testing-optout.stderr
+++ b/src/test/ui/ui-testing-optout.stderr
@@ -11,7 +11,7 @@ error[E0412]: cannot find type `D` in this scope
   | ----------- similarly named type alias `A` defined here
 ...
 7 | type C = D;
-  |          ^ help: a type alias with a similar name exists: `A`
+  |          ^ help: did you mean `A`? (a similarly named type alias)
 
 error[E0412]: cannot find type `F` in this scope
   --> $DIR/ui-testing-optout.rs:92:10
@@ -20,7 +20,7 @@ error[E0412]: cannot find type `F` in this scope
    | ----------- similarly named type alias `A` defined here
 ...
 92 | type E = F;
-   |          ^ help: a type alias with a similar name exists: `A`
+   |          ^ help: did you mean `A`? (a similarly named type alias)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/union/union-suggest-field.mirunsafeck.stderr
+++ b/src/test/ui/union/union-suggest-field.mirunsafeck.stderr
@@ -2,13 +2,13 @@ error[E0560]: union `U` has no field named `principle`
   --> $DIR/union-suggest-field.rs:13:17
    |
 LL |     let u = U { principle: 0 };
-   |                 ^^^^^^^^^ help: a field with a similar name exists: `principal`
+   |                 ^^^^^^^^^ help: did you mean `principal`? (a similarly named field)
 
 error[E0609]: no field `principial` on type `U`
   --> $DIR/union-suggest-field.rs:17:15
    |
 LL |     let w = u.principial;
-   |               ^^^^^^^^^^ help: a field with a similar name exists: `principal`
+   |               ^^^^^^^^^^ help: did you mean `principal`? (a similarly named field)
 
 error[E0615]: attempted to take value of method `calculate` on type `U`
   --> $DIR/union-suggest-field.rs:21:15

--- a/src/test/ui/union/union-suggest-field.rs
+++ b/src/test/ui/union/union-suggest-field.rs
@@ -12,10 +12,10 @@ impl U {
 fn main() {
     let u = U { principle: 0 };
     //~^ ERROR union `U` has no field named `principle`
-    //~| HELP a field with a similar name exists
+    //~| HELP did you mean `principal`?
     //~| SUGGESTION principal
     let w = u.principial; //~ ERROR no field `principial` on type `U`
-                          //~| HELP a field with a similar name exists
+                          //~| HELP did you mean `principal`?
                           //~| SUGGESTION principal
 
     let y = u.calculate; //~ ERROR attempted to take value of method `calculate` on type `U`

--- a/src/test/ui/union/union-suggest-field.thirunsafeck.stderr
+++ b/src/test/ui/union/union-suggest-field.thirunsafeck.stderr
@@ -2,13 +2,13 @@ error[E0560]: union `U` has no field named `principle`
   --> $DIR/union-suggest-field.rs:13:17
    |
 LL |     let u = U { principle: 0 };
-   |                 ^^^^^^^^^ help: a field with a similar name exists: `principal`
+   |                 ^^^^^^^^^ help: did you mean `principal`? (a similarly named field)
 
 error[E0609]: no field `principial` on type `U`
   --> $DIR/union-suggest-field.rs:17:15
    |
 LL |     let w = u.principial;
-   |               ^^^^^^^^^^ help: a field with a similar name exists: `principal`
+   |               ^^^^^^^^^^ help: did you mean `principal`? (a similarly named field)
 
 error[E0615]: attempted to take value of method `calculate` on type `U`
   --> $DIR/union-suggest-field.rs:21:15


### PR DESCRIPTION
The goal is to give a message that the user can parse and respond to more quickly. For example...

Before:

    a local variable with a similar name exists: `x`

After:

    did you mean `x`? (a similarly named local variable)

I believe in most cases the user will see that the suggestion is correct and won't even read the rest of the message.

I also added `span_suggestion_hide_inline` so that it doesn't print `` : `x` `` at the end, but will show the snippet if the message is too long to be shown inline.