### PR TITLE
rustdoc: do not emit tuple variant fields if none are documented

### DIFF
--- a/src/test/rustdoc/issue-88600.rs
+++ b/src/test/rustdoc/issue-88600.rs
@@ -18,17 +18,18 @@ pub enum FooEnum {
     // @has - '//*[@id="variant.MixedHiddenFirst"]//code' 'MixedHiddenFirst(_, S)'
     // @count - '//*[@id="variant.MixedHiddenFirst.field.0"]' 0
     // @has - '//*[@id="variant.MixedHiddenFirst.field.1"]' '1: S'
-    MixedHiddenFirst(#[doc(hidden)] H, S),
+    MixedHiddenFirst(#[doc(hidden)] H, /** dox */ S),
     // @has - '//*[@id="variant.MixedHiddenLast"]//code' 'MixedHiddenLast(S, _)'
     // @has - '//*[@id="variant.MixedHiddenLast.field.0"]' '0: S'
     // @count - '//*[@id="variant.MixedHiddenLast.field.1"]' 0
-    MixedHiddenLast(S, #[doc(hidden)] H),
+    MixedHiddenLast(/** dox */ S, #[doc(hidden)] H),
     // @has - '//*[@id="variant.HiddenStruct"]//code' 'HiddenStruct'
     // @count - '//*[@id="variant.HiddenStruct.field.h"]' 0
     // @has - '//*[@id="variant.HiddenStruct.field.s"]' 's: S'
     HiddenStruct {
         #[doc(hidden)]
         h: H,
+        /// dox
         s: S,
     },
 }

--- a/src/test/rustdoc/tuple-struct-fields-doc.rs
+++ b/src/test/rustdoc/tuple-struct-fields-doc.rs
@@ -24,6 +24,9 @@ pub struct Foo(
 // @has - '//*[@id="variant.BarVariant.field.0"]' '0: String'
 // @has - '//*[@id="variant.BarVariant.fields"]//*[@class="docblock"]' 'Hello docs'
 // @matches - '//*[@id="variant.FooVariant.fields"]/h4' '^Fields$'
+// @has - '//*[@id="variant.BazVariant.fields"]//*[@class="docblock"]' 'dox'
+// @has - '//*[@id="variant.OtherVariant.fields"]//*[@class="docblock"]' 'dox'
+// @!matches - '//*[@id="variant.QuuxVariant.fields"]/h4' '^Tuple Fields$'
 pub enum Bar {
     BarVariant(
         /// Hello docs
@@ -33,4 +36,15 @@ pub enum Bar {
        /// hello
        x: u32,
     },
+    BazVariant(
+        String,
+        /// dox
+        u32,
+    ),
+    OtherVariant(
+        /// dox
+        String,
+        u32,
+    ),
+    QuuxVariant(String),
 }


### PR DESCRIPTION
Fixes #90824.

Before:

![2021-12-15T22:26:41](https://user-images.githubusercontent.com/1372438/146302871-4d265433-b9aa-4e53-adfb-e7cb92107180.png)

After:

![2021-12-15T22:27:01](https://user-images.githubusercontent.com/1372438/146302872-e39eda3d-2fb2-4fb9-aae7-2008e4e1b4dd.png)
