### PR TITLE
manually implement `Hash` for `DefId`

### DIFF
--- a/src/test/ui/coherence/coherence-orphan.stderr
+++ b/src/test/ui/coherence/coherence-orphan.stderr
@@ -1,15 +1,4 @@
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-  --> $DIR/coherence-orphan.rs:17:1
-   |
-LL | impl !Send for Vec<isize> { }
-   | ^^^^^^^^^^^^^^^----------
-   | |              |
-   | |              `Vec` is not defined in the current crate
-   | impl doesn't use only types from inside the current crate
-   |
-   = note: define and implement a trait or new type instead
-
-error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-orphan.rs:10:1
    |
 LL | impl TheTrait<usize> for isize { }
@@ -17,6 +6,17 @@ LL | impl TheTrait<usize> for isize { }
    | |    |                   |
    | |    |                   `isize` is not defined in the current crate
    | |    `usize` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/coherence-orphan.rs:17:1
+   |
+LL | impl !Send for Vec<isize> { }
+   | ^^^^^^^^^^^^^^^----------
+   | |              |
+   | |              `Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/methods/method-ambig-two-traits-cross-crate.stderr
+++ b/src/test/ui/methods/method-ambig-two-traits-cross-crate.stderr
@@ -4,20 +4,20 @@ error[E0034]: multiple applicable items in scope
 LL | fn main() { 1_usize.me(); }
    |                     ^^ multiple `me` found
    |
-note: candidate #1 is defined in an impl of the trait `Me2` for the type `usize`
+   = note: candidate #1 is defined in an impl of the trait `Me` for the type `usize`
+note: candidate #2 is defined in an impl of the trait `Me2` for the type `usize`
   --> $DIR/method-ambig-two-traits-cross-crate.rs:10:22
    |
 LL | impl Me2 for usize { fn me(&self) -> usize { *self } }
    |                      ^^^^^^^^^^^^^^^^^^^^^
-   = note: candidate #2 is defined in an impl of the trait `Me` for the type `usize`
 help: disambiguate the associated function for candidate #1
-   |
-LL | fn main() { Me2::me(&1_usize); }
-   |             ~~~~~~~~~~~~~~~~~
-help: disambiguate the associated function for candidate #2
    |
 LL | fn main() { Me::me(&1_usize); }
    |             ~~~~~~~~~~~~~~~~
+help: disambiguate the associated function for candidate #2
+   |
+LL | fn main() { Me2::me(&1_usize); }
+   |             ~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This might speed up hashing for hashers that can work on individual u64s. Just as an experiment, suggested in a reddit thread on `FxHasher`. cc @nnethercote  

Note that this should not be merged as is without cfg-ing the code path for 64 bits.