### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -878,29 +878,29 @@ impl<'a> PrintState<'a> for State<'a> {
     }
 
     fn print_ident(&mut self, ident: Ident) {
-        self.s.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
+        self.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
         self.ann.post(self, AnnNode::Ident(&ident))
     }
 
     fn print_generic_args(&mut self, args: &ast::GenericArgs, colons_before_params: bool) {
         if colons_before_params {
-            self.s.word("::")
+            self.word("::")
         }
 
         match *args {
             ast::GenericArgs::AngleBracketed(ref data) => {
-                self.s.word("<");
+                self.word("<");
                 self.commasep(Inconsistent, &data.args, |s, arg| match arg {
                     ast::AngleBracketedArg::Arg(a) => s.print_generic_arg(a),
                     ast::AngleBracketedArg::Constraint(c) => s.print_assoc_constraint(c),
                 });
-                self.s.word(">")
+                self.word(">")
             }
 
             ast::GenericArgs::Parenthesized(ref data) => {
-                self.s.word("(");
+                self.word("(");
                 self.commasep(Inconsistent, &data.inputs, |s, ty| s.print_type(ty));
-                self.s.word(")");
+                self.word(")");
                 self.print_fn_ret_ty(&data.output);
             }
         }
@@ -925,7 +925,7 @@ impl<'a> State<'a> {
             op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",");
+                self.word(",");
                 self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()));
                 self.space_if_not_bol();
             }
