### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "atty",
  "bitflags",
  "strsim",

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -878,29 +878,29 @@ impl<'a> PrintState<'a> for State<'a> {
     }
 
     fn print_ident(&mut self, ident: Ident) {
-        self.s.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
+        self.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
         self.ann.post(self, AnnNode::Ident(&ident))
     }
 
     fn print_generic_args(&mut self, args: &ast::GenericArgs, colons_before_params: bool) {
         if colons_before_params {
-            self.s.word("::")
+            self.word("::")
         }
 
         match *args {
             ast::GenericArgs::AngleBracketed(ref data) => {
-                self.s.word("<");
+                self.word("<");
                 self.commasep(Inconsistent, &data.args, |s, arg| match arg {
                     ast::AngleBracketedArg::Arg(a) => s.print_generic_arg(a),
                     ast::AngleBracketedArg::Constraint(c) => s.print_assoc_constraint(c),
                 });
-                self.s.word(">")
+                self.word(">")
             }
 
             ast::GenericArgs::Parenthesized(ref data) => {
-                self.s.word("(");
+                self.word("(");
                 self.commasep(Inconsistent, &data.inputs, |s, ty| s.print_type(ty));
-                self.s.word(")");
+                self.word(")");
                 self.print_fn_ret_ty(&data.output);
             }
         }
@@ -925,7 +925,7 @@ impl<'a> State<'a> {
             op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",");
+                self.word(",");
                 self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()));
                 self.space_if_not_bol();
             }
