### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "atty",
  "bitflags",
  "strsim",


### PR DESCRIPTION
8 commits in 294967c53f0c70d598fc54ca189313c86c576ea7..40dc281755137ee804bc9b3b08e782773b726e44
2021-11-29 19:04:22 +0000 to 2021-12-06 21:54:44 +0000
- Unify the description of quiet flag (rust-lang/cargo#10168)
- Stabilize future-incompat-report (rust-lang/cargo#10165)
- Support abbreviating `--release` as `-r` (rust-lang/cargo#10133)
- doc: nudge towards simple version requirements (rust-lang/cargo#10158)
- Upgrade clap to 2.34.0 (rust-lang/cargo#10164)
- Treat EOPNOTSUPP the same as ENOTSUP when ignoring failed flock calls. (rust-lang/cargo#10157)
- Add note about RUSTFLAGS removal from build scripts. (rust-lang/cargo#10141)
- Make clippy happy (rust-lang/cargo#10139)