### PR TITLE
Delete Utf8Lossy::from_str

### DIFF
--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -13,11 +13,6 @@ pub struct Utf8Lossy {
 
 impl Utf8Lossy {
     #[must_use]
-    pub fn from_str(s: &str) -> &Utf8Lossy {
-        Utf8Lossy::from_bytes(s.as_bytes())
-    }
-
-    #[must_use]
     pub fn from_bytes(bytes: &[u8]) -> &Utf8Lossy {
         // SAFETY: Both use the same memory layout, and UTF-8 correctness isn't required.
         unsafe { mem::transmute(bytes) }


### PR DESCRIPTION
This whole type is marked as being for str internals only, but this constructor is never used by str internals. If you had a &amp;str already and wanted to lossy display it or iterate its lossy utf8 chunks, you would simply not use Utf8Lossy because the whole &amp;str is known to be one contiguous valid utf8 chunk.

If code really does need to obtain a value of type &amp;Utf8Lossy somewhere, and has only a &amp;str, `Utf8Lossy::from_bytes(s.as_bytes())` remains available. As currently implemented, there is no performance penalty relative to `from_str` i.e. the Utf8Lossy does not "remember" that it was constructed using `from_str` to bypass later utf8 decoding.