### PR TITLE
Fix `Vec::reserve_exact` documentation

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -822,7 +822,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the new capacity overflows `usize`.
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The documentation previously said the new capacity cannot overflow `usize`, but in fact it cannot exceed `isize::MAX`.