### PR TITLE
Implement `core::future::lazy`

### DIFF
--- a/library/core/src/future/lazy.rs
+++ b/library/core/src/future/lazy.rs
@@ -1,0 +1,54 @@
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+/// A future that lazily executes a closure.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[unstable(feature = "future_lazy", issue = "91647")]
+pub struct Lazy<F>(Option<F>);
+
+#[unstable(feature = "future_lazy", issue = "91647")]
+impl<F> Unpin for Lazy<F> {}
+
+/// Creates a new future that lazily executes a closure.
+///
+/// The provided closure is only run once the future is polled.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(future_lazy)]
+///
+/// # let _ = async {
+/// use std::future;
+///
+/// let a = future::lazy(|_| 1);
+/// assert_eq!(a.await, 1);
+///
+/// let b = future::lazy(|_| -> i32 {
+///     panic!("oh no!")
+/// });
+/// drop(b); // closure is never run
+/// # };
+/// ```
+#[unstable(feature = "future_lazy", issue = "91647")]
+pub fn lazy<F, R>(f: F) -> Lazy<F>
+where
+    F: FnOnce(&mut Context<'_>) -> R,
+{
+    Lazy(Some(f))
+}
+
+#[unstable(feature = "future_lazy", issue = "91647")]
+impl<F, R> Future for Lazy<F>
+where
+    F: FnOnce(&mut Context<'_>) -> R,
+{
+    type Output = R;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
+        let f = self.0.take().expect("`Lazy` polled after completion");
+        Poll::Ready((f)(cx))
+    }
+}

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 
 mod future;
 mod into_future;
+mod lazy;
 mod pending;
 mod poll_fn;
 mod ready;
@@ -28,6 +29,9 @@ pub use ready::{ready, Ready};
 
 #[unstable(feature = "future_poll_fn", issue = "72302")]
 pub use poll_fn::{poll_fn, PollFn};
+
+#[unstable(feature = "future_lazy", issue = "91647")]
+pub use self::lazy::{lazy, Lazy};
 
 /// This type is needed because:
 ///


### PR DESCRIPTION
`Lazy` executes a closure the first time it is polled:
```rust
let a = std::future::lazy(|_| 1);
assert_eq!(a.await, 1);
```

Prior art: https://docs.rs/futures/latest/futures/future/fn.lazy.html

The argument for exposing `task::Context` to the closure is that `lazy` can serve as a one-time `poll_fn` that accepts an `FnOnce`, as opposed to an `FnMut`. See [here](https://github.com/rust-lang/futures-rs/pull/878) for details.

(Would a better name be `once`?)