### PR TITLE
rustc_serialize: make assert more informative.

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -666,7 +666,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     fn read_str(&mut self) -> Result<Cow<'_, str>, Self::Error> {
         let len = self.read_usize()?;
         let sentinel = self.data[self.position + len];
-        assert!(sentinel == STR_SENTINEL);
+        assert_eq!(sentinel, STR_SENTINEL);
         let s = unsafe {
             std::str::from_utf8_unchecked(&self.data[self.position..self.position + len])
         };


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/91650#issuecomment-988534705

Make sure it prints the left/right values when it fails.