### PR TITLE
Add `-webkit-appearance: none` to search input

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -836,6 +836,10 @@ h2.small-section-header > .anchor {
 	top: 10px;
 }
 .search-input {
+	/* Override Normalize.css: it has a rule that sets
+	   -webkit-appearance: textfield for search inputs. That
+	   causes rounded corners and no border on iOS Safari. */
+	-webkit-appearance: none;
 	/* Override Normalize.css: we have margins and do
 	 not want to overflow - the `moz` attribute is necessary
 	 until Firefox 29, too early to drop at this point */


### PR DESCRIPTION
This fixes an issue when displaying on iPad, where the search box had no borders.

r? @GuillaumeGomez

Demo https://rustdoc.crud.net/jsha/webkit-appearance-search-input/std/string/struct.String.html