### PR TITLE
Add missing whitespace before disabled HTML attribute

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -20,7 +20,7 @@
           id="mainThemeStyle"> {#- -#}
     {%- for theme in themes -%}
         <link rel="stylesheet" type="text/css" {# -#}
-            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {#- -#}
+            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {# -#}
         {%- if theme == "light" -%}
             id="themeStyle"
         {%- else -%}


### PR DESCRIPTION
On the [w3c HTML checker](https://validator.w3.org/nu/#textarea), with the current generated HTML we get:

![Screenshot from 2021-12-07 15-10-38](https://user-images.githubusercontent.com/3050060/145044653-b38fb679-da76-4890-853f-b696d8fdc06e.png)

The problem was that we were telling tera to remove too many whitespace.

r? @notriddle