### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -492,7 +492,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool /* did we suggest to call a function because of missing parentheses? */ {
         err.span_label(span, ty.to_string());
         if let FnDef(def_id, _) = *ty.kind() {
-            let source_map = self.tcx.sess.source_map();
             if !self.tcx.has_typeck_results(def_id) {
                 return false;
             }
@@ -517,20 +516,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .lookup_op_method(fn_sig.output(), &[other_ty], Op::Binary(op, is_assign))
                 .is_ok()
             {
-                if let Ok(snippet) = source_map.span_to_snippet(span) {
-                    let (variable_snippet, applicability) = if !fn_sig.inputs().is_empty() {
-                        (format!("{}( /* arguments */ )", snippet), Applicability::HasPlaceholders)
-                    } else {
-                        (format!("{}()", snippet), Applicability::MaybeIncorrect)
-                    };
+                let (variable_snippet, applicability) = if !fn_sig.inputs().is_empty() {
+                    ("( /* arguments */ )".to_string(), Applicability::HasPlaceholders)
+                } else {
+                    ("()".to_string(), Applicability::MaybeIncorrect)
+                };
 
-                    err.span_suggestion(
-                        span,
-                        "you might have forgotten to call this function",
-                        variable_snippet,
-                        applicability,
-                    );
-                }
+                err.span_suggestion_verbose(
+                    span.shrink_to_hi(),
+                    "you might have forgotten to call this function",
+                    variable_snippet,
+                    applicability,
+                );
                 return true;
             }
         }

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -720,9 +720,9 @@ impl<T, A: Allocator> VecDeque<T, A> {
     ///
     /// Note that the allocator may give the collection more space than it
     /// requests. Therefore, capacity can not be relied upon to be precisely
-    /// minimal. Prefer [`reserve`] if future insertions are expected.
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///
-    /// [`reserve`]: VecDeque::reserve
+    /// [`try_reserve`]: VecDeque::try_reserve
     ///
     /// # Errors
     ///

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1044,9 +1044,9 @@ impl String {
     ///
     /// Note that the allocator may give the collection more space than it
     /// requests. Therefore, capacity can not be relied upon to be precisely
-    /// minimal. Prefer [`reserve`] if future insertions are expected.
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///
-    /// [`reserve`]: String::reserve
+    /// [`try_reserve`]: String::try_reserve
     ///
     /// # Errors
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -881,9 +881,9 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// Note that the allocator may give the collection more space than it
     /// requests. Therefore, capacity can not be relied upon to be precisely
-    /// minimal. Prefer [`reserve`] if future insertions are expected.
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///
-    /// [`reserve`]: Vec::reserve
+    /// [`try_reserve`]: Vec::try_reserve
     ///
     /// # Errors
     ///

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -578,28 +578,25 @@ pub fn home_dir() -> Option<PathBuf> {
 /// may result in "insecure temporary file" security vulnerabilities. Consider
 /// using a crate that securely creates temporary files or directories.
 ///
-/// # Unix
+/// # Platform-specific behavior
 ///
-/// Returns the value of the `TMPDIR` environment variable if it is
+/// On Unix, returns the value of the `TMPDIR` environment variable if it is
 /// set, otherwise for non-Android it returns `/tmp`. If Android, since there
 /// is no global temporary folder (it is usually allocated per-app), it returns
 /// `/data/local/tmp`.
+/// On Windows, the behavior is equivalent to that of [`GetTempPath2`][GetTempPath2] /
+/// [`GetTempPath`][GetTempPath], which this function uses internally.
+/// Note that, this [may change in the future][changes].
 ///
-/// # Windows
-///
-/// Returns the value of, in order, the `TMP`, `TEMP`,
-/// `USERPROFILE` environment variable if any are set and not the empty
-/// string. Otherwise, `temp_dir` returns the path of the Windows directory.
-/// This behavior is identical to that of [`GetTempPath`][msdn], which this
-/// function uses internally.
-///
-/// [msdn]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
+/// [changes]: io#platform-specific-behavior
+/// [GetTempPath2]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a
+/// [GetTempPath]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
 ///
 /// ```no_run
 /// use std::env;
 ///
 /// fn main() {
-///     let mut dir = env::temp_dir();
+///     let dir = env::temp_dir();
 ///     println!("Temporary directory: {}", dir.display());
 /// }
 /// ```

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -1102,6 +1102,12 @@ compat_fn! {
                                           -> () {
         GetSystemTimeAsFileTime(lpSystemTimeAsFileTime)
     }
+
+    // >= Win11
+    // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a
+    pub fn GetTempPath2W(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD {
+        GetTempPathW(nBufferLength, lpBuffer)
+    }
 }
 
 compat_fn! {

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -1103,7 +1103,7 @@ compat_fn! {
         GetSystemTimeAsFileTime(lpSystemTimeAsFileTime)
     }
 
-    // >= Win11
+    // >= Win11 / Server 2022
     // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a
     pub fn GetTempPath2W(nBufferLength: DWORD, lpBuffer: LPCWSTR) -> DWORD {
         GetTempPathW(nBufferLength, lpBuffer)

--- a/library/std/src/sys/windows/os.rs
+++ b/library/std/src/sys/windows/os.rs
@@ -275,7 +275,7 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
 }
 
 pub fn temp_dir() -> PathBuf {
-    super::fill_utf16_buf(|buf, sz| unsafe { c::GetTempPathW(sz, buf) }, super::os2path).unwrap()
+    super::fill_utf16_buf(|buf, sz| unsafe { c::GetTempPath2W(sz, buf) }, super::os2path).unwrap()
 }
 
 #[cfg(not(target_vendor = "uwp"))]

--- a/src/test/incremental/issue-85360-eval-obligation-ice.rs
+++ b/src/test/incremental/issue-85360-eval-obligation-ice.rs
@@ -1,0 +1,117 @@
+// revisions:cfail1 cfail2
+// compile-flags: --crate-type=lib --edition=2021
+// build-pass
+
+use core::any::Any;
+use core::marker::PhantomData;
+
+struct DerefWrap<T>(T);
+
+impl<T> core::ops::Deref for DerefWrap<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct Storage<T, D> {
+    phantom: PhantomData<(T, D)>,
+}
+
+type ReadStorage<T> = Storage<T, DerefWrap<MaskedStorage<T>>>;
+
+pub trait Component {
+    type Storage;
+}
+
+struct VecStorage;
+
+struct Pos;
+
+impl Component for Pos {
+    type Storage = VecStorage;
+}
+
+struct GenericComp<T> {
+    _t: T,
+}
+
+impl<T: 'static> Component for GenericComp<T> {
+    type Storage = VecStorage;
+}
+struct ReadData {
+    pos_interpdata: ReadStorage<GenericComp<Pos>>,
+}
+
+trait System {
+    type SystemData;
+
+    fn run(data: Self::SystemData, any: Box<dyn Any>);
+}
+
+struct Sys;
+
+impl System for Sys {
+    type SystemData = (ReadData, ReadStorage<Pos>);
+
+    fn run((data, pos): Self::SystemData, any: Box<dyn Any>) {
+        <ReadStorage<GenericComp<Pos>> as SystemData>::setup(any);
+
+        ParJoin::par_join((&pos, &data.pos_interpdata));
+    }
+}
+
+trait ParJoin {
+    fn par_join(self)
+    where
+        Self: Sized,
+    {
+    }
+}
+
+impl<'a, T, D> ParJoin for &'a Storage<T, D>
+where
+    T: Component,
+    D: core::ops::Deref<Target = MaskedStorage<T>>,
+    T::Storage: Sync,
+{
+}
+
+impl<A, B> ParJoin for (A, B)
+where
+    A: ParJoin,
+    B: ParJoin,
+{
+}
+
+pub trait SystemData {
+    fn setup(any: Box<dyn Any>);
+}
+
+impl<T: 'static> SystemData for ReadStorage<T>
+where
+    T: Component,
+{
+    fn setup(any: Box<dyn Any>) {
+        let storage: &MaskedStorage<T> = any.downcast_ref().unwrap();
+
+        <dyn Any as CastFrom<MaskedStorage<T>>>::cast(&storage);
+    }
+}
+
+pub struct MaskedStorage<T: Component> {
+    _inner: T::Storage,
+}
+
+pub unsafe trait CastFrom<T> {
+    fn cast(t: &T) -> &Self;
+}
+
+unsafe impl<T> CastFrom<T> for dyn Any
+where
+    T: Any + 'static,
+{
+    fn cast(t: &T) -> &Self {
+        t
+    }
+}

--- a/src/test/ui/fn/fn-compare-mismatch.stderr
+++ b/src/test/ui/fn/fn-compare-mismatch.stderr
@@ -9,11 +9,11 @@ LL |     let x = f == g;
 help: you might have forgotten to call this function
    |
 LL |     let x = f() == g;
-   |             ~~~
+   |              ++
 help: you might have forgotten to call this function
    |
 LL |     let x = f == g();
-   |                  ~~~
+   |                   ++
 
 error[E0308]: mismatched types
   --> $DIR/fn-compare-mismatch.rs:4:18

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -5,7 +5,11 @@ LL |     foo > 12;
    |     --- ^ -- {integer}
    |     |
    |     fn() -> i32 {foo}
-   |     help: you might have forgotten to call this function: `foo()`
+   |
+help: you might have forgotten to call this function
+   |
+LL |     foo() > 12;
+   |        ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-59488.rs:14:11
@@ -23,7 +27,11 @@ LL |     bar > 13;
    |     --- ^ -- {integer}
    |     |
    |     fn(i64) -> i64 {bar}
-   |     help: you might have forgotten to call this function: `bar( /* arguments */ )`
+   |
+help: you might have forgotten to call this function
+   |
+LL |     bar( /* arguments */ ) > 13;
+   |        +++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-59488.rs:18:11
@@ -45,11 +53,11 @@ LL |     foo > foo;
 help: you might have forgotten to call this function
    |
 LL |     foo() > foo;
-   |     ~~~~~
+   |        ++
 help: you might have forgotten to call this function
    |
 LL |     foo > foo();
-   |           ~~~~~
+   |              ++
 
 error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
   --> $DIR/issue-59488.rs:25:9

--- a/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
+++ b/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
@@ -6,9 +6,12 @@ LL |     assert_eq!(a, 0);
    |     |
    |     fn() -> i32 {a}
    |     {integer}
-   |     help: you might have forgotten to call this function: `*left_val()`
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might have forgotten to call this function
+   |
+LL |                 if !(*left_val() == *right_val) {
+   |                               ++
 
 error[E0308]: mismatched types
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -9,6 +9,10 @@ fn main() {
     test::<MaskedStorage<GenericComp<Pos>>>(make());
     //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
     //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+
+    test::<MaskedStorage<GenericComp2<Pos>>>(make());
+    //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+    //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
 }
 
 #[rustc_evaluate_where_clauses]
@@ -52,6 +56,15 @@ struct GenericComp<T> {
 impl<T: 'static> Component for GenericComp<T> {
     type Storage = VecStorage;
 }
+
+struct GenericComp2<T> {
+    _t: T,
+}
+
+impl<T: 'static> Component for GenericComp2<T> where for<'a> &'a bool: 'a {
+    type Storage = VecStorage;
+}
+
 struct ReadData {
     pos_interpdata: ReadStorage<GenericComp<Pos>>,
 }

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -1,10 +1,22 @@
-// revisions:cfail1 cfail2
-//[cfail1] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=not-loaded
-//[cfail2] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=loaded
-// build-pass
+// compile-flags: --edition=2021
+
+#![feature(rustc_attrs)]
 
 use core::any::Any;
 use core::marker::PhantomData;
+
+fn main() {
+    test::<MaskedStorage<GenericComp<Pos>>>(make());
+    //~^ ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+    //~| ERROR evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+}
+
+#[rustc_evaluate_where_clauses]
+fn test<T: Sized>(_: T) {}
+
+fn make<T>() -> T {
+    todo!()
+}
 
 struct DerefWrap<T>(T);
 

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -1,0 +1,20 @@
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
+   |
+LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |         - predicate
+
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOk)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
+   |
+LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |            ----- predicate
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/src/test/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -16,5 +16,23 @@ LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
 LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
-error: aborting due to 2 previous errors
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+   |
+LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |         - predicate
+
+error: evaluate(Binder(TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), [])) = Ok(EvaluatedToOkModuloRegions)
+  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+   |
+LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn test<T: Sized>(_: T) {}
+   |            ----- predicate
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #89999 (Update std::env::temp_dir to use GetTempPath2 on Windows when available.)
 - #91065 (Add test for evaluate_obligation: Ok(EvaluatedToOkModuloRegions) ICE)
 - #91493 (Remove a dead code path.)
 - #91503 (Tweak "call this function" suggestion to have smaller span)
 - #91547 (Suggest try_reserve in try_reserve_exact)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89999,91065,91493,91503,91547)
<!-- homu-ignore:end -->