### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "atty",
  "bitflags",
  "strsim",

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -57,7 +57,7 @@ impl LitKind {
                 // string in the token.
                 let s = symbol.as_str();
                 let symbol =
-                    if s.contains(&['\\', '\r'][..]) {
+                    if s.contains(&['\\', '\r']) {
                         let mut buf = String::with_capacity(s.len());
                         let mut error = Ok(());
                         unescape_literal(&s, Mode::Str, &mut |_, unescaped_char| {

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -347,7 +347,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
                     if let Some(modifiers) = nested_meta.value_str() {
                         for modifier in modifiers.as_str().split(',') {
-                            if let Some(modifier) = modifier.strip_prefix(&['+', '-'][..]) {
+                            if let Some(modifier) = modifier.strip_prefix(&['+', '-']) {
                                 macro_rules! gate_modifier { ($($name:literal => $feature:ident)*) => {
                                     $(if modifier == $name {
                                         let msg = concat!("`#[link(modifiers=\"", $name, "\")]` is unstable");
@@ -383,7 +383,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             }
 
             ast::ItemKind::Fn(..) => {
-                if self.sess.contains_name(&i.attrs[..], sym::start) {
+                if self.sess.contains_name(&i.attrs, sym::start) {
                     gate_feature_post!(
                         &self,
                         start,
@@ -396,7 +396,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             }
 
             ast::ItemKind::Struct(..) => {
-                for attr in self.sess.filter_by_name(&i.attrs[..], sym::repr) {
+                for attr in self.sess.filter_by_name(&i.attrs, sym::repr) {
                     for item in attr.meta_item_list().unwrap_or_else(Vec::new) {
                         if item.has_name(sym::simd) {
                             gate_feature_post!(

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -499,7 +499,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             ast::MetaItemKind::List(ref items) => {
                 self.print_path(&item.path, false, 0);
                 self.popen();
-                self.commasep(Consistent, &items[..], |s, i| s.print_meta_list_item(i));
+                self.commasep(Consistent, &items, |s, i| s.print_meta_list_item(i));
                 self.pclose();
             }
         }
@@ -997,7 +997,7 @@ impl<'a> State<'a> {
             }
             ast::TyKind::Tup(ref elts) => {
                 self.popen();
-                self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(ty));
+                self.commasep(Inconsistent, &elts, |s, ty| s.print_type(ty));
                 if elts.len() == 1 {
                     self.s.word(",");
                 }
@@ -1017,10 +1017,10 @@ impl<'a> State<'a> {
             ast::TyKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, false),
             ast::TyKind::TraitObject(ref bounds, syntax) => {
                 let prefix = if syntax == ast::TraitObjectSyntax::Dyn { "dyn" } else { "" };
-                self.print_type_bounds(prefix, &bounds[..]);
+                self.print_type_bounds(prefix, &bounds);
             }
             ast::TyKind::ImplTrait(_, ref bounds) => {
-                self.print_type_bounds("impl", &bounds[..]);
+                self.print_type_bounds("impl", &bounds);
             }
             ast::TyKind::Array(ref ty, ref length) => {
                 self.s.word("[");
@@ -1339,7 +1339,7 @@ impl<'a> State<'a> {
                         real_bounds.push(b.clone());
                     }
                 }
-                self.print_type_bounds(":", &real_bounds[..]);
+                self.print_type_bounds(":", &real_bounds);
                 self.print_where_clause(&generics.where_clause);
                 self.s.word(" ");
                 self.bopen();
@@ -1368,7 +1368,7 @@ impl<'a> State<'a> {
                     }
                 }
                 self.nbsp();
-                self.print_type_bounds("=", &real_bounds[..]);
+                self.print_type_bounds("=", &real_bounds);
                 self.print_where_clause(&generics.where_clause);
                 self.s.word(";");
             }
@@ -1960,10 +1960,10 @@ impl<'a> State<'a> {
                 self.print_expr_tup(exprs);
             }
             ast::ExprKind::Call(ref func, ref args) => {
-                self.print_expr_call(func, &args[..]);
+                self.print_expr_call(func, &args);
             }
             ast::ExprKind::MethodCall(ref segment, ref args, _) => {
-                self.print_expr_method_call(segment, &args[..]);
+                self.print_expr_method_call(segment, &args);
             }
             ast::ExprKind::Binary(op, ref lhs, ref rhs) => {
                 self.print_expr_binary(op, lhs, rhs);
@@ -2443,11 +2443,11 @@ impl<'a> State<'a> {
                     self.print_path(path, true, 0);
                 }
                 self.popen();
-                self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
+                self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 self.pclose();
             }
             PatKind::Or(ref pats) => {
-                self.strsep("|", true, Inconsistent, &pats[..], |s, p| s.print_pat(p));
+                self.strsep("|", true, Inconsistent, &pats, |s, p| s.print_pat(p));
             }
             PatKind::Path(None, ref path) => {
                 self.print_path(path, true, 0);
@@ -2465,7 +2465,7 @@ impl<'a> State<'a> {
                 self.word_space("{");
                 self.commasep_cmnt(
                     Consistent,
-                    &fields[..],
+                    &fields,
                     |s, f| {
                         s.cbox(INDENT_UNIT);
                         if !f.is_shorthand {
@@ -2488,7 +2488,7 @@ impl<'a> State<'a> {
             }
             PatKind::Tuple(ref elts) => {
                 self.popen();
-                self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
+                self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 if elts.len() == 1 {
                     self.s.word(",");
                 }
@@ -2530,7 +2530,7 @@ impl<'a> State<'a> {
             }
             PatKind::Slice(ref elts) => {
                 self.s.word("[");
-                self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
+                self.commasep(Inconsistent, &elts, |s, p| s.print_pat(p));
                 self.s.word("]");
             }
             PatKind::Rest => self.s.word(".."),
@@ -2839,7 +2839,7 @@ impl<'a> State<'a> {
                     self.print_path(&tree.prefix, false, 0);
                     self.s.word("::{");
                 }
-                self.commasep(Inconsistent, &items[..], |this, &(ref tree, _)| {
+                self.commasep(Inconsistent, &items, |this, &(ref tree, _)| {
                     this.print_use_tree(tree)
                 });
                 self.s.word("}");

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -712,7 +712,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
                             Some(&idx) => Some(idx),
                             None => {
                                 let msg = format!("there is no argument named `{}`", name);
-                                ecx.struct_span_err(span, &msg[..]).emit();
+                                ecx.struct_span_err(span, &msg).emit();
                                 None
                             }
                         },

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -766,8 +766,8 @@ impl<'a> TraitDef<'a> {
                         self,
                         struct_def,
                         type_ident,
-                        &self_args[..],
-                        &nonself_args[..],
+                        &self_args,
+                        &nonself_args,
                     )
                 } else {
                     method_def.expand_struct_method_body(
@@ -775,8 +775,8 @@ impl<'a> TraitDef<'a> {
                         self,
                         struct_def,
                         type_ident,
-                        &self_args[..],
-                        &nonself_args[..],
+                        &self_args,
+                        &nonself_args,
                         use_temporaries,
                     )
                 };
@@ -815,8 +815,8 @@ impl<'a> TraitDef<'a> {
                         self,
                         enum_def,
                         type_ident,
-                        &self_args[..],
-                        &nonself_args[..],
+                        &self_args,
+                        &nonself_args,
                     )
                 } else {
                     method_def.expand_enum_method_body(
@@ -825,7 +825,7 @@ impl<'a> TraitDef<'a> {
                         enum_def,
                         type_ident,
                         self_args,
-                        &nonself_args[..],
+                        &nonself_args,
                     )
                 };
 
@@ -1217,7 +1217,7 @@ impl<'a> MethodDef<'a> {
         let vi_idents = self_arg_names
             .iter()
             .map(|name| {
-                let vi_suffix = format!("{}_vi", &name[..]);
+                let vi_suffix = format!("{}_vi", name);
                 Ident::from_str_and_span(&vi_suffix, span)
             })
             .collect::<Vec<Ident>>();
@@ -1226,7 +1226,7 @@ impl<'a> MethodDef<'a> {
         // delegated expression that handles the catch-all case,
         // using `__variants_tuple` to drive logic if necessary.
         let catch_all_substructure =
-            EnumNonMatchingCollapsed(self_arg_idents, &variants[..], &vi_idents[..]);
+            EnumNonMatchingCollapsed(self_arg_idents, &variants, &vi_idents);
 
         let first_fieldless = variants.iter().find(|v| v.data.fields().is_empty());
 
@@ -1261,7 +1261,7 @@ impl<'a> MethodDef<'a> {
                     idents
                 };
                 for self_arg_name in &self_arg_names[1..] {
-                    let (p, idents) = mk_self_pat(cx, &self_arg_name[..]);
+                    let (p, idents) = mk_self_pat(cx, &self_arg_name);
                     subpats.push(p);
                     self_pats_idents.push(idents);
                 }

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -549,7 +549,7 @@ impl<'a, 'b> Context<'a, 'b> {
                             } else {
                                 self.fmtsp
                             };
-                            let mut err = self.ecx.struct_span_err(sp, &msg[..]);
+                            let mut err = self.ecx.struct_span_err(sp, &msg);
 
                             err.note(&format!(
                                 "did you intend to capture a variable `{}` from \

--- a/compiler/rustc_codegen_gcc/src/back/write.rs
+++ b/compiler/rustc_codegen_gcc/src/back/write.rs
@@ -32,7 +32,7 @@ pub(crate) unsafe fn codegen(cgcx: &CodegenContext<GccCodegenBackend>, _diag_han
         if config.emit_asm {
             let _timer = cgcx
                 .prof
-                .generic_activity_with_arg("LLVM_module_codegen_emit_asm", &module.name[..]);
+                .generic_activity_with_arg("LLVM_module_codegen_emit_asm", &*module.name);
             let path = cgcx.output_filenames.temp_path(OutputType::Assembly, module_name);
             context.compile_to_file(OutputKind::Assembler, path.to_str().expect("path to str"));
         }
@@ -41,7 +41,7 @@ pub(crate) unsafe fn codegen(cgcx: &CodegenContext<GccCodegenBackend>, _diag_han
             EmitObj::ObjectCode(_) => {
                 let _timer = cgcx
                     .prof
-                    .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &module.name[..]);
+                    .generic_activity_with_arg("LLVM_module_codegen_emit_obj", &*module.name);
                 match &*module.name {
                     "std_example.7rcbfp3g-cgu.15" => {
                         println!("Dumping reproducer {}", module.name);

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -474,7 +474,7 @@ pub(crate) fn inline_asm_call(
         .collect::<Vec<_>>();
 
     debug!("Asm Output Type: {:?}", output);
-    let fty = bx.cx.type_func(&argtys[..], output);
+    let fty = bx.cx.type_func(&argtys, output);
     unsafe {
         // Ask LLVM to verify that the constraints are well-formed.
         let constraints_ok = llvm::LLVMRustInlineAsmVerify(fty, cons.as_ptr().cast(), cons.len());

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -587,7 +587,7 @@ pub(crate) fn run_pass_manager(
     config: &ModuleConfig,
     thin: bool,
 ) -> Result<(), FatalError> {
-    let _timer = cgcx.prof.extra_verbose_generic_activity("LLVM_lto_optimize", &module.name[..]);
+    let _timer = cgcx.prof.extra_verbose_generic_activity("LLVM_lto_optimize", &*module.name);
 
     // Now we have one massive module inside of llmod. Time to run the
     // LTO-specific optimization passes that LLVM provides.

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -120,7 +120,7 @@ impl CodegenCx<'ll, 'tcx> {
                 !null_terminated as Bool,
             );
             let sym = self.generate_local_symbol_name("str");
-            let g = self.define_global(&sym[..], self.val_ty(sc)).unwrap_or_else(|| {
+            let g = self.define_global(&sym, self.val_ty(sc)).unwrap_or_else(|| {
                 bug!("symbol `{}` is already defined", sym);
             });
             llvm::LLVMSetInitializer(g, sc);

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -225,7 +225,7 @@ impl CodegenCx<'ll, 'tcx> {
             let gv = match kind {
                 Some(kind) if !self.tcx.sess.fewer_names() => {
                     let name = self.generate_local_symbol_name(kind);
-                    let gv = self.define_global(&name[..], self.val_ty(cv)).unwrap_or_else(|| {
+                    let gv = self.define_global(&name, self.val_ty(cv)).unwrap_or_else(|| {
                         bug!("symbol `{}` is already defined", name);
                     });
                     llvm::LLVMRustSetLinkage(gv, llvm::Linkage::PrivateLinkage);

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -89,7 +89,7 @@ pub fn finalize<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {
     });
 
     let filenames_size = filenames_buffer.len();
-    let filenames_val = cx.const_bytes(&filenames_buffer[..]);
+    let filenames_val = cx.const_bytes(&filenames_buffer);
     let filenames_ref = coverageinfo::hash_bytes(filenames_buffer);
 
     // Generate the LLVM IR representation of the coverage map and store it in a well-known global
@@ -238,7 +238,7 @@ fn save_function_record(
 ) {
     // Concatenate the encoded coverage mappings
     let coverage_mapping_size = coverage_mapping_buffer.len();
-    let coverage_mapping_val = cx.const_bytes(&coverage_mapping_buffer[..]);
+    let coverage_mapping_val = cx.const_bytes(&coverage_mapping_buffer);
 
     let func_name_hash = coverageinfo::hash_str(&mangled_function_name);
     let func_name_hash_val = cx.const_u64(func_name_hash);

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -456,7 +456,7 @@ fn vec_slice_metadata(
     let metadata = composite_type_metadata(
         cx,
         slice_ptr_type,
-        &slice_type_name[..],
+        &slice_type_name,
         unique_type_id,
         member_descriptions,
         NO_SCOPE_METADATA,
@@ -579,7 +579,7 @@ fn trait_pointer_metadata(
     composite_type_metadata(
         cx,
         trait_object_type.unwrap_or(trait_type),
-        &trait_type_name[..],
+        &trait_type_name,
         unique_type_id,
         member_descriptions,
         containing_scope,
@@ -2398,7 +2398,7 @@ fn set_members_of_composite_type(
 
     let type_params = compute_type_parameters(cx, composite_type);
     unsafe {
-        let type_array = create_DIArray(DIB(cx), &member_metadata[..]);
+        let type_array = create_DIArray(DIB(cx), &member_metadata);
         llvm::LLVMRustDICompositeTypeReplaceArrays(
             DIB(cx),
             composite_type_metadata,
@@ -2437,7 +2437,7 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> &'ll DIAr
                 })
                 .collect();
 
-            return create_DIArray(DIB(cx), &template_params[..]);
+            return create_DIArray(DIB(cx), &template_params);
         }
     }
     return create_DIArray(DIB(cx), &[]);

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -474,7 +474,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 vec![]
             };
 
-            create_DIArray(DIB(cx), &template_params[..])
+            create_DIArray(DIB(cx), &template_params)
         }
 
         fn get_parameter_names(cx: &CodegenCx<'_, '_>, generics: &ty::Generics) -> Vec<Symbol> {

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -682,11 +682,11 @@ impl<B: WriteBackendMethods> WorkItem<B> {
     fn start_profiling<'a>(&self, cgcx: &'a CodegenContext<B>) -> TimingGuard<'a> {
         match *self {
             WorkItem::Optimize(ref m) => {
-                cgcx.prof.generic_activity_with_arg("codegen_module_optimize", &m.name[..])
+                cgcx.prof.generic_activity_with_arg("codegen_module_optimize", &*m.name)
             }
             WorkItem::CopyPostLtoArtifacts(ref m) => cgcx
                 .prof
-                .generic_activity_with_arg("codegen_copy_artifacts_from_incr_cache", &m.name[..]),
+                .generic_activity_with_arg("codegen_copy_artifacts_from_incr_cache", &*m.name),
             WorkItem::LTO(ref m) => {
                 cgcx.prof.generic_activity_with_arg("codegen_module_perform_lto", m.name())
             }

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -122,8 +122,8 @@ pub fn langcall(tcx: TyCtxt<'_>, span: Option<Span>, msg: &str, li: LangItem) ->
     tcx.lang_items().require(li).unwrap_or_else(|s| {
         let msg = format!("{} {}", msg, s);
         match span {
-            Some(span) => tcx.sess.span_fatal(span, &msg[..]),
-            None => tcx.sess.fatal(&msg[..]),
+            Some(span) => tcx.sess.span_fatal(span, &msg),
+            None => tcx.sess.fatal(&msg),
         }
     })
 }

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -103,7 +103,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.eval_fn_call(
                     fn_val,
                     abi,
-                    &args[..],
+                    &args,
                     ret,
                     match (cleanup, caller_can_unwind) {
                         (Some(cleanup), true) => StackPopUnwind::Cleanup(*cleanup),

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -812,7 +812,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     trace!("attempting to call a trait method");
                     if !self.tcx.features().const_trait_impl {
-                        self.check_op(ops::FnCallNonConst);
+                        self.check_op(ops::FnCallNonConst(Some((callee, substs))));
                         return;
                     }
 
@@ -868,7 +868,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                             }
 
                             if !nonconst_call_permission {
-                                self.check_op(ops::FnCallNonConst);
+                                self.check_op(ops::FnCallNonConst(None));
                                 return;
                             }
                         }
@@ -937,7 +937,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                     }
 
                     if !nonconst_call_permission {
-                        self.check_op(ops::FnCallNonConst);
+                        self.check_op(ops::FnCallNonConst(None));
                         return;
                     }
                 }

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -142,7 +142,7 @@ impl_stable_hash_via_hash!(Fingerprint);
 impl<E: rustc_serialize::Encoder> Encodable<E> for Fingerprint {
     #[inline]
     fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        s.emit_raw_bytes(&self.to_le_bytes()[..])?;
+        s.emit_raw_bytes(&self.to_le_bytes())?;
         Ok(())
     }
 }
@@ -151,7 +151,7 @@ impl<D: rustc_serialize::Decoder> Decodable<D> for Fingerprint {
     #[inline]
     fn decode(d: &mut D) -> Result<Self, D::Error> {
         let mut bytes = [0u8; 16];
-        d.read_raw_bytes_into(&mut bytes[..])?;
+        d.read_raw_bytes_into(&mut bytes)?;
         Ok(Fingerprint::from_le_bytes(bytes))
     }
 }

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -649,7 +649,7 @@ impl Drop for VerboseTimingGuard<'_> {
     fn drop(&mut self) {
         if let Some((start_time, start_rss, ref message)) = self.start_and_message {
             let end_rss = get_resident_set_size();
-            print_time_passes_entry(&message[..], start_time.elapsed(), start_rss, end_rss);
+            print_time_passes_entry(&message, start_time.elapsed(), start_rss, end_rss);
         }
     }
 }

--- a/compiler/rustc_data_structures/src/small_c_str.rs
+++ b/compiler/rustc_data_structures/src/small_c_str.rs
@@ -46,7 +46,7 @@ impl SmallCStr {
 
     #[inline]
     pub fn as_c_str(&self) -> &ffi::CStr {
-        unsafe { ffi::CStr::from_bytes_with_nul_unchecked(&self.data[..]) }
+        unsafe { ffi::CStr::from_bytes_with_nul_unchecked(&self.data) }
     }
 
     #[inline]

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -253,7 +253,7 @@ fn generic_extension<'cx>(
     for (i, lhs) in lhses.iter().enumerate() {
         // try each arm's matchers
         let lhs_tt = match *lhs {
-            mbe::TokenTree::Delimited(_, ref delim) => &delim.tts[..],
+            mbe::TokenTree::Delimited(_, ref delim) => &delim.tts,
             _ => cx.span_bug(sp, "malformed macro lhs"),
         };
 
@@ -353,7 +353,7 @@ fn generic_extension<'cx>(
         for lhs in lhses {
             // try each arm's matchers
             let lhs_tt = match *lhs {
-                mbe::TokenTree::Delimited(_, ref delim) => &delim.tts[..],
+                mbe::TokenTree::Delimited(_, ref delim) => &delim.tts,
                 _ => continue,
             };
             if let Success(_) =
@@ -677,11 +677,11 @@ impl FirstSets {
                         first.replace_with(tt.clone());
                     }
                     TokenTree::Delimited(span, ref delimited) => {
-                        build_recur(sets, &delimited.tts[..]);
+                        build_recur(sets, &delimited.tts);
                         first.replace_with(delimited.open_tt(span));
                     }
                     TokenTree::Sequence(sp, ref seq_rep) => {
-                        let subfirst = build_recur(sets, &seq_rep.tts[..]);
+                        let subfirst = build_recur(sets, &seq_rep.tts);
 
                         match sets.first.entry(sp.entire()) {
                             Entry::Vacant(vac) => {
@@ -748,7 +748,7 @@ impl FirstSets {
                     let subfirst = match self.first.get(&sp.entire()) {
                         Some(&Some(ref subfirst)) => subfirst,
                         Some(&None) => {
-                            subfirst_owned = self.first(&seq_rep.tts[..]);
+                            subfirst_owned = self.first(&seq_rep.tts);
                             &subfirst_owned
                         }
                         None => {

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -175,12 +175,12 @@ pub(super) fn transcribe<'a>(
                         ));
                     }
 
-                    LockstepIterSize::Contradiction(ref msg) => {
+                    LockstepIterSize::Contradiction(msg) => {
                         // FIXME: this really ought to be caught at macro definition time... It
                         // happens when two meta-variables are used in the same repetition in a
                         // sequence, but they come from different sequence matchers and repeat
                         // different amounts.
-                        return Err(cx.struct_span_err(seq.span(), &msg[..]));
+                        return Err(cx.struct_span_err(seq.span(), &msg));
                     }
 
                     LockstepIterSize::Constraint(len, _) => {

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -659,7 +659,7 @@ where
         }
 
         writeln!(text, ";").unwrap();
-        w.write_all(&text[..])?;
+        w.write_all(&text)?;
 
         text.clear();
     }
@@ -684,7 +684,7 @@ where
         }
 
         writeln!(text, ";").unwrap();
-        w.write_all(&text[..])?;
+        w.write_all(&text)?;
 
         text.clear();
     }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -316,7 +316,7 @@ impl<'a> State<'a> {
             }
             hir::TyKind::Tup(ref elts) => {
                 self.popen();
-                self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty));
+                self.commasep(Inconsistent, &elts, |s, ty| s.print_type(&ty));
                 if elts.len() == 1 {
                     self.s.word(",");
                 }
@@ -1862,7 +1862,7 @@ impl<'a> State<'a> {
                         self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
-                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p));
+                    self.commasep(Inconsistent, &elts, |s, p| s.print_pat(&p));
                 }
                 self.pclose();
             }
@@ -1875,7 +1875,7 @@ impl<'a> State<'a> {
                 self.word_space("{");
                 self.commasep_cmnt(
                     Consistent,
-                    &fields[..],
+                    &fields,
                     |s, f| {
                         s.cbox(INDENT_UNIT);
                         if !f.is_shorthand {
@@ -1897,7 +1897,7 @@ impl<'a> State<'a> {
                 self.s.word("}");
             }
             PatKind::Or(ref pats) => {
-                self.strsep("|", true, Inconsistent, &pats[..], |s, p| s.print_pat(&p));
+                self.strsep("|", true, Inconsistent, &pats, |s, p| s.print_pat(&p));
             }
             PatKind::Tuple(ref elts, ddpos) => {
                 self.popen();
@@ -1958,7 +1958,7 @@ impl<'a> State<'a> {
             }
             PatKind::Slice(ref before, ref slice, ref after) => {
                 self.s.word("[");
-                self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p));
+                self.commasep(Inconsistent, &before, |s, p| s.print_pat(&p));
                 if let Some(ref p) = *slice {
                     if !before.is_empty() {
                         self.word_space(",");
@@ -1973,7 +1973,7 @@ impl<'a> State<'a> {
                         self.word_space(",");
                     }
                 }
-                self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p));
+                self.commasep(Inconsistent, &after, |s, p| s.print_pat(&p));
                 self.s.word("]");
             }
         }

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -151,7 +151,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
                                     compilation session directory: {}",
                         e
                     );
-                    sess.fatal(&msg[..])
+                    sess.fatal(&msg)
                 });
 
             for swp in work_products {

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -207,7 +207,7 @@ fn check_panic_str<'tcx>(
     arg: &'tcx hir::Expr<'tcx>,
     fmt: &str,
 ) {
-    if !fmt.contains(&['{', '}'][..]) {
+    if !fmt.contains(&['{', '}']) {
         // No brace, no problem.
         return;
     }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -132,7 +132,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                 if let Some(modifiers) = item.value_str() {
                     let span = item.name_value_literal_span().unwrap();
                     for modifier in modifiers.as_str().split(',') {
-                        let (modifier, value) = match modifier.strip_prefix(&['+', '-'][..]) {
+                        let (modifier, value) = match modifier.strip_prefix(&['+', '-']) {
                             Some(m) => (m, modifier.starts_with('+')),
                             None => {
                                 sess.span_err(

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2119,7 +2119,7 @@ impl EncodedMetadata {
 
     #[inline]
     pub fn raw_data(&self) -> &[u8] {
-        &self.raw_data[..]
+        &self.raw_data
     }
 }
 

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -530,6 +530,6 @@ impl CodegenUnitNameBuilder<'tcx> {
             write!(cgu_name, ".{}", special_suffix).unwrap();
         }
 
-        Symbol::intern(&cgu_name[..])
+        Symbol::intern(&cgu_name)
     }
 }

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -342,7 +342,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             | InlineAsm { destination: Some(ref t), cleanup: Some(ref u), .. } => {
                 Some(t).into_iter().chain(slice::from_ref(u))
             }
-            SwitchInt { ref targets, .. } => None.into_iter().chain(&targets.targets[..]),
+            SwitchInt { ref targets, .. } => None.into_iter().chain(&targets.targets),
             FalseEdge { ref real_target, ref imaginary_target } => {
                 Some(real_target).into_iter().chain(slice::from_ref(imaginary_target))
             }
@@ -380,7 +380,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             | InlineAsm { destination: Some(ref mut t), cleanup: Some(ref mut u), .. } => {
                 Some(t).into_iter().chain(slice::from_mut(u))
             }
-            SwitchInt { ref mut targets, .. } => None.into_iter().chain(&mut targets.targets[..]),
+            SwitchInt { ref mut targets, .. } => None.into_iter().chain(&mut targets.targets),
             FalseEdge { ref mut real_target, ref mut imaginary_target } => {
                 Some(real_target).into_iter().chain(slice::from_mut(imaginary_target))
             }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -587,18 +587,18 @@ impl<'tcx, N> ImplSource<'tcx, N> {
     pub fn borrow_nested_obligations(&self) -> &[N] {
         match &self {
             ImplSource::UserDefined(i) => &i.nested[..],
-            ImplSource::Param(n, _) => &n[..],
-            ImplSource::Builtin(i) => &i.nested[..],
-            ImplSource::AutoImpl(d) => &d.nested[..],
-            ImplSource::Closure(c) => &c.nested[..],
-            ImplSource::Generator(c) => &c.nested[..],
-            ImplSource::Object(d) => &d.nested[..],
-            ImplSource::FnPointer(d) => &d.nested[..],
+            ImplSource::Param(n, _) => &n,
+            ImplSource::Builtin(i) => &i.nested,
+            ImplSource::AutoImpl(d) => &d.nested,
+            ImplSource::Closure(c) => &c.nested,
+            ImplSource::Generator(c) => &c.nested,
+            ImplSource::Object(d) => &d.nested,
+            ImplSource::FnPointer(d) => &d.nested,
             ImplSource::DiscriminantKind(ImplSourceDiscriminantKindData)
             | ImplSource::Pointee(ImplSourcePointeeData)
             | ImplSource::ConstDrop(ImplSourceConstDropData) => &[],
-            ImplSource::TraitAlias(d) => &d.nested[..],
-            ImplSource::TraitUpcasting(d) => &d.nested[..],
+            ImplSource::TraitAlias(d) => &d.nested,
+            ImplSource::TraitUpcasting(d) => &d.nested,
         }
     }
 

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -1,4 +1,4 @@
-use super::{AttrWrapper, Capturing, ForceCollect, Parser, PathStyle};
+use super::{AttrWrapper, Capturing, FnParseMode, ForceCollect, Parser, PathStyle};
 use rustc_ast as ast;
 use rustc_ast::attr;
 use rustc_ast::token::{self, Nonterminal};
@@ -177,7 +177,7 @@ impl<'a> Parser<'a> {
             AttrWrapper::empty(),
             true,
             false,
-            |_| true,
+            FnParseMode { req_name: |_| true, req_body: true },
             ForceCollect::No,
         ) {
             Ok(Some(item)) => {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1129,7 +1129,8 @@ impl<'a> Parser<'a> {
     }
 
     pub fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
-        if self.eat(&token::Semi) {
+        if self.token.kind == TokenKind::Semi {
+            self.bump();
             let mut err = self.struct_span_err(self.prev_token.span, "expected item, found `;`");
             err.span_suggestion_short(
                 self.prev_token.span,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -306,7 +306,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let expect = tokens_to_string(&expected[..]);
+        let expect = tokens_to_string(&expected);
         let actual = super::token_descr(&self.token);
         let (msg_exp, (label_sp, label_exp)) = if expected.len() > 1 {
             let short_expect = if expected.len() > 6 {
@@ -909,7 +909,7 @@ impl<'a> Parser<'a> {
                         // So far we have parsed `foo<bar<`, consume the rest of the type args.
                         let modifiers =
                             [(token::Lt, 1), (token::Gt, -1), (token::BinOp(token::Shr), -2)];
-                        self.consume_tts(1, &modifiers[..]);
+                        self.consume_tts(1, &modifiers);
 
                         if !&[token::OpenDelim(token::Paren), token::ModSep]
                             .contains(&self.token.kind)
@@ -1001,7 +1001,7 @@ impl<'a> Parser<'a> {
         // Consume the fn call arguments.
         let modifiers =
             [(token::OpenDelim(token::Paren), 1), (token::CloseDelim(token::Paren), -1)];
-        self.consume_tts(1, &modifiers[..]);
+        self.consume_tts(1, &modifiers);
 
         if self.token.kind == token::Eof {
             // Not entirely sure that what we consumed were fn arguments, rollback.

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -950,7 +950,7 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<ForeignItem>>>> {
-        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: false };
         Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match ForeignItemKind::try_from(kind) {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -78,16 +78,17 @@ pub(super) type ItemInfo = (Ident, ItemKind);
 
 impl<'a> Parser<'a> {
     pub fn parse_item(&mut self, force_collect: ForceCollect) -> PResult<'a, Option<P<Item>>> {
-        self.parse_item_(|_| true, force_collect).map(|i| i.map(P))
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        self.parse_item_(fn_parse_mode, force_collect).map(|i| i.map(P))
     }
 
     fn parse_item_(
         &mut self,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Item>> {
         let attrs = self.parse_outer_attributes()?;
-        self.parse_item_common(attrs, true, false, req_name, force_collect)
+        self.parse_item_common(attrs, true, false, fn_parse_mode, force_collect)
     }
 
     pub(super) fn parse_item_common(
@@ -95,7 +96,7 @@ impl<'a> Parser<'a> {
         attrs: AttrWrapper,
         mac_allowed: bool,
         attrs_allowed: bool,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Item>> {
         // Don't use `maybe_whole` so that we have precise control
@@ -113,7 +114,8 @@ impl<'a> Parser<'a> {
         let mut unclosed_delims = vec![];
         let item =
             self.collect_tokens_trailing_token(attrs, force_collect, |this: &mut Self, attrs| {
-                let item = this.parse_item_common_(attrs, mac_allowed, attrs_allowed, req_name);
+                let item =
+                    this.parse_item_common_(attrs, mac_allowed, attrs_allowed, fn_parse_mode);
                 unclosed_delims.append(&mut this.unclosed_delims);
                 Ok((item?, TrailingToken::None))
             })?;
@@ -127,12 +129,13 @@ impl<'a> Parser<'a> {
         mut attrs: Vec<Attribute>,
         mac_allowed: bool,
         attrs_allowed: bool,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
     ) -> PResult<'a, Option<Item>> {
         let lo = self.token.span;
         let vis = self.parse_visibility(FollowedByType::No)?;
         let mut def = self.parse_defaultness();
-        let kind = self.parse_item_kind(&mut attrs, mac_allowed, lo, &vis, &mut def, req_name)?;
+        let kind =
+            self.parse_item_kind(&mut attrs, mac_allowed, lo, &vis, &mut def, fn_parse_mode)?;
         if let Some((ident, kind)) = kind {
             self.error_on_unconsumed_default(def, &kind);
             let span = lo.to(self.prev_token.span);
@@ -192,7 +195,7 @@ impl<'a> Parser<'a> {
         lo: Span,
         vis: &Visibility,
         def: &mut Defaultness,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
     ) -> PResult<'a, Option<ItemInfo>> {
         let def_final = def == &Defaultness::Final;
         let mut def = || mem::replace(def, Defaultness::Final);
@@ -219,7 +222,7 @@ impl<'a> Parser<'a> {
             (Ident::empty(), ItemKind::Use(tree))
         } else if self.check_fn_front_matter(def_final) {
             // FUNCTION ITEM
-            let (ident, sig, generics, body) = self.parse_fn(attrs, req_name, lo)?;
+            let (ident, sig, generics, body) = self.parse_fn(attrs, fn_parse_mode, lo)?;
             (ident, ItemKind::Fn(Box::new(Fn { defaultness: def(), sig, generics, body })))
         } else if self.eat_keyword(kw::Extern) {
             if self.eat_keyword(kw::Crate) {
@@ -733,23 +736,26 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        self.parse_assoc_item(|_| true, force_collect)
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        self.parse_assoc_item(fn_parse_mode, force_collect)
     }
 
     pub fn parse_trait_item(
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        self.parse_assoc_item(|edition| edition >= Edition::Edition2018, force_collect)
+        let fn_parse_mode =
+            FnParseMode { req_name: |edition| edition >= Edition::Edition2018, req_body: false };
+        self.parse_assoc_item(fn_parse_mode, force_collect)
     }
 
     /// Parses associated items.
     fn parse_assoc_item(
         &mut self,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        Ok(self.parse_item_(req_name, force_collect)?.map(
+        Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match AssocItemKind::try_from(kind) {
                     Ok(kind) => kind,
@@ -944,7 +950,8 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<ForeignItem>>>> {
-        Ok(self.parse_item_(|_| true, force_collect)?.map(
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match ForeignItemKind::try_from(kind) {
                     Ok(kind) => kind,
@@ -1484,7 +1491,8 @@ impl<'a> Parser<'a> {
         if !is_raw && ident.is_reserved() {
             let err = if self.check_fn_front_matter(false) {
                 // We use `parse_fn` to get a span for the function
-                if let Err(mut db) = self.parse_fn(&mut Vec::new(), |_| true, lo) {
+                let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+                if let Err(mut db) = self.parse_fn(&mut Vec::new(), fn_parse_mode, lo) {
                     db.delay_as_bug();
                 }
                 let mut err = self.struct_span_err(
@@ -1700,23 +1708,33 @@ impl<'a> Parser<'a> {
 /// The function decides if, per-parameter `p`, `p` must have a pattern or just a type.
 type ReqName = fn(Edition) -> bool;
 
+/// Parsing configuration for functions.
+/// This include the edition-specific name requirements, plus information on whether the
+/// function is allowed to go without a body.
+#[derive(Clone, Copy)]
+pub(crate) struct FnParseMode {
+    pub req_name: ReqName,
+    pub req_body: bool,
+}
+
 /// Parsing of functions and methods.
 impl<'a> Parser<'a> {
     /// Parse a function starting from the front matter (`const ...`) to the body `{ ... }` or `;`.
     fn parse_fn(
         &mut self,
         attrs: &mut Vec<Attribute>,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         sig_lo: Span,
     ) -> PResult<'a, (Ident, FnSig, Generics, Option<P<Block>>)> {
         let header = self.parse_fn_front_matter()?; // `const ... fn`
         let ident = self.parse_ident()?; // `foo`
         let mut generics = self.parse_generics()?; // `<'a, T, ...>`
-        let decl = self.parse_fn_decl(req_name, AllowPlus::Yes, RecoverReturnSign::Yes)?; // `(p: u8, ...)`
+        let decl =
+            self.parse_fn_decl(fn_parse_mode.req_name, AllowPlus::Yes, RecoverReturnSign::Yes)?; // `(p: u8, ...)`
         generics.where_clause = self.parse_where_clause()?; // `where T: Ord`
 
         let mut sig_hi = self.prev_token.span;
-        let body = self.parse_fn_body(attrs, &ident, &mut sig_hi)?; // `;` or `{ ... }`.
+        let body = self.parse_fn_body(attrs, &ident, &mut sig_hi, fn_parse_mode.req_body)?; // `;` or `{ ... }`.
         let fn_sig_span = sig_lo.to(sig_hi);
         Ok((ident, FnSig { header, decl, span: fn_sig_span }, generics, body))
     }
@@ -1729,9 +1747,17 @@ impl<'a> Parser<'a> {
         attrs: &mut Vec<Attribute>,
         ident: &Ident,
         sig_hi: &mut Span,
+        req_body: bool,
     ) -> PResult<'a, Option<P<Block>>> {
-        let (inner_attrs, body) = if self.eat(&token::Semi) {
+        let has_semi = if req_body {
+            self.token.kind == TokenKind::Semi
+        } else {
+            // Only include `;` in list of expected tokens if body is not required
+            self.check(&TokenKind::Semi)
+        };
+        let (inner_attrs, body) = if has_semi {
             // Include the trailing semicolon in the span of the signature
+            self.expect_semi()?;
             *sig_hi = self.prev_token.span;
             (Vec::new(), None)
         } else if self.check(&token::OpenDelim(token::Brace)) || self.token.is_whole_block() {
@@ -1752,9 +1778,12 @@ impl<'a> Parser<'a> {
                 .emit();
             (Vec::new(), Some(self.mk_block_err(span)))
         } else {
-            if let Err(mut err) =
-                self.expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
-            {
+            let expected = if req_body {
+                &[token::OpenDelim(token::Brace)][..]
+            } else {
+                &[token::Semi, token::OpenDelim(token::Brace)]
+            };
+            if let Err(mut err) = self.expected_one_of_not_found(&[], &expected) {
                 if self.token.kind == token::CloseDelim(token::Brace) {
                     // The enclosing `mod`, `trait` or `impl` is being closed, so keep the `fn` in
                     // the AST for typechecking.

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -14,6 +14,7 @@ use crate::lexer::UnmatchedBrace;
 pub use attr_wrapper::AttrWrapper;
 pub use diagnostics::AttemptLocalParseRecovery;
 use diagnostics::Error;
+pub(crate) use item::FnParseMode;
 pub use pat::{RecoverColon, RecoverComma};
 pub use path::PathStyle;
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -4,7 +4,9 @@ use super::expr::LhsExpr;
 use super::pat::RecoverComma;
 use super::path::PathStyle;
 use super::TrailingToken;
-use super::{AttrWrapper, BlockMode, ForceCollect, Parser, Restrictions, SemiColonMode};
+use super::{
+    AttrWrapper, BlockMode, FnParseMode, ForceCollect, Parser, Restrictions, SemiColonMode,
+};
 use crate::maybe_whole;
 
 use rustc_ast as ast;
@@ -79,9 +81,13 @@ impl<'a> Parser<'a> {
             } else {
                 self.parse_stmt_path_start(lo, attrs)
             }?
-        } else if let Some(item) =
-            self.parse_item_common(attrs.clone(), false, true, |_| true, force_collect)?
-        {
+        } else if let Some(item) = self.parse_item_common(
+            attrs.clone(),
+            false,
+            true,
+            FnParseMode { req_name: |_| true, req_body: true },
+            force_collect,
+        )? {
             // FIXME: Bad copy of attrs
             self.mk_stmt(lo.to(item.span), StmtKind::Item(P(item)))
         } else if self.eat(&token::Semi) {

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -158,7 +158,7 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
 
         // Wrap in a scope so we can borrow `data`.
         let footer: Footer = {
-            let mut decoder = opaque::Decoder::new(&data[..], start_pos);
+            let mut decoder = opaque::Decoder::new(&data, start_pos);
 
             // Decode the *position* of the footer, which can be found in the
             // last 8 bytes of the file.

--- a/compiler/rustc_serialize/src/json.rs
+++ b/compiler/rustc_serialize/src/json.rs
@@ -2320,12 +2320,12 @@ impl crate::Decoder for Decoder {
         let name = match self.pop() {
             Json::String(s) => s,
             Json::Object(mut o) => {
-                let n = match o.remove(&"variant".to_owned()) {
+                let n = match o.remove("variant") {
                     Some(Json::String(s)) => s,
                     Some(val) => return Err(ExpectedError("String".to_owned(), val.to_string())),
                     None => return Err(MissingFieldError("variant".to_owned())),
                 };
-                match o.remove(&"fields".to_string()) {
+                match o.remove("fields") {
                     Some(Json::Array(l)) => {
                         self.stack.extend(l.into_iter().rev());
                     }
@@ -2365,7 +2365,7 @@ impl crate::Decoder for Decoder {
     {
         let mut obj = expect!(self.pop(), Object)?;
 
-        let value = match obj.remove(&name.to_string()) {
+        let value = match obj.remove(name) {
             None => {
                 // Add a Null and try to parse it as an Option<_>
                 // to get None as a default value.

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1735,7 +1735,7 @@ fn parse_native_lib_modifiers(
 ) -> (NativeLibKind, Option<bool>) {
     let mut verbatim = None;
     for modifier in modifiers.split(',') {
-        let (modifier, value) = match modifier.strip_prefix(&['+', '-'][..]) {
+        let (modifier, value) = match modifier.strip_prefix(&['+', '-']) {
             Some(m) => (m, modifier.starts_with('+')),
             None => early_error(
                 error_format,
@@ -2027,7 +2027,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 
     let unparsed_crate_types = matches.opt_strs("crate-type");
     let crate_types = parse_crate_types_from_list(unparsed_crate_types)
-        .unwrap_or_else(|e| early_error(error_format, &e[..]));
+        .unwrap_or_else(|e| early_error(error_format, &e));
 
     let mut debugging_opts = DebuggingOptions::build(matches, error_format);
     let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
@@ -2151,7 +2151,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 
     let mut search_paths = vec![];
     for s in &matches.opt_strs("L") {
-        search_paths.push(SearchPath::from_cli_opt(&s[..], error_format));
+        search_paths.push(SearchPath::from_cli_opt(&s, error_format));
     }
 
     let libs = parse_libs(matches, error_format);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1383,7 +1383,7 @@ impl<S: Encoder> Encodable<S> for SourceFile {
                     // Encode the first element.
                     lines[0].encode(s)?;
 
-                    let diff_iter = lines[..].array_windows().map(|&[fst, snd]| snd - fst);
+                    let diff_iter = lines.array_windows().map(|&[fst, snd]| snd - fst);
 
                     match bytes_per_diff {
                         1 => {
@@ -1506,7 +1506,7 @@ impl SourceFile {
         assert!(end_pos <= u32::MAX as usize);
 
         let (lines, multibyte_chars, non_narrow_chars) =
-            analyze_source_file::analyze_source_file(&src[..], start_pos);
+            analyze_source_file::analyze_source_file(&src, start_pos);
 
         SourceFile {
             name,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -231,7 +231,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         if let Ok(Some(command)) =
             OnUnimplementedDirective::of_item(self.tcx, trait_ref.def_id, def_id)
         {
-            command.evaluate(self.tcx, trait_ref, &flags[..])
+            command.evaluate(self.tcx, trait_ref, &flags)
         } else {
             OnUnimplementedNote::default()
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -804,7 +804,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         } else if let ObligationCauseCode::BindingObligation(_, _)
         | ObligationCauseCode::ItemObligation(_) = &*code
         {
-            try_borrowing(*poly_trait_ref, &never_suggest_borrow[..])
+            try_borrowing(*poly_trait_ref, &never_suggest_borrow)
         } else {
             false
         }
@@ -1132,7 +1132,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             <https://doc.rust-lang.org/book/ch17-02-trait-objects.html\
             #using-trait-objects-that-allow-for-values-of-different-types>";
         let has_dyn = snippet.split_whitespace().next().map_or(false, |s| s == "dyn");
-        let trait_obj = if has_dyn { &snippet[4..] } else { &snippet[..] };
+        let trait_obj = if has_dyn { &snippet[4..] } else { &snippet };
         if only_never_return {
             // No return paths, probably using `panic!()` or similar.
             // Suggest `-> T`, `-> impl Trait`, and if `Trait` is object safe, `-> Box<dyn Trait>`.

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1350,7 +1350,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     tcx,
                     span,
                     item.trait_ref().def_id(),
-                    &object_safety_violations[..],
+                    &object_safety_violations,
                 )
                 .emit();
                 return tcx.ty_error();

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -496,7 +496,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             call_expr.span,
             call_expr,
             fn_sig.inputs(),
-            &expected_arg_tys[..],
+            &expected_arg_tys,
             arg_exprs,
             fn_sig.c_variadic,
             TupleArgumentsFlag::DontTupleArguments,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1436,7 +1436,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             <dyn AstConv<'_>>::create_substs_for_generic_args(
                 tcx,
                 def_id,
-                &[][..],
+                &[],
                 has_self,
                 self_ty,
                 &arg_count,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -54,13 +54,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let err_inputs = match tuple_arguments {
                 DontTupleArguments => err_inputs,
-                TupleArguments => vec![self.tcx.intern_tup(&err_inputs[..])],
+                TupleArguments => vec![self.tcx.intern_tup(&err_inputs)],
             };
 
             self.check_argument_types(
                 sp,
                 expr,
-                &err_inputs[..],
+                &err_inputs,
                 &[],
                 args_no_rcvr,
                 false,
@@ -324,7 +324,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.point_at_type_arg_instead_of_call_if_possible(errors, expr);
                     self.point_at_arg_instead_of_call_if_possible(
                         errors,
-                        &final_arg_types[..],
+                        &final_arg_types,
                         expr,
                         sp,
                         &args,

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -1372,7 +1372,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
 
         if applicable_candidates.len() > 1 {
             if let Some(pick) =
-                self.collapse_candidates_to_trait_pick(self_ty, &applicable_candidates[..])
+                self.collapse_candidates_to_trait_pick(self_ty, &applicable_candidates)
             {
                 return Some(Ok(pick));
             }

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1324,7 +1324,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if candidates.len() > limit {
                 msg.push_str(&format!("\nand {} others", candidates.len() - limit));
             }
-            err.note(&msg[..]);
+            err.note(&msg);
         }
     }
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2998,9 +2998,9 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     )
                     .emit();
                     InlineAttr::None
-                } else if list_contains_name(&items[..], sym::always) {
+                } else if list_contains_name(&items, sym::always) {
                     InlineAttr::Always
-                } else if list_contains_name(&items[..], sym::never) {
+                } else if list_contains_name(&items, sym::never) {
                     InlineAttr::Never
                 } else {
                     struct_span_err!(
@@ -3034,9 +3034,9 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                 if items.len() != 1 {
                     err(attr.span, "expected one argument");
                     OptimizeAttr::None
-                } else if list_contains_name(&items[..], sym::size) {
+                } else if list_contains_name(&items, sym::size) {
                     OptimizeAttr::Size
-                } else if list_contains_name(&items[..], sym::speed) {
+                } else if list_contains_name(&items, sym::speed) {
                     OptimizeAttr::Speed
                 } else {
                     err(items[0].span(), "invalid argument");

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -81,9 +81,9 @@
 //! [`OsStr`] and Rust strings work similarly to those for [`CString`]
 //! and [`CStr`].
 //!
-//! * [`OsString`] represents an owned string in whatever
-//! representation the operating system prefers. In the Rust standard
-//! library, various APIs that transfer strings to/from the operating
+//! * [`OsString`] losslessly represents an owned platform string. However, this
+//! representation is not necessarily in a form native to the platform.
+//! In the Rust standard library, various APIs that transfer strings to/from the operating
 //! system use [`OsString`] instead of plain strings. For example,
 //! [`env::var_os()`] is used to query environment variables; it
 //! returns an <code>[Option]<[OsString]></code>. If the environment variable
@@ -92,9 +92,9 @@
 //! your code can detect errors in case the environment variable did
 //! not in fact contain valid Unicode data.
 //!
-//! * [`OsStr`] represents a borrowed reference to a string in a
-//! format that can be passed to the operating system. It can be
-//! converted into a UTF-8 Rust string slice in a similar way to
+//! * [`OsStr`] losslessly represents a borrowed reference to a platform string.
+//! However, this representation is not necessarily in a form native to the platform.
+//! It can be converted into a UTF-8 Rust string slice in a similar way to
 //! [`OsString`].
 //!
 //! # Conversions
@@ -113,16 +113,19 @@
 //!
 //! ## On Windows
 //!
+//! An [`OsStr`] can be losslessly converted to a native Windows string. And
+//! a native Windows string can be losslessly converted to an [`OsString`].
+//!
 //! On Windows, [`OsStr`] implements the
 //! <code>std::os::windows::ffi::[OsStrExt][windows.OsStrExt]</code> trait,
 //! which provides an [`encode_wide`] method. This provides an
-//! iterator that can be [`collect`]ed into a vector of [`u16`].
+//! iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
+//! characters is appended, this is the same as a native Windows string.
 //!
 //! Additionally, on Windows [`OsString`] implements the
 //! <code>std::os::windows:ffi::[OsStringExt][windows.OsStringExt]</code>
-//! trait, which provides a [`from_wide`] method. The result of this
-//! method is an [`OsString`] which can be round-tripped to a Windows
-//! string losslessly.
+//! trait, which provides a [`from_wide`] method to convert a native Windows
+//! string (without the terminating nul character) to an [`OsString`].
 //!
 //! [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
 //! [Unicode code point]: https://www.unicode.org/glossary/#code_point

--- a/src/test/ui/consts/issue-90870.fixed
+++ b/src/test/ui/consts/issue-90870.fixed
@@ -1,0 +1,34 @@
+// Regression test for issue #90870.
+
+// run-rustfix
+
+#![allow(dead_code)]
+
+const fn f(a: &u8, b: &u8) -> bool {
+    *a == *b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn g(a: &&&&i64, b: &&&&i64) -> bool {
+    ****a == ****b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
+    while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
+        if *l == *r {
+        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~| HELP: consider dereferencing here
+            a = at;
+            b = bt;
+        } else {
+            return false;
+        }
+    }
+
+    a.is_empty() && b.is_empty()
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-90870.rs
+++ b/src/test/ui/consts/issue-90870.rs
@@ -1,0 +1,34 @@
+// Regression test for issue #90870.
+
+// run-rustfix
+
+#![allow(dead_code)]
+
+const fn f(a: &u8, b: &u8) -> bool {
+    a == b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn g(a: &&&&i64, b: &&&&i64) -> bool {
+    a == b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
+    while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
+        if l == r {
+        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~| HELP: consider dereferencing here
+            a = at;
+            b = bt;
+        } else {
+            return false;
+        }
+    }
+
+    a.is_empty() && b.is_empty()
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-90870.stderr
+++ b/src/test/ui/consts/issue-90870.stderr
@@ -1,0 +1,36 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:8:5
+   |
+LL |     a == b
+   |     ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |     *a == *b
+   |     +     +
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:14:5
+   |
+LL |     a == b
+   |     ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |     ****a == ****b
+   |     ++++     ++++
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:21:12
+   |
+LL |         if l == r {
+   |            ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |         if *l == *r {
+   |            +     +
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/fn/fn-recover-return-sign2.rs
+++ b/src/test/ui/fn/fn-recover-return-sign2.rs
@@ -3,6 +3,6 @@
 
 fn foo() => impl Fn() => bool {
     //~^ ERROR return types are denoted using `->`
-    //~| ERROR expected one of `+`, `->`, `::`, `;`, `where`, or `{`, found `=>`
+    //~| ERROR expected one of `+`, `->`, `::`, `where`, or `{`, found `=>`
     unimplemented!()
 }

--- a/src/test/ui/fn/fn-recover-return-sign2.stderr
+++ b/src/test/ui/fn/fn-recover-return-sign2.stderr
@@ -4,11 +4,11 @@ error: return types are denoted using `->`
 LL | fn foo() => impl Fn() => bool {
    |          ^^ help: use `->` instead
 
-error: expected one of `+`, `->`, `::`, `;`, `where`, or `{`, found `=>`
+error: expected one of `+`, `->`, `::`, `where`, or `{`, found `=>`
   --> $DIR/fn-recover-return-sign2.rs:4:23
    |
 LL | fn foo() => impl Fn() => bool {
-   |                       ^^ expected one of `+`, `->`, `::`, `;`, `where`, or `{`
+   |                       ^^ expected one of `+`, `->`, `::`, `where`, or `{`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issues/issue-24780.rs
+++ b/src/test/ui/parser/issues/issue-24780.rs
@@ -2,7 +2,7 @@
 // to happen in #24780. For example, following should be an error:
 // expected one of ..., `>`, ... found `>`.
 
-fn foo() -> Vec<usize>> { //~ ERROR expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+fn foo() -> Vec<usize>> { //~ ERROR expected one of `!`, `+`, `::`, `where`, or `{`, found `>`
     Vec::new()
 }
 

--- a/src/test/ui/parser/issues/issue-24780.stderr
+++ b/src/test/ui/parser/issues/issue-24780.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+error: expected one of `!`, `+`, `::`, `where`, or `{`, found `>`
   --> $DIR/issue-24780.rs:5:23
    |
 LL | fn foo() -> Vec<usize>> {
-   |                       ^ expected one of `!`, `+`, `::`, `;`, `where`, or `{`
+   |                       ^ expected one of `!`, `+`, `::`, `where`, or `{`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-58856-1.rs
+++ b/src/test/ui/parser/issues/issue-58856-1.rs
@@ -2,7 +2,7 @@ impl A {
     //~^ ERROR cannot find type `A` in this scope
     fn b(self>
     //~^ ERROR expected one of `)`, `,`, or `:`, found `>`
-    //~| ERROR expected one of `->`, `;`, `where`, or `{`, found `>`
+    //~| ERROR expected one of `->`, `where`, or `{`, found `>`
 }
 
 fn main() {}

--- a/src/test/ui/parser/issues/issue-58856-1.stderr
+++ b/src/test/ui/parser/issues/issue-58856-1.stderr
@@ -6,14 +6,14 @@ LL |     fn b(self>
    |         |
    |         unclosed delimiter
 
-error: expected one of `->`, `;`, `where`, or `{`, found `>`
+error: expected one of `->`, `where`, or `{`, found `>`
   --> $DIR/issue-58856-1.rs:3:14
    |
 LL | impl A {
    |        - while parsing this item list starting here
 LL |
 LL |     fn b(self>
-   |              ^ expected one of `->`, `;`, `where`, or `{`
+   |              ^ expected one of `->`, `where`, or `{`
 ...
 LL | }
    | - the item list ends here

--- a/src/test/ui/parser/issues/issue-84148-1.stderr
+++ b/src/test/ui/parser/issues/issue-84148-1.stderr
@@ -13,11 +13,11 @@ LL | fn f(t:for<>t?)
    |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
    |              help: missing `,`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/issue-84148-1.rs:1:15
    |
 LL | fn f(t:for<>t?)
-   |               ^ expected one of `->`, `;`, `where`, or `{`
+   |               ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/issues/issue-84148-2.stderr
+++ b/src/test/ui/parser/issues/issue-84148-2.stderr
@@ -21,11 +21,11 @@ LL | fn f(t:for<>t?
    |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
    |              help: missing `,`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/issue-84148-2.rs:4:16
    |
 LL | fn f(t:for<>t?
-   |                ^ expected one of `->`, `;`, `where`, or `{`
+   |                ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issues/issue-87635.rs
+++ b/src/test/ui/parser/issues/issue-87635.rs
@@ -2,8 +2,8 @@ struct Foo {}
 
 impl Foo {
     pub fn bar()
-    //~^ ERROR: expected `;`, found `}`
-    //~| ERROR: associated function in `impl` without body
+    //~^ ERROR: associated function in `impl` without body
 }
+//~^ERROR expected one of `->`, `where`, or `{`, found `}`
 
 fn main() {}

--- a/src/test/ui/parser/issues/issue-87635.stderr
+++ b/src/test/ui/parser/issues/issue-87635.stderr
@@ -1,11 +1,13 @@
-error: expected `;`, found `}`
-  --> $DIR/issue-87635.rs:4:17
+error: expected one of `->`, `where`, or `{`, found `}`
+  --> $DIR/issue-87635.rs:6:1
    |
 LL |     pub fn bar()
-   |                 ^ help: add `;` here
-...
+   |            ---  - expected one of `->`, `where`, or `{`
+   |            |
+   |            while parsing this `fn`
+LL |
 LL | }
-   | - unexpected token
+   | ^ unexpected token
 
 error: associated function in `impl` without body
   --> $DIR/issue-87635.rs:4:5

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -22,11 +22,11 @@ error: expected one of `:` or `|`, found `)`
 LL | fn main((ؼ
    |           ^ expected one of `:` or `|`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/missing_right_paren.rs:3:11
    |
 LL | fn main((ؼ
-   |           ^ expected one of `->`, `;`, `where`, or `{`
+   |           ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.fixed
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[allow(dead_code)]
+
+extern "C" {
+  fn foo(); //~ERROR expected `;`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.rs
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[allow(dead_code)]
+
+extern "C" {
+  fn foo() //~ERROR expected `;`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
@@ -1,0 +1,10 @@
+error: expected `;`, found `}`
+  --> $DIR/suggest-semicolon-for-fn-in-extern-block.rs:6:11
+   |
+LL |   fn foo()
+   |           ^ help: add `;` here
+LL | }
+   | - unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #91272 (Print a suggestion when comparing references to primitive types in `const fn`)
 - #91467 (Emphasise that an OsStr[ing] is not necessarily a platform string)
 - #91531 (Do not add `;` to expected tokens list when it's wrong)
 - #91619 (Update cargo)
 - #91625 (Remove redundant [..]s)
 - #91626 (rustc_serialize: don't allocate `String`s as key for `BTreeMap`, when `str` is enought)

Failed merges:

 - #91571 (Remove unneeded access to pretty printer's `s` field in favor of deref)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91272,91467,91531,91619,91625,91626)
<!-- homu-ignore:end -->