### PR TITLE
Remove the match on `ErrorKind::Other`

### DIFF
--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -76,9 +76,7 @@ fn rm_rf(path: &Path) {
                 fs::remove_dir(p).or_else(|e| {
                     // Check for dir not empty on Windows
                     #[cfg(windows)]
-                    if matches!(e.kind(), std::io::ErrorKind::Other)
-                        && e.raw_os_error() == Some(145)
-                    {
+                    if e.raw_os_error() == Some(145) {
                         return Ok(());
                     }
 

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -75,6 +75,8 @@ fn rm_rf(path: &Path) {
             do_op(path, "remove dir", |p| {
                 fs::remove_dir(p).or_else(|e| {
                     // Check for dir not empty on Windows
+                    // FIXME: Once `ErrorKind::DirectoryNotEmpty` is stabilized,
+                    // match on `e.kind()` instead.
                     #[cfg(windows)]
                     if e.raw_os_error() == Some(145) {
                         return Ok(());


### PR DESCRIPTION
It's a) superfluous and b) doesn't work any more.