@@ -954,7 +954,7 @@ impl<'a> State<'a> {
     pub fn print_assoc_constraint(&mut self, constraint: &ast::AssocTyConstraint) {
         self.print_ident(constraint.ident);
         constraint.gen_args.as_ref().map(|args| self.print_generic_args(args, false));
-        self.s.space();
+        self.space();
         match &constraint.kind {
             ast::AssocTyConstraintKind::Equality { ty } => {
                 self.word_space("=");
@@ -979,27 +979,27 @@ impl<'a> State<'a> {
         self.ibox(0);
         match ty.kind {
             ast::TyKind::Slice(ref ty) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(ty);
-                self.s.word("]");
+                self.word("]");
             }
             ast::TyKind::Ptr(ref mt) => {
-                self.s.word("*");
+                self.word("*");
                 self.print_mt(mt, true);
             }
             ast::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lifetime);
                 self.print_mt(mt, false);
             }
             ast::TyKind::Never => {
-                self.s.word("!");
+                self.word("!");
             }
             ast::TyKind::Tup(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(ty));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
@@ -1023,33 +1023,33 @@ impl<'a> State<'a> {
                 self.print_type_bounds("impl", &bounds[..]);
             }
             ast::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(ty);
-                self.s.word("; ");
+                self.word("; ");
                 self.print_expr(&length.value);
-                self.s.word("]");
+                self.word("]");
             }
             ast::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(");
+                self.word("typeof(");
                 self.print_expr(&e.value);
-                self.s.word(")");
+                self.word(")");
             }
             ast::TyKind::Infer => {
-                self.s.word("_");
+                self.word("_");
             }
             ast::TyKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
             ast::TyKind::ImplicitSelf => {
-                self.s.word("Self");
+                self.word("Self");
             }
             ast::TyKind::MacCall(ref m) => {
                 self.print_mac(m);
             }
             ast::TyKind::CVarArgs => {
-                self.s.word("...");
+                self.word("...");
             }
         }
         self.end();
@@ -1087,7 +1087,7 @@ impl<'a> State<'a> {
             ast::ForeignItemKind::MacCall(m) => {
                 self.print_mac(m);
                 if m.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1115,13 +1115,13 @@ impl<'a> State<'a> {
         self.print_ident(ident);
         self.word_space(":");
         self.print_type(ty);
-        self.s.space();
+        self.space();
         self.end(); // end the head-ibox
         if let Some(body) = body {
             self.word_space("=");
             self.print_expr(body);
         }
-        self.s.word(";");
+        self.word(";");
         self.end(); // end the outer cbox
     }
 
@@ -1143,11 +1143,11 @@ impl<'a> State<'a> {
         self.print_type_bounds(":", bounds);
         self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_type(ty);
         }
-        self.s.word(";");
+        self.word(";");
         self.end(); // end inner head-block
         self.end(); // end outer head-block
     }
@@ -1163,19 +1163,19 @@ impl<'a> State<'a> {
                 self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
                     self.print_name(orig_name);
-                    self.s.space();
-                    self.s.word("as");
-                    self.s.space();
+                    self.space();
+                    self.word("as");
+                    self.space();
                 }
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
             ast::ItemKind::Use(ref tree) => {
                 self.head(visibility_qualified(&item.vis, "use"));
                 self.print_use_tree(tree);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
@@ -1218,7 +1218,7 @@ impl<'a> State<'a> {
                         self.bclose(item.span, empty);
                     }
                     ModKind::Unloaded => {
-                        self.s.word(";");
+                        self.word(";");
                         self.end(); // end inner head-block
                         self.end(); // end outer head-block
                     }
@@ -1289,23 +1289,23 @@ impl<'a> State<'a> {
 
                 if !generics.params.is_empty() {
                     self.print_generic_params(&generics.params);
-                    self.s.space();
+                    self.space();
                 }
 
                 if let ast::ImplPolarity::Negative(_) = polarity {
-                    self.s.word("!");
+                    self.word("!");
                 }
 
                 if let Some(ref t) = *of_trait {
                     self.print_trait_ref(t);
-                    self.s.space();
+                    self.space();
                     self.word_space("for");
                 }
 
                 self.print_type(self_ty);
                 self.print_where_clause(&generics.where_clause);
 
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes(&item.attrs);
                 for impl_item in items {
@@ -1332,7 +1332,7 @@ impl<'a> State<'a> {
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -1341,7 +1341,7 @@ impl<'a> State<'a> {
                 }
                 self.print_type_bounds(":", &real_bounds[..]);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(" ");
+                self.word(" ");
                 self.bopen();
                 self.print_inner_attributes(&item.attrs);
                 for trait_item in items {
@@ -1360,7 +1360,7 @@ impl<'a> State<'a> {
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -1370,12 +1370,12 @@ impl<'a> State<'a> {
                 self.nbsp();
                 self.print_type_bounds("=", &real_bounds[..]);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(";");
+                self.word(";");
             }
             ast::ItemKind::MacCall(ref mac) => {
                 self.print_mac(mac);
                 if mac.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
             ast::ItemKind::MacroDef(ref macro_def) => {
@@ -1393,7 +1393,7 @@ impl<'a> State<'a> {
 
     fn print_formal_generic_params(&mut self, generic_params: &[ast::GenericParam]) {
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
             self.nbsp();
         }
@@ -1416,7 +1416,7 @@ impl<'a> State<'a> {
         self.print_ident(ident);
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
@@ -1428,7 +1428,7 @@ impl<'a> State<'a> {
             self.print_outer_attributes(&v.attrs);
             self.ibox(INDENT_UNIT);
             self.print_variant(v);
-            self.s.word(",");
+            self.word(",");
             self.end();
             self.maybe_print_trailing_comment(v.span, None);
         }
@@ -1477,7 +1477,7 @@ impl<'a> State<'a> {
                 self.print_ident(field.ident.unwrap());
                 self.word_nbsp(":");
                 self.print_type(&field.ty);
-                self.s.word(",");
+                self.word(",");
             }
         }
 
@@ -1508,7 +1508,7 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";");
+                    self.word(";");
                 }
                 self.end();
                 self.end(); // Close the outer-box.
@@ -1526,7 +1526,7 @@ impl<'a> State<'a> {
         let generics = ast::Generics::default();
         self.print_struct(&v.data, &generics, v.ident, v.span, false);
         if let Some(ref d) = v.disr_expr {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_expr(&d.value)
         }
@@ -1558,7 +1558,7 @@ impl<'a> State<'a> {
             ast::AssocItemKind::MacCall(m) => {
                 self.print_mac(m);
                 if m.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1584,11 +1584,11 @@ impl<'a> State<'a> {
                     if let Some(els) = els {
                         self.cbox(INDENT_UNIT);
                         self.ibox(INDENT_UNIT);
-                        self.s.word(" else ");
+                        self.word(" else ");
                         self.print_block(els);
                     }
                 }
-                self.s.word(";");
+                self.word(";");
                 self.end(); // `let` ibox
             }
             ast::StmtKind::Item(ref item) => self.print_item(item),
@@ -1596,24 +1596,24 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
                 if classify::expr_requires_semi_to_be_stmt(expr) {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
             ast::StmtKind::Semi(ref expr) => {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
-                self.s.word(";");
+                self.word(";");
             }
             ast::StmtKind::Empty => {
                 self.space_if_not_bol();
-                self.s.word(";");
+                self.word(";");
             }
             ast::StmtKind::MacCall(ref mac) => {
                 self.space_if_not_bol();
                 self.print_outer_attributes(&mac.attrs);
                 self.print_mac(&mac.mac);
                 if mac.style == ast::MacStmtStyle::Semicolon {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1667,9 +1667,9 @@ impl<'a> State<'a> {
 
     /// Print a `let pat = expr` expression.
     crate fn print_let(&mut self, pat: &ast::Pat, expr: &ast::Expr) {
-        self.s.word("let ");
+        self.word("let ");
         self.print_pat(pat);
-        self.s.space();
+        self.space();
         self.word_space("=");
         let npals = || parser::needs_par_as_let_scrutinee(expr.precedence().order());
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
@@ -1682,9 +1682,9 @@ impl<'a> State<'a> {
                 ast::ExprKind::If(ref i, ref then, ref e) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else if ");
+                    self.word(" else if ");
                     self.print_expr_as_cond(i);
-                    self.s.space();
+                    self.space();
                     self.print_block(then);
                     self.print_else(e.as_deref())
                 }
@@ -1692,7 +1692,7 @@ impl<'a> State<'a> {
                 ast::ExprKind::Block(ref b, _) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else ");
+                    self.word(" else ");
                     self.print_block(b)
                 }
                 // Constraints would be great here!
@@ -1706,7 +1706,7 @@ impl<'a> State<'a> {
     crate fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block, elseopt: Option<&ast::Expr>) {
         self.head("if");
         self.print_expr_as_cond(test);
-        self.s.space();
+        self.space();
         self.print_block(blk);
         self.print_else(elseopt)
     }
@@ -1763,26 +1763,26 @@ impl<'a> State<'a> {
 
     fn print_expr_vec(&mut self, exprs: &[P<ast::Expr>]) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.commasep_exprs(Inconsistent, exprs);
-        self.s.word("]");
+        self.word("]");
         self.end();
     }
 
     fn print_expr_anon_const(&mut self, expr: &ast::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("const");
+        self.word("const");
         self.print_expr(&expr.value);
         self.end();
     }
 
     fn print_expr_repeat(&mut self, element: &ast::Expr, count: &ast::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.print_expr(element);
         self.word_space(";");
         self.print_expr(&count.value);
-        self.s.word("]");
+        self.word("]");
         self.end();
     }
 
@@ -1798,7 +1798,7 @@ impl<'a> State<'a> {
         } else {
             self.print_path(path, true, 0);
         }
-        self.s.word("{");
+        self.word("{");
         self.commasep_cmnt(
             Consistent,
             fields,
@@ -1818,26 +1818,26 @@ impl<'a> State<'a> {
             ast::StructRest::Base(_) | ast::StructRest::Rest(_) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
-                    self.s.word(",");
-                    self.s.space();
+                    self.word(",");
+                    self.space();
                 }
-                self.s.word("..");
+                self.word("..");
                 if let ast::StructRest::Base(ref expr) = *rest {
                     self.print_expr(expr);
                 }
                 self.end();
             }
-            ast::StructRest::None if !fields.is_empty() => self.s.word(","),
+            ast::StructRest::None if !fields.is_empty() => self.word(","),
             _ => {}
         }
-        self.s.word("}");
+        self.word("}");
     }
 
     fn print_expr_tup(&mut self, exprs: &[P<ast::Expr>]) {
         self.popen();
         self.commasep_exprs(Inconsistent, exprs);
         if exprs.len() == 1 {
-            self.s.word(",");
+            self.word(",");
         }
         self.pclose()
     }
@@ -1855,7 +1855,7 @@ impl<'a> State<'a> {
     fn print_expr_method_call(&mut self, segment: &ast::PathSegment, args: &[P<ast::Expr>]) {
         let base_args = &args[1..];
         self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
-        self.s.word(".");
+        self.word(".");
         self.print_ident(segment.ident);
         if let Some(ref args) = segment.args {
             self.print_generic_args(args, true);
@@ -1896,13 +1896,13 @@ impl<'a> State<'a> {
         };
 
         self.print_expr_maybe_paren(lhs, left_prec);
-        self.s.space();
+        self.space();
         self.word_space(op.node.to_string());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
     fn print_expr_unary(&mut self, op: ast::UnOp, expr: &ast::Expr) {
-        self.s.word(ast::UnOp::to_string(op));
+        self.word(ast::UnOp::to_string(op));
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
@@ -1912,7 +1912,7 @@ impl<'a> State<'a> {
         mutability: ast::Mutability,
         expr: &ast::Expr,
     ) {
-        self.s.word("&");
+        self.word("&");
         match kind {
             ast::BorrowKind::Ref => self.print_mutability(mutability, false),
             ast::BorrowKind::Raw => {
@@ -1980,7 +1980,7 @@ impl<'a> State<'a> {
             ast::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
                 self.print_expr_maybe_paren(expr, prec);
-                self.s.space();
+                self.space();
                 self.word_space("as");
                 self.print_type(ty);
             }
@@ -2003,7 +2003,7 @@ impl<'a> State<'a> {
                 }
                 self.head("while");
                 self.print_expr_as_cond(test);
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::ForLoop(ref pat, ref iter, ref blk, opt_label) => {
@@ -2013,10 +2013,10 @@ impl<'a> State<'a> {
                 }
                 self.head("for");
                 self.print_pat(pat);
-                self.s.space();
+                self.space();
                 self.word_space("in");
                 self.print_expr_as_cond(iter);
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Loop(ref blk, opt_label) => {
@@ -2032,7 +2032,7 @@ impl<'a> State<'a> {
                 self.ibox(INDENT_UNIT);
                 self.word_nbsp("match");
                 self.print_expr_as_cond(expr);
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes_no_trailing_hardbreak(attrs);
                 for arm in arms {
@@ -2054,7 +2054,7 @@ impl<'a> State<'a> {
                 self.print_capture_clause(capture_clause);
 
                 self.print_fn_params_and_ret(decl, true);
-                self.s.space();
+                self.space();
                 self.print_expr(body);
                 self.end(); // need to close a box
 
@@ -2084,33 +2084,33 @@ impl<'a> State<'a> {
             }
             ast::ExprKind::Await(ref expr) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".await");
+                self.word(".await");
             }
             ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
-                self.s.space();
+                self.space();
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
-                self.s.space();
-                self.s.word(op.node.to_string());
+                self.space();
+                self.word(op.node.to_string());
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::Field(ref expr, ident) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".");
+                self.word(".");
                 self.print_ident(ident);
             }
             ast::ExprKind::Index(ref expr, ref index) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word("[");
+                self.word("[");
                 self.print_expr(index);
-                self.s.word("]");
+                self.word("]");
             }
             ast::ExprKind::Range(ref start, ref end, limits) => {
                 // Special case for `Range`.  `AssocOp` claims that `Range` has higher precedence
@@ -2122,41 +2122,41 @@ impl<'a> State<'a> {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
                 if limits == ast::RangeLimits::HalfOpen {
-                    self.s.word("..");
+                    self.word("..");
                 } else {
-                    self.s.word("..=");
+                    self.word("..=");
                 }
                 if let Some(ref e) = *end {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
             }
-            ast::ExprKind::Underscore => self.s.word("_"),
+            ast::ExprKind::Underscore => self.word("_"),
             ast::ExprKind::Path(None, ref path) => self.print_path(path, true, 0),
             ast::ExprKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, true),
             ast::ExprKind::Break(opt_label, ref opt_expr) => {
-                self.s.word("break");
-                self.s.space();
+                self.word("break");
+                self.space();
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
-                    self.s.space();
+                    self.space();
                 }
                 if let Some(ref expr) = *opt_expr {
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
-                    self.s.space();
+                    self.space();
                 }
             }
             ast::ExprKind::Continue(opt_label) => {
-                self.s.word("continue");
-                self.s.space();
+                self.word("continue");
+                self.space();
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
-                    self.s.space()
+                    self.space()
                 }
             }
             ast::ExprKind::Ret(ref result) => {
-                self.s.word("return");
+                self.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ");
+                    self.word(" ");
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
@@ -2165,7 +2165,7 @@ impl<'a> State<'a> {
                 self.print_inline_asm(a);
             }
             ast::ExprKind::LlvmInlineAsm(ref a) => {
-                self.s.word("llvm_asm!");
+                self.word("llvm_asm!");
                 self.popen();
                 self.print_symbol(a.asm, a.asm_str_style);
                 self.word_space(":");
@@ -2183,7 +2183,7 @@ impl<'a> State<'a> {
                     s.print_expr(&out.expr);
                     s.pclose();
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &a.inputs, |s, &(co, ref o)| {
@@ -2192,7 +2192,7 @@ impl<'a> State<'a> {
                     s.print_expr(o);
                     s.pclose();
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &a.clobbers, |s, &co| {
@@ -2211,7 +2211,7 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space();
+                    self.space();
                     self.word_space(":");
                     self.commasep(Inconsistent, &options, |s, &co| {
                         s.print_string(co, ast::StrStyle::Cooked);
@@ -2227,25 +2227,25 @@ impl<'a> State<'a> {
                 self.pclose();
             }
             ast::ExprKind::Yield(ref e) => {
-                self.s.word("yield");
+                self.word("yield");
 
                 if let Some(ref expr) = *e {
-                    self.s.space();
+                    self.space();
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
             ast::ExprKind::Try(ref e) => {
                 self.print_expr_maybe_paren(e, parser::PREC_POSTFIX);
-                self.s.word("?")
+                self.word("?")
             }
             ast::ExprKind::TryBlock(ref blk) => {
                 self.head("try");
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs)
             }
             ast::ExprKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose()
             }
         }
@@ -2387,22 +2387,22 @@ impl<'a> State<'a> {
     }
 
     crate fn print_name(&mut self, name: Symbol) {
-        self.s.word(name.to_string());
+        self.word(name.to_string());
         self.ann.post(self, AnnNode::Name(&name))
     }
 
     fn print_qpath(&mut self, path: &ast::Path, qself: &ast::QSelf, colons_before_params: bool) {
-        self.s.word("<");
+        self.word("<");
         self.print_type(&qself.ty);
         if qself.position > 0 {
-            self.s.space();
+            self.space();
             self.word_space("as");
             let depth = path.segments.len() - qself.position;
             self.print_path(path, false, depth);
         }
-        self.s.word(">");
+        self.word(">");
         for item_segment in &path.segments[qself.position..] {
-            self.s.word("::");
+            self.word("::");
             self.print_ident(item_segment.ident);
             if let Some(ref args) = item_segment.args {
                 self.print_generic_args(args, colons_before_params)
@@ -2416,7 +2416,7 @@ impl<'a> State<'a> {
         /* Pat isn't normalized, but the beauty of it
         is that it doesn't matter */
         match pat.kind {
-            PatKind::Wild => self.s.word("_"),
+            PatKind::Wild => self.word("_"),
             PatKind::Ident(binding_mode, ident, ref sub) => {
                 match binding_mode {
                     ast::BindingMode::ByRef(mutbl) => {
@@ -2430,8 +2430,8 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.space();
-                    self.s.word_space("@");
+                    self.space();
+                    self.word_space("@");
                     self.print_pat(p);
                 }
             }
@@ -2480,27 +2480,27 @@ impl<'a> State<'a> {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                 }
-                self.s.space();
-                self.s.word("}");
+                self.space();
+                self.word("}");
             }
             PatKind::Tuple(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
             PatKind::Box(ref inner) => {
-                self.s.word("box ");
+                self.word("box ");
                 self.print_pat(inner);
             }
             PatKind::Ref(ref inner, mutbl) => {
-                self.s.word("&");
+                self.word("&");
                 if mutbl == ast::Mutability::Mut {
-                    self.s.word("mut ");
+                    self.word("mut ");
                 }
                 if let PatKind::Ident(ast::BindingMode::ByValue(ast::Mutability::Mut), ..) =
                     inner.kind
@@ -2516,23 +2516,23 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {
                 if let Some(e) = begin {
                     self.print_expr(e);
-                    self.s.space();
+                    self.space();
                 }
                 match *end_kind {
-                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.s.word("..."),
-                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.s.word("..="),
-                    RangeEnd::Excluded => self.s.word(".."),
+                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.word("..."),
+                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.word("..="),
+                    RangeEnd::Excluded => self.word(".."),
                 }
                 if let Some(e) = end {
                     self.print_expr(e);
                 }
             }
             PatKind::Slice(ref elts) => {
-                self.s.word("[");
+                self.word("[");
                 self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
-                self.s.word("]");
+                self.word("]");
             }
-            PatKind::Rest => self.s.word(".."),
+            PatKind::Rest => self.word(".."),
             PatKind::Paren(ref inner) => {
                 self.popen();
                 self.print_pat(inner);
@@ -2546,18 +2546,18 @@ impl<'a> State<'a> {
     fn print_arm(&mut self, arm: &ast::Arm) {
         // Note, I have no idea why this check is necessary, but here it is.
         if arm.attrs.is_empty() {
-            self.s.space();
+            self.space();
         }
         self.cbox(INDENT_UNIT);
         self.ibox(0);
         self.maybe_print_comment(arm.pat.span.lo());
         self.print_outer_attributes(&arm.attrs);
         self.print_pat(&arm.pat);
-        self.s.space();
+        self.space();
         if let Some(ref e) = arm.guard {
             self.word_space("if");
             self.print_expr(e);
-            self.s.space();
+            self.space();
         }
         self.word_space("=>");
 
@@ -2573,13 +2573,13 @@ impl<'a> State<'a> {
 
                 // If it is a user-provided unsafe block, print a comma after it.
                 if let BlockCheckMode::Unsafe(ast::UserProvided) = blk.rules {
-                    self.s.word(",");
+                    self.word(",");
                 }
             }
             _ => {
                 self.end(); // Close the ibox for the pattern.
                 self.print_expr(&arm.body);
-                self.s.word(",");
+                self.word(",");
             }
         }
         self.end(); // Close enclosing cbox.
@@ -2589,17 +2589,17 @@ impl<'a> State<'a> {
         match explicit_self.node {
             SelfKind::Value(m) => {
                 self.print_mutability(m, false);
-                self.s.word("self")
+                self.word("self")
             }
             SelfKind::Region(ref lt, m) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lt);
                 self.print_mutability(m, false);
-                self.s.word("self")
+                self.word("self")
             }
             SelfKind::Explicit(ref typ, m) => {
                 self.print_mutability(m, false);
-                self.s.word("self");
+                self.word("self");
                 self.word_space(":");
                 self.print_type(typ)
             }
@@ -2626,7 +2626,7 @@ impl<'a> State<'a> {
             self.nbsp();
             self.print_block_with_attrs(body, attrs);
         } else {
-            self.s.word(";");
+            self.word(";");
         }
     }
 
@@ -2677,7 +2677,7 @@ impl<'a> State<'a> {
 
     pub fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound]) {
         if !bounds.is_empty() {
-            self.s.word(prefix);
+            self.word(prefix);
             let mut first = true;
             for bound in bounds {
                 if !(first && prefix.is_empty()) {
@@ -2692,7 +2692,7 @@ impl<'a> State<'a> {
                 match bound {
                     GenericBound::Trait(tref, modifier) => {
                         if modifier == &TraitBoundModifier::Maybe {
-                            self.s.word("?");
+                            self.word("?");
                         }
                         self.print_poly_trait_ref(tref);
                     }
@@ -2713,10 +2713,10 @@ impl<'a> State<'a> {
     ) {
         self.print_lifetime(lifetime);
         if !bounds.is_empty() {
-            self.s.word(": ");
+            self.word(": ");
             for (i, bound) in bounds.iter().enumerate() {
                 if i != 0 {
-                    self.s.word(" + ");
+                    self.word(" + ");
                 }
                 match bound {
                     ast::GenericBound::Outlives(lt) => self.print_lifetime(*lt),
@@ -2731,7 +2731,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.word("<");
+        self.word("<");
 
         self.commasep(Inconsistent, &generic_params, |s, param| {
             s.print_outer_attributes_inline(&param.attrs);
@@ -2745,7 +2745,7 @@ impl<'a> State<'a> {
                     s.print_ident(param.ident);
                     s.print_type_bounds(":", &param.bounds);
                     if let Some(ref default) = default {
-                        s.s.space();
+                        s.space();
                         s.word_space("=");
                         s.print_type(default)
                     }
@@ -2753,12 +2753,12 @@ impl<'a> State<'a> {
                 ast::GenericParamKind::Const { ref ty, kw_span: _, ref default } => {
                     s.word_space("const");
                     s.print_ident(param.ident);
-                    s.s.space();
+                    s.space();
                     s.word_space(":");
                     s.print_type(ty);
                     s.print_type_bounds(":", &param.bounds);
                     if let Some(ref default) = default {
-                        s.s.space();
+                        s.space();
                         s.word_space("=");
                         s.print_expr(&default.value);
                     }
@@ -2766,7 +2766,7 @@ impl<'a> State<'a> {
             }
         });
 
-        self.s.word(">");
+        self.word(">");
     }
 
     crate fn print_where_clause(&mut self, where_clause: &ast::WhereClause) {
@@ -2774,7 +2774,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.space();
+        self.space();
         self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
@@ -2806,7 +2806,7 @@ impl<'a> State<'a> {
                     ..
                 }) => {
                     self.print_type(lhs_ty);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(rhs_ty);
                 }
@@ -2819,7 +2819,7 @@ impl<'a> State<'a> {
             ast::UseTreeKind::Simple(rename, ..) => {
                 self.print_path(&tree.prefix, false, 0);
                 if let Some(rename) = rename {
-                    self.s.space();
+                    self.space();
                     self.word_space("as");
                     self.print_ident(rename);
                 }
@@ -2827,21 +2827,21 @@ impl<'a> State<'a> {
             ast::UseTreeKind::Glob => {
                 if !tree.prefix.segments.is_empty() {
                     self.print_path(&tree.prefix, false, 0);
-                    self.s.word("::");
+                    self.word("::");
                 }
-                self.s.word("*");
+                self.word("*");
             }
             ast::UseTreeKind::Nested(ref items) => {
                 if tree.prefix.segments.is_empty() {
-                    self.s.word("{");
+                    self.word("{");
                 } else {
                     self.print_path(&tree.prefix, false, 0);
-                    self.s.word("::{");
+                    self.word("::{");
                 }
                 self.commasep(Inconsistent, &items[..], |this, &(ref tree, _)| {
                     this.print_use_tree(tree)
                 });
-                self.s.word("}");
+                self.word("}");
             }
         }
     }
@@ -2880,8 +2880,8 @@ impl<'a> State<'a> {
                     };
                     if !invalid {
                         self.print_pat(&input.pat);
-                        self.s.word(":");
-                        self.s.space();
+                        self.word(":");
+                        self.space();
                     }
                     self.print_type(&input.ty);
                 }
@@ -2911,7 +2911,7 @@ impl<'a> State<'a> {
     ) {
         self.ibox(INDENT_UNIT);
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
         }
         let generics = ast::Generics {
@@ -2945,7 +2945,7 @@ impl<'a> State<'a> {
             }
         }
 
-        self.s.word("fn")
+        self.word("fn")
     }
 
     crate fn print_unsafety(&mut self, s: ast::Unsafe) {

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -812,7 +812,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     trace!("attempting to call a trait method");
                     if !self.tcx.features().const_trait_impl {
-                        self.check_op(ops::FnCallNonConst);
+                        self.check_op(ops::FnCallNonConst(Some((callee, substs))));
                         return;
                     }
 
@@ -868,7 +868,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                             }
 
                             if !nonconst_call_permission {
-                                self.check_op(ops::FnCallNonConst);
+                                self.check_op(ops::FnCallNonConst(None));
                                 return;
                             }
                         }
@@ -937,7 +937,7 @@ impl Visitor<'tcx> for Checker<'mir, 'tcx> {
                     }
 
                     if !nonconst_call_permission {
-                        self.check_op(ops::FnCallNonConst);
+                        self.check_op(ops::FnCallNonConst(None));
                         return;
                     }
                 }

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -402,7 +402,24 @@ impl<'a> StripUnconfigured<'a> {
                 );
                 trees.push((bracket_group, Spacing::Alone));
                 let tokens = Some(LazyTokenStream::new(AttrAnnotatedTokenStream::new(trees)));
-                self.process_cfg_attr(attr::mk_attr_from_item(item, tokens, attr.style, span))
+                let attr = attr::mk_attr_from_item(item, tokens, attr.style, span);
+                if attr.has_name(sym::crate_type) {
+                    self.sess.parse_sess.buffer_lint(
+                        rustc_lint_defs::builtin::DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
+                        attr.span,
+                        ast::CRATE_NODE_ID,
+                        "`crate_type` within an `#![cfg_attr] attribute is deprecated`",
+                    );
+                }
+                if attr.has_name(sym::crate_name) {
+                    self.sess.parse_sess.buffer_lint(
+                        rustc_lint_defs::builtin::DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
+                        attr.span,
+                        ast::CRATE_NODE_ID,
+                        "`crate_name` within an `#![cfg_attr] attribute is deprecated`",
+                    );
+                }
+                self.process_cfg_attr(attr)
             })
             .collect()
     }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -89,7 +89,7 @@ impl<'a> State<'a> {
             Node::TraitRef(a) => self.print_trait_ref(&a),
             Node::Binding(a) | Node::Pat(a) => self.print_pat(&a),
             Node::Arm(a) => self.print_arm(&a),
-            Node::Infer(_) => self.s.word("_"),
+            Node::Infer(_) => self.word("_"),
             Node::Block(a) => {
                 // Containing cbox, will be closed by print-block at `}`.
                 self.cbox(INDENT_UNIT);
@@ -130,7 +130,7 @@ impl<'a> PrintState<'a> for State<'a> {
     }
 
     fn print_ident(&mut self, ident: Ident) {
-        self.s.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
+        self.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
         self.ann.post(self, AnnNode::Name(&ident.name))
     }
 
@@ -194,7 +194,7 @@ where
 pub fn visibility_qualified<S: Into<Cow<'static, str>>>(vis: &hir::Visibility<'_>, w: S) -> String {
     to_string(NO_ANN, |s| {
         s.print_visibility(vis);
-        s.s.word(w)
+        s.word(w)
     })
 }
 
@@ -244,7 +244,7 @@ impl<'a> State<'a> {
     pub fn bclose_maybe_open(&mut self, span: rustc_span::Span, close_box: bool) {
         self.maybe_print_comment(span.hi());
         self.break_offset_if_not_bol(1, -(INDENT_UNIT as isize));
-        self.s.word("}");
+        self.word("}");
         if close_box {
             self.end(); // close the outer-box
         }
@@ -267,7 +267,7 @@ impl<'a> State<'a> {
             op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",");
+                self.word(",");
                 self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()));
                 self.space_if_not_bol();
             }
@@ -298,27 +298,27 @@ impl<'a> State<'a> {
         self.ibox(0);
         match ty.kind {
             hir::TyKind::Slice(ref ty) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(&ty);
-                self.s.word("]");
+                self.word("]");
             }
             hir::TyKind::Ptr(ref mt) => {
-                self.s.word("*");
+                self.word("*");
                 self.print_mt(mt, true);
             }
             hir::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lifetime);
                 self.print_mt(mt, false);
             }
             hir::TyKind::Never => {
-                self.s.word("!");
+                self.word("!");
             }
             hir::TyKind::Tup(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
@@ -332,7 +332,7 @@ impl<'a> State<'a> {
                     f.param_names,
                 );
             }
-            hir::TyKind::OpaqueDef(..) => self.s.word("/*impl Trait*/"),
+            hir::TyKind::OpaqueDef(..) => self.word("/*impl Trait*/"),
             hir::TyKind::Path(ref qpath) => self.print_qpath(qpath, false),
             hir::TyKind::TraitObject(bounds, ref lifetime, syntax) => {
                 if syntax == ast::TraitObjectSyntax::Dyn {
@@ -355,24 +355,24 @@ impl<'a> State<'a> {
                 }
             }
             hir::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(&ty);
-                self.s.word("; ");
+                self.word("; ");
                 self.print_anon_const(length);
-                self.s.word("]");
+                self.word("]");
             }
             hir::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(");
+                self.word("typeof(");
                 self.print_anon_const(e);
-                self.s.word(")");
+                self.word(")");
             }
             hir::TyKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
             hir::TyKind::Infer => {
-                self.s.word("_");
+                self.word("_");
             }
         }
         self.end()
@@ -400,7 +400,7 @@ impl<'a> State<'a> {
                     None,
                 );
                 self.end(); // end head-ibox
-                self.s.word(";");
+                self.word(";");
                 self.end() // end the outer fn box
             }
             hir::ForeignItemKind::Static(ref t, m) => {
@@ -411,14 +411,14 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&t);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
             hir::ForeignItemKind::Type => {
                 self.head(visibility_qualified(&item.vis, "type"));
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
@@ -432,17 +432,17 @@ impl<'a> State<'a> {
         default: Option<hir::BodyId>,
         vis: &hir::Visibility<'_>,
     ) {
-        self.s.word(visibility_qualified(vis, ""));
+        self.word(visibility_qualified(vis, ""));
         self.word_space("const");
         self.print_ident(ident);
         self.word_space(":");
         self.print_type(ty);
         if let Some(expr) = default {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.ann.nested(self, Nested::Body(expr));
         }
-        self.s.word(";")
+        self.word(";")
     }
 
     fn print_associated_type(
@@ -460,11 +460,11 @@ impl<'a> State<'a> {
         }
         self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_type(ty);
         }
-        self.s.word(";")
+        self.word(";")
     }
 
     fn print_item_type(
@@ -479,9 +479,9 @@ impl<'a> State<'a> {
         self.end(); // end the inner ibox
 
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         inner(self);
-        self.s.word(";");
+        self.word(";");
         self.end(); // end the outer ibox
     }
 
@@ -497,12 +497,12 @@ impl<'a> State<'a> {
                 self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
                     self.print_name(orig_name);
-                    self.s.space();
-                    self.s.word("as");
-                    self.s.space();
+                    self.space();
+                    self.word("as");
+                    self.space();
                 }
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
@@ -513,14 +513,14 @@ impl<'a> State<'a> {
                 match kind {
                     hir::UseKind::Single => {
                         if path.segments.last().unwrap().ident != item.ident {
-                            self.s.space();
+                            self.space();
                             self.word_space("as");
                             self.print_ident(item.ident);
                         }
-                        self.s.word(";");
+                        self.word(";");
                     }
-                    hir::UseKind::Glob => self.s.word("::*;"),
-                    hir::UseKind::ListStem => self.s.word("::{};"),
+                    hir::UseKind::Glob => self.word("::*;"),
+                    hir::UseKind::ListStem => self.word("::{};"),
                 }
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
@@ -533,12 +533,12 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&ty);
-                self.s.space();
+                self.space();
                 self.end(); // end the head-ibox
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the outer cbox
             }
             hir::ItemKind::Const(ref ty, expr) => {
@@ -546,12 +546,12 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&ty);
-                self.s.space();
+                self.space();
                 self.end(); // end the head-ibox
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the outer cbox
             }
             hir::ItemKind::Fn(ref sig, ref param_names, body) => {
@@ -565,7 +565,7 @@ impl<'a> State<'a> {
                     &[],
                     Some(body),
                 );
-                self.s.word(" ");
+                self.word(" ");
                 self.end(); // need to close a box
                 self.end(); // need to close a box
                 self.ann.nested(self, Nested::Body(body));
@@ -609,7 +609,7 @@ impl<'a> State<'a> {
                     let mut real_bounds = Vec::with_capacity(opaque_ty.bounds.len());
                     for b in opaque_ty.bounds.iter() {
                         if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                            state.s.space();
+                            state.space();
                             state.word_space("for ?");
                             state.print_trait_ref(&ptr.trait_ref);
                         } else {
@@ -649,7 +649,7 @@ impl<'a> State<'a> {
 
                 if !generics.params.is_empty() {
                     self.print_generic_params(&generics.params);
-                    self.s.space();
+                    self.space();
                 }
 
                 if constness == hir::Constness::Const {
@@ -657,19 +657,19 @@ impl<'a> State<'a> {
                 }
 
                 if let hir::ImplPolarity::Negative(_) = polarity {
-                    self.s.word("!");
+                    self.word("!");
                 }
 
                 if let Some(ref t) = of_trait {
                     self.print_trait_ref(t);
-                    self.s.space();
+                    self.space();
                     self.word_space("for");
                 }
 
                 self.print_type(&self_ty);
                 self.print_where_clause(&generics.where_clause);
 
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes(attrs);
                 for impl_item in items {
@@ -688,7 +688,7 @@ impl<'a> State<'a> {
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -697,7 +697,7 @@ impl<'a> State<'a> {
                 }
                 self.print_bounds(":", real_bounds);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(" ");
+                self.word(" ");
                 self.bopen();
                 for trait_item in trait_items {
                     self.ann.nested(self, Nested::TraitItem(trait_item.id));
@@ -714,7 +714,7 @@ impl<'a> State<'a> {
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -724,7 +724,7 @@ impl<'a> State<'a> {
                 self.nbsp();
                 self.print_bounds("=", real_bounds);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(";");
+                self.word(";");
             }
         }
         self.ann.post(self, AnnNode::Item(item))
@@ -736,7 +736,7 @@ impl<'a> State<'a> {
 
     fn print_formal_generic_params(&mut self, generic_params: &[hir::GenericParam<'_>]) {
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
             self.nbsp();
         }
@@ -759,7 +759,7 @@ impl<'a> State<'a> {
         self.print_name(name);
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
@@ -771,7 +771,7 @@ impl<'a> State<'a> {
             self.print_outer_attributes(self.attrs(v.id));
             self.ibox(INDENT_UNIT);
             self.print_variant(v);
-            self.s.word(",");
+            self.word(",");
             self.end();
             self.maybe_print_trailing_comment(v.span, None);
         }
@@ -784,10 +784,10 @@ impl<'a> State<'a> {
             hir::VisibilityKind::Crate(ast::CrateSugar::JustCrate) => self.word_nbsp("crate"),
             hir::VisibilityKind::Crate(ast::CrateSugar::PubCrate) => self.word_nbsp("pub(crate)"),
             hir::VisibilityKind::Restricted { ref path, .. } => {
-                self.s.word("pub(");
+                self.word("pub(");
                 if path.segments.len() == 1 && path.segments[0].ident.name == kw::Super {
                     // Special case: `super` can print like `pub(super)`.
-                    self.s.word("super");
+                    self.word("super");
                 } else {
                     // Everything else requires `in` at present.
                     self.word_nbsp("in");
@@ -830,7 +830,7 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";");
+                    self.word(";");
                 }
                 self.end();
                 self.end() // close the outer-box
@@ -849,7 +849,7 @@ impl<'a> State<'a> {
                     self.print_ident(field.ident);
                     self.word_nbsp(":");
                     self.print_type(&field.ty);
-                    self.s.word(",");
+                    self.word(",");
                 }
 
                 self.bclose(span)
@@ -862,7 +862,7 @@ impl<'a> State<'a> {
         let generics = hir::Generics::empty();
         self.print_struct(&v.data, &generics, v.ident.name, v.span, false);
         if let Some(ref d) = v.disr_expr {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_anon_const(d);
         }
@@ -894,7 +894,7 @@ impl<'a> State<'a> {
                 let vis =
                     Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Inherited };
                 self.print_method_sig(ti.ident, sig, &ti.generics, &vis, arg_names, None);
-                self.s.word(";");
+                self.word(";");
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
                 let vis =
@@ -975,11 +975,11 @@ impl<'a> State<'a> {
             hir::StmtKind::Semi(ref expr) => {
                 self.space_if_not_bol();
                 self.print_expr(&expr);
-                self.s.word(";");
+                self.word(";");
             }
         }
         if stmt_ends_with_semi(&st.kind) {
-            self.s.word(";");
+            self.word(";");
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
@@ -1031,9 +1031,9 @@ impl<'a> State<'a> {
                 hir::ExprKind::If(ref i, ref then, ref e) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else if ");
+                    self.word(" else if ");
                     self.print_expr_as_cond(&i);
-                    self.s.space();
+                    self.space();
                     self.print_expr(&then);
                     self.print_else(e.as_ref().map(|e| &**e))
                 }
@@ -1041,7 +1041,7 @@ impl<'a> State<'a> {
                 hir::ExprKind::Block(ref b, _) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else ");
+                    self.word(" else ");
                     self.print_block(&b)
                 }
                 // Constraints would be great here!
@@ -1060,7 +1060,7 @@ impl<'a> State<'a> {
     ) {
         self.head("if");
         self.print_expr_as_cond(test);
-        self.s.space();
+        self.space();
         self.print_expr(blk);
         self.print_else(elseopt)
     }
@@ -1102,9 +1102,9 @@ impl<'a> State<'a> {
 
     /// Print a `let pat = expr` expression.
     fn print_let(&mut self, pat: &hir::Pat<'_>, expr: &hir::Expr<'_>) {
-        self.s.word("let ");
+        self.word("let ");
         self.print_pat(pat);
-        self.s.space();
+        self.space();
         self.word_space("=");
         let npals = || parser::needs_par_as_let_scrutinee(expr.precedence().order());
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
@@ -1123,26 +1123,26 @@ impl<'a> State<'a> {
 
     fn print_expr_vec(&mut self, exprs: &[hir::Expr<'_>]) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.commasep_exprs(Inconsistent, exprs);
-        self.s.word("]");
+        self.word("]");
         self.end()
     }
 
     fn print_expr_anon_const(&mut self, anon_const: &hir::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word_space("const");
+        self.word_space("const");
         self.print_anon_const(anon_const);
         self.end()
     }
 
     fn print_expr_repeat(&mut self, element: &hir::Expr<'_>, count: &hir::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.print_expr(element);
         self.word_space(";");
         self.print_anon_const(count);
-        self.s.word("]");
+        self.word("]");
         self.end()
     }
 
@@ -1153,7 +1153,7 @@ impl<'a> State<'a> {
         wth: &Option<&hir::Expr<'_>>,
     ) {
         self.print_qpath(qpath, true);
-        self.s.word("{");
+        self.word("{");
         self.commasep_cmnt(
             Consistent,
             fields,
@@ -1172,27 +1172,27 @@ impl<'a> State<'a> {
             Some(ref expr) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
-                    self.s.word(",");
-                    self.s.space();
+                    self.word(",");
+                    self.space();
                 }
-                self.s.word("..");
+                self.word("..");
                 self.print_expr(&expr);
                 self.end();
             }
             _ => {
                 if !fields.is_empty() {
-                    self.s.word(",")
+                    self.word(",")
                 }
             }
         }
-        self.s.word("}");
+        self.word("}");
     }
 
     fn print_expr_tup(&mut self, exprs: &[hir::Expr<'_>]) {
         self.popen();
         self.commasep_exprs(Inconsistent, exprs);
         if exprs.len() == 1 {
-            self.s.word(",");
+            self.word(",");
         }
         self.pclose()
     }
@@ -1210,7 +1210,7 @@ impl<'a> State<'a> {
     fn print_expr_method_call(&mut self, segment: &hir::PathSegment<'_>, args: &[hir::Expr<'_>]) {
         let base_args = &args[1..];
         self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
-        self.s.word(".");
+        self.word(".");
         self.print_ident(segment.ident);
 
         let generic_args = segment.args();
@@ -1246,13 +1246,13 @@ impl<'a> State<'a> {
         };
 
         self.print_expr_maybe_paren(lhs, left_prec);
-        self.s.space();
+        self.space();
         self.word_space(op.node.as_str());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
     fn print_expr_unary(&mut self, op: hir::UnOp, expr: &hir::Expr<'_>) {
-        self.s.word(op.as_str());
+        self.word(op.as_str());
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
@@ -1262,7 +1262,7 @@ impl<'a> State<'a> {
         mutability: hir::Mutability,
         expr: &hir::Expr<'_>,
     ) {
-        self.s.word("&");
+        self.word("&");
         match kind {
             hir::BorrowKind::Ref => self.print_mutability(mutability, false),
             hir::BorrowKind::Raw => {
@@ -1434,7 +1434,7 @@ impl<'a> State<'a> {
             hir::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
                 self.print_expr_maybe_paren(&expr, prec);
-                self.s.space();
+                self.space();
                 self.word_space("as");
                 self.print_type(&ty);
             }
@@ -1453,7 +1453,7 @@ impl<'a> State<'a> {
                 // Print `let _t = $init;`:
                 let temp = Ident::from_str("_t");
                 self.print_local(Some(init), |this| this.print_ident(temp));
-                self.s.word(";");
+                self.word(";");
 
                 // Print `_t`:
                 self.space_if_not_bol();
@@ -1481,7 +1481,7 @@ impl<'a> State<'a> {
                 self.ibox(INDENT_UNIT);
                 self.word_nbsp("match");
                 self.print_expr_as_cond(&expr);
-                self.s.space();
+                self.space();
                 self.bopen();
                 for arm in arms {
                     self.print_arm(arm);
@@ -1492,7 +1492,7 @@ impl<'a> State<'a> {
                 self.print_capture_clause(capture_clause);
 
                 self.print_closure_params(&decl, body);
-                self.s.space();
+                self.space();
 
                 // This is a bare expression.
                 self.ann.nested(self, Nested::Body(body));
@@ -1517,54 +1517,54 @@ impl<'a> State<'a> {
             hir::ExprKind::Assign(ref lhs, ref rhs, _) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(&lhs, prec + 1);
-                self.s.space();
+                self.space();
                 self.word_space("=");
                 self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(&lhs, prec + 1);
-                self.s.space();
-                self.s.word(op.node.as_str());
+                self.space();
+                self.word(op.node.as_str());
                 self.word_space("=");
                 self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::Field(ref expr, ident) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".");
+                self.word(".");
                 self.print_ident(ident);
             }
             hir::ExprKind::Index(ref expr, ref index) => {
                 self.print_expr_maybe_paren(&expr, parser::PREC_POSTFIX);
-                self.s.word("[");
+                self.word("[");
                 self.print_expr(&index);
-                self.s.word("]");
+                self.word("]");
             }
             hir::ExprKind::Path(ref qpath) => self.print_qpath(qpath, true),
             hir::ExprKind::Break(destination, ref opt_expr) => {
-                self.s.word("break");
-                self.s.space();
+                self.word("break");
+                self.space();
                 if let Some(label) = destination.label {
                     self.print_ident(label.ident);
-                    self.s.space();
+                    self.space();
                 }
                 if let Some(ref expr) = *opt_expr {
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
-                    self.s.space();
+                    self.space();
                 }
             }
             hir::ExprKind::Continue(destination) => {
-                self.s.word("continue");
-                self.s.space();
+                self.word("continue");
+                self.space();
                 if let Some(label) = destination.label {
                     self.print_ident(label.ident);
-                    self.s.space()
+                    self.space()
                 }
             }
             hir::ExprKind::Ret(ref result) => {
-                self.s.word("return");
+                self.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ");
+                    self.word(" ");
                     self.print_expr_maybe_paren(&expr, parser::PREC_JUMP);
                 }
             }
@@ -1574,7 +1574,7 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::LlvmInlineAsm(ref a) => {
                 let i = &a.inner;
-                self.s.word("llvm_asm!");
+                self.word("llvm_asm!");
                 self.popen();
                 self.print_symbol(i.asm, i.asm_str_style);
                 self.word_space(":");
@@ -1594,7 +1594,7 @@ impl<'a> State<'a> {
                     s.pclose();
                     out_idx += 1;
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 let mut in_idx = 0;
@@ -1605,7 +1605,7 @@ impl<'a> State<'a> {
                     s.pclose();
                     in_idx += 1;
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &i.clobbers, |s, &co| {
@@ -1624,7 +1624,7 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space();
+                    self.space();
                     self.word_space(":");
                     self.commasep(Inconsistent, &options, |s, &co| {
                         s.print_string(co, ast::StrStyle::Cooked);
@@ -1639,7 +1639,7 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
         }
@@ -1664,7 +1664,7 @@ impl<'a> State<'a> {
 
         for (i, segment) in path.segments.iter().enumerate() {
             if i > 0 {
-                self.s.word("::")
+                self.word("::")
             }
             if segment.ident.name != kw::PathRoot {
                 self.print_ident(segment.ident);
@@ -1684,14 +1684,14 @@ impl<'a> State<'a> {
         match *qpath {
             hir::QPath::Resolved(None, ref path) => self.print_path(path, colons_before_params),
             hir::QPath::Resolved(Some(ref qself), ref path) => {
-                self.s.word("<");
+                self.word("<");
                 self.print_type(qself);
-                self.s.space();
+                self.space();
                 self.word_space("as");
 
                 for (i, segment) in path.segments[..path.segments.len() - 1].iter().enumerate() {
                     if i > 0 {
-                        self.s.word("::")
+                        self.word("::")
                     }
                     if segment.ident.name != kw::PathRoot {
                         self.print_ident(segment.ident);
@@ -1703,8 +1703,8 @@ impl<'a> State<'a> {
                     }
                 }
 
-                self.s.word(">");
-                self.s.word("::");
+                self.word(">");
+                self.word("::");
                 let item_segment = path.segments.last().unwrap();
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(
@@ -1720,12 +1720,12 @@ impl<'a> State<'a> {
                 if let hir::TyKind::Path(hir::QPath::Resolved(None, _)) = &qself.kind {
                     self.print_type(qself);
                 } else {
-                    self.s.word("<");
+                    self.word("<");
                     self.print_type(qself);
-                    self.s.word(">");
+                    self.word(">");
                 }
 
-                self.s.word("::");
+                self.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(
                     item_segment.args(),
@@ -1734,9 +1734,9 @@ impl<'a> State<'a> {
                 )
             }
             hir::QPath::LangItem(lang_item, span) => {
-                self.s.word("#[lang = \"");
+                self.word("#[lang = \"");
                 self.print_ident(Ident::new(lang_item.name(), span));
-                self.s.word("\"]");
+                self.word("\"]");
             }
         }
     }
@@ -1748,9 +1748,9 @@ impl<'a> State<'a> {
         colons_before_params: bool,
     ) {
         if generic_args.parenthesized {
-            self.s.word("(");
+            self.word("(");
             self.commasep(Inconsistent, generic_args.inputs(), |s, ty| s.print_type(&ty));
-            self.s.word(")");
+            self.word(")");
 
             self.space_if_not_bol();
             self.word_space("->");
@@ -1761,7 +1761,7 @@ impl<'a> State<'a> {
             let start_or_comma = |this: &mut Self| {
                 if empty.get() {
                     empty.set(false);
-                    this.s.word(start)
+                    this.word(start)
                 } else {
                     this.word_space(",")
                 }
@@ -1795,14 +1795,14 @@ impl<'a> State<'a> {
             // "non-exhaustive patterns: `Some::<..>(_)` not covered").
             if infer_args && false {
                 start_or_comma(self);
-                self.s.word("..");
+                self.word("..");
             }
 
             for binding in generic_args.bindings.iter() {
                 start_or_comma(self);
                 self.print_ident(binding.ident);
                 self.print_generic_args(binding.gen_args, false, false);
-                self.s.space();
+                self.space();
                 match generic_args.bindings[0].kind {
                     hir::TypeBindingKind::Equality { ref ty } => {
                         self.word_space("=");
@@ -1815,7 +1815,7 @@ impl<'a> State<'a> {
             }
 
             if !empty.get() {
-                self.s.word(">")
+                self.word(">")
             }
         }
     }
@@ -1826,7 +1826,7 @@ impl<'a> State<'a> {
         // Pat isn't normalized, but the beauty of it
         // is that it doesn't matter
         match pat.kind {
-            PatKind::Wild => self.s.word("_"),
+            PatKind::Wild => self.word("_"),
             PatKind::Binding(binding_mode, _, ident, ref sub) => {
                 match binding_mode {
                     hir::BindingAnnotation::Ref => {
@@ -1844,7 +1844,7 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.word("@");
+                    self.word("@");
                     self.print_pat(&p);
                 }
             }
@@ -1856,9 +1856,9 @@ impl<'a> State<'a> {
                     if ddpos != 0 {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",");
+                        self.word(",");
                         self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
@@ -1891,10 +1891,10 @@ impl<'a> State<'a> {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                 }
-                self.s.space();
-                self.s.word("}");
+                self.space();
+                self.word("}");
             }
             PatKind::Or(ref pats) => {
                 self.strsep("|", true, Inconsistent, &pats[..], |s, p| s.print_pat(&p));
@@ -1906,22 +1906,22 @@ impl<'a> State<'a> {
                     if ddpos != 0 {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",");
+                        self.word(",");
                         self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
                     self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p));
                     if elts.len() == 1 {
-                        self.s.word(",");
+                        self.word(",");
                     }
                 }
                 self.pclose();
             }
             PatKind::Box(ref inner) => {
                 let is_range_inner = matches!(inner.kind, PatKind::Range(..));
-                self.s.word("box ");
+                self.word("box ");
                 if is_range_inner {
                     self.popen();
                 }
@@ -1932,8 +1932,8 @@ impl<'a> State<'a> {
             }
             PatKind::Ref(ref inner, mutbl) => {
                 let is_range_inner = matches!(inner.kind, PatKind::Range(..));
-                self.s.word("&");
-                self.s.word(mutbl.prefix_str());
+                self.word("&");
+                self.word(mutbl.prefix_str());
                 if is_range_inner {
                     self.popen();
                 }
@@ -1946,18 +1946,18 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, ref end_kind) => {
                 if let Some(expr) = begin {
                     self.print_expr(expr);
-                    self.s.space();
+                    self.space();
                 }
                 match *end_kind {
-                    RangeEnd::Included => self.s.word("..."),
-                    RangeEnd::Excluded => self.s.word(".."),
+                    RangeEnd::Included => self.word("..."),
+                    RangeEnd::Excluded => self.word(".."),
                 }
                 if let Some(expr) = end {
                     self.print_expr(expr);
                 }
             }
             PatKind::Slice(ref before, ref slice, ref after) => {
-                self.s.word("[");
+                self.word("[");
                 self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p));
                 if let Some(ref p) = *slice {
                     if !before.is_empty() {
@@ -1968,13 +1968,13 @@ impl<'a> State<'a> {
                     } else {
                         self.print_pat(&p);
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if !after.is_empty() {
                         self.word_space(",");
                     }
                 }
                 self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p));
-                self.s.word("]");
+                self.word("]");
             }
         }
         self.ann.post(self, AnnNode::Pat(pat))
@@ -1989,29 +1989,29 @@ impl<'a> State<'a> {
         // I have no idea why this check is necessary, but here it
         // is :(
         if self.attrs(arm.hir_id).is_empty() {
-            self.s.space();
+            self.space();
         }
         self.cbox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Arm(arm));
         self.ibox(0);
         self.print_outer_attributes(&self.attrs(arm.hir_id));
         self.print_pat(&arm.pat);
-        self.s.space();
+        self.space();
         if let Some(ref g) = arm.guard {
             match g {
                 hir::Guard::If(e) => {
                     self.word_space("if");
                     self.print_expr(&e);
-                    self.s.space();
+                    self.space();
                 }
                 hir::Guard::IfLet(pat, e) => {
                     self.word_nbsp("if");
                     self.word_nbsp("let");
                     self.print_pat(&pat);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_expr(&e);
-                    self.s.space();
+                    self.space();
                 }
             }
         }
@@ -2029,13 +2029,13 @@ impl<'a> State<'a> {
                 // If it is a user-provided unsafe block, print a comma after it
                 if let hir::BlockCheckMode::UnsafeBlock(hir::UnsafeSource::UserProvided) = blk.rules
                 {
-                    self.s.word(",");
+                    self.word(",");
                 }
             }
             _ => {
                 self.end(); // close the ibox for the pattern
                 self.print_expr(&arm.body);
-                self.s.word(",");
+                self.word(",");
             }
         }
         self.ann.post(self, AnnNode::Arm(arm));
@@ -2067,20 +2067,20 @@ impl<'a> State<'a> {
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
             s.ibox(INDENT_UNIT);
             if let Some(arg_name) = arg_names.get(i) {
-                s.s.word(arg_name.to_string());
-                s.s.word(":");
-                s.s.space();
+                s.word(arg_name.to_string());
+                s.word(":");
+                s.space();
             } else if let Some(body_id) = body_id {
                 s.ann.nested(s, Nested::BodyParamPat(body_id, i));
-                s.s.word(":");
-                s.s.space();
+                s.word(":");
+                s.space();
             }
             i += 1;
             s.print_type(ty);
             s.end()
         });
         if decl.c_variadic {
-            self.s.word(", ...");
+            self.word(", ...");
         }
         self.pclose();
 
@@ -2089,7 +2089,7 @@ impl<'a> State<'a> {
     }
 
     fn print_closure_params(&mut self, decl: &hir::FnDecl<'_>, body_id: hir::BodyId) {
-        self.s.word("|");
+        self.word("|");
         let mut i = 0;
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
             s.ibox(INDENT_UNIT);
@@ -2100,13 +2100,13 @@ impl<'a> State<'a> {
             if let hir::TyKind::Infer = ty.kind {
                 // Print nothing.
             } else {
-                s.s.word(":");
-                s.s.space();
+                s.word(":");
+                s.space();
                 s.print_type(ty);
             }
             s.end();
         });
-        self.s.word("|");
+        self.word("|");
 
         if let hir::FnRetTy::DefaultReturn(..) = decl.output {
             return;
@@ -2138,7 +2138,7 @@ impl<'a> State<'a> {
         let mut first = true;
         for bound in bounds {
             if first {
-                self.s.word(prefix);
+                self.word(prefix);
             }
             if !(first && prefix.is_empty()) {
                 self.nbsp();
@@ -2152,14 +2152,14 @@ impl<'a> State<'a> {
             match bound {
                 GenericBound::Trait(tref, modifier) => {
                     if modifier == &TraitBoundModifier::Maybe {
-                        self.s.word("?");
+                        self.word("?");
                     }
                     self.print_poly_trait_ref(tref);
                 }
                 GenericBound::LangItemTrait(lang_item, span, ..) => {
-                    self.s.word("#[lang = \"");
+                    self.word("#[lang = \"");
                     self.print_ident(Ident::new(lang_item.name(), *span));
-                    self.s.word("\"]");
+                    self.word("\"]");
                 }
                 GenericBound::Outlives(lt) => {
                     self.print_lifetime(lt);
@@ -2170,11 +2170,11 @@ impl<'a> State<'a> {
 
     pub fn print_generic_params(&mut self, generic_params: &[GenericParam<'_>]) {
         if !generic_params.is_empty() {
-            self.s.word("<");
+            self.word("<");
 
             self.commasep(Inconsistent, generic_params, |s, param| s.print_generic_param(param));
 
-            self.s.word(">");
+            self.word(">");
         }
     }
 
@@ -2191,7 +2191,7 @@ impl<'a> State<'a> {
                 for bound in param.bounds {
                     match bound {
                         GenericBound::Outlives(ref lt) => {
-                            self.s.word(sep);
+                            self.word(sep);
                             self.print_lifetime(lt);
                             sep = "+";
                         }
@@ -2202,7 +2202,7 @@ impl<'a> State<'a> {
             GenericParamKind::Type { ref default, .. } => {
                 self.print_bounds(":", param.bounds);
                 if let Some(default) = default {
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(&default)
                 }
@@ -2211,7 +2211,7 @@ impl<'a> State<'a> {
                 self.word_space(":");
                 self.print_type(ty);
                 if let Some(ref default) = default {
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_anon_const(&default)
                 }
@@ -2228,7 +2228,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.space();
+        self.space();
         self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
@@ -2253,7 +2253,7 @@ impl<'a> State<'a> {
                     ..
                 }) => {
                     self.print_lifetime(lifetime);
-                    self.s.word(":");
+                    self.word(":");
 
                     for (i, bound) in bounds.iter().enumerate() {
                         match bound {
@@ -2264,7 +2264,7 @@ impl<'a> State<'a> {
                         }
 
                         if i != 0 {
-                            self.s.word(":");
+                            self.word(":");
                         }
                     }
                 }
@@ -2272,7 +2272,7 @@ impl<'a> State<'a> {
                     lhs_ty, rhs_ty, ..
                 }) => {
                     self.print_type(lhs_ty);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(rhs_ty);
                 }
@@ -2326,7 +2326,7 @@ impl<'a> State<'a> {
     ) {
         self.ibox(INDENT_UNIT);
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
         }
         let generics = hir::Generics {
@@ -2352,7 +2352,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_fn_header_info(&mut self, header: hir::FnHeader, vis: &hir::Visibility<'_>) {
-        self.s.word(visibility_qualified(vis, ""));
+        self.word(visibility_qualified(vis, ""));
 
         match header.constness {
             hir::Constness::NotConst => {}
@@ -2371,7 +2371,7 @@ impl<'a> State<'a> {
             self.word_nbsp(header.abi.to_string());
         }
 
-        self.s.word("fn")
+        self.word("fn")
     }
 
     pub fn print_unsafety(&mut self, s: hir::Unsafety) {

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -939,9 +939,7 @@ impl<'tcx> ResolvedTypeParamEraser<'tcx> {
     /// Replace not yet inferred const params with their def name.
     fn replace_infers(&self, c: &'tcx Const<'tcx>, index: u32, name: Symbol) -> &'tcx Const<'tcx> {
         match c.val {
-            ty::ConstKind::Infer(..) => {
-                self.tcx().mk_const_param(index, name, c.ty)
-            }
+            ty::ConstKind::Infer(..) => self.tcx().mk_const_param(index, name, c.ty),
             _ => c,
         }
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -10,7 +10,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::infer::unify_key::ConstVariableOriginKind;
 use rustc_middle::ty::print::Print;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
-use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
+use rustc_middle::ty::{self, Const, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
 use rustc_span::symbol::kw;
 use rustc_span::Span;
 use std::borrow::Cow;
@@ -305,6 +305,15 @@ pub enum UnderspecifiedArgKind {
     Const { is_parameter: bool },
 }
 
+impl UnderspecifiedArgKind {
+    fn descr(&self) -> &'static str {
+        match self {
+            Self::Type { .. } => "type",
+            Self::Const { .. } => "const",
+        }
+    }
+}
+
 impl InferenceDiagnosticsData {
     /// Generate a label for a generic argument which can't be inferred. When not
     /// much is known about the argument, `use_diag` may be used to describe the
@@ -587,6 +596,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
         }
 
+        let param_type = arg_data.kind.descr();
         let suffix = match local_visitor.found_node_ty {
             Some(ty) if ty.is_closure() => {
                 let substs =
@@ -625,15 +635,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && arg_data.name == "_" => {
                 let ty = ty_to_string(ty);
-                format!("the explicit type `{}`, with the type parameters specified", ty)
+                format!("the explicit type `{}`, with the {} parameters specified", ty, param_type)
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && ty.to_string() != arg_data.name => {
                 let ty = ResolvedTypeParamEraser::new(self.tcx).fold_ty(ty);
                 let ty = ErrTypeParamEraser(self.tcx).fold_ty(ty);
                 let ty = ty_to_string(ty);
                 format!(
-                    "the explicit type `{}`, where the type parameter `{}` is specified",
-                    ty, arg_data.name,
+                    "the explicit type `{}`, where the {} parameter `{}` is specified",
+                    ty, param_type, arg_data.name,
                 )
             }
             _ => "a type".to_string(),
@@ -910,7 +920,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 }
 
-/// Turn resolved type params into `[type error]` to signal we don't want to display them.
+/// Turn *resolved* type params into `[type error]` to signal we don't want to display them. After
+/// performing that replacement, we'll turn all remaining infer type params to use their name from
+/// their definition, and replace all the `[type error]`s back to being infer so they display in
+/// the output as `_`. If we didn't go through `[type error]`, we would either show all type params
+/// by their name *or* `_`, neither of which is desireable: we want to show all types that we could
+/// infer as `_` to reduce verbosity and avoid telling the user about unnecessary type annotations.
 struct ResolvedTypeParamEraser<'tcx> {
     tcx: TyCtxt<'tcx>,
     level: usize,
@@ -920,7 +935,18 @@ impl<'tcx> ResolvedTypeParamEraser<'tcx> {
     fn new(tcx: TyCtxt<'tcx>) -> Self {
         ResolvedTypeParamEraser { tcx, level: 0 }
     }
+
+    /// Replace not yet inferred const params with their def name.
+    fn replace_infers(&self, c: &'tcx Const<'tcx>, index: u32, name: Symbol) -> &'tcx Const<'tcx> {
+        match c.val {
+            ty::ConstKind::Infer(..) => {
+                self.tcx().mk_const_param(index, name, c.ty)
+            }
+            _ => c,
+        }
+    }
 }
+
 impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
     fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
         self.tcx
@@ -940,29 +966,22 @@ impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
                     .map(|(subst, param)| match &(subst.unpack(), &param.kind) {
                         (_, ty::GenericParamDefKind::Type { has_default: true, .. }) => subst,
                         (crate::infer::GenericArgKind::Const(c), _) => {
-                            match c.val {
-                                ty::ConstKind::Infer(..) => {
-                                    // Replace not yet inferred const params with their def name.
-                                    self.tcx().mk_const_param(param.index, param.name, c.ty).into()
-                                }
-                                _ => subst,
-                            }
+                            self.replace_infers(c, param.index, param.name).into()
                         }
                         _ => subst.super_fold_with(self),
                     })
                     .collect();
-                if self.level == 1
-                    || substs.iter().any(|subst| match subst.unpack() {
-                        ty::subst::GenericArgKind::Type(t) => match t.kind() {
-                            ty::Error(_) => false,
-                            _ => true,
-                        },
-                        // Account for `const` params here, otherwise `doesnt_infer.rs`
-                        // shows `_` instead of `Foo<{ _: u32 }>`
-                        ty::subst::GenericArgKind::Const(_) => true,
-                        _ => false,
-                    })
-                {
+                let should_keep = |subst: &GenericArg<'_>| match subst.unpack() {
+                    ty::subst::GenericArgKind::Type(t) => match t.kind() {
+                        ty::Error(_) => false,
+                        _ => true,
+                    },
+                    // Account for `const` params here, otherwise `doesnt_infer.rs`
+                    // shows `_` instead of `Foo<{ _: u32 }>`
+                    ty::subst::GenericArgKind::Const(_) => true,
+                    _ => false,
+                };
+                if self.level == 1 || substs.iter().any(should_keep) {
                     let substs = self.tcx().intern_substs(&substs[..]);
                     self.tcx().mk_ty(ty::Adt(def, substs))
                 } else {
@@ -986,18 +1005,9 @@ impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
             | ty::Opaque(..)
             | ty::Projection(_)
             | ty::Never => t.super_fold_with(self),
-            ty::Array(ty, c) => {
-                self.tcx().mk_ty(ty::Array(
-                    self.fold_ty(ty),
-                    match c.val {
-                        ty::ConstKind::Infer(..) => {
-                            // Replace not yet inferred const params with their def name.
-                            self.tcx().mk_const_param(0, Symbol::intern("N"), c.ty).into()
-                        }
-                        _ => c,
-                    },
-                ))
-            }
+            ty::Array(ty, c) => self
+                .tcx()
+                .mk_ty(ty::Array(self.fold_ty(ty), self.replace_infers(c, 0, Symbol::intern("N")))),
             // We don't want to hide type params that haven't been resolved yet.
             // This would be the type that will be written out with the type param
             // name in the output.

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -11,7 +11,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::infer::unify_key::ConstVariableOriginKind;
 use rustc_middle::ty::print::Print;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
-use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt};
+use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
 use rustc_span::symbol::kw;
 use rustc_span::Span;
 use std::borrow::Cow;
@@ -629,6 +629,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 format!("the explicit type `{}`, with the type parameters specified", ty)
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && ty.to_string() != arg_data.name => {
+                let ty = ResolvedTypeParamEraser::new(self.tcx).fold_ty(ty);
+                let ty = ErrTypeParamEraser(self.tcx).fold_ty(ty);
                 let ty = ty_to_string(ty);
                 format!(
                     "the explicit type `{}`, where the type parameter `{}` is specified",
@@ -906,5 +908,101 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         );
         err.span_label(span, data.cannot_infer_msg(None));
         err
+    }
+}
+
+/// Turn resolved type params into `[type error]` to signal we don't want to display them.
+struct ResolvedTypeParamEraser<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    level: usize,
+}
+
+impl<'tcx> ResolvedTypeParamEraser<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        ResolvedTypeParamEraser { tcx, level: 0 }
+    }
+}
+impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
+    fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        self.level += 1;
+        let t = match t.kind() {
+            // We'll hide this type only if all its type params are hidden as well.
+            ty::Adt(def, substs) => {
+                let generics = self.tcx().generics_of(def.did);
+                // Account for params with default values, like `Vec`, where we
+                // want to show `Vec<T>`, not `Vec<T, _>`. If we replaced that
+                // subst, then we'd get the incorrect output, so we passthrough.
+                let substs: Vec<_> = substs
+                    .iter()
+                    .zip(generics.params.iter())
+                    .map(|(subst, param)| match &param.kind {
+                        ty::GenericParamDefKind::Type { has_default: true, .. } => subst,
+                        _ => subst.super_fold_with(self),
+                    })
+                    .collect();
+                if self.level == 1
+                    || substs.iter().any(|subst| match subst.unpack() {
+                        ty::subst::GenericArgKind::Type(t) => match t.kind() {
+                            ty::Error(_) => false,
+                            _ => true,
+                        },
+                        // Account for `const` params here, otherwise `doesnt_infer.rs`
+                        // shows `_` instead of `Foo<{ _: u32 }>`
+                        ty::subst::GenericArgKind::Const(_) => true,
+                        _ => false,
+                    })
+                {
+                    let substs = self.tcx().intern_substs(&substs[..]);
+                    self.tcx().mk_ty(ty::Adt(def, substs))
+                } else {
+                    self.tcx().ty_error()
+                }
+            }
+            ty::Ref(_, ty, _) => {
+                let ty = self.fold_ty(ty);
+                match ty.kind() {
+                    // Avoid `&_`, these can be safely presented as `_`.
+                    ty::Error(_) => self.tcx().ty_error(),
+                    _ => t.super_fold_with(self),
+                }
+            }
+            // We could account for `()` if we wanted to replace it, but it's assured to be short.
+            ty::Tuple(_)
+            | ty::Slice(_)
+            | ty::RawPtr(_)
+            | ty::FnDef(..)
+            | ty::FnPtr(_)
+            | ty::Opaque(..)
+            | ty::Projection(_)
+            | ty::Never
+            | ty::Array(..) => t.super_fold_with(self),
+            // We don't want to hide type params that haven't been resolved yet.
+            // This would be the type that will be written out with the type param
+            // name in the output.
+            ty::Infer(_) => t,
+            // We don't want to hide the outermost type, only its type params.
+            _ if self.level == 1 => t.super_fold_with(self),
+            // Hide this type
+            _ => self.tcx().ty_error(),
+        };
+        self.level -= 1;
+        t
+    }
+}
+
+/// Replace `[type error]` with `ty::Infer(ty::Var)` to display `_`.
+struct ErrTypeParamEraser<'tcx>(TyCtxt<'tcx>);
+impl<'tcx> TypeFolder<'tcx> for ErrTypeParamEraser<'tcx> {
+    fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
+        self.0
+    }
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        match t.kind() {
+            ty::Error(_) => self.tcx().mk_ty_var(ty::TyVid::from_u32(0)),
+            _ => t.super_fold_with(self),
+        }
     }
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2960,6 +2960,41 @@ declare_lint! {
     "detects large moves or copies",
 }
 
+declare_lint! {
+    /// The `deprecated_cfg_attr_crate_type_name` lint detects uses of the
+    /// `#![cfg_attr(..., crate_type = "...")]` and
+    /// `#![cfg_attr(..., crate_name = "...")]` attributes to conditionally
+    /// specify the crate type and name in the source code.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![cfg_attr(debug_assertions, crate_type = "lib")]
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    ///
+    /// ### Explanation
+    ///
+    /// The `#![crate_type]` and `#![crate_name]` attributes require a hack in
+    /// the compiler to be able to change the used crate type and crate name
+    /// after macros have been expanded. Neither attribute works in combination
+    /// with Cargo as it explicitly passes `--crate-type` and `--crate-name` on
+    /// the commandline. These values must match the value used in the source
+    /// code to prevent an error.
+    ///
+    /// To fix the warning use `--crate-type` on the commandline when running
+    /// rustc instead of `#![cfg_attr(..., crate_type = "...")]` and
+    /// `--crate-name` instead of `#![cfg_attr(..., crate_name = "...")]`.
+    pub DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
+    Warn,
+    "detects usage of `#![cfg_attr(..., crate_type/crate_name = \"...\")]`",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #91632 <https://github.com/rust-lang/rust/issues/91632>",
+    };
+}
+
 declare_lint_pass! {
     /// Does nothing as a lint pass, but registers some `Lint`s
     /// that are used by other parts of the compiler.
@@ -3056,6 +3091,7 @@ declare_lint_pass! {
         NON_EXHAUSTIVE_OMITTED_PATTERNS,
         TEXT_DIRECTION_CODEPOINT_IN_COMMENT,
         DEREF_INTO_DYN_SUPERTRAIT,
+        DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
     ]
 }
 

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -34,7 +34,7 @@ fn is_stable(place: PlaceRef<'_>) -> bool {
 }
 
 /// Determine whether this type may be a reference (or box), and thus needs retagging.
-fn may_be_reference(ty: Ty<'tcx>) -> bool {
+fn may_be_reference(ty: Ty<'_>) -> bool {
     match ty.kind() {
         // Primitive types that are not references
         ty::Bool

--- a/compiler/rustc_mir_transform/src/check_const_item_mutation.rs
+++ b/compiler/rustc_mir_transform/src/check_const_item_mutation.rs
@@ -23,7 +23,7 @@ struct ConstMutationChecker<'a, 'tcx> {
     target_local: Option<Local>,
 }
 
-impl<'a, 'tcx> ConstMutationChecker<'a, 'tcx> {
+impl<'tcx> ConstMutationChecker<'_, 'tcx> {
     fn is_const_item(&self, local: Local) -> Option<DefId> {
         if let Some(box LocalInfo::ConstRef { def_id }) = self.body.local_decls[local].local_info {
             Some(def_id)
@@ -95,7 +95,7 @@ impl<'a, 'tcx> ConstMutationChecker<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for ConstMutationChecker<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for ConstMutationChecker<'_, 'tcx> {
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         if let StatementKind::Assign(box (lhs, _)) = &stmt.kind {
             // Check for assignment to fields of a constant

--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -66,7 +66,7 @@ fn builtin_derive_def_id(tcx: TyCtxt<'_>, def_id: DefId) -> Option<DefId> {
     }
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for PackedRefChecker<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         // Make sure we know where in the MIR we are.
         self.source_info = terminator.source_info;

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         self.source_info = terminator.source_info;
         match terminator.kind {
@@ -244,7 +244,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
+impl<'tcx> UnsafetyChecker<'_, 'tcx> {
     fn require_unsafe(&mut self, kind: UnsafetyViolationKind, details: UnsafetyViolationDetails) {
         // Violations can turn out to be `UnsafeFn` during analysis, but they should not start out as such.
         assert_ne!(kind, UnsafetyViolationKind::UnsafeFn);
@@ -397,7 +397,7 @@ struct UnusedUnsafeVisitor<'a> {
     unsafe_blocks: &'a mut Vec<(hir::HirId, bool)>,
 }
 
-impl<'a, 'tcx> intravisit::Visitor<'tcx> for UnusedUnsafeVisitor<'a> {
+impl<'tcx> intravisit::Visitor<'tcx> for UnusedUnsafeVisitor<'_> {
     type Map = intravisit::ErasedMap<'tcx>;
 
     fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {

--- a/compiler/rustc_mir_transform/src/const_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/const_debuginfo.rs
@@ -89,7 +89,7 @@ fn find_optimization_oportunities<'tcx>(body: &Body<'tcx>) -> Vec<(Local, Consta
     eligable_locals
 }
 
-impl<'tcx> Visitor<'tcx> for LocalUseVisitor {
+impl Visitor<'_> for LocalUseVisitor {
     fn visit_local(&mut self, local: &Local, context: PlaceContext, location: Location) {
         if context.is_mutating_use() {
             self.local_mutating_uses[*local] = self.local_mutating_uses[*local].saturating_add(1);

--- a/compiler/rustc_mir_transform/src/const_goto.rs
+++ b/compiler/rustc_mir_transform/src/const_goto.rs
@@ -54,7 +54,7 @@ impl<'tcx> MirPass<'tcx> for ConstGoto {
     }
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'_, 'tcx> {
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         let _: Option<_> = try {
             let target = terminator.kind.as_goto()?;

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -171,7 +171,7 @@ struct ConstPropMachine<'mir, 'tcx> {
     can_const_prop: IndexVec<Local, ConstPropMode>,
 }
 
-impl<'mir, 'tcx> ConstPropMachine<'mir, 'tcx> {
+impl ConstPropMachine<'_, '_> {
     fn new(
         only_propagate_inside_block_locals: BitSet<Local>,
         can_const_prop: IndexVec<Local, ConstPropMode>,
@@ -308,14 +308,14 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx>
     }
 
     #[inline(always)]
-    fn stack(
+    fn stack<'a>(
         ecx: &'a InterpCx<'mir, 'tcx, Self>,
     ) -> &'a [Frame<'mir, 'tcx, Self::PointerTag, Self::FrameExtra>] {
         &ecx.machine.stack
     }
 
     #[inline(always)]
-    fn stack_mut(
+    fn stack_mut<'a>(
         ecx: &'a mut InterpCx<'mir, 'tcx, Self>,
     ) -> &'a mut Vec<Frame<'mir, 'tcx, Self::PointerTag, Self::FrameExtra>> {
         &mut ecx.machine.stack
@@ -336,7 +336,7 @@ struct ConstPropagator<'mir, 'tcx> {
     source_info: Option<SourceInfo>,
 }
 
-impl<'mir, 'tcx> LayoutOfHelpers<'tcx> for ConstPropagator<'mir, 'tcx> {
+impl<'tcx> LayoutOfHelpers<'tcx> for ConstPropagator<'_, 'tcx> {
     type LayoutOfResult = Result<TyAndLayout<'tcx>, LayoutError<'tcx>>;
 
     #[inline]
@@ -345,21 +345,21 @@ impl<'mir, 'tcx> LayoutOfHelpers<'tcx> for ConstPropagator<'mir, 'tcx> {
     }
 }
 
-impl<'mir, 'tcx> HasDataLayout for ConstPropagator<'mir, 'tcx> {
+impl HasDataLayout for ConstPropagator<'_, '_> {
     #[inline]
     fn data_layout(&self) -> &TargetDataLayout {
         &self.tcx.data_layout
     }
 }
 
-impl<'mir, 'tcx> ty::layout::HasTyCtxt<'tcx> for ConstPropagator<'mir, 'tcx> {
+impl<'tcx> ty::layout::HasTyCtxt<'tcx> for ConstPropagator<'_, 'tcx> {
     #[inline]
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 }
 
-impl<'mir, 'tcx> ty::layout::HasParamEnv<'tcx> for ConstPropagator<'mir, 'tcx> {
+impl<'tcx> ty::layout::HasParamEnv<'tcx> for ConstPropagator<'_, 'tcx> {
     #[inline]
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
@@ -971,7 +971,7 @@ struct CanConstProp {
 
 impl CanConstProp {
     /// Returns true if `local` can be propagated
-    fn check(
+    fn check<'tcx>(
         tcx: TyCtxt<'tcx>,
         param_env: ParamEnv<'tcx>,
         body: &Body<'tcx>,
@@ -1019,7 +1019,7 @@ impl CanConstProp {
     }
 }
 
-impl<'tcx> Visitor<'tcx> for CanConstProp {
+impl Visitor<'_> for CanConstProp {
     fn visit_local(&mut self, &local: &Local, context: PlaceContext, _: Location) {
         use rustc_middle::mir::visit::PlaceContext::*;
         match context {
@@ -1079,7 +1079,7 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
     }
 }
 
-impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
+impl<'tcx> MutVisitor<'tcx> for ConstPropagator<'_, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }

--- a/compiler/rustc_mir_transform/src/coverage/debug.rs
+++ b/compiler/rustc_mir_transform/src/coverage/debug.rs
@@ -629,7 +629,7 @@ impl UsedExpressions {
 }
 
 /// Generates the MIR pass `CoverageSpan`-specific spanview dump file.
-pub(super) fn dump_coverage_spanview(
+pub(super) fn dump_coverage_spanview<'tcx>(
     tcx: TyCtxt<'tcx>,
     mir_body: &mir::Body<'tcx>,
     basic_coverage_blocks: &CoverageGraph,
@@ -651,7 +651,7 @@ pub(super) fn dump_coverage_spanview(
 }
 
 /// Converts the computed `BasicCoverageBlockData`s into `SpanViewable`s.
-fn span_viewables(
+fn span_viewables<'tcx>(
     tcx: TyCtxt<'tcx>,
     mir_body: &mir::Body<'tcx>,
     basic_coverage_blocks: &CoverageGraph,
@@ -670,7 +670,7 @@ fn span_viewables(
 }
 
 /// Generates the MIR pass coverage-specific graphviz dump file.
-pub(super) fn dump_coverage_graphviz(
+pub(super) fn dump_coverage_graphviz<'tcx>(
     tcx: TyCtxt<'tcx>,
     mir_body: &mir::Body<'tcx>,
     pass_name: &str,
@@ -750,7 +750,7 @@ pub(super) fn dump_coverage_graphviz(
         .expect("Unexpected error writing BasicCoverageBlock graphviz DOT file");
 }
 
-fn bcb_to_string_sections(
+fn bcb_to_string_sections<'tcx>(
     tcx: TyCtxt<'tcx>,
     mir_body: &mir::Body<'tcx>,
     debug_counters: &DebugCounters,
@@ -817,7 +817,7 @@ fn bcb_to_string_sections(
 
 /// Returns a simple string representation of a `TerminatorKind` variant, independent of any
 /// values it might hold.
-pub(super) fn term_type(kind: &TerminatorKind<'tcx>) -> &'static str {
+pub(super) fn term_type(kind: &TerminatorKind<'_>) -> &'static str {
     match kind {
         TerminatorKind::Goto { .. } => "Goto",
         TerminatorKind::SwitchInt { .. } => "SwitchInt",

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -27,7 +27,7 @@ pub(super) struct CoverageGraph {
 }
 
 impl CoverageGraph {
-    pub fn from_mir(mir_body: &mir::Body<'tcx>) -> Self {
+    pub fn from_mir(mir_body: &mir::Body<'_>) -> Self {
         let (bcbs, bb_to_bcb) = Self::compute_basic_coverage_blocks(mir_body);
 
         // Pre-transform MIR `BasicBlock` successors and predecessors into the BasicCoverageBlock
@@ -74,7 +74,7 @@ impl CoverageGraph {
     }
 
     fn compute_basic_coverage_blocks(
-        mir_body: &mir::Body<'tcx>,
+        mir_body: &mir::Body<'_>,
     ) -> (
         IndexVec<BasicCoverageBlock, BasicCoverageBlockData>,
         IndexVec<BasicBlock, Option<BasicCoverageBlock>>,
@@ -267,7 +267,7 @@ impl graph::WithSuccessors for CoverageGraph {
     }
 }
 
-impl graph::GraphPredecessors<'graph> for CoverageGraph {
+impl<'graph> graph::GraphPredecessors<'graph> for CoverageGraph {
     type Item = BasicCoverageBlock;
     type Iter = std::iter::Copied<std::slice::Iter<'graph, BasicCoverageBlock>>;
 }

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -443,7 +443,7 @@ impl<'a, 'tcx> Instrumentor<'a, 'tcx> {
 }
 
 fn inject_edge_counter_basic_block(
-    mir_body: &mut mir::Body<'tcx>,
+    mir_body: &mut mir::Body<'_>,
     from_bb: BasicBlock,
     to_bb: BasicBlock,
 ) -> BasicBlock {
@@ -466,7 +466,7 @@ fn inject_edge_counter_basic_block(
 }
 
 fn inject_statement(
-    mir_body: &mut mir::Body<'tcx>,
+    mir_body: &mut mir::Body<'_>,
     counter_kind: CoverageKind,
     bb: BasicBlock,
     some_code_region: Option<CodeRegion>,
@@ -488,7 +488,7 @@ fn inject_statement(
 }
 
 // Non-code expressions are injected into the coverage map, without generating executable code.
-fn inject_intermediate_expression(mir_body: &mut mir::Body<'tcx>, expression: CoverageKind) {
+fn inject_intermediate_expression(mir_body: &mut mir::Body<'_>, expression: CoverageKind) {
     debug_assert!(matches!(expression, CoverageKind::Expression { .. }));
     debug!("  injecting non-code expression {:?}", expression);
     let inject_in_bb = mir::START_BLOCK;

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -137,7 +137,7 @@ fn coverageinfo<'tcx>(tcx: TyCtxt<'tcx>, instance_def: ty::InstanceDef<'tcx>) ->
     coverage_visitor.info
 }
 
-fn covered_file_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<Symbol> {
+fn covered_file_name(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Symbol> {
     if tcx.is_mir_available(def_id) {
         let body = mir_body(tcx, def_id);
         for bb_data in body.basic_blocks().iter() {

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -21,7 +21,7 @@ pub(super) enum CoverageStatement {
 }
 
 impl CoverageStatement {
-    pub fn format(&self, tcx: TyCtxt<'tcx>, mir_body: &'a mir::Body<'tcx>) -> String {
+    pub fn format<'tcx>(&self, tcx: TyCtxt<'tcx>, mir_body: &mir::Body<'tcx>) -> String {
         match *self {
             Self::Statement(bb, span, stmt_index) => {
                 let stmt = &mir_body[bb].statements[stmt_index];
@@ -86,7 +86,7 @@ impl CoverageSpan {
     }
 
     pub fn for_statement(
-        statement: &Statement<'tcx>,
+        statement: &Statement<'_>,
         span: Span,
         expn_span: Span,
         bcb: BasicCoverageBlock,
@@ -151,7 +151,7 @@ impl CoverageSpan {
         self.bcb == other.bcb
     }
 
-    pub fn format(&self, tcx: TyCtxt<'tcx>, mir_body: &'a mir::Body<'tcx>) -> String {
+    pub fn format<'tcx>(&self, tcx: TyCtxt<'tcx>, mir_body: &mir::Body<'tcx>) -> String {
         format!(
             "{}\n    {}",
             source_range_no_file(tcx, &self.span),
@@ -159,10 +159,10 @@ impl CoverageSpan {
         )
     }
 
-    pub fn format_coverage_statements(
+    pub fn format_coverage_statements<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
-        mir_body: &'a mir::Body<'tcx>,
+        mir_body: &mir::Body<'tcx>,
     ) -> String {
         let mut sorted_coverage_statements = self.coverage_statements.clone();
         sorted_coverage_statements.sort_unstable_by_key(|covstmt| match *covstmt {
@@ -803,7 +803,7 @@ impl<'a, 'tcx> CoverageSpans<'a, 'tcx> {
 
 /// If the MIR `Statement` has a span contributive to computing coverage spans,
 /// return it; otherwise return `None`.
-pub(super) fn filtered_statement_span(statement: &'a Statement<'tcx>) -> Option<Span> {
+pub(super) fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span> {
     match statement.kind {
         // These statements have spans that are often outside the scope of the executed source code
         // for their parent `BasicBlock`.
@@ -847,7 +847,7 @@ pub(super) fn filtered_statement_span(statement: &'a Statement<'tcx>) -> Option<
 
 /// If the MIR `Terminator` has a span contributive to computing coverage spans,
 /// return it; otherwise return `None`.
-pub(super) fn filtered_terminator_span(terminator: &'a Terminator<'tcx>) -> Option<Span> {
+pub(super) fn filtered_terminator_span(terminator: &Terminator<'_>) -> Option<Span> {
     match terminator.kind {
         // These terminators have spans that don't positively contribute to computing a reasonable
         // span of actually executed source code. (For example, SwitchInt terminators extracted from

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -180,7 +180,7 @@ impl<'tcx> MockBlocks<'tcx> {
     }
 }
 
-fn debug_basic_blocks(mir_body: &Body<'tcx>) -> String {
+fn debug_basic_blocks<'tcx>(mir_body: &Body<'tcx>) -> String {
     format!(
         "{:?}",
         mir_body
@@ -273,7 +273,7 @@ fn print_coverage_graphviz(
 }
 
 /// Create a mock `Body` with a simple flow.
-fn goto_switchint() -> Body<'a> {
+fn goto_switchint<'a>() -> Body<'a> {
     let mut blocks = MockBlocks::new();
     let start = blocks.call(None);
     let goto = blocks.goto(Some(start));
@@ -363,7 +363,7 @@ fn test_covgraph_goto_switchint() {
 }
 
 /// Create a mock `Body` with a loop.
-fn switchint_then_loop_else_return() -> Body<'a> {
+fn switchint_then_loop_else_return<'a>() -> Body<'a> {
     let mut blocks = MockBlocks::new();
     let start = blocks.call(None);
     let switchint = blocks.switchint(Some(start));
@@ -449,7 +449,7 @@ fn test_covgraph_switchint_then_loop_else_return() {
 }
 
 /// Create a mock `Body` with nested loops.
-fn switchint_loop_then_inner_loop_else_break() -> Body<'a> {
+fn switchint_loop_then_inner_loop_else_break<'a>() -> Body<'a> {
     let mut blocks = MockBlocks::new();
     let start = blocks.call(None);
     let switchint = blocks.switchint(Some(start));

--- a/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
+++ b/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
@@ -54,7 +54,7 @@ impl<'tcx> MutVisitor<'tcx> for OptApplier<'tcx> {
     }
 }
 
-fn find_duplicates<'a, 'tcx>(body: &'a Body<'tcx>) -> FxHashMap<BasicBlock, BasicBlock> {
+fn find_duplicates(body: &Body<'_>) -> FxHashMap<BasicBlock, BasicBlock> {
     let mut duplicates = FxHashMap::default();
 
     let bbs_to_go_through =
@@ -102,7 +102,7 @@ struct BasicBlockHashable<'tcx, 'a> {
     basic_block_data: &'a BasicBlockData<'tcx>,
 }
 
-impl<'tcx, 'a> Hash for BasicBlockHashable<'tcx, 'a> {
+impl Hash for BasicBlockHashable<'_, '_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         hash_statements(state, self.basic_block_data.statements.iter());
         // Note that since we only hash the kind, we lose span information if we deduplicate the blocks
@@ -110,9 +110,9 @@ impl<'tcx, 'a> Hash for BasicBlockHashable<'tcx, 'a> {
     }
 }
 
-impl<'tcx, 'a> Eq for BasicBlockHashable<'tcx, 'a> {}
+impl Eq for BasicBlockHashable<'_, '_> {}
 
-impl<'tcx, 'a> PartialEq for BasicBlockHashable<'tcx, 'a> {
+impl PartialEq for BasicBlockHashable<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         self.basic_block_data.statements.len() == other.basic_block_data.statements.len()
             && &self.basic_block_data.terminator().kind == &other.basic_block_data.terminator().kind
@@ -132,7 +132,7 @@ fn hash_statements<'a, 'tcx, H: Hasher>(
     }
 }
 
-fn statement_hash<'tcx, H: Hasher>(hasher: &mut H, stmt: &StatementKind<'tcx>) {
+fn statement_hash<H: Hasher>(hasher: &mut H, stmt: &StatementKind<'_>) {
     match stmt {
         StatementKind::Assign(box (place, rvalue)) => {
             place.hash(hasher);
@@ -142,14 +142,14 @@ fn statement_hash<'tcx, H: Hasher>(hasher: &mut H, stmt: &StatementKind<'tcx>) {
     };
 }
 
-fn rvalue_hash<H: Hasher>(hasher: &mut H, rvalue: &Rvalue<'tcx>) {
+fn rvalue_hash<H: Hasher>(hasher: &mut H, rvalue: &Rvalue<'_>) {
     match rvalue {
         Rvalue::Use(op) => operand_hash(hasher, op),
         x => x.hash(hasher),
     };
 }
 
-fn operand_hash<H: Hasher>(hasher: &mut H, operand: &Operand<'tcx>) {
+fn operand_hash<H: Hasher>(hasher: &mut H, operand: &Operand<'_>) {
     match operand {
         Operand::Constant(box Constant { user_ty: _, literal, span: _ }) => literal.hash(hasher),
         x => x.hash(hasher),
@@ -168,7 +168,7 @@ fn statement_eq<'tcx>(lhs: &StatementKind<'tcx>, rhs: &StatementKind<'tcx>) -> b
     res
 }
 
-fn rvalue_eq(lhs: &Rvalue<'tcx>, rhs: &Rvalue<'tcx>) -> bool {
+fn rvalue_eq<'tcx>(lhs: &Rvalue<'tcx>, rhs: &Rvalue<'tcx>) -> bool {
     let res = match (lhs, rhs) {
         (Rvalue::Use(op1), Rvalue::Use(op2)) => operand_eq(op1, op2),
         (x, y) => x == y,
@@ -177,7 +177,7 @@ fn rvalue_eq(lhs: &Rvalue<'tcx>, rhs: &Rvalue<'tcx>) -> bool {
     res
 }
 
-fn operand_eq(lhs: &Operand<'tcx>, rhs: &Operand<'tcx>) -> bool {
+fn operand_eq<'tcx>(lhs: &Operand<'tcx>, rhs: &Operand<'tcx>) -> bool {
     let res = match (lhs, rhs) {
         (
             Operand::Constant(box Constant { user_ty: _, literal, span: _ }),

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -241,7 +241,7 @@ struct Replacements<'tcx> {
     kill: BitSet<Local>,
 }
 
-impl Replacements<'tcx> {
+impl<'tcx> Replacements<'tcx> {
     fn new(locals: usize) -> Self {
         Self { map: IndexVec::from_elem_n(None, locals), kill: BitSet::new_empty(locals) }
     }
@@ -298,7 +298,7 @@ struct Replacer<'tcx> {
 }
 
 impl<'tcx> MutVisitor<'tcx> for Replacer<'tcx> {
-    fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 
@@ -372,7 +372,7 @@ struct Conflicts<'a> {
     unified_locals: InPlaceUnificationTable<UnifyLocal>,
 }
 
-impl Conflicts<'a> {
+impl<'a> Conflicts<'a> {
     fn build<'tcx>(
         tcx: TyCtxt<'tcx>,
         body: &'_ Body<'tcx>,
@@ -820,10 +820,7 @@ struct CandidateAssignment<'tcx> {
 /// comment) and also throw out assignments that involve a local that has its address taken or is
 /// otherwise ineligible (eg. locals used as array indices are ignored because we cannot propagate
 /// arbitrary places into array indices).
-fn find_candidates<'a, 'tcx>(
-    tcx: TyCtxt<'tcx>,
-    body: &'a Body<'tcx>,
-) -> Vec<CandidateAssignment<'tcx>> {
+fn find_candidates<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> Vec<CandidateAssignment<'tcx>> {
     let mut visitor = FindAssignments {
         tcx,
         body,
@@ -843,7 +840,7 @@ struct FindAssignments<'a, 'tcx> {
     locals_used_as_array_index: BitSet<Local>,
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for FindAssignments<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for FindAssignments<'_, 'tcx> {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         if let StatementKind::Assign(box (
             dest,

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -167,7 +167,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
     }
 }
 
-fn is_switch<'tcx>(terminator: &Terminator<'tcx>) -> bool {
+fn is_switch(terminator: &Terminator<'_>) -> bool {
     matches!(terminator.kind, TerminatorKind::SwitchInt { .. })
 }
 
@@ -208,7 +208,7 @@ struct OptimizationInfo<'tcx> {
     second_switch_info: SwitchDiscriminantInfo<'tcx>,
 }
 
-impl<'a, 'tcx> Helper<'a, 'tcx> {
+impl<'tcx> Helper<'_, 'tcx> {
     pub fn go(
         &self,
         bb: &BasicBlockData<'tcx>,

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -149,13 +149,13 @@ struct Elaborator<'a, 'b, 'tcx> {
     ctxt: &'a mut ElaborateDropsCtxt<'b, 'tcx>,
 }
 
-impl<'a, 'b, 'tcx> fmt::Debug for Elaborator<'a, 'b, 'tcx> {
+impl fmt::Debug for Elaborator<'_, '_, '_> {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Ok(())
     }
 }
 
-impl<'a, 'b, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, 'b, 'tcx> {
+impl<'a, 'tcx> DropElaborator<'a, 'tcx> for Elaborator<'a, '_, 'tcx> {
     type Path = MovePathIndex;
 
     fn patch(&mut self) -> &mut MirPatch<'tcx> {

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -27,7 +27,7 @@ struct FunctionItemRefChecker<'a, 'tcx> {
     body: &'a Body<'tcx>,
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for FunctionItemRefChecker<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for FunctionItemRefChecker<'_, 'tcx> {
     /// Emits a lint for function reference arguments bound by `fmt::Pointer` or passed to
     /// `transmute`. This only handles arguments in calls outside macro expansions to avoid double
     /// counting function references formatted as pointers by macros.
@@ -92,7 +92,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FunctionItemRefChecker<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> FunctionItemRefChecker<'a, 'tcx> {
+impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
     /// Emits a lint for function reference arguments bound by `fmt::Pointer` in calls to the
     /// function defined by `def_id` with the substitutions `substs_ref`.
     fn check_bound_args(

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -57,7 +57,7 @@ impl<'tcx> MirPass<'tcx> for Inline {
     }
 }
 
-fn inline(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
+fn inline<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> bool {
     let def_id = body.source.def_id();
     let hir_id = tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
 
@@ -95,7 +95,7 @@ struct Inliner<'tcx> {
     changed: bool,
 }
 
-impl Inliner<'tcx> {
+impl<'tcx> Inliner<'tcx> {
     fn process_blocks(&mut self, caller_body: &mut Body<'tcx>, blocks: Range<BasicBlock>) {
         for bb in blocks {
             let bb_data = &caller_body[bb];
@@ -786,7 +786,7 @@ struct Integrator<'a, 'tcx> {
     always_live_locals: BitSet<Local>,
 }
 
-impl<'a, 'tcx> Integrator<'a, 'tcx> {
+impl Integrator<'_, '_> {
     fn map_local(&self, local: Local) -> Local {
         let new = if local == RETURN_PLACE {
             self.destination.local
@@ -815,7 +815,7 @@ impl<'a, 'tcx> Integrator<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
+impl<'tcx> MutVisitor<'tcx> for Integrator<'_, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -10,7 +10,7 @@ use rustc_session::Limit;
 // FIXME: check whether it is cheaper to precompute the entire call graph instead of invoking
 // this query riddiculously often.
 #[instrument(level = "debug", skip(tcx, root, target))]
-crate fn mir_callgraph_reachable(
+crate fn mir_callgraph_reachable<'tcx>(
     tcx: TyCtxt<'tcx>,
     (root, target): (ty::Instance<'tcx>, LocalDefId),
 ) -> bool {
@@ -33,7 +33,7 @@ crate fn mir_callgraph_reachable(
         level = "debug",
         skip(tcx, param_env, target, stack, seen, recursion_limiter, caller, recursion_limit)
     )]
-    fn process(
+    fn process<'tcx>(
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         caller: ty::Instance<'tcx>,

--- a/compiler/rustc_mir_transform/src/instcombine.rs
+++ b/compiler/rustc_mir_transform/src/instcombine.rs
@@ -38,7 +38,7 @@ struct InstCombineContext<'tcx, 'a> {
     local_decls: &'a LocalDecls<'tcx>,
 }
 
-impl<'tcx, 'a> InstCombineContext<'tcx, 'a> {
+impl<'tcx> InstCombineContext<'tcx, '_> {
     fn should_combine(&self, source_info: &SourceInfo, rvalue: &Rvalue<'tcx>) -> bool {
         self.tcx.consider_optimizing(|| {
             format!("InstCombine - Rvalue: {:?} SourceInfo: {:?}", rvalue, source_info)

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -480,8 +480,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             // FIXME(#70073): This pass is responsible for both optimization as well as some lints.
             &const_prop::ConstProp,
             //
-            // FIXME: The old pass manager ran this only at mir-opt-level >= 1, but
-            // const-prop runs unconditionally. Should this run unconditionally as well?
+            // Const-prop runs unconditionally, but doesn't mutate the MIR at mir-opt-level=0.
             &o1(simplify_branches::SimplifyConstCondition::new("after-const-prop")),
             &early_otherwise_branch::EarlyOtherwiseBranch,
             &simplify_comparison_integral::SimplifyComparisonIntegral,

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
-#![feature(in_band_lifetimes)]
 #![feature(iter_zip)]
 #![feature(let_else)]
 #![feature(map_try_insert)]
@@ -150,7 +149,7 @@ fn mir_keys(tcx: TyCtxt<'_>, (): ()) -> FxHashSet<LocalDefId> {
         tcx: TyCtxt<'tcx>,
         set: &'a mut FxHashSet<LocalDefId>,
     }
-    impl<'a, 'tcx> Visitor<'tcx> for GatherCtors<'a, 'tcx> {
+    impl<'tcx> Visitor<'tcx> for GatherCtors<'_, 'tcx> {
         fn visit_variant_data(
             &mut self,
             v: &'tcx hir::VariantData<'tcx>,
@@ -243,7 +242,7 @@ fn mir_const<'tcx>(
 }
 
 /// Compute the main MIR body and the list of MIR bodies of the promoteds.
-fn mir_promoted(
+fn mir_promoted<'tcx>(
     tcx: TyCtxt<'tcx>,
     def: ty::WithOptConstParam<LocalDefId>,
 ) -> (&'tcx Steal<Body<'tcx>>, &'tcx Steal<IndexVec<Promoted, Body<'tcx>>>) {

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -135,7 +135,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
     }
 }
 
-fn resolve_rust_intrinsic(
+fn resolve_rust_intrinsic<'tcx>(
     tcx: TyCtxt<'tcx>,
     func_ty: Ty<'tcx>,
 ) -> Option<(Symbol, SubstsRef<'tcx>)> {
@@ -148,7 +148,7 @@ fn resolve_rust_intrinsic(
     None
 }
 
-fn validate_simd_shuffle(tcx: TyCtxt<'tcx>, args: &[Operand<'tcx>], span: Span) {
+fn validate_simd_shuffle<'tcx>(tcx: TyCtxt<'tcx>, args: &[Operand<'tcx>], span: Span) {
     match &args[2] {
         Operand::Constant(_) => {} // all good
         _ => {

--- a/compiler/rustc_mir_transform/src/normalize_array_len.rs
+++ b/compiler/rustc_mir_transform/src/normalize_array_len.rs
@@ -85,7 +85,7 @@ struct Patcher<'a, 'tcx> {
     statement_idx: usize,
 }
 
-impl<'a, 'tcx> Patcher<'a, 'tcx> {
+impl<'tcx> Patcher<'_, 'tcx> {
     fn patch_expand_statement(
         &mut self,
         statement: &mut Statement<'tcx>,

--- a/compiler/rustc_mir_transform/src/nrvo.rs
+++ b/compiler/rustc_mir_transform/src/nrvo.rs
@@ -165,7 +165,7 @@ struct RenameToReturnPlace<'tcx> {
 }
 
 /// Replaces all uses of `self.to_rename` with `_0`.
-impl MutVisitor<'tcx> for RenameToReturnPlace<'tcx> {
+impl<'tcx> MutVisitor<'tcx> for RenameToReturnPlace<'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
@@ -221,7 +221,7 @@ impl IsReturnPlaceRead {
     }
 }
 
-impl Visitor<'tcx> for IsReturnPlaceRead {
+impl<'tcx> Visitor<'tcx> for IsReturnPlaceRead {
     fn visit_local(&mut self, &l: &Local, ctxt: PlaceContext, _: Location) {
         if l == mir::RETURN_PLACE && ctxt.is_use() && !ctxt.is_place_assignment() {
             self.0 = true;

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -28,7 +28,7 @@ pub trait MirLint<'tcx> {
 #[derive(Debug, Clone)]
 pub struct Lint<T>(pub T);
 
-impl<T> MirPass<'tcx> for Lint<T>
+impl<'tcx, T> MirPass<'tcx> for Lint<T>
 where
     T: MirLint<'tcx>,
 {
@@ -51,7 +51,7 @@ where
 
 pub struct WithMinOptLevel<T>(pub u32, pub T);
 
-impl<T> MirPass<'tcx> for WithMinOptLevel<T>
+impl<'tcx, T> MirPass<'tcx> for WithMinOptLevel<T>
 where
     T: MirPass<'tcx>,
 {
@@ -72,7 +72,7 @@ where
     }
 }
 
-pub fn run_passes(tcx: TyCtxt<'tcx>, body: &'mir mut Body<'tcx>, passes: &[&dyn MirPass<'tcx>]) {
+pub fn run_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, passes: &[&dyn MirPass<'tcx>]) {
     let start_phase = body.phase;
     let mut cnt = 0;
 
@@ -119,11 +119,11 @@ pub fn run_passes(tcx: TyCtxt<'tcx>, body: &'mir mut Body<'tcx>, passes: &[&dyn 
     }
 }
 
-pub fn validate_body(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, when: String) {
+pub fn validate_body<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, when: String) {
     validate::Validator { when, mir_phase: body.phase }.run_pass(tcx, body);
 }
 
-pub fn dump_mir(
+pub fn dump_mir<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
     phase: MirPhase,

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -86,7 +86,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUninitDrops {
     }
 }
 
-fn is_needs_drop_and_init(
+fn is_needs_drop_and_init<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
     maybe_inits: &BitSet<MovePathIndex>,
@@ -158,7 +158,7 @@ fn is_needs_drop_and_init(
     }
 }
 
-fn variant_needs_drop(
+fn variant_needs_drop<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
     substs: SubstsRef<'tcx>,

--- a/compiler/rustc_mir_transform/src/required_consts.rs
+++ b/compiler/rustc_mir_transform/src/required_consts.rs
@@ -12,7 +12,7 @@ impl<'a, 'tcx> RequiredConstsVisitor<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for RequiredConstsVisitor<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for RequiredConstsVisitor<'_, 'tcx> {
     fn visit_constant(&mut self, constant: &Constant<'tcx>, _: Location) {
         if let Some(ct) = constant.literal.const_for_ty() {
             if let ConstKind::Unevaluated(_) = ct.val {

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -59,7 +59,7 @@ impl<'tcx> MirPass<'tcx> for SeparateConstSwitch {
 }
 
 /// Returns the amount of blocks that were duplicated
-pub fn separate_const_switch<'tcx>(body: &mut Body<'tcx>) -> usize {
+pub fn separate_const_switch(body: &mut Body<'_>) -> usize {
     let mut new_blocks: SmallVec<[(BasicBlock, BasicBlock); 6]> = SmallVec::new();
     let predecessors = body.predecessors();
     'block_iter: for (block_id, block) in body.basic_blocks().iter_enumerated() {

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -247,7 +247,7 @@ pub struct DropShimElaborator<'a, 'tcx> {
     pub param_env: ty::ParamEnv<'tcx>,
 }
 
-impl<'a, 'tcx> fmt::Debug for DropShimElaborator<'a, 'tcx> {
+impl fmt::Debug for DropShimElaborator<'_, '_> {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         Ok(())
     }
@@ -337,7 +337,7 @@ struct CloneShimBuilder<'tcx> {
     sig: ty::FnSig<'tcx>,
 }
 
-impl CloneShimBuilder<'tcx> {
+impl<'tcx> CloneShimBuilder<'tcx> {
     fn new(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -> Self {
         // we must subst the self_ty because it's
         // otherwise going to be TySelf and we can't index

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -64,7 +64,19 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
 
             build_call_shim(tcx, instance, Some(Adjustment::RefMut), CallKind::Direct(call_mut))
         }
-        ty::InstanceDef::DropGlue(def_id, ty) => build_drop_shim(tcx, def_id, ty),
+
+        ty::InstanceDef::DropGlue(def_id, ty) => {
+            // FIXME(#91576): Drop shims for generators aren't subject to the MIR passes at the end
+            // of this function. Is this intentional?
+            if let Some(ty::Generator(gen_def_id, substs, _)) = ty.map(ty::TyS::kind) {
+                let body = tcx.optimized_mir(*gen_def_id).generator_drop().unwrap();
+                let body = body.clone().subst(tcx, substs);
+                debug!("make_shim({:?}) = {:?}", instance, body);
+                return body;
+            }
+
+            build_drop_shim(tcx, def_id, ty)
+        }
         ty::InstanceDef::CloneShim(def_id, ty) => build_clone_shim(tcx, def_id, ty),
         ty::InstanceDef::Virtual(..) => {
             bug!("InstanceDef::Virtual ({:?}) is for direct calls only", instance)
@@ -74,14 +86,6 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
         }
     };
     debug!("make_shim({:?}) = untransformed {:?}", instance, result);
-
-    // In some of the above cases, we seem to be invoking the passes for non-shim MIR bodies.
-    // If that happens, there's no need to run them again.
-    //
-    // FIXME: Is this intentional?
-    if result.phase >= MirPhase::Const {
-        return result;
-    }
 
     pm::run_passes(
         tcx,
@@ -140,11 +144,7 @@ fn local_decls_for_sig<'tcx>(
 fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>) -> Body<'tcx> {
     debug!("build_drop_shim(def_id={:?}, ty={:?})", def_id, ty);
 
-    // Check if this is a generator, if so, return the drop glue for it
-    if let Some(&ty::Generator(gen_def_id, substs, _)) = ty.map(|ty| ty.kind()) {
-        let body = tcx.optimized_mir(gen_def_id).generator_drop().unwrap();
-        return body.clone().subst(tcx, substs);
-    }
+    assert!(!matches!(ty, Some(ty) if ty.is_generator()));
 
     let substs = if let Some(ty) = ty {
         tcx.intern_substs(&[ty.into()])

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -47,7 +47,7 @@ impl SimplifyCfg {
     }
 }
 
-pub fn simplify_cfg(tcx: TyCtxt<'tcx>, body: &mut Body<'_>) {
+pub fn simplify_cfg<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     CfgSimplifier::new(body).simplify();
     remove_dead_blocks(tcx, body);
 
@@ -262,7 +262,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
     }
 }
 
-pub fn remove_dead_blocks(tcx: TyCtxt<'tcx>, body: &mut Body<'_>) {
+pub fn remove_dead_blocks<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let reachable = traversal::reachable_as_bitset(body);
     let num_blocks = body.basic_blocks().len();
     if num_blocks == reachable.count() {
@@ -454,7 +454,7 @@ impl UsedLocals {
     }
 
     /// Updates the use counts to reflect the removal of given statement.
-    fn statement_removed(&mut self, statement: &Statement<'tcx>) {
+    fn statement_removed(&mut self, statement: &Statement<'_>) {
         self.increment = false;
 
         // The location of the statement is irrelevant.
@@ -463,7 +463,7 @@ impl UsedLocals {
     }
 
     /// Visits a left-hand side of an assignment.
-    fn visit_lhs(&mut self, place: &Place<'tcx>, location: Location) {
+    fn visit_lhs(&mut self, place: &Place<'_>, location: Location) {
         if place.is_indirect() {
             // A use, not a definition.
             self.visit_place(place, PlaceContext::MutatingUse(MutatingUseContext::Store), location);
@@ -480,7 +480,7 @@ impl UsedLocals {
     }
 }
 
-impl Visitor<'_> for UsedLocals {
+impl<'tcx> Visitor<'tcx> for UsedLocals {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         match statement.kind {
             StatementKind::LlvmInlineAsm(..)
@@ -518,7 +518,7 @@ impl Visitor<'_> for UsedLocals {
 }
 
 /// Removes unused definitions. Updates the used locals to reflect the changes made.
-fn remove_unused_definitions<'a, 'tcx>(used_locals: &'a mut UsedLocals, body: &mut Body<'tcx>) {
+fn remove_unused_definitions(used_locals: &mut UsedLocals, body: &mut Body<'_>) {
     // The use counts are updated as we remove the statements. A local might become unused
     // during the retain operation, leading to a temporary inconsistency (storage statements or
     // definitions referencing the local might remain). For correctness it is crucial that this

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -148,7 +148,7 @@ struct OptimizationFinder<'a, 'tcx> {
     body: &'a Body<'tcx>,
 }
 
-impl<'a, 'tcx> OptimizationFinder<'a, 'tcx> {
+impl<'tcx> OptimizationFinder<'_, 'tcx> {
     fn find_optimizations(&self) -> Vec<OptimizationInfo<'tcx>> {
         self.body
             .basic_blocks()

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -64,7 +64,7 @@ impl MirPass<'_> for UnreachablePropagation {
     }
 }
 
-fn remove_successors<F>(
+fn remove_successors<'tcx, F>(
     terminator_kind: &TerminatorKind<'tcx>,
     predicate: F,
 ) -> Option<TerminatorKind<'tcx>>

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -1,4 +1,4 @@
-use super::{AttrWrapper, Capturing, ForceCollect, Parser, PathStyle};
+use super::{AttrWrapper, Capturing, FnParseMode, ForceCollect, Parser, PathStyle};
 use rustc_ast as ast;
 use rustc_ast::attr;
 use rustc_ast::token::{self, Nonterminal};
@@ -177,7 +177,7 @@ impl<'a> Parser<'a> {
             AttrWrapper::empty(),
             true,
             false,
-            |_| true,
+            FnParseMode { req_name: |_| true, req_body: true },
             ForceCollect::No,
         ) {
             Ok(Some(item)) => {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1129,7 +1129,8 @@ impl<'a> Parser<'a> {
     }
 
     pub fn maybe_consume_incorrect_semicolon(&mut self, items: &[P<Item>]) -> bool {
-        if self.eat(&token::Semi) {
+        if self.token.kind == TokenKind::Semi {
+            self.bump();
             let mut err = self.struct_span_err(self.prev_token.span, "expected item, found `;`");
             err.span_suggestion_short(
                 self.prev_token.span,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -950,7 +950,7 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<ForeignItem>>>> {
-        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: false };
         Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match ForeignItemKind::try_from(kind) {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -78,16 +78,17 @@ pub(super) type ItemInfo = (Ident, ItemKind);
 
 impl<'a> Parser<'a> {
     pub fn parse_item(&mut self, force_collect: ForceCollect) -> PResult<'a, Option<P<Item>>> {
-        self.parse_item_(|_| true, force_collect).map(|i| i.map(P))
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        self.parse_item_(fn_parse_mode, force_collect).map(|i| i.map(P))
     }
 
     fn parse_item_(
         &mut self,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Item>> {
         let attrs = self.parse_outer_attributes()?;
-        self.parse_item_common(attrs, true, false, req_name, force_collect)
+        self.parse_item_common(attrs, true, false, fn_parse_mode, force_collect)
     }
 
     pub(super) fn parse_item_common(
@@ -95,7 +96,7 @@ impl<'a> Parser<'a> {
         attrs: AttrWrapper,
         mac_allowed: bool,
         attrs_allowed: bool,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Item>> {
         // Don't use `maybe_whole` so that we have precise control
@@ -113,7 +114,8 @@ impl<'a> Parser<'a> {
         let mut unclosed_delims = vec![];
         let item =
             self.collect_tokens_trailing_token(attrs, force_collect, |this: &mut Self, attrs| {
-                let item = this.parse_item_common_(attrs, mac_allowed, attrs_allowed, req_name);
+                let item =
+                    this.parse_item_common_(attrs, mac_allowed, attrs_allowed, fn_parse_mode);
                 unclosed_delims.append(&mut this.unclosed_delims);
                 Ok((item?, TrailingToken::None))
             })?;
@@ -127,12 +129,13 @@ impl<'a> Parser<'a> {
         mut attrs: Vec<Attribute>,
         mac_allowed: bool,
         attrs_allowed: bool,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
     ) -> PResult<'a, Option<Item>> {
         let lo = self.token.span;
         let vis = self.parse_visibility(FollowedByType::No)?;
         let mut def = self.parse_defaultness();
-        let kind = self.parse_item_kind(&mut attrs, mac_allowed, lo, &vis, &mut def, req_name)?;
+        let kind =
+            self.parse_item_kind(&mut attrs, mac_allowed, lo, &vis, &mut def, fn_parse_mode)?;
         if let Some((ident, kind)) = kind {
             self.error_on_unconsumed_default(def, &kind);
             let span = lo.to(self.prev_token.span);
@@ -192,7 +195,7 @@ impl<'a> Parser<'a> {
         lo: Span,
         vis: &Visibility,
         def: &mut Defaultness,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
     ) -> PResult<'a, Option<ItemInfo>> {
         let def_final = def == &Defaultness::Final;
         let mut def = || mem::replace(def, Defaultness::Final);
@@ -219,7 +222,7 @@ impl<'a> Parser<'a> {
             (Ident::empty(), ItemKind::Use(tree))
         } else if self.check_fn_front_matter(def_final) {
             // FUNCTION ITEM
-            let (ident, sig, generics, body) = self.parse_fn(attrs, req_name, lo)?;
+            let (ident, sig, generics, body) = self.parse_fn(attrs, fn_parse_mode, lo)?;
             (ident, ItemKind::Fn(Box::new(Fn { defaultness: def(), sig, generics, body })))
         } else if self.eat_keyword(kw::Extern) {
             if self.eat_keyword(kw::Crate) {
@@ -733,23 +736,26 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        self.parse_assoc_item(|_| true, force_collect)
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        self.parse_assoc_item(fn_parse_mode, force_collect)
     }
 
     pub fn parse_trait_item(
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        self.parse_assoc_item(|edition| edition >= Edition::Edition2018, force_collect)
+        let fn_parse_mode =
+            FnParseMode { req_name: |edition| edition >= Edition::Edition2018, req_body: false };
+        self.parse_assoc_item(fn_parse_mode, force_collect)
     }
 
     /// Parses associated items.
     fn parse_assoc_item(
         &mut self,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<AssocItem>>>> {
-        Ok(self.parse_item_(req_name, force_collect)?.map(
+        Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match AssocItemKind::try_from(kind) {
                     Ok(kind) => kind,
@@ -944,7 +950,8 @@ impl<'a> Parser<'a> {
         &mut self,
         force_collect: ForceCollect,
     ) -> PResult<'a, Option<Option<P<ForeignItem>>>> {
-        Ok(self.parse_item_(|_| true, force_collect)?.map(
+        let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+        Ok(self.parse_item_(fn_parse_mode, force_collect)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
                 let kind = match ForeignItemKind::try_from(kind) {
                     Ok(kind) => kind,
@@ -1484,7 +1491,8 @@ impl<'a> Parser<'a> {
         if !is_raw && ident.is_reserved() {
             let err = if self.check_fn_front_matter(false) {
                 // We use `parse_fn` to get a span for the function
-                if let Err(mut db) = self.parse_fn(&mut Vec::new(), |_| true, lo) {
+                let fn_parse_mode = FnParseMode { req_name: |_| true, req_body: true };
+                if let Err(mut db) = self.parse_fn(&mut Vec::new(), fn_parse_mode, lo) {
                     db.delay_as_bug();
                 }
                 let mut err = self.struct_span_err(
@@ -1700,23 +1708,33 @@ impl<'a> Parser<'a> {
 /// The function decides if, per-parameter `p`, `p` must have a pattern or just a type.
 type ReqName = fn(Edition) -> bool;
 
+/// Parsing configuration for functions.
+/// This include the edition-specific name requirements, plus information on whether the
+/// function is allowed to go without a body.
+#[derive(Clone, Copy)]
+pub(crate) struct FnParseMode {
+    pub req_name: ReqName,
+    pub req_body: bool,
+}
+
 /// Parsing of functions and methods.
 impl<'a> Parser<'a> {
     /// Parse a function starting from the front matter (`const ...`) to the body `{ ... }` or `;`.
     fn parse_fn(
         &mut self,
         attrs: &mut Vec<Attribute>,
-        req_name: ReqName,
+        fn_parse_mode: FnParseMode,
         sig_lo: Span,
     ) -> PResult<'a, (Ident, FnSig, Generics, Option<P<Block>>)> {
         let header = self.parse_fn_front_matter()?; // `const ... fn`
         let ident = self.parse_ident()?; // `foo`
         let mut generics = self.parse_generics()?; // `<'a, T, ...>`
-        let decl = self.parse_fn_decl(req_name, AllowPlus::Yes, RecoverReturnSign::Yes)?; // `(p: u8, ...)`
+        let decl =
+            self.parse_fn_decl(fn_parse_mode.req_name, AllowPlus::Yes, RecoverReturnSign::Yes)?; // `(p: u8, ...)`
         generics.where_clause = self.parse_where_clause()?; // `where T: Ord`
 
         let mut sig_hi = self.prev_token.span;
-        let body = self.parse_fn_body(attrs, &ident, &mut sig_hi)?; // `;` or `{ ... }`.
+        let body = self.parse_fn_body(attrs, &ident, &mut sig_hi, fn_parse_mode.req_body)?; // `;` or `{ ... }`.
         let fn_sig_span = sig_lo.to(sig_hi);
         Ok((ident, FnSig { header, decl, span: fn_sig_span }, generics, body))
     }
@@ -1729,9 +1747,17 @@ impl<'a> Parser<'a> {
         attrs: &mut Vec<Attribute>,
         ident: &Ident,
         sig_hi: &mut Span,
+        req_body: bool,
     ) -> PResult<'a, Option<P<Block>>> {
-        let (inner_attrs, body) = if self.eat(&token::Semi) {
+        let has_semi = if req_body {
+            self.token.kind == TokenKind::Semi
+        } else {
+            // Only include `;` in list of expected tokens if body is not required
+            self.check(&TokenKind::Semi)
+        };
+        let (inner_attrs, body) = if has_semi {
             // Include the trailing semicolon in the span of the signature
+            self.expect_semi()?;
             *sig_hi = self.prev_token.span;
             (Vec::new(), None)
         } else if self.check(&token::OpenDelim(token::Brace)) || self.token.is_whole_block() {
@@ -1752,9 +1778,12 @@ impl<'a> Parser<'a> {
                 .emit();
             (Vec::new(), Some(self.mk_block_err(span)))
         } else {
-            if let Err(mut err) =
-                self.expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
-            {
+            let expected = if req_body {
+                &[token::OpenDelim(token::Brace)][..]
+            } else {
+                &[token::Semi, token::OpenDelim(token::Brace)]
+            };
+            if let Err(mut err) = self.expected_one_of_not_found(&[], &expected) {
                 if self.token.kind == token::CloseDelim(token::Brace) {
                     // The enclosing `mod`, `trait` or `impl` is being closed, so keep the `fn` in
                     // the AST for typechecking.

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -14,6 +14,7 @@ use crate::lexer::UnmatchedBrace;
 pub use attr_wrapper::AttrWrapper;
 pub use diagnostics::AttemptLocalParseRecovery;
 use diagnostics::Error;
+pub(crate) use item::FnParseMode;
 pub use pat::{RecoverColon, RecoverComma};
 pub use path::PathStyle;
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -4,7 +4,9 @@ use super::expr::LhsExpr;
 use super::pat::RecoverComma;
 use super::path::PathStyle;
 use super::TrailingToken;
-use super::{AttrWrapper, BlockMode, ForceCollect, Parser, Restrictions, SemiColonMode};
+use super::{
+    AttrWrapper, BlockMode, FnParseMode, ForceCollect, Parser, Restrictions, SemiColonMode,
+};
 use crate::maybe_whole;
 
 use rustc_ast as ast;
@@ -79,9 +81,13 @@ impl<'a> Parser<'a> {
             } else {
                 self.parse_stmt_path_start(lo, attrs)
             }?
-        } else if let Some(item) =
-            self.parse_item_common(attrs.clone(), false, true, |_| true, force_collect)?
-        {
+        } else if let Some(item) = self.parse_item_common(
+            attrs.clone(),
+            false,
+            true,
+            FnParseMode { req_name: |_| true, req_body: true },
+            force_collect,
+        )? {
             // FIXME: Bad copy of attrs
             self.mk_stmt(lo.to(item.span), StmtKind::Item(P(item)))
         } else if self.eat(&token::Semi) {

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -137,6 +137,11 @@ pub fn spin_loop() {
             unsafe { crate::arch::arm::__yield() };
         }
     }
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        crate::arch::riscv::pause();
+    }
 }
 
 /// An identity function that *__hints__* to the compiler to be maximally pessimistic about what

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -81,9 +81,9 @@
 //! [`OsStr`] and Rust strings work similarly to those for [`CString`]
 //! and [`CStr`].
 //!
-//! * [`OsString`] represents an owned string in whatever
-//! representation the operating system prefers. In the Rust standard
-//! library, various APIs that transfer strings to/from the operating
+//! * [`OsString`] losslessly represents an owned platform string. However, this
+//! representation is not necessarily in a form native to the platform.
+//! In the Rust standard library, various APIs that transfer strings to/from the operating
 //! system use [`OsString`] instead of plain strings. For example,
 //! [`env::var_os()`] is used to query environment variables; it
 //! returns an <code>[Option]<[OsString]></code>. If the environment variable
@@ -92,9 +92,9 @@
 //! your code can detect errors in case the environment variable did
 //! not in fact contain valid Unicode data.
 //!
-//! * [`OsStr`] represents a borrowed reference to a string in a
-//! format that can be passed to the operating system. It can be
-//! converted into a UTF-8 Rust string slice in a similar way to
+//! * [`OsStr`] losslessly represents a borrowed reference to a platform string.
+//! However, this representation is not necessarily in a form native to the platform.
+//! It can be converted into a UTF-8 Rust string slice in a similar way to
 //! [`OsString`].
 //!
 //! # Conversions
@@ -113,16 +113,19 @@
 //!
 //! ## On Windows
 //!
+//! An [`OsStr`] can be losslessly converted to a native Windows string. And
+//! a native Windows string can be losslessly converted to an [`OsString`].
+//!
 //! On Windows, [`OsStr`] implements the
 //! <code>std::os::windows::ffi::[OsStrExt][windows.OsStrExt]</code> trait,
 //! which provides an [`encode_wide`] method. This provides an
-//! iterator that can be [`collect`]ed into a vector of [`u16`].
+//! iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
+//! characters is appended, this is the same as a native Windows string.
 //!
 //! Additionally, on Windows [`OsString`] implements the
 //! <code>std::os::windows:ffi::[OsStringExt][windows.OsStringExt]</code>
-//! trait, which provides a [`from_wide`] method. The result of this
-//! method is an [`OsString`] which can be round-tripped to a Windows
-//! string losslessly.
+//! trait, which provides a [`from_wide`] method to convert a native Windows
+//! string (without the terminating nul character) to an [`OsString`].
 //!
 //! [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
 //! [Unicode code point]: https://www.unicode.org/glossary/#code_point

--- a/library/std/src/os/raw/mod.rs
+++ b/library/std/src/os/raw/mod.rs
@@ -45,94 +45,8 @@ macro_rules! type_alias {
     }
 }
 
-type_alias! { "char.md", c_char = u8, NonZero_c_char = NonZeroU8;
-#[doc(cfg(all()))]
-#[cfg(any(
-    all(
-        target_os = "linux",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "hexagon",
-            target_arch = "powerpc",
-            target_arch = "powerpc64",
-            target_arch = "s390x",
-            target_arch = "riscv64",
-            target_arch = "riscv32"
-        )
-    ),
-    all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
-    all(target_os = "l4re", target_arch = "x86_64"),
-    all(
-        target_os = "freebsd",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "powerpc",
-            target_arch = "powerpc64",
-            target_arch = "riscv64"
-        )
-    ),
-    all(
-        target_os = "netbsd",
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "powerpc")
-    ),
-    all(target_os = "openbsd", target_arch = "aarch64"),
-    all(
-        target_os = "vxworks",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "powerpc64",
-            target_arch = "powerpc"
-        )
-    ),
-    all(target_os = "fuchsia", target_arch = "aarch64")
-))]}
-type_alias! { "char.md", c_char = i8, NonZero_c_char = NonZeroI8;
-#[doc(cfg(all()))]
-#[cfg(not(any(
-    all(
-        target_os = "linux",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "hexagon",
-            target_arch = "powerpc",
-            target_arch = "powerpc64",
-            target_arch = "s390x",
-            target_arch = "riscv64",
-            target_arch = "riscv32"
-        )
-    ),
-    all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
-    all(target_os = "l4re", target_arch = "x86_64"),
-    all(
-        target_os = "freebsd",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "powerpc",
-            target_arch = "powerpc64",
-            target_arch = "riscv64"
-        )
-    ),
-    all(
-        target_os = "netbsd",
-        any(target_arch = "aarch64", target_arch = "arm", target_arch = "powerpc")
-    ),
-    all(target_os = "openbsd", target_arch = "aarch64"),
-    all(
-        target_os = "vxworks",
-        any(
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "powerpc64",
-            target_arch = "powerpc"
-        )
-    ),
-    all(target_os = "fuchsia", target_arch = "aarch64")
-)))]}
+type_alias! { "char.md", c_char = c_char_definition::c_char, NonZero_c_char = c_char_definition::NonZero_c_char;
+#[doc(cfg(all()))] }
 type_alias! { "schar.md", c_schar = i8, NonZero_c_schar = NonZeroI8; }
 type_alias! { "uchar.md", c_uchar = u8, NonZero_c_uchar = NonZeroU8; }
 type_alias! { "short.md", c_short = i16, NonZero_c_short = NonZeroI16; }
@@ -180,3 +94,58 @@ pub type c_ptrdiff_t = isize;
 /// platforms where this is not the case.
 #[unstable(feature = "c_size_t", issue = "88345")]
 pub type c_ssize_t = isize;
+
+mod c_char_definition {
+    cfg_if::cfg_if! {
+        // These are the targets on which c_char is unsigned.
+        if #[cfg(any(
+            all(
+                target_os = "linux",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "arm",
+                    target_arch = "hexagon",
+                    target_arch = "powerpc",
+                    target_arch = "powerpc64",
+                    target_arch = "s390x",
+                    target_arch = "riscv64",
+                    target_arch = "riscv32"
+                )
+            ),
+            all(target_os = "android", any(target_arch = "aarch64", target_arch = "arm")),
+            all(target_os = "l4re", target_arch = "x86_64"),
+            all(
+                target_os = "freebsd",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "arm",
+                    target_arch = "powerpc",
+                    target_arch = "powerpc64",
+                    target_arch = "riscv64"
+                )
+            ),
+            all(
+                target_os = "netbsd",
+                any(target_arch = "aarch64", target_arch = "arm", target_arch = "powerpc")
+            ),
+            all(target_os = "openbsd", target_arch = "aarch64"),
+            all(
+                target_os = "vxworks",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "arm",
+                    target_arch = "powerpc64",
+                    target_arch = "powerpc"
+                )
+            ),
+            all(target_os = "fuchsia", target_arch = "aarch64")
+        ))] {
+            pub type c_char = u8;
+            pub type NonZero_c_char = core::num::NonZeroU8;
+        } else {
+            // On every other target, c_char is signed.
+            pub type c_char = i8;
+            pub type NonZero_c_char = core::num::NonZeroI8;
+        }
+    }
+}

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -12,8 +12,37 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import sqlite3
 
 from time import time
+
+# Acquire a lock on the build directory to make sure that
+# we don't cause a race condition while building
+# Lock is created in `build_dir/lock.db`
+def acquire_lock(build_dir):
+    path = os.path.join(build_dir, "lock.db")
+    try:
+        con = sqlite3.Connection(path, timeout=0)
+        curs = con.cursor()
+        curs.execute("BEGIN EXCLUSIVE")
+        # The lock is released when the cursor is dropped
+        return curs
+    # If the database is busy then lock has already been acquired
+    # so we wait for the lock.
+    # We retry every quarter second so that execution is passed back to python
+    # so that it can handle signals
+    except sqlite3.OperationalError:
+        del con
+        del curs
+        print("Waiting for lock on build directory")
+        con = sqlite3.Connection(path, timeout=0.25)
+        curs = con.cursor()
+        while True:
+            try:
+                curs.execute("BEGIN EXCLUSIVE")
+            except sqlite3.OperationalError:
+                pass
+        return curs
 
 def support_xz():
     try:
@@ -1225,6 +1254,12 @@ def bootstrap(help_triggered):
     build.set_dist_environment(data["dist_server"])
 
     build.build = args.build or build.build_triple()
+
+    # Acquire the lock before doing any build actions
+    # The lock is released when `lock` is dropped
+    if not os.path.exists(build.build_dir):
+        os.makedirs(build.build_dir)
+    lock = acquire_lock(build.build_dir)
     build.update_submodules()
 
     # Fetch/build the bootstrap

--- a/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
@@ -1,4 +1,17 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates
+WORKDIR /tmp
+RUN curl -f https://curl.se/ca/cacert.pem -o cacert.pem
+
 FROM ubuntu:16.04
+
+# The ca-certificates in ubuntu-16 is too old, so update the certificates
+# with something more recent.
+COPY --from=0 /tmp/cacert.pem /tmp/cacert.pem
+ENV CURL_CA_BUNDLE /tmp/cacert.pem
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh

--- a/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-arm-linux/Dockerfile
@@ -1,4 +1,17 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates
+WORKDIR /tmp
+RUN curl -f https://curl.se/ca/cacert.pem -o cacert.pem
+
 FROM ubuntu:16.04
+
+# The ca-certificates in ubuntu-16 is too old, so update the certificates
+# with something more recent.
+COPY --from=0 /tmp/cacert.pem /tmp/cacert.pem
+ENV CURL_CA_BUNDLE /tmp/cacert.pem
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh

--- a/src/ci/docker/host-x86_64/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-armhf-linux/Dockerfile
@@ -1,4 +1,17 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates
+WORKDIR /tmp
+RUN curl -f https://curl.se/ca/cacert.pem -o cacert.pem
+
 FROM ubuntu:16.04
+
+# The ca-certificates in ubuntu-16 is too old, so update the certificates
+# with something more recent.
+COPY --from=0 /tmp/cacert.pem /tmp/cacert.pem
+ENV CURL_CA_BUNDLE /tmp/cacert.pem
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh

--- a/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
@@ -1,4 +1,17 @@
+FROM ubuntu:20.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates
+WORKDIR /tmp
+RUN curl -f https://curl.se/ca/cacert.pem -o cacert.pem
+
 FROM ubuntu:16.04
+
+# The ca-certificates in ubuntu-16 is too old, so update the certificates
+# with something more recent.
+COPY --from=0 /tmp/cacert.pem /tmp/cacert.pem
+ENV CURL_CA_BUNDLE /tmp/cacert.pem
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -20,7 +20,7 @@
           id="mainThemeStyle"> {#- -#}
     {%- for theme in themes -%}
         <link rel="stylesheet" type="text/css" {# -#}
-            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {#- -#}
+            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {# -#}
         {%- if theme == "light" -%}
             id="themeStyle"
         {%- else -%}

--- a/src/test/ui/cfg/auxiliary/crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/auxiliary/crate-attributes-using-cfg_attr.rs
@@ -1,6 +1,0 @@
-// no-prefer-dynamic
-// compile-flags: --cfg foo
-
-#![cfg_attr(foo, crate_type="lib")]
-
-pub fn foo() {}

--- a/src/test/ui/cfg/crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/crate-attributes-using-cfg_attr.rs
@@ -1,6 +1,0 @@
-// run-pass
-// aux-build:crate-attributes-using-cfg_attr.rs
-
-extern crate crate_attributes_using_cfg_attr;
-
-pub fn main() {}

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
@@ -1,0 +1,12 @@
+// check-fail
+// compile-flags:--cfg foo
+
+#![deny(warnings)]
+#![cfg_attr(foo, crate_type="bin")]
+//~^ERROR `crate_type` within
+//~| WARN this was previously accepted
+#![cfg_attr(foo, crate_name="bar")]
+//~^ERROR `crate_name` within
+//~| WARN this was previously accepted
+
+fn main() {}

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
@@ -1,0 +1,26 @@
+error: `crate_type` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:5:18
+   |
+LL | #![cfg_attr(foo, crate_type="bin")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:4:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(deprecated_cfg_attr_crate_type_name)]` implied by `#[deny(warnings)]`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:8:18
+   |
+LL | #![cfg_attr(foo, crate_name="bar")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<{_: u32}>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<{_: _}>`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<{_: _}>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<N>`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<N>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<N>`, where the const parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-90870.fixed
+++ b/src/test/ui/consts/issue-90870.fixed
@@ -1,0 +1,34 @@
+// Regression test for issue #90870.
+
+// run-rustfix
+
+#![allow(dead_code)]
+
+const fn f(a: &u8, b: &u8) -> bool {
+    *a == *b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn g(a: &&&&i64, b: &&&&i64) -> bool {
+    ****a == ****b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
+    while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
+        if *l == *r {
+        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~| HELP: consider dereferencing here
+            a = at;
+            b = bt;
+        } else {
+            return false;
+        }
+    }
+
+    a.is_empty() && b.is_empty()
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-90870.rs
+++ b/src/test/ui/consts/issue-90870.rs
@@ -1,0 +1,34 @@
+// Regression test for issue #90870.
+
+// run-rustfix
+
+#![allow(dead_code)]
+
+const fn f(a: &u8, b: &u8) -> bool {
+    a == b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn g(a: &&&&i64, b: &&&&i64) -> bool {
+    a == b
+    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~| HELP: consider dereferencing here
+}
+
+const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
+    while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
+        if l == r {
+        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~| HELP: consider dereferencing here
+            a = at;
+            b = bt;
+        } else {
+            return false;
+        }
+    }
+
+    a.is_empty() && b.is_empty()
+}
+
+fn main() {}

--- a/src/test/ui/consts/issue-90870.stderr
+++ b/src/test/ui/consts/issue-90870.stderr
@@ -1,0 +1,36 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:8:5
+   |
+LL |     a == b
+   |     ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |     *a == *b
+   |     +     +
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:14:5
+   |
+LL |     a == b
+   |     ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |     ****a == ****b
+   |     ++++     ++++
+
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-90870.rs:21:12
+   |
+LL |         if l == r {
+   |            ^^^^^^
+   |
+help: consider dereferencing here
+   |
+LL |         if *l == *r {
+   |            +     +
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/fn/fn-recover-return-sign2.rs
+++ b/src/test/ui/fn/fn-recover-return-sign2.rs
@@ -3,6 +3,6 @@
 
 fn foo() => impl Fn() => bool {
     //~^ ERROR return types are denoted using `->`
-    //~| ERROR expected one of `+`, `->`, `::`, `;`, `where`, or `{`, found `=>`
+    //~| ERROR expected one of `+`, `->`, `::`, `where`, or `{`, found `=>`
     unimplemented!()
 }

--- a/src/test/ui/fn/fn-recover-return-sign2.stderr
+++ b/src/test/ui/fn/fn-recover-return-sign2.stderr
@@ -4,11 +4,11 @@ error: return types are denoted using `->`
 LL | fn foo() => impl Fn() => bool {
    |          ^^ help: use `->` instead
 
-error: expected one of `+`, `->`, `::`, `;`, `where`, or `{`, found `=>`
+error: expected one of `+`, `->`, `::`, `where`, or `{`, found `=>`
   --> $DIR/fn-recover-return-sign2.rs:4:23
    |
 LL | fn foo() => impl Fn() => bool {
-   |                       ^^ expected one of `+`, `->`, `::`, `;`, `where`, or `{`
+   |                       ^^ expected one of `+`, `->`, `::`, `where`, or `{`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/erase-type-params-in-label.rs
+++ b/src/test/ui/inference/erase-type-params-in-label.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let foo = new(1, ""); //~ ERROR E0283
+}
+
+struct Bar<T, K, N: Default> {
+    t: T,
+    k: K,
+    n: N,
+}
+
+fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+    Bar { t, k, n: Default::default() }
+}

--- a/src/test/ui/inference/erase-type-params-in-label.rs
+++ b/src/test/ui/inference/erase-type-params-in-label.rs
@@ -1,5 +1,8 @@
 fn main() {
-    let foo = new(1, ""); //~ ERROR E0283
+    let foo = foo(1, ""); //~ ERROR E0283
+}
+fn baz() {
+    let bar = bar(1, ""); //~ ERROR E0283
 }
 
 struct Bar<T, K, N: Default> {
@@ -8,6 +11,17 @@ struct Bar<T, K, N: Default> {
     n: N,
 }
 
-fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
     Bar { t, k, n: Default::default() }
+}
+
+struct Foo<T, K, N: Default, M: Default> {
+    t: T,
+    k: K,
+    n: N,
+    m: M,
+}
+
+fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+    Foo { t, k, n: Default::default(), m: Default::default() }
 }

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -1,22 +1,41 @@
-error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+error[E0283]: type annotations needed for `Foo<i32, &str, W, Z>`
   --> $DIR/erase-type-params-in-label.rs:2:15
    |
-LL |     let foo = new(1, "");
-   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `new`
+LL |     let foo = foo(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `W` declared on the function `foo`
    |         |
-   |         consider giving `foo` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |         consider giving `foo` the explicit type `Foo<_, _, W, Z>`, where the type parameter `W` is specified
    |
    = note: cannot satisfy `_: Default`
-note: required by a bound in `new`
-  --> $DIR/erase-type-params-in-label.rs:11:17
+note: required by a bound in `foo`
+  --> $DIR/erase-type-params-in-label.rs:25:17
    |
-LL | fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
-   |                 ^^^^^^^ required by this bound in `new`
+LL | fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+   |                 ^^^^^^^ required by this bound in `foo`
 help: consider specifying the type arguments in the function call
    |
-LL |     let foo = new::<T, K, Z>(1, "");
+LL |     let foo = foo::<T, K, W, Z>(1, "");
+   |                  ++++++++++++++
+
+error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+  --> $DIR/erase-type-params-in-label.rs:5:15
+   |
+LL |     let bar = bar(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `bar`
+   |         |
+   |         consider giving `bar` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |
+   = note: cannot satisfy `_: Default`
+note: required by a bound in `bar`
+  --> $DIR/erase-type-params-in-label.rs:14:17
+   |
+LL | fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   |                 ^^^^^^^ required by this bound in `bar`
+help: consider specifying the type arguments in the function call
+   |
+LL |     let bar = bar::<T, K, Z>(1, "");
    |                  +++++++++++
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+  --> $DIR/erase-type-params-in-label.rs:2:15
+   |
+LL |     let foo = new(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `new`
+   |         |
+   |         consider giving `foo` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |
+   = note: cannot satisfy `_: Default`
+note: required by a bound in `new`
+  --> $DIR/erase-type-params-in-label.rs:11:17
+   |
+LL | fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   |                 ^^^^^^^ required by this bound in `new`
+help: consider specifying the type arguments in the function call
+   |
+LL |     let foo = new::<T, K, Z>(1, "");
+   |                  +++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[usize; _]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; _]`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[_; _]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; N]`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[_; N]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; N]`, where the const parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,16 +1,31 @@
 #![allow(incomplete_features)]
 #![feature(inline_const_pat)]
+#![feature(generic_const_exprs)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 
 fn foo<const V: usize>() {
-  match 0 {
-    const { V } => {},
-    //~^ ERROR const parameters cannot be referenced in patterns [E0158]
-    _ => {},
-  }
+    match 0 {
+        const { V } => {},
+        //~^ ERROR const parameters cannot be referenced in patterns [E0158]
+        _ => {},
+    }
+}
+
+const fn f(x: usize) -> usize {
+    x + 1
+}
+
+fn bar<const V: usize>() where [(); f(V)]: {
+    match 0 {
+        const { f(V) } => {},
+        //~^ ERROR constant pattern depends on a generic parameter
+        //~| ERROR constant pattern depends on a generic parameter
+        _ => {},
+    }
 }
 
 fn main() {
     foo::<1>();
+    bar::<1>();
 }

--- a/src/test/ui/inline-const/const-match-pat-generic.stderr
+++ b/src/test/ui/inline-const/const-match-pat-generic.stderr
@@ -1,9 +1,21 @@
 error[E0158]: const parameters cannot be referenced in patterns
-  --> $DIR/const-match-pat-generic.rs:8:11
+  --> $DIR/const-match-pat-generic.rs:9:9
    |
-LL |     const { V } => {},
-   |           ^^^^^
+LL |         const { V } => {},
+   |         ^^^^^^^^^^^
 
-error: aborting due to previous error
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0158`.

--- a/src/test/ui/parser/issues/issue-24780.rs
+++ b/src/test/ui/parser/issues/issue-24780.rs
@@ -2,7 +2,7 @@
 // to happen in #24780. For example, following should be an error:
 // expected one of ..., `>`, ... found `>`.
 
-fn foo() -> Vec<usize>> { //~ ERROR expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+fn foo() -> Vec<usize>> { //~ ERROR expected one of `!`, `+`, `::`, `where`, or `{`, found `>`
     Vec::new()
 }
 

--- a/src/test/ui/parser/issues/issue-24780.stderr
+++ b/src/test/ui/parser/issues/issue-24780.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+error: expected one of `!`, `+`, `::`, `where`, or `{`, found `>`
   --> $DIR/issue-24780.rs:5:23
    |
 LL | fn foo() -> Vec<usize>> {
-   |                       ^ expected one of `!`, `+`, `::`, `;`, `where`, or `{`
+   |                       ^ expected one of `!`, `+`, `::`, `where`, or `{`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-58856-1.rs
+++ b/src/test/ui/parser/issues/issue-58856-1.rs
@@ -2,7 +2,7 @@ impl A {
     //~^ ERROR cannot find type `A` in this scope
     fn b(self>
     //~^ ERROR expected one of `)`, `,`, or `:`, found `>`
-    //~| ERROR expected one of `->`, `;`, `where`, or `{`, found `>`
+    //~| ERROR expected one of `->`, `where`, or `{`, found `>`
 }
 
 fn main() {}

--- a/src/test/ui/parser/issues/issue-58856-1.stderr
+++ b/src/test/ui/parser/issues/issue-58856-1.stderr
@@ -6,14 +6,14 @@ LL |     fn b(self>
    |         |
    |         unclosed delimiter
 
-error: expected one of `->`, `;`, `where`, or `{`, found `>`
+error: expected one of `->`, `where`, or `{`, found `>`
   --> $DIR/issue-58856-1.rs:3:14
    |
 LL | impl A {
    |        - while parsing this item list starting here
 LL |
 LL |     fn b(self>
-   |              ^ expected one of `->`, `;`, `where`, or `{`
+   |              ^ expected one of `->`, `where`, or `{`
 ...
 LL | }
    | - the item list ends here

--- a/src/test/ui/parser/issues/issue-84148-1.stderr
+++ b/src/test/ui/parser/issues/issue-84148-1.stderr
@@ -13,11 +13,11 @@ LL | fn f(t:for<>t?)
    |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
    |              help: missing `,`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/issue-84148-1.rs:1:15
    |
 LL | fn f(t:for<>t?)
-   |               ^ expected one of `->`, `;`, `where`, or `{`
+   |               ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/issues/issue-84148-2.stderr
+++ b/src/test/ui/parser/issues/issue-84148-2.stderr
@@ -21,11 +21,11 @@ LL | fn f(t:for<>t?
    |              expected one of `(`, `)`, `+`, `,`, `::`, or `<`
    |              help: missing `,`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/issue-84148-2.rs:4:16
    |
 LL | fn f(t:for<>t?
-   |                ^ expected one of `->`, `;`, `where`, or `{`
+   |                ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issues/issue-87635.rs
+++ b/src/test/ui/parser/issues/issue-87635.rs
@@ -2,8 +2,8 @@ struct Foo {}
 
 impl Foo {
     pub fn bar()
-    //~^ ERROR: expected `;`, found `}`
-    //~| ERROR: associated function in `impl` without body
+    //~^ ERROR: associated function in `impl` without body
 }
+//~^ERROR expected one of `->`, `where`, or `{`, found `}`
 
 fn main() {}

--- a/src/test/ui/parser/issues/issue-87635.stderr
+++ b/src/test/ui/parser/issues/issue-87635.stderr
@@ -1,11 +1,13 @@
-error: expected `;`, found `}`
-  --> $DIR/issue-87635.rs:4:17
+error: expected one of `->`, `where`, or `{`, found `}`
+  --> $DIR/issue-87635.rs:6:1
    |
 LL |     pub fn bar()
-   |                 ^ help: add `;` here
-...
+   |            ---  - expected one of `->`, `where`, or `{`
+   |            |
+   |            while parsing this `fn`
+LL |
 LL | }
-   | - unexpected token
+   | ^ unexpected token
 
 error: associated function in `impl` without body
   --> $DIR/issue-87635.rs:4:5

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -22,11 +22,11 @@ error: expected one of `:` or `|`, found `)`
 LL | fn main((ؼ
    |           ^ expected one of `:` or `|`
 
-error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
+error: expected one of `->`, `where`, or `{`, found `<eof>`
   --> $DIR/missing_right_paren.rs:3:11
    |
 LL | fn main((ؼ
-   |           ^ expected one of `->`, `;`, `where`, or `{`
+   |           ^ expected one of `->`, `where`, or `{`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.fixed
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[allow(dead_code)]
+
+extern "C" {
+  fn foo(); //~ERROR expected `;`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.rs
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+
+#[allow(dead_code)]
+
+extern "C" {
+  fn foo() //~ERROR expected `;`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
+++ b/src/test/ui/suggestions/suggest-semicolon-for-fn-in-extern-block.stderr
@@ -1,0 +1,10 @@
+error: expected `;`, found `}`
+  --> $DIR/suggest-semicolon-for-fn-in-extern-block.rs:6:11
+   |
+LL |   fn foo()
+   |           ^ help: add `;` here
+LL | }
+   | - unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #83744 (Deprecate crate_type and crate_name nested inside #![cfg_attr])
 - #88310 (Lock bootstrap (x.py) build directory)
 - #90550 (Update certificates in some Ubuntu 16 images.)
 - #90709 (Only shown relevant type params in E0283 label)
 - #91272 (Print a suggestion when comparing references to primitive types in `const fn`)
 - #91467 (Emphasise that an OsStr[ing] is not necessarily a platform string)
 - #91531 (Do not add `;` to expected tokens list when it's wrong)
 - #91548 (Add spin_loop hint for RISC-V architecture)
 - #91570 (Evaluate inline const pat early and report error if too generic)
 - #91571 (Remove unneeded access to pretty printer's `s` field in favor of deref)
 - #91577 (Address some FIXMEs left over from #91475)
 - #91630 (Add missing whitespace before disabled HTML attribute)
 - #91638 (Remove `in_band_lifetimes` from `rustc_mir_transform`)
 - #91641 (Define c_char using cfg_if rather than repeating 40-line cfg)

Failed merges:

 - #91625 (Remove redundant [..]s)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83744,88310,90550,90709,91272,91467,91531,91548,91570,91571,91577,91630,91638,91641)
<!-- homu-ignore:end -->