@@ -954,7 +954,7 @@ impl<'a> State<'a> {
     pub fn print_assoc_constraint(&mut self, constraint: &ast::AssocTyConstraint) {
         self.print_ident(constraint.ident);
         constraint.gen_args.as_ref().map(|args| self.print_generic_args(args, false));
-        self.s.space();
+        self.space();
         match &constraint.kind {
             ast::AssocTyConstraintKind::Equality { ty } => {
                 self.word_space("=");
@@ -979,27 +979,27 @@ impl<'a> State<'a> {
         self.ibox(0);
         match ty.kind {
             ast::TyKind::Slice(ref ty) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(ty);
-                self.s.word("]");
+                self.word("]");
             }
             ast::TyKind::Ptr(ref mt) => {
-                self.s.word("*");
+                self.word("*");
                 self.print_mt(mt, true);
             }
             ast::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lifetime);
                 self.print_mt(mt, false);
             }
             ast::TyKind::Never => {
-                self.s.word("!");
+                self.word("!");
             }
             ast::TyKind::Tup(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(ty));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
@@ -1023,33 +1023,33 @@ impl<'a> State<'a> {
                 self.print_type_bounds("impl", &bounds[..]);
             }
             ast::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(ty);
-                self.s.word("; ");
+                self.word("; ");
                 self.print_expr(&length.value);
-                self.s.word("]");
+                self.word("]");
             }
             ast::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(");
+                self.word("typeof(");
                 self.print_expr(&e.value);
-                self.s.word(")");
+                self.word(")");
             }
             ast::TyKind::Infer => {
-                self.s.word("_");
+                self.word("_");
             }
             ast::TyKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
             ast::TyKind::ImplicitSelf => {
-                self.s.word("Self");
+                self.word("Self");
             }
             ast::TyKind::MacCall(ref m) => {
                 self.print_mac(m);
             }
             ast::TyKind::CVarArgs => {
-                self.s.word("...");
+                self.word("...");
             }
         }
         self.end();
@@ -1087,7 +1087,7 @@ impl<'a> State<'a> {
             ast::ForeignItemKind::MacCall(m) => {
                 self.print_mac(m);
                 if m.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1115,13 +1115,13 @@ impl<'a> State<'a> {
         self.print_ident(ident);
         self.word_space(":");
         self.print_type(ty);
-        self.s.space();
+        self.space();
         self.end(); // end the head-ibox
         if let Some(body) = body {
             self.word_space("=");
             self.print_expr(body);
         }
-        self.s.word(";");
+        self.word(";");
         self.end(); // end the outer cbox
     }
 
@@ -1143,11 +1143,11 @@ impl<'a> State<'a> {
         self.print_type_bounds(":", bounds);
         self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_type(ty);
         }
-        self.s.word(";");
+        self.word(";");
         self.end(); // end inner head-block
         self.end(); // end outer head-block
     }
@@ -1163,19 +1163,19 @@ impl<'a> State<'a> {
                 self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
                     self.print_name(orig_name);
-                    self.s.space();
-                    self.s.word("as");
-                    self.s.space();
+                    self.space();
+                    self.word("as");
+                    self.space();
                 }
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
             ast::ItemKind::Use(ref tree) => {
                 self.head(visibility_qualified(&item.vis, "use"));
                 self.print_use_tree(tree);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
@@ -1218,7 +1218,7 @@ impl<'a> State<'a> {
                         self.bclose(item.span, empty);
                     }
                     ModKind::Unloaded => {
-                        self.s.word(";");
+                        self.word(";");
                         self.end(); // end inner head-block
                         self.end(); // end outer head-block
                     }
@@ -1289,23 +1289,23 @@ impl<'a> State<'a> {
 
                 if !generics.params.is_empty() {
                     self.print_generic_params(&generics.params);
-                    self.s.space();
+                    self.space();
                 }
 
                 if let ast::ImplPolarity::Negative(_) = polarity {
-                    self.s.word("!");
+                    self.word("!");
                 }
 
                 if let Some(ref t) = *of_trait {
                     self.print_trait_ref(t);
-                    self.s.space();
+                    self.space();
                     self.word_space("for");
                 }
 
                 self.print_type(self_ty);
                 self.print_where_clause(&generics.where_clause);
 
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes(&item.attrs);
                 for impl_item in items {
@@ -1332,7 +1332,7 @@ impl<'a> State<'a> {
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -1341,7 +1341,7 @@ impl<'a> State<'a> {
                 }
                 self.print_type_bounds(":", &real_bounds[..]);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(" ");
+                self.word(" ");
                 self.bopen();
                 self.print_inner_attributes(&item.attrs);
                 for trait_item in items {
@@ -1360,7 +1360,7 @@ impl<'a> State<'a> {
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -1370,12 +1370,12 @@ impl<'a> State<'a> {
                 self.nbsp();
                 self.print_type_bounds("=", &real_bounds[..]);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(";");
+                self.word(";");
             }
             ast::ItemKind::MacCall(ref mac) => {
                 self.print_mac(mac);
                 if mac.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
             ast::ItemKind::MacroDef(ref macro_def) => {
@@ -1393,7 +1393,7 @@ impl<'a> State<'a> {
 
     fn print_formal_generic_params(&mut self, generic_params: &[ast::GenericParam]) {
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
             self.nbsp();
         }
@@ -1416,7 +1416,7 @@ impl<'a> State<'a> {
         self.print_ident(ident);
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
@@ -1428,7 +1428,7 @@ impl<'a> State<'a> {
             self.print_outer_attributes(&v.attrs);
             self.ibox(INDENT_UNIT);
             self.print_variant(v);
-            self.s.word(",");
+            self.word(",");
             self.end();
             self.maybe_print_trailing_comment(v.span, None);
         }
@@ -1477,7 +1477,7 @@ impl<'a> State<'a> {
                 self.print_ident(field.ident.unwrap());
                 self.word_nbsp(":");
                 self.print_type(&field.ty);
-                self.s.word(",");
+                self.word(",");
             }
         }
 
@@ -1508,7 +1508,7 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";");
+                    self.word(";");
                 }
                 self.end();
                 self.end(); // Close the outer-box.
@@ -1526,7 +1526,7 @@ impl<'a> State<'a> {
         let generics = ast::Generics::default();
         self.print_struct(&v.data, &generics, v.ident, v.span, false);
         if let Some(ref d) = v.disr_expr {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_expr(&d.value)
         }
@@ -1558,7 +1558,7 @@ impl<'a> State<'a> {
             ast::AssocItemKind::MacCall(m) => {
                 self.print_mac(m);
                 if m.args.need_semicolon() {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1584,11 +1584,11 @@ impl<'a> State<'a> {
                     if let Some(els) = els {
                         self.cbox(INDENT_UNIT);
                         self.ibox(INDENT_UNIT);
-                        self.s.word(" else ");
+                        self.word(" else ");
                         self.print_block(els);
                     }
                 }
-                self.s.word(";");
+                self.word(";");
                 self.end(); // `let` ibox
             }
             ast::StmtKind::Item(ref item) => self.print_item(item),
@@ -1596,24 +1596,24 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
                 if classify::expr_requires_semi_to_be_stmt(expr) {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
             ast::StmtKind::Semi(ref expr) => {
                 self.space_if_not_bol();
                 self.print_expr_outer_attr_style(expr, false);
-                self.s.word(";");
+                self.word(";");
             }
             ast::StmtKind::Empty => {
                 self.space_if_not_bol();
-                self.s.word(";");
+                self.word(";");
             }
             ast::StmtKind::MacCall(ref mac) => {
                 self.space_if_not_bol();
                 self.print_outer_attributes(&mac.attrs);
                 self.print_mac(&mac.mac);
                 if mac.style == ast::MacStmtStyle::Semicolon {
-                    self.s.word(";");
+                    self.word(";");
                 }
             }
         }
@@ -1667,9 +1667,9 @@ impl<'a> State<'a> {
 
     /// Print a `let pat = expr` expression.
     crate fn print_let(&mut self, pat: &ast::Pat, expr: &ast::Expr) {
-        self.s.word("let ");
+        self.word("let ");
         self.print_pat(pat);
-        self.s.space();
+        self.space();
         self.word_space("=");
         let npals = || parser::needs_par_as_let_scrutinee(expr.precedence().order());
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
@@ -1682,9 +1682,9 @@ impl<'a> State<'a> {
                 ast::ExprKind::If(ref i, ref then, ref e) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else if ");
+                    self.word(" else if ");
                     self.print_expr_as_cond(i);
-                    self.s.space();
+                    self.space();
                     self.print_block(then);
                     self.print_else(e.as_deref())
                 }
@@ -1692,7 +1692,7 @@ impl<'a> State<'a> {
                 ast::ExprKind::Block(ref b, _) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else ");
+                    self.word(" else ");
                     self.print_block(b)
                 }
                 // Constraints would be great here!
@@ -1706,7 +1706,7 @@ impl<'a> State<'a> {
     crate fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block, elseopt: Option<&ast::Expr>) {
         self.head("if");
         self.print_expr_as_cond(test);
-        self.s.space();
+        self.space();
         self.print_block(blk);
         self.print_else(elseopt)
     }
@@ -1763,26 +1763,26 @@ impl<'a> State<'a> {
 
     fn print_expr_vec(&mut self, exprs: &[P<ast::Expr>]) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.commasep_exprs(Inconsistent, exprs);
-        self.s.word("]");
+        self.word("]");
         self.end();
     }
 
     fn print_expr_anon_const(&mut self, expr: &ast::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("const");
+        self.word("const");
         self.print_expr(&expr.value);
         self.end();
     }
 
     fn print_expr_repeat(&mut self, element: &ast::Expr, count: &ast::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.print_expr(element);
         self.word_space(";");
         self.print_expr(&count.value);
-        self.s.word("]");
+        self.word("]");
         self.end();
     }
 
@@ -1798,7 +1798,7 @@ impl<'a> State<'a> {
         } else {
             self.print_path(path, true, 0);
         }
-        self.s.word("{");
+        self.word("{");
         self.commasep_cmnt(
             Consistent,
             fields,
@@ -1818,26 +1818,26 @@ impl<'a> State<'a> {
             ast::StructRest::Base(_) | ast::StructRest::Rest(_) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
-                    self.s.word(",");
-                    self.s.space();
+                    self.word(",");
+                    self.space();
                 }
-                self.s.word("..");
+                self.word("..");
                 if let ast::StructRest::Base(ref expr) = *rest {
                     self.print_expr(expr);
                 }
                 self.end();
             }
-            ast::StructRest::None if !fields.is_empty() => self.s.word(","),
+            ast::StructRest::None if !fields.is_empty() => self.word(","),
             _ => {}
         }
-        self.s.word("}");
+        self.word("}");
     }
 
     fn print_expr_tup(&mut self, exprs: &[P<ast::Expr>]) {
         self.popen();
         self.commasep_exprs(Inconsistent, exprs);
         if exprs.len() == 1 {
-            self.s.word(",");
+            self.word(",");
         }
         self.pclose()
     }
@@ -1855,7 +1855,7 @@ impl<'a> State<'a> {
     fn print_expr_method_call(&mut self, segment: &ast::PathSegment, args: &[P<ast::Expr>]) {
         let base_args = &args[1..];
         self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
-        self.s.word(".");
+        self.word(".");
         self.print_ident(segment.ident);
         if let Some(ref args) = segment.args {
             self.print_generic_args(args, true);
@@ -1896,13 +1896,13 @@ impl<'a> State<'a> {
         };
 
         self.print_expr_maybe_paren(lhs, left_prec);
-        self.s.space();
+        self.space();
         self.word_space(op.node.to_string());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
     fn print_expr_unary(&mut self, op: ast::UnOp, expr: &ast::Expr) {
-        self.s.word(ast::UnOp::to_string(op));
+        self.word(ast::UnOp::to_string(op));
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
@@ -1912,7 +1912,7 @@ impl<'a> State<'a> {
         mutability: ast::Mutability,
         expr: &ast::Expr,
     ) {
-        self.s.word("&");
+        self.word("&");
         match kind {
             ast::BorrowKind::Ref => self.print_mutability(mutability, false),
             ast::BorrowKind::Raw => {
@@ -1980,7 +1980,7 @@ impl<'a> State<'a> {
             ast::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
                 self.print_expr_maybe_paren(expr, prec);
-                self.s.space();
+                self.space();
                 self.word_space("as");
                 self.print_type(ty);
             }
@@ -2003,7 +2003,7 @@ impl<'a> State<'a> {
                 }
                 self.head("while");
                 self.print_expr_as_cond(test);
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::ForLoop(ref pat, ref iter, ref blk, opt_label) => {
@@ -2013,10 +2013,10 @@ impl<'a> State<'a> {
                 }
                 self.head("for");
                 self.print_pat(pat);
-                self.s.space();
+                self.space();
                 self.word_space("in");
                 self.print_expr_as_cond(iter);
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Loop(ref blk, opt_label) => {
@@ -2032,7 +2032,7 @@ impl<'a> State<'a> {
                 self.ibox(INDENT_UNIT);
                 self.word_nbsp("match");
                 self.print_expr_as_cond(expr);
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes_no_trailing_hardbreak(attrs);
                 for arm in arms {
@@ -2054,7 +2054,7 @@ impl<'a> State<'a> {
                 self.print_capture_clause(capture_clause);
 
                 self.print_fn_params_and_ret(decl, true);
-                self.s.space();
+                self.space();
                 self.print_expr(body);
                 self.end(); // need to close a box
 
@@ -2084,33 +2084,33 @@ impl<'a> State<'a> {
             }
             ast::ExprKind::Await(ref expr) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".await");
+                self.word(".await");
             }
             ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
-                self.s.space();
+                self.space();
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(lhs, prec + 1);
-                self.s.space();
-                self.s.word(op.node.to_string());
+                self.space();
+                self.word(op.node.to_string());
                 self.word_space("=");
                 self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::Field(ref expr, ident) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".");
+                self.word(".");
                 self.print_ident(ident);
             }
             ast::ExprKind::Index(ref expr, ref index) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word("[");
+                self.word("[");
                 self.print_expr(index);
-                self.s.word("]");
+                self.word("]");
             }
             ast::ExprKind::Range(ref start, ref end, limits) => {
                 // Special case for `Range`.  `AssocOp` claims that `Range` has higher precedence
@@ -2122,41 +2122,41 @@ impl<'a> State<'a> {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
                 if limits == ast::RangeLimits::HalfOpen {
-                    self.s.word("..");
+                    self.word("..");
                 } else {
-                    self.s.word("..=");
+                    self.word("..=");
                 }
                 if let Some(ref e) = *end {
                     self.print_expr_maybe_paren(e, fake_prec);
                 }
             }
-            ast::ExprKind::Underscore => self.s.word("_"),
+            ast::ExprKind::Underscore => self.word("_"),
             ast::ExprKind::Path(None, ref path) => self.print_path(path, true, 0),
             ast::ExprKind::Path(Some(ref qself), ref path) => self.print_qpath(path, qself, true),
             ast::ExprKind::Break(opt_label, ref opt_expr) => {
-                self.s.word("break");
-                self.s.space();
+                self.word("break");
+                self.space();
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
-                    self.s.space();
+                    self.space();
                 }
                 if let Some(ref expr) = *opt_expr {
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
-                    self.s.space();
+                    self.space();
                 }
             }
             ast::ExprKind::Continue(opt_label) => {
-                self.s.word("continue");
-                self.s.space();
+                self.word("continue");
+                self.space();
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
-                    self.s.space()
+                    self.space()
                 }
             }
             ast::ExprKind::Ret(ref result) => {
-                self.s.word("return");
+                self.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ");
+                    self.word(" ");
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
@@ -2165,7 +2165,7 @@ impl<'a> State<'a> {
                 self.print_inline_asm(a);
             }
             ast::ExprKind::LlvmInlineAsm(ref a) => {
-                self.s.word("llvm_asm!");
+                self.word("llvm_asm!");
                 self.popen();
                 self.print_symbol(a.asm, a.asm_str_style);
                 self.word_space(":");
@@ -2183,7 +2183,7 @@ impl<'a> State<'a> {
                     s.print_expr(&out.expr);
                     s.pclose();
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &a.inputs, |s, &(co, ref o)| {
@@ -2192,7 +2192,7 @@ impl<'a> State<'a> {
                     s.print_expr(o);
                     s.pclose();
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &a.clobbers, |s, &co| {
@@ -2211,7 +2211,7 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space();
+                    self.space();
                     self.word_space(":");
                     self.commasep(Inconsistent, &options, |s, &co| {
                         s.print_string(co, ast::StrStyle::Cooked);
@@ -2227,25 +2227,25 @@ impl<'a> State<'a> {
                 self.pclose();
             }
             ast::ExprKind::Yield(ref e) => {
-                self.s.word("yield");
+                self.word("yield");
 
                 if let Some(ref expr) = *e {
-                    self.s.space();
+                    self.space();
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
             ast::ExprKind::Try(ref e) => {
                 self.print_expr_maybe_paren(e, parser::PREC_POSTFIX);
-                self.s.word("?")
+                self.word("?")
             }
             ast::ExprKind::TryBlock(ref blk) => {
                 self.head("try");
-                self.s.space();
+                self.space();
                 self.print_block_with_attrs(blk, attrs)
             }
             ast::ExprKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose()
             }
         }
@@ -2387,22 +2387,22 @@ impl<'a> State<'a> {
     }
 
     crate fn print_name(&mut self, name: Symbol) {
-        self.s.word(name.to_string());
+        self.word(name.to_string());
         self.ann.post(self, AnnNode::Name(&name))
     }
 
     fn print_qpath(&mut self, path: &ast::Path, qself: &ast::QSelf, colons_before_params: bool) {
-        self.s.word("<");
+        self.word("<");
         self.print_type(&qself.ty);
         if qself.position > 0 {
-            self.s.space();
+            self.space();
             self.word_space("as");
             let depth = path.segments.len() - qself.position;
             self.print_path(path, false, depth);
         }
-        self.s.word(">");
+        self.word(">");
         for item_segment in &path.segments[qself.position..] {
-            self.s.word("::");
+            self.word("::");
             self.print_ident(item_segment.ident);
             if let Some(ref args) = item_segment.args {
                 self.print_generic_args(args, colons_before_params)
@@ -2416,7 +2416,7 @@ impl<'a> State<'a> {
         /* Pat isn't normalized, but the beauty of it
         is that it doesn't matter */
         match pat.kind {
-            PatKind::Wild => self.s.word("_"),
+            PatKind::Wild => self.word("_"),
             PatKind::Ident(binding_mode, ident, ref sub) => {
                 match binding_mode {
                     ast::BindingMode::ByRef(mutbl) => {
@@ -2430,8 +2430,8 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.space();
-                    self.s.word_space("@");
+                    self.space();
+                    self.word_space("@");
                     self.print_pat(p);
                 }
             }
@@ -2480,27 +2480,27 @@ impl<'a> State<'a> {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                 }
-                self.s.space();
-                self.s.word("}");
+                self.space();
+                self.word("}");
             }
             PatKind::Tuple(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
             PatKind::Box(ref inner) => {
-                self.s.word("box ");
+                self.word("box ");
                 self.print_pat(inner);
             }
             PatKind::Ref(ref inner, mutbl) => {
-                self.s.word("&");
+                self.word("&");
                 if mutbl == ast::Mutability::Mut {
-                    self.s.word("mut ");
+                    self.word("mut ");
                 }
                 if let PatKind::Ident(ast::BindingMode::ByValue(ast::Mutability::Mut), ..) =
                     inner.kind
@@ -2516,23 +2516,23 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {
                 if let Some(e) = begin {
                     self.print_expr(e);
-                    self.s.space();
+                    self.space();
                 }
                 match *end_kind {
-                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.s.word("..."),
-                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.s.word("..="),
-                    RangeEnd::Excluded => self.s.word(".."),
+                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.word("..."),
+                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.word("..="),
+                    RangeEnd::Excluded => self.word(".."),
                 }
                 if let Some(e) = end {
                     self.print_expr(e);
                 }
             }
             PatKind::Slice(ref elts) => {
-                self.s.word("[");
+                self.word("[");
                 self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
-                self.s.word("]");
+                self.word("]");
             }
-            PatKind::Rest => self.s.word(".."),
+            PatKind::Rest => self.word(".."),
             PatKind::Paren(ref inner) => {
                 self.popen();
                 self.print_pat(inner);
@@ -2546,18 +2546,18 @@ impl<'a> State<'a> {
     fn print_arm(&mut self, arm: &ast::Arm) {
         // Note, I have no idea why this check is necessary, but here it is.
         if arm.attrs.is_empty() {
-            self.s.space();
+            self.space();
         }
         self.cbox(INDENT_UNIT);
         self.ibox(0);
         self.maybe_print_comment(arm.pat.span.lo());
         self.print_outer_attributes(&arm.attrs);
         self.print_pat(&arm.pat);
-        self.s.space();
+        self.space();
         if let Some(ref e) = arm.guard {
             self.word_space("if");
             self.print_expr(e);
-            self.s.space();
+            self.space();
         }
         self.word_space("=>");
 
@@ -2573,13 +2573,13 @@ impl<'a> State<'a> {
 
                 // If it is a user-provided unsafe block, print a comma after it.
                 if let BlockCheckMode::Unsafe(ast::UserProvided) = blk.rules {
-                    self.s.word(",");
+                    self.word(",");
                 }
             }
             _ => {
                 self.end(); // Close the ibox for the pattern.
                 self.print_expr(&arm.body);
-                self.s.word(",");
+                self.word(",");
             }
         }
         self.end(); // Close enclosing cbox.
@@ -2589,17 +2589,17 @@ impl<'a> State<'a> {
         match explicit_self.node {
             SelfKind::Value(m) => {
                 self.print_mutability(m, false);
-                self.s.word("self")
+                self.word("self")
             }
             SelfKind::Region(ref lt, m) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lt);
                 self.print_mutability(m, false);
-                self.s.word("self")
+                self.word("self")
             }
             SelfKind::Explicit(ref typ, m) => {
                 self.print_mutability(m, false);
-                self.s.word("self");
+                self.word("self");
                 self.word_space(":");
                 self.print_type(typ)
             }
@@ -2626,7 +2626,7 @@ impl<'a> State<'a> {
             self.nbsp();
             self.print_block_with_attrs(body, attrs);
         } else {
-            self.s.word(";");
+            self.word(";");
         }
     }
 
@@ -2677,7 +2677,7 @@ impl<'a> State<'a> {
 
     pub fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound]) {
         if !bounds.is_empty() {
-            self.s.word(prefix);
+            self.word(prefix);
             let mut first = true;
             for bound in bounds {
                 if !(first && prefix.is_empty()) {
@@ -2692,7 +2692,7 @@ impl<'a> State<'a> {
                 match bound {
                     GenericBound::Trait(tref, modifier) => {
                         if modifier == &TraitBoundModifier::Maybe {
-                            self.s.word("?");
+                            self.word("?");
                         }
                         self.print_poly_trait_ref(tref);
                     }
@@ -2713,10 +2713,10 @@ impl<'a> State<'a> {
     ) {
         self.print_lifetime(lifetime);
         if !bounds.is_empty() {
-            self.s.word(": ");
+            self.word(": ");
             for (i, bound) in bounds.iter().enumerate() {
                 if i != 0 {
-                    self.s.word(" + ");
+                    self.word(" + ");
                 }
                 match bound {
                     ast::GenericBound::Outlives(lt) => self.print_lifetime(*lt),
@@ -2731,7 +2731,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.word("<");
+        self.word("<");
 
         self.commasep(Inconsistent, &generic_params, |s, param| {
             s.print_outer_attributes_inline(&param.attrs);
@@ -2745,7 +2745,7 @@ impl<'a> State<'a> {
                     s.print_ident(param.ident);
                     s.print_type_bounds(":", &param.bounds);
                     if let Some(ref default) = default {
-                        s.s.space();
+                        s.space();
                         s.word_space("=");
                         s.print_type(default)
                     }
@@ -2753,12 +2753,12 @@ impl<'a> State<'a> {
                 ast::GenericParamKind::Const { ref ty, kw_span: _, ref default } => {
                     s.word_space("const");
                     s.print_ident(param.ident);
-                    s.s.space();
+                    s.space();
                     s.word_space(":");
                     s.print_type(ty);
                     s.print_type_bounds(":", &param.bounds);
                     if let Some(ref default) = default {
-                        s.s.space();
+                        s.space();
                         s.word_space("=");
                         s.print_expr(&default.value);
                     }
@@ -2766,7 +2766,7 @@ impl<'a> State<'a> {
             }
         });
 
-        self.s.word(">");
+        self.word(">");
     }
 
     crate fn print_where_clause(&mut self, where_clause: &ast::WhereClause) {
@@ -2774,7 +2774,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.space();
+        self.space();
         self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
@@ -2806,7 +2806,7 @@ impl<'a> State<'a> {
                     ..
                 }) => {
                     self.print_type(lhs_ty);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(rhs_ty);
                 }
@@ -2819,7 +2819,7 @@ impl<'a> State<'a> {
             ast::UseTreeKind::Simple(rename, ..) => {
                 self.print_path(&tree.prefix, false, 0);
                 if let Some(rename) = rename {
-                    self.s.space();
+                    self.space();
                     self.word_space("as");
                     self.print_ident(rename);
                 }
@@ -2827,21 +2827,21 @@ impl<'a> State<'a> {
             ast::UseTreeKind::Glob => {
                 if !tree.prefix.segments.is_empty() {
                     self.print_path(&tree.prefix, false, 0);
-                    self.s.word("::");
+                    self.word("::");
                 }
-                self.s.word("*");
+                self.word("*");
             }
             ast::UseTreeKind::Nested(ref items) => {
                 if tree.prefix.segments.is_empty() {
-                    self.s.word("{");
+                    self.word("{");
                 } else {
                     self.print_path(&tree.prefix, false, 0);
-                    self.s.word("::{");
+                    self.word("::{");
                 }
                 self.commasep(Inconsistent, &items[..], |this, &(ref tree, _)| {
                     this.print_use_tree(tree)
                 });
-                self.s.word("}");
+                self.word("}");
             }
         }
     }
@@ -2880,8 +2880,8 @@ impl<'a> State<'a> {
                     };
                     if !invalid {
                         self.print_pat(&input.pat);
-                        self.s.word(":");
-                        self.s.space();
+                        self.word(":");
+                        self.space();
                     }
                     self.print_type(&input.ty);
                 }
@@ -2911,7 +2911,7 @@ impl<'a> State<'a> {
     ) {
         self.ibox(INDENT_UNIT);
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
         }
         let generics = ast::Generics {
@@ -2945,7 +2945,7 @@ impl<'a> State<'a> {
             }
         }
 
-        self.s.word("fn")
+        self.word("fn")
     }
 
     crate fn print_unsafety(&mut self, s: ast::Unsafe) {

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -512,7 +512,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             self.param_env,
             self.layout_of(self.subst_from_current_frame_and_normalize_erasing_regions(
                 place.ty(&self.frame().body.local_decls, *self.tcx).ty
-            ))?,
+            )?)?,
             op.layout,
         ));
         Ok(op)
@@ -534,7 +534,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             Constant(ref constant) => {
                 let val =
-                    self.subst_from_current_frame_and_normalize_erasing_regions(constant.literal);
+                    self.subst_from_current_frame_and_normalize_erasing_regions(constant.literal)?;
                 // This can still fail:
                 // * During ConstProp, with `TooGeneric` or since the `requried_consts` were not all
                 //   checked yet.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -643,7 +643,7 @@ where
             self.param_env,
             self.layout_of(self.subst_from_current_frame_and_normalize_erasing_regions(
                 place.ty(&self.frame().body.local_decls, *self.tcx).ty
-            ))?,
+            )?)?,
             place_ty.layout,
         ));
         Ok(place_ty)

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -276,7 +276,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             NullaryOp(null_op, ty) => {
-                let ty = self.subst_from_current_frame_and_normalize_erasing_regions(ty);
+                let ty = self.subst_from_current_frame_and_normalize_erasing_regions(ty)?;
                 let layout = self.layout_of(ty)?;
                 if layout.is_unsized() {
                     // FIXME: This should be a span_bug (#80742)
@@ -302,7 +302,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             Cast(cast_kind, ref operand, cast_ty) => {
                 let src = self.eval_operand(operand, None)?;
-                let cast_ty = self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty);
+                let cast_ty =
+                    self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty)?;
                 self.cast(&src, cast_kind, cast_ty, &dest)?;
             }
 

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -89,7 +89,7 @@ impl<'a> State<'a> {
             Node::TraitRef(a) => self.print_trait_ref(&a),
             Node::Binding(a) | Node::Pat(a) => self.print_pat(&a),
             Node::Arm(a) => self.print_arm(&a),
-            Node::Infer(_) => self.s.word("_"),
+            Node::Infer(_) => self.word("_"),
             Node::Block(a) => {
                 // Containing cbox, will be closed by print-block at `}`.
                 self.cbox(INDENT_UNIT);
@@ -130,7 +130,7 @@ impl<'a> PrintState<'a> for State<'a> {
     }
 
     fn print_ident(&mut self, ident: Ident) {
-        self.s.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
+        self.word(IdentPrinter::for_ast_ident(ident, ident.is_raw_guess()).to_string());
         self.ann.post(self, AnnNode::Name(&ident.name))
     }
 
@@ -194,7 +194,7 @@ where
 pub fn visibility_qualified<S: Into<Cow<'static, str>>>(vis: &hir::Visibility<'_>, w: S) -> String {
     to_string(NO_ANN, |s| {
         s.print_visibility(vis);
-        s.s.word(w)
+        s.word(w)
     })
 }
 
@@ -244,7 +244,7 @@ impl<'a> State<'a> {
     pub fn bclose_maybe_open(&mut self, span: rustc_span::Span, close_box: bool) {
         self.maybe_print_comment(span.hi());
         self.break_offset_if_not_bol(1, -(INDENT_UNIT as isize));
-        self.s.word("}");
+        self.word("}");
         if close_box {
             self.end(); // close the outer-box
         }
@@ -267,7 +267,7 @@ impl<'a> State<'a> {
             op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",");
+                self.word(",");
                 self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()));
                 self.space_if_not_bol();
             }
@@ -298,27 +298,27 @@ impl<'a> State<'a> {
         self.ibox(0);
         match ty.kind {
             hir::TyKind::Slice(ref ty) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(&ty);
-                self.s.word("]");
+                self.word("]");
             }
             hir::TyKind::Ptr(ref mt) => {
-                self.s.word("*");
+                self.word("*");
                 self.print_mt(mt, true);
             }
             hir::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&");
+                self.word("&");
                 self.print_opt_lifetime(lifetime);
                 self.print_mt(mt, false);
             }
             hir::TyKind::Never => {
-                self.s.word("!");
+                self.word("!");
             }
             hir::TyKind::Tup(ref elts) => {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty));
                 if elts.len() == 1 {
-                    self.s.word(",");
+                    self.word(",");
                 }
                 self.pclose();
             }
@@ -332,7 +332,7 @@ impl<'a> State<'a> {
                     f.param_names,
                 );
             }
-            hir::TyKind::OpaqueDef(..) => self.s.word("/*impl Trait*/"),
+            hir::TyKind::OpaqueDef(..) => self.word("/*impl Trait*/"),
             hir::TyKind::Path(ref qpath) => self.print_qpath(qpath, false),
             hir::TyKind::TraitObject(bounds, ref lifetime, syntax) => {
                 if syntax == ast::TraitObjectSyntax::Dyn {
@@ -355,24 +355,24 @@ impl<'a> State<'a> {
                 }
             }
             hir::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[");
+                self.word("[");
                 self.print_type(&ty);
-                self.s.word("; ");
+                self.word("; ");
                 self.print_anon_const(length);
-                self.s.word("]");
+                self.word("]");
             }
             hir::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(");
+                self.word("typeof(");
                 self.print_anon_const(e);
-                self.s.word(")");
+                self.word(")");
             }
             hir::TyKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
             hir::TyKind::Infer => {
-                self.s.word("_");
+                self.word("_");
             }
         }
         self.end()
@@ -400,7 +400,7 @@ impl<'a> State<'a> {
                     None,
                 );
                 self.end(); // end head-ibox
-                self.s.word(";");
+                self.word(";");
                 self.end() // end the outer fn box
             }
             hir::ForeignItemKind::Static(ref t, m) => {
@@ -411,14 +411,14 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&t);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
             hir::ForeignItemKind::Type => {
                 self.head(visibility_qualified(&item.vis, "type"));
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
@@ -432,17 +432,17 @@ impl<'a> State<'a> {
         default: Option<hir::BodyId>,
         vis: &hir::Visibility<'_>,
     ) {
-        self.s.word(visibility_qualified(vis, ""));
+        self.word(visibility_qualified(vis, ""));
         self.word_space("const");
         self.print_ident(ident);
         self.word_space(":");
         self.print_type(ty);
         if let Some(expr) = default {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.ann.nested(self, Nested::Body(expr));
         }
-        self.s.word(";")
+        self.word(";")
     }
 
     fn print_associated_type(
@@ -460,11 +460,11 @@ impl<'a> State<'a> {
         }
         self.print_where_clause(&generics.where_clause);
         if let Some(ty) = ty {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_type(ty);
         }
-        self.s.word(";")
+        self.word(";")
     }
 
     fn print_item_type(
@@ -479,9 +479,9 @@ impl<'a> State<'a> {
         self.end(); // end the inner ibox
 
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         inner(self);
-        self.s.word(";");
+        self.word(";");
         self.end(); // end the outer ibox
     }
 
@@ -497,12 +497,12 @@ impl<'a> State<'a> {
                 self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
                     self.print_name(orig_name);
-                    self.s.space();
-                    self.s.word("as");
-                    self.s.space();
+                    self.space();
+                    self.word("as");
+                    self.space();
                 }
                 self.print_ident(item.ident);
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
@@ -513,14 +513,14 @@ impl<'a> State<'a> {
                 match kind {
                     hir::UseKind::Single => {
                         if path.segments.last().unwrap().ident != item.ident {
-                            self.s.space();
+                            self.space();
                             self.word_space("as");
                             self.print_ident(item.ident);
                         }
-                        self.s.word(";");
+                        self.word(";");
                     }
-                    hir::UseKind::Glob => self.s.word("::*;"),
-                    hir::UseKind::ListStem => self.s.word("::{};"),
+                    hir::UseKind::Glob => self.word("::*;"),
+                    hir::UseKind::ListStem => self.word("::{};"),
                 }
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
@@ -533,12 +533,12 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&ty);
-                self.s.space();
+                self.space();
                 self.end(); // end the head-ibox
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the outer cbox
             }
             hir::ItemKind::Const(ref ty, expr) => {
@@ -546,12 +546,12 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.word_space(":");
                 self.print_type(&ty);
-                self.s.space();
+                self.space();
                 self.end(); // end the head-ibox
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
-                self.s.word(";");
+                self.word(";");
                 self.end(); // end the outer cbox
             }
             hir::ItemKind::Fn(ref sig, ref param_names, body) => {
@@ -565,7 +565,7 @@ impl<'a> State<'a> {
                     &[],
                     Some(body),
                 );
-                self.s.word(" ");
+                self.word(" ");
                 self.end(); // need to close a box
                 self.end(); // need to close a box
                 self.ann.nested(self, Nested::Body(body));
@@ -609,7 +609,7 @@ impl<'a> State<'a> {
                     let mut real_bounds = Vec::with_capacity(opaque_ty.bounds.len());
                     for b in opaque_ty.bounds.iter() {
                         if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                            state.s.space();
+                            state.space();
                             state.word_space("for ?");
                             state.print_trait_ref(&ptr.trait_ref);
                         } else {
@@ -649,7 +649,7 @@ impl<'a> State<'a> {
 
                 if !generics.params.is_empty() {
                     self.print_generic_params(&generics.params);
-                    self.s.space();
+                    self.space();
                 }
 
                 if constness == hir::Constness::Const {
@@ -657,19 +657,19 @@ impl<'a> State<'a> {
                 }
 
                 if let hir::ImplPolarity::Negative(_) = polarity {
-                    self.s.word("!");
+                    self.word("!");
                 }
 
                 if let Some(ref t) = of_trait {
                     self.print_trait_ref(t);
-                    self.s.space();
+                    self.space();
                     self.word_space("for");
                 }
 
                 self.print_type(&self_ty);
                 self.print_where_clause(&generics.where_clause);
 
-                self.s.space();
+                self.space();
                 self.bopen();
                 self.print_inner_attributes(attrs);
                 for impl_item in items {
@@ -688,7 +688,7 @@ impl<'a> State<'a> {
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -697,7 +697,7 @@ impl<'a> State<'a> {
                 }
                 self.print_bounds(":", real_bounds);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(" ");
+                self.word(" ");
                 self.bopen();
                 for trait_item in trait_items {
                     self.ann.nested(self, Nested::TraitItem(trait_item.id));
@@ -714,7 +714,7 @@ impl<'a> State<'a> {
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space();
+                        self.space();
                         self.word_space("for ?");
                         self.print_trait_ref(&ptr.trait_ref);
                     } else {
@@ -724,7 +724,7 @@ impl<'a> State<'a> {
                 self.nbsp();
                 self.print_bounds("=", real_bounds);
                 self.print_where_clause(&generics.where_clause);
-                self.s.word(";");
+                self.word(";");
             }
         }
         self.ann.post(self, AnnNode::Item(item))
@@ -736,7 +736,7 @@ impl<'a> State<'a> {
 
     fn print_formal_generic_params(&mut self, generic_params: &[hir::GenericParam<'_>]) {
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
             self.nbsp();
         }
@@ -759,7 +759,7 @@ impl<'a> State<'a> {
         self.print_name(name);
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
-        self.s.space();
+        self.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
@@ -771,7 +771,7 @@ impl<'a> State<'a> {
             self.print_outer_attributes(self.attrs(v.id));
             self.ibox(INDENT_UNIT);
             self.print_variant(v);
-            self.s.word(",");
+            self.word(",");
             self.end();
             self.maybe_print_trailing_comment(v.span, None);
         }
@@ -784,10 +784,10 @@ impl<'a> State<'a> {
             hir::VisibilityKind::Crate(ast::CrateSugar::JustCrate) => self.word_nbsp("crate"),
             hir::VisibilityKind::Crate(ast::CrateSugar::PubCrate) => self.word_nbsp("pub(crate)"),
             hir::VisibilityKind::Restricted { ref path, .. } => {
-                self.s.word("pub(");
+                self.word("pub(");
                 if path.segments.len() == 1 && path.segments[0].ident.name == kw::Super {
                     // Special case: `super` can print like `pub(super)`.
-                    self.s.word("super");
+                    self.word("super");
                 } else {
                     // Everything else requires `in` at present.
                     self.word_nbsp("in");
@@ -830,7 +830,7 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";");
+                    self.word(";");
                 }
                 self.end();
                 self.end() // close the outer-box
@@ -849,7 +849,7 @@ impl<'a> State<'a> {
                     self.print_ident(field.ident);
                     self.word_nbsp(":");
                     self.print_type(&field.ty);
-                    self.s.word(",");
+                    self.word(",");
                 }
 
                 self.bclose(span)
@@ -862,7 +862,7 @@ impl<'a> State<'a> {
         let generics = hir::Generics::empty();
         self.print_struct(&v.data, &generics, v.ident.name, v.span, false);
         if let Some(ref d) = v.disr_expr {
-            self.s.space();
+            self.space();
             self.word_space("=");
             self.print_anon_const(d);
         }
@@ -894,7 +894,7 @@ impl<'a> State<'a> {
                 let vis =
                     Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Inherited };
                 self.print_method_sig(ti.ident, sig, &ti.generics, &vis, arg_names, None);
-                self.s.word(";");
+                self.word(";");
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
                 let vis =
@@ -975,11 +975,11 @@ impl<'a> State<'a> {
             hir::StmtKind::Semi(ref expr) => {
                 self.space_if_not_bol();
                 self.print_expr(&expr);
-                self.s.word(";");
+                self.word(";");
             }
         }
         if stmt_ends_with_semi(&st.kind) {
-            self.s.word(";");
+            self.word(";");
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
@@ -1031,9 +1031,9 @@ impl<'a> State<'a> {
                 hir::ExprKind::If(ref i, ref then, ref e) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else if ");
+                    self.word(" else if ");
                     self.print_expr_as_cond(&i);
-                    self.s.space();
+                    self.space();
                     self.print_expr(&then);
                     self.print_else(e.as_ref().map(|e| &**e))
                 }
@@ -1041,7 +1041,7 @@ impl<'a> State<'a> {
                 hir::ExprKind::Block(ref b, _) => {
                     self.cbox(INDENT_UNIT - 1);
                     self.ibox(0);
-                    self.s.word(" else ");
+                    self.word(" else ");
                     self.print_block(&b)
                 }
                 // Constraints would be great here!
@@ -1060,7 +1060,7 @@ impl<'a> State<'a> {
     ) {
         self.head("if");
         self.print_expr_as_cond(test);
-        self.s.space();
+        self.space();
         self.print_expr(blk);
         self.print_else(elseopt)
     }
@@ -1102,9 +1102,9 @@ impl<'a> State<'a> {
 
     /// Print a `let pat = expr` expression.
     fn print_let(&mut self, pat: &hir::Pat<'_>, expr: &hir::Expr<'_>) {
-        self.s.word("let ");
+        self.word("let ");
         self.print_pat(pat);
-        self.s.space();
+        self.space();
         self.word_space("=");
         let npals = || parser::needs_par_as_let_scrutinee(expr.precedence().order());
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
@@ -1123,26 +1123,26 @@ impl<'a> State<'a> {
 
     fn print_expr_vec(&mut self, exprs: &[hir::Expr<'_>]) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.commasep_exprs(Inconsistent, exprs);
-        self.s.word("]");
+        self.word("]");
         self.end()
     }
 
     fn print_expr_anon_const(&mut self, anon_const: &hir::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word_space("const");
+        self.word_space("const");
         self.print_anon_const(anon_const);
         self.end()
     }
 
     fn print_expr_repeat(&mut self, element: &hir::Expr<'_>, count: &hir::AnonConst) {
         self.ibox(INDENT_UNIT);
-        self.s.word("[");
+        self.word("[");
         self.print_expr(element);
         self.word_space(";");
         self.print_anon_const(count);
-        self.s.word("]");
+        self.word("]");
         self.end()
     }
 
@@ -1153,7 +1153,7 @@ impl<'a> State<'a> {
         wth: &Option<&hir::Expr<'_>>,
     ) {
         self.print_qpath(qpath, true);
-        self.s.word("{");
+        self.word("{");
         self.commasep_cmnt(
             Consistent,
             fields,
@@ -1172,27 +1172,27 @@ impl<'a> State<'a> {
             Some(ref expr) => {
                 self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
-                    self.s.word(",");
-                    self.s.space();
+                    self.word(",");
+                    self.space();
                 }
-                self.s.word("..");
+                self.word("..");
                 self.print_expr(&expr);
                 self.end();
             }
             _ => {
                 if !fields.is_empty() {
-                    self.s.word(",")
+                    self.word(",")
                 }
             }
         }
-        self.s.word("}");
+        self.word("}");
     }
 
     fn print_expr_tup(&mut self, exprs: &[hir::Expr<'_>]) {
         self.popen();
         self.commasep_exprs(Inconsistent, exprs);
         if exprs.len() == 1 {
-            self.s.word(",");
+            self.word(",");
         }
         self.pclose()
     }
@@ -1210,7 +1210,7 @@ impl<'a> State<'a> {
     fn print_expr_method_call(&mut self, segment: &hir::PathSegment<'_>, args: &[hir::Expr<'_>]) {
         let base_args = &args[1..];
         self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
-        self.s.word(".");
+        self.word(".");
         self.print_ident(segment.ident);
 
         let generic_args = segment.args();
@@ -1246,13 +1246,13 @@ impl<'a> State<'a> {
         };
 
         self.print_expr_maybe_paren(lhs, left_prec);
-        self.s.space();
+        self.space();
         self.word_space(op.node.as_str());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
     fn print_expr_unary(&mut self, op: hir::UnOp, expr: &hir::Expr<'_>) {
-        self.s.word(op.as_str());
+        self.word(op.as_str());
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
@@ -1262,7 +1262,7 @@ impl<'a> State<'a> {
         mutability: hir::Mutability,
         expr: &hir::Expr<'_>,
     ) {
-        self.s.word("&");
+        self.word("&");
         match kind {
             hir::BorrowKind::Ref => self.print_mutability(mutability, false),
             hir::BorrowKind::Raw => {
@@ -1434,7 +1434,7 @@ impl<'a> State<'a> {
             hir::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
                 self.print_expr_maybe_paren(&expr, prec);
-                self.s.space();
+                self.space();
                 self.word_space("as");
                 self.print_type(&ty);
             }
@@ -1453,7 +1453,7 @@ impl<'a> State<'a> {
                 // Print `let _t = $init;`:
                 let temp = Ident::from_str("_t");
                 self.print_local(Some(init), |this| this.print_ident(temp));
-                self.s.word(";");
+                self.word(";");
 
                 // Print `_t`:
                 self.space_if_not_bol();
@@ -1481,7 +1481,7 @@ impl<'a> State<'a> {
                 self.ibox(INDENT_UNIT);
                 self.word_nbsp("match");
                 self.print_expr_as_cond(&expr);
-                self.s.space();
+                self.space();
                 self.bopen();
                 for arm in arms {
                     self.print_arm(arm);
@@ -1492,7 +1492,7 @@ impl<'a> State<'a> {
                 self.print_capture_clause(capture_clause);
 
                 self.print_closure_params(&decl, body);
-                self.s.space();
+                self.space();
 
                 // This is a bare expression.
                 self.ann.nested(self, Nested::Body(body));
@@ -1517,54 +1517,54 @@ impl<'a> State<'a> {
             hir::ExprKind::Assign(ref lhs, ref rhs, _) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(&lhs, prec + 1);
-                self.s.space();
+                self.space();
                 self.word_space("=");
                 self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
                 self.print_expr_maybe_paren(&lhs, prec + 1);
-                self.s.space();
-                self.s.word(op.node.as_str());
+                self.space();
+                self.word(op.node.as_str());
                 self.word_space("=");
                 self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::Field(ref expr, ident) => {
                 self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
-                self.s.word(".");
+                self.word(".");
                 self.print_ident(ident);
             }
             hir::ExprKind::Index(ref expr, ref index) => {
                 self.print_expr_maybe_paren(&expr, parser::PREC_POSTFIX);
-                self.s.word("[");
+                self.word("[");
                 self.print_expr(&index);
-                self.s.word("]");
+                self.word("]");
             }
             hir::ExprKind::Path(ref qpath) => self.print_qpath(qpath, true),
             hir::ExprKind::Break(destination, ref opt_expr) => {
-                self.s.word("break");
-                self.s.space();
+                self.word("break");
+                self.space();
                 if let Some(label) = destination.label {
                     self.print_ident(label.ident);
-                    self.s.space();
+                    self.space();
                 }
                 if let Some(ref expr) = *opt_expr {
                     self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
-                    self.s.space();
+                    self.space();
                 }
             }
             hir::ExprKind::Continue(destination) => {
-                self.s.word("continue");
-                self.s.space();
+                self.word("continue");
+                self.space();
                 if let Some(label) = destination.label {
                     self.print_ident(label.ident);
-                    self.s.space()
+                    self.space()
                 }
             }
             hir::ExprKind::Ret(ref result) => {
-                self.s.word("return");
+                self.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ");
+                    self.word(" ");
                     self.print_expr_maybe_paren(&expr, parser::PREC_JUMP);
                 }
             }
@@ -1574,7 +1574,7 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::LlvmInlineAsm(ref a) => {
                 let i = &a.inner;
-                self.s.word("llvm_asm!");
+                self.word("llvm_asm!");
                 self.popen();
                 self.print_symbol(i.asm, i.asm_str_style);
                 self.word_space(":");
@@ -1594,7 +1594,7 @@ impl<'a> State<'a> {
                     s.pclose();
                     out_idx += 1;
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 let mut in_idx = 0;
@@ -1605,7 +1605,7 @@ impl<'a> State<'a> {
                     s.pclose();
                     in_idx += 1;
                 });
-                self.s.space();
+                self.space();
                 self.word_space(":");
 
                 self.commasep(Inconsistent, &i.clobbers, |s, &co| {
@@ -1624,7 +1624,7 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space();
+                    self.space();
                     self.word_space(":");
                     self.commasep(Inconsistent, &options, |s, &co| {
                         s.print_string(co, ast::StrStyle::Cooked);
@@ -1639,7 +1639,7 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::Err => {
                 self.popen();
-                self.s.word("/*ERROR*/");
+                self.word("/*ERROR*/");
                 self.pclose();
             }
         }
@@ -1664,7 +1664,7 @@ impl<'a> State<'a> {
 
         for (i, segment) in path.segments.iter().enumerate() {
             if i > 0 {
-                self.s.word("::")
+                self.word("::")
             }
             if segment.ident.name != kw::PathRoot {
                 self.print_ident(segment.ident);
@@ -1684,14 +1684,14 @@ impl<'a> State<'a> {
         match *qpath {
             hir::QPath::Resolved(None, ref path) => self.print_path(path, colons_before_params),
             hir::QPath::Resolved(Some(ref qself), ref path) => {
-                self.s.word("<");
+                self.word("<");
                 self.print_type(qself);
-                self.s.space();
+                self.space();
                 self.word_space("as");
 
                 for (i, segment) in path.segments[..path.segments.len() - 1].iter().enumerate() {
                     if i > 0 {
-                        self.s.word("::")
+                        self.word("::")
                     }
                     if segment.ident.name != kw::PathRoot {
                         self.print_ident(segment.ident);
@@ -1703,8 +1703,8 @@ impl<'a> State<'a> {
                     }
                 }
 
-                self.s.word(">");
-                self.s.word("::");
+                self.word(">");
+                self.word("::");
                 let item_segment = path.segments.last().unwrap();
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(
@@ -1720,12 +1720,12 @@ impl<'a> State<'a> {
                 if let hir::TyKind::Path(hir::QPath::Resolved(None, _)) = &qself.kind {
                     self.print_type(qself);
                 } else {
-                    self.s.word("<");
+                    self.word("<");
                     self.print_type(qself);
-                    self.s.word(">");
+                    self.word(">");
                 }
 
-                self.s.word("::");
+                self.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(
                     item_segment.args(),
@@ -1734,9 +1734,9 @@ impl<'a> State<'a> {
                 )
             }
             hir::QPath::LangItem(lang_item, span) => {
-                self.s.word("#[lang = \"");
+                self.word("#[lang = \"");
                 self.print_ident(Ident::new(lang_item.name(), span));
-                self.s.word("\"]");
+                self.word("\"]");
             }
         }
     }
@@ -1748,9 +1748,9 @@ impl<'a> State<'a> {
         colons_before_params: bool,
     ) {
         if generic_args.parenthesized {
-            self.s.word("(");
+            self.word("(");
             self.commasep(Inconsistent, generic_args.inputs(), |s, ty| s.print_type(&ty));
-            self.s.word(")");
+            self.word(")");
 
             self.space_if_not_bol();
             self.word_space("->");
@@ -1761,7 +1761,7 @@ impl<'a> State<'a> {
             let start_or_comma = |this: &mut Self| {
                 if empty.get() {
                     empty.set(false);
-                    this.s.word(start)
+                    this.word(start)
                 } else {
                     this.word_space(",")
                 }
@@ -1795,14 +1795,14 @@ impl<'a> State<'a> {
             // "non-exhaustive patterns: `Some::<..>(_)` not covered").
             if infer_args && false {
                 start_or_comma(self);
-                self.s.word("..");
+                self.word("..");
             }
 
             for binding in generic_args.bindings.iter() {
                 start_or_comma(self);
                 self.print_ident(binding.ident);
                 self.print_generic_args(binding.gen_args, false, false);
-                self.s.space();
+                self.space();
                 match generic_args.bindings[0].kind {
                     hir::TypeBindingKind::Equality { ref ty } => {
                         self.word_space("=");
@@ -1815,7 +1815,7 @@ impl<'a> State<'a> {
             }
 
             if !empty.get() {
-                self.s.word(">")
+                self.word(">")
             }
         }
     }
@@ -1826,7 +1826,7 @@ impl<'a> State<'a> {
         // Pat isn't normalized, but the beauty of it
         // is that it doesn't matter
         match pat.kind {
-            PatKind::Wild => self.s.word("_"),
+            PatKind::Wild => self.word("_"),
             PatKind::Binding(binding_mode, _, ident, ref sub) => {
                 match binding_mode {
                     hir::BindingAnnotation::Ref => {
@@ -1844,7 +1844,7 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.word("@");
+                    self.word("@");
                     self.print_pat(&p);
                 }
             }
@@ -1856,9 +1856,9 @@ impl<'a> State<'a> {
                     if ddpos != 0 {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",");
+                        self.word(",");
                         self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
@@ -1891,10 +1891,10 @@ impl<'a> State<'a> {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                 }
-                self.s.space();
-                self.s.word("}");
+                self.space();
+                self.word("}");
             }
             PatKind::Or(ref pats) => {
                 self.strsep("|", true, Inconsistent, &pats[..], |s, p| s.print_pat(&p));
@@ -1906,22 +1906,22 @@ impl<'a> State<'a> {
                     if ddpos != 0 {
                         self.word_space(",");
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",");
+                        self.word(",");
                         self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
                     self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p));
                     if elts.len() == 1 {
-                        self.s.word(",");
+                        self.word(",");
                     }
                 }
                 self.pclose();
             }
             PatKind::Box(ref inner) => {
                 let is_range_inner = matches!(inner.kind, PatKind::Range(..));
-                self.s.word("box ");
+                self.word("box ");
                 if is_range_inner {
                     self.popen();
                 }
@@ -1932,8 +1932,8 @@ impl<'a> State<'a> {
             }
             PatKind::Ref(ref inner, mutbl) => {
                 let is_range_inner = matches!(inner.kind, PatKind::Range(..));
-                self.s.word("&");
-                self.s.word(mutbl.prefix_str());
+                self.word("&");
+                self.word(mutbl.prefix_str());
                 if is_range_inner {
                     self.popen();
                 }
@@ -1946,18 +1946,18 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, ref end_kind) => {
                 if let Some(expr) = begin {
                     self.print_expr(expr);
-                    self.s.space();
+                    self.space();
                 }
                 match *end_kind {
-                    RangeEnd::Included => self.s.word("..."),
-                    RangeEnd::Excluded => self.s.word(".."),
+                    RangeEnd::Included => self.word("..."),
+                    RangeEnd::Excluded => self.word(".."),
                 }
                 if let Some(expr) = end {
                     self.print_expr(expr);
                 }
             }
             PatKind::Slice(ref before, ref slice, ref after) => {
-                self.s.word("[");
+                self.word("[");
                 self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p));
                 if let Some(ref p) = *slice {
                     if !before.is_empty() {
@@ -1968,13 +1968,13 @@ impl<'a> State<'a> {
                     } else {
                         self.print_pat(&p);
                     }
-                    self.s.word("..");
+                    self.word("..");
                     if !after.is_empty() {
                         self.word_space(",");
                     }
                 }
                 self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p));
-                self.s.word("]");
+                self.word("]");
             }
         }
         self.ann.post(self, AnnNode::Pat(pat))
@@ -1989,29 +1989,29 @@ impl<'a> State<'a> {
         // I have no idea why this check is necessary, but here it
         // is :(
         if self.attrs(arm.hir_id).is_empty() {
-            self.s.space();
+            self.space();
         }
         self.cbox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Arm(arm));
         self.ibox(0);
         self.print_outer_attributes(&self.attrs(arm.hir_id));
         self.print_pat(&arm.pat);
-        self.s.space();
+        self.space();
         if let Some(ref g) = arm.guard {
             match g {
                 hir::Guard::If(e) => {
                     self.word_space("if");
                     self.print_expr(&e);
-                    self.s.space();
+                    self.space();
                 }
                 hir::Guard::IfLet(pat, e) => {
                     self.word_nbsp("if");
                     self.word_nbsp("let");
                     self.print_pat(&pat);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_expr(&e);
-                    self.s.space();
+                    self.space();
                 }
             }
         }
@@ -2029,13 +2029,13 @@ impl<'a> State<'a> {
                 // If it is a user-provided unsafe block, print a comma after it
                 if let hir::BlockCheckMode::UnsafeBlock(hir::UnsafeSource::UserProvided) = blk.rules
                 {
-                    self.s.word(",");
+                    self.word(",");
                 }
             }
             _ => {
                 self.end(); // close the ibox for the pattern
                 self.print_expr(&arm.body);
-                self.s.word(",");
+                self.word(",");
             }
         }
         self.ann.post(self, AnnNode::Arm(arm));
@@ -2067,20 +2067,20 @@ impl<'a> State<'a> {
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
             s.ibox(INDENT_UNIT);
             if let Some(arg_name) = arg_names.get(i) {
-                s.s.word(arg_name.to_string());
-                s.s.word(":");
-                s.s.space();
+                s.word(arg_name.to_string());
+                s.word(":");
+                s.space();
             } else if let Some(body_id) = body_id {
                 s.ann.nested(s, Nested::BodyParamPat(body_id, i));
-                s.s.word(":");
-                s.s.space();
+                s.word(":");
+                s.space();
             }
             i += 1;
             s.print_type(ty);
             s.end()
         });
         if decl.c_variadic {
-            self.s.word(", ...");
+            self.word(", ...");
         }
         self.pclose();
 
@@ -2089,7 +2089,7 @@ impl<'a> State<'a> {
     }
 
     fn print_closure_params(&mut self, decl: &hir::FnDecl<'_>, body_id: hir::BodyId) {
-        self.s.word("|");
+        self.word("|");
         let mut i = 0;
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
             s.ibox(INDENT_UNIT);
@@ -2100,13 +2100,13 @@ impl<'a> State<'a> {
             if let hir::TyKind::Infer = ty.kind {
                 // Print nothing.
             } else {
-                s.s.word(":");
-                s.s.space();
+                s.word(":");
+                s.space();
                 s.print_type(ty);
             }
             s.end();
         });
-        self.s.word("|");
+        self.word("|");
 
         if let hir::FnRetTy::DefaultReturn(..) = decl.output {
             return;
@@ -2138,7 +2138,7 @@ impl<'a> State<'a> {
         let mut first = true;
         for bound in bounds {
             if first {
-                self.s.word(prefix);
+                self.word(prefix);
             }
             if !(first && prefix.is_empty()) {
                 self.nbsp();
@@ -2152,14 +2152,14 @@ impl<'a> State<'a> {
             match bound {
                 GenericBound::Trait(tref, modifier) => {
                     if modifier == &TraitBoundModifier::Maybe {
-                        self.s.word("?");
+                        self.word("?");
                     }
                     self.print_poly_trait_ref(tref);
                 }
                 GenericBound::LangItemTrait(lang_item, span, ..) => {
-                    self.s.word("#[lang = \"");
+                    self.word("#[lang = \"");
                     self.print_ident(Ident::new(lang_item.name(), *span));
-                    self.s.word("\"]");
+                    self.word("\"]");
                 }
                 GenericBound::Outlives(lt) => {
                     self.print_lifetime(lt);
@@ -2170,11 +2170,11 @@ impl<'a> State<'a> {
 
     pub fn print_generic_params(&mut self, generic_params: &[GenericParam<'_>]) {
         if !generic_params.is_empty() {
-            self.s.word("<");
+            self.word("<");
 
             self.commasep(Inconsistent, generic_params, |s, param| s.print_generic_param(param));
 
-            self.s.word(">");
+            self.word(">");
         }
     }
 
@@ -2191,7 +2191,7 @@ impl<'a> State<'a> {
                 for bound in param.bounds {
                     match bound {
                         GenericBound::Outlives(ref lt) => {
-                            self.s.word(sep);
+                            self.word(sep);
                             self.print_lifetime(lt);
                             sep = "+";
                         }
@@ -2202,7 +2202,7 @@ impl<'a> State<'a> {
             GenericParamKind::Type { ref default, .. } => {
                 self.print_bounds(":", param.bounds);
                 if let Some(default) = default {
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(&default)
                 }
@@ -2211,7 +2211,7 @@ impl<'a> State<'a> {
                 self.word_space(":");
                 self.print_type(ty);
                 if let Some(ref default) = default {
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_anon_const(&default)
                 }
@@ -2228,7 +2228,7 @@ impl<'a> State<'a> {
             return;
         }
 
-        self.s.space();
+        self.space();
         self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
@@ -2253,7 +2253,7 @@ impl<'a> State<'a> {
                     ..
                 }) => {
                     self.print_lifetime(lifetime);
-                    self.s.word(":");
+                    self.word(":");
 
                     for (i, bound) in bounds.iter().enumerate() {
                         match bound {
@@ -2264,7 +2264,7 @@ impl<'a> State<'a> {
                         }
 
                         if i != 0 {
-                            self.s.word(":");
+                            self.word(":");
                         }
                     }
                 }
@@ -2272,7 +2272,7 @@ impl<'a> State<'a> {
                     lhs_ty, rhs_ty, ..
                 }) => {
                     self.print_type(lhs_ty);
-                    self.s.space();
+                    self.space();
                     self.word_space("=");
                     self.print_type(rhs_ty);
                 }
@@ -2326,7 +2326,7 @@ impl<'a> State<'a> {
     ) {
         self.ibox(INDENT_UNIT);
         if !generic_params.is_empty() {
-            self.s.word("for");
+            self.word("for");
             self.print_generic_params(generic_params);
         }
         let generics = hir::Generics {
@@ -2352,7 +2352,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_fn_header_info(&mut self, header: hir::FnHeader, vis: &hir::Visibility<'_>) {
-        self.s.word(visibility_qualified(vis, ""));
+        self.word(visibility_qualified(vis, ""));
 
         match header.constness {
             hir::Constness::NotConst => {}
@@ -2371,7 +2371,7 @@ impl<'a> State<'a> {
             self.word_nbsp(header.abi.to_string());
         }
 
-        self.s.word("fn")
+        self.word("fn")
     }
 
     pub fn print_unsafety(&mut self, s: hir::Unsafety) {

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -939,9 +939,7 @@ impl<'tcx> ResolvedTypeParamEraser<'tcx> {
     /// Replace not yet inferred const params with their def name.
     fn replace_infers(&self, c: &'tcx Const<'tcx>, index: u32, name: Symbol) -> &'tcx Const<'tcx> {
         match c.val {
-            ty::ConstKind::Infer(..) => {
-                self.tcx().mk_const_param(index, name, c.ty)
-            }
+            ty::ConstKind::Infer(..) => self.tcx().mk_const_param(index, name, c.ty),
             _ => c,
         }
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -10,7 +10,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::infer::unify_key::ConstVariableOriginKind;
 use rustc_middle::ty::print::Print;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
-use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
+use rustc_middle::ty::{self, Const, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
 use rustc_span::symbol::kw;
 use rustc_span::Span;
 use std::borrow::Cow;
@@ -305,6 +305,15 @@ pub enum UnderspecifiedArgKind {
     Const { is_parameter: bool },
 }
 
+impl UnderspecifiedArgKind {
+    fn descr(&self) -> &'static str {
+        match self {
+            Self::Type { .. } => "type",
+            Self::Const { .. } => "const",
+        }
+    }
+}
+
 impl InferenceDiagnosticsData {
     /// Generate a label for a generic argument which can't be inferred. When not
     /// much is known about the argument, `use_diag` may be used to describe the
@@ -587,6 +596,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
         }
 
+        let param_type = arg_data.kind.descr();
         let suffix = match local_visitor.found_node_ty {
             Some(ty) if ty.is_closure() => {
                 let substs =
@@ -625,15 +635,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && arg_data.name == "_" => {
                 let ty = ty_to_string(ty);
-                format!("the explicit type `{}`, with the type parameters specified", ty)
+                format!("the explicit type `{}`, with the {} parameters specified", ty, param_type)
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && ty.to_string() != arg_data.name => {
                 let ty = ResolvedTypeParamEraser::new(self.tcx).fold_ty(ty);
                 let ty = ErrTypeParamEraser(self.tcx).fold_ty(ty);
                 let ty = ty_to_string(ty);
                 format!(
-                    "the explicit type `{}`, where the type parameter `{}` is specified",
-                    ty, arg_data.name,
+                    "the explicit type `{}`, where the {} parameter `{}` is specified",
+                    ty, param_type, arg_data.name,
                 )
             }
             _ => "a type".to_string(),
@@ -910,7 +920,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 }
 
-/// Turn resolved type params into `[type error]` to signal we don't want to display them.
+/// Turn *resolved* type params into `[type error]` to signal we don't want to display them. After
+/// performing that replacement, we'll turn all remaining infer type params to use their name from
+/// their definition, and replace all the `[type error]`s back to being infer so they display in
+/// the output as `_`. If we didn't go through `[type error]`, we would either show all type params
+/// by their name *or* `_`, neither of which is desireable: we want to show all types that we could
+/// infer as `_` to reduce verbosity and avoid telling the user about unnecessary type annotations.
 struct ResolvedTypeParamEraser<'tcx> {
     tcx: TyCtxt<'tcx>,
     level: usize,
@@ -920,7 +935,18 @@ impl<'tcx> ResolvedTypeParamEraser<'tcx> {
     fn new(tcx: TyCtxt<'tcx>) -> Self {
         ResolvedTypeParamEraser { tcx, level: 0 }
     }
+
+    /// Replace not yet inferred const params with their def name.
+    fn replace_infers(&self, c: &'tcx Const<'tcx>, index: u32, name: Symbol) -> &'tcx Const<'tcx> {
+        match c.val {
+            ty::ConstKind::Infer(..) => {
+                self.tcx().mk_const_param(index, name, c.ty)
+            }
+            _ => c,
+        }
+    }
 }
+
 impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
     fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
         self.tcx
@@ -940,29 +966,22 @@ impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
                     .map(|(subst, param)| match &(subst.unpack(), &param.kind) {
                         (_, ty::GenericParamDefKind::Type { has_default: true, .. }) => subst,
                         (crate::infer::GenericArgKind::Const(c), _) => {
-                            match c.val {
-                                ty::ConstKind::Infer(..) => {
-                                    // Replace not yet inferred const params with their def name.
-                                    self.tcx().mk_const_param(param.index, param.name, c.ty).into()
-                                }
-                                _ => subst,
-                            }
+                            self.replace_infers(c, param.index, param.name).into()
                         }
                         _ => subst.super_fold_with(self),
                     })
                     .collect();
-                if self.level == 1
-                    || substs.iter().any(|subst| match subst.unpack() {
-                        ty::subst::GenericArgKind::Type(t) => match t.kind() {
-                            ty::Error(_) => false,
-                            _ => true,
-                        },
-                        // Account for `const` params here, otherwise `doesnt_infer.rs`
-                        // shows `_` instead of `Foo<{ _: u32 }>`
-                        ty::subst::GenericArgKind::Const(_) => true,
-                        _ => false,
-                    })
-                {
+                let should_keep = |subst: &GenericArg<'_>| match subst.unpack() {
+                    ty::subst::GenericArgKind::Type(t) => match t.kind() {
+                        ty::Error(_) => false,
+                        _ => true,
+                    },
+                    // Account for `const` params here, otherwise `doesnt_infer.rs`
+                    // shows `_` instead of `Foo<{ _: u32 }>`
+                    ty::subst::GenericArgKind::Const(_) => true,
+                    _ => false,
+                };
+                if self.level == 1 || substs.iter().any(should_keep) {
                     let substs = self.tcx().intern_substs(&substs[..]);
                     self.tcx().mk_ty(ty::Adt(def, substs))
                 } else {
@@ -986,18 +1005,9 @@ impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
             | ty::Opaque(..)
             | ty::Projection(_)
             | ty::Never => t.super_fold_with(self),
-            ty::Array(ty, c) => {
-                self.tcx().mk_ty(ty::Array(
-                    self.fold_ty(ty),
-                    match c.val {
-                        ty::ConstKind::Infer(..) => {
-                            // Replace not yet inferred const params with their def name.
-                            self.tcx().mk_const_param(0, Symbol::intern("N"), c.ty).into()
-                        }
-                        _ => c,
-                    },
-                ))
-            }
+            ty::Array(ty, c) => self
+                .tcx()
+                .mk_ty(ty::Array(self.fold_ty(ty), self.replace_infers(c, 0, Symbol::intern("N")))),
             // We don't want to hide type params that haven't been resolved yet.
             // This would be the type that will be written out with the type param
             // name in the output.

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -11,7 +11,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::infer::unify_key::ConstVariableOriginKind;
 use rustc_middle::ty::print::Print;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
-use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt};
+use rustc_middle::ty::{self, DefIdTree, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder};
 use rustc_span::symbol::kw;
 use rustc_span::Span;
 use std::borrow::Cow;
@@ -629,6 +629,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 format!("the explicit type `{}`, with the type parameters specified", ty)
             }
             Some(ty) if is_named_and_not_impl_trait(ty) && ty.to_string() != arg_data.name => {
+                let ty = ResolvedTypeParamEraser::new(self.tcx).fold_ty(ty);
+                let ty = ErrTypeParamEraser(self.tcx).fold_ty(ty);
                 let ty = ty_to_string(ty);
                 format!(
                     "the explicit type `{}`, where the type parameter `{}` is specified",
@@ -906,5 +908,101 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         );
         err.span_label(span, data.cannot_infer_msg(None));
         err
+    }
+}
+
+/// Turn resolved type params into `[type error]` to signal we don't want to display them.
+struct ResolvedTypeParamEraser<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    level: usize,
+}
+
+impl<'tcx> ResolvedTypeParamEraser<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        ResolvedTypeParamEraser { tcx, level: 0 }
+    }
+}
+impl<'tcx> TypeFolder<'tcx> for ResolvedTypeParamEraser<'tcx> {
+    fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        self.level += 1;
+        let t = match t.kind() {
+            // We'll hide this type only if all its type params are hidden as well.
+            ty::Adt(def, substs) => {
+                let generics = self.tcx().generics_of(def.did);
+                // Account for params with default values, like `Vec`, where we
+                // want to show `Vec<T>`, not `Vec<T, _>`. If we replaced that
+                // subst, then we'd get the incorrect output, so we passthrough.
+                let substs: Vec<_> = substs
+                    .iter()
+                    .zip(generics.params.iter())
+                    .map(|(subst, param)| match &param.kind {
+                        ty::GenericParamDefKind::Type { has_default: true, .. } => subst,
+                        _ => subst.super_fold_with(self),
+                    })
+                    .collect();
+                if self.level == 1
+                    || substs.iter().any(|subst| match subst.unpack() {
+                        ty::subst::GenericArgKind::Type(t) => match t.kind() {
+                            ty::Error(_) => false,
+                            _ => true,
+                        },
+                        // Account for `const` params here, otherwise `doesnt_infer.rs`
+                        // shows `_` instead of `Foo<{ _: u32 }>`
+                        ty::subst::GenericArgKind::Const(_) => true,
+                        _ => false,
+                    })
+                {
+                    let substs = self.tcx().intern_substs(&substs[..]);
+                    self.tcx().mk_ty(ty::Adt(def, substs))
+                } else {
+                    self.tcx().ty_error()
+                }
+            }
+            ty::Ref(_, ty, _) => {
+                let ty = self.fold_ty(ty);
+                match ty.kind() {
+                    // Avoid `&_`, these can be safely presented as `_`.
+                    ty::Error(_) => self.tcx().ty_error(),
+                    _ => t.super_fold_with(self),
+                }
+            }
+            // We could account for `()` if we wanted to replace it, but it's assured to be short.
+            ty::Tuple(_)
+            | ty::Slice(_)
+            | ty::RawPtr(_)
+            | ty::FnDef(..)
+            | ty::FnPtr(_)
+            | ty::Opaque(..)
+            | ty::Projection(_)
+            | ty::Never
+            | ty::Array(..) => t.super_fold_with(self),
+            // We don't want to hide type params that haven't been resolved yet.
+            // This would be the type that will be written out with the type param
+            // name in the output.
+            ty::Infer(_) => t,
+            // We don't want to hide the outermost type, only its type params.
+            _ if self.level == 1 => t.super_fold_with(self),
+            // Hide this type
+            _ => self.tcx().ty_error(),
+        };
+        self.level -= 1;
+        t
+    }
+}
+
+/// Replace `[type error]` with `ty::Infer(ty::Var)` to display `_`.
+struct ErrTypeParamEraser<'tcx>(TyCtxt<'tcx>);
+impl<'tcx> TypeFolder<'tcx> for ErrTypeParamEraser<'tcx> {
+    fn tcx<'a>(&'a self) -> TyCtxt<'tcx> {
+        self.0
+    }
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        match t.kind() {
+            ty::Error(_) => self.tcx().mk_ty_var(ty::TyVid::from_u32(0)),
+            _ => t.super_fold_with(self),
+        }
     }
 }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -7,6 +7,7 @@ use rustc_hir::def::Namespace;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_macros::HashStable;
+use rustc_middle::ty::normalize_erasing_regions::NormalizationError;
 
 use std::fmt;
 
@@ -572,6 +573,23 @@ impl<'tcx> Instance<'tcx> {
             tcx.subst_and_normalize_erasing_regions(substs, param_env, v)
         } else {
             tcx.normalize_erasing_regions(param_env, v)
+        }
+    }
+
+    #[inline(always)]
+    pub fn try_subst_mir_and_normalize_erasing_regions<T>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+        v: T,
+    ) -> Result<T, NormalizationError<'tcx>>
+    where
+        T: TypeFoldable<'tcx> + Clone,
+    {
+        if let Some(substs) = self.substs_for_mir_body() {
+            tcx.try_subst_and_normalize_erasing_regions(substs, param_env, v)
+        } else {
+            tcx.try_normalize_erasing_regions(param_env, v)
         }
     }
 

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -396,7 +396,7 @@ Note that the third item is the crate root, which in this case is undocumented.
 ### `-w`/`--output-format`: output format
 
 `--output-format json` emits documentation in the experimental
-[JSON format](https://github.com/rust-lang/rfcs/pull/2963). `--output-format html` has no effect,
+[JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/). `--output-format html` has no effect,
 and is also accepted on stable toolchains.
 
 It can also be used with `--show-coverage`. Take a look at its

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -20,7 +20,7 @@
           id="mainThemeStyle"> {#- -#}
     {%- for theme in themes -%}
         <link rel="stylesheet" type="text/css" {# -#}
-            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {#- -#}
+            href="{{static_root_path | safe}}{{theme}}{{page.resource_suffix}}.css" {# -#}
         {%- if theme == "light" -%}
             id="themeStyle"
         {%- else -%}

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<{_: u32}>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<{_: _}>`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<{_: _}>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<N>`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/src/test/ui/const-generics/defaults/doesnt_infer.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Foo<{_: u32}>`
 LL |     let foo = Foo::foo();
    |         ---   ^^^^^^^^ cannot infer the value of const parameter `N`
    |         |
-   |         consider giving `foo` the explicit type `Foo<N>`, where the type parameter `N` is specified
+   |         consider giving `foo` the explicit type `Foo<N>`, where the const parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-72845.rs
+++ b/src/test/ui/const-generics/issues/issue-72845.rs
@@ -1,0 +1,49 @@
+#![feature(generic_const_exprs)]
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+//--------------------------------------------------
+
+trait Depth {
+    const C: usize;
+}
+
+trait Type {
+    type AT: Depth;
+}
+
+//--------------------------------------------------
+
+enum Predicate<const B: bool> {}
+
+trait Satisfied {}
+
+impl Satisfied for Predicate<true> {}
+
+//--------------------------------------------------
+
+trait Spec1 {}
+
+impl<T: Type> Spec1 for T where Predicate<{T::AT::C > 0}>: Satisfied {}
+
+trait Spec2 {}
+
+//impl<T: Type > Spec2 for T where Predicate<{T::AT::C > 1}>: Satisfied {}
+impl<T: Type > Spec2 for T where Predicate<true>: Satisfied {}
+
+//--------------------------------------------------
+
+trait Foo {
+    fn Bar();
+}
+
+impl<T: Spec1> Foo for T {
+    default fn Bar() {}
+}
+
+impl<T: Spec2> Foo for T {
+//~^ ERROR conflicting implementations of trait
+    fn Bar() {}
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-72845.stderr
+++ b/src/test/ui/const-generics/issues/issue-72845.stderr
@@ -1,0 +1,12 @@
+error[E0119]: conflicting implementations of trait `Foo`
+  --> $DIR/issue-72845.rs:44:1
+   |
+LL | impl<T: Spec1> Foo for T {
+   | ------------------------ first implementation here
+...
+LL | impl<T: Spec2> Foo for T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -20,7 +20,7 @@ error[E0080]: evaluation of constant value failed
 LL |     let x: &'static i32 = &X;
    |                            ^ referenced constant has errors
 query stack during panic:
-#0 [normalize_mir_const_after_erasing_regions] normalizing `main::promoted[1]`
+#0 [try_normalize_mir_const_after_erasing_regions] normalizing `main::promoted[1]`
 #1 [optimized_mir] optimizing MIR for `main`
 #2 [collect_and_partition_mono_items] collect_and_partition_mono_items
 end of query stack

--- a/src/test/ui/inference/erase-type-params-in-label.rs
+++ b/src/test/ui/inference/erase-type-params-in-label.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let foo = new(1, ""); //~ ERROR E0283
+}
+
+struct Bar<T, K, N: Default> {
+    t: T,
+    k: K,
+    n: N,
+}
+
+fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+    Bar { t, k, n: Default::default() }
+}

--- a/src/test/ui/inference/erase-type-params-in-label.rs
+++ b/src/test/ui/inference/erase-type-params-in-label.rs
@@ -1,5 +1,8 @@
 fn main() {
-    let foo = new(1, ""); //~ ERROR E0283
+    let foo = foo(1, ""); //~ ERROR E0283
+}
+fn baz() {
+    let bar = bar(1, ""); //~ ERROR E0283
 }
 
 struct Bar<T, K, N: Default> {
@@ -8,6 +11,17 @@ struct Bar<T, K, N: Default> {
     n: N,
 }
 
-fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
     Bar { t, k, n: Default::default() }
+}
+
+struct Foo<T, K, N: Default, M: Default> {
+    t: T,
+    k: K,
+    n: N,
+    m: M,
+}
+
+fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+    Foo { t, k, n: Default::default(), m: Default::default() }
 }

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -1,22 +1,41 @@
-error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+error[E0283]: type annotations needed for `Foo<i32, &str, W, Z>`
   --> $DIR/erase-type-params-in-label.rs:2:15
    |
-LL |     let foo = new(1, "");
-   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `new`
+LL |     let foo = foo(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `W` declared on the function `foo`
    |         |
-   |         consider giving `foo` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |         consider giving `foo` the explicit type `Foo<_, _, W, Z>`, where the type parameter `W` is specified
    |
    = note: cannot satisfy `_: Default`
-note: required by a bound in `new`
-  --> $DIR/erase-type-params-in-label.rs:11:17
+note: required by a bound in `foo`
+  --> $DIR/erase-type-params-in-label.rs:25:17
    |
-LL | fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
-   |                 ^^^^^^^ required by this bound in `new`
+LL | fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+   |                 ^^^^^^^ required by this bound in `foo`
 help: consider specifying the type arguments in the function call
    |
-LL |     let foo = new::<T, K, Z>(1, "");
+LL |     let foo = foo::<T, K, W, Z>(1, "");
+   |                  ++++++++++++++
+
+error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+  --> $DIR/erase-type-params-in-label.rs:5:15
+   |
+LL |     let bar = bar(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `bar`
+   |         |
+   |         consider giving `bar` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |
+   = note: cannot satisfy `_: Default`
+note: required by a bound in `bar`
+  --> $DIR/erase-type-params-in-label.rs:14:17
+   |
+LL | fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   |                 ^^^^^^^ required by this bound in `bar`
+help: consider specifying the type arguments in the function call
+   |
+LL |     let bar = bar::<T, K, Z>(1, "");
    |                  +++++++++++
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
+  --> $DIR/erase-type-params-in-label.rs:2:15
+   |
+LL |     let foo = new(1, "");
+   |         ---   ^^^ cannot infer type for type parameter `Z` declared on the function `new`
+   |         |
+   |         consider giving `foo` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
+   |
+   = note: cannot satisfy `_: Default`
+note: required by a bound in `new`
+  --> $DIR/erase-type-params-in-label.rs:11:17
+   |
+LL | fn new<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   |                 ^^^^^^^ required by this bound in `new`
+help: consider specifying the type arguments in the function call
+   |
+LL |     let foo = new::<T, K, Z>(1, "");
+   |                  +++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[usize; _]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; _]`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[_; _]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; N]`, where the type parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
    |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |         |
-   |         consider giving this pattern the explicit type `[_; N]`, where the type parameter `N` is specified
+   |         consider giving this pattern the explicit type `[_; N]`, where the const parameter `N` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,16 +1,31 @@
 #![allow(incomplete_features)]
 #![feature(inline_const_pat)]
+#![feature(generic_const_exprs)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 
 fn foo<const V: usize>() {
-  match 0 {
-    const { V } => {},
-    //~^ ERROR const parameters cannot be referenced in patterns [E0158]
-    _ => {},
-  }
+    match 0 {
+        const { V } => {},
+        //~^ ERROR const parameters cannot be referenced in patterns [E0158]
+        _ => {},
+    }
+}
+
+const fn f(x: usize) -> usize {
+    x + 1
+}
+
+fn bar<const V: usize>() where [(); f(V)]: {
+    match 0 {
+        const { f(V) } => {},
+        //~^ ERROR constant pattern depends on a generic parameter
+        //~| ERROR constant pattern depends on a generic parameter
+        _ => {},
+    }
 }
 
 fn main() {
     foo::<1>();
+    bar::<1>();
 }

--- a/src/test/ui/inline-const/const-match-pat-generic.stderr
+++ b/src/test/ui/inline-const/const-match-pat-generic.stderr
@@ -1,9 +1,21 @@
 error[E0158]: const parameters cannot be referenced in patterns
-  --> $DIR/const-match-pat-generic.rs:8:11
+  --> $DIR/const-match-pat-generic.rs:9:9
    |
-LL |     const { V } => {},
-   |           ^^^^^
+LL |         const { V } => {},
+   |         ^^^^^^^^^^^
 
-error: aborting due to previous error
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: constant pattern depends on a generic parameter
+  --> $DIR/const-match-pat-generic.rs:21:9
+   |
+LL |         const { f(V) } => {},
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0158`.


### PR DESCRIPTION
Successful merges:

 - #90709 (Only shown relevant type params in E0283 label)
 - #91551 (Allow for failure of subst_normalize_erasing_regions in const_eval)
 - #91570 (Evaluate inline const pat early and report error if too generic)
 - #91571 (Remove unneeded access to pretty printer's `s` field in favor of deref)
 - #91610 (Link to rustdoc_json_types docs instead of rustdoc-json RFC)
 - #91619 (Update cargo)
 - #91630 (Add missing whitespace before disabled HTML attribute)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90709,91551,91570,91571,91610,91619,91630)
<!-- homu-ignore:end